### PR TITLE
Fix empty result handling when query returns zero rows

### DIFF
--- a/jdbc/src/test/java/com/snowflake/jdbc/e2e/query/EmptyResultTest.java
+++ b/jdbc/src/test/java/com/snowflake/jdbc/e2e/query/EmptyResultTest.java
@@ -1,0 +1,81 @@
+package com.snowflake.jdbc.e2e.query;
+
+import com.snowflake.jdbc.SnowflakeDriver;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.*;
+import java.util.Properties;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/**
+ * Tests for empty result handling
+ */
+public class EmptyResultTest {
+
+    private Properties loadConnectionProperties() throws Exception {
+        String paramPath = System.getenv("PARAMETER_PATH");
+        if (paramPath == null) {
+            paramPath = "/parameters.json";
+        }
+        InputStream input = new java.io.FileInputStream(paramPath);
+        if (input == null) {
+            throw new RuntimeException("Could not find parameters.json");
+        }
+
+        JSONObject params = new JSONObject(new JSONTokener(new InputStreamReader(input)));
+        params = params.getJSONObject("testconnection");
+        
+        Properties props = new Properties();
+        props.setProperty("user", params.getString("SNOWFLAKE_TEST_USER"));
+        props.setProperty("password", params.getString("SNOWFLAKE_TEST_PASSWORD"));
+        props.setProperty("db", params.getString("SNOWFLAKE_TEST_DATABASE"));
+        props.setProperty("schema", params.getString("SNOWFLAKE_TEST_SCHEMA"));
+        props.setProperty("warehouse", params.getString("SNOWFLAKE_TEST_WAREHOUSE"));
+        props.setProperty("account", params.getString("SNOWFLAKE_TEST_ACCOUNT"));
+        
+        if (params.has("SNOWFLAKE_TEST_PORT")) {
+            props.setProperty("port", String.valueOf(params.getInt("SNOWFLAKE_TEST_PORT")));
+        }
+        if (params.has("SNOWFLAKE_TEST_ROLE")) {
+            props.setProperty("role", params.getString("SNOWFLAKE_TEST_ROLE"));
+        }
+        
+        return props;
+    }
+
+    /**
+     * Test: should return empty result when query produces no rows
+     */
+    @Test
+    public void shouldReturnEmptyResultWhenQueryProducesNoRows() throws Exception {
+        // Given Snowflake client is logged in
+        Properties props = loadConnectionProperties();
+        String url = "jdbc:snowflake://" + props.getProperty("account") + ".snowflakecomputing.com";
+        if (props.getProperty("port") != null) {
+            url += ":" + props.getProperty("port");
+        }
+        
+        SnowflakeDriver.empty();
+        Connection conn = DriverManager.getConnection(url, props);
+
+        try {
+            // When Query "SELECT 1 WHERE FALSE" is executed
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("SELECT 1 WHERE FALSE");
+            
+            // Then empty result set is returned
+            assertNotNull("ResultSet should not be null", rs);
+            assertFalse("ResultSet should have no rows", rs.next());
+
+            rs.close();
+            stmt.close();
+        } finally {
+            conn.close();
+        }
+    }
+}
+

--- a/odbc_tests/tests/e2e/query/empty_result.cpp
+++ b/odbc_tests/tests/e2e/query/empty_result.cpp
@@ -1,0 +1,26 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+
+Connection get_connection() { return Connection(); }
+
+TEST_CASE("should return empty result when query produces no rows", "[empty_result]") {
+  // Given Snowflake client is logged in
+  auto conn = get_connection();
+
+  // When Query "SELECT 1 WHERE FALSE" is executed
+  auto stmt = conn.createStatement();
+  const auto sql = "SELECT 1 WHERE FALSE";
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then empty result set is returned
+  SQLSMALLINT num_cols;
+  ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  CHECK_ODBC(ret, stmt);
+  REQUIRE(num_cols == 1);
+
+  // Verify first fetch returns SQL_NO_DATA (no rows)
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_NO_DATA);
+}

--- a/python/tests/e2e/query/test_empty_result.py
+++ b/python/tests/e2e/query/test_empty_result.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+class TestEmptyResult:
+
+    def test_should_return_empty_result_when_query_produces_no_rows(self, cursor):
+        # Given Snowflake client is logged in
+        assert not cursor.connection.is_closed(), "Connection should be open"
+
+        # When Query "SELECT 1 WHERE FALSE" is executed
+        cursor.execute("SELECT 1 WHERE FALSE")
+        rows = cursor.fetchall()
+
+        # Then empty result set is returned
+        assert rows == []

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -67,6 +67,11 @@ async fn read_batches(
     if let Some(rowset_base64) = &data.rowset_base64 {
         let rowset_bytes = BASE64.decode(rowset_base64).context(Base64DecodingSnafu)?;
 
+        // Handle empty result - return empty reader with schema from rowtype
+        if rowset_bytes.is_empty() {
+            return create_empty_reader_from_rowtype(data);
+        }
+
         let reader_result = if let Some(chunk_download_data) = data.to_chunk_download_data() {
             ChunkReader::multi_chunk(
                 rowset_bytes,
@@ -186,6 +191,30 @@ fn build_generic_text_rowtype(name: &str) -> RowType {
 
 fn build_generic_fixed_rowtype(name: &str) -> RowType {
     RowType::fixed_with_scale_zero(name, false, PUT_GET_ROWSET_FIXED_LENGTH)
+}
+
+/// Creates an empty Arrow reader with schema from rowtype metadata.
+/// Used when query returns 0 rows (empty rowsetBase64).
+fn create_empty_reader_from_rowtype(
+    data: &query_response::Data,
+) -> Result<Box<dyn RecordBatchReader + Send>, ReadBatchesError> {
+    if let Some(rowtype) = &data.row_type {
+        let row_types: Vec<RowType> = rowtype
+            .iter()
+            .map(|rt| rt.try_into())
+            .collect::<Result<Vec<_>, _>>()
+            .context(RowTypeParsingSnafu)?;
+
+        let schema = create_schema(&row_types).context(RowsetConversionSnafu)?;
+
+        // Create empty reader with just the schema (no batches)
+        Ok(Box::new(arrow::record_batch::RecordBatchIterator::new(
+            std::iter::empty(),
+            schema,
+        )))
+    } else {
+        MissingRowsetOrRowtypeSnafu.fail()
+    }
 }
 
 #[derive(Debug, Snafu)]

--- a/tests/definitions/shared/query/empty_result.feature
+++ b/tests/definitions/shared/query/empty_result.feature
@@ -1,0 +1,13 @@
+@odbc @python @jdbc
+Feature: Empty Result Handling
+
+  When a query returns zero rows (e.g., "SELECT 1 WHERE FALSE"), the driver
+  should handle this gracefully and return an empty result set rather than
+  throwing an error.
+
+  @odbc_e2e @python_e2e @jdbc_e2e
+  Scenario: should return empty result when query produces no rows
+    Given Snowflake client is logged in
+    When Query "SELECT 1 WHERE FALSE" is executed
+    Then empty result set is returned
+


### PR DESCRIPTION
When Snowflake returns zero rows, it sends an empty rowsetBase64 string. This made wrappers finish with an error.

This fix checks for empty decoded bytes and creates an empty Arrow reader with the schema from rowtype instead of attempting to parse empty IPC data.

