### PR TITLE
NO-SNOW: Fix odbc flaky tests

### DIFF
--- a/odbc_tests/common/include/Connection.hpp
+++ b/odbc_tests/common/include/Connection.hpp
@@ -1,3 +1,6 @@
+#ifndef CONNECTION_HPP
+#define CONNECTION_HPP
+
 #include <sql.h>
 #include <sqlext.h>
 
@@ -58,3 +61,5 @@ class Connection {
   EnvironmentHandleWrapper env;
   ConnectionHandleWrapper dbc;
 };
+
+#endif  // CONNECTION_HPP

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -1,0 +1,31 @@
+#ifndef SCHEMA_HPP
+#define SCHEMA_HPP
+
+#include <chrono>
+#include <random>
+#include <string>
+
+#include "Connection.hpp"
+
+class Schema {
+ public:
+  Schema(Connection& conn, const std::string& schema_name) : conn(conn), schema_name(schema_name) {
+    conn.execute("CREATE SCHEMA IF NOT EXISTS " + schema_name);
+    conn.execute("USE SCHEMA " + schema_name);
+  }
+
+  static Schema use_random_schema(Connection& conn) {
+    std::random_device rd;
+    std::mt19937 gen(std::chrono::steady_clock::now().time_since_epoch().count());
+    const std::string schema_name = "schema_" + std::to_string(gen());
+    return Schema(conn, schema_name);
+  }
+
+  ~Schema() { conn.execute("DROP SCHEMA IF EXISTS " + schema_name); }
+
+ private:
+  Connection& conn;
+  std::string schema_name;
+};
+
+#endif  // SCHEMA_HPP

--- a/odbc_tests/tests/bindings_tests/test.cpp
+++ b/odbc_tests/tests/bindings_tests/test.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
+#include "Schema.hpp"
 
 TEST_CASE("Test integer single column, single row binding", "[bindings_tests]") {
   Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("DROP TABLE IF EXISTS universal_driver_odbc_small_binding_integer_test_table");
   conn.execute("CREATE TABLE universal_driver_odbc_small_binding_integer_test_table (id NUMBER)");
 

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -19,12 +19,14 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
+#include "Schema.hpp"
 #include "get_data.hpp"
 #include "macros.hpp"
 #include "test_setup.hpp"
 
 TEST_CASE("Test decimal conversion", "[datatype][number]") {
   Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("DROP TABLE IF EXISTS test_number");
   conn.execute(
       "CREATE TABLE test_number (num0 NUMBER, num10 NUMBER(10,1), dec20 DECIMAL(20,2), numeric30 "
@@ -150,6 +152,7 @@ void test_string_at_limits(Connection& conn) {
 
 TEST_CASE("Test at limits", "[datatype][number]") {
   Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
   test_at_limits<SQL_C_LONG>(conn);
   test_at_limits<SQL_C_SLONG>(conn);
   test_at_limits<SQL_C_ULONG>(conn);

--- a/odbc_tests/tests/datatype_tests/string_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/string_tests.cpp
@@ -14,11 +14,13 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
+#include "Schema.hpp"
 #include "macros.hpp"
 #include "test_setup.hpp"
 
 TEST_CASE("Test string basic query", "[datatype][string]") {
   Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("DROP TABLE IF EXISTS test_string_basic");
   conn.execute("CREATE TABLE test_string_basic (str_col VARCHAR(1000))");
   conn.execute("INSERT INTO test_string_basic (str_col) VALUES ('Hello World')");
@@ -42,6 +44,7 @@ TEST_CASE("Test string basic query", "[datatype][string]") {
 
 TEST_CASE("Test basic string binding", "[datatype][string]") {
   Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("DROP TABLE IF EXISTS test_string_basic_binding");
   conn.execute("CREATE TABLE test_string_basic_binding (str_col VARCHAR(1000))");
   auto stmt = conn.createStatement();


### PR DESCRIPTION
### TL;DR

Added a Schema class to manage temporary schemas for tests, ensuring test isolation and preventing conflicts.

### What changed?

- Added header guards to `Connection.hpp`
- Created a new `Schema.hpp` file with a `Schema` class that:
  - Creates a schema on construction and drops it on destruction
  - Provides a static method to create a schema with a random name
- Updated test files to use the new `Schema` class, creating random schemas for each test

### Why make this change?

This change improves test isolation by ensuring each test runs in its own schema. This prevents tests from interfering with each other when run concurrently or when tests fail without proper cleanup. The random schema names also reduce the chance of conflicts with existing schemas in the database.