### PR TITLE
SNOW-2371565: Provide async query execution and retry policies

### DIFF
--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 mod connection;
 mod database;
 pub(crate) mod error;

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -1,9 +1,11 @@
 use crate::chunks::ChunkDownloadData;
+use crate::config::rest_parameters::{ClientInfo, QueryParameters};
 use crate::config::retry::{BackoffConfig, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::error::SfError;
-use crate::rest::snowflake::{query_request, query_response};
-use reqwest::header;
+use crate::rest::snowflake::{
+    QUERY_REQUEST_PATH, apply_json_content_type, apply_query_headers, query_request, query_response,
+};
 use reqwest::{Method, StatusCode};
 use snafu::Location;
 use std::collections::HashMap;
@@ -18,8 +20,6 @@ const INLINE_SHORT_POLL_DELAYS: &[Duration] = &[
     Duration::from_millis(20),
     Duration::from_millis(40),
 ];
-const QUERY_REQUEST_PATH: &str = "/queries/v1/query-request";
-const JSON_MIME: &str = "application/json";
 const QUERY_SEQUENCE_ID: u64 = 1;
 
 fn join_server_path(server_url: &str, path: &str) -> Result<String, SfError> {
@@ -59,26 +59,15 @@ fn build_async_query_request(
 fn build_submit_request(
     client: &reqwest::Client,
     endpoint: &str,
+    client_info: &ClientInfo,
     session_token: &str,
     request_id: uuid::Uuid,
     payload: &query_request::Request,
 ) -> reqwest::RequestBuilder {
-    let auth_header = authorization_header(session_token);
-    client
-        .post(endpoint)
-        .header(header::AUTHORIZATION, auth_header)
-        .header(header::ACCEPT, header::HeaderValue::from_static(JSON_MIME))
-        .header(
-            header::CONTENT_TYPE,
-            header::HeaderValue::from_static(JSON_MIME),
-        )
+    let builder = client.post(endpoint);
+    apply_json_content_type(apply_query_headers(builder, client_info, session_token))
         .query(&[("requestId", request_id.to_string())])
         .json(payload)
-}
-
-fn authorization_header(session_token: &str) -> header::HeaderValue {
-    let value = format!("Snowflake Token=\"{session_token}\"");
-    header::HeaderValue::from_str(&value).expect("authorization header construction must succeed")
 }
 
 async fn parse_submit_response(
@@ -133,17 +122,27 @@ fn current_epoch_millis() -> i64 {
 
 pub async fn submit_statement_async(
     client: &reqwest::Client,
-    server_url: &str,
+    params: &QueryParameters,
     session_token: &str,
     sql: String,
     parameter_bindings: Option<&HashMap<String, query_request::BindParameter>>,
     request_id: uuid::Uuid,
     policy: &RetryPolicy,
 ) -> Result<SubmitOk, SfError> {
+    let server_url = &params.server_url;
+    let client_info = &params.client_info;
     let endpoint = join_server_path(server_url, QUERY_REQUEST_PATH)?;
     let request_body = build_async_query_request(sql, parameter_bindings);
-    let submit_request =
-        || build_submit_request(client, &endpoint, session_token, request_id, &request_body);
+    let submit_request = || {
+        build_submit_request(
+            client,
+            &endpoint,
+            client_info,
+            session_token,
+            request_id,
+            &request_body,
+        )
+    };
 
     let ctx = HttpContext::new(Method::POST, QUERY_REQUEST_PATH).allow_post_retry();
     let response = execute_with_retry(submit_request, &ctx, policy, |r| async move { Ok(r) })
@@ -155,19 +154,14 @@ pub async fn submit_statement_async(
 
 pub async fn poll_query_status(
     client: &reqwest::Client,
+    client_info: &ClientInfo,
     session_token: &str,
     get_result_url: &str,
     policy: &RetryPolicy,
 ) -> Result<query_response::Response, SfError> {
     let result_url = get_result_url.to_string();
-    let session = session_token.to_string();
-    let auth_header = authorization_header(&session);
-    let poll_request = move || {
-        client
-            .get(result_url.clone())
-            .header(header::AUTHORIZATION, auth_header.clone())
-            .header(header::ACCEPT, header::HeaderValue::from_static(JSON_MIME))
-    };
+    let poll_request =
+        move || apply_query_headers(client.get(result_url.clone()), client_info, session_token);
     let ctx = HttpContext::new(Method::GET, get_result_url.to_string());
     let response = execute_with_retry(poll_request, &ctx, policy, |r| async move { Ok(r) })
         .await
@@ -200,16 +194,17 @@ pub async fn poll_query_status(
 
 pub async fn execute_blocking_with_async(
     client: &reqwest::Client,
-    server_url: &str,
+    params: &QueryParameters,
     session_token: &str,
     sql: String,
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
     request_id: uuid::Uuid,
     policy: &RetryPolicy,
 ) -> Result<query_response::Response, SfError> {
+    let client_info = &params.client_info;
     let submitted = submit_statement_async(
         client,
-        server_url,
+        params,
         session_token,
         sql,
         parameter_bindings.as_ref(),
@@ -232,11 +227,13 @@ pub async fn execute_blocking_with_async(
             })?;
 
         if let Some(inline) =
-            inline_poll_for_completion(client, session_token, result_url, policy).await?
+            inline_poll_for_completion(client, client_info, session_token, result_url, policy)
+                .await?
         {
             response = inline;
         } else {
-            response = wait_for_completion(client, session_token, result_url, policy).await?;
+            response =
+                wait_for_completion(client, client_info, session_token, result_url, policy).await?;
         }
     }
 
@@ -319,11 +316,13 @@ fn http_status_error(status: StatusCode) -> SfError {
 
 pub async fn refresh_chunk_download_data_from_get_result(
     client: &reqwest::Client,
+    client_info: &ClientInfo,
     session_token: &str,
     get_result_url: &str,
     policy: &RetryPolicy,
 ) -> Result<Option<Vec<ChunkDownloadData>>, SfError> {
-    let resp = poll_query_status(client, session_token, get_result_url, policy).await?;
+    let resp =
+        poll_query_status(client, client_info, session_token, get_result_url, policy).await?;
     if resp.success {
         Ok(resp.data.to_chunk_download_data())
     } else {
@@ -370,11 +369,13 @@ fn response_has_tabular_data(resp: &query_response::Response) -> bool {
 
 async fn inline_poll_for_completion(
     client: &reqwest::Client,
+    client_info: &ClientInfo,
     session_token: &str,
     result_url: &str,
     policy: &RetryPolicy,
 ) -> Result<Option<query_response::Response>, SfError> {
-    let response = poll_query_status(client, session_token, result_url, policy).await?;
+    let response =
+        poll_query_status(client, client_info, session_token, result_url, policy).await?;
     handle_poll_response(response)
 }
 
@@ -386,6 +387,7 @@ async fn inline_poll_for_completion(
 /// error, or the overall deadline / retry budget is exhausted.
 async fn wait_for_completion(
     client: &reqwest::Client,
+    client_info: &ClientInfo,
     session_token: &str,
     result_url: &str,
     policy: &RetryPolicy,
@@ -441,7 +443,8 @@ async fn wait_for_completion(
 
         let mut poll_policy = policy.clone();
         poll_policy.max_elapsed = remaining;
-        let response = poll_query_status(client, session_token, result_url, &poll_policy).await?;
+        let response =
+            poll_query_status(client, client_info, session_token, result_url, &poll_policy).await?;
 
         if let Some(done) = handle_poll_response(response)? {
             return Ok(done);

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -1,0 +1,237 @@
+use crate::chunks::ChunkDownloadData;
+use crate::config::retry::RetryPolicy;
+use crate::http::retry::{HttpContext, execute_with_retry};
+use crate::rest::snowflake::error::SfError;
+use crate::rest::snowflake::{query_request, query_response};
+use once_cell::sync::Lazy;
+use reqwest::Method;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+pub struct SubmitOk {
+    pub query_id: String,
+    pub response: query_response::Response,
+}
+
+pub async fn submit_statement_async(
+    client: &reqwest::Client,
+    server_url: &str,
+    session_token: &str,
+    sql: String,
+    parameter_bindings: Option<std::collections::HashMap<String, query_request::BindParameter>>,
+    request_id: uuid::Uuid,
+    policy: &RetryPolicy,
+) -> Result<SubmitOk, SfError> {
+    let query_url = format!("{server_url}/queries/v1/query-request");
+
+    let query_request = query_request::Request {
+        sql_text: sql,
+        async_exec: true,
+        sequence_id: 1,
+        query_submission_time: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64,
+        is_internal: false,
+        describe_only: None,
+        parameters: None,
+        bindings: parameter_bindings,
+        bind_stage: None,
+        query_context: query_request::QueryContext { entries: None },
+    };
+
+    let build = || {
+        client
+            .post(&query_url)
+            .header(
+                "Authorization",
+                format!("Snowflake Token=\"{session_token}\""),
+            )
+            .header("Accept", "application/json")
+            .query(&[("requestId", request_id.to_string())])
+            .json(&query_request)
+    };
+
+    let ctx = HttpContext {
+        method: Method::POST,
+        path: "/queries/v1/query-request".to_string(),
+        idempotent: false,
+        allow_post_retry: true, // safe due to stable requestId
+    };
+
+    let resp = match execute_with_retry(client, build, &ctx, policy, |r| async move { Ok(r) }).await
+    {
+        Ok(r) => r,
+        Err(crate::http::retry::HttpError::Transport(source)) => {
+            return Err(SfError::Transport {
+                source,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Err(crate::http::retry::HttpError::DeadlineExceeded) => {
+            return Err(SfError::DeadlineExceeded {
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Err(crate::http::retry::HttpError::HttpStatus { status, .. }) => {
+            return Err(SfError::HttpStatus {
+                status,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+    };
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(SfError::HttpStatus {
+            status,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        });
+    }
+
+    let body_text = resp.text().await.map_err(|source| SfError::Transport {
+        source,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })?;
+    let parsed: query_response::Response =
+        serde_json::from_str(&body_text).map_err(|source| SfError::BodyParse {
+            source,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+    Ok(SubmitOk {
+        query_id: String::new(),
+        response: parsed,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PollState {
+    NotReady,
+    Success,
+    Failure,
+    Cancelled,
+}
+
+pub async fn poll_query_status(
+    client: &reqwest::Client,
+    get_result_url: &str,
+    policy: &RetryPolicy,
+) -> Result<(PollState, query_response::Response), SfError> {
+    let build = || client.get(get_result_url);
+    let ctx = HttpContext {
+        method: Method::GET,
+        path: get_result_url.to_string(),
+        idempotent: true,
+        allow_post_retry: false,
+    };
+    let resp = match execute_with_retry(client, build, &ctx, policy, |r| async move { Ok(r) }).await
+    {
+        Ok(r) => r,
+        Err(crate::http::retry::HttpError::Transport(source)) => {
+            return Err(SfError::Transport {
+                source,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Err(crate::http::retry::HttpError::DeadlineExceeded) => {
+            return Err(SfError::DeadlineExceeded {
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Err(crate::http::retry::HttpError::HttpStatus { status, .. }) => {
+            return Err(SfError::HttpStatus {
+                status,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+    };
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(SfError::HttpStatus {
+            status,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        });
+    }
+    let body_text = resp.text().await.map_err(|source| SfError::Transport {
+        source,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })?;
+    let parsed: query_response::Response =
+        serde_json::from_str(&body_text).map_err(|source| SfError::BodyParse {
+            source,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+    if parsed.success {
+        Ok((PollState::Success, parsed))
+    } else {
+        Ok((PollState::Failure, parsed))
+    }
+}
+
+pub async fn execute_blocking_with_async(
+    client: &reqwest::Client,
+    server_url: &str,
+    session_token: &str,
+    sql: String,
+    parameter_bindings: Option<std::collections::HashMap<String, query_request::BindParameter>>,
+    request_id: uuid::Uuid,
+    policy: &RetryPolicy,
+) -> Result<query_response::Response, SfError> {
+    let submitted = submit_statement_async(
+        client,
+        server_url,
+        session_token,
+        sql,
+        parameter_bindings,
+        request_id,
+        policy,
+    )
+    .await?;
+
+    // Inline short-poll
+    let start = Instant::now();
+    for d in &policy.inline_short_poll.delays {
+        if start.elapsed() > policy.inline_short_poll.budget {
+            break;
+        }
+        if d.as_millis() > 0 {
+            tokio::time::sleep(*d).await;
+        }
+        // If get_result_url existed we'd poll it; for now assume success response is terminal
+        if submitted.response.success {
+            return Ok(submitted.response);
+        }
+    }
+
+    Ok(submitted.response)
+}
+
+static REQUEST_TO_QUERY: Lazy<RequestQueryMap> = Lazy::new(RequestQueryMap::default);
+
+#[derive(Default)]
+struct RequestQueryMap(Mutex<HashMap<uuid::Uuid, String>>);
+
+impl RequestQueryMap {
+    fn insert(&self, rid: uuid::Uuid, qid: String) {
+        if let Ok(mut g) = self.0.lock() {
+            g.insert(rid, qid);
+        }
+    }
+    #[allow(dead_code)]
+    fn get(&self, rid: &uuid::Uuid) -> Option<String> {
+        self.0.lock().ok().and_then(|g| g.get(rid).cloned())
+    }
+}
+
+pub async fn refresh_chunk_download_data_from_get_result(
+    client: &reqwest::Client,
+    get_result_url: &str,
+    policy: &RetryPolicy,
+) -> Result<Option<Vec<ChunkDownloadData>>, SfError> {
+    let (state, resp) = poll_query_status(client, get_result_url, policy).await?;
+    match state {
+        PollState::Success => Ok(resp.data.to_chunk_download_data()),
+        _ => Ok(None),
+    }
+}

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -1,16 +1,27 @@
 use crate::chunks::ChunkDownloadData;
-use crate::config::retry::RetryPolicy;
-use crate::http::retry::{HttpContext, execute_with_retry};
+use crate::config::retry::{BackoffConfig, RetryPolicy};
+use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::{query_request, query_response};
 use once_cell::sync::Lazy;
-use reqwest::Method;
+use reqwest::{Method, StatusCode};
+use snafu::Location;
 use std::collections::HashMap;
+use std::panic::Location as StdLocation;
 use std::sync::Mutex;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tracing::debug;
+use url::Url;
 
+const INLINE_SHORT_POLL_DELAYS: &[Duration] = &[
+    Duration::from_millis(0),
+    Duration::from_millis(50),
+    Duration::from_millis(125),
+    Duration::from_millis(250),
+];
 pub struct SubmitOk {
-    pub query_id: String,
+    pub query_id: Option<String>,
+    pub get_result_url: Option<String>,
     pub response: query_response::Response,
 }
 
@@ -53,120 +64,93 @@ pub async fn submit_statement_async(
             .json(&query_request)
     };
 
-    let ctx = HttpContext {
-        method: Method::POST,
-        path: "/queries/v1/query-request".to_string(),
-        idempotent: false,
-        allow_post_retry: true, // safe due to stable requestId
-    };
+    let ctx = HttpContext::new(Method::POST, "/queries/v1/query-request").allow_post_retry();
 
-    let resp = match execute_with_retry(client, build, &ctx, policy, |r| async move { Ok(r) }).await
-    {
-        Ok(r) => r,
-        Err(crate::http::retry::HttpError::Transport(source)) => {
-            return Err(SfError::Transport {
-                source,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-        Err(crate::http::retry::HttpError::DeadlineExceeded) => {
-            return Err(SfError::DeadlineExceeded {
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-        Err(crate::http::retry::HttpError::HttpStatus { status, .. }) => {
-            return Err(SfError::HttpStatus {
-                status,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-    };
+    let resp = execute_with_retry(build, &ctx, policy, |r| async move { Ok(r) })
+        .await
+        .map_err(map_http_error)?;
 
     let status = resp.status();
     if !status.is_success() {
-        return Err(SfError::HttpStatus {
-            status,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        });
+        return Err(http_status_error(status));
     }
 
-    let body_text = resp.text().await.map_err(|source| SfError::Transport {
-        source,
-        location: snafu::Location::new(file!(), line!(), column!()),
-    })?;
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|source| transport_error(source))?;
     let parsed: query_response::Response =
-        serde_json::from_str(&body_text).map_err(|source| SfError::BodyParse {
-            source,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        })?;
+        serde_json::from_str(&body_text).map_err(|source| body_parse_error(source))?;
+    let query_id = parsed.data.query_id.clone();
+    let get_result_url = parsed
+        .data
+        .get_result_url
+        .as_deref()
+        .map(|u| normalize_get_result_url(server_url, u))
+        .transpose()?;
+    debug!(
+        success = parsed.success,
+        rowset_present = parsed.data.rowset.is_some(),
+        rowset_base64_present = parsed.data.rowset_base64.is_some(),
+        chunks = parsed
+            .data
+            .chunks
+            .as_ref()
+            .map(|c| c.len())
+            .unwrap_or_default(),
+        query_id = query_id.as_deref().unwrap_or_default(),
+        get_result_url = get_result_url.as_deref().unwrap_or_default(),
+        "submitted async query"
+    );
     Ok(SubmitOk {
-        query_id: String::new(),
+        query_id,
+        get_result_url,
         response: parsed,
     })
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum PollState {
-    NotReady,
-    Success,
-    Failure,
-    Cancelled,
-}
-
 pub async fn poll_query_status(
     client: &reqwest::Client,
+    session_token: &str,
     get_result_url: &str,
     policy: &RetryPolicy,
-) -> Result<(PollState, query_response::Response), SfError> {
-    let build = || client.get(get_result_url);
-    let ctx = HttpContext {
-        method: Method::GET,
-        path: get_result_url.to_string(),
-        idempotent: true,
-        allow_post_retry: false,
+) -> Result<query_response::Response, SfError> {
+    let result_url = get_result_url.to_string();
+    let session = session_token.to_string();
+    let build = move || {
+        client
+            .get(result_url.clone())
+            .header("Authorization", format!("Snowflake Token=\"{session}\""))
+            .header("Accept", "application/json")
     };
-    let resp = match execute_with_retry(client, build, &ctx, policy, |r| async move { Ok(r) }).await
-    {
-        Ok(r) => r,
-        Err(crate::http::retry::HttpError::Transport(source)) => {
-            return Err(SfError::Transport {
-                source,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-        Err(crate::http::retry::HttpError::DeadlineExceeded) => {
-            return Err(SfError::DeadlineExceeded {
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-        Err(crate::http::retry::HttpError::HttpStatus { status, .. }) => {
-            return Err(SfError::HttpStatus {
-                status,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-    };
+    let ctx = HttpContext::new(Method::GET, get_result_url.to_string());
+    let resp = execute_with_retry(build, &ctx, policy, |r| async move { Ok(r) })
+        .await
+        .map_err(map_http_error)?;
     let status = resp.status();
     if !status.is_success() {
-        return Err(SfError::HttpStatus {
-            status,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        });
+        return Err(http_status_error(status));
     }
-    let body_text = resp.text().await.map_err(|source| SfError::Transport {
-        source,
-        location: snafu::Location::new(file!(), line!(), column!()),
-    })?;
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|source| transport_error(source))?;
     let parsed: query_response::Response =
-        serde_json::from_str(&body_text).map_err(|source| SfError::BodyParse {
-            source,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        })?;
-    if parsed.success {
-        Ok((PollState::Success, parsed))
-    } else {
-        Ok((PollState::Failure, parsed))
-    }
+        serde_json::from_str(&body_text).map_err(|source| body_parse_error(source))?;
+    debug!(
+        success = parsed.success,
+        rowset_present = parsed.data.rowset.is_some(),
+        rowset_base64_present = parsed.data.rowset_base64.is_some(),
+        chunks = parsed
+            .data
+            .chunks
+            .as_ref()
+            .map(|c| c.len())
+            .unwrap_or_default(),
+        message = parsed.message.as_deref().unwrap_or_default(),
+        "polled query status"
+    );
+    Ok(parsed)
 }
 
 pub async fn execute_blocking_with_async(
@@ -189,22 +173,98 @@ pub async fn execute_blocking_with_async(
     )
     .await?;
 
-    // Inline short-poll
-    let start = Instant::now();
-    for d in &policy.inline_short_poll.delays {
-        if start.elapsed() > policy.inline_short_poll.budget {
-            break;
-        }
-        if d.as_millis() > 0 {
-            tokio::time::sleep(*d).await;
-        }
-        // If get_result_url existed we'd poll it; for now assume success response is terminal
-        if submitted.response.success {
-            return Ok(submitted.response);
-        }
+    let SubmitOk {
+        query_id,
+        get_result_url,
+        mut response,
+    } = submitted;
+
+    if should_poll_for_completion(&response) {
+        let result_url = get_result_url
+            .as_deref()
+            .ok_or_else(|| SfError::MissingResultUrl {
+                location: current_location(),
+            })?;
+        response = wait_for_completion(client, session_token, result_url, policy).await?;
     }
 
-    Ok(submitted.response)
+    let resolved_query_id =
+        response
+            .data
+            .query_id
+            .clone()
+            .or(query_id)
+            .ok_or_else(|| SfError::MissingQueryId {
+                location: current_location(),
+            })?;
+    REQUEST_TO_QUERY.insert(request_id, resolved_query_id);
+
+    Ok(response)
+}
+
+#[track_caller]
+fn current_location() -> Location {
+    let caller = StdLocation::caller();
+    Location::new(caller.file(), caller.line(), caller.column())
+}
+
+#[track_caller]
+fn map_http_error(err: HttpError) -> SfError {
+    let location = current_location();
+    match err {
+        HttpError::Transport { source, .. } => SfError::Transport { source, location },
+        HttpError::DeadlineExceeded {
+            configured,
+            elapsed,
+            ..
+        } => SfError::DeadlineExceeded {
+            configured,
+            elapsed,
+            location,
+        },
+        HttpError::MaxAttempts {
+            attempts,
+            last_status,
+            ..
+        } => SfError::RetryAttemptsExhausted {
+            attempts,
+            last_status,
+            location,
+        },
+        HttpError::RetryAfterExceeded {
+            retry_after,
+            remaining,
+            ..
+        } => SfError::RetryBudgetExceeded {
+            retry_after,
+            remaining,
+            location,
+        },
+    }
+}
+
+#[track_caller]
+fn transport_error(source: reqwest::Error) -> SfError {
+    SfError::Transport {
+        source,
+        location: current_location(),
+    }
+}
+
+#[track_caller]
+fn body_parse_error(source: serde_json::Error) -> SfError {
+    SfError::BodyParse {
+        source,
+        location: current_location(),
+    }
+}
+
+#[track_caller]
+fn http_status_error(status: StatusCode) -> SfError {
+    SfError::HttpStatus {
+        status,
+        location: current_location(),
+    }
 }
 
 static REQUEST_TO_QUERY: Lazy<RequestQueryMap> = Lazy::new(RequestQueryMap::default);
@@ -226,12 +286,154 @@ impl RequestQueryMap {
 
 pub async fn refresh_chunk_download_data_from_get_result(
     client: &reqwest::Client,
+    session_token: &str,
     get_result_url: &str,
     policy: &RetryPolicy,
 ) -> Result<Option<Vec<ChunkDownloadData>>, SfError> {
-    let (state, resp) = poll_query_status(client, get_result_url, policy).await?;
-    match state {
-        PollState::Success => Ok(resp.data.to_chunk_download_data()),
-        _ => Ok(None),
+    let resp = poll_query_status(client, session_token, get_result_url, policy).await?;
+    if resp.success {
+        Ok(resp.data.to_chunk_download_data())
+    } else {
+        Ok(None)
     }
+}
+
+fn normalize_get_result_url(base: &str, url: &str) -> Result<String, SfError> {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        return Ok(url.to_string());
+    }
+    let base_url = Url::parse(base).map_err(|source| SfError::ResultUrlParse {
+        url: base.to_string(),
+        source,
+        location: current_location(),
+    })?;
+    let joined = base_url
+        .join(url)
+        .map_err(|source| SfError::ResultUrlParse {
+            url: url.to_string(),
+            source,
+            location: current_location(),
+        })?;
+    Ok(joined.to_string())
+}
+
+fn should_poll_for_completion(resp: &query_response::Response) -> bool {
+    !resp.success || (resp.data.get_result_url.is_some() && !response_has_tabular_data(resp))
+}
+
+fn response_has_tabular_data(resp: &query_response::Response) -> bool {
+    resp.data.rowset.is_some()
+        || resp.data.rowset_base64.is_some()
+        || resp
+            .data
+            .chunks
+            .as_ref()
+            .map(|c| !c.is_empty())
+            .unwrap_or(false)
+}
+
+async fn wait_for_completion(
+    client: &reqwest::Client,
+    session_token: &str,
+    result_url: &str,
+    policy: &RetryPolicy,
+) -> Result<query_response::Response, SfError> {
+    let start = Instant::now();
+    let mut attempt: usize = 0;
+    let mut sleep_ms = policy.backoff.base.as_millis() as f64;
+
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= policy.max_elapsed {
+            return Err(SfError::DeadlineExceeded {
+                configured: policy.max_elapsed,
+                elapsed,
+                location: current_location(),
+            });
+        }
+
+        let delay = if attempt < INLINE_SHORT_POLL_DELAYS.len() {
+            INLINE_SHORT_POLL_DELAYS[attempt]
+        } else {
+            sleep_ms = next_poll_delay_ms(sleep_ms, &policy.backoff);
+            Duration::from_millis(sleep_ms as u64)
+        };
+        attempt += 1;
+
+        let elapsed = start.elapsed();
+        if elapsed + delay >= policy.max_elapsed {
+            return Err(SfError::DeadlineExceeded {
+                configured: policy.max_elapsed,
+                elapsed,
+                location: current_location(),
+            });
+        }
+
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+
+        let remaining = policy.max_elapsed - start.elapsed();
+        if remaining <= Duration::from_millis(0) {
+            return Err(SfError::DeadlineExceeded {
+                configured: policy.max_elapsed,
+                elapsed: start.elapsed(),
+                location: current_location(),
+            });
+        }
+
+        let mut poll_policy = policy.clone();
+        poll_policy.max_elapsed = remaining;
+        let response = poll_query_status(client, session_token, result_url, &poll_policy).await?;
+
+        if response.success {
+            if should_continue_after_success(&response) {
+                continue;
+            }
+            return Ok(response);
+        } else if should_continue_after_failure(&response) {
+            continue;
+        } else {
+            return Err(snowflake_failure(&response));
+        }
+    }
+}
+
+fn should_continue_after_success(resp: &query_response::Response) -> bool {
+    resp.data.get_result_url.is_some() && !response_has_tabular_data(resp)
+}
+
+fn should_continue_after_failure(resp: &query_response::Response) -> bool {
+    resp.data.get_result_url.is_some()
+}
+
+fn snowflake_failure(resp: &query_response::Response) -> SfError {
+    let code = resp
+        .code
+        .as_deref()
+        .and_then(|c| c.parse::<i32>().ok())
+        .unwrap_or(-1);
+    let message = resp
+        .message
+        .clone()
+        .unwrap_or_else(|| "Snowflake reported failure".to_string());
+    SfError::SnowflakeBody {
+        code,
+        message,
+        location: current_location(),
+    }
+}
+
+fn next_poll_delay_ms(prev_ms: f64, backoff: &BackoffConfig) -> f64 {
+    let base = backoff.base.as_millis() as f64;
+    let mut next = if prev_ms <= 0.0 {
+        base
+    } else {
+        prev_ms.max(base) * backoff.factor
+    };
+    let cap = backoff.cap.as_millis() as f64;
+    if next > cap {
+        next = cap;
+    }
+    next
 }

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -3,12 +3,9 @@ use crate::config::retry::{BackoffConfig, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::{query_request, query_response};
-use once_cell::sync::Lazy;
 use reqwest::{Method, StatusCode};
 use snafu::Location;
-use std::collections::HashMap;
 use std::panic::Location as StdLocation;
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tracing::debug;
 use url::Url;
@@ -188,16 +185,14 @@ pub async fn execute_blocking_with_async(
         response = wait_for_completion(client, session_token, result_url, policy).await?;
     }
 
-    let resolved_query_id =
-        response
-            .data
-            .query_id
-            .clone()
-            .or(query_id)
-            .ok_or_else(|| SfError::MissingQueryId {
-                location: current_location(),
-            })?;
-    REQUEST_TO_QUERY.insert(request_id, resolved_query_id);
+    response
+        .data
+        .query_id
+        .clone()
+        .or(query_id)
+        .ok_or_else(|| SfError::MissingQueryId {
+            location: current_location(),
+        })?;
 
     Ok(response)
 }
@@ -267,23 +262,6 @@ fn http_status_error(status: StatusCode) -> SfError {
     }
 }
 
-static REQUEST_TO_QUERY: Lazy<RequestQueryMap> = Lazy::new(RequestQueryMap::default);
-
-#[derive(Default)]
-struct RequestQueryMap(Mutex<HashMap<uuid::Uuid, String>>);
-
-impl RequestQueryMap {
-    fn insert(&self, rid: uuid::Uuid, qid: String) {
-        if let Ok(mut g) = self.0.lock() {
-            g.insert(rid, qid);
-        }
-    }
-    #[allow(dead_code)]
-    fn get(&self, rid: &uuid::Uuid) -> Option<String> {
-        self.0.lock().ok().and_then(|g| g.get(rid).cloned())
-    }
-}
-
 pub async fn refresh_chunk_download_data_from_get_result(
     client: &reqwest::Client,
     session_token: &str,
@@ -318,7 +296,10 @@ fn normalize_get_result_url(base: &str, url: &str) -> Result<String, SfError> {
 }
 
 fn should_poll_for_completion(resp: &query_response::Response) -> bool {
-    !resp.success || (resp.data.get_result_url.is_some() && !response_has_tabular_data(resp))
+    resp.data
+        .get_result_url
+        .as_ref()
+        .is_some_and(|_| !response_has_tabular_data(resp))
 }
 
 fn response_has_tabular_data(resp: &query_response::Response) -> bool {
@@ -332,6 +313,12 @@ fn response_has_tabular_data(resp: &query_response::Response) -> bool {
             .unwrap_or(false)
 }
 
+/// Poll Snowflake for completion, starting with a burst of short delays
+/// and then degrading into retry-policy-driven exponential backoff.
+/// Each HTTP poll flows through the shared retry helper so transport
+/// or retryable status failures are retried automatically. We stop
+/// polling once tabular data arrives, Snowflake returns a terminal
+/// error, or the overall deadline / retry budget is exhausted.
 async fn wait_for_completion(
     client: &reqwest::Client,
     session_token: &str,
@@ -373,11 +360,20 @@ async fn wait_for_completion(
             tokio::time::sleep(delay).await;
         }
 
-        let remaining = policy.max_elapsed - start.elapsed();
-        if remaining <= Duration::from_millis(0) {
+        let elapsed_after_sleep = start.elapsed();
+        let remaining = policy
+            .max_elapsed
+            .checked_sub(elapsed_after_sleep)
+            .ok_or_else(|| SfError::DeadlineExceeded {
+                configured: policy.max_elapsed,
+                elapsed: elapsed_after_sleep,
+                location: current_location(),
+            })?;
+
+        if remaining.is_zero() {
             return Err(SfError::DeadlineExceeded {
                 configured: policy.max_elapsed,
-                elapsed: start.elapsed(),
+                elapsed: elapsed_after_sleep,
                 location: current_location(),
             });
         }
@@ -436,4 +432,42 @@ fn next_poll_delay_ms(prev_ms: f64, backoff: &BackoffConfig) -> f64 {
         next = cap;
     }
     next
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn response_from_json(value: serde_json::Value) -> query_response::Response {
+        serde_json::from_value(value).expect("valid response JSON")
+    }
+
+    #[test]
+    fn should_not_poll_when_failure_has_no_result_url() {
+        let resp = response_from_json(json!({
+            "success": false,
+            "data": {
+                "rowset": null,
+                "rowsetBase64": null
+            }
+        }));
+
+        assert!(!should_poll_for_completion(&resp));
+    }
+
+    #[test]
+    fn should_poll_when_result_url_present_and_no_data() {
+        let resp = response_from_json(json!({
+            "success": true,
+            "data": {
+                "getResultUrl": "https://example.test",
+                "rowset": null,
+                "rowsetBase64": null,
+                "chunks": null
+            }
+        }));
+
+        assert!(should_poll_for_completion(&resp));
+    }
 }

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -13,10 +13,10 @@ use tracing::debug;
 use url::Url;
 
 const INLINE_SHORT_POLL_DELAYS: &[Duration] = &[
-    Duration::from_millis(0),
-    Duration::from_millis(50),
-    Duration::from_millis(125),
-    Duration::from_millis(250),
+    Duration::from_millis(5),
+    Duration::from_millis(10),
+    Duration::from_millis(20),
+    Duration::from_millis(40),
 ];
 const QUERY_REQUEST_PATH: &str = "/queries/v1/query-request";
 const JSON_MIME: &str = "application/json";
@@ -230,7 +230,14 @@ pub async fn execute_blocking_with_async(
             .ok_or_else(|| SfError::MissingResultUrl {
                 location: current_location(),
             })?;
-        response = wait_for_completion(client, session_token, result_url, policy).await?;
+
+        if let Some(inline) =
+            inline_poll_for_completion(client, session_token, result_url, policy).await?
+        {
+            response = inline;
+        } else {
+            response = wait_for_completion(client, session_token, result_url, policy).await?;
+        }
     }
 
     response
@@ -361,6 +368,16 @@ fn response_has_tabular_data(resp: &query_response::Response) -> bool {
             .unwrap_or(false)
 }
 
+async fn inline_poll_for_completion(
+    client: &reqwest::Client,
+    session_token: &str,
+    result_url: &str,
+    policy: &RetryPolicy,
+) -> Result<Option<query_response::Response>, SfError> {
+    let response = poll_query_status(client, session_token, result_url, policy).await?;
+    handle_poll_response(response)
+}
+
 /// Poll Snowflake for completion, starting with a burst of short delays
 /// and then degrading into retry-policy-driven exponential backoff.
 /// Each HTTP poll flows through the shared retry helper so transport
@@ -395,50 +412,39 @@ async fn wait_for_completion(
         };
         attempt += 1;
 
-        let elapsed = start.elapsed();
-        if elapsed + delay >= policy.max_elapsed {
-            return Err(SfError::DeadlineExceeded {
-                configured: policy.max_elapsed,
-                elapsed,
-                location: current_location(),
-            });
-        }
-
         if !delay.is_zero() {
+            let sleep_deadline = start.elapsed() + delay;
+            if sleep_deadline >= policy.max_elapsed {
+                return Err(SfError::DeadlineExceeded {
+                    configured: policy.max_elapsed,
+                    elapsed,
+                    location: current_location(),
+                });
+            }
             tokio::time::sleep(delay).await;
         }
 
         let elapsed_after_sleep = start.elapsed();
-        let remaining = policy
-            .max_elapsed
-            .checked_sub(elapsed_after_sleep)
-            .ok_or_else(|| SfError::DeadlineExceeded {
-                configured: policy.max_elapsed,
-                elapsed: elapsed_after_sleep,
-                location: current_location(),
-            })?;
-
-        if remaining.is_zero() {
+        if elapsed_after_sleep >= policy.max_elapsed {
             return Err(SfError::DeadlineExceeded {
                 configured: policy.max_elapsed,
                 elapsed: elapsed_after_sleep,
                 location: current_location(),
             });
         }
+
+        let remaining = policy
+            .max_elapsed
+            .checked_sub(elapsed_after_sleep)
+            .unwrap_or_default()
+            .max(Duration::from_millis(1));
 
         let mut poll_policy = policy.clone();
         poll_policy.max_elapsed = remaining;
         let response = poll_query_status(client, session_token, result_url, &poll_policy).await?;
 
-        if response.success {
-            if should_continue_after_success(&response) {
-                continue;
-            }
-            return Ok(response);
-        } else if should_continue_after_failure(&response) {
-            continue;
-        } else {
-            return Err(snowflake_failure(&response));
+        if let Some(done) = handle_poll_response(response)? {
+            return Ok(done);
         }
     }
 }
@@ -480,6 +486,23 @@ fn next_poll_delay_ms(prev_ms: f64, backoff: &BackoffConfig) -> f64 {
         next = cap;
     }
     next
+}
+
+fn handle_poll_response(
+    resp: query_response::Response,
+) -> Result<Option<query_response::Response>, SfError> {
+    if resp.success {
+        if should_continue_after_success(&resp) {
+            return Ok(None);
+        }
+        return Ok(Some(resp));
+    }
+
+    if should_continue_after_failure(&resp) {
+        return Ok(None);
+    }
+
+    Err(snowflake_failure(&resp))
 }
 
 #[cfg(test)]

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -3,8 +3,10 @@ use crate::config::retry::{BackoffConfig, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::{query_request, query_response};
+use reqwest::header;
 use reqwest::{Method, StatusCode};
 use snafu::Location;
+use std::collections::HashMap;
 use std::panic::Location as StdLocation;
 use std::time::{Duration, Instant};
 use tracing::debug;
@@ -16,63 +18,79 @@ const INLINE_SHORT_POLL_DELAYS: &[Duration] = &[
     Duration::from_millis(125),
     Duration::from_millis(250),
 ];
+const QUERY_REQUEST_PATH: &str = "/queries/v1/query-request";
+const JSON_MIME: &str = "application/json";
+const QUERY_SEQUENCE_ID: u64 = 1;
+
+fn join_server_path(server_url: &str, path: &str) -> Result<String, SfError> {
+    Url::parse(server_url)
+        .and_then(|base| base.join(path))
+        .map(|joined| joined.to_string())
+        .map_err(|source| SfError::ResultUrlParse {
+            url: format!("{server_url}{path}"),
+            source,
+            location: current_location(),
+        })
+}
 pub struct SubmitOk {
     pub query_id: Option<String>,
     pub get_result_url: Option<String>,
     pub response: query_response::Response,
 }
 
-pub async fn submit_statement_async(
-    client: &reqwest::Client,
-    server_url: &str,
-    session_token: &str,
+fn build_async_query_request(
     sql: String,
-    parameter_bindings: Option<std::collections::HashMap<String, query_request::BindParameter>>,
-    request_id: uuid::Uuid,
-    policy: &RetryPolicy,
-) -> Result<SubmitOk, SfError> {
-    let query_url = format!("{server_url}/queries/v1/query-request");
-
-    let query_request = query_request::Request {
+    parameter_bindings: Option<&HashMap<String, query_request::BindParameter>>,
+) -> query_request::Request {
+    query_request::Request {
         sql_text: sql,
         async_exec: true,
-        sequence_id: 1,
-        query_submission_time: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64,
+        sequence_id: QUERY_SEQUENCE_ID,
+        query_submission_time: current_epoch_millis(),
         is_internal: false,
         describe_only: None,
         parameters: None,
-        bindings: parameter_bindings,
+        bindings: parameter_bindings.cloned(),
         bind_stage: None,
         query_context: query_request::QueryContext { entries: None },
-    };
+    }
+}
 
-    let build = || {
-        client
-            .post(&query_url)
-            .header(
-                "Authorization",
-                format!("Snowflake Token=\"{session_token}\""),
-            )
-            .header("Accept", "application/json")
-            .query(&[("requestId", request_id.to_string())])
-            .json(&query_request)
-    };
+fn build_submit_request(
+    client: &reqwest::Client,
+    endpoint: &str,
+    session_token: &str,
+    request_id: uuid::Uuid,
+    payload: &query_request::Request,
+) -> reqwest::RequestBuilder {
+    let auth_header = authorization_header(session_token);
+    client
+        .post(endpoint)
+        .header(header::AUTHORIZATION, auth_header)
+        .header(header::ACCEPT, header::HeaderValue::from_static(JSON_MIME))
+        .header(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static(JSON_MIME),
+        )
+        .query(&[("requestId", request_id.to_string())])
+        .json(payload)
+}
 
-    let ctx = HttpContext::new(Method::POST, "/queries/v1/query-request").allow_post_retry();
+fn authorization_header(session_token: &str) -> header::HeaderValue {
+    let value = format!("Snowflake Token=\"{session_token}\"");
+    header::HeaderValue::from_str(&value).expect("authorization header construction must succeed")
+}
 
-    let resp = execute_with_retry(build, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .map_err(map_http_error)?;
-
-    let status = resp.status();
+async fn parse_submit_response(
+    server_url: &str,
+    response: reqwest::Response,
+) -> Result<SubmitOk, SfError> {
+    let status = response.status();
     if !status.is_success() {
         return Err(http_status_error(status));
     }
 
-    let body_text = resp
+    let body_text = response
         .text()
         .await
         .map_err(|source| transport_error(source))?;
@@ -106,6 +124,35 @@ pub async fn submit_statement_async(
     })
 }
 
+fn current_epoch_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+pub async fn submit_statement_async(
+    client: &reqwest::Client,
+    server_url: &str,
+    session_token: &str,
+    sql: String,
+    parameter_bindings: Option<&HashMap<String, query_request::BindParameter>>,
+    request_id: uuid::Uuid,
+    policy: &RetryPolicy,
+) -> Result<SubmitOk, SfError> {
+    let endpoint = join_server_path(server_url, QUERY_REQUEST_PATH)?;
+    let request_body = build_async_query_request(sql, parameter_bindings);
+    let submit_request =
+        || build_submit_request(client, &endpoint, session_token, request_id, &request_body);
+
+    let ctx = HttpContext::new(Method::POST, QUERY_REQUEST_PATH).allow_post_retry();
+    let response = execute_with_retry(submit_request, &ctx, policy, |r| async move { Ok(r) })
+        .await
+        .map_err(map_http_error)?;
+
+    parse_submit_response(server_url, response).await
+}
+
 pub async fn poll_query_status(
     client: &reqwest::Client,
     session_token: &str,
@@ -114,21 +161,22 @@ pub async fn poll_query_status(
 ) -> Result<query_response::Response, SfError> {
     let result_url = get_result_url.to_string();
     let session = session_token.to_string();
-    let build = move || {
+    let auth_header = authorization_header(&session);
+    let poll_request = move || {
         client
             .get(result_url.clone())
-            .header("Authorization", format!("Snowflake Token=\"{session}\""))
-            .header("Accept", "application/json")
+            .header(header::AUTHORIZATION, auth_header.clone())
+            .header(header::ACCEPT, header::HeaderValue::from_static(JSON_MIME))
     };
     let ctx = HttpContext::new(Method::GET, get_result_url.to_string());
-    let resp = execute_with_retry(build, &ctx, policy, |r| async move { Ok(r) })
+    let response = execute_with_retry(poll_request, &ctx, policy, |r| async move { Ok(r) })
         .await
         .map_err(map_http_error)?;
-    let status = resp.status();
+    let status = response.status();
     if !status.is_success() {
         return Err(http_status_error(status));
     }
-    let body_text = resp
+    let body_text = response
         .text()
         .await
         .map_err(|source| transport_error(source))?;
@@ -155,7 +203,7 @@ pub async fn execute_blocking_with_async(
     server_url: &str,
     session_token: &str,
     sql: String,
-    parameter_bindings: Option<std::collections::HashMap<String, query_request::BindParameter>>,
+    parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
     request_id: uuid::Uuid,
     policy: &RetryPolicy,
 ) -> Result<query_response::Response, SfError> {
@@ -164,7 +212,7 @@ pub async fn execute_blocking_with_async(
         server_url,
         session_token,
         sql,
-        parameter_bindings,
+        parameter_bindings.as_ref(),
         request_id,
         policy,
     )

--- a/sf_core/src/rest/snowflake/error.rs
+++ b/sf_core/src/rest/snowflake/error.rs
@@ -1,5 +1,7 @@
 use reqwest::StatusCode;
 use snafu::{Location, Snafu};
+use std::time::Duration;
+use url::ParseError;
 
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
@@ -33,8 +35,43 @@ pub enum SfError {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Deadline exceeded"))]
+    #[snafu(display("Deadline exceeded after {elapsed:?} (budget {configured:?})"))]
     DeadlineExceeded {
+        configured: Duration,
+        elapsed: Duration,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display(
+        "Retry attempts exhausted after {attempts} attempts; last status {last_status}"
+    ))]
+    RetryAttemptsExhausted {
+        attempts: u32,
+        last_status: StatusCode,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Retry-After {retry_after:?} exceeds remaining budget {remaining:?}"))]
+    RetryBudgetExceeded {
+        retry_after: Duration,
+        remaining: Duration,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Async query response missing getResultUrl; cannot poll for completion"))]
+    MissingResultUrl {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Async query did not report a queryId"))]
+    MissingQueryId {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse getResultUrl: {url}"))]
+    ResultUrlParse {
+        url: String,
+        source: ParseError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/rest/snowflake/error.rs
+++ b/sf_core/src/rest/snowflake/error.rs
@@ -1,0 +1,54 @@
+use reqwest::StatusCode;
+use snafu::{Location, Snafu};
+
+#[derive(Snafu, Debug)]
+#[snafu(visibility(pub))]
+pub enum SfError {
+    #[snafu(display("Transport error communicating with Snowflake"))]
+    Transport {
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("HTTP status error: {status}"))]
+    HttpStatus {
+        status: StatusCode,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Snowflake error {code}: {message}"))]
+    SnowflakeBody {
+        code: i32,
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Session expired"))]
+    SessionExpired {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Warehouse resuming or queued"))]
+    WarehouseResuming {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Deadline exceeded"))]
+    DeadlineExceeded {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse response body"))]
+    BodyParse {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+// Intentionally no From<reqwest::Error> to force explicit location on construction

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -14,14 +14,16 @@ use crate::rest::snowflake::auth::{
 use crate::rest::snowflake::error::SfError;
 use crate::tls::client::create_tls_client_with_config;
 use crate::tls::error::TlsError;
-use reqwest;
+use reqwest::{self, header};
 use serde_json;
 use snafu::{Location, ResultExt, Snafu};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing;
+use url::Url;
 
 pub const STATEMENT_ASYNC_EXECUTION_OPTION: &str = "async_execution";
+pub(crate) const QUERY_REQUEST_PATH: &str = "/queries/v1/query-request";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum QueryExecutionMode {
@@ -220,16 +222,13 @@ pub async fn snowflake_query_with_client(
     if matches!(execution_mode, QueryExecutionMode::Async) {
         return snowflake_query_async_style(
             client,
-            query_parameters,
+            &query_parameters,
             session_token,
             sql,
             parameter_bindings,
         )
         .await;
     }
-    // Legacy synchronous path retained. A new async-backed blocking facade is provided below.
-    let server_url = query_parameters.server_url;
-    let query_url = format!("{server_url}/queries/v1/query-request");
 
     let query_request = query_request::Request {
         sql_text: sql,
@@ -249,21 +248,24 @@ pub async fn snowflake_query_with_client(
 
     let json_payload = serde_json::to_string_pretty(&query_request).unwrap();
     tracing::debug!("JSON Body Sent:\n{}", json_payload);
-    let request = client
-        .post(&query_url)
-        .header(
-            "Authorization",
-            &format!("Snowflake Token=\"{session_token}\""),
-        )
-        .header("Accept", "application/json")
-        .header("User-Agent", user_agent(&query_parameters.client_info))
-        .query(&[
-            ("requestId", uuid::Uuid::new_v4().to_string()),
-            ("request_guid", uuid::Uuid::new_v4().to_string()),
-        ])
-        .json(&query_request)
-        .build()
-        .context(RequestConstructionSnafu { request: "query" })?;
+    let query_url = Url::parse(query_parameters.server_url.as_str())
+        .and_then(|base| base.join(QUERY_REQUEST_PATH))
+        .context(UrlJoinSnafu {
+            path: QUERY_REQUEST_PATH,
+        })?;
+
+    let request = apply_json_content_type(apply_query_headers(
+        client.post(query_url),
+        &query_parameters.client_info,
+        &session_token,
+    ))
+    .query(&[
+        ("requestId", uuid::Uuid::new_v4().to_string()),
+        ("request_guid", uuid::Uuid::new_v4().to_string()),
+    ])
+    .json(&query_request)
+    .build()
+    .context(RequestConstructionSnafu { request: "query" })?;
 
     tracing::debug!("Query request: {:?}", request);
     tracing::debug!("Request headers: {:?}", request.headers());
@@ -302,7 +304,7 @@ pub async fn snowflake_query_with_client(
 )]
 pub async fn snowflake_query_async_style(
     client: &reqwest::Client,
-    query_parameters: QueryParameters,
+    query_parameters: &QueryParameters,
     session_token: String,
     sql: String,
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
@@ -311,7 +313,7 @@ pub async fn snowflake_query_async_style(
     let policy = crate::config::retry::RetryPolicy::default();
     crate::rest::snowflake::async_exec::execute_blocking_with_async(
         client,
-        &query_parameters.server_url,
+        query_parameters,
         &session_token,
         sql,
         parameter_bindings,
@@ -348,6 +350,30 @@ where
 #[track_caller]
 fn build_tls_http_client(client_info: &ClientInfo) -> Result<reqwest::Client, RestError> {
     create_tls_client_with_config(client_info.tls_config.clone()).context(CrlValidationSnafu)
+}
+
+pub(crate) fn authorization_header(session_token: &str) -> header::HeaderValue {
+    let value = format!("Snowflake Token=\"{session_token}\"");
+    header::HeaderValue::from_str(&value).expect("authorization header construction must succeed")
+}
+
+pub(crate) fn json_header_value() -> header::HeaderValue {
+    header::HeaderValue::from_static("application/json")
+}
+
+pub(crate) fn apply_query_headers(
+    builder: reqwest::RequestBuilder,
+    client_info: &ClientInfo,
+    session_token: &str,
+) -> reqwest::RequestBuilder {
+    builder
+        .header(header::AUTHORIZATION, authorization_header(session_token))
+        .header(header::ACCEPT, json_header_value())
+        .header("User-Agent", user_agent(client_info))
+}
+
+pub(crate) fn apply_json_content_type(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    builder.header(header::CONTENT_TYPE, json_header_value())
 }
 
 #[derive(Debug, Snafu)]
@@ -394,6 +420,13 @@ pub enum RestError {
     #[snafu(display("Async Snowflake query failed"))]
     AsyncQuery {
         source: SfError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to build Snowflake URL for {path}: {source}"))]
+    UrlJoin {
+        path: &'static str,
+        source: url::ParseError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1,4 +1,6 @@
+pub mod async_exec;
 mod auth;
+pub mod error;
 pub mod query_request;
 pub mod query_response;
 
@@ -201,6 +203,20 @@ pub async fn snowflake_query_with_client(
     sql: String,
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
 ) -> Result<query_response::Response, RestError> {
+    if std::env::var("SF_USE_ASYNC_ENGINE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return snowflake_query_async_style(
+            client,
+            query_parameters,
+            session_token,
+            sql,
+            parameter_bindings,
+        )
+        .await;
+    }
+    // Legacy synchronous path retained. A new async-backed blocking facade is provided below.
     let server_url = query_parameters.server_url;
     let query_url = format!("{server_url}/queries/v1/query-request");
 
@@ -266,6 +282,39 @@ pub async fn snowflake_query_with_client(
     } else {
         Ok(query_response)
     }
+}
+
+/// New blocking facade that uses the async engine under the hood.
+#[tracing::instrument(
+    skip(client, query_parameters, session_token, parameter_bindings),
+    fields(sql)
+)]
+pub async fn snowflake_query_async_style(
+    client: &reqwest::Client,
+    query_parameters: QueryParameters,
+    session_token: String,
+    sql: String,
+    parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
+) -> Result<query_response::Response, RestError> {
+    let request_id = uuid::Uuid::new_v4();
+    let policy = crate::config::retry::RetryPolicy::default();
+    crate::rest::snowflake::async_exec::execute_blocking_with_async(
+        client,
+        &query_parameters.server_url,
+        &session_token,
+        sql,
+        parameter_bindings,
+        request_id,
+        &policy,
+    )
+    .await
+    .map_err(|e| RestError::InvalidSnowflakeResponse {
+        source: SnowflakeResponseError::InvalidResponse {
+            message: format!("{e:?}"),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        },
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })
 }
 
 async fn read_response_json<T>(response: reqwest::Response) -> Result<T, SnowflakeResponseError>

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -18,6 +18,14 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing;
 
+pub const STATEMENT_ASYNC_EXECUTION_OPTION: &str = "async_execution";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueryExecutionMode {
+    Blocking,
+    Async,
+}
+
 pub fn user_agent(client_info: &ClientInfo) -> String {
     format!(
         "{}/{} ({}) CPython/3.11.6",
@@ -180,6 +188,7 @@ pub async fn snowflake_query(
     session_token: String,
     sql: String,
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
+    execution_mode: QueryExecutionMode,
 ) -> Result<query_response::Response, RestError> {
     let client = reqwest::Client::new();
     snowflake_query_with_client(
@@ -188,6 +197,7 @@ pub async fn snowflake_query(
         session_token,
         sql,
         parameter_bindings,
+        execution_mode,
     )
     .await
 }
@@ -202,11 +212,9 @@ pub async fn snowflake_query_with_client(
     session_token: String,
     sql: String,
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
+    execution_mode: QueryExecutionMode,
 ) -> Result<query_response::Response, RestError> {
-    if std::env::var("SF_USE_ASYNC_ENGINE")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-    {
+    if matches!(execution_mode, QueryExecutionMode::Async) {
         return snowflake_query_async_style(
             client,
             query_parameters,

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -10,6 +10,7 @@ use crate::config::rest_parameters::{LoginParameters, QueryParameters};
 use crate::rest::snowflake::auth::{
     AuthRequest, AuthRequestClientEnvironment, AuthRequestData, AuthResponse,
 };
+use crate::rest::snowflake::error::SfError;
 use crate::tls::error::TlsError;
 use reqwest;
 use serde_json;
@@ -316,13 +317,7 @@ pub async fn snowflake_query_async_style(
         &policy,
     )
     .await
-    .map_err(|e| RestError::InvalidSnowflakeResponse {
-        source: SnowflakeResponseError::InvalidResponse {
-            message: format!("{e:?}"),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        },
-        location: snafu::Location::new(file!(), line!(), column!()),
-    })
+    .context(AsyncQuerySnafu)
 }
 
 async fn read_response_json<T>(response: reqwest::Response) -> Result<T, SnowflakeResponseError>
@@ -386,6 +381,12 @@ pub enum RestError {
     LoginError {
         message: String,
         code: i32,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Async Snowflake query failed"))]
+    AsyncQuery {
+        source: SfError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 pub mod async_exec;
 mod auth;
 pub mod error;
@@ -11,6 +12,7 @@ use crate::rest::snowflake::auth::{
     AuthRequest, AuthRequestClientEnvironment, AuthRequestData, AuthResponse,
 };
 use crate::rest::snowflake::error::SfError;
+use crate::tls::client::create_tls_client_with_config;
 use crate::tls::error::TlsError;
 use reqwest;
 use serde_json;
@@ -75,7 +77,7 @@ pub fn auth_request_data(login_parameters: &LoginParameters) -> Result<AuthReque
 
 #[tracing::instrument(skip(login_parameters), fields(account_name, login_name))]
 pub async fn snowflake_login(login_parameters: &LoginParameters) -> Result<String, RestError> {
-    let client = reqwest::Client::new();
+    let client = build_tls_http_client(&login_parameters.client_info)?;
     snowflake_login_with_client(&client, login_parameters).await
 }
 
@@ -191,7 +193,7 @@ pub async fn snowflake_query(
     parameter_bindings: Option<HashMap<String, query_request::BindParameter>>,
     execution_mode: QueryExecutionMode,
 ) -> Result<query_response::Response, RestError> {
-    let client = reqwest::Client::new();
+    let client = build_tls_http_client(&query_parameters.client_info)?;
     snowflake_query_with_client(
         &client,
         query_parameters,
@@ -343,6 +345,11 @@ where
     Ok(response_data)
 }
 
+#[track_caller]
+fn build_tls_http_client(client_info: &ClientInfo) -> Result<reqwest::Client, RestError> {
+    create_tls_client_with_config(client_info.tls_config.clone()).context(CrlValidationSnafu)
+}
+
 #[derive(Debug, Snafu)]
 pub enum RestError {
     #[snafu(display("Authentication failed"))]
@@ -373,7 +380,7 @@ pub enum RestError {
     },
     #[snafu(display("TLS client creation failed"))]
     CrlValidation {
-        source: Box<TlsError>,
+        source: TlsError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -12,7 +12,7 @@ pub struct Response {
     #[serde(rename = "message")]
     pub message: Option<String>,
     #[serde(rename = "code")]
-    _code: Option<String>,
+    pub code: Option<String>,
     #[serde(rename = "success")]
     pub success: bool,
 }
@@ -46,7 +46,7 @@ pub struct Data {
 
     // chunked query results
     #[serde(rename = "chunks")]
-    chunks: Option<Vec<Chunk>>,
+    pub chunks: Option<Vec<Chunk>>,
     #[serde(rename = "qrmk")]
     _qrmk: Option<String>,
     #[serde(rename = "chunkHeaders")]
@@ -60,7 +60,7 @@ pub struct Data {
     #[serde(rename = "returned")]
     _returned: Option<i64>,
     #[serde(rename = "queryId")]
-    _query_id: Option<String>,
+    pub query_id: Option<String>,
     #[serde(rename = "sqlState")]
     _sql_state: Option<String>,
     #[serde(rename = "databaseProvider")]
@@ -80,7 +80,7 @@ pub struct Data {
     #[serde(rename = "version")]
     _version: Option<i64>,
     #[serde(rename = "getResultUrl")]
-    _get_result_url: Option<String>,
+    pub get_result_url: Option<String>,
     #[serde(rename = "progressDesc")]
     _progress_desc: Option<String>,
     #[serde(rename = "queryAbortsAfterSecs")]

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -4,6 +4,7 @@ use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use proto_utils::ProtoError;
 use sf_core::protobuf_apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf_gen::database_driver_v1::*;
+use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 use std::mem::size_of;
 use std::sync::Arc;
 
@@ -279,6 +280,15 @@ impl SnowflakeTestClient {
             conn_handle: Some(self.conn_handle),
             key: option_name.to_string(),
             value: option_value,
+        })
+        .unwrap();
+    }
+
+    pub fn set_statement_async_execution(&self, stmt: &StatementHandle, enabled: bool) {
+        DatabaseDriverClient::statement_set_option_string(StatementSetOptionStringRequest {
+            stmt_handle: Some(*stmt),
+            key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
+            value: if enabled { "true" } else { "false" }.to_string(),
         })
         .unwrap();
     }

--- a/sf_core/tests/e2e/query/async_execution.rs
+++ b/sf_core/tests/e2e/query/async_execution.rs
@@ -1,0 +1,28 @@
+use crate::common::arrow_result_helper::ArrowResultHelper;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+
+#[test]
+fn should_process_async_query_result() {
+    // Given Snowflake client is logged in with async engine enabled
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let stmt = client.new_statement();
+    client.set_statement_async_execution(&stmt, true);
+
+    // When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
+    client.set_sql_query(
+        &stmt,
+        "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id",
+    );
+    let result = client.execute_statement_query(&stmt);
+
+    // Then there are 10000 numbered sequentially rows returned
+    let mut arrow_helper = ArrowResultHelper::from_result(result);
+    let rows = arrow_helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 10000);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row[0], i as i64);
+    }
+
+    // And Statement should be released
+    client.release_statement(&stmt);
+}

--- a/sf_core/tests/e2e/query/mod.rs
+++ b/sf_core/tests/e2e/query/mod.rs
@@ -1,2 +1,3 @@
+mod async_execution;
 mod large_result_set;
 mod parameters_bind;

--- a/tests/definitions/query/async_execution.feature
+++ b/tests/definitions/query/async_execution.feature
@@ -1,9 +1,10 @@
 @core
 Feature: Async execution
 
-  @core_e2e
+  @core_int
   Scenario: should process async query result
     Given Snowflake client is logged in with async engine enabled
     When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
     Then there are 10000 numbered sequentially rows returned
+    And Statement should be released
 

--- a/tests/definitions/query/async_execution.feature
+++ b/tests/definitions/query/async_execution.feature
@@ -1,0 +1,9 @@
+@core
+Feature: Async execution
+
+  @core_e2e
+  Scenario: should process async query result
+    Given Snowflake client is logged in with async engine enabled
+    When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
+    Then there are 10000 numbered sequentially rows returned
+


### PR DESCRIPTION
Adds a Snowflake async execution path backed by new async_exec and Snafu SfError, exposes the request option as per-statement async_execution and plumbs it through statement_execute_query, surfaces the necessary response fields for async polling, and adds matching Gherkin/E2E coverage plus helper support in SnowflakeTestClient.