### PR TITLE
NO-SNOW: get rid of special Python Connector compression behavior

### DIFF
--- a/pep249_dbapi/tests/integ/test_put_get_simple.py
+++ b/pep249_dbapi/tests/integ/test_put_get_simple.py
@@ -21,6 +21,8 @@ from .utils_put_get import (
     LS_ROW_NAME_IDX,
 )
 
+from ..connector_types import ConnectorType
+
 
 def test_put_select(cursor):
     stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_PUT_SELECT")
@@ -96,7 +98,7 @@ def test_get(cursor):
         assert decompressed == original
 
 
-def test_put_get_rowset(cursor):
+def test_put_get_rowset(cursor, connector_type):
     stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_PUT_ROWSET")
     filename = "test_put_get_rowset.csv"
 
@@ -113,7 +115,13 @@ def test_put_get_rowset(cursor):
         assert row[PUT_ROW_SOURCE_IDX] == "test_put_get_rowset.csv"
         assert row[PUT_ROW_TARGET_IDX] == "test_put_get_rowset.csv.gz"
         assert row[PUT_ROW_SOURCE_SIZE_IDX] == 6
-        assert row[PUT_ROW_TARGET_SIZE_IDX] == 64
+
+        # BREAKING CHANGE: changing the compression behavior reduces the size of a compressed file
+        if connector_type == ConnectorType.REFERENCE:
+            assert row[PUT_ROW_TARGET_SIZE_IDX] == 64
+        else:
+            assert row[PUT_ROW_TARGET_SIZE_IDX] == 32
+
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "NONE"
         assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "GZIP"
         assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
@@ -126,6 +134,12 @@ def test_put_get_rowset(cursor):
         row = cursor.fetchone()
 
         assert row[GET_ROW_FILE_IDX] == "test_put_get_rowset.csv.gz"
-        assert row[GET_ROW_SIZE_IDX] == 52
+
+        # BREAKING CHANGE: changing the compression behavior reduces the size of a compressed file
+        if connector_type == ConnectorType.REFERENCE:
+            assert row[GET_ROW_SIZE_IDX] == 52
+        else:
+            assert row[GET_ROW_SIZE_IDX] == 26
+
         assert row[GET_ROW_STATUS_IDX] == "DOWNLOADED"
         assert row[GET_ROW_MESSAGE_IDX] == ""

--- a/sf_core/src/compression.rs
+++ b/sf_core/src/compression.rs
@@ -3,15 +3,10 @@ use snafu::{Location, ResultExt, Snafu};
 use std::io::{Read, Write};
 
 // PUT/GET compression
-pub fn compress_data(input_data: Vec<u8>, filename: &str) -> Result<Vec<u8>, CompressionError> {
-    // Python Connector adds a "_c" suffix to the filename and replaces it with spaces
-    // To match that behavior, we replace the filename with spaces + 2
-    let spaces_filename = " ".repeat(filename.len() + 2);
-
+pub fn compress_data(input_data: Vec<u8>) -> Result<Vec<u8>, CompressionError> {
     // Use GzBuilder to create gzip with spaces filename and zeroed timestamp
     let mut encoder = GzBuilder::new()
         .mtime(0) // Set timestamp to 0 for consistent normalization
-        .filename(spaces_filename) // TODO: remove this when we have more PUT/GET tests
         .write(Vec::new(), Compression::best());
 
     encoder.write_all(&input_data).context(DataWritingSnafu)?;
@@ -44,58 +39,4 @@ pub enum CompressionError {
         #[snafu(implicit)]
         location: Location,
     },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_utils::{bytes_to_hex, hex_to_bytes};
-
-    // TODO: Remove this test once we got rid of special python connector behavior
-    #[test]
-    fn test_compress_test_normal_put_csv() {
-        let content = "1,2,3\n";
-        let expected_content_hex = "312c322c330a";
-
-        // Expected content after compression (hex bytes):
-        let expected_compressed_hex = "1f8b08080000000002ff2020202020202020202020202020202020202020200033d431d231e602002eb41e0506000000";
-
-        // Create a temporary directory and file with exact name "test_normal_put.csv"
-        let temp_dir = tempfile::tempdir().unwrap();
-        let file_path = temp_dir.path().join("test_normal_put.csv");
-        std::fs::write(&file_path, content.as_bytes()).unwrap();
-
-        let file_path = file_path.to_str().unwrap();
-
-        // Verify content before compression
-        let content_hex = bytes_to_hex(content.as_bytes());
-
-        // Verify content hex matches expected
-        assert_eq!(
-            content_hex, expected_content_hex,
-            "Content hex should be 312c322c330a (1,2,3\\n)"
-        );
-
-        // Read the file content as bytes
-        let file_content = std::fs::read(file_path).expect("Failed to read file");
-
-        // Extract just the filename from the path
-        let filename = file_path.split('/').next_back().unwrap();
-
-        // Compress the file using our compress_data function
-        let compressed_data =
-            compress_data(file_content, filename).expect("Compression should succeed");
-
-        // Convert result to hex for comparison
-        let result_hex = bytes_to_hex(&compressed_data);
-
-        // Convert expected hex to bytes for comparison
-        let expected = hex_to_bytes(expected_compressed_hex).expect("Invalid expected hex");
-
-        // Verify the compressed output matches exactly
-        assert_eq!(
-            compressed_data, expected,
-            "Compressed output doesn't match expected result.\nExpected: {expected_compressed_hex}\nActual:   {result_hex}"
-        );
-    }
 }

--- a/sf_core/src/compression.rs
+++ b/sf_core/src/compression.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 
 // PUT/GET compression
 pub fn compress_data(input_data: Vec<u8>) -> Result<Vec<u8>, CompressionError> {
-    // Use GzBuilder to create gzip with spaces filename and zeroed timestamp
+    // Use GzBuilder to create gzip with a zeroed timestamp for consistent normalization
     let mut encoder = GzBuilder::new()
         .mtime(0) // Set timestamp to 0 for consistent normalization
         .write(Vec::new(), Compression::best());

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -98,8 +98,7 @@ fn preprocess_file_before_upload(
 
     // Compress the data if needed
     let target_compression = if data.auto_compress && source_compression == CompressionType::None {
-        file_buffer =
-            compress_data(file_buffer, data.filename.as_str()).context(CompressionSnafu)?;
+        file_buffer = compress_data(file_buffer).context(CompressionSnafu)?;
         target = format!("{}.gz", data.filename);
         CompressionType::Gzip
     } else {

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -16,5 +16,6 @@ mod file_manager;
 pub mod handle_manager;
 pub mod logging;
 mod rest;
+mod test_utils;
 pub mod thrift_gen;
 mod transport;

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -16,6 +16,5 @@ mod file_manager;
 pub mod handle_manager;
 pub mod logging;
 mod rest;
-mod test_utils;
 pub mod thrift_gen;
 mod transport;

--- a/sf_core/src/test_utils.rs
+++ b/sf_core/src/test_utils.rs
@@ -1,4 +1,3 @@
-
 /// Sets up logging for tests
 #[cfg(test)]
 pub fn setup_logging() {

--- a/sf_core/src/test_utils.rs
+++ b/sf_core/src/test_utils.rs
@@ -1,16 +1,3 @@
-// Helper function for hex conversion
-#[cfg(test)]
-pub fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
-    (0..hex.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16))
-        .collect()
-}
-
-#[cfg(test)]
-pub fn bytes_to_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
-}
 
 /// Sets up logging for tests
 #[cfg(test)]

--- a/sf_core/tests/put_get_simple_tests.rs
+++ b/sf_core/tests/put_get_simple_tests.rs
@@ -136,7 +136,7 @@ fn test_put_get_rowset() {
     assert_eq!(put_result.source, "test_put_get_rowset.csv");
     assert_eq!(put_result.target, "test_put_get_rowset.csv.gz");
     assert_eq!(put_result.source_size, 6);
-    assert_eq!(put_result.target_size, 64);
+    assert_eq!(put_result.target_size, 32);
     assert_eq!(put_result.source_compression, "NONE");
     assert_eq!(put_result.target_compression, "GZIP");
     assert_eq!(put_result.status, "UPLOADED");
@@ -154,7 +154,7 @@ fn test_put_get_rowset() {
         .expect("Failed to fetch GET result");
 
     assert_eq!(get_result.file, "test_put_get_rowset.csv.gz");
-    assert_eq!(get_result.size, 52);
+    assert_eq!(get_result.size, 26);
     assert_eq!(get_result.status, "DOWNLOADED");
     assert_eq!(get_result.message, "");
 }


### PR DESCRIPTION
Python Connector sets the filename in the header of gzip compressed files, which is inconsistent with other drivers. We no longer want to mimic that behavior.