### PR TITLE
python - logical types support

### DIFF
--- a/python/tests/e2e/types/test_boolean.py
+++ b/python/tests/e2e/types/test_boolean.py
@@ -10,8 +10,7 @@ from .utils import assert_type
 # =============================================================================
 # LARGE RESULT SET SIZE
 # =============================================================================
-LARGE_RESULT_SET_SIZE_GENERATOR = 1_000_000
-LARGE_RESULT_SET_SIZE_TABLE = 1_000_000
+LARGE_RESULT_SET_SIZE = 1_000_000
 
 
 class TestBooleanTypeCasting:
@@ -57,13 +56,13 @@ class TestBooleanLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-        sql = f"SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE_GENERATOR})) v"
+        sql = f"SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v"
         rows = execute_query(sql)
         result = [row[0] for row in rows]
 
         # Then Result should contain 1000000 alternating TRUE and FALSE values
         assert_type(result, bool)
-        assert result == [True, False] * (LARGE_RESULT_SET_SIZE_GENERATOR // 2)
+        assert result == [True, False] * (LARGE_RESULT_SET_SIZE // 2)
 
 
 class TestBooleanTable:
@@ -112,7 +111,7 @@ class TestBooleanTable:
         execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
         execute_query(
             f"INSERT INTO {table_name} SELECT (seq8() % 2 = 0)::BOOLEAN "
-            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE_TABLE}))"
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
         # When Query "SELECT * FROM <table>" is executed
@@ -121,7 +120,7 @@ class TestBooleanTable:
 
         # Then Result should contain 1000000 alternating boolean values
         assert_type(result, bool)
-        assert result == [True, False] * (LARGE_RESULT_SET_SIZE_GENERATOR // 2)
+        assert result == [True, False] * (LARGE_RESULT_SET_SIZE // 2)
 
 
 class TestBooleanBinding:

--- a/python/tests/e2e/types/test_boolean.py
+++ b/python/tests/e2e/types/test_boolean.py
@@ -1,0 +1,165 @@
+"""BOOLEAN type tests for Universal Driver."""
+
+from __future__ import annotations
+
+import pytest
+
+from .utils import assert_type
+
+
+# =============================================================================
+# LARGE RESULT SET SIZE
+# =============================================================================
+LARGE_RESULT_SET_SIZE_GENERATOR = 1_000_000
+LARGE_RESULT_SET_SIZE_TABLE = 1_000_000
+
+
+class TestBooleanTypeCasting:
+    """Tests for BOOLEAN type casting to appropriate type."""
+
+    def test_should_cast_boolean_values_to_appropriate_type(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
+        result = execute_query("SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN", single_row=True)
+
+        # Then All values should be returned as appropriate type
+        assert_type(result, bool)
+
+        # And Values should match [TRUE, FALSE, TRUE]
+        assert result == (True, False, True)
+
+
+class TestBooleanLiteral:
+    """Tests for BOOLEAN type using SELECT with literals (no tables)."""
+
+    def test_should_select_boolean_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
+        result = execute_query("SELECT TRUE::BOOLEAN, FALSE::BOOLEAN", single_row=True)
+
+        # Then Result should contain [TRUE, FALSE]
+        assert result == (True, False)
+        assert_type(result, bool)
+
+    def test_should_handle_null_values_from_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
+        result = execute_query("SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN", single_row=True)
+
+        # Then Result should contain [FALSE, NULL, TRUE, NULL]
+        assert result == (False, None, True, None)
+        assert_type(result, bool, can_be_none=True)
+
+    def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        sql = f"SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE_GENERATOR})) v"
+        rows = execute_query(sql)
+        result = [row[0] for row in rows]
+
+        # Then Result should contain 1000000 alternating TRUE and FALSE values
+        assert_type(result, bool)
+        assert result == [True, False] * (LARGE_RESULT_SET_SIZE_GENERATOR // 2)
+
+
+class TestBooleanTable:
+    """Tests for BOOLEAN type using table operations."""
+
+    def test_should_select_boolean_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
+        table_name = f"{tmp_schema}.boolean_table"
+        execute_query(f"CREATE TABLE {table_name} (col1 BOOLEAN, col2 BOOLEAN, col3 BOOLEAN)")
+
+        # And Row (TRUE, FALSE, TRUE) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (TRUE, FALSE, TRUE)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        result = execute_query(f"SELECT * FROM {table_name}", single_row=True)
+
+        # Then Result should contain [TRUE, FALSE, TRUE]
+        assert_type(result, bool)
+        assert result == (True, False, True)
+
+    def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with BOOLEAN column exists
+        table_name = f"{tmp_schema}.null_table"
+        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
+
+        # And Rows [NULL, TRUE, FALSE] are inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL), (TRUE), (FALSE)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should contain [NULL, TRUE, FALSE]
+        result = [row[0] for row in rows]
+        assert result == [None, True, False]
+        assert_type(result, bool, can_be_none=True)
+
+    def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with BOOLEAN column exists with 1000000 alternating boolean values
+        table_name = f"{tmp_schema}.large_boolean_table"
+        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
+        execute_query(
+            f"INSERT INTO {table_name} SELECT (seq8() % 2 = 0)::BOOLEAN "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE_TABLE}))"
+        )
+
+        # When Query "SELECT * FROM <table>" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+        result = [row[0] for row in rows]
+
+        # Then Result should contain 1000000 alternating boolean values
+        assert_type(result, bool)
+        assert result == [True, False] * (LARGE_RESULT_SET_SIZE_GENERATOR // 2)
+
+
+class TestBooleanBinding:
+    """Tests for BOOLEAN type using parameter binding."""
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_select_boolean_using_parameter_binding(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN" is executed
+        # with bound boolean values [TRUE, FALSE, TRUE]
+        result = execute_query("SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN", (True, False, True), single_row=True)
+
+        # Then Result should contain [TRUE, FALSE, TRUE]
+        assert result == (True, False, True)
+        assert_type(result, bool)
+
+        # When Query "SELECT ?::BOOLEAN" is executed with bound NULL value
+        result = execute_query("SELECT ?::BOOLEAN", (None,), single_row=True)
+
+        # Then Result should contain [NULL]
+        assert result == (None,)
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    def test_should_insert_boolean_using_parameter_binding(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with BOOLEAN column exists
+        table_name = f"{tmp_schema}.boolean_bind_table"
+        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
+
+        # When Boolean values [TRUE, FALSE, NULL] are inserted using binding
+        test_values = [True, False, None]
+        for val in test_values:
+            execute_query(f"INSERT INTO {table_name} VALUES (?)", (val,))
+
+        # Then SELECT should return the same exact values
+        rows = execute_query(f"SELECT * FROM {table_name}")
+        result = [row[0] for row in rows]
+        assert result == test_values
+        assert_type(result, bool, can_be_none=True)

--- a/python/tests/e2e/types/test_boolean.py
+++ b/python/tests/e2e/types/test_boolean.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -55,14 +55,22 @@ class TestBooleanLiteral:
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-        sql = f"SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v"
-        rows = execute_query(sql)
-        result = [row[0] for row in rows]
+        # When Query "SELECT (id % 2 = 0)::BOOLEAN, id FROM <generator> ORDER BY id" is executed
 
-        # Then Result should contain 1000000 alternating TRUE and FALSE values
-        assert_type(result, bool)
-        assert result == [True, False] * (LARGE_RESULT_SET_SIZE // 2)
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
+        sql = (
+            f"SELECT ((ROW_NUMBER() OVER (ORDER BY seq8()) - 1) % 2 = 0)::BOOLEAN as val, "
+            f"ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as id "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
+            f"ORDER BY id"
+        )
+        rows = execute_query(sql)
+
+        # Then Result should contain 500000 TRUE and 500000 FALSE values
+        values = [row[0] for row in rows]
+        assert_type(values, bool)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=lambda i: i % 2 == 0)
 
 
 class TestBooleanTable:
@@ -98,29 +106,34 @@ class TestBooleanTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name}")
 
-        # Then Result should contain [NULL, TRUE, FALSE]
+        # Then Result should contain [NULL, TRUE, FALSE] in any order
         result = [row[0] for row in rows]
-        assert result == [None, True, False]
+        assert set(result) == {None, True, False}
         assert_type(result, bool, can_be_none=True)
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
 
-        # And Table with BOOLEAN column exists with 1000000 alternating boolean values
+        # And Table with BOOLEAN and ID columns exists with 1000000 alternating boolean values
+
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_boolean_table"
-        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
+        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN, id INT)")
         execute_query(
-            f"INSERT INTO {table_name} SELECT (seq8() % 2 = 0)::BOOLEAN "
+            f"INSERT INTO {table_name} "
+            f"SELECT ((ROW_NUMBER() OVER (ORDER BY seq8()) - 1) % 2 = 0)::BOOLEAN, "
+            f"ROW_NUMBER() OVER (ORDER BY seq8()) - 1 "
             f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
-        # When Query "SELECT * FROM <table>" is executed
-        rows = execute_query(f"SELECT * FROM {table_name}")
-        result = [row[0] for row in rows]
+        # When Query "SELECT col FROM <table> ORDER BY id" is executed
+        rows = execute_query(f"SELECT col FROM {table_name} ORDER BY id")
 
-        # Then Result should contain 1000000 alternating boolean values
-        assert_type(result, bool)
-        assert result == [True, False] * (LARGE_RESULT_SET_SIZE // 2)
+        # Then Result should contain 500000 TRUE and 500000 FALSE values
+        values = [row[0] for row in rows]
+        assert_type(values, bool)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=lambda i: i % 2 == 0)
 
 
 class TestBooleanBinding:
@@ -157,8 +170,8 @@ class TestBooleanBinding:
         for val in test_values:
             execute_query(f"INSERT INTO {table_name} VALUES (?)", (val,))
 
-        # Then SELECT should return the same exact values
+        # Then SELECT should return the same values in any order
         rows = execute_query(f"SELECT * FROM {table_name}")
         result = [row[0] for row in rows]
-        assert result == test_values
+        assert set(result) == set(test_values)
         assert_type(result, bool, can_be_none=True)

--- a/python/tests/e2e/types/test_boolean.py
+++ b/python/tests/e2e/types/test_boolean.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from .utils import assert_sequential_values, assert_type
+from .utils import assert_type
 
 
 # =============================================================================
@@ -55,22 +55,17 @@ class TestBooleanLiteral:
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT (id % 2 = 0)::BOOLEAN, id FROM <generator> ORDER BY id" is executed
+        # When Query "SELECT (id % 2 = 0)::BOOLEAN FROM <generator>" is executed
 
-        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
-        # so we use ROW_NUMBER() to ensure sequential integers.
-        sql = (
-            f"SELECT ((ROW_NUMBER() OVER (ORDER BY seq8()) - 1) % 2 = 0)::BOOLEAN as val, "
-            f"ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as id "
-            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
-            f"ORDER BY id"
-        )
+        sql = f"SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         rows = execute_query(sql)
 
         # Then Result should contain 500000 TRUE and 500000 FALSE values
         values = [row[0] for row in rows]
         assert_type(values, bool)
-        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=lambda i: i % 2 == 0)
+        total, num_true = len(values), sum(values)
+        assert total == LARGE_RESULT_SET_SIZE
+        assert num_true == LARGE_RESULT_SET_SIZE // 2
 
 
 class TestBooleanTable:
@@ -114,26 +109,25 @@ class TestBooleanTable:
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
 
-        # And Table with BOOLEAN and ID columns exists with 1000000 alternating boolean values
+        # And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
 
-        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
-        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_boolean_table"
-        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN, id INT)")
+        execute_query(f"CREATE TABLE {table_name} (col BOOLEAN)")
         execute_query(
             f"INSERT INTO {table_name} "
-            f"SELECT ((ROW_NUMBER() OVER (ORDER BY seq8()) - 1) % 2 = 0)::BOOLEAN, "
-            f"ROW_NUMBER() OVER (ORDER BY seq8()) - 1 "
+            f"SELECT (seq8() % 2 = 0)::BOOLEAN "
             f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
-        # When Query "SELECT col FROM <table> ORDER BY id" is executed
-        rows = execute_query(f"SELECT col FROM {table_name} ORDER BY id")
+        # When Query "SELECT col FROM <table>" is executed
+        rows = execute_query(f"SELECT col FROM {table_name}")
 
         # Then Result should contain 500000 TRUE and 500000 FALSE values
         values = [row[0] for row in rows]
         assert_type(values, bool)
-        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=lambda i: i % 2 == 0)
+        total, num_true = len(values), sum(values)
+        assert total == LARGE_RESULT_SET_SIZE
+        assert num_true == LARGE_RESULT_SET_SIZE // 2
 
 
 class TestBooleanBinding:

--- a/python/tests/e2e/types/test_boolean_numpy.py
+++ b/python/tests/e2e/types/test_boolean_numpy.py
@@ -1,0 +1,30 @@
+"""BOOLEAN type NumPy tests for Universal Driver (Python-specific)."""
+
+from __future__ import annotations
+
+import pytest
+
+from .utils import assert_type
+
+
+# NumPy is optional for these tests
+np = pytest.importorskip("numpy")
+
+
+class TestBooleanNumPy:
+    """Test suite for BOOLEAN type NumPy conversion (Python-specific)."""
+
+    @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
+    def test_should_cast_boolean_to_numpy_bool_type(self, cursor_with_numpy):
+        # Given Snowflake client is logged in with NumPy mode enabled
+
+        # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
+        sql = "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN, FALSE::BOOLEAN"
+        cursor_with_numpy.execute(sql)
+        result = cursor_with_numpy.fetchone()
+
+        # Then All values should be returned as numpy.bool_ type
+        assert_type(result, np.bool_)
+
+        # And Values should be [TRUE, FALSE, TRUE, FALSE]
+        assert result == (True, False, True, False)

--- a/tests/definitions/python/types/boolean_numpy.feature
+++ b/tests/definitions/python/types/boolean_numpy.feature
@@ -1,0 +1,9 @@
+@python @numpy
+Feature: BOOLEAN type NumPy support (Python-specific)
+
+  @python_e2e
+  Scenario: should cast boolean to numpy bool type
+    Given Snowflake client is logged in with NumPy mode enabled
+    When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
+    Then All values should be returned as numpy.bool_ type
+    And Values should be [TRUE, FALSE, TRUE, FALSE]

--- a/tests/definitions/shared/types/boolean.feature
+++ b/tests/definitions/shared/types/boolean.feature
@@ -1,0 +1,82 @@
+@python
+Feature: BOOLEAN type support
+
+  # =========================================================================== #
+  #                               Type casting                                  #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should cast boolean values to appropriate type
+    # Python: Values should be cast to 'bool' type
+    Given Snowflake client is logged in
+    When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
+    Then All values should be returned as appropriate type
+    And Values should match [TRUE, FALSE, TRUE]
+
+  # =========================================================================== #
+  #                     SELECT with literals (no tables)                        #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select boolean literals
+    Given Snowflake client is logged in
+    When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
+    Then Result should contain [TRUE, FALSE]
+
+  @python_e2e
+  Scenario: should handle NULL values from literals
+    Given Snowflake client is logged in
+    When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
+    Then Result should contain [FALSE, NULL, TRUE, NULL]
+    
+  @python_e2e
+  Scenario: should download large result set with multiple chunks from GENERATOR
+    Given Snowflake client is logged in
+    When Query "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+    Then Result should contain 1000000 alternating TRUE and FALSE values
+
+  # =========================================================================== #
+  #                             Table operations                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select boolean values from table
+    Given Snowflake client is logged in
+    And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
+    And Row (TRUE, FALSE, TRUE) is inserted
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain [TRUE, FALSE, TRUE]
+
+  @python_e2e
+  Scenario: should handle NULL values from table
+    Given Snowflake client is logged in
+    And Table with BOOLEAN column exists
+    And Rows [NULL, TRUE, FALSE] are inserted
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain [NULL, TRUE, FALSE]
+
+  @python_e2e
+  Scenario: should download large result set with multiple chunks from table
+    Given Snowflake client is logged in
+    And Table with BOOLEAN column exists with 1000000 alternating boolean values
+    When Query "SELECT * FROM <table>" is executed
+    Then Result should contain 1000000 alternating boolean values
+
+  # =========================================================================== #
+  #                            Parameter binding                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select boolean using parameter binding
+    Given Snowflake client is logged in
+    When Query "SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN" is executed with bound boolean values [TRUE, FALSE, TRUE]
+    Then Result should contain [TRUE, FALSE, TRUE]
+    When Query "SELECT ?::BOOLEAN" is executed with bound NULL value
+    Then Result should contain [NULL]
+
+  @python_e2e
+  Scenario: should insert boolean using parameter binding
+    Given Snowflake client is logged in
+    And Table with BOOLEAN column exists
+    When Boolean values [TRUE, FALSE, NULL] are inserted using binding
+    Then SELECT should return the same exact values

--- a/tests/definitions/shared/types/boolean.feature
+++ b/tests/definitions/shared/types/boolean.feature
@@ -31,7 +31,7 @@ Feature: BOOLEAN type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in
-    When Query "SELECT (id % 2 = 0)::BOOLEAN, id FROM <generator> ORDER BY id" is executed
+    When Query "SELECT (id % 2 = 0)::BOOLEAN FROM <generator>" is executed
     Then Result should contain 500000 TRUE and 500000 FALSE values
 
   # =========================================================================== #
@@ -57,8 +57,8 @@ Feature: BOOLEAN type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from table
     Given Snowflake client is logged in
-    And Table with BOOLEAN and ID columns exists with 1000000 alternating boolean values
-    When Query "SELECT col FROM <table> ORDER BY id" is executed
+    And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
+    When Query "SELECT col FROM <table>" is executed
     Then Result should contain 500000 TRUE and 500000 FALSE values
 
   # =========================================================================== #

--- a/tests/definitions/shared/types/boolean.feature
+++ b/tests/definitions/shared/types/boolean.feature
@@ -31,8 +31,8 @@ Feature: BOOLEAN type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in
-    When Query "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-    Then Result should contain 1000000 alternating TRUE and FALSE values
+    When Query "SELECT (id % 2 = 0)::BOOLEAN, id FROM <generator> ORDER BY id" is executed
+    Then Result should contain 500000 TRUE and 500000 FALSE values
 
   # =========================================================================== #
   #                             Table operations                                #
@@ -52,14 +52,14 @@ Feature: BOOLEAN type support
     And Table with BOOLEAN column exists
     And Rows [NULL, TRUE, FALSE] are inserted
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain [NULL, TRUE, FALSE]
+    Then Result should contain [NULL, TRUE, FALSE] in any order
 
   @python_e2e
   Scenario: should download large result set with multiple chunks from table
     Given Snowflake client is logged in
-    And Table with BOOLEAN column exists with 1000000 alternating boolean values
-    When Query "SELECT * FROM <table>" is executed
-    Then Result should contain 1000000 alternating boolean values
+    And Table with BOOLEAN and ID columns exists with 1000000 alternating boolean values
+    When Query "SELECT col FROM <table> ORDER BY id" is executed
+    Then Result should contain 500000 TRUE and 500000 FALSE values
 
   # =========================================================================== #
   #                            Parameter binding                                #
@@ -78,4 +78,4 @@ Feature: BOOLEAN type support
     Given Snowflake client is logged in
     And Table with BOOLEAN column exists
     When Boolean values [TRUE, FALSE, NULL] are inserted using binding
-    Then SELECT should return the same exact values
+    Then SELECT should return the same values in any order

--- a/tests/definitions/shared/types/boolean.feature
+++ b/tests/definitions/shared/types/boolean.feature
@@ -28,7 +28,6 @@ Feature: BOOLEAN type support
     Given Snowflake client is logged in
     When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
     Then Result should contain [FALSE, NULL, TRUE, NULL]
-    
   @python_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in


### PR DESCRIPTION
Add tests for BOOLEAN convertion according to [test plan](https://docs.google.com/document/d/1FCioVbI1rGEQSsDRJQE-I_ob_8IjpU9-hyIZzkDM42w/edit?tab=t.0.) and [documentation](https://docs.snowflake.com/en/sql-reference/data-types-logical)