### PR TITLE
NO-SNOW: fix clippy errors in ODBC

### DIFF
--- a/odbc/src/read_arrow.rs
+++ b/odbc/src/read_arrow.rs
@@ -25,7 +25,7 @@ impl std::error::Error for ExtractError {}
 
 impl Display for ExtractError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/odbc/src/write_arrow.rs
+++ b/odbc/src/write_arrow.rs
@@ -27,7 +27,7 @@ impl std::error::Error for ArrowBindingError {}
 
 impl std::fmt::Display for ArrowBindingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
Fix clippy errros in ODBC to unlock pre-commit.