### PR TITLE
SNOW-2371565: Enable async execution by default with auto-detection for blocking statements

### DIFF
--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -154,7 +154,7 @@ pub fn statement_execute_query(stmt_handle: Handle) -> Result<ExecuteResult, Api
     let mut stmt = stmt_ptr
         .lock()
         .map_err(|_| StatementLockingSnafu {}.build())?;
-    let query = stmt.query.take().ok_or_else(|| {
+    let query_str = stmt.query.as_deref().ok_or_else(|| {
         InvalidArgumentSnafu {
             argument: "Query not found".to_string(),
         }
@@ -184,6 +184,9 @@ pub fn statement_execute_query(stmt_handle: Handle) -> Result<ExecuteResult, Api
         )
     };
 
+    let execution_mode = stmt.execution_mode(Some(query_str));
+    let query = stmt.query.take().expect("query must be present");
+
     let response = rt
         .block_on(snowflake_query_with_client(
             &http_client,
@@ -197,7 +200,7 @@ pub fn statement_execute_query(stmt_handle: Handle) -> Result<ExecuteResult, Api
                 .build()
             })?,
             &retry_policy,
-            stmt.execution_mode(),
+            execution_mode,
         ))
         .context(LoginSnafu)?;
 
@@ -316,38 +319,52 @@ impl Statement {
         }
     }
 
-    fn execution_mode(&self) -> QueryExecutionMode {
+    fn execution_mode(&self, query: Option<&str>) -> QueryExecutionMode {
         match self
             .settings
             .get(snowflake::STATEMENT_ASYNC_EXECUTION_OPTION)
         {
             Some(Setting::String(value)) => {
-                if value.eq_ignore_ascii_case("true")
-                    || value.eq_ignore_ascii_case("yes")
-                    || value == "1"
+                let normalized = value.trim();
+                if normalized.eq_ignore_ascii_case("false")
+                    || normalized.eq_ignore_ascii_case("no")
+                    || normalized == "0"
                 {
-                    QueryExecutionMode::Async
-                } else {
                     QueryExecutionMode::Blocking
+                } else {
+                    QueryExecutionMode::Async
                 }
             }
             Some(Setting::Int(value)) => {
-                if *value != 0 {
-                    QueryExecutionMode::Async
-                } else {
+                if *value == 0 {
                     QueryExecutionMode::Blocking
+                } else {
+                    QueryExecutionMode::Async
                 }
             }
             Some(Setting::Double(value)) => {
-                if *value != 0.0 {
-                    QueryExecutionMode::Async
-                } else {
+                if *value == 0.0 {
                     QueryExecutionMode::Blocking
+                } else {
+                    QueryExecutionMode::Async
                 }
             }
-            Some(Setting::Bytes(_)) | None => QueryExecutionMode::Blocking,
+            Some(Setting::Bytes(_)) => QueryExecutionMode::Async,
+            None => match query {
+                Some(sql) if requires_blocking(sql) => QueryExecutionMode::Blocking,
+                _ => QueryExecutionMode::Async,
+            },
         }
     }
+}
+
+fn requires_blocking(sql: &str) -> bool {
+    let trimmed = sql.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let upper = trimmed.to_ascii_uppercase();
+    upper.starts_with("PUT ") || upper == "PUT" || upper.starts_with("GET ") || upper == "GET"
 }
 
 #[derive(Snafu, Debug)]

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -324,32 +324,11 @@ impl Statement {
             .settings
             .get(snowflake::STATEMENT_ASYNC_EXECUTION_OPTION)
         {
-            Some(Setting::String(value)) => {
-                let normalized = value.trim();
-                if normalized.eq_ignore_ascii_case("false")
-                    || normalized.eq_ignore_ascii_case("no")
-                    || normalized == "0"
-                {
-                    QueryExecutionMode::Blocking
-                } else {
-                    QueryExecutionMode::Async
-                }
-            }
-            Some(Setting::Int(value)) => {
-                if *value == 0 {
-                    QueryExecutionMode::Blocking
-                } else {
-                    QueryExecutionMode::Async
-                }
-            }
-            Some(Setting::Double(value)) => {
-                if *value == 0.0 {
-                    QueryExecutionMode::Blocking
-                } else {
-                    QueryExecutionMode::Async
-                }
-            }
-            Some(Setting::Bytes(_)) => QueryExecutionMode::Async,
+            Some(setting) => match parse_bool_setting(setting) {
+                Some(true) => QueryExecutionMode::Async,
+                Some(false) => QueryExecutionMode::Blocking,
+                None => QueryExecutionMode::Async,
+            },
             None => match query {
                 Some(sql) if requires_blocking(sql) => QueryExecutionMode::Blocking,
                 _ => QueryExecutionMode::Async,
@@ -358,13 +337,31 @@ impl Statement {
     }
 }
 
+fn parse_bool_setting(setting: &Setting) -> Option<bool> {
+    match setting {
+        Setting::String(s) => {
+            let s = s.trim();
+            if s.eq_ignore_ascii_case("true") || s.eq_ignore_ascii_case("yes") || s == "1" {
+                Some(true)
+            } else if s.eq_ignore_ascii_case("false") || s.eq_ignore_ascii_case("no") || s == "0" {
+                Some(false)
+            } else {
+                None
+            }
+        }
+        Setting::Int(v) => Some(*v != 0),
+        _ => None,
+    }
+}
+
 fn requires_blocking(sql: &str) -> bool {
-    let trimmed = sql.trim_start();
-    if trimmed.is_empty() {
+    let s = sql.trim_start();
+    if s.len() < 3 {
         return false;
     }
-    let upper = trimmed.to_ascii_uppercase();
-    upper.starts_with("PUT ") || upper == "PUT" || upper.starts_with("GET ") || upper == "GET"
+    let prefix = &s[..3];
+    let is_put_or_get = prefix.eq_ignore_ascii_case("PUT") || prefix.eq_ignore_ascii_case("GET");
+    is_put_or_get && (s.len() == 3 || s.as_bytes()[3] == b' ')
 }
 
 #[derive(Snafu, Debug)]
@@ -381,4 +378,61 @@ pub enum StatementError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requires_blocking_detects_put_statements() {
+        assert!(requires_blocking("PUT file://local @stage"));
+        assert!(requires_blocking("put file://local @stage"));
+        assert!(requires_blocking("Put file://local @stage"));
+        assert!(requires_blocking("PUT"));
+        assert!(requires_blocking("put"));
+    }
+
+    #[test]
+    fn requires_blocking_detects_get_statements() {
+        assert!(requires_blocking("GET @stage file://local"));
+        assert!(requires_blocking("get @stage file://local"));
+        assert!(requires_blocking("Get @stage file://local"));
+        assert!(requires_blocking("GET"));
+        assert!(requires_blocking("get"));
+    }
+
+    #[test]
+    fn requires_blocking_handles_leading_whitespace() {
+        assert!(requires_blocking("  PUT file://local @stage"));
+        assert!(requires_blocking("\t\nGET @stage file://local"));
+        assert!(requires_blocking("   put"));
+    }
+
+    #[test]
+    fn requires_blocking_rejects_non_blocking_statements() {
+        assert!(!requires_blocking("SELECT * FROM table"));
+        assert!(!requires_blocking("INSERT INTO table VALUES (1)"));
+        assert!(!requires_blocking("UPDATE table SET x = 1"));
+        assert!(!requires_blocking("DELETE FROM table"));
+        assert!(!requires_blocking("CREATE TABLE t (id INT)"));
+    }
+
+    #[test]
+    fn requires_blocking_rejects_similar_prefixes() {
+        // Should not match words that start with PUT/GET but aren't commands
+        assert!(!requires_blocking("PUTTING"));
+        assert!(!requires_blocking("GETTING"));
+        assert!(!requires_blocking("PUTTER"));
+        assert!(!requires_blocking("GETAWAY"));
+    }
+
+    #[test]
+    fn requires_blocking_handles_edge_cases() {
+        assert!(!requires_blocking(""));
+        assert!(!requires_blocking("   "));
+        assert!(!requires_blocking("PU"));
+        assert!(!requires_blocking("GE"));
+        assert!(!requires_blocking("P"));
+    }
 }

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -330,7 +330,7 @@ impl Statement {
                 None => QueryExecutionMode::Async,
             },
             None => match query {
-                Some(sql) if requires_blocking(sql) => QueryExecutionMode::Blocking,
+                Some(sql) if is_file_transfer(sql) => QueryExecutionMode::Blocking,
                 _ => QueryExecutionMode::Async,
             },
         }
@@ -354,14 +354,54 @@ fn parse_bool_setting(setting: &Setting) -> Option<bool> {
     }
 }
 
-fn requires_blocking(sql: &str) -> bool {
-    let s = sql.trim_start();
-    if s.len() < 3 {
+/// Best-effort detection of file transfer commands (PUT/GET) from SQL text.
+///
+/// Snowflake's async API does not support file transfers. Submitting PUT/GET with
+/// asyncExec=true returns a poll URL, but polling returns error 612 "Result not found"
+/// because file transfer metadata is only available synchronously.
+///
+/// We parse SQL to detect PUT/GET and force sync mode. If detection fails, error 612
+/// triggers a retry with sync mode (see snowflake_query_with_client).
+fn is_file_transfer(sql: &str) -> bool {
+    let s = skip_leading_whitespace_and_comments(sql);
+    if s.len() < 4 {
         return false;
     }
     let prefix = &s[..3];
+    let next_char = s.as_bytes()[3];
     let is_put_or_get = prefix.eq_ignore_ascii_case("PUT") || prefix.eq_ignore_ascii_case("GET");
-    is_put_or_get && (s.len() == 3 || s.as_bytes()[3] == b' ')
+    // Must be followed by whitespace or comment start (-- or /*)
+    let valid_separator = next_char.is_ascii_whitespace() || next_char == b'/' || next_char == b'-';
+    is_put_or_get && valid_separator
+}
+
+/// Strips leading whitespace, line comments (--), and block comments (/* */)
+fn skip_leading_whitespace_and_comments(s: &str) -> &str {
+    let mut s = s;
+    loop {
+        s = s.trim_start();
+
+        // Skip line comments: -- ... \n
+        if s.starts_with("--") {
+            match s.find('\n') {
+                Some(pos) => s = &s[pos + 1..],
+                None => return "", // Comment extends to end
+            }
+            continue;
+        }
+
+        // Skip block comments: /* ... */
+        if s.starts_with("/*") {
+            match s.find("*/") {
+                Some(pos) => s = &s[pos + 2..],
+                None => return "", // Unterminated comment
+            }
+            continue;
+        }
+
+        break;
+    }
+    s
 }
 
 #[derive(Snafu, Debug)]
@@ -385,54 +425,114 @@ mod tests {
     use super::*;
 
     #[test]
-    fn requires_blocking_detects_put_statements() {
-        assert!(requires_blocking("PUT file://local @stage"));
-        assert!(requires_blocking("put file://local @stage"));
-        assert!(requires_blocking("Put file://local @stage"));
-        assert!(requires_blocking("PUT"));
-        assert!(requires_blocking("put"));
+    fn is_file_transfer_detects_put_statements() {
+        assert!(is_file_transfer("PUT file://local @stage"));
+        assert!(is_file_transfer("put file://local @stage"));
+        assert!(is_file_transfer("Put file://local @stage"));
     }
 
     #[test]
-    fn requires_blocking_detects_get_statements() {
-        assert!(requires_blocking("GET @stage file://local"));
-        assert!(requires_blocking("get @stage file://local"));
-        assert!(requires_blocking("Get @stage file://local"));
-        assert!(requires_blocking("GET"));
-        assert!(requires_blocking("get"));
+    fn is_file_transfer_detects_get_statements() {
+        assert!(is_file_transfer("GET @stage file://local"));
+        assert!(is_file_transfer("get @stage file://local"));
+        assert!(is_file_transfer("Get @stage file://local"));
     }
 
     #[test]
-    fn requires_blocking_handles_leading_whitespace() {
-        assert!(requires_blocking("  PUT file://local @stage"));
-        assert!(requires_blocking("\t\nGET @stage file://local"));
-        assert!(requires_blocking("   put"));
+    fn is_file_transfer_handles_whitespace_after_command() {
+        // Space
+        assert!(is_file_transfer("PUT file://local"));
+        // Tab
+        assert!(is_file_transfer("PUT\tfile://local"));
+        // Newline
+        assert!(is_file_transfer("PUT\nfile://local"));
+        assert!(is_file_transfer("GET\n@stage"));
     }
 
     #[test]
-    fn requires_blocking_rejects_non_blocking_statements() {
-        assert!(!requires_blocking("SELECT * FROM table"));
-        assert!(!requires_blocking("INSERT INTO table VALUES (1)"));
-        assert!(!requires_blocking("UPDATE table SET x = 1"));
-        assert!(!requires_blocking("DELETE FROM table"));
-        assert!(!requires_blocking("CREATE TABLE t (id INT)"));
+    fn is_file_transfer_handles_comment_after_command() {
+        // Block comment immediately after PUT/GET
+        assert!(is_file_transfer("PUT/* comment */file://local"));
+        assert!(is_file_transfer("GET/**/file://local"));
+        // Line comment immediately after PUT/GET
+        assert!(is_file_transfer("PUT-- comment\nfile://local"));
+        assert!(is_file_transfer("GET--\n@stage"));
     }
 
     #[test]
-    fn requires_blocking_rejects_similar_prefixes() {
+    fn is_file_transfer_handles_leading_whitespace() {
+        assert!(is_file_transfer("  PUT file://local @stage"));
+        assert!(is_file_transfer("\t\nGET @stage file://local"));
+    }
+
+    #[test]
+    fn is_file_transfer_handles_line_comments() {
+        assert!(is_file_transfer("-- comment\nPUT file://local @stage"));
+        assert!(is_file_transfer(
+            "-- line1\n-- line2\nGET @stage file://local"
+        ));
+        assert!(is_file_transfer("  -- indented comment\nPUT file://local"));
+    }
+
+    #[test]
+    fn is_file_transfer_handles_block_comments() {
+        assert!(is_file_transfer("/* comment */PUT file://local @stage"));
+        assert!(is_file_transfer("/* comment */ PUT file://local @stage"));
+        assert!(is_file_transfer(
+            "/* c1 */ /* c2 */ GET @stage file://local"
+        ));
+        assert!(is_file_transfer("/*\nmultiline\n*/PUT file://local"));
+    }
+
+    #[test]
+    fn is_file_transfer_handles_mixed_comments() {
+        assert!(is_file_transfer("-- line\n/* block */PUT file://local"));
+        assert!(is_file_transfer("/* block */-- line\nGET @stage"));
+        assert!(is_file_transfer(
+            "  /* block */ -- line\n  PUT file://local"
+        ));
+    }
+
+    #[test]
+    fn is_file_transfer_rejects_comment_only() {
+        assert!(!is_file_transfer("-- just a comment"));
+        assert!(!is_file_transfer("/* unterminated comment"));
+        assert!(!is_file_transfer("-- comment\n-- another"));
+    }
+
+    #[test]
+    fn is_file_transfer_rejects_bare_commands() {
+        // PUT or GET alone is not a valid command
+        assert!(!is_file_transfer("PUT"));
+        assert!(!is_file_transfer("GET"));
+        assert!(!is_file_transfer("put"));
+        assert!(!is_file_transfer("get"));
+    }
+
+    #[test]
+    fn is_file_transfer_rejects_non_blocking_statements() {
+        assert!(!is_file_transfer("SELECT * FROM table"));
+        assert!(!is_file_transfer("INSERT INTO table VALUES (1)"));
+        assert!(!is_file_transfer("UPDATE table SET x = 1"));
+        assert!(!is_file_transfer("DELETE FROM table"));
+        assert!(!is_file_transfer("CREATE TABLE t (id INT)"));
+    }
+
+    #[test]
+    fn is_file_transfer_rejects_similar_prefixes() {
         // Should not match words that start with PUT/GET but aren't commands
-        assert!(!requires_blocking("PUTTING"));
-        assert!(!requires_blocking("GETTING"));
-        assert!(!requires_blocking("PUTTER"));
-        assert!(!requires_blocking("GETAWAY"));
+        assert!(!is_file_transfer("PUTTING"));
+        assert!(!is_file_transfer("GETTING"));
+        assert!(!is_file_transfer("PUTTER"));
+        assert!(!is_file_transfer("GETAWAY"));
     }
 
     #[test]
-    fn requires_blocking_handles_edge_cases() {
-        assert!(!requires_blocking(""));
-        assert!(!requires_blocking("   "));
-        assert!(!requires_blocking("PU"));
-        assert!(!requires_blocking("GE"));
-        assert!(!requires_blocking("P"));
+    fn is_file_transfer_handles_edge_cases() {
+        assert!(!is_file_transfer(""));
+        assert!(!is_file_transfer("   "));
+        assert!(!is_file_transfer("PU"));
+        assert!(!is_file_transfer("GE"));
+        assert!(!is_file_transfer("P"));
     }
 }

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -391,7 +391,7 @@ fn body_parse_error(source: serde_json::Error) -> SfError {
 
 #[track_caller]
 fn http_status_error(status: StatusCode) -> SfError {
-    // TODO(session-refresh): Implement automatic session renewal on 401.
+    // TODO(SNOW-2371565): Implement automatic session renewal on 401.
     // See gosnowflake's renewRestfulSession for reference:
     // 1. auth.rs: Expose master_token from AuthResponseMain (remove _ prefix)
     // 2. mod.rs: Return both session_token and master_token from login

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -22,6 +22,75 @@ const INLINE_SHORT_POLL_DELAYS: &[Duration] = &[
 ];
 const QUERY_SEQUENCE_ID: u64 = 1;
 
+/// Metrics for async query execution phases, logged for monitoring and debugging.
+///
+/// Async execution follows this flow:
+/// 1. **Submit**: Initial statement submission to Snowflake (always occurs)
+/// 2. **Inline Poll**: Quick polls with short delays (5-40ms) hoping for fast completion
+/// 3. **Wait**: Exponential backoff polling if inline polling didn't complete
+///
+/// Either inline_poll completes the query, or we fall through to wait phase.
+#[derive(Debug, Default)]
+struct AsyncExecutionMetrics {
+    /// Time spent submitting the initial async statement request.
+    submit: Duration,
+    /// Metrics from the inline polling phase (short delays, hoping for quick completion).
+    inline_poll: Option<InlinePollMetrics>,
+    /// Metrics from the wait phase (exponential backoff, used for longer queries).
+    wait: Option<WaitMetrics>,
+}
+
+/// Metrics from the inline polling phase.
+#[derive(Debug)]
+struct InlinePollMetrics {
+    /// Total time spent in inline polling.
+    duration: Duration,
+    /// Whether the query completed during inline polling (true) or fell through to wait (false).
+    completed: bool,
+}
+
+/// Metrics from the exponential backoff wait phase.
+#[derive(Debug)]
+struct WaitMetrics {
+    /// Total time spent waiting for completion.
+    duration: Duration,
+    /// Number of poll requests made during the wait phase.
+    polls: usize,
+}
+
+impl AsyncExecutionMetrics {
+    fn record_submit(&mut self, duration: Duration) {
+        self.submit = duration;
+    }
+
+    fn record_inline(&mut self, duration: Duration, completed: bool) {
+        self.inline_poll = Some(InlinePollMetrics {
+            duration,
+            completed,
+        });
+    }
+
+    fn record_wait(&mut self, duration: Duration, polls: usize) {
+        self.wait = Some(WaitMetrics { duration, polls });
+    }
+
+    fn emit(&self) {
+        fn ms(d: Duration) -> f64 {
+            d.as_secs_f64() * 1000.0
+        }
+
+        let inline_ms = self.inline_poll.as_ref().map(|m| ms(m.duration));
+        let inline_completed = self.inline_poll.as_ref().map(|m| m.completed);
+        let wait_ms = self.wait.as_ref().map(|w| ms(w.duration));
+        let wait_polls = self.wait.as_ref().map(|w| w.polls);
+
+        debug!(
+            submit_ms = ms(self.submit),
+            inline_ms, inline_completed, wait_ms, wait_polls, "async execution timings"
+        );
+    }
+}
+
 fn join_server_path(server_url: &str, path: &str) -> Result<String, SfError> {
     Url::parse(server_url)
         .and_then(|base| base.join(path))
@@ -79,12 +148,12 @@ async fn parse_submit_response(
         return Err(http_status_error(status));
     }
 
-    let body_text = response
-        .text()
+    let body_bytes = response
+        .bytes()
         .await
         .map_err(|source| transport_error(source))?;
     let parsed: query_response::Response =
-        serde_json::from_str(&body_text).map_err(|source| body_parse_error(source))?;
+        serde_json::from_slice(&body_bytes).map_err(|source| body_parse_error(source))?;
     let query_id = parsed.data.query_id.clone();
     let get_result_url = parsed
         .data
@@ -170,12 +239,12 @@ pub async fn poll_query_status(
     if !status.is_success() {
         return Err(http_status_error(status));
     }
-    let body_text = response
-        .text()
+    let body_bytes = response
+        .bytes()
         .await
         .map_err(|source| transport_error(source))?;
     let parsed: query_response::Response =
-        serde_json::from_str(&body_text).map_err(|source| body_parse_error(source))?;
+        serde_json::from_slice(&body_bytes).map_err(|source| body_parse_error(source))?;
     debug!(
         success = parsed.success,
         rowset_present = parsed.data.rowset.is_some(),
@@ -202,6 +271,8 @@ pub async fn execute_blocking_with_async(
     policy: &RetryPolicy,
 ) -> Result<query_response::Response, SfError> {
     let client_info = &params.client_info;
+    let mut metrics = AsyncExecutionMetrics::default();
+    let submit_start = Instant::now();
     let submitted = submit_statement_async(
         client,
         params,
@@ -212,6 +283,7 @@ pub async fn execute_blocking_with_async(
         policy,
     )
     .await?;
+    metrics.record_submit(submit_start.elapsed());
 
     let SubmitOk {
         query_id,
@@ -226,14 +298,23 @@ pub async fn execute_blocking_with_async(
                 location: current_location(),
             })?;
 
-        if let Some(inline) =
-            inline_poll_for_completion(client, client_info, session_token, result_url, policy)
-                .await?
+        let inline_start = Instant::now();
+        match inline_poll_for_completion(client, client_info, session_token, result_url, policy)
+            .await?
         {
-            response = inline;
-        } else {
-            response =
-                wait_for_completion(client, client_info, session_token, result_url, policy).await?;
+            Some(inline) => {
+                metrics.record_inline(inline_start.elapsed(), true);
+                response = inline;
+            }
+            None => {
+                metrics.record_inline(inline_start.elapsed(), false);
+                let wait_start = Instant::now();
+                let (waited, polls) =
+                    wait_for_completion(client, client_info, session_token, result_url, policy)
+                        .await?;
+                metrics.record_wait(wait_start.elapsed(), polls);
+                response = waited;
+            }
         }
     }
 
@@ -246,6 +327,7 @@ pub async fn execute_blocking_with_async(
             location: current_location(),
         })?;
 
+    metrics.emit();
     Ok(response)
 }
 
@@ -308,6 +390,19 @@ fn body_parse_error(source: serde_json::Error) -> SfError {
 
 #[track_caller]
 fn http_status_error(status: StatusCode) -> SfError {
+    // TODO(session-refresh): Implement automatic session renewal on 401.
+    // See gosnowflake's renewRestfulSession for reference:
+    // 1. auth.rs: Expose master_token from AuthResponseMain (remove _ prefix)
+    // 2. mod.rs: Return both session_token and master_token from login
+    // 3. connection.rs: Store both tokens in Connection struct
+    // 4. New: POST /session/token-request with master_token auth and
+    //    body {"oldSessionToken": "...", "requestType": "RENEW"}
+    // 5. On 401 here: attempt refresh before returning SessionExpired
+    if status == StatusCode::UNAUTHORIZED {
+        return SfError::SessionExpired {
+            location: current_location(),
+        };
+    }
     SfError::HttpStatus {
         status,
         location: current_location(),
@@ -391,10 +486,11 @@ async fn wait_for_completion(
     session_token: &str,
     result_url: &str,
     policy: &RetryPolicy,
-) -> Result<query_response::Response, SfError> {
+) -> Result<(query_response::Response, usize), SfError> {
     let start = Instant::now();
     let mut attempt: usize = 0;
     let mut sleep_ms = policy.backoff.base.as_millis() as f64;
+    let mut polls: usize = 0;
 
     loop {
         let elapsed = start.elapsed();
@@ -445,19 +541,12 @@ async fn wait_for_completion(
         poll_policy.max_elapsed = remaining;
         let response =
             poll_query_status(client, client_info, session_token, result_url, &poll_policy).await?;
+        polls += 1;
 
         if let Some(done) = handle_poll_response(response)? {
-            return Ok(done);
+            return Ok((done, polls));
         }
     }
-}
-
-fn should_continue_after_success(resp: &query_response::Response) -> bool {
-    resp.data.get_result_url.is_some() && !response_has_tabular_data(resp)
-}
-
-fn should_continue_after_failure(resp: &query_response::Response) -> bool {
-    resp.data.get_result_url.is_some()
 }
 
 fn snowflake_failure(resp: &query_response::Response) -> SfError {
@@ -489,6 +578,18 @@ fn next_poll_delay_ms(prev_ms: f64, backoff: &BackoffConfig) -> f64 {
         next = cap;
     }
     next
+}
+
+/// Returns true if a successful response still requires more polling.
+/// This occurs when we have a result URL but no tabular data yet.
+fn should_continue_after_success(resp: &query_response::Response) -> bool {
+    resp.data.get_result_url.is_some() && !response_has_tabular_data(resp)
+}
+
+/// Returns true if a failed response should continue polling.
+/// This occurs when the response has a result URL (query still running).
+fn should_continue_after_failure(resp: &query_response::Response) -> bool {
+    resp.data.get_result_url.is_some()
 }
 
 fn handle_poll_response(
@@ -543,5 +644,26 @@ mod tests {
         }));
 
         assert!(should_poll_for_completion(&resp));
+    }
+
+    #[test]
+    fn http_401_returns_session_expired() {
+        let err = http_status_error(StatusCode::UNAUTHORIZED);
+        assert!(
+            matches!(err, SfError::SessionExpired { .. }),
+            "expected SessionExpired, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn http_503_returns_http_status() {
+        let err = http_status_error(StatusCode::SERVICE_UNAVAILABLE);
+        match err {
+            SfError::HttpStatus { status, .. } => {
+                assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+            }
+            other => panic!("expected HttpStatus, got {:?}", other),
+        }
     }
 }

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -255,6 +255,7 @@ pub async fn poll_query_status(
             .as_ref()
             .map(|c| c.len())
             .unwrap_or_default(),
+        code = parsed.code.as_deref().unwrap_or_default(),
         message = parsed.message.as_deref().unwrap_or_default(),
         "polled query status"
     );
@@ -471,7 +472,7 @@ async fn inline_poll_for_completion(
 ) -> Result<Option<query_response::Response>, SfError> {
     let response =
         poll_query_status(client, client_info, session_token, result_url, policy).await?;
-    handle_poll_response(response)
+    handle_poll_response(response, true) // First poll
 }
 
 /// Poll Snowflake for completion, starting with a burst of short delays
@@ -543,18 +544,32 @@ async fn wait_for_completion(
             poll_query_status(client, client_info, session_token, result_url, &poll_policy).await?;
         polls += 1;
 
-        if let Some(done) = handle_poll_response(response)? {
+        if let Some(done) = handle_poll_response(response, false)? {
             return Ok((done, polls));
         }
     }
 }
 
-fn snowflake_failure(resp: &query_response::Response) -> SfError {
+/// Error code 612 indicates "Result not found" - typically returned when
+/// trying to poll for file transfer (PUT/GET) results in async mode.
+const SNOWFLAKE_ERROR_RESULT_NOT_FOUND: i32 = 612;
+
+fn snowflake_failure(resp: &query_response::Response, is_first_poll: bool) -> SfError {
     let code = resp
         .code
         .as_deref()
         .and_then(|c| c.parse::<i32>().ok())
         .unwrap_or(-1);
+
+    // Error 612 "Result not found" occurs when polling for PUT/GET results.
+    // File transfer commands don't support async mode.
+    if code == SNOWFLAKE_ERROR_RESULT_NOT_FOUND {
+        return SfError::AsyncPollResultNotFound {
+            is_first_poll,
+            location: current_location(),
+        };
+    }
+
     let message = resp
         .message
         .clone()
@@ -594,6 +609,7 @@ fn should_continue_after_failure(resp: &query_response::Response) -> bool {
 
 fn handle_poll_response(
     resp: query_response::Response,
+    is_first_poll: bool,
 ) -> Result<Option<query_response::Response>, SfError> {
     if resp.success {
         if should_continue_after_success(&resp) {
@@ -606,7 +622,7 @@ fn handle_poll_response(
         return Ok(None);
     }
 
-    Err(snowflake_failure(&resp))
+    Err(snowflake_failure(&resp, is_first_poll))
 }
 
 #[cfg(test)]
@@ -665,5 +681,45 @@ mod tests {
             }
             other => panic!("expected HttpStatus, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn error_612_returns_async_poll_result_not_found() {
+        // Error 612 "Result not found" is returned when polling for PUT/GET results
+        let resp = response_from_json(json!({
+            "success": false,
+            "code": "612",
+            "message": "Result not found",
+            "data": {
+                "rowset": null,
+                "rowsetBase64": null
+            }
+        }));
+
+        let err = snowflake_failure(&resp, true);
+        assert!(
+            matches!(
+                err,
+                SfError::AsyncPollResultNotFound {
+                    is_first_poll: true,
+                    ..
+                }
+            ),
+            "expected AsyncPollResultNotFound with is_first_poll=true, got {:?}",
+            err
+        );
+
+        let err = snowflake_failure(&resp, false);
+        assert!(
+            matches!(
+                err,
+                SfError::AsyncPollResultNotFound {
+                    is_first_poll: false,
+                    ..
+                }
+            ),
+            "expected AsyncPollResultNotFound with is_first_poll=false, got {:?}",
+            err
+        );
     }
 }

--- a/sf_core/src/rest/snowflake/error.rs
+++ b/sf_core/src/rest/snowflake/error.rs
@@ -25,6 +25,15 @@ pub enum SfError {
         #[snafu(implicit)]
         location: Location,
     },
+    /// Error 612 from async polling - triggers automatic retry with sync mode
+    /// only on first poll. If we've made progress, don't retry.
+    #[snafu(display("Async poll returned error 612 (result not found)"))]
+    AsyncPollResultNotFound {
+        /// True if this was the first poll attempt (safe to retry with sync)
+        is_first_poll: bool,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Session expired"))]
     SessionExpired {
         #[snafu(implicit)]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -223,17 +223,63 @@ pub async fn snowflake_query_with_client(
     retry_policy: &RetryPolicy,
     execution_mode: QueryExecutionMode,
 ) -> Result<query_response::Response, RestError> {
+    // Try async mode if requested
+    let mut retried_612 = false;
     if matches!(execution_mode, QueryExecutionMode::Async) {
-        return snowflake_query_async_style(
+        match snowflake_query_async_style(
             client,
             &query_parameters,
-            session_token,
-            sql,
-            parameter_bindings,
+            session_token.clone(),
+            sql.clone(),
+            parameter_bindings.clone(),
             retry_policy,
         )
-        .await;
+        .await
+        {
+            Ok(response) => return Ok(response),
+            Err(RestError::AsyncQuery {
+                source:
+                    SfError::AsyncPollResultNotFound {
+                        is_first_poll: true,
+                        ..
+                    },
+                ..
+            }) => {
+                // Error 612 "Result not found" on first poll - safe to retry with sync.
+                // We'll log after sync completes based on actual command type.
+                retried_612 = true;
+            }
+            Err(RestError::AsyncQuery {
+                source:
+                    SfError::AsyncPollResultNotFound {
+                        is_first_poll: false,
+                        ..
+                    },
+                ..
+            }) => {
+                // Got 612 after successful polls - something went wrong, don't retry
+                tracing::error!(
+                    sql_prefix = sql.chars().take(50).collect::<String>(),
+                    "Error 612 after prior successful polls; not retrying"
+                );
+                return Err(RestError::AsyncQuery {
+                    source: SfError::AsyncPollResultNotFound {
+                        is_first_poll: false,
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    },
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+            Err(e) => return Err(e),
+        }
     }
+
+    // Save prefix for logging if we retried due to 612
+    let sql_prefix = if retried_612 {
+        Some(sql.chars().take(50).collect::<String>())
+    } else {
+        None
+    };
 
     let query_request = query_request::Request {
         sql_text: sql,
@@ -305,6 +351,27 @@ pub async fn snowflake_query_with_client(
             .fail()
             .context(InvalidSnowflakeResponseSnafu)
     } else {
+        // Log if we retried due to 612, now that we know the actual command type
+        if let Some(sql_prefix) = sql_prefix {
+            let is_file_transfer = query_response
+                .data
+                .command
+                .as_deref()
+                .map(|c| c.eq_ignore_ascii_case("UPLOAD") || c.eq_ignore_ascii_case("DOWNLOAD"))
+                .unwrap_or(false);
+            if is_file_transfer {
+                tracing::info!(
+                    command = query_response.data.command.as_deref(),
+                    "Retried async 612 with sync; confirmed file transfer"
+                );
+            } else {
+                tracing::warn!(
+                    command = query_response.data.command.as_deref(),
+                    sql_prefix,
+                    "Retried async 612 with sync; unexpected non-file-transfer query"
+                );
+            }
+        }
         Ok(query_response)
     }
 }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -19,7 +19,7 @@ use reqwest::{self, header};
 use serde_json;
 use snafu::{Location, ResultExt, Snafu};
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tracing;
 use url::Url;
 
@@ -282,6 +282,7 @@ pub async fn snowflake_query_with_client(
     // tracing::debug!("Request accept: {:?}", request.accept());
     // tracing::debug!("Request accept-encoding: {:?}", request.accept_encoding());
 
+    let send_start = Instant::now();
     let response = client.execute(request).await.context(CommunicationSnafu {
         context: "Failed to execute query request",
     })?;
@@ -289,6 +290,12 @@ pub async fn snowflake_query_with_client(
     let query_response = read_response_json::<query_response::Response>(response)
         .await
         .context(InvalidSnowflakeResponseSnafu)?;
+    let elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
+    tracing::debug!(
+        elapsed_ms,
+        query_id = query_response.data.query_id.as_deref().unwrap_or_default(),
+        "blocking endpoint returned response"
+    );
 
     if !query_response.success {
         let message = query_response
@@ -337,6 +344,11 @@ where
     let response_text = response.text().await;
 
     if !response_status.is_success() {
+        // TODO(session-refresh): Implement automatic session renewal on 401.
+        // See gosnowflake's renewRestfulSession and TODO in async_exec.rs.
+        if response_status == reqwest::StatusCode::UNAUTHORIZED {
+            return SessionExpiredSnafu.fail();
+        }
         return ResponseStatusSnafu {
             status: response_status,
             message: response_text.unwrap_or("Unknown error".to_string()),
@@ -454,6 +466,11 @@ pub enum SnowflakeResponseError {
     ResponseStatus {
         status: reqwest::StatusCode,
         message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Session expired - reauthentication required"))]
+    SessionExpired {
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/tls/client.rs
+++ b/sf_core/src/tls/client.rs
@@ -4,10 +4,11 @@ use crate::tls::config::TlsConfig;
 use crate::tls::error::{
     ClientBuildSnafu, PemParseSnafu, RootStoreAddSnafu, TlsError, VerifierBuildSnafu,
 };
-use reqwest::Client;
+use reqwest::{Client, ClientBuilder};
 use rustls::ClientConfig;
 use snafu::ResultExt;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Create a reqwest Client with TLS configuration
 ///
@@ -17,7 +18,7 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
     // Handle insecure configurations
     if !tls_config.verify_certificates {
         tracing::warn!("Creating insecure TLS client - certificate verification disabled");
-        return Client::builder()
+        return configure_http_client(Client::builder())
             .danger_accept_invalid_certs(true)
             .danger_accept_invalid_hostnames(true)
             .build()
@@ -47,7 +48,9 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
                     "Custom root store specified but CRL validation disabled - custom roots will be ignored"
                 );
             }
-            Client::builder().build().context(ClientBuildSnafu)
+            configure_http_client(Client::builder())
+                .build()
+                .context(ClientBuildSnafu)
         }
         CertRevocationCheckMode::Enabled | CertRevocationCheckMode::Advisory => {
             tracing::debug!(
@@ -80,12 +83,12 @@ pub fn create_crl_tls_client_with_root_store(
         .with_no_client_auth();
 
     // Create reqwest client with custom TLS configuration
-    let client = Client::builder()
+    let client = configure_http_client(Client::builder())
         .use_preconfigured_tls(tls_config)
-        .timeout(std::time::Duration::from_secs(
-            crl_config.http_timeout.num_seconds() as u64,
+        .timeout(Duration::from_secs(
+            crl_config.http_timeout.num_seconds() as u64
         ))
-        .connect_timeout(std::time::Duration::from_secs(
+        .connect_timeout(Duration::from_secs(
             crl_config.connection_timeout.num_seconds() as u64,
         ))
         .build()
@@ -113,4 +116,11 @@ pub fn create_root_store_from_pem(pem_data: &[u8]) -> Result<rustls::RootCertSto
         root_store.add(cert).context(RootStoreAddSnafu)?;
     }
     Ok(root_store)
+}
+
+fn configure_http_client(builder: ClientBuilder) -> ClientBuilder {
+    builder
+        .pool_idle_timeout(Some(Duration::from_secs(30)))
+        .pool_max_idle_per_host(32)
+        .tcp_keepalive(Some(Duration::from_secs(60)))
 }

--- a/sf_core/tests/e2e/query/async_execution.rs
+++ b/sf_core/tests/e2e/query/async_execution.rs
@@ -26,3 +26,42 @@ fn should_process_async_query_result() {
     // And Statement should be released
     client.release_statement(&stmt);
 }
+
+#[test]
+fn should_match_blocking_results_when_async_execution_enabled() {
+    // Given Snowflake client is logged in
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let blocking_stmt = client.new_statement();
+    let async_stmt = client.new_statement();
+
+    // And Statement A has async execution disabled
+    client.set_statement_async_execution(&blocking_stmt, false);
+
+    // And Statement B has async execution enabled
+    client.set_statement_async_execution(&async_stmt, true);
+
+    // When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000)) v ORDER BY id" is executed on both statements
+    let sql = "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000)) v ORDER BY id";
+    client.set_sql_query(&blocking_stmt, sql);
+    client.set_sql_query(&async_stmt, sql);
+    let blocking_result = client.execute_statement_query(&blocking_stmt);
+    let async_result = client.execute_statement_query(&async_stmt);
+
+    // Then both result sets have identical sequential ids
+    let mut blocking_helper = ArrowResultHelper::from_result(blocking_result);
+    let blocking_rows = blocking_helper.transform_into_array::<i64>().unwrap();
+    let mut async_helper = ArrowResultHelper::from_result(async_result);
+    let async_rows = async_helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(
+        blocking_rows, async_rows,
+        "async and blocking results must match"
+    );
+    assert_eq!(blocking_rows.len(), 1000);
+    for (i, row) in blocking_rows.iter().enumerate() {
+        assert_eq!(row[0], i as i64);
+    }
+
+    // And Both statements should be released
+    client.release_statement(&blocking_stmt);
+    client.release_statement(&async_stmt);
+}

--- a/sf_core/tests/e2e/query/async_execution.rs
+++ b/sf_core/tests/e2e/query/async_execution.rs
@@ -65,3 +65,30 @@ fn should_match_blocking_results_when_async_execution_enabled() {
     client.release_statement(&blocking_stmt);
     client.release_statement(&async_stmt);
 }
+
+#[test]
+fn should_use_async_by_default_when_no_execution_mode_specified() {
+    // Given Snowflake client is logged in
+    let client = SnowflakeTestClient::connect_with_default_auth();
+
+    // And Statement has no async execution setting
+    let stmt = client.new_statement(); // no set_statement_async_execution call
+
+    // When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 100)) v ORDER BY id" is executed
+    client.set_sql_query(
+        &stmt,
+        "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 100)) v ORDER BY id",
+    );
+    let result = client.execute_statement_query(&stmt);
+
+    // Then there are 100 numbered sequentially rows returned
+    let mut arrow_helper = ArrowResultHelper::from_result(result);
+    let rows = arrow_helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 100);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row[0], i as i64);
+    }
+
+    // And Statement should be released
+    client.release_statement(&stmt);
+}

--- a/sf_core/tests/integration/http/retry.rs
+++ b/sf_core/tests/integration/http/retry.rs
@@ -160,6 +160,127 @@ async fn should_fail_after_reaching_max_attempts() {
     server.await.unwrap();
 }
 
+/// Demonstrates sync-style behavior: no retry, fails on first transient error
+#[tokio::test]
+async fn sync_style_fails_on_transient_error() {
+    // Given a server that fails once then succeeds
+    let (addr, attempts, server) = spawn_test_server(2, |attempt| async move {
+        if attempt == 1 {
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .to_vec()
+        } else {
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".to_vec()
+        }
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{}", addr);
+
+    // When using direct execute (sync-style, no retry wrapper)
+    let response = client.get(&url).send().await.expect("request to complete");
+
+    // Then it fails with 503 - no retry attempted
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1); // Only one attempt
+    drop(server); // Clean up (server still waiting for second connection)
+}
+
+/// Demonstrates async-style behavior: retries transient errors, succeeds
+#[tokio::test]
+async fn async_style_retries_transient_error() {
+    // Given a server that fails once then succeeds (same setup)
+    let (addr, attempts, server) = spawn_test_server(2, |attempt| async move {
+        if attempt == 1 {
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nRetry-After: 0\r\nConnection: close\r\n\r\n"
+                .to_vec()
+        } else {
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".to_vec()
+        }
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{}", addr);
+    let ctx = HttpContext::new(Method::GET, url.clone());
+
+    // When using execute_with_retry (async-style)
+    let body = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default())
+        .await
+        .expect("retry to succeed");
+
+    // Then it retries and succeeds
+    assert_eq!(body, b"ok");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2); // Two attempts
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn should_retry_after_connection_reset() {
+    // Given a server that resets the connection on first attempt, then succeeds
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_clone = attempts.clone();
+
+    let server = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let attempt = attempts_clone.fetch_add(1, Ordering::SeqCst) + 1;
+
+            if attempt == 1 {
+                // First attempt: accept connection then immediately close (connection reset)
+                drop(stream);
+            } else {
+                // Second attempt: read request and respond successfully
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf).await;
+                let response =
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+                stream.write_all(response).await.unwrap();
+                let _ = stream.shutdown().await;
+                break;
+            }
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{}", addr);
+    let ctx = HttpContext::new(Method::GET, url.clone());
+
+    // When the helper executes the request
+    let body = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default())
+        .await
+        .expect("should retry after connection reset");
+
+    // Then it should have retried and succeeded
+    assert_eq!(body, b"ok");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn should_not_retry_401_unauthorized() {
+    // Given a server that returns 401 Unauthorized
+    let (addr, attempts, server) = spawn_test_server(1, |_| async move {
+        b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 16\r\nConnection: close\r\n\r\nSession expired".to_vec()
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{}", addr);
+    let ctx = HttpContext::new(Method::GET, url.clone());
+
+    // When the helper executes the request
+    let result = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default()).await;
+
+    // Then it should NOT retry (401 is not retryable) and return the response
+    // The caller is responsible for handling 401 as session expired
+    assert!(result.is_err()); // 401 is surfaced as Transport error
+    assert_eq!(attempts.load(Ordering::SeqCst), 1); // No retry
+    server.await.unwrap();
+}
+
 async fn spawn_test_server<F, Fut>(
     max_attempts: usize,
     responder: F,

--- a/sf_core/tests/parity_tests.rs
+++ b/sf_core/tests/parity_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn async_facade_symbol_exists() {
+    // Ensure the async-backed blocking facade symbol is exported.
+    let _sym = sf_core::rest::snowflake::snowflake_query_async_style as *const ();
+}

--- a/tests/definitions/shared/query/async_execution.feature
+++ b/tests/definitions/shared/query/async_execution.feature
@@ -7,3 +7,13 @@ Feature: Async execution
     When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
     Then there are 10000 numbered sequentially rows returned
     And Statement should be released
+
+  @core_int
+  Scenario: should match blocking results when async execution enabled
+    Given Snowflake client is logged in
+    And Statement A has async execution disabled
+    And Statement B has async execution enabled
+    When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000)) v ORDER BY id" is executed on both statements
+    Then both result sets have identical sequential ids
+    And Both statements should be released
+

--- a/tests/definitions/shared/query/async_execution.feature
+++ b/tests/definitions/shared/query/async_execution.feature
@@ -8,7 +8,7 @@ Feature: Async execution
     Then there are 10000 numbered sequentially rows returned
     And Statement should be released
 
-  @core_int
+  @core_e2e
   Scenario: should match blocking results when async execution enabled
     Given Snowflake client is logged in
     And Statement A has async execution disabled
@@ -16,4 +16,12 @@ Feature: Async execution
     When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000)) v ORDER BY id" is executed on both statements
     Then both result sets have identical sequential ids
     And Both statements should be released
+
+  @core_e2e
+  Scenario: should use async by default when no execution mode specified
+    Given Snowflake client is logged in
+    And Statement has no async execution setting
+    When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 100)) v ORDER BY id" is executed
+    Then there are 100 numbered sequentially rows returned
+    And Statement should be released
 

--- a/tests/performance/drivers/core/app/src/config.rs
+++ b/tests/performance/drivers/core/app/src/config.rs
@@ -13,6 +13,7 @@ pub struct TestConfig {
     pub test_type: TestType,
     pub iterations: usize,
     pub warmup_iterations: usize,
+    pub statement_async_override: Option<bool>,
     pub params: ParametersJson,
     pub setup_queries: Vec<String>,
 }
@@ -56,14 +57,51 @@ impl TestConfig {
             Vec::new()
         };
 
+        let statement_async_override = match env::var("STATEMENT_ASYNC_EXECUTION") {
+            Ok(value) => parse_async_override(&value)?,
+            Err(_) => None,
+        };
+
         Ok(Self {
             sql_command,
             test_name,
             test_type,
             iterations,
             warmup_iterations,
+            statement_async_override,
             params,
             setup_queries,
         })
+    }
+}
+
+/// Parse async execution override from string value.
+/// Returns `Some(true)` for enabled, `Some(false)` for disabled, `None` for auto/unset.
+fn parse_async_override(value: &str) -> Result<Option<bool>> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" => Ok(Some(true)),
+        "false" | "0" | "no" => Ok(Some(false)),
+        "auto" => Ok(None),
+        other => Err(format!(
+            "Invalid STATEMENT_ASYNC_EXECUTION value: {} (expected true/false/auto)",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_async_override_accepts_boolean_strings() {
+        assert_eq!(parse_async_override("true").unwrap(), Some(true));
+        assert_eq!(parse_async_override("false").unwrap(), Some(false));
+        assert_eq!(parse_async_override("auto").unwrap(), None);
+        assert!(parse_async_override("invalid").is_err());
     }
 }

--- a/tests/performance/drivers/core/app/src/config.rs
+++ b/tests/performance/drivers/core/app/src/config.rs
@@ -75,22 +75,26 @@ impl TestConfig {
     }
 }
 
-/// Parse async execution override from string value.
-/// Returns `Some(true)` for enabled, `Some(false)` for disabled, `None` for auto/unset.
-fn parse_async_override(value: &str) -> Result<Option<bool>> {
+/// Parse a boolean option from string value.
+/// Returns `Some(true)` for truthy, `Some(false)` for falsy, `None` for auto/unset.
+fn parse_bool_option(value: &str, field_name: &str) -> Result<Option<bool>> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Ok(None);
     }
     match trimmed.to_ascii_lowercase().as_str() {
-        "true" | "1" | "yes" => Ok(Some(true)),
-        "false" | "0" | "no" => Ok(Some(false)),
+        "true" | "1" | "yes" | "y" => Ok(Some(true)),
+        "false" | "0" | "no" | "n" => Ok(Some(false)),
         "auto" => Ok(None),
         other => Err(format!(
-            "Invalid STATEMENT_ASYNC_EXECUTION value: {} (expected true/false/auto)",
-            other
+            "Invalid {} value: '{}' (expected true/false/yes/no/y/n/1/0/auto)",
+            field_name, other
         )),
     }
+}
+
+fn parse_async_override(value: &str) -> Result<Option<bool>> {
+    parse_bool_option(value, "STATEMENT_ASYNC_EXECUTION")
 }
 
 #[cfg(test)]
@@ -98,10 +102,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_async_override_accepts_boolean_strings() {
+    fn parse_bool_option_accepts_various_formats() {
+        // Truthy values
+        assert_eq!(parse_bool_option("true", "test").unwrap(), Some(true));
+        assert_eq!(parse_bool_option("TRUE", "test").unwrap(), Some(true));
+        assert_eq!(parse_bool_option("1", "test").unwrap(), Some(true));
+        assert_eq!(parse_bool_option("yes", "test").unwrap(), Some(true));
+        assert_eq!(parse_bool_option("y", "test").unwrap(), Some(true));
+        assert_eq!(parse_bool_option("Y", "test").unwrap(), Some(true));
+
+        // Falsy values
+        assert_eq!(parse_bool_option("false", "test").unwrap(), Some(false));
+        assert_eq!(parse_bool_option("FALSE", "test").unwrap(), Some(false));
+        assert_eq!(parse_bool_option("0", "test").unwrap(), Some(false));
+        assert_eq!(parse_bool_option("no", "test").unwrap(), Some(false));
+        assert_eq!(parse_bool_option("n", "test").unwrap(), Some(false));
+        assert_eq!(parse_bool_option("N", "test").unwrap(), Some(false));
+
+        // Auto/none
+        assert_eq!(parse_bool_option("auto", "test").unwrap(), None);
+        assert_eq!(parse_bool_option("", "test").unwrap(), None);
+        assert_eq!(parse_bool_option("  ", "test").unwrap(), None);
+
+        // Invalid
+        assert!(parse_bool_option("invalid", "test").is_err());
+        assert!(parse_bool_option("maybe", "test").is_err());
+    }
+
+    #[test]
+    fn parse_async_override_uses_bool_option() {
         assert_eq!(parse_async_override("true").unwrap(), Some(true));
+        assert_eq!(parse_async_override("y").unwrap(), Some(true));
         assert_eq!(parse_async_override("false").unwrap(), Some(false));
+        assert_eq!(parse_async_override("n").unwrap(), Some(false));
         assert_eq!(parse_async_override("auto").unwrap(), None);
-        assert!(parse_async_override("invalid").is_err());
     }
 }

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -4,6 +4,7 @@ type Result<T> = std::result::Result<T, String>;
 use arrow_array::StringArray;
 use sf_core::protobuf_apis::RustTransport;
 use sf_core::protobuf_gen::database_driver_v1::*;
+use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 use std::fs;
 
 use crate::types::TestConnectionParams;
@@ -45,6 +46,9 @@ pub fn create_connection(
     set_connection_option(&conn_handle, "authenticator", "SNOWFLAKE_JWT")?;
     let private_key_file = write_private_key_to_file(&params.private_key_contents)?;
     set_connection_option(&conn_handle, "private_key_file", &private_key_file)?;
+    if let Some(password) = &params.private_key_password {
+        set_connection_option(&conn_handle, "private_key_password", password)?;
+    }
 
     set_connection_option(&conn_handle, "database", &params.database)?;
     set_connection_option(&conn_handle, "schema", &params.schema)?;
@@ -62,7 +66,11 @@ pub fn create_connection(
     Ok(conn_handle)
 }
 
-pub fn create_statement(conn_handle: ConnectionHandle, sql: &str) -> Result<StatementHandle> {
+pub fn create_statement(
+    conn_handle: ConnectionHandle,
+    sql: &str,
+    async_override: Option<bool>,
+) -> Result<StatementHandle> {
     let stmt_response = DatabaseDriver::statement_new(StatementNewRequest {
         conn_handle: Some(conn_handle),
     })
@@ -77,6 +85,16 @@ pub fn create_statement(conn_handle: ConnectionHandle, sql: &str) -> Result<Stat
         query: sql.to_string(),
     })
     .map_err(|e| format!("Failed to set SQL query: {:?}", e))?;
+
+    if let Some(enabled) = async_override {
+        let value = if enabled { "true" } else { "false" }.to_string();
+        DatabaseDriver::statement_set_option_string(StatementSetOptionStringRequest {
+            stmt_handle: Some(stmt_handle),
+            key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
+            value,
+        })
+        .map_err(|e| format!("Failed to set async execution option: {:?}", e))?;
+    }
 
     Ok(stmt_handle)
 }
@@ -93,7 +111,7 @@ pub fn reset_statement_query(stmt_handle: StatementHandle, sql: &str) -> Result<
 pub fn get_server_version(conn_handle: ConnectionHandle) -> Result<String> {
     use crate::arrow::create_arrow_reader;
 
-    let version_stmt = create_statement(conn_handle, "SELECT CURRENT_VERSION() AS VERSION")?;
+    let version_stmt = create_statement(conn_handle, "SELECT CURRENT_VERSION() AS VERSION", None)?;
     let response = DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {
         stmt_handle: Some(version_stmt),
     })
@@ -145,7 +163,7 @@ pub fn execute_setup_queries(
     for (i, query) in setup_queries.iter().enumerate() {
         println!("  Setup query {}: {}", i + 1, query);
 
-        let stmt_handle = create_statement(conn_handle, query)
+        let stmt_handle = create_statement(conn_handle, query, None)
             .map_err(|e| format!("Failed to create setup statement: {:?}", e))?;
 
         DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {

--- a/tests/performance/drivers/core/app/src/main.rs
+++ b/tests/performance/drivers/core/app/src/main.rs
@@ -47,8 +47,12 @@ fn run() -> Result<()> {
     execute_setup_queries(conn_handle, &config.setup_queries)
         .map_err(|e| format!("Failed to execute setup queries: {:?}", e))?;
 
-    let stmt_handle = create_statement(conn_handle, &config.sql_command)
-        .map_err(|e| format!("Failed to prepare statement: {:?}", e))?;
+    let stmt_handle = create_statement(
+        conn_handle,
+        &config.sql_command,
+        config.statement_async_override,
+    )
+    .map_err(|e| format!("Failed to prepare statement: {:?}", e))?;
 
     match config.test_type {
         TestType::Select => execute_fetch_test(

--- a/tests/performance/drivers/core/app/src/results.rs
+++ b/tests/performance/drivers/core/app/src/results.rs
@@ -189,3 +189,42 @@ where
 
     Ok(filename.display().to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_stats_empty_returns_zeros() {
+        let stats = calculate_stats(vec![]);
+        assert_eq!(stats.median, 0.0);
+        assert_eq!(stats.min, 0.0);
+        assert_eq!(stats.max, 0.0);
+    }
+
+    #[test]
+    fn calculate_stats_single_element() {
+        let stats = calculate_stats(vec![5.0]);
+        assert_eq!(stats.median, 5.0);
+        assert_eq!(stats.min, 5.0);
+        assert_eq!(stats.max, 5.0);
+    }
+
+    #[test]
+    fn calculate_stats_odd_count_median() {
+        // [1, 2, 3, 4, 5] -> median is 3 (middle element)
+        let stats = calculate_stats(vec![3.0, 1.0, 5.0, 2.0, 4.0]);
+        assert_eq!(stats.median, 3.0);
+        assert_eq!(stats.min, 1.0);
+        assert_eq!(stats.max, 5.0);
+    }
+
+    #[test]
+    fn calculate_stats_even_count_median() {
+        // [1, 2, 3, 4] -> median is (2 + 3) / 2 = 2.5
+        let stats = calculate_stats(vec![4.0, 1.0, 3.0, 2.0]);
+        assert_eq!(stats.median, 2.5);
+        assert_eq!(stats.min, 1.0);
+        assert_eq!(stats.max, 4.0);
+    }
+}

--- a/tests/performance/drivers/core/app/src/types.rs
+++ b/tests/performance/drivers/core/app/src/types.rs
@@ -12,6 +12,8 @@ pub struct TestConnectionParams {
     pub user: String,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")]
     pub private_key_contents: Vec<String>,
+    #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD")]
+    pub private_key_password: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_DATABASE")]
     pub database: String,
     #[serde(rename = "SNOWFLAKE_TEST_SCHEMA")]

--- a/tests/wiremock/mappings/retry/poll_401_session_expired.json
+++ b/tests/wiremock/mappings/retry/poll_401_session_expired.json
@@ -1,0 +1,12 @@
+{
+  "name": "Poll returns 401 session expired",
+  "request": {
+    "urlPathPattern": "/queries/.*/result.*",
+    "method": "GET"
+  },
+  "response": {
+    "status": 401,
+    "body": "Session expired"
+  }
+}
+

--- a/tests/wiremock/mappings/retry/poll_503_then_success.json
+++ b/tests/wiremock/mappings/retry/poll_503_then_success.json
@@ -1,0 +1,38 @@
+{
+  "mappings": [
+    {
+      "name": "First poll returns 503",
+      "scenarioName": "poll-retry",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "first-failure",
+      "request": {
+        "urlPathPattern": "/queries/.*/result.*",
+        "method": "GET"
+      },
+      "response": {
+        "status": 503,
+        "body": "Service Unavailable"
+      }
+    },
+    {
+      "name": "Second poll returns success",
+      "scenarioName": "poll-retry",
+      "requiredScenarioState": "first-failure",
+      "request": {
+        "urlPathPattern": "/queries/.*/result.*",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "success": true,
+          "data": {
+            "queryId": "test-query-id",
+            "rowset": [["1", "test"]]
+          }
+        }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
Queries now use async mode unless explicitly disabled or the statement is PUT/GET (which requires blocking)
Add metrics for submit, inline poll, and wait phase timings for performance analysis.

Default behavior is submit, get query id, poll for results. Remaining TODO is to handle session refresh. This results in at least one additional round trip. For a user running in the same cloud region, this should be negligible (~5 ms). From my laptop hitting us-west-2, it adds another 180ms. I think this is the right tradeoff for us.

On the snowflake backend, this will cause all queries will be persisted. This is probably too expensive to keep this as the default long term due to the effect on hybrid tables latency and the load on FDB. 