### PR TITLE
NO-SNOW: Load core module from python package data

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -31,14 +31,15 @@ jobs:
           sudo apt-get update
 
       - name: Build Rust core library
+        working-directory: ./python
         run: |
-          RUSTFLAGS="" cargo build --package sf_core
+          RUSTFLAGS="" make dev-build
 
       - name: Upload Rust artifacts
         uses: actions/upload-artifact@v4
         with:
           name: rust-core-library
-          path: target/debug/libsf_core.so
+          path: python/src/snowflake/ud_connector/_core/libsf_core.so
 
   # Combined unit + integration tests with universal connector
   python_tests:
@@ -76,7 +77,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: target/debug/
+          path: python/src/snowflake/ud_connector/_core/
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,7 +17,7 @@ env:
   REFERENCE_PYTHON_VERSION: "3.13"
   # OS version for consistent naming across jobs
   REFERENCE_OS_VERSION: "ubuntu-latest"
-  PYTHON_CORE_DOWNLOAD_PATH: "python/src/snowflake/ud_connector/_core"
+  PYTHON_CORE_DOWNLOAD_PATH: "${{ github.workspace }}/python/src/snowflake/ud_connector/_core"
 
 jobs:
   # Build Rust core library once and share across Python jobs
@@ -167,7 +167,7 @@ jobs:
 
       - name: Run reference integration tests
         env:
-          CORE_PATH: ${{ github.workspace }}/target/debug/libsf_core.so
+          CORE_PATH: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
         run: make ci-test-reference PYTHON_VERSION=${{ env.REFERENCE_PYTHON_VERSION }} OS_VERSION=${{ env.REFERENCE_OS_VERSION }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,7 +17,7 @@ env:
   REFERENCE_PYTHON_VERSION: "3.13"
   # OS version for consistent naming across jobs
   REFERENCE_OS_VERSION: "ubuntu-latest"
-  PYTHON_CORE_DOWNLOAD_PATH: "${{ github.workspace }}/python/src/snowflake/ud_connector/_core"
+  PYTHON_CORE_MODULE_PATH: "${{ github.workspace }}/python/src/snowflake/ud_connector/_core"
 
 jobs:
   # Build Rust core library once and share across Python jobs
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rust-core-library
-          path: "${{ env.PYTHON_CORE_DOWNLOAD_PATH }}/libsf_core.so"
+          path: "${{ env.PYTHON_CORE_MODULE_PATH }}/libsf_core.so"
 
   # Combined unit + integration tests with universal connector
   python_tests:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
+          path: ${{ env.PYTHON_CORE_MODULE_PATH }}
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
@@ -153,7 +153,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
+          path: ${{ env.PYTHON_CORE_MODULE_PATH }}
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rust-core-library
-          path: "${PYTHON_CORE_DOWNLOAD_PATH}/libsf_core.so"
+          path: "${{ env.PYTHON_CORE_DOWNLOAD_PATH }}/libsf_core.so"
 
   # Combined unit + integration tests with universal connector
   python_tests:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: $PYTHON_CORE_DOWNLOAD_PATH
+          path: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
@@ -154,7 +154,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: $PYTHON_CORE_DOWNLOAD_PATH
+          path: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,6 +17,7 @@ env:
   REFERENCE_PYTHON_VERSION: "3.13"
   # OS version for consistent naming across jobs
   REFERENCE_OS_VERSION: "ubuntu-latest"
+  PYTHON_CORE_DOWNLOAD_PATH: "python/src/snowflake/ud_connector/_core"
 
 jobs:
   # Build Rust core library once and share across Python jobs
@@ -39,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rust-core-library
-          path: python/src/snowflake/ud_connector/_core/libsf_core.so
+          path: "${PYTHON_CORE_DOWNLOAD_PATH}/libsf_core.so"
 
   # Combined unit + integration tests with universal connector
   python_tests:
@@ -77,7 +78,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: python/src/snowflake/ud_connector/_core/
+          path: $PYTHON_CORE_DOWNLOAD_PATH
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
@@ -153,7 +154,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rust-core-library
-          path: target/debug/
+          path: $PYTHON_CORE_DOWNLOAD_PATH
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build Rust core library
         working-directory: ./python
         run: |
-          RUSTFLAGS="" make dev-build
+          RUSTFLAGS="" make build-core
 
       - name: Upload Rust artifacts
         uses: actions/upload-artifact@v4
@@ -91,7 +91,6 @@ jobs:
 
       - name: Run all tests with coverage
         env:
-          CORE_PATH: ${{ github.workspace }}/target/debug/libsf_core.so
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
         run: |
@@ -167,7 +166,6 @@ jobs:
 
       - name: Run reference integration tests
         env:
-          CORE_PATH: ${{ env.PYTHON_CORE_DOWNLOAD_PATH }}
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
         run: make ci-test-reference PYTHON_VERSION=${{ env.REFERENCE_PYTHON_VERSION }} OS_VERSION=${{ env.REFERENCE_OS_VERSION }}

--- a/python/Makefile
+++ b/python/Makefile
@@ -217,6 +217,10 @@ clean-reports:
 
 clean: clean-reports # Short alias
 
+dev-build:
+	cd .. && cargo build --package sf_core --target-dir=python/src/snowflake/ud_connector/_core \
+	&& cd python/src/snowflake/ud_connector/_core && mv debug/* . &&  rm -rf debug/
+
 # Below: Allow passing pytest args directly after make target
 # $(filter-out target-name alias,$(MAKECMDGOALS)) captures trailing args but excludes the target itself
 # Without this, "make test -k connection" would pass "test" to pytest, causing it to look for a test named "test"

--- a/python/Makefile
+++ b/python/Makefile
@@ -13,12 +13,12 @@ PROJECT_ROOT := $(abspath ..)
 
 # Library search paths (for dependent native libs)
 # Default search locations derived from PROJECT_ROOT
-DEFAULT_LIB_DEBUG := $(PROJECT_ROOT)/python/src/snowflake/ud_connector/_core
+CORE_MODULE_DIR := $(PROJECT_ROOT)/python/src/snowflake/ud_connector/_core
 
 # Absolute paths to avoid relative path issues across different working directories
-# Derive all core-related paths from DEFAULT_LIB_DEBUG
-DEFAULT_CORE_PATH_MACOS := $(DEFAULT_LIB_DEBUG)/libsf_core.dylib
-DEFAULT_CORE_PATH_LINUX := $(DEFAULT_LIB_DEBUG)/libsf_core.so
+# Derive all core-related paths from CORE_MODULE_DIR
+DEFAULT_CORE_PATH_MACOS := $(CORE_MODULE_DIR)/libsf_core.dylib
+DEFAULT_CORE_PATH_LINUX := $(CORE_MODULE_DIR)/libsf_core.so
 DEFAULT_PARAMETER_PATH := $(PROJECT_ROOT)/parameters.json
 
 SHELL := bash
@@ -72,7 +72,7 @@ TOX_REFERENCE_ENV = py$(PYTHON_ID)-reference
 build-core:
 	@echo "Using CORE_PATH: $(DETECTED_CORE_PATH)"
 	@echo "Using PARAMETER_PATH: $(DETECTED_PARAMETER_PATH)"
-	cd .. && cargo build --package sf_core --target-dir=$(DEFAULT_LIB_DEBUG) && cd $(DEFAULT_LIB_DEBUG) && mv debug/* . &&  rm -rf debug/ || { \
+	cd .. && cargo build --package sf_core --target-dir=$(CORE_MODULE_DIR) && cd $(CORE_MODULE_DIR) && mv debug/* . &&  rm -rf debug/ || { \
 		echo "Failed to build Rust core library"; \
 		echo "Make sure Rust toolchain is installed: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; \
 		exit 1; \

--- a/python/Makefile
+++ b/python/Makefile
@@ -13,8 +13,7 @@ PROJECT_ROOT := $(abspath ..)
 
 # Library search paths (for dependent native libs)
 # Default search locations derived from PROJECT_ROOT
-DEFAULT_LIB_DEBUG := $(PROJECT_ROOT)/target/debug
-DEFAULT_LIB_DEPS := $(DEFAULT_LIB_DEBUG)/deps
+DEFAULT_LIB_DEBUG := $(PROJECT_ROOT)/python/src/snowflake/ud_connector/_core
 
 # Absolute paths to avoid relative path issues across different working directories
 # Derive all core-related paths from DEFAULT_LIB_DEBUG
@@ -32,9 +31,7 @@ SHELL := bash
 
 # Platform-aware path detection with environment variable override
 DETECTED_CORE_PATH := $(shell \
-	if [ -n "$$CORE_PATH" ]; then \
-		echo "$$CORE_PATH"; \
-	elif [[ "$$(uname)" == "Darwin" ]]; then \
+	if [[ "$$(uname)" == "Darwin" ]]; then \
 		echo "$(DEFAULT_CORE_PATH_MACOS)"; \
 	else \
 		echo "$(DEFAULT_CORE_PATH_LINUX)"; \
@@ -71,16 +68,17 @@ TOX_E2E_ENV = py$(PYTHON_ID)-e2e
 TOX_REFERENCE_ENV = py$(PYTHON_ID)-reference
 
 
-
 # Local development: auto-build missing Rust core
-check-env-or-build:
+build-core:
 	@echo "Using CORE_PATH: $(DETECTED_CORE_PATH)"
 	@echo "Using PARAMETER_PATH: $(DETECTED_PARAMETER_PATH)"
-	cd .. && cargo build --package sf_core || { \
+	cd .. && cargo build --package sf_core --target-dir=$(DEFAULT_LIB_DEBUG) && cd $(DEFAULT_LIB_DEBUG) && mv debug/* . &&  rm -rf debug/ || { \
 		echo "Failed to build Rust core library"; \
 		echo "Make sure Rust toolchain is installed: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; \
 		exit 1; \
 	}
+
+check-env-or-build: build-core
 	@if [ ! -f "$(DETECTED_CORE_PATH)" ]; then \
 		echo "Error: Core library not found at $(DETECTED_CORE_PATH)"; \
 		exit 1; \
@@ -89,12 +87,8 @@ check-env-or-build:
 
 # CI: fail fast if environment not properly set up
 check-env-or-fail:
-	@if [ -z "$(CORE_PATH)" ]; then \
-		echo "Error: CORE_PATH environment variable not set"; \
-		exit 1; \
-	fi
-	@if [ ! -f "$(CORE_PATH)" ]; then \
-		echo "Error: Core library not found at $(CORE_PATH)"; \
+	@if [ ! -f "$(DETECTED_CORE_PATH)" ]; then \
+		echo "Error: Core library not found at $(DETECTED_CORE_PATH)"; \
 		exit 1; \
 	fi
 
@@ -216,10 +210,6 @@ clean-reports:
 	rm -rf $(REPORTS_DIR)
 
 clean: clean-reports # Short alias
-
-dev-build:
-	cd .. && cargo build --package sf_core --target-dir=python/src/snowflake/ud_connector/_core \
-	&& cd python/src/snowflake/ud_connector/_core && mv debug/* . &&  rm -rf debug/
 
 # Below: Allow passing pytest args directly after make target
 # $(filter-out target-name alias,$(MAKECMDGOALS)) captures trailing args but excludes the target itself

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,7 @@ A Python library that implements [PEP 249 (Python Database API Specification 2.0
 ## Development
 To build core library for local development run:
 ```bash
-make dev-build
+make build-core
 ```
 
 ## Testing

--- a/python/README.md
+++ b/python/README.md
@@ -2,6 +2,12 @@
 
 A Python library that implements [PEP 249 (Python Database API Specification 2.0)](https://peps.python.org/pep-0249/) with empty interface implementations. This library provides a complete skeleton implementation that follows the PEP 249 specification, making it an ideal starting point for creating new database drivers or for testing database API compliance.
 
+## Development
+To build core library for local development run:
+```bash
+make dev-build
+```
+
 ## Testing
 
 ### Quick Start

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 where = ["src"]
 include = ["snowflake.*"]
 
+[tool.setuptools.package-data]
+"snowflake.ud_connector._core" = ["*.so", "*.dll", "*.dylib"]
+
 [project.optional-dependencies]
 test = [
     "pytest>=8",

--- a/python/src/snowflake/ud_connector/_core/.gitignore
+++ b/python/src/snowflake/ud_connector/_core/.gitignore
@@ -1,3 +1,3 @@
 *
 !.gitignore
-__init__.py
+!__init__.py

--- a/python/src/snowflake/ud_connector/_core/.gitignore
+++ b/python/src/snowflake/ud_connector/_core/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+__init__.py

--- a/python/src/snowflake/ud_connector/connection.py
+++ b/python/src/snowflake/ud_connector/connection.py
@@ -7,6 +7,16 @@ from ._internal.api_client.client_api import database_driver_client
 from .cursor import Cursor
 from .exceptions import NotSupportedError, InterfaceError
 
+from snowflake.ud_connector._internal.protobuf_gen.database_driver_v1_services import (
+    DatabaseNewRequest,
+    DatabaseInitRequest,
+    ConnectionNewRequest,
+    ConnectionSetOptionIntRequest,
+    ConnectionSetOptionStringRequest,
+    ConnectionSetOptionDoubleRequest,
+    ConnectionInitRequest
+)
+
 
 class Connection:
     """

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,7 +3,6 @@ pytest configuration and fixtures for PEP 249 tests.
 """
 
 import pytest
-from pathlib import Path
 
 from .connector_factory import ConnectorFactory, create_connection_with_adapter
 from .compatibility import set_current_connector
@@ -39,13 +38,10 @@ def connector_adapter(request, connector_type):
     """Create the appropriate connector adapter based on command line option."""
     reference_package = request.config.getoption("--reference-package")
 
-    try:
-        if connector_type == ConnectorType.REFERENCE:
-            return ConnectorFactory.create_adapter(connector_type, package_name=reference_package)
-        else:
-            return ConnectorFactory.create_adapter(connector_type)
-    except ImportError as e:
-        pytest.skip(f"Connector {connector_type} not available: {e}")
+    if connector_type == ConnectorType.REFERENCE:
+        return ConnectorFactory.create_adapter(connector_type, package_name=reference_package)
+
+    return ConnectorFactory.create_adapter(connector_type)
 
 
 @pytest.fixture

--- a/python/tests/connector_factory.py
+++ b/python/tests/connector_factory.py
@@ -46,8 +46,8 @@ class UniversalConnectorAdapter(ConnectorAdapter):
     
     def __init__(self):
         # Import the universal connector
-        import python
-        self.connector = python
+        from snowflake import ud_connector
+        self.connector = ud_connector
     
     def connect(self, **kwargs) -> Any:
         """Create a connection using the universal connector."""


### PR DESCRIPTION
Load core module from Python package sources instead of environment variable path. Adds `make dev-build` for easy development setup to populate `snowflake.ud_connector._core` with core binaries.