### PR TITLE
python - add support for DECFLOAT

### DIFF
--- a/python/tests/e2e/types/conftest.py
+++ b/python/tests/e2e/types/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for type tests."""
+
+from __future__ import annotations
+
+from decimal import getcontext
+
+import pytest
+
+
+# =============================================================================
+# DECIMAL CONTEXT CONFIGURATION
+# =============================================================================
+# DECFLOAT and NUMBER types require Python's Decimal context to have 38-digit
+# precision to properly represent all values without rounding
+DECIMAL_PRECISION_38 = 38
+
+
+@pytest.fixture(autouse=True)
+def setup_decimal_precision():
+    """Set decimal context precision to 38 for all type tests.
+
+    This ensures Decimal operations don't lose precision for DECFLOAT
+    and NUMBER types which support up to 38 significant digits.
+    """
+    old_prec = getcontext().prec
+    getcontext().prec = DECIMAL_PRECISION_38
+    yield
+    getcontext().prec = old_prec

--- a/python/tests/e2e/types/conftest.py
+++ b/python/tests/e2e/types/conftest.py
@@ -24,5 +24,7 @@ def setup_decimal_precision():
     """
     old_prec = getcontext().prec
     getcontext().prec = DECIMAL_PRECISION_38
-    yield
-    getcontext().prec = old_prec
+    try:
+        yield
+    finally:
+        getcontext().prec = old_prec

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -299,6 +299,21 @@ class TestDecfloatBinding:
         # Then Result should contain [NULL]
         assert result == (None,)
 
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_select_extreme_decfloat_values_using_parameter_binding(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
+        result = execute_query(
+            "SELECT ?::DECFLOAT",
+            (("DECFLOAT", DECFLOAT_MAX_EXPONENT),),
+            single_row=True,
+        )
+
+        # Then Result should contain [1E+16384]
+        assert result == (DECFLOAT_MAX_EXPONENT,)
+        assert_type(result, Decimal)
+
         # When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
         result = execute_query(
             "SELECT ?::DECFLOAT",
@@ -308,6 +323,7 @@ class TestDecfloatBinding:
 
         # Then Result should contain [-1.234E+8000]
         assert result == (DECFLOAT_LARGE_POS_EXPONENT,)
+        assert_type(result, Decimal)
 
     @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
     def test_should_insert_decfloat_using_parameter_binding(self, execute_query, tmp_schema):
@@ -317,12 +333,11 @@ class TestDecfloatBinding:
         table_name = f"{tmp_schema}.decfloat_bind_table"
         execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
 
-        # When DECFLOAT values [0, 123.456, -789.012, 1.23e100, NULL] are inserted using explicit binding
+        # When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
         test_values = [
             Decimal("0"),
             Decimal("123.456"),
             Decimal("-789.012"),
-            Decimal("1.23E+100"),
             None,
         ]
         for val in test_values:
@@ -335,7 +350,31 @@ class TestDecfloatBinding:
         rows = execute_query(f"SELECT * FROM {table_name}")
 
         # Then SELECT should return the same exact values
-        # And All precision should be preserved
         result = [row[0] for row in rows]
         assert result == test_values
         assert_type(result, Decimal, can_be_none=True)
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_insert_extreme_decfloat_values_using_parameter_binding(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists
+        table_name = f"{tmp_schema}.decfloat_extreme_bind_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+
+        # When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
+        extreme_values = [
+            DECFLOAT_MAX_EXPONENT,
+            DECFLOAT_MIN_EXPONENT,
+            DECFLOAT_LARGE_POS_EXPONENT,
+        ]
+        for val in extreme_values:
+            execute_query(f"INSERT INTO {table_name} VALUES (?)", (("DECFLOAT", val),))
+
+        # And Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then SELECT should return the same exact values
+        result = [row[0] for row in rows]
+        assert result == extreme_values
+        assert_type(result, Decimal)

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -1,0 +1,341 @@
+"""DECFLOAT type tests for Universal Driver.
+
+This module tests DECFLOAT type which provides exact 38-digit decimal precision
+with a wide exponent range (-16383 to +16384).
+
+DECFLOAT has NO type synonyms (unlike FLOAT).
+DECFLOAT does NOT support special values (NaN, inf, -inf) unlike FLOAT.
+
+All values are returned as Python Decimal type with full 38-digit precision.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+
+import pytest
+
+from .utils import assert_types
+
+
+# =============================================================================
+# DECIMAL CONTEXT CONFIGURATION
+# =============================================================================
+# DECFLOAT requires Python's Decimal context to have 38-digit precision
+# to properly represent all values without rounding
+DECFLOAT_PRECISION = 38
+
+
+@pytest.fixture(autouse=True)
+def setup_decimal_precision():
+    """Set decimal context precision to 38 for all DECFLOAT tests."""
+    old_prec = getcontext().prec
+    getcontext().prec = DECFLOAT_PRECISION
+    yield
+    getcontext().prec = old_prec
+
+
+# =============================================================================
+# PRECISION TEST VALUES (38 significant decimal digits)
+# =============================================================================
+# Plain 38-digit integer
+DECFLOAT_38_DIGITS = Decimal("12345678901234567890123456789012345678")
+# 38 digits with positive exponent (very large number)
+DECFLOAT_38_DIGITS_POS_EXP = Decimal("1.2345678901234567890123456789012345678E+100")
+# 38 digits with negative exponent (very small number)
+DECFLOAT_38_DIGITS_NEG_EXP = Decimal("1.2345678901234567890123456789012345678E-100")
+
+# =============================================================================
+# EXTREME EXPONENT VALUES
+# =============================================================================
+# DECFLOAT exponent range: -16383 to +16384 (vastly exceeds FLOAT's ~±308)
+DECFLOAT_MAX_EXPONENT = Decimal("1E+16384")
+DECFLOAT_MIN_EXPONENT = Decimal("1E-16383")
+# Large positive/negative exponents for testing
+DECFLOAT_LARGE_POS_EXPONENT = Decimal("-1.234E+8000")
+DECFLOAT_LARGE_NEG_EXPONENT = Decimal("9.876E-8000")
+
+# =============================================================================
+# LARGE RESULT SET SIZE
+# =============================================================================
+LARGE_RESULT_SET_SIZE = 1_000_000
+
+
+class TestDecfloatTypeCasting:
+    """Tests for DECFLOAT type casting to appropriate type."""
+
+    def test_should_cast_decfloat_values_to_appropriate_type(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT,
+        # '12345678901234567890123456789012345678'::DECFLOAT" is executed
+        sql = f"SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT, '{DECFLOAT_38_DIGITS}'::DECFLOAT"
+        result = execute_query(sql, single_row=True)
+
+        # Then All values should be returned as appropriate type
+        assert_types(result, Decimal)
+
+        # And Values should maintain full 38-digit precision
+        assert result == (Decimal("0"), Decimal("123.456"), Decimal("1.23E+37"), DECFLOAT_38_DIGITS)
+
+
+class TestDecfloatLiteral:
+    """Tests for DECFLOAT type using SELECT with literals (no tables)."""
+
+    def test_should_select_decfloat_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT,
+        # 123.456789::DECFLOAT, -987.654321::DECFLOAT" is executed
+        sql = "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT"
+        result = execute_query(sql, single_row=True)
+
+        # Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
+        expected = (
+            Decimal("0"),
+            Decimal("1.5"),
+            Decimal("-1.5"),
+            Decimal("123.456789"),
+            Decimal("-987.654321"),
+        )
+        assert result == expected
+        assert_types(result, Decimal)
+
+    def test_should_handle_full_38_digit_precision_values_from_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT,
+        # '1.2345678901234567890123456789012345678E+100'::DECFLOAT,
+        # '1.2345678901234567890123456789012345678E-100'::DECFLOAT" is executed
+        sql = (
+            f"SELECT '{DECFLOAT_38_DIGITS}'::DECFLOAT, "
+            f"'{DECFLOAT_38_DIGITS_POS_EXP}'::DECFLOAT, "
+            f"'{DECFLOAT_38_DIGITS_NEG_EXP}'::DECFLOAT"
+        )
+        result = execute_query(sql, single_row=True)
+
+        # Then Result should preserve all 38 digits for each value
+        assert result == (DECFLOAT_38_DIGITS, DECFLOAT_38_DIGITS_POS_EXP, DECFLOAT_38_DIGITS_NEG_EXP)
+        assert_types(result, Decimal)
+
+    def test_should_handle_extreme_exponent_values_from_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
+        result = execute_query(
+            f"SELECT '{DECFLOAT_MAX_EXPONENT}'::DECFLOAT, '{DECFLOAT_MIN_EXPONENT}'::DECFLOAT",
+            single_row=True,
+        )
+        # Then Result should contain [1E+16384, 1E-16383]
+        assert result == (DECFLOAT_MAX_EXPONENT, DECFLOAT_MIN_EXPONENT)
+        assert_types(result, Decimal)
+
+        # When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
+        result = execute_query(
+            f"SELECT '{DECFLOAT_LARGE_POS_EXPONENT}'::DECFLOAT, '{DECFLOAT_LARGE_NEG_EXPONENT}'::DECFLOAT",
+            single_row=True,
+        )
+        # Then Result should contain [-1.234E+8000, 9.876E-8000]
+        assert result == (DECFLOAT_LARGE_POS_EXPONENT, DECFLOAT_LARGE_NEG_EXPONENT)
+        assert_types(result, Decimal)
+
+    def test_should_handle_null_values_from_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
+        result = execute_query("SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT", single_row=True)
+
+        # Then Result should contain [NULL, 42.5, NULL]
+        assert result == (None, Decimal("42.5"), None)
+        assert_types(result, Decimal, can_be_none=True)
+
+    def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        sql = f"SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v"
+        rows = execute_query(sql)
+
+        # Then Result should contain consecutive numbers from 0 to 999999
+        values = [row[0] for row in rows]
+        assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
+
+        # And All values should be returned as appropriate type
+        assert_types(values, Decimal)
+
+
+class TestDecfloatTable:
+    """Tests for DECFLOAT type using table operations."""
+
+    def test_should_select_decfloats_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+        table_name = f"{tmp_schema}.decfloat_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+        test_values = [
+            Decimal("0"),
+            Decimal("123.456"),
+            Decimal("-789.012"),
+            Decimal("1.23E+20"),
+            Decimal("-9.87E-15"),
+        ]
+        for val in test_values:
+            execute_query(f"INSERT INTO {table_name} VALUES ('{val}')")
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+        result = [row[0] for row in rows]
+        assert result == test_values
+        assert_types(result, Decimal)
+
+    def test_should_handle_full_38_digit_precision_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists with values
+        # [12345678901234567890123456789012345678,
+        # 1.2345678901234567890123456789012345678E+100,
+        # 1.2345678901234567890123456789012345678E-100]
+        table_name = f"{tmp_schema}.precision_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+        precision_values = [DECFLOAT_38_DIGITS, DECFLOAT_38_DIGITS_POS_EXP, DECFLOAT_38_DIGITS_NEG_EXP]
+        for val in precision_values:
+            execute_query(f"INSERT INTO {table_name} VALUES ('{val}')")
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should preserve all 38 digits for each value
+        result = [row[0] for row in rows]
+        assert result == precision_values
+        assert_types(result, Decimal)
+
+    def test_should_handle_extreme_exponent_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists with values
+        # [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+        table_name = f"{tmp_schema}.extreme_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+        extreme_values = [
+            DECFLOAT_MAX_EXPONENT,
+            DECFLOAT_MIN_EXPONENT,
+            DECFLOAT_LARGE_POS_EXPONENT,
+            DECFLOAT_LARGE_NEG_EXPONENT,
+        ]
+        for val in extreme_values:
+            execute_query(f"INSERT INTO {table_name} VALUES ('{val}')")
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+        result = [row[0] for row in rows]
+        assert result == extreme_values
+        assert_types(result, Decimal)
+
+    def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
+        table_name = f"{tmp_schema}.null_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL), (123.456), (NULL), (-789.012)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+        values = [row[0] for row in rows]
+
+        # Then Result should contain [NULL, 123.456, NULL, -789.012]
+        assert values == [None, Decimal("123.456"), None, Decimal("-789.012")]
+        assert_types(values, Decimal, can_be_none=True)
+
+    def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists with values from 0 to 999999
+        table_name = f"{tmp_schema}.large_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+        execute_query(
+            f"INSERT INTO {table_name} SELECT seq8()::DECFLOAT "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+        )
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
+
+        # Then Result should contain consecutive numbers from 0 to 999999
+        values = [row[0] for row in rows]
+        assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
+
+        # And All values should be returned as appropriate type
+        assert_types(values, Decimal)
+
+
+class TestDecfloatBinding:
+    """Tests for DECFLOAT type using parameter binding."""
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_select_decfloat_using_parameter_binding(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed
+        # with bound DECFLOAT values [123.456, -789.012, 42.0]
+        result = execute_query(
+            "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT",
+            (("DECFLOAT", Decimal("123.456")), ("DECFLOAT", Decimal("-789.012")), ("DECFLOAT", Decimal("42.0"))),
+            single_row=True,
+        )
+
+        # Then Result should contain [123.456, -789.012, 42.0]
+        assert result == (Decimal("123.456"), Decimal("-789.012"), Decimal("42.0"))
+        assert_types(result, Decimal)
+
+        # When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
+        result = execute_query("SELECT ?::DECFLOAT", (None,), single_row=True)
+
+        # Then Result should contain [NULL]
+        assert result == (None,)
+
+        # When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
+        result = execute_query(
+            "SELECT ?::DECFLOAT",
+            (("DECFLOAT", DECFLOAT_LARGE_POS_EXPONENT),),
+            single_row=True,
+        )
+
+        # Then Result should contain [-1.234E+8000]
+        assert result == (DECFLOAT_LARGE_POS_EXPONENT,)
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_insert_decfloat_using_parameter_binding(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with DECFLOAT column exists
+        table_name = f"{tmp_schema}.decfloat_bind_table"
+        execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
+
+        # When DECFLOAT values [0, 123.456, -789.012, 1.23e100, NULL] are inserted using explicit binding
+        test_values = [
+            Decimal("0"),
+            Decimal("123.456"),
+            Decimal("-789.012"),
+            Decimal("1.23E+100"),
+            None,
+        ]
+        for val in test_values:
+            if val is None:
+                execute_query(f"INSERT INTO {table_name} VALUES (?)", (None,))
+            else:
+                execute_query(f"INSERT INTO {table_name} VALUES (?)", (("DECFLOAT", val),))
+
+        # And Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then SELECT should return the same exact values
+        # And All precision should be preserved
+        result = [row[0] for row in rows]
+        assert result == test_values
+        assert_types(result, Decimal, can_be_none=True)

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -15,7 +15,7 @@ from decimal import Decimal, getcontext
 
 import pytest
 
-from .utils import assert_types
+from .utils import assert_type
 
 
 # =============================================================================
@@ -73,7 +73,7 @@ class TestDecfloatTypeCasting:
         result = execute_query(sql, single_row=True)
 
         # Then All values should be returned as appropriate type
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
         # And Values should maintain full 38-digit precision
         assert result == (Decimal("0"), Decimal("123.456"), Decimal("1.23E+37"), DECFLOAT_38_DIGITS)
@@ -99,7 +99,7 @@ class TestDecfloatLiteral:
             Decimal("-987.654321"),
         )
         assert result == expected
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_full_38_digit_precision_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
@@ -116,7 +116,7 @@ class TestDecfloatLiteral:
 
         # Then Result should preserve all 38 digits for each value
         assert result == (DECFLOAT_38_DIGITS, DECFLOAT_38_DIGITS_POS_EXP, DECFLOAT_38_DIGITS_NEG_EXP)
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_extreme_exponent_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
@@ -128,7 +128,7 @@ class TestDecfloatLiteral:
         )
         # Then Result should contain [1E+16384, 1E-16383]
         assert result == (DECFLOAT_MAX_EXPONENT, DECFLOAT_MIN_EXPONENT)
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
         # When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
         result = execute_query(
@@ -137,7 +137,7 @@ class TestDecfloatLiteral:
         )
         # Then Result should contain [-1.234E+8000, 9.876E-8000]
         assert result == (DECFLOAT_LARGE_POS_EXPONENT, DECFLOAT_LARGE_NEG_EXPONENT)
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_null_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
@@ -147,7 +147,7 @@ class TestDecfloatLiteral:
 
         # Then Result should contain [NULL, 42.5, NULL]
         assert result == (None, Decimal("42.5"), None)
-        assert_types(result, Decimal, can_be_none=True)
+        assert_type(result, Decimal, can_be_none=True)
 
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
@@ -161,7 +161,7 @@ class TestDecfloatLiteral:
         assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
 
         # And All values should be returned as appropriate type
-        assert_types(values, Decimal)
+        assert_type(values, Decimal)
 
 
 class TestDecfloatTable:
@@ -189,7 +189,7 @@ class TestDecfloatTable:
         # Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
         result = [row[0] for row in rows]
         assert result == test_values
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_full_38_digit_precision_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
@@ -210,7 +210,7 @@ class TestDecfloatTable:
         # Then Result should preserve all 38 digits for each value
         result = [row[0] for row in rows]
         assert result == precision_values
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_extreme_exponent_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
@@ -234,7 +234,7 @@ class TestDecfloatTable:
         # Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
         result = [row[0] for row in rows]
         assert result == extreme_values
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
     def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
@@ -250,7 +250,7 @@ class TestDecfloatTable:
 
         # Then Result should contain [NULL, 123.456, NULL, -789.012]
         assert values == [None, Decimal("123.456"), None, Decimal("-789.012")]
-        assert_types(values, Decimal, can_be_none=True)
+        assert_type(values, Decimal, can_be_none=True)
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
@@ -271,7 +271,7 @@ class TestDecfloatTable:
         assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
 
         # And All values should be returned as appropriate type
-        assert_types(values, Decimal)
+        assert_type(values, Decimal)
 
 
 class TestDecfloatBinding:
@@ -291,7 +291,7 @@ class TestDecfloatBinding:
 
         # Then Result should contain [123.456, -789.012, 42.0]
         assert result == (Decimal("123.456"), Decimal("-789.012"), Decimal("42.0"))
-        assert_types(result, Decimal)
+        assert_type(result, Decimal)
 
         # When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
         result = execute_query("SELECT ?::DECFLOAT", (None,), single_row=True)
@@ -338,4 +338,4 @@ class TestDecfloatBinding:
         # And All precision should be preserved
         result = [row[0] for row in rows]
         assert result == test_values
-        assert_types(result, Decimal, can_be_none=True)
+        assert_type(result, Decimal, can_be_none=True)

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -11,28 +11,11 @@ All values are returned as Python Decimal type with full 38-digit precision.
 
 from __future__ import annotations
 
-from decimal import Decimal, getcontext
+from decimal import Decimal
 
 import pytest
 
 from .utils import assert_type
-
-
-# =============================================================================
-# DECIMAL CONTEXT CONFIGURATION
-# =============================================================================
-# DECFLOAT requires Python's Decimal context to have 38-digit precision
-# to properly represent all values without rounding
-DECFLOAT_PRECISION = 38
-
-
-@pytest.fixture(autouse=True)
-def setup_decimal_precision():
-    """Set decimal context precision to 38 for all DECFLOAT tests."""
-    old_prec = getcontext().prec
-    getcontext().prec = DECFLOAT_PRECISION
-    yield
-    getcontext().prec = old_prec
 
 
 # =============================================================================

--- a/python/tests/e2e/types/test_decfloat_numpy.py
+++ b/python/tests/e2e/types/test_decfloat_numpy.py
@@ -1,0 +1,91 @@
+"""DECFLOAT type NumPy tests for Universal Driver (Python-specific).
+
+This module tests DECFLOAT type conversion to numpy.float64 when NumPy mode is enabled.
+These tests are Python-specific and not shared with other driver implementations.
+
+IMPORTANT: NumPy mode causes precision loss for DECFLOAT values!
+- DECFLOAT has 38-digit precision
+- numpy.float64 has only ~15-digit precision
+- Extreme exponents may overflow to infinity or underflow to zero
+
+Use standard mode (Python Decimal) when precision is critical.
+"""
+
+from __future__ import annotations
+
+from decimal import getcontext
+
+import pytest
+
+
+# NumPy is optional for these tests
+np = pytest.importorskip("numpy")
+
+# =============================================================================
+# DECIMAL CONTEXT CONFIGURATION
+# =============================================================================
+DECFLOAT_PRECISION = 38
+
+
+@pytest.fixture(autouse=True)
+def setup_decimal_precision():
+    """Set decimal context precision to 38 for all DECFLOAT tests."""
+    old_prec = getcontext().prec
+    getcontext().prec = DECFLOAT_PRECISION
+    yield
+    getcontext().prec = old_prec
+
+
+class TestDecfloatNumPy:
+    """Test suite for DECFLOAT type NumPy conversion (Python-specific)."""
+
+    @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
+    def test_should_cast_decfloat_values_to_numpy_float64(self, cursor_with_numpy):
+        # Given Snowflake client is logged in with NumPy mode enabled
+
+        # When Query "SELECT 1.234::DECFLOAT, 123.456::DECFLOAT, -789.012::DECFLOAT" is executed
+        sql = "SELECT 1.234::DECFLOAT, 123.456::DECFLOAT, -789.012::DECFLOAT"
+        cursor_with_numpy.execute(sql)
+        result = cursor_with_numpy.fetchone()
+
+        # Then All values should be returned as numpy.float64 type
+        expected = [1.234, 123.456, -789.012]
+        assert len(result) == len(expected)
+        for actual in result:
+            assert isinstance(actual, np.float64), f"Expected numpy.float64, got {type(actual)}"
+
+        # And Values should match approximately [1.234, 123.456, -789.012] within float64 precision
+        for actual, expect in zip(result, expected):
+            assert np.isclose(actual, expect, rtol=1e-14), f"Expected {expect}, got {actual}"
+
+    @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
+    def test_numpy_handles_extreme_exponents_within_float64_range(self, cursor_with_numpy):
+        # Given Snowflake client is logged in with NumPy mode enabled
+
+        # When Query with exponents within float64 range is executed
+        sql = "SELECT '1.23e100'::DECFLOAT, '9.87e-100'::DECFLOAT"
+        cursor_with_numpy.execute(sql)
+        result = cursor_with_numpy.fetchone()
+
+        # Then Values should be numpy.float64
+        assert isinstance(result[0], np.float64)
+        assert isinstance(result[1], np.float64)
+
+        # And Values should be approximately correct
+        assert np.isclose(result[0], 1.23e100, rtol=1e-14)
+        assert np.isclose(result[1], 9.87e-100, rtol=1e-14)
+
+    @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
+    def test_numpy_overflows_extreme_exponents_beyond_float64_range(self, cursor_with_numpy):
+        # Given Snowflake client is logged in with NumPy mode enabled
+
+        # When Query with exponents exceeding float64 range is executed
+        sql = "SELECT '1e16384'::DECFLOAT, '1e-16383'::DECFLOAT"
+        cursor_with_numpy.execute(sql)
+        result = cursor_with_numpy.fetchone()
+
+        # Then e16384 exceeds float64 max (~e308) and becomes infinity
+        assert np.isinf(result[0])
+
+        # And e-16383 is below float64 min (~e-308) and becomes 0
+        assert result[1] == 0.0 or np.isclose(result[1], 0.0)

--- a/python/tests/e2e/types/test_decfloat_numpy.py
+++ b/python/tests/e2e/types/test_decfloat_numpy.py
@@ -17,6 +17,8 @@ from decimal import getcontext
 
 import pytest
 
+from .utils import assert_floats_equal, assert_type
+
 
 # NumPy is optional for these tests
 np = pytest.importorskip("numpy")
@@ -49,14 +51,10 @@ class TestDecfloatNumPy:
         result = cursor_with_numpy.fetchone()
 
         # Then All values should be returned as numpy.float64 type
-        expected = [1.234, 123.456, -789.012]
-        assert len(result) == len(expected)
-        for actual in result:
-            assert isinstance(actual, np.float64), f"Expected numpy.float64, got {type(actual)}"
+        assert_type(result, np.float64)
 
         # And Values should match approximately [1.234, 123.456, -789.012] within float64 precision
-        for actual, expect in zip(result, expected):
-            assert np.isclose(actual, expect, rtol=1e-14), f"Expected {expect}, got {actual}"
+        assert_floats_equal(result, (1.234, 123.456, -789.012))
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
     def test_numpy_handles_extreme_exponents_within_float64_range(self, cursor_with_numpy):
@@ -68,12 +66,10 @@ class TestDecfloatNumPy:
         result = cursor_with_numpy.fetchone()
 
         # Then Values should be numpy.float64
-        assert isinstance(result[0], np.float64)
-        assert isinstance(result[1], np.float64)
+        assert_type(result, np.float64)
 
         # And Values should be approximately correct
-        assert np.isclose(result[0], 1.23e100, rtol=1e-14)
-        assert np.isclose(result[1], 9.87e-100, rtol=1e-14)
+        assert_floats_equal(result, (1.23e100, 9.87e-100))
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
     def test_numpy_overflows_extreme_exponents_beyond_float64_range(self, cursor_with_numpy):
@@ -85,7 +81,6 @@ class TestDecfloatNumPy:
         result = cursor_with_numpy.fetchone()
 
         # Then e16384 exceeds float64 max (~e308) and becomes infinity
-        assert np.isinf(result[0])
-
         # And e-16383 is below float64 min (~e-308) and becomes 0
-        assert result[1] == 0.0 or np.isclose(result[1], 0.0)
+        assert_floats_equal(result, (float("inf"), 0.0))
+        assert_type(result, np.float64)

--- a/python/tests/e2e/types/test_decfloat_numpy.py
+++ b/python/tests/e2e/types/test_decfloat_numpy.py
@@ -13,8 +13,6 @@ Use standard mode (Python Decimal) when precision is critical.
 
 from __future__ import annotations
 
-from decimal import getcontext
-
 import pytest
 
 from .utils import assert_floats_equal, assert_type
@@ -22,20 +20,6 @@ from .utils import assert_floats_equal, assert_type
 
 # NumPy is optional for these tests
 np = pytest.importorskip("numpy")
-
-# =============================================================================
-# DECIMAL CONTEXT CONFIGURATION
-# =============================================================================
-DECFLOAT_PRECISION = 38
-
-
-@pytest.fixture(autouse=True)
-def setup_decimal_precision():
-    """Set decimal context precision to 38 for all DECFLOAT tests."""
-    old_prec = getcontext().prec
-    getcontext().prec = DECFLOAT_PRECISION
-    yield
-    getcontext().prec = old_prec
 
 
 class TestDecfloatNumPy:

--- a/tests/definitions/python/types/decfloat_numpy.feature
+++ b/tests/definitions/python/types/decfloat_numpy.feature
@@ -1,0 +1,24 @@
+@python @numpy
+Feature: DECFLOAT type NumPy support (Python-specific)
+
+  @python_e2e
+  Scenario: should cast decfloat values to numpy float64
+    Given Snowflake client is logged in with NumPy mode enabled
+    When Query "SELECT 1.234::DECFLOAT, 123.456::DECFLOAT, -789.012::DECFLOAT" is executed
+    Then All values should be returned as numpy.float64 type
+    And Values should match approximately [1.234, 123.456, -789.012] within float64 precision
+
+  @python_e2e
+  Scenario: numpy handles extreme exponents within float64 range
+    Given Snowflake client is logged in with NumPy mode enabled
+    When Query with exponents within float64 range is executed
+    Then Values should be numpy.float64
+    And Values should be approximately correct
+
+  @python_e2e
+  Scenario: numpy overflows extreme exponents beyond float64 range
+    Given Snowflake client is logged in with NumPy mode enabled
+    When Query with exponents exceeding float64 range is executed
+    Then e16384 exceeds float64 max (~e308) and becomes infinity
+    And e-16383 is below float64 min (~e-308) and becomes 0
+

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -125,4 +125,3 @@ Feature: DECFLOAT type support
     When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
     And Query "SELECT * FROM <table>" is executed
     Then SELECT should return the same exact values
-

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -1,0 +1,115 @@
+@python
+Feature: DECFLOAT type support
+
+  # =========================================================================== #
+  #                               Type casting                                  #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should cast decfloat values to appropriate type
+    # Python: Values should be cast to 'Decimal' type with 38-digit precision
+    Given Snowflake client is logged in
+    When Query "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT, '12345678901234567890123456789012345678'::DECFLOAT" is executed
+    Then All values should be returned as appropriate type
+    And Values should maintain full 38-digit precision
+
+  # =========================================================================== #
+  #                     SELECT with literals (no tables)                        #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select decfloat literals
+    Given Snowflake client is logged in
+    When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT" is executed
+    Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
+
+  @python_e2e
+  Scenario: should handle full 38-digit precision values from literals
+    Given Snowflake client is logged in
+    When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT, '1.2345678901234567890123456789012345678E+100'::DECFLOAT, '1.2345678901234567890123456789012345678E-100'::DECFLOAT" is executed
+    Then Result should preserve all 38 digits for each value
+
+  @python_e2e
+  Scenario: should handle extreme exponent values from literals
+    Given Snowflake client is logged in
+    When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
+    Then Result should contain [1E+16384, 1E-16383]
+    When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
+    Then Result should contain [-1.234E+8000, 9.876E-8000]
+
+  @python_e2e
+  Scenario: should handle NULL values from literals
+    Given Snowflake client is logged in
+    When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
+    Then Result should contain [NULL, 42.5, NULL]
+
+  @python_e2e
+  Scenario: should download large result set with multiple chunks from GENERATOR
+    Given Snowflake client is logged in
+    When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+    Then Result should contain consecutive numbers from 0 to 999999
+    And All values should be returned as appropriate type
+
+  # =========================================================================== #
+  #                             Table operations                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select decfloats from table
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+
+  @python_e2e
+  Scenario: should handle full 38-digit precision values from table
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists with values [12345678901234567890123456789012345678, 1.2345678901234567890123456789012345678E+100, 1.2345678901234567890123456789012345678E-100]
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should preserve all 38 digits for each value
+
+  @python_e2e
+  Scenario: should handle extreme exponent values from table
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+
+  @python_e2e
+  Scenario: should handle NULL values from table
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain [NULL, 123.456, NULL, -789.012]
+
+  @python_e2e
+  Scenario: should download large result set with multiple chunks from table
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists with values from 0 to 999999
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain consecutive numbers from 0 to 999999
+    And All values should be returned as appropriate type
+
+  # =========================================================================== #
+  #                            Parameter binding                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select decfloat using parameter binding
+    Given Snowflake client is logged in
+    When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed with bound DECFLOAT values [123.456, -789.012, 42.0]
+    Then Result should contain [123.456, -789.012, 42.0]
+    When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
+    Then Result should contain [NULL]
+    When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
+    Then Result should contain [-1.234E+8000]
+
+  @python_e2e
+  Scenario: should insert decfloat using parameter binding
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists
+    When DECFLOAT values [0, 123.456, -789.012, 1.23e100, NULL] are inserted using explicit binding
+    And Query "SELECT * FROM <table>" is executed
+    Then SELECT should return the same exact values
+    And All precision should be preserved
+

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -101,6 +101,12 @@ Feature: DECFLOAT type support
     Then Result should contain [123.456, -789.012, 42.0]
     When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
     Then Result should contain [NULL]
+
+  @python_e2e
+  Scenario: should select extreme decfloat values using parameter binding
+    Given Snowflake client is logged in
+    When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
+    Then Result should contain [1E+16384]
     When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
     Then Result should contain [-1.234E+8000]
 
@@ -108,8 +114,15 @@ Feature: DECFLOAT type support
   Scenario: should insert decfloat using parameter binding
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists
-    When DECFLOAT values [0, 123.456, -789.012, 1.23e100, NULL] are inserted using explicit binding
+    When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
     And Query "SELECT * FROM <table>" is executed
     Then SELECT should return the same exact values
-    And All precision should be preserved
+
+  @python_e2e
+  Scenario: should insert extreme decfloat values using parameter binding
+    Given Snowflake client is logged in
+    And Table with DECFLOAT column exists
+    When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
+    And Query "SELECT * FROM <table>" is executed
+    Then SELECT should return the same exact values
 


### PR DESCRIPTION
Add tests for decfloat type according to https://docs.google.com/document/d/1FCioVbI1rGEQSsDRJQE-I_ob_8IjpU9-hyIZzkDM42w/edit?tab=t.0.
Tests are explicitly separated to float range and extreme values - wrapper which does not support them will have place to document its behavior
Base PR: #195 