### PR TITLE
Provide rpath so loading built dependencies works

### DIFF
--- a/build_common.rs
+++ b/build_common.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+use std::{env, fs};
+
+#[inline]
+fn loader_prefix() -> &'static str {
+    if cfg!(target_os = "linux") {
+        return "$ORIGIN";
+    }
+    "@loader_path"
+}
+
+// Finds all artifact directories (*-sys*) under the build directory.
+fn artifact_dirs_under_build(build_dir: &Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    if let Ok(mut entries) = fs::read_dir(build_dir) {
+        while let Some(Ok(entry)) = entries.next() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.contains("-sys") {
+                let artifacts = entry.path().join("out/build/artifacts");
+                if artifacts.is_dir() {
+                    found.push(artifacts);
+                }
+            }
+        }
+    }
+    found
+}
+
+pub fn emit_loader_rpaths() {
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", loader_prefix());
+
+    if let Ok(out_dir) = env::var("OUT_DIR") {
+        let build_dir_opt = Path::new(&out_dir)
+            .ancestors()
+            .find(|p| p.file_name().map(|n| n == "build").unwrap_or(false))
+            .map(|p| p.to_path_buf());
+
+        if let Some(build_dir) = build_dir_opt
+            && let Some(target_debug_dir) = build_dir.parent()
+        {
+            for artifacts_abs in artifact_dirs_under_build(&build_dir) {
+                if let Ok(rel) = artifacts_abs.strip_prefix(target_debug_dir) {
+                    println!(
+                        "cargo:rustc-link-arg=-Wl,-rpath,{}/{}",
+                        loader_prefix(),
+                        rel.display()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/odbc/build.rs
+++ b/odbc/build.rs
@@ -1,43 +1,5 @@
-use std::env;
-use std::path::PathBuf;
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../build_common.rs"));
 
 fn main() {
-    // Loader-relative rpath so colocated deps resolve at runtime
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
-    } else if cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
-    }
-
-    // Best-effort: add absolute rpath to aws-lc artifacts dir if present
-    if let Ok(out_dir) = env::var("OUT_DIR") {
-        // OUT_DIR typically looks like: target/debug/build/odbc-<hash>/out
-        let mut p = PathBuf::from(out_dir);
-        // Walk up the directory tree until we find the "build" directory
-        while let Some(component) = p.file_name() {
-            if component == "build" {
-                break;
-            }
-            let _ = p.pop();
-            if p.as_os_str().is_empty() {
-                break;
-            }
-        }
-        let build_dir = p.clone();
-        if let Ok(entries) = std::fs::read_dir(&build_dir) {
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                if name.starts_with("aws-lc-fips-sys-") {
-                    let artifacts_abs = entry.path().join("out/build/artifacts");
-                    if artifacts_abs.is_dir() {
-                        println!(
-                            "cargo:rustc-link-arg=-Wl,-rpath,{}",
-                            artifacts_abs.display()
-                        );
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    emit_loader_rpaths();
 }

--- a/odbc/build.rs
+++ b/odbc/build.rs
@@ -2,19 +2,18 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    // Always include an rpath relative to the loaded library location so colocated deps work
+    // Loader-relative rpath so colocated deps resolve at runtime
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
     } else if cfg!(target_os = "linux") {
         println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
     }
 
-    // Best-effort: add rpath to AWS-LC artifacts if present in target dir layout
-    // target/debug/build/aws-lc-fips-sys-*/out/build/artifacts
+    // Best-effort: add absolute rpath to aws-lc artifacts dir if present
     if let Ok(out_dir) = env::var("OUT_DIR") {
-        // OUT_DIR typically looks like: target/debug/build/sf_core-<hash>/out
+        // OUT_DIR typically looks like: target/debug/build/odbc-<hash>/out
         let mut p = PathBuf::from(out_dir);
-        // Walk up the directory tree until we find the "build" directory.
+        // Walk up the directory tree until we find the "build" directory
         while let Some(component) = p.file_name() {
             if component == "build" {
                 break;
@@ -31,7 +30,6 @@ fn main() {
                 if name.starts_with("aws-lc-fips-sys-") {
                     let artifacts_abs = entry.path().join("out/build/artifacts");
                     if artifacts_abs.is_dir() {
-                        // Compute relative path from the produced dylib location to artifacts dir.
                         println!(
                             "cargo:rustc-link-arg=-Wl,-rpath,{}",
                             artifacts_abs.display()

--- a/pep249_dbapi/Makefile
+++ b/pep249_dbapi/Makefile
@@ -7,17 +7,18 @@ REFERENCE_DRIVER_VERSION ?= 3.17.2
 PYTEST_ARGS ?=
 FAIL_ON_REGRESSIONS ?= 0
 
+# Project root (absolute)
+PROJECT_ROOT := $(abspath ..)
+
 # Library search paths (for dependent native libs)
-# Default search locations
-DEFAULT_LIB_DEBUG := $(shell cd .. && pwd)/target/debug
-DEFAULT_LIB_DEPS := $(shell cd .. && pwd)/target/debug/deps
+# Default search locations derived from PROJECT_ROOT
+DEFAULT_LIB_DEBUG := $(PROJECT_ROOT)/target/debug
+DEFAULT_LIB_DEPS := $(DEFAULT_LIB_DEBUG)/deps
 
 # Absolute paths to avoid relative path issues across different working directories
-# Derive all core-related paths from DEFAULT_LIB_DEBUG (../target/debug)
+# Derive all core-related paths from DEFAULT_LIB_DEBUG
 DEFAULT_CORE_PATH_MACOS := $(DEFAULT_LIB_DEBUG)/libsf_core.dylib
 DEFAULT_CORE_PATH_LINUX := $(DEFAULT_LIB_DEBUG)/libsf_core.so
-# Project root is two levels up from DEFAULT_LIB_DEBUG (../target/debug -> ../..)
-PROJECT_ROOT := $(abspath $(DEFAULT_LIB_DEBUG)/../..)
 DEFAULT_PARAMETER_PATH := $(PROJECT_ROOT)/parameters.json
 
 SHELL := bash

--- a/pep249_dbapi/Makefile
+++ b/pep249_dbapi/Makefile
@@ -7,10 +7,18 @@ REFERENCE_DRIVER_VERSION ?= 3.17.2
 PYTEST_ARGS ?=
 FAIL_ON_REGRESSIONS ?= 0
 
+# Library search paths (for dependent native libs)
+# Default search locations
+DEFAULT_LIB_DEBUG := $(shell cd .. && pwd)/target/debug
+DEFAULT_LIB_DEPS := $(shell cd .. && pwd)/target/debug/deps
+
 # Absolute paths to avoid relative path issues across different working directories
-DEFAULT_CORE_PATH_MACOS := $(shell cd .. && pwd)/target/debug/libsf_core.dylib
-DEFAULT_CORE_PATH_LINUX := $(shell cd .. && pwd)/target/debug/libsf_core.so
-DEFAULT_PARAMETER_PATH := $(shell cd .. && pwd)/parameters.json
+# Derive all core-related paths from DEFAULT_LIB_DEBUG (../target/debug)
+DEFAULT_CORE_PATH_MACOS := $(DEFAULT_LIB_DEBUG)/libsf_core.dylib
+DEFAULT_CORE_PATH_LINUX := $(DEFAULT_LIB_DEBUG)/libsf_core.so
+# Project root is two levels up from DEFAULT_LIB_DEBUG (../target/debug -> ../..)
+PROJECT_ROOT := $(abspath $(DEFAULT_LIB_DEBUG)/../..)
+DEFAULT_PARAMETER_PATH := $(PROJECT_ROOT)/parameters.json
 
 SHELL := bash
 .ONESHELL:  # Execute each recipe in a single shell (needed for multi-line commands)

--- a/pep249_dbapi/pep249_dbapi/api_client/c_api.py
+++ b/pep249_dbapi/pep249_dbapi/api_client/c_api.py
@@ -11,7 +11,9 @@ class CAPIHandle(ctypes.Structure):
 try:
     import os
     if "CORE_PATH" not in os.environ:
-        raise ValueError("CORE_PATH environment variable not set")
+        raise ImportError(
+            "CORE_PATH environment variable not set. Set CORE_PATH to the built core library, e.g. ../target/debug/libsf_core.dylib"
+        )
     core = ctypes.CDLL(os.environ["CORE_PATH"])
 except OSError as e:
     print(f"Error loading library {e}")

--- a/sf_core/build.rs
+++ b/sf_core/build.rs
@@ -1,45 +1,5 @@
-use std::env;
-use std::path::PathBuf;
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../build_common.rs"));
 
 fn main() {
-    // Always include an rpath relative to the loaded library location so colocated deps work
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
-    } else if cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
-    }
-
-    // Best-effort: add rpath to AWS-LC artifacts if present in target dir layout
-    // target/debug/build/aws-lc-fips-sys-*/out/build/artifacts
-    if let Ok(out_dir) = env::var("OUT_DIR") {
-        // OUT_DIR typically looks like: target/debug/build/sf_core-<hash>/out
-        let mut p = PathBuf::from(out_dir);
-        // Walk up the directory tree until we find the "build" directory.
-        while let Some(component) = p.file_name() {
-            if component == "build" {
-                break;
-            }
-            let _ = p.pop();
-            if p.as_os_str().is_empty() {
-                break;
-            }
-        }
-        let build_dir = p.clone();
-        if let Ok(entries) = std::fs::read_dir(&build_dir) {
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                if name.starts_with("aws-lc-fips-sys-") {
-                    let artifacts_abs = entry.path().join("out/build/artifacts");
-                    if artifacts_abs.is_dir() {
-                        // Compute relative path from the produced dylib location to artifacts dir.
-                        println!(
-                            "cargo:rustc-link-arg=-Wl,-rpath,{}",
-                            artifacts_abs.display()
-                        );
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    emit_loader_rpaths();
 }

--- a/sf_core/build.rs
+++ b/sf_core/build.rs
@@ -1,0 +1,40 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Always include an rpath relative to the loaded library location so colocated deps work
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+    } else if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    }
+
+    // Best-effort: add rpath to AWS-LC artifacts if present in target dir layout
+    // target/debug/build/aws-lc-fips-sys-*/out/build/artifacts
+    if let Ok(out_dir) = env::var("OUT_DIR") {
+        // OUT_DIR like: target/debug/build/sf_core-<hash>/out
+        let mut p = PathBuf::from(out_dir);
+        // Walk up to target/debug
+        for _ in 0..3 {
+            let _ = p.pop();
+        }
+        // p now points to target/debug
+        let build_dir = p.join("build");
+        if let Ok(entries) = std::fs::read_dir(&build_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name.starts_with("aws-lc-fips-sys-") {
+                    let artifacts_abs = entry.path().join("out/build/artifacts");
+                    if artifacts_abs.is_dir() {
+                        // Compute relative path from the produced dylib location to artifacts dir.
+                        println!(
+                            "cargo:rustc-link-arg=-Wl,-rpath,{}",
+                            artifacts_abs.display()
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We now depend on the aws-lc library, which is built as part of the core. We thus need to add an rpath so the library can be found. We should consider whether we want this to be dynamic or static long term, but fixing the paths at least unblocks testing.