### PR TITLE
NO-SNOW: add rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.89.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Add rust-toolchain.toml file for reproducibility between local and remote testing environments (to have one common version of clippy etc.)