### PR TITLE
Python: Run pre-commit only on changed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     -   id: python-checks
         name: Python code checks (ruff + mypy)
         description: Run linting, formatting, and type checks on changed Python files
-        entry: bash -c 'cd python && hatch run precommit:check "$@"' --
+        entry: bash -c 'cd python && hatch run precommit:check $(echo "$@" | sed "s|python/||g")' --
         pass_filenames: true
         files: ^python/.*\.py$
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,8 @@ repos:
         language: system
     -   id: python-checks
         name: Python code checks (ruff + mypy)
-        description: Run linting, formatting, and type checks on Python files in python/ directory
-        entry: bash -c 'cd python && hatch run precommit:check'
-        pass_filenames: false
+        description: Run linting, formatting, and type checks on changed Python files
+        entry: bash -c 'cd python && hatch run precommit:check "$@"' --
+        pass_filenames: true
         files: ^python/.*\.py$
         language: system

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -159,8 +159,8 @@ show-paths = "python scripts/detect_core_path.py --export"
 # Precommit environment
 [tool.hatch.envs.precommit.scripts]
 check = [
-    'ruff format --check src/snowflake tests',
-    'ruff check src/snowflake tests',
+    'ruff format --check {args:src/snowflake tests}',
+    'ruff check {args:src/snowflake tests}',
     'mypy --install-types --non-interactive -p snowflake.ud_connector',
 ]
 fix = [


### PR DESCRIPTION
Makes pre-commit faster by running ruff only on changed Python files instead of all files.