### PR TITLE
NO-SNOW: fix pep249 put/get tests to work with Python Connector

### DIFF
--- a/pep249_dbapi/BreakingChanges.md
+++ b/pep249_dbapi/BreakingChanges.md
@@ -1,0 +1,7 @@
+# Breaking changes
+
+## 1: Header of a gzip-compressed file does not contain filename
+
+## 2: DEFLATE compression type option is now correctly auto-detected
+
+## 3: BROTLI compression type option is now supported

--- a/pep249_dbapi/tests/conftest.py
+++ b/pep249_dbapi/tests/conftest.py
@@ -5,6 +5,7 @@ pytest configuration and fixtures for PEP 249 tests.
 import pytest
 
 from .connector_factory import ConnectorFactory, create_connection_with_adapter
+from .utils import set_current_connector
 from .connector_types import ConnectorType
 
 
@@ -80,6 +81,8 @@ def cursor(connection):
 def pytest_runtest_setup(item):
     """Skip tests based on connector type and markers."""
     connector_type = item.config.getoption("--connector")
+    # Set the current connector for driver-gated helpers
+    set_current_connector(connector_type)
     
     if connector_type == "universal" and item.get_closest_marker("skip_universal"):
         pytest.skip("Skipping test for universal driver")

--- a/pep249_dbapi/tests/integ/test_put_get_simple.py
+++ b/pep249_dbapi/tests/integ/test_put_get_simple.py
@@ -22,6 +22,7 @@ from .utils_put_get import (
 )
 
 from ..connector_types import ConnectorType
+from ..utils import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY, select_by_driver
 
 
 def test_put_select(cursor):
@@ -116,10 +117,10 @@ def test_put_get_rowset(cursor, connector_type):
         assert row[PUT_ROW_TARGET_IDX] == "test_put_get_rowset.csv.gz"
         assert row[PUT_ROW_SOURCE_SIZE_IDX] == 6
 
-        # BREAKING CHANGE: changing the compression behavior reduces the size of a compressed file
-        if connector_type == ConnectorType.REFERENCE:
+        if OLD_DRIVER_ONLY("BC#1: header of a gzip-compressed file does not contain filename"):
             assert row[PUT_ROW_TARGET_SIZE_IDX] == 64
-        else:
+        
+        if NEW_DRIVER_ONLY("BC#1: header of a gzip-compressed file does not contain filename"):
             assert row[PUT_ROW_TARGET_SIZE_IDX] == 32
 
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "NONE"

--- a/pep249_dbapi/tests/integ/test_put_get_simple.py
+++ b/pep249_dbapi/tests/integ/test_put_get_simple.py
@@ -21,7 +21,6 @@ from .utils_put_get import (
     LS_ROW_NAME_IDX,
 )
 
-from ..connector_types import ConnectorType
 from ..utils import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 
 
@@ -99,7 +98,7 @@ def test_get(cursor):
         assert decompressed == original
 
 
-def test_put_get_rowset(cursor, connector_type):
+def test_put_get_rowset(cursor):
     stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_PUT_ROWSET")
     filename = "test_put_get_rowset.csv"
 
@@ -117,10 +116,10 @@ def test_put_get_rowset(cursor, connector_type):
         assert row[PUT_ROW_TARGET_IDX] == "test_put_get_rowset.csv.gz"
         assert row[PUT_ROW_SOURCE_SIZE_IDX] == 6
 
-        if OLD_DRIVER_ONLY("BC#1: header of a gzip-compressed file does not contain filename"):
+        if OLD_DRIVER_ONLY("BC#1"):
             assert row[PUT_ROW_TARGET_SIZE_IDX] == 64
         
-        if NEW_DRIVER_ONLY("BC#1: header of a gzip-compressed file does not contain filename"):
+        if NEW_DRIVER_ONLY("BC#1"):
             assert row[PUT_ROW_TARGET_SIZE_IDX] == 32
 
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "NONE"
@@ -136,10 +135,10 @@ def test_put_get_rowset(cursor, connector_type):
 
         assert row[GET_ROW_FILE_IDX] == "test_put_get_rowset.csv.gz"
 
-        # BREAKING CHANGE: changing the compression behavior reduces the size of a compressed file
-        if connector_type == ConnectorType.REFERENCE:
+        if OLD_DRIVER_ONLY("BC#1"):
             assert row[GET_ROW_SIZE_IDX] == 52
-        else:
+        
+        if NEW_DRIVER_ONLY("BC#1"):
             assert row[GET_ROW_SIZE_IDX] == 26
 
         assert row[GET_ROW_STATUS_IDX] == "DOWNLOADED"

--- a/pep249_dbapi/tests/integ/test_put_get_simple.py
+++ b/pep249_dbapi/tests/integ/test_put_get_simple.py
@@ -22,7 +22,7 @@ from .utils_put_get import (
 )
 
 from ..connector_types import ConnectorType
-from ..utils import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY, select_by_driver
+from ..utils import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 
 
 def test_put_select(cursor):

--- a/pep249_dbapi/tests/integ/test_put_get_source_compression.py
+++ b/pep249_dbapi/tests/integ/test_put_get_source_compression.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from ..utils import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 from .utils_put_get import (
     write_text_file,
     write_binary_file,
@@ -21,10 +22,9 @@ from .utils_put_get import (
     "filename,compression_type",
     [
         ("test_gzip.csv.gz", "GZIP"),
-        ("test_bzip2.csv.bz2", "BZ2"),
+        ("test_bzip2.csv.bz2", "BZIP2"),
         ("test_brotli.csv.br", "BROTLI"),
         ("test_zstd.csv.zst", "ZSTD"),
-        ("test_deflate.csv.deflate", "DEFLATE"),
     ],
 )
 def test_put_source_compression_auto_detect_standard_types(cursor, filename, compression_type):
@@ -51,27 +51,36 @@ def test_put_source_compression_auto_detect_standard_types(cursor, filename, com
         assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
 
 
-def test_put_source_compression_auto_detect_raw_deflate(cursor):
-    stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_AUTO_DETECT_RAW_DEFLATE")
-    filename = "test_raw_deflate.csv.raw_deflate"
+def test_put_source_compression_auto_detect_deflate(cursor):
+    stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_AUTO_DETECT_DEFLATE")
+    filename = "test_deflate.csv.deflate"
+    content = b"1,2,3\n"
 
-    # Create a temporary file with .raw_deflate extension
-    # Since raw deflate data does not have any headers, we rely on extension for compression type detection
+    # Create a temporary file and compress it
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = Path(tmp)
-        path = write_binary_file(tmpdir, filename, b"rawdeflatedata")
+        comp_bytes = compress_bytes(content, "DEFLATE")
+        path = write_binary_file(tmpdir, filename, comp_bytes)
 
-        # Upload the raw deflate file to the stage with AUTO_DETECT
+        # Upload the compressed file to the stage with AUTO_DETECT
         cursor.execute(
             f"PUT 'file://{as_file_uri(path)}' @{stage_name} SOURCE_COMPRESSION=AUTO_DETECT"
         )
 
-        # Verify that the file was uploaded, compression type was detected correctly and the file was not compressed again
-        row = cursor.fetchone()
+    row = cursor.fetchone()
+
+    if OLD_DRIVER_ONLY("BC#2: DEFLATE compression type option is now correctly auto-detected"):
+        assert row[PUT_ROW_SOURCE_IDX] == filename
+        assert row[PUT_ROW_TARGET_IDX] == filename + ".gz"
+        assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "NONE"
+        assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "GZIP"
+        assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
+
+    if NEW_DRIVER_ONLY("BC#2: DEFLATE compression type option is now correctly auto-detected"):
         assert row[PUT_ROW_SOURCE_IDX] == filename
         assert row[PUT_ROW_TARGET_IDX] == filename
-        assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "RAW_DEFLATE"
-        assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "RAW_DEFLATE"
+        assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "DEFLATE"
+        assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "DEFLATE"
         assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
 
 
@@ -125,8 +134,7 @@ def test_put_source_compression_auto_detect_none_with_auto_compress(cursor):
     "filename,compression_type",
     [
         ("test_gzip.csv", "GZIP"),
-        ("test_bzip2.csv", "BZ2"),
-        ("test_brotli.csv", "BROTLI"),
+        ("test_bzip2.csv", "BZIP2"),
         ("test_zstd.csv", "ZSTD"),
         ("test_deflate.csv", "DEFLATE"),
     ],
@@ -152,6 +160,36 @@ def test_put_source_compression_explicit_standard_types(cursor, filename, compre
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == compression_type
         assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == compression_type
         assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
+
+
+def test_put_source_compression_explicit_brotli(cursor):
+    stage_name = create_temporary_stage(cursor, "PYTEST_STAGE_EXPLICIT_BROTLI")
+    filename = "test_explicit_brotli"
+
+    # Create a temporary file without the .brotli extension
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        path = write_binary_file(tmpdir, filename, b"brotli")
+
+        # Upload the brotli file to the stage with the specified compression type
+        if OLD_DRIVER_ONLY("BC#3: BROTLI compression type option is now supported"):
+            # Old driver should reject unsupported SOURCE_COMPRESSION
+            with pytest.raises(Exception):
+                cursor.execute(
+                    f"PUT 'file://{as_file_uri(path)}' @{stage_name} SOURCE_COMPRESSION=BROTLI"
+                )
+
+        if NEW_DRIVER_ONLY("BC#3: BROTLI compression type option is now supported"):
+            cursor.execute(
+                f"PUT 'file://{as_file_uri(path)}' @{stage_name} SOURCE_COMPRESSION=BROTLI"
+            )
+            # Verify that the file was uploaded, compression type was detected correctly and the file was not compressed again
+            row = cursor.fetchone()
+            assert row[PUT_ROW_SOURCE_IDX] == filename
+            assert row[PUT_ROW_TARGET_IDX] == filename
+            assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "BROTLI"
+            assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "BROTLI"
+            assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
 
 
 def test_put_source_compression_explicit_raw_deflate(cursor):

--- a/pep249_dbapi/tests/integ/test_put_get_source_compression.py
+++ b/pep249_dbapi/tests/integ/test_put_get_source_compression.py
@@ -69,14 +69,14 @@ def test_put_source_compression_auto_detect_deflate(cursor):
 
     row = cursor.fetchone()
 
-    if OLD_DRIVER_ONLY("BC#2: DEFLATE compression type option is now correctly auto-detected"):
+    if OLD_DRIVER_ONLY("BC#2"):
         assert row[PUT_ROW_SOURCE_IDX] == filename
         assert row[PUT_ROW_TARGET_IDX] == filename + ".gz"
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "NONE"
         assert row[PUT_ROW_TARGET_COMPRESSION_IDX] == "GZIP"
         assert row[PUT_ROW_STATUS_IDX] == "UPLOADED"
 
-    if NEW_DRIVER_ONLY("BC#2: DEFLATE compression type option is now correctly auto-detected"):
+    if NEW_DRIVER_ONLY("BC#2"):
         assert row[PUT_ROW_SOURCE_IDX] == filename
         assert row[PUT_ROW_TARGET_IDX] == filename
         assert row[PUT_ROW_SOURCE_COMPRESSION_IDX] == "DEFLATE"
@@ -172,14 +172,14 @@ def test_put_source_compression_explicit_brotli(cursor):
         path = write_binary_file(tmpdir, filename, b"brotli")
 
         # Upload the brotli file to the stage with the specified compression type
-        if OLD_DRIVER_ONLY("BC#3: BROTLI compression type option is now supported"):
+        if OLD_DRIVER_ONLY("BC#3"):
             # Old driver should reject unsupported SOURCE_COMPRESSION
             with pytest.raises(Exception):
                 cursor.execute(
                     f"PUT 'file://{as_file_uri(path)}' @{stage_name} SOURCE_COMPRESSION=BROTLI"
                 )
 
-        if NEW_DRIVER_ONLY("BC#3: BROTLI compression type option is now supported"):
+        if NEW_DRIVER_ONLY("BC#3"):
             cursor.execute(
                 f"PUT 'file://{as_file_uri(path)}' @{stage_name} SOURCE_COMPRESSION=BROTLI"
             )

--- a/pep249_dbapi/tests/integ/utils_put_get.py
+++ b/pep249_dbapi/tests/integ/utils_put_get.py
@@ -66,7 +66,7 @@ def compress_bytes(data: bytes, comp: str) -> bytes:
         with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
             gz.write(data)
         return buf.getvalue()
-    if comp == "BZ2":
+    if comp == "BZIP2":
         return bz2.compress(data)
     if comp == "DEFLATE":
         return zlib.compress(data)
@@ -74,4 +74,3 @@ def compress_bytes(data: bytes, comp: str) -> bytes:
         return brotli.compress(data)
     if comp == "ZSTD":
         return zstd.ZstdCompressor().compress(data)
-    pytest.skip(f"Unsupported compression type in test: {comp}")

--- a/pep249_dbapi/tests/utils.py
+++ b/pep249_dbapi/tests/utils.py
@@ -1,0 +1,25 @@
+from typing import Any, Optional
+
+
+_current_connector: Optional[str] = None  # "universal" or "reference"
+
+
+def set_current_connector(name: str) -> None:
+    global _current_connector
+    _current_connector = name
+
+
+def is_new_driver() -> bool:
+    return _current_connector == "universal"
+
+
+def is_old_driver() -> bool:
+    return _current_connector == "reference"
+
+
+def NEW_DRIVER_ONLY(bc_id: str) -> bool:
+    return is_new_driver()
+
+
+def OLD_DRIVER_ONLY(bc_id: str) -> bool:
+    return is_old_driver()

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -101,6 +101,7 @@ fn try_guess_compression_type_from_filename(
     }
 }
 
+// TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
 fn try_guess_compression_type_from_buffer(
     file_buffer: &[u8],
 ) -> Result<Option<CompressionType>, CompressionTypeError> {


### PR DESCRIPTION
Tests should now work with Python Connector, but will fail for universal driver. This is for a reason and I will fix this the universal driver in the next PR.