### PR TITLE
TLS CRL validation plumbing: parsing, caching, verifier integration, and safer defaults

### DIFF
--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -192,6 +192,52 @@ impl CrlCache {
             return Ok(mem.crl);
         }
 
+        // Disk cache fallback before network fetch
+        if self.config.enable_disk_caching
+            && let Some(dir) = self.config.get_cache_dir()
+        {
+            let file_name = Self::url_digest(url);
+            let path = dir.join(file_name);
+            match std::fs::read(&path) {
+                Ok(bytes) => {
+                    // Determine expiration based on CRL nextUpdate
+                    let expires_at = match crate::tls::x509_utils::extract_crl_next_update(&bytes) {
+                        Ok(Some(dt)) => dt,
+                        _ => Utc::now() + self.config.validity_time,
+                    };
+                    if Utc::now() <= expires_at {
+                        // Populate memory cache for subsequent lookups; ignore errors
+                        let _ = self.put(CachedCrl {
+                            crl: bytes.clone(),
+                            download_time: Utc::now(),
+                            url: url.to_string(),
+                            expires_at,
+                        });
+                        let ms = start.elapsed().as_millis() as u64;
+                        metrics()
+                            .get_ms
+                            .record(ms, &[KeyValue::new("source", "disk")]);
+                        metrics()
+                            .get_total
+                            .add(1, &[KeyValue::new("source", "disk")]);
+                        return Ok(bytes);
+                    }
+                    // Stale on disk; proceed to network
+                    tracing::debug!(target: "sf_core::crl", "Disk cache entry expired for {}, refetching", url);
+                }
+                Err(e) => {
+                    // It's ok if disk cache miss; only warn on unexpected errors
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        tracing::debug!(
+                            target: "sf_core::crl",
+                            "Failed to read CRL cache from disk at {}: {}",
+                            path.display(), e
+                        );
+                    }
+                }
+            }
+        }
+
         // Fetch and optionally persist while holding the per-URL lock to avoid duplicate downloads
         let fetched = self.fetch(url).await?;
         if self.config.enable_disk_caching
@@ -318,6 +364,4 @@ impl CrlCache {
         guard.remove(url);
         Ok(())
     }
-
-    // keep only one definition of check_revocation; duplicate removed
 }

--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -71,6 +71,7 @@ impl CrlCache {
         let serial = crate::crl::certificate_parser::get_certificate_serial_number(cert_der)
             .context(crate::tls::revocation::CrlOperationSnafu)?;
         // Try URLs
+        let mut any_verified = false;
         for url in crl_urls.iter() {
             let bytes = self
                 .get(url)
@@ -81,6 +82,7 @@ impl CrlCache {
             {
                 continue;
             }
+            any_verified = true;
             let is_revoked =
                 crate::crl::certificate_parser::check_certificate_in_crl(&serial, &bytes)
                     .context(crate::tls::revocation::CrlOperationSnafu)?;
@@ -90,6 +92,9 @@ impl CrlCache {
                     revocation_time: None,
                 });
             }
+        }
+        if !any_verified {
+            return Ok(RevocationOutcome::NotDetermined);
         }
         Ok(RevocationOutcome::NotRevoked)
     }
@@ -223,15 +228,16 @@ impl CrlCache {
                         return Ok(bytes);
                     }
                     // Stale on disk; proceed to network
-                    tracing::debug!(target: "sf_core::crl", "Disk cache entry expired for {}, refetching", url);
+                    tracing::debug!(target: "sf_core::crl", "Disk cache entry expired for {url}, refetching");
                 }
                 Err(e) => {
                     // It's ok if disk cache miss; only warn on unexpected errors
                     if e.kind() != std::io::ErrorKind::NotFound {
                         tracing::debug!(
                             target: "sf_core::crl",
-                            "Failed to read CRL cache from disk at {}: {}",
-                            path.display(), e
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to read CRL cache from disk"
                         );
                     }
                 }
@@ -246,8 +252,9 @@ impl CrlCache {
             if let Err(e) = std::fs::create_dir_all(&dir) {
                 tracing::warn!(
                     target: "sf_core::crl",
-                    "Failed to create CRL cache directory {}: {}",
-                    dir.display(), e
+                    dir = %dir.display(),
+                    error = %e,
+                    "Failed to create CRL cache directory"
                 );
             }
             let file_name = Self::url_digest(url);
@@ -255,8 +262,9 @@ impl CrlCache {
             if let Err(e) = std::fs::write(&path, &fetched) {
                 tracing::warn!(
                     target: "sf_core::crl",
-                    "Failed to write CRL cache to disk at {}: {}",
-                    path.display(), e
+                    path = %path.display(),
+                    error = %e,
+                    "Failed to write CRL cache to disk"
                 );
             }
         }
@@ -272,8 +280,7 @@ impl CrlCache {
         }) {
             tracing::warn!(
                 target: "sf_core::crl",
-                "Failed to put CRL into memory cache for url {}: {}",
-                url, e
+                "Failed to put CRL into memory cache for url {url}: {e}"
             );
         }
         let ms = start.elapsed().as_millis() as u64;

--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -318,4 +318,6 @@ impl CrlCache {
         guard.remove(url);
         Ok(())
     }
+
+    // keep only one definition of check_revocation; duplicate removed
 }

--- a/sf_core/src/crl/certificate_parser.rs
+++ b/sf_core/src/crl/certificate_parser.rs
@@ -4,35 +4,64 @@ use snafu::ResultExt;
 use x509_parser::extensions::{GeneralName, ParsedExtension};
 use x509_parser::prelude::*;
 
+/// Extract CRL distribution points from a DER-encoded certificate
 pub fn extract_crl_distribution_points(cert_der: &[u8]) -> Result<Vec<String>, CrlError> {
     let (_, cert) =
         x509_parser::certificate::X509Certificate::from_der(cert_der).context(CrlParsingSnafu)?;
 
     let mut crl_urls = Vec::new();
     for ext in cert.extensions() {
-        if ext.oid == x509_parser::oid_registry::OID_X509_EXT_CRL_DISTRIBUTION_POINTS
-            && let ParsedExtension::CRLDistributionPoints(crl_dist_points) = &ext.parsed_extension()
-        {
-            for dist_point in &crl_dist_points.points {
-                if let Some(x509_parser::extensions::DistributionPointName::FullName(
-                    general_names,
-                )) = &dist_point.distribution_point
-                {
-                    for general_name in general_names {
-                        if let GeneralName::URI(uri) = general_name {
-                            let url = uri.to_string();
-                            if url.starts_with("http://") || url.starts_with("https://") {
-                                crl_urls.push(url);
+        if ext.oid == x509_parser::oid_registry::OID_X509_EXT_CRL_DISTRIBUTION_POINTS {
+            match &ext.parsed_extension() {
+                ParsedExtension::CRLDistributionPoints(crl_dist_points) => {
+                    for dist_point in &crl_dist_points.points {
+                        if let Some(dist_point_name) = &dist_point.distribution_point {
+                            match dist_point_name {
+                                x509_parser::extensions::DistributionPointName::FullName(
+                                    general_names,
+                                ) => {
+                                    for general_name in general_names {
+                                        if let GeneralName::URI(uri) = general_name {
+                                            let url = uri.to_string();
+                                            // Per RFC 5280 and CA/B BRs, CRL DP URIs are HTTP endpoints (http/https).
+                                            if url.starts_with("http://")
+                                                || url.starts_with("https://")
+                                            {
+                                                crl_urls.push(url);
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    // Handle other distribution point name types if needed
+                                    tracing::debug!("Unsupported distribution point name type");
+                                }
                             }
                         }
                     }
                 }
+                _ => {
+                    tracing::debug!("CRL Distribution Points extension present but not parsed");
+                }
             }
         }
     }
+
+    // Return empty list if none found; policy is handled by validator
+    if crl_urls.is_empty() {
+        tracing::debug!("No CRL distribution points found in certificate");
+        return Ok(Vec::new());
+    }
+
+    tracing::debug!(
+        "Found {} CRL distribution points: {:?}",
+        crl_urls.len(),
+        crl_urls
+    );
     Ok(crl_urls)
 }
 
+/// Check if a certificate is short-lived (validity period <= 7 days)
 pub fn is_short_lived_certificate(cert_der: &[u8]) -> Result<bool, CrlError> {
     let (_, cert) =
         x509_parser::certificate::X509Certificate::from_der(cert_der).context(CrlParsingSnafu)?;
@@ -50,44 +79,107 @@ pub fn is_short_lived_certificate(cert_der: &[u8]) -> Result<bool, CrlError> {
         })?;
 
     let validity_period_seconds = (not_after_dt - not_before_dt).num_seconds();
-    let seven_days_seconds = 7 * 24 * 60 * 60;
-    Ok(validity_period_seconds <= seven_days_seconds)
+    let seven_days_seconds = 7 * 24 * 60 * 60; // 7 days in seconds
+
+    let is_short_lived = validity_period_seconds <= seven_days_seconds;
+
+    if is_short_lived {
+        tracing::info!(
+            "Certificate is short-lived ({} days), skipping CRL check",
+            validity_period_seconds / (24 * 60 * 60)
+        );
+    }
+
+    Ok(is_short_lived)
 }
 
+/// Get certificate serial number as bytes for CRL comparison
 pub fn get_certificate_serial_number(cert_der: &[u8]) -> Result<Vec<u8>, CrlError> {
     let (_, cert) =
         x509_parser::certificate::X509Certificate::from_der(cert_der).context(CrlParsingSnafu)?;
     Ok(cert.serial.to_bytes_be())
 }
 
+/// Parse and validate a CRL, checking if a certificate serial number is revoked
 pub fn check_certificate_in_crl(cert_serial: &[u8], crl_der: &[u8]) -> Result<bool, CrlError> {
     use x509_parser::revocation_list::CertificateRevocationList;
     let (_, crl) = CertificateRevocationList::from_der(crl_der).context(CrlParsingSnafu)?;
 
+    // Check if the CRL has expired
     let now = chrono::Utc::now();
     if let Some(next_update) = crl.tbs_cert_list.next_update {
         let next_update_time =
             asn1_time_to_datetime(&next_update).ok_or_else(|| CrlError::CrlExpired {
                 location: Location::new(file!(), line!(), 0),
             })?;
+
         if now > next_update_time {
+            tracing::warn!("CRL has expired (next update was {})", next_update_time);
             return Err(CrlError::CrlExpired {
                 location: Location::new(file!(), line!(), 0),
             });
         }
     }
+
+    // Check if certificate is in the revoked list
     for revoked_cert in crl.iter_revoked_certificates() {
         if revoked_cert.raw_serial() == cert_serial {
-            return Ok(true);
+            tracing::warn!(
+                "Certificate with serial {:?} found in CRL revocation list",
+                hex::encode(cert_serial)
+            );
+            return Ok(true); // Certificate is revoked
         }
     }
-    Ok(false)
+
+    tracing::debug!(
+        "Certificate with serial {:?} not found in CRL revocation list",
+        hex::encode(cert_serial)
+    );
+    Ok(false) // Certificate is not revoked
 }
 
+/// Convert ASN.1 time to chrono DateTime
 pub(crate) fn asn1_time_to_datetime(
     asn1_time: &x509_parser::time::ASN1Time,
 ) -> Option<chrono::DateTime<chrono::Utc>> {
-    let dt = asn1_time.to_datetime();
+    // x509-parser exposes to_datetime() returning time::OffsetDateTime in recent versions
+    let dt = asn1_time.to_datetime(); // time::OffsetDateTime
     let ts = dt.unix_timestamp();
     chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_crl_distribution_points_empty_cert() {
+        // Test with invalid certificate data
+        let invalid_cert = vec![0x00, 0x01, 0x02];
+        let result = extract_crl_distribution_points(&invalid_cert);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_short_lived_certificate_invalid() {
+        let invalid_cert = vec![0x00, 0x01, 0x02];
+        let result = is_short_lived_certificate(&invalid_cert);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_certificate_serial_number_invalid() {
+        let invalid_cert = vec![0x00, 0x01, 0x02];
+        let result = get_certificate_serial_number(&invalid_cert);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_check_certificate_in_crl_invalid() {
+        let cert_serial = vec![0x01, 0x02, 0x03];
+        let invalid_crl = vec![0x00, 0x01, 0x02];
+        let result = check_certificate_in_crl(&cert_serial, &invalid_crl);
+        assert!(result.is_err());
+    }
 }

--- a/sf_core/src/crl/certificate_parser.rs
+++ b/sf_core/src/crl/certificate_parser.rs
@@ -53,11 +53,8 @@ pub fn extract_crl_distribution_points(cert_der: &[u8]) -> Result<Vec<String>, C
         return Ok(Vec::new());
     }
 
-    tracing::debug!(
-        "Found {} CRL distribution points: {:?}",
-        crl_urls.len(),
-        crl_urls
-    );
+    let count = crl_urls.len();
+    tracing::debug!("Found {count} CRL distribution points: {crl_urls:?}");
     Ok(crl_urls)
 }
 
@@ -84,10 +81,8 @@ pub fn is_short_lived_certificate(cert_der: &[u8]) -> Result<bool, CrlError> {
     let is_short_lived = validity_period_seconds <= seven_days_seconds;
 
     if is_short_lived {
-        tracing::info!(
-            "Certificate is short-lived ({} days), skipping CRL check",
-            validity_period_seconds / (24 * 60 * 60)
-        );
+        let days = validity_period_seconds / (24 * 60 * 60);
+        tracing::info!("Certificate is short-lived ({days} days), skipping CRL check");
     }
 
     Ok(is_short_lived)
@@ -114,7 +109,7 @@ pub fn check_certificate_in_crl(cert_serial: &[u8], crl_der: &[u8]) -> Result<bo
             })?;
 
         if now > next_update_time {
-            tracing::warn!("CRL has expired (next update was {})", next_update_time);
+            tracing::warn!("CRL has expired (next update was {next_update_time})");
             return Err(CrlError::CrlExpired {
                 location: Location::new(file!(), line!(), 0),
             });
@@ -124,18 +119,14 @@ pub fn check_certificate_in_crl(cert_serial: &[u8], crl_der: &[u8]) -> Result<bo
     // Check if certificate is in the revoked list
     for revoked_cert in crl.iter_revoked_certificates() {
         if revoked_cert.raw_serial() == cert_serial {
-            tracing::warn!(
-                "Certificate with serial {:?} found in CRL revocation list",
-                hex::encode(cert_serial)
-            );
+            let serial_hex = hex::encode(cert_serial);
+            tracing::warn!("Certificate with serial {serial_hex} found in CRL revocation list");
             return Ok(true); // Certificate is revoked
         }
     }
 
-    tracing::debug!(
-        "Certificate with serial {:?} not found in CRL revocation list",
-        hex::encode(cert_serial)
-    );
+    let serial_hex = hex::encode(cert_serial);
+    tracing::debug!("Certificate with serial {serial_hex} not found in CRL revocation list");
     Ok(false) // Certificate is not revoked
 }
 

--- a/sf_core/src/crl/config.rs
+++ b/sf_core/src/crl/config.rs
@@ -5,8 +5,13 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CertRevocationCheckMode {
+    /// Default - disables CRL checking (TLS handshake still in place)
     Disabled,
+    /// Fails the connection if certificate is revoked or there is other revocation status check issue
     Enabled,
+    /// Fails the request for revoked certificate only. In case of any other problems
+    /// (like connection issues with CRL endpoints, CRL parsing errors etc) assumes
+    /// that the certificate is not revoked and allows to connect.
     Advisory,
 }
 
@@ -51,7 +56,6 @@ impl CrlConfig {
             p
         })
     }
-
     pub fn get_cache_dir(&self) -> Option<PathBuf> {
         self.cache_dir.clone().or_else(Self::default_cache_dir)
     }

--- a/sf_core/src/crl/error.rs
+++ b/sf_core/src/crl/error.rs
@@ -83,4 +83,22 @@ pub enum CrlError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Failed to parse CRL using x509-cert"))]
+    CrlListParse {
+        source: x509_cert::der::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to encode CRL TBS to DER"))]
+    CrlToDer {
+        source: x509_cert::der::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse certificate using x509-cert"))]
+    CertificateParse {
+        source: x509_cert::der::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/sf_core/src/crl/mod.rs
+++ b/sf_core/src/crl/mod.rs
@@ -3,3 +3,4 @@ pub mod certificate_parser;
 pub mod config;
 pub mod error;
 pub mod validator;
+pub mod worker;

--- a/sf_core/src/crl/worker.rs
+++ b/sf_core/src/crl/worker.rs
@@ -1,0 +1,55 @@
+use crate::crl::error::CrlError;
+use crate::crl::validator::CrlValidator;
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, Sender};
+
+pub struct CrlWorkerRequest {
+    pub cert_chains: Vec<Vec<Vec<u8>>>,
+    pub reply: mpsc::Sender<Result<(), CrlError>>,
+}
+
+pub struct CrlWorker {
+    tx: Sender<CrlWorkerRequest>,
+}
+
+static GLOBAL_WORKER: OnceCell<CrlWorker> = OnceCell::new();
+
+impl CrlWorker {
+    pub fn global(validator: Arc<CrlValidator>) -> &'static CrlWorker {
+        GLOBAL_WORKER.get_or_init(|| {
+            let (tx, rx): (Sender<CrlWorkerRequest>, Receiver<CrlWorkerRequest>) = mpsc::channel();
+
+            std::thread::Builder::new()
+                .name("crl-worker".into())
+                .spawn(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("Failed to create CRL worker runtime");
+
+                    rt.block_on(async move {
+                        while let Ok(req) = rx.recv() {
+                            let res = validator
+                                .validate_certificate_chains(&req.cert_chains)
+                                .await;
+                            let _ = req.reply.send(res);
+                        }
+                    });
+                })
+                .expect("Failed to spawn CRL worker thread");
+
+            CrlWorker { tx }
+        })
+    }
+
+    pub fn validate(&self, cert_chains: Vec<Vec<Vec<u8>>>) -> Result<(), CrlError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let msg = CrlWorkerRequest {
+            cert_chains,
+            reply: reply_tx,
+        };
+        self.tx.send(msg).expect("CRL worker channel closed");
+        reply_rx.recv().expect("CRL worker reply channel closed")
+    }
+}

--- a/sf_core/src/tls/crl_verifier.rs
+++ b/sf_core/src/tls/crl_verifier.rs
@@ -63,7 +63,6 @@ impl ServerCertVerifier for CrlServerCertVerifier {
             chain.push(i.as_ref().to_vec());
         }
         let chains = vec![chain];
-        // Use shared Tokio runtime to avoid per-handshake runtimes
         let res = shared_runtime().block_on(async {
             self.crl_validator
                 .validate_certificate_chains(&chains)

--- a/sf_core/src/tls/mod.rs
+++ b/sf_core/src/tls/mod.rs
@@ -9,3 +9,4 @@ pub use client::{create_root_store_from_pem, create_tls_client_with_config};
 pub use config::TlsConfig;
 pub use crl_verifier::CrlServerCertVerifier;
 pub use error::TlsError;
+pub use x509_utils::{crl_times, extract_skid, subject_der_hash, verify_crl_signature_best_effort};

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 use snafu::{Location, ResultExt, Snafu};
 // Small helpers to centralize dual x509 crate usage
-use crate::crl::error::CrlError;
+use crate::crl::error::{
+    CertificateParseSnafu, CrlError, CrlListParseSnafu, CrlParsingSnafu, CrlToDerSnafu,
+};
 use const_oid::ObjectIdentifier;
 use x509_cert::crl::CertificateList as RcCertificateList;
 use x509_cert::der::{Decode, Encode};
@@ -64,9 +66,7 @@ pub fn verify_crl_signature_best_effort(
     crl_der: &[u8],
     issuer_der: Option<&[u8]>,
 ) -> Result<(), CrlError> {
-    let crl = RcCertificateList::from_der(crl_der).map_err(|_| CrlError::InvalidCrlSignature {
-        location: snafu::Location::new(file!(), line!(), 0),
-    })?;
+    let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
     let sig = crl
         .signature
         .as_bytes()
@@ -79,11 +79,8 @@ pub fn verify_crl_signature_best_effort(
         Some(v) => v,
         None => return Ok(()),
     };
-    let issuer_cert = x509_cert::Certificate::from_der(issuer_der).map_err(|_| {
-        CrlError::InvalidCrlSignature {
-            location: snafu::Location::new(file!(), line!(), 0),
-        }
-    })?;
+    let issuer_cert =
+        x509_cert::Certificate::from_der(issuer_der).context(CertificateParseSnafu)?;
     if issuer_cert.tbs_certificate.subject != crl.tbs_cert_list.issuer {
         return Err(CrlError::CrlIssuerMismatch {
             location: snafu::Location::new(file!(), line!(), 0),
@@ -290,14 +287,8 @@ pub fn verify_crl_signature_best_effort(
 
 /// Return canonical DER of the CRL's TBS (to-be-signed) part
 pub fn tbs_crl_der(crl_der: &[u8]) -> Result<Vec<u8>, CrlError> {
-    let crl = RcCertificateList::from_der(crl_der).map_err(|_| CrlError::InvalidCrlSignature {
-        location: snafu::Location::new(file!(), line!(), 0),
-    })?;
-    crl.tbs_cert_list
-        .to_der()
-        .map_err(|_| CrlError::InvalidCrlSignature {
-            location: snafu::Location::new(file!(), line!(), 0),
-        })
+    let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
+    crl.tbs_cert_list.to_der().context(CrlToDerSnafu)
 }
 
 /// Extract thisUpdate and nextUpdate from a CRL, converted to chrono
@@ -312,10 +303,7 @@ pub fn crl_times(
 > {
     use x509_parser::prelude::FromDer;
     let (_, crl) = x509_parser::revocation_list::CertificateRevocationList::from_der(crl_der)
-        .map_err(|e| CrlError::CrlParsing {
-            source: e,
-            location: snafu::Location::new(file!(), line!(), 0),
-        })?;
+        .context(CrlParsingSnafu)?;
     let this_dt =
         crate::crl::certificate_parser::asn1_time_to_datetime(&crl.tbs_cert_list.this_update)
             .ok_or_else(|| CrlError::CrlParsing {

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -1,5 +1,6 @@
+use crate::crl::error::{CrlIssuerMismatchSnafu, InvalidCrlSignatureSnafu};
 use chrono::{DateTime, Utc};
-use snafu::{Location, ResultExt, Snafu};
+use snafu::{Location, OptionExt, ResultExt, Snafu};
 // Small helpers to centralize dual x509 crate usage
 use crate::crl::error::{
     CertificateParseSnafu, CrlError, CrlListParseSnafu, CrlParsingSnafu, CrlToDerSnafu,
@@ -67,12 +68,7 @@ pub fn verify_crl_signature_best_effort(
     issuer_der: Option<&[u8]>,
 ) -> Result<(), CrlError> {
     let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
-    let sig = crl
-        .signature
-        .as_bytes()
-        .ok_or_else(|| CrlError::InvalidCrlSignature {
-            location: snafu::Location::new(file!(), line!(), 0),
-        })?;
+    let sig = crl.signature.as_bytes().context(InvalidCrlSignatureSnafu)?;
     let tbs = tbs_crl_der(crl_der)?;
 
     let issuer_der = match issuer_der {
@@ -82,9 +78,7 @@ pub fn verify_crl_signature_best_effort(
     let issuer_cert =
         x509_cert::Certificate::from_der(issuer_der).context(CertificateParseSnafu)?;
     if issuer_cert.tbs_certificate.subject != crl.tbs_cert_list.issuer {
-        return Err(CrlError::CrlIssuerMismatch {
-            location: snafu::Location::new(file!(), line!(), 0),
-        });
+        return CrlIssuerMismatchSnafu {}.fail();
     }
 
     // Enforce AKID/SKID and critical extension policy
@@ -104,16 +98,12 @@ pub fn verify_crl_signature_best_effort(
                 crl_akid = akid.key_identifier.as_ref().map(|kid| kid.0);
             }
             if ext.oid == oid_delta {
-                return Err(CrlError::InvalidCrlSignature {
-                    location: snafu::Location::new(file!(), line!(), 0),
-                });
+                return InvalidCrlSignatureSnafu {}.fail();
             }
             if ext.critical {
                 let known = ext.oid == oid_akid || ext.oid == oid_idp || ext.oid == oid_crl_number;
                 if !known {
-                    return Err(CrlError::InvalidCrlSignature {
-                        location: snafu::Location::new(file!(), line!(), 0),
-                    });
+                    return InvalidCrlSignatureSnafu {}.fail();
                 }
             }
         }
@@ -132,9 +122,7 @@ pub fn verify_crl_signature_best_effort(
             if let Some(skid) = issuer_skid
                 && skid != akid_key
             {
-                return Err(CrlError::InvalidCrlSignature {
-                    location: snafu::Location::new(file!(), line!(), 0),
-                });
+                return InvalidCrlSignatureSnafu {}.fail();
             }
         }
     }
@@ -145,9 +133,7 @@ pub fn verify_crl_signature_best_effort(
         .subject_public_key_info
         .subject_public_key
         .as_bytes()
-        .ok_or_else(|| CrlError::InvalidCrlSignature {
-            location: snafu::Location::new(file!(), line!(), 0),
-        })?;
+        .context(InvalidCrlSignatureSnafu)?;
     // First, try verification using aws-lc-rs (ring-compatible API)
     let try_verify = |alg: &'static dyn aws_lc_rs::signature::VerificationAlgorithm| {
         aws_lc_rs::signature::UnparsedPublicKey::new(alg, spk_bytes).verify(&tbs, sig)
@@ -280,9 +266,7 @@ pub fn verify_crl_signature_best_effort(
     if verified {
         return Ok(());
     }
-    Err(CrlError::InvalidCrlSignature {
-        location: snafu::Location::new(file!(), line!(), 0),
-    })
+    InvalidCrlSignatureSnafu {}.fail()
 }
 
 // Return canonical DER of the CRL's TBS (to-be-signed) part

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -1,5 +1,11 @@
 use chrono::{DateTime, Utc};
 use snafu::{Location, ResultExt, Snafu};
+// Small helpers to centralize dual x509 crate usage
+use crate::crl::error::CrlError;
+use const_oid::ObjectIdentifier;
+use x509_cert::crl::CertificateList as RcCertificateList;
+use x509_cert::der::{Decode, Encode};
+use x509_parser::prelude::FromDer;
 use x509_parser::prelude::*;
 
 #[derive(Snafu, Debug)]
@@ -52,11 +58,259 @@ pub fn extract_crl_next_update(crl_der: &[u8]) -> Result<Option<DateTime<Utc>>, 
     Ok(None)
 }
 
-// Best-effort CRL signature verification placeholder
+/// Best-effort CRL signature verification using issuer public key
+/// Returns Ok(()) if verification passes or issuer is None; Err otherwise.
 pub fn verify_crl_signature_best_effort(
-    _crl_der: &[u8],
-    _issuer_der: Option<&[u8]>,
-) -> Result<(), X509Error> {
-    // TODO: Implement real signature verification; for now assume OK
-    Ok(())
+    crl_der: &[u8],
+    issuer_der: Option<&[u8]>,
+) -> Result<(), CrlError> {
+    let crl = RcCertificateList::from_der(crl_der).map_err(|_| CrlError::InvalidCrlSignature {
+        location: snafu::Location::new(file!(), line!(), 0),
+    })?;
+    let sig = crl
+        .signature
+        .as_bytes()
+        .ok_or_else(|| CrlError::InvalidCrlSignature {
+            location: snafu::Location::new(file!(), line!(), 0),
+        })?;
+    let tbs = tbs_crl_der(crl_der)?;
+
+    let issuer_der = match issuer_der {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let issuer_cert = x509_cert::Certificate::from_der(issuer_der).map_err(|_| {
+        CrlError::InvalidCrlSignature {
+            location: snafu::Location::new(file!(), line!(), 0),
+        }
+    })?;
+    if issuer_cert.tbs_certificate.subject != crl.tbs_cert_list.issuer {
+        return Err(CrlError::CrlIssuerMismatch {
+            location: snafu::Location::new(file!(), line!(), 0),
+        });
+    }
+
+    // Enforce AKID/SKID and critical extension policy
+    if let Ok((_, parsed_crl)) =
+        x509_parser::revocation_list::CertificateRevocationList::from_der(crl_der)
+    {
+        use x509_parser::extensions::ParsedExtension;
+        let oid_akid = x509_parser::oid_registry::OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER;
+        let oid_idp = x509_parser::oid_registry::OID_X509_EXT_ISSUER_DISTRIBUTION_POINT;
+        let oid_crl_number = x509_parser::oid_registry::OID_X509_EXT_CRL_NUMBER;
+        let oid_delta = x509_parser::oid_registry::OID_X509_EXT_DELTA_CRL_INDICATOR;
+        let mut crl_akid: Option<&[u8]> = None;
+        for ext in parsed_crl.tbs_cert_list.extensions() {
+            if ext.oid == oid_akid
+                && let ParsedExtension::AuthorityKeyIdentifier(akid) = ext.parsed_extension()
+            {
+                crl_akid = akid.key_identifier.as_ref().map(|kid| kid.0);
+            }
+            if ext.oid == oid_delta {
+                return Err(CrlError::InvalidCrlSignature {
+                    location: snafu::Location::new(file!(), line!(), 0),
+                });
+            }
+            if ext.critical {
+                let known = ext.oid == oid_akid || ext.oid == oid_idp || ext.oid == oid_crl_number;
+                if !known {
+                    return Err(CrlError::InvalidCrlSignature {
+                        location: snafu::Location::new(file!(), line!(), 0),
+                    });
+                }
+            }
+        }
+        if let Some(akid_key) = crl_akid
+            && let Ok((_, parsed_issuer)) =
+                x509_parser::certificate::X509Certificate::from_der(issuer_der)
+        {
+            let mut issuer_skid: Option<&[u8]> = None;
+            for ext in parsed_issuer.extensions() {
+                if ext.oid == x509_parser::oid_registry::OID_X509_EXT_SUBJECT_KEY_IDENTIFIER
+                    && let ParsedExtension::SubjectKeyIdentifier(kid) = ext.parsed_extension()
+                {
+                    issuer_skid = Some(kid.0);
+                }
+            }
+            if let Some(skid) = issuer_skid
+                && skid != akid_key
+            {
+                return Err(CrlError::InvalidCrlSignature {
+                    location: snafu::Location::new(file!(), line!(), 0),
+                });
+            }
+        }
+    }
+
+    // Verify signature using OpenSSL
+    let oid = crl.signature_algorithm.oid;
+    let oid_sha256_rsa = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
+    let oid_sha384_rsa = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12");
+    let oid_sha512_rsa = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
+    let oid_rsassa_pss = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
+    let oid_ecdsa_sha256 = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
+    let oid_ecdsa_sha384 = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3");
+    let oid_ed25519 = ObjectIdentifier::new_unwrap("1.3.101.112");
+
+    let verify_pkcs1 = |md: openssl::hash::MessageDigest| -> bool {
+        if let Ok(issuer_x509) = openssl::x509::X509::from_der(issuer_der)
+            && let Ok(pkey) = issuer_x509.public_key()
+            && let Ok(mut verifier) = openssl::sign::Verifier::new(md, &pkey)
+            && verifier.update(&tbs).is_ok()
+            && verifier.verify(sig).unwrap_or(false)
+        {
+            return true;
+        }
+        false
+    };
+    let verify_pss = |md: openssl::hash::MessageDigest| -> bool {
+        if let Ok(issuer_x509) = openssl::x509::X509::from_der(issuer_der)
+            && let Ok(pkey) = issuer_x509.public_key()
+            && let Ok(mut verifier) = openssl::sign::Verifier::new(md, &pkey)
+            && verifier
+                .set_rsa_padding(openssl::rsa::Padding::PKCS1_PSS)
+                .is_ok()
+            && verifier.set_rsa_mgf1_md(md).is_ok()
+            && verifier
+                .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::DIGEST_LENGTH)
+                .is_ok()
+            && verifier.update(&tbs).is_ok()
+            && verifier.verify(sig).unwrap_or(false)
+        {
+            return true;
+        }
+        false
+    };
+    let verify_ecdsa = |md: openssl::hash::MessageDigest| -> bool {
+        if let Ok(issuer_x509) = openssl::x509::X509::from_der(issuer_der)
+            && let Ok(pkey) = issuer_x509.public_key()
+            && let Ok(mut verifier) = openssl::sign::Verifier::new(md, &pkey)
+            && verifier.update(&tbs).is_ok()
+            && verifier.verify(sig).unwrap_or(false)
+        {
+            return true;
+        }
+        false
+    };
+    let verify_ed25519 = || -> bool {
+        if let Ok(issuer_x509) = openssl::x509::X509::from_der(issuer_der)
+            && let Ok(pkey) = issuer_x509.public_key()
+            && let Ok(mut verifier) = openssl::sign::Verifier::new_without_digest(&pkey)
+            && verifier.verify_oneshot(sig, &tbs).is_ok()
+        {
+            return true;
+        }
+        false
+    };
+
+    let verified = if oid == oid_sha256_rsa {
+        verify_pkcs1(openssl::hash::MessageDigest::sha256())
+    } else if oid == oid_sha384_rsa {
+        verify_pkcs1(openssl::hash::MessageDigest::sha384())
+    } else if oid == oid_sha512_rsa {
+        verify_pkcs1(openssl::hash::MessageDigest::sha512())
+    } else if oid == oid_rsassa_pss {
+        verify_pss(openssl::hash::MessageDigest::sha256())
+            || verify_pss(openssl::hash::MessageDigest::sha384())
+            || verify_pss(openssl::hash::MessageDigest::sha512())
+    } else if oid == oid_ecdsa_sha256 {
+        verify_ecdsa(openssl::hash::MessageDigest::sha256())
+    } else if oid == oid_ecdsa_sha384 {
+        verify_ecdsa(openssl::hash::MessageDigest::sha384())
+    } else if oid == oid_ed25519 {
+        verify_ed25519()
+    } else {
+        verify_pkcs1(openssl::hash::MessageDigest::sha256())
+            || verify_pkcs1(openssl::hash::MessageDigest::sha384())
+            || verify_pkcs1(openssl::hash::MessageDigest::sha512())
+            || verify_pss(openssl::hash::MessageDigest::sha256())
+            || verify_pss(openssl::hash::MessageDigest::sha384())
+            || verify_pss(openssl::hash::MessageDigest::sha512())
+            || verify_ecdsa(openssl::hash::MessageDigest::sha256())
+            || verify_ecdsa(openssl::hash::MessageDigest::sha384())
+            || verify_ed25519()
+    };
+    if verified {
+        return Ok(());
+    }
+
+    Err(CrlError::InvalidCrlSignature {
+        location: snafu::Location::new(file!(), line!(), 0),
+    })
+}
+
+/// Return canonical DER of the CRL's TBS (to-be-signed) part
+pub fn tbs_crl_der(crl_der: &[u8]) -> Result<Vec<u8>, CrlError> {
+    let crl = RcCertificateList::from_der(crl_der).map_err(|_| CrlError::InvalidCrlSignature {
+        location: snafu::Location::new(file!(), line!(), 0),
+    })?;
+    crl.tbs_cert_list
+        .to_der()
+        .map_err(|_| CrlError::InvalidCrlSignature {
+            location: snafu::Location::new(file!(), line!(), 0),
+        })
+}
+
+/// Extract thisUpdate and nextUpdate from a CRL, converted to chrono
+pub fn crl_times(
+    crl_der: &[u8],
+) -> Result<
+    (
+        chrono::DateTime<chrono::Utc>,
+        Option<chrono::DateTime<chrono::Utc>>,
+    ),
+    CrlError,
+> {
+    use x509_parser::prelude::FromDer;
+    let (_, crl) = x509_parser::revocation_list::CertificateRevocationList::from_der(crl_der)
+        .map_err(|e| CrlError::CrlParsing {
+            source: e,
+            location: snafu::Location::new(file!(), line!(), 0),
+        })?;
+    let this_dt =
+        crate::crl::certificate_parser::asn1_time_to_datetime(&crl.tbs_cert_list.this_update)
+            .ok_or_else(|| CrlError::CrlParsing {
+                source: x509_parser::nom::Err::Failure(x509_parser::error::X509Error::InvalidDate),
+                location: snafu::Location::new(file!(), line!(), 0),
+            })?;
+    let next_dt_opt = match crl.tbs_cert_list.next_update {
+        Some(ref n) => Some(
+            crate::crl::certificate_parser::asn1_time_to_datetime(n).ok_or_else(|| {
+                CrlError::CrlParsing {
+                    source: x509_parser::nom::Err::Failure(
+                        x509_parser::error::X509Error::InvalidDate,
+                    ),
+                    location: snafu::Location::new(file!(), line!(), 0),
+                }
+            })?,
+        ),
+        None => None,
+    };
+    Ok((this_dt, next_dt_opt))
+}
+
+/// Extract issuer SKID if present
+pub fn extract_issuer_skid(issuer_der: &[u8]) -> Option<Vec<u8>> {
+    if let Ok((_, issuer)) = x509_parser::certificate::X509Certificate::from_der(issuer_der) {
+        for ext in issuer.extensions() {
+            if ext.oid == x509_parser::oid_registry::OID_X509_EXT_SUBJECT_KEY_IDENTIFIER
+                && let x509_parser::extensions::ParsedExtension::SubjectKeyIdentifier(k) =
+                    ext.parsed_extension()
+            {
+                return Some(k.0.to_vec());
+            }
+        }
+    }
+    None
+}
+
+/// Stable hash of the issuer Subject DER (not its string form)
+pub fn subject_der_hash(issuer_der: &[u8]) -> Option<Vec<u8>> {
+    use x509_cert::der::Encode;
+    let cert = x509_cert::Certificate::from_der(issuer_der).ok()?;
+    let der = cert.tbs_certificate.subject.to_der().ok()?;
+    let mut hasher = sha2::Sha256::new();
+    use sha2::Digest;
+    hasher.update(&der);
+    Some(hasher.finalize().to_vec())
 }

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -60,8 +60,8 @@ pub fn extract_crl_next_update(crl_der: &[u8]) -> Result<Option<DateTime<Utc>>, 
     Ok(None)
 }
 
-/// Best-effort CRL signature verification using issuer public key
-/// Returns Ok(()) if verification passes or issuer is None; Err otherwise.
+// Best-effort CRL signature verification using issuer public key
+// Returns Ok(()) if verification passes or issuer is None; Err otherwise.
 pub fn verify_crl_signature_best_effort(
     crl_der: &[u8],
     issuer_der: Option<&[u8]>,
@@ -285,13 +285,13 @@ pub fn verify_crl_signature_best_effort(
     })
 }
 
-/// Return canonical DER of the CRL's TBS (to-be-signed) part
+// Return canonical DER of the CRL's TBS (to-be-signed) part
 pub fn tbs_crl_der(crl_der: &[u8]) -> Result<Vec<u8>, CrlError> {
     let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
     crl.tbs_cert_list.to_der().context(CrlToDerSnafu)
 }
 
-/// Extract thisUpdate and nextUpdate from a CRL, converted to chrono
+// Extract thisUpdate and nextUpdate from a CRL, converted to chrono
 pub fn crl_times(
     crl_der: &[u8],
 ) -> Result<
@@ -326,7 +326,7 @@ pub fn crl_times(
     Ok((this_dt, next_dt_opt))
 }
 
-/// Extract issuer SKID if present
+// Extract issuer SKID if present
 pub fn extract_issuer_skid(issuer_der: &[u8]) -> Option<Vec<u8>> {
     if let Ok((_, issuer)) = x509_parser::certificate::X509Certificate::from_der(issuer_der) {
         for ext in issuer.extensions() {
@@ -341,7 +341,7 @@ pub fn extract_issuer_skid(issuer_der: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
-/// Stable hash of the issuer Subject DER (not its string form)
+// Stable hash of the issuer Subject DER (not its string form)
 pub fn subject_der_hash(issuer_der: &[u8]) -> Option<Vec<u8>> {
     use x509_cert::der::Encode;
     let cert = x509_cert::Certificate::from_der(issuer_der).ok()?;

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -142,7 +142,24 @@ pub fn verify_crl_signature_best_effort(
         }
     }
 
-    // Verify signature using OpenSSL
+    // Verify signature
+    let spk_bytes = issuer_cert
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .as_bytes()
+        .ok_or_else(|| CrlError::InvalidCrlSignature {
+            location: snafu::Location::new(file!(), line!(), 0),
+        })?;
+    // First, try verification using aws-lc-rs (ring-compatible API)
+    let try_verify = |alg: &'static dyn aws_lc_rs::signature::VerificationAlgorithm| {
+        aws_lc_rs::signature::UnparsedPublicKey::new(alg, spk_bytes).verify(&tbs, sig)
+    };
+    use aws_lc_rs::signature::{
+        ECDSA_P256_SHA256_ASN1, ECDSA_P384_SHA384_ASN1, ED25519, RSA_PKCS1_2048_8192_SHA256,
+        RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256,
+        RSA_PSS_2048_8192_SHA384, RSA_PSS_2048_8192_SHA512,
+    };
     let oid = crl.signature_algorithm.oid;
     let oid_sha256_rsa = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
     let oid_sha384_rsa = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12");
@@ -152,6 +169,38 @@ pub fn verify_crl_signature_best_effort(
     let oid_ecdsa_sha384 = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3");
     let oid_ed25519 = ObjectIdentifier::new_unwrap("1.3.101.112");
 
+    // Try aws-lc-rs first
+    let ring_like = if oid == oid_sha256_rsa {
+        try_verify(&RSA_PKCS1_2048_8192_SHA256)
+    } else if oid == oid_sha384_rsa {
+        try_verify(&RSA_PKCS1_2048_8192_SHA384)
+    } else if oid == oid_sha512_rsa {
+        try_verify(&RSA_PKCS1_2048_8192_SHA512)
+    } else if oid == oid_rsassa_pss {
+        try_verify(&RSA_PSS_2048_8192_SHA256)
+            .or_else(|_| try_verify(&RSA_PSS_2048_8192_SHA384))
+            .or_else(|_| try_verify(&RSA_PSS_2048_8192_SHA512))
+    } else if oid == oid_ecdsa_sha256 {
+        try_verify(&ECDSA_P256_SHA256_ASN1)
+    } else if oid == oid_ecdsa_sha384 {
+        try_verify(&ECDSA_P384_SHA384_ASN1)
+    } else if oid == oid_ed25519 {
+        try_verify(&ED25519)
+    } else {
+        try_verify(&RSA_PKCS1_2048_8192_SHA256)
+            .or_else(|_| try_verify(&RSA_PKCS1_2048_8192_SHA384))
+            .or_else(|_| try_verify(&RSA_PKCS1_2048_8192_SHA512))
+            .or_else(|_| try_verify(&RSA_PSS_2048_8192_SHA256))
+            .or_else(|_| try_verify(&RSA_PSS_2048_8192_SHA384))
+            .or_else(|_| try_verify(&RSA_PSS_2048_8192_SHA512))
+            .or_else(|_| try_verify(&ECDSA_P256_SHA256_ASN1))
+            .or_else(|_| try_verify(&ECDSA_P384_SHA384_ASN1))
+    };
+    if ring_like.is_ok() {
+        return Ok(());
+    }
+
+    // OpenSSL-based verification for common algorithms (RSA PKCS#1, RSA-PSS, ECDSA, Ed25519)
     let verify_pkcs1 = |md: openssl::hash::MessageDigest| -> bool {
         if let Ok(issuer_x509) = openssl::x509::X509::from_der(issuer_der)
             && let Ok(pkey) = issuer_x509.public_key()
@@ -220,6 +269,7 @@ pub fn verify_crl_signature_best_effort(
     } else if oid == oid_ed25519 {
         verify_ed25519()
     } else {
+        // Try a set of common algorithms as a fallback
         verify_pkcs1(openssl::hash::MessageDigest::sha256())
             || verify_pkcs1(openssl::hash::MessageDigest::sha384())
             || verify_pkcs1(openssl::hash::MessageDigest::sha512())
@@ -233,7 +283,6 @@ pub fn verify_crl_signature_best_effort(
     if verified {
         return Ok(());
     }
-
     Err(CrlError::InvalidCrlSignature {
         location: snafu::Location::new(file!(), line!(), 0),
     })


### PR DESCRIPTION
Introduces CRL-based certificate revocation checking into the TLS stack with best-effort signature verification, in-memory and optional disk caching, and a custom rustls server cert verifier. Adds robust error types and consistent logging.