### PR TITLE
Use rustls_native_certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.3",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3381,7 +3381,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3771,6 +3771,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rustls 0.23.32",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
  "serde",
@@ -3792,7 +3793,6 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "webpki-roots 0.26.11",
  "x509-cert",
  "x509-parser",
  "zstd",
@@ -4737,15 +4737,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -46,7 +46,7 @@ glob = "0.3.3"
 rustls = { version = "0.23.20", features = ["aws_lc_rs", "fips"] }
 rustls-pemfile = "2.2.0"
 rustls-webpki = "0.102"
-webpki-roots = "0.26.7"
+rustls-native-certs = "0.8"
 thiserror = "1.0.69"
 aws-lc-rs = "1.13.2"
 x509-parser = "0.16"

--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -395,14 +395,14 @@ impl CrlCache {
         let mut attempted_anchor = false;
         if !verified
             && let Some(store) = root_store
-            && let Some(anchor_view) =
+            && let Some(anchor) =
                 crate::tls::x509_utils::resolve_anchor_issuer_key(crl_bytes, store)
         {
             attempted_anchor = true;
             verified = crate::tls::x509_utils::verify_crl_sig_with_name_and_spki(
                 crl_bytes,
-                anchor_view.subject_der().as_ref(),
-                anchor_view.spki_der().as_ref(),
+                anchor.subject.as_ref(),
+                anchor.subject_public_key_info.as_ref(),
             )
             .is_ok();
         }

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -336,16 +336,11 @@ pub fn resolve_anchor_issuer_key(
 ) -> Option<TrustAnchor<'static>> {
     let crl = RcCertificateList::from_der(crl_der).ok()?;
     let issuer_der = crl.tbs_cert_list.issuer.to_der().ok()?;
-    let issuer_subject = ensure_name_der(issuer_der.as_slice());
-    let issuer_canon = canonicalize_name(issuer_der.as_slice());
+    let issuer_canon = canonicalize_name(issuer_der.as_slice())?;
     for anchor in root_store.roots.iter() {
-        let anchor_subject = ensure_name_der(anchor.subject.as_ref());
-        let anchor_canon = canonicalize_name(anchor.subject.as_ref());
-        let matches = match (issuer_canon.as_deref(), anchor_canon.as_deref()) {
-            (Some(lhs), Some(rhs)) => lhs == rhs,
-            _ => anchor_subject.as_ref() == issuer_subject.as_ref(),
-        };
-        if matches {
+        if let Some(anchor_canon) = canonicalize_name(anchor.subject.as_ref())
+            && anchor_canon == issuer_canon
+        {
             return Some(anchor.clone());
         }
     }

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -232,13 +232,13 @@ pub fn verify_crl_sig_with_name_and_spki(
     spki_der: &[u8],
 ) -> Result<(), CrlError> {
     let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
-    let issuer_name_bytes = wrap_if_needed(issuer_name_der);
+    let issuer_name_bytes = ensure_name_der(issuer_name_der);
     if let Ok(issuer_name) = x509_cert::name::Name::from_der(issuer_name_bytes.as_ref())
         && issuer_name != crl.tbs_cert_list.issuer
     {
         return CrlIssuerMismatchSnafu {}.fail();
     }
-    let spki_bytes = wrap_if_needed(spki_der);
+    let spki_bytes = ensure_spki_der(spki_der);
     let spki = x509_cert::spki::SubjectPublicKeyInfoRef::from_der(spki_bytes.as_ref())
         .context(CrlToDerSnafu)?;
     verify_crl_sig_with_spki(&crl, spki)
@@ -336,10 +336,10 @@ pub fn resolve_anchor_issuer_key(
 ) -> Option<TrustAnchor<'static>> {
     let crl = RcCertificateList::from_der(crl_der).ok()?;
     let issuer_der = crl.tbs_cert_list.issuer.to_der().ok()?;
-    let issuer_subject = wrap_if_needed(issuer_der.as_slice());
+    let issuer_subject = ensure_name_der(issuer_der.as_slice());
     let issuer_canon = canonicalize_name(issuer_der.as_slice());
     for anchor in root_store.roots.iter() {
-        let anchor_subject = wrap_if_needed(anchor.subject.as_ref());
+        let anchor_subject = ensure_name_der(anchor.subject.as_ref());
         let anchor_canon = canonicalize_name(anchor.subject.as_ref());
         let matches = match (issuer_canon.as_deref(), anchor_canon.as_deref()) {
             (Some(lhs), Some(rhs)) => lhs == rhs,
@@ -354,8 +354,8 @@ pub fn resolve_anchor_issuer_key(
 
 // Webpki stores subjects as the bare RDN sequence while `x509-parser` expects a canonical
 // DER `SEQUENCE`.
-fn canonicalize_name(der: &[u8]) -> Option<String> {
-    let wrapped = wrap_if_needed(der);
+pub fn canonicalize_name(der: &[u8]) -> Option<String> {
+    let wrapped = ensure_name_der(der);
     canonicalize_from_der(wrapped.as_ref())
 }
 
@@ -378,8 +378,16 @@ fn canonicalize_from_der(der: &[u8]) -> Option<String> {
     None
 }
 
-fn wrap_if_needed(bytes: &[u8]) -> Cow<'_, [u8]> {
-    if bytes.first() == Some(&0x30) {
+fn ensure_name_der(bytes: &[u8]) -> Cow<'_, [u8]> {
+    if x509_cert::name::Name::from_der(bytes).is_ok() {
+        Cow::Borrowed(bytes)
+    } else {
+        Cow::Owned(wrap_as_der_sequence(bytes))
+    }
+}
+
+fn ensure_spki_der(bytes: &[u8]) -> Cow<'_, [u8]> {
+    if x509_cert::spki::SubjectPublicKeyInfoRef::from_der(bytes).is_ok() {
         Cow::Borrowed(bytes)
     } else {
         Cow::Owned(wrap_as_der_sequence(bytes))

--- a/sf_core/src/tls/x509_utils.rs
+++ b/sf_core/src/tls/x509_utils.rs
@@ -6,9 +6,10 @@ use crate::crl::error::{
     CertificateParseSnafu, CrlError, CrlListParseSnafu, CrlParsingSnafu, CrlToDerSnafu,
 };
 use const_oid::ObjectIdentifier;
-use num_traits::ToPrimitive;
+use num_traits::cast::ToPrimitive;
 use rustls::pki_types::TrustAnchor;
 use std::borrow::Cow;
+use std::mem::size_of;
 use x509_cert::crl::CertificateList as RcCertificateList;
 use x509_cert::der::{Decode, Encode};
 use x509_cert::name::Name as CertName;
@@ -33,6 +34,17 @@ pub enum X509Error {
         #[snafu(implicit)]
         location: Location,
     },
+}
+
+/// Load the platform's default TLS trust anchors into a `rustls::RootCertStore`.
+pub fn load_system_root_store() -> Result<rustls::RootCertStore, rustls_native_certs::Error> {
+    let mut result = rustls_native_certs::load_native_certs();
+    if let Some(err) = result.errors.pop() {
+        return Err(err);
+    }
+    let mut store = rustls::RootCertStore::empty();
+    store.add_parsable_certificates(result.certs);
+    Ok(store)
 }
 
 pub fn extract_skid(cert_der: &[u8]) -> Result<Option<Vec<u8>>, X509Error> {
@@ -220,23 +232,22 @@ pub fn verify_crl_sig_with_name_and_spki(
     spki_der: &[u8],
 ) -> Result<(), CrlError> {
     let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
-    let issuer_name_bytes = wrap_if_needed_cow(issuer_name_der, name_is_valid_der);
+    let issuer_name_bytes = wrap_if_needed(issuer_name_der);
     if let Ok(issuer_name) = x509_cert::name::Name::from_der(issuer_name_bytes.as_ref())
         && issuer_name != crl.tbs_cert_list.issuer
     {
         return CrlIssuerMismatchSnafu {}.fail();
     }
-    let spki_bytes = wrap_if_needed_cow(spki_der, spki_is_valid_der);
+    let spki_bytes = wrap_if_needed(spki_der);
     let spki = x509_cert::spki::SubjectPublicKeyInfoRef::from_der(spki_bytes.as_ref())
         .context(CrlToDerSnafu)?;
-    verify_crl_sig_with_spki(crl_der, spki)
+    verify_crl_sig_with_spki(&crl, spki)
 }
 
 fn verify_crl_sig_with_spki(
-    crl_der: &[u8],
+    crl: &RcCertificateList,
     spki: x509_cert::spki::SubjectPublicKeyInfoRef<'_>,
 ) -> Result<(), CrlError> {
-    let crl = RcCertificateList::from_der(crl_der).context(CrlListParseSnafu)?;
     let spk_bytes = spki
         .subject_public_key
         .as_bytes()
@@ -257,7 +268,7 @@ fn verify_crl_sig_with_spki(
     let oid_ecdsa_sha512 = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.4");
     let oid_ed25519 = ObjectIdentifier::new_unwrap("1.3.101.112");
 
-    let tbs = tbs_crl_der(crl_der)?;
+    let tbs = crl.tbs_cert_list.to_der().context(CrlToDerSnafu)?;
     let sig_bytes = crl.signature.as_bytes().context(InvalidCrlSignatureSnafu)?;
     let try_verify = |alg: &'static dyn aws_lc_rs::signature::VerificationAlgorithm| {
         aws_lc_rs::signature::UnparsedPublicKey::new(alg, spk_bytes).verify(&tbs, sig_bytes)
@@ -322,18 +333,20 @@ fn crl_preflight_checks(crl_der: &[u8]) -> Result<(), CrlError> {
 pub fn resolve_anchor_issuer_key(
     crl_der: &[u8],
     root_store: &rustls::RootCertStore,
-) -> Option<TrustAnchorView> {
+) -> Option<TrustAnchor<'static>> {
     let crl = RcCertificateList::from_der(crl_der).ok()?;
     let issuer_der = crl.tbs_cert_list.issuer.to_der().ok()?;
+    let issuer_subject = wrap_if_needed(issuer_der.as_slice());
     let issuer_canon = canonicalize_name(issuer_der.as_slice());
     for anchor in root_store.roots.iter() {
-        let view = TrustAnchorView::new(anchor);
-        let matches = match (issuer_canon.as_deref(), view.canonical_subject()) {
+        let anchor_subject = wrap_if_needed(anchor.subject.as_ref());
+        let anchor_canon = canonicalize_name(anchor.subject.as_ref());
+        let matches = match (issuer_canon.as_deref(), anchor_canon.as_deref()) {
             (Some(lhs), Some(rhs)) => lhs == rhs,
-            _ => view.subject_der().as_ref() == issuer_der.as_slice(),
+            _ => anchor_subject.as_ref() == issuer_subject.as_ref(),
         };
         if matches {
-            return Some(view);
+            return Some(anchor.clone());
         }
     }
     None
@@ -342,10 +355,8 @@ pub fn resolve_anchor_issuer_key(
 // Webpki stores subjects as the bare RDN sequence while `x509-parser` expects a canonical
 // DER `SEQUENCE`.
 fn canonicalize_name(der: &[u8]) -> Option<String> {
-    canonicalize_from_der(der).or_else(|| {
-        let wrapped = wrap_as_der_sequence(der);
-        canonicalize_from_der(wrapped.as_slice())
-    })
+    let wrapped = wrap_if_needed(der);
+    canonicalize_from_der(wrapped.as_ref())
 }
 
 fn canonicalize_from_der(der: &[u8]) -> Option<String> {
@@ -367,8 +378,15 @@ fn canonicalize_from_der(der: &[u8]) -> Option<String> {
     None
 }
 
+fn wrap_if_needed(bytes: &[u8]) -> Cow<'_, [u8]> {
+    if bytes.first() == Some(&0x30) {
+        Cow::Borrowed(bytes)
+    } else {
+        Cow::Owned(wrap_as_der_sequence(bytes))
+    }
+}
+
 fn wrap_as_der_sequence(input: &[u8]) -> Vec<u8> {
-    // webpki drops the outer SEQUENCE header for both Name and SPKI bodies
     let len = input.len();
     // length + tag + form indicator + length bytes
     let mut out = Vec::with_capacity(len + 1 + 1 + size_of::<usize>());
@@ -389,69 +407,6 @@ fn wrap_as_der_sequence(input: &[u8]) -> Vec<u8> {
     }
     out.extend_from_slice(input);
     out
-}
-
-/// Adapter that reconciles rustls/webpki trust anchors with the DER-encoded
-/// structures expected by `x509-parser`/`x509-cert`.
-pub struct TrustAnchorView {
-    subject_der: Vec<u8>,
-    spki_der: Vec<u8>,
-    canonical_subject: Option<String>,
-}
-
-impl TrustAnchorView {
-    pub fn new(anchor: &TrustAnchor<'static>) -> Self {
-        let subject_der = wrap_if_needed(anchor.subject.as_ref(), name_is_valid_der);
-        let spki_der = wrap_if_needed(anchor.subject_public_key_info.as_ref(), spki_is_valid_der);
-        let canonical_subject = canonicalize_name(subject_der.as_slice());
-        Self {
-            subject_der,
-            spki_der,
-            canonical_subject,
-        }
-    }
-
-    pub fn subject_der(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.subject_der.as_slice())
-    }
-
-    pub fn spki_der(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.spki_der.as_slice())
-    }
-
-    pub fn canonical_subject(&self) -> Option<&str> {
-        self.canonical_subject.as_deref()
-    }
-}
-
-fn wrap_if_needed<T, E, F>(bytes: &[u8], parser: F) -> Vec<u8>
-where
-    for<'a> F: Fn(&'a [u8]) -> Result<T, E>,
-{
-    if parser(bytes).is_ok() {
-        bytes.to_vec()
-    } else {
-        wrap_as_der_sequence(bytes)
-    }
-}
-
-fn wrap_if_needed_cow<T, E, F>(bytes: &[u8], parser: F) -> Cow<'_, [u8]>
-where
-    for<'a> F: Fn(&'a [u8]) -> Result<T, E>,
-{
-    if parser(bytes).is_ok() {
-        Cow::Borrowed(bytes)
-    } else {
-        Cow::Owned(wrap_as_der_sequence(bytes))
-    }
-}
-
-fn name_is_valid_der(bytes: &[u8]) -> Result<(), x509_cert::der::Error> {
-    x509_cert::name::Name::from_der(bytes).map(|_| ())
-}
-
-fn spki_is_valid_der(bytes: &[u8]) -> Result<(), x509_cert::der::Error> {
-    x509_cert::spki::SubjectPublicKeyInfoRef::from_der(bytes).map(|_| ())
 }
 
 // Return canonical DER of the CRL's TBS (to-be-signed) part
@@ -779,16 +734,21 @@ mod tests {
             Err(_) => return, // skip if fixture unavailable
         };
 
-        // Build default root store (webpki_roots)
-        let mut store = rustls::RootCertStore::empty();
-        store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        // Build default root store (system roots)
+        let store = match load_system_root_store() {
+            Ok(store) => store,
+            Err(err) => {
+                eprintln!("Unable to load native root store for anchor resolution test: {err}");
+                return;
+            }
+        };
 
         // Try to resolve anchor by CRL issuer subject
         let anchor = super::resolve_anchor_issuer_key(&crl_bytes, &store);
 
-        if let Some(anchor_view) = anchor {
-            let subject_der = anchor_view.subject_der();
-            let spki_der = anchor_view.spki_der();
+        if let Some(anchor) = anchor {
+            let subject_der = anchor.subject;
+            let spki_der = anchor.subject_public_key_info;
             // If an anchor matches, verify CRL signature using that anchor's SPKI
             let ok = super::verify_crl_sig_with_name_and_spki(
                 &crl_bytes,
@@ -812,14 +772,13 @@ mod tests {
     }
 
     #[test]
-    fn trust_anchor_view_provides_compatibility_with_x509() {
+    fn trust_anchor_subject_matches_canonical_form() {
         let cert_der = build_self_signed_cert("Example Root");
         let mut store = rustls::RootCertStore::empty();
         store
             .add(CertificateDer::from(cert_der.clone()))
             .expect("root insert");
         let anchor = store.roots.first().expect("root anchor present");
-        let view = TrustAnchorView::new(anchor);
 
         let (_, parsed_cert) =
             x509_parser::certificate::X509Certificate::from_der(cert_der.as_slice()).unwrap();
@@ -828,11 +787,8 @@ mod tests {
             .to_string_with_registry(oid_registry())
             .unwrap()
             .to_lowercase();
-        assert_eq!(
-            view.canonical_subject(),
-            Some(expected.as_str()),
-            "canonical subject should match original certificate"
-        );
+        let actual = canonicalize_name(anchor.subject.as_ref());
+        assert_eq!(actual.as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/sf_core/tests/e2e/tls/crl_enabled.rs
+++ b/sf_core/tests/e2e/tls/crl_enabled.rs
@@ -1,9 +1,9 @@
-use super::super::common::test_utils::*;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
 
 #[test]
 fn should_connect_and_select_with_crl_enabled() {
     // Given Snowflake client is logged in
-    let client = SnowflakeTestClient::with_default_params();
+    let client = SnowflakeTestClient::connect_with_default_auth();
 
     // And CRL is enabled
     client.set_connection_option("crl_mode", "ENABLED");

--- a/sf_core/tests/e2e/tls/mod.rs
+++ b/sf_core/tests/e2e/tls/mod.rs
@@ -1,2 +1,3 @@
 mod connection_init;
+mod crl_enabled;
 mod handshake;


### PR DESCRIPTION
This means we no longer use the distributed webpki root certs and get native overrides via `SSL_CERT_FILE` for free.
It also simplifies our DER handling, as we no longer have to re-wrap the certs. As a side note, that wouldn't have been necessary if I had used webpki-root-certs rather than webpki-roots.

Surprise - we fix our e2e crl test in rust, as it was not actually running from the test module.