### PR TITLE
NO-SNOW: fix compression type BZIP2 for compatibility with python and odbc

### DIFF
--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -16,7 +16,7 @@ impl CompressionType {
     pub fn get_snowflake_representation(&self) -> &str {
         match self {
             CompressionType::Gzip => "GZIP",
-            CompressionType::Bzip2 => "BZ2",
+            CompressionType::Bzip2 => "BZIP2",
             CompressionType::Brotli => "BROTLI",
             CompressionType::Zstd => "ZSTD",
             CompressionType::Deflate => "DEFLATE",

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -325,6 +325,8 @@ impl Data {
             })?
             .clone();
 
+        // TODO: We should support other names for existing compression types that were supported in Python Connector,
+        // like "BR" and "X-BR" for Brotli etc.
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -328,7 +328,7 @@ impl Data {
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,
-            "BZ2" => SourceCompressionParam::Bzip2,
+            "BZIP2" => SourceCompressionParam::Bzip2,
             "BROTLI" => SourceCompressionParam::Brotli,
             "ZSTD" => SourceCompressionParam::Zstd,
             "DEFLATE" => SourceCompressionParam::Deflate,

--- a/sf_core/tests/put_get_source_compression_tests.rs
+++ b/sf_core/tests/put_get_source_compression_tests.rs
@@ -23,7 +23,7 @@ fn test_put_source_compression_auto_detect_standard_types() {
     // Test cases for standard compression types that follow the same pattern
     let test_cases = [
         ("test_gzip.csv.gz", "GZIP"),
-        ("test_bzip2.csv.bz2", "BZ2"),
+        ("test_bzip2.csv.bz2", "BZIP2"),
         ("test_brotli.csv.br", "BROTLI"),
         ("test_zstd.csv.zst", "ZSTD"),
         ("test_deflate.csv.deflate", "DEFLATE"),
@@ -41,7 +41,7 @@ fn test_put_source_compression_auto_detect_standard_types() {
                 encoder.write_all(content.as_bytes()).unwrap();
                 encoder.finish().unwrap();
             }
-            "BZ2" => {
+            "BZIP2" => {
                 let mut encoder = bzip2::write::BzEncoder::new(file, bzip2::Compression::default());
                 encoder.write_all(content.as_bytes()).unwrap();
                 encoder.finish().unwrap();
@@ -269,7 +269,7 @@ fn test_put_source_compression_explicit_standard_types() {
     // Test cases for explicitly specified compression types
     let test_cases = [
         ("test_explicit_gzip.dat", "GZIP"),
-        ("test_explicit_bzip2.dat", "BZ2"),
+        ("test_explicit_bzip2.dat", "BZIP2"),
         ("test_explicit_brotli.dat", "BROTLI"),
         ("test_explicit_zstd.dat", "ZSTD"),
         ("test_explicit_deflate.dat", "DEFLATE"),
@@ -287,7 +287,7 @@ fn test_put_source_compression_explicit_standard_types() {
                 encoder.write_all(content.as_bytes()).unwrap();
                 encoder.finish().unwrap();
             }
-            "BZ2" => {
+            "BZIP2" => {
                 let mut encoder = bzip2::write::BzEncoder::new(file, bzip2::Compression::default());
                 encoder.write_all(content.as_bytes()).unwrap();
                 encoder.finish().unwrap();


### PR DESCRIPTION
Rust core now recognizes the SOURCE_COMPRESSION option argument "BZIP2" instead of "BZ2". This is inconsistent with documentation, but consistent with other existing drivers. 