### PR TITLE
Add arrow converters to JDBC

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -16,8 +16,7 @@ repositories {
 }
 
 dependencies {
-    // No external dependencies for the stub implementation
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
     testImplementation 'org.json:json:20231013'
     implementation 'org.slf4j:slf4j-api:2.0.9'
@@ -127,7 +126,7 @@ publishing {
 }
 
 test {
-    useJUnit()
+    useJUnitPlatform()
     finalizedBy jacocoTestReport
 
     if (JavaVersion.current().isJava9Compatible()) {
@@ -142,6 +141,9 @@ test {
         showExceptions true
         showCauses true
         showStackTraces true
+    }
+    afterTest { desc, result ->
+        println "TEST ${desc.className}.${desc.name}: ${result.resultType}"
     }
     // Set CORE_PATH environment variable for tests
     def libPath = file('../target/debug').exists() ? '../target/debug' : '../target/release'

--- a/jdbc/src/main/java/com/snowflake/jdbc/SnowflakeResultSet.java
+++ b/jdbc/src/main/java/com/snowflake/jdbc/SnowflakeResultSet.java
@@ -27,7 +27,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.snowflake.client.internal.core.arrow.ArrowVectorConverter;
@@ -63,7 +62,7 @@ public class SnowflakeResultSet implements ResultSet {
   private ArrowArrayStream stream;
   private ArrowReader reader;
   private BufferAllocator allocator;
-  private final Map<Integer, ArrowVectorConverter> converterCache = new HashMap<>();
+  private ArrowVectorConverter[] converterCache;
   private static final DataConversionContext EMPTY_CONTEXT = new DataConversionContext() {};
 
   public SnowflakeResultSet(SnowflakeStatement statement, ExecuteResult result) {
@@ -1233,14 +1232,20 @@ public class SnowflakeResultSet implements ResultSet {
   }
 
   private ArrowVectorConverter getConverter(int columnIndex) throws SQLException {
-    if (converterCache.containsKey(columnIndex)) {
-      return converterCache.get(columnIndex);
+    ensureSchemaInitialized();
+    int index = columnIndex - 1;
+    if (index < 0 || index >= converterCache.length) {
+      throw new SQLException("Invalid column index: " + columnIndex);
+    }
+    ArrowVectorConverter cached = converterCache[index];
+    if (cached != null) {
+      return cached;
     }
     try {
-      FieldVector vector = reader.getVectorSchemaRoot().getVector(columnIndex - 1);
+      FieldVector vector = reader.getVectorSchemaRoot().getVector(index);
       ArrowVectorConverter converter =
-          ArrowVectorConverterUtil.initConverter(vector, EMPTY_CONTEXT, columnIndex - 1);
-      converterCache.put(columnIndex, converter);
+          ArrowVectorConverterUtil.initConverter(vector, EMPTY_CONTEXT, index);
+      converterCache[index] = converter;
       return converter;
     } catch (SnowflakeSQLException e) {
       throw new SQLException("Unable to create converter for column " + columnIndex, e);
@@ -1250,7 +1255,7 @@ public class SnowflakeResultSet implements ResultSet {
   }
 
   private void ensureSchemaInitialized() throws SQLException {
-    if (columnNames != null && columnTypes != null) {
+    if (columnNames != null && columnTypes != null && converterCache != null) {
       return;
     }
     List<Field> fields;
@@ -1261,6 +1266,7 @@ public class SnowflakeResultSet implements ResultSet {
     }
     columnNames = new String[fields.size()];
     columnTypes = new int[fields.size()];
+    converterCache = new ArrowVectorConverter[fields.size()];
     for (int i = 0; i < fields.size(); i++) {
       Field field = fields.get(i);
       columnNames[i] = field.getName();

--- a/jdbc/src/main/java/com/snowflake/jdbc/SnowflakeResultSet.java
+++ b/jdbc/src/main/java/com/snowflake/jdbc/SnowflakeResultSet.java
@@ -27,13 +27,22 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import net.snowflake.client.internal.core.arrow.ArrowVectorConverter;
+import net.snowflake.client.internal.core.arrow.ArrowVectorConverterUtil;
+import net.snowflake.client.internal.core.arrow.DataConversionContext;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeType;
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Field;
 
 /**
  * Snowflake JDBC ResultSet implementation
@@ -49,13 +58,13 @@ public class SnowflakeResultSet implements ResultSet {
   private int fetchSize = 0;
   private int fetchDirection = FETCH_FORWARD;
 
-  // Stub data for demonstration
-  private String[][] data;
   private String[] columnNames;
   private int[] columnTypes;
   private ArrowArrayStream stream;
   private ArrowReader reader;
   private BufferAllocator allocator;
+  private final Map<Integer, ArrowVectorConverter> converterCache = new HashMap<>();
+  private static final DataConversionContext EMPTY_CONTEXT = new DataConversionContext() {};
 
   public SnowflakeResultSet(SnowflakeStatement statement, ExecuteResult result) {
     this.statement = statement;
@@ -72,6 +81,8 @@ public class SnowflakeResultSet implements ResultSet {
     checkClosed();
     try {
       reader.loadNextBatch();
+      currentRow = 0;
+      ensureSchemaInitialized();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -94,10 +105,14 @@ public class SnowflakeResultSet implements ResultSet {
     checkClosed();
     checkRowPosition();
     checkColumnIndex(columnIndex);
-
-    String value = data[currentRow][columnIndex - 1];
-    wasNull = (value == null);
-    return value;
+    ArrowVectorConverter converter = getConverter(columnIndex);
+    try {
+      String value = converter.toString(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to String", e);
+    }
   }
 
   @Override
@@ -137,14 +152,13 @@ public class SnowflakeResultSet implements ResultSet {
 
   @Override
   public int getInt(int columnIndex) throws SQLException {
-    if (wasNull) {
-      return 0;
-    }
+    ArrowVectorConverter converter = getConverter(columnIndex);
     try {
-      TinyIntVector vec = (TinyIntVector) reader.getVectorSchemaRoot().getVector(columnIndex - 1);
-      return vec.get(0);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      int value = converter.toInt(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to int", e);
     }
   }
 
@@ -163,51 +177,47 @@ public class SnowflakeResultSet implements ResultSet {
 
   @Override
   public float getFloat(int columnIndex) throws SQLException {
-    String value = getString(columnIndex);
-    if (wasNull) {
-      return 0.0f;
-    }
+    ArrowVectorConverter converter = getConverter(columnIndex);
     try {
-      return Float.parseFloat(value);
-    } catch (NumberFormatException e) {
-      throw new SQLException("Cannot convert '" + value + "' to float", e);
+      float value = converter.toFloat(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to float", e);
     }
   }
 
   @Override
   public double getDouble(int columnIndex) throws SQLException {
-    String value = getString(columnIndex);
-    if (wasNull) {
-      return 0.0;
-    }
+    ArrowVectorConverter converter = getConverter(columnIndex);
     try {
-      return Double.parseDouble(value);
-    } catch (NumberFormatException e) {
-      throw new SQLException("Cannot convert '" + value + "' to double", e);
+      double value = converter.toDouble(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to double", e);
     }
   }
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-    String value = getString(columnIndex);
-    if (wasNull) {
+    BigDecimal value = getBigDecimal(columnIndex);
+    if (value == null) {
       return null;
     }
-    try {
-      BigDecimal bd = new BigDecimal(value);
-      return bd.setScale(scale, BigDecimal.ROUND_HALF_UP);
-    } catch (NumberFormatException e) {
-      throw new SQLException("Cannot convert '" + value + "' to BigDecimal", e);
-    }
+    return value.setScale(scale, BigDecimal.ROUND_HALF_UP);
   }
 
   @Override
   public byte[] getBytes(int columnIndex) throws SQLException {
-    String value = getString(columnIndex);
-    if (wasNull) {
-      return null;
+    ArrowVectorConverter converter = getConverter(columnIndex);
+    try {
+      byte[] value = converter.toBytes(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to bytes", e);
     }
-    return value.getBytes();
   }
 
   @Override
@@ -365,12 +375,20 @@ public class SnowflakeResultSet implements ResultSet {
   @Override
   public ResultSetMetaData getMetaData() throws SQLException {
     checkClosed();
+    ensureSchemaInitialized();
     return new SnowflakeResultSetMetaData(columnNames, columnTypes);
   }
 
   @Override
   public Object getObject(int columnIndex) throws SQLException {
-    return getString(columnIndex);
+    ArrowVectorConverter converter = getConverter(columnIndex);
+    try {
+      Object value = converter.toObject(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to Object", e);
+    }
   }
 
   @Override
@@ -401,14 +419,13 @@ public class SnowflakeResultSet implements ResultSet {
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-    String value = getString(columnIndex);
-    if (wasNull) {
-      return null;
-    }
+    ArrowVectorConverter converter = getConverter(columnIndex);
     try {
-      return new BigDecimal(value);
-    } catch (NumberFormatException e) {
-      throw new SQLException("Cannot convert '" + value + "' to BigDecimal", e);
+      BigDecimal value = converter.toBigDecimal(0);
+      wasNull = converter.isNull(0);
+      return value;
+    } catch (SFException e) {
+      throw new SQLException("Cannot convert column " + columnIndex + " to BigDecimal", e);
     }
   }
 
@@ -426,7 +443,7 @@ public class SnowflakeResultSet implements ResultSet {
   @Override
   public boolean isAfterLast() throws SQLException {
     checkClosed();
-    return currentRow >= data.length;
+    return currentRow > 0;
   }
 
   @Override
@@ -438,7 +455,7 @@ public class SnowflakeResultSet implements ResultSet {
   @Override
   public boolean isLast() throws SQLException {
     checkClosed();
-    return currentRow == data.length - 1;
+    return currentRow == 0;
   }
 
   @Override
@@ -1201,14 +1218,76 @@ public class SnowflakeResultSet implements ResultSet {
     if (currentRow < 0) {
       throw new SQLException("Before first row");
     }
-    if (currentRow >= data.length) {
+    if (columnNames != null && currentRow >= 1) {
       throw new SQLException("After last row");
     }
   }
 
   private void checkColumnIndex(int columnIndex) throws SQLException {
+    if (columnNames == null) {
+      ensureSchemaInitialized();
+    }
     if (columnIndex < 1 || columnIndex > columnNames.length) {
       throw new SQLException("Invalid column index: " + columnIndex);
+    }
+  }
+
+  private ArrowVectorConverter getConverter(int columnIndex) throws SQLException {
+    if (converterCache.containsKey(columnIndex)) {
+      return converterCache.get(columnIndex);
+    }
+    try {
+      FieldVector vector = reader.getVectorSchemaRoot().getVector(columnIndex - 1);
+      ArrowVectorConverter converter =
+          ArrowVectorConverterUtil.initConverter(vector, EMPTY_CONTEXT, columnIndex - 1);
+      converterCache.put(columnIndex, converter);
+      return converter;
+    } catch (SnowflakeSQLException e) {
+      throw new SQLException("Unable to create converter for column " + columnIndex, e);
+    } catch (IOException e) {
+      throw new SQLException("Unable to read Arrow schema for column " + columnIndex, e);
+    }
+  }
+
+  private void ensureSchemaInitialized() throws SQLException {
+    if (columnNames != null && columnTypes != null) {
+      return;
+    }
+    List<Field> fields;
+    try {
+      fields = reader.getVectorSchemaRoot().getSchema().getFields();
+    } catch (IOException e) {
+      throw new SQLException("Unable to read Arrow schema", e);
+    }
+    columnNames = new String[fields.size()];
+    columnTypes = new int[fields.size()];
+    for (int i = 0; i < fields.size(); i++) {
+      Field field = fields.get(i);
+      columnNames[i] = field.getName();
+      SnowflakeType logicalType = ArrowVectorConverterUtil.getSnowflakeTypeFromFieldMetadata(field);
+      columnTypes[i] = mapLogicalTypeToSqlType(logicalType);
+    }
+  }
+
+  private int mapLogicalTypeToSqlType(SnowflakeType logicalType) {
+    if (logicalType == null) {
+      return Types.OTHER;
+    }
+    switch (logicalType) {
+      case TEXT:
+      case CHAR:
+      case VARIANT:
+        return Types.VARCHAR;
+      case FIXED:
+        return Types.DECIMAL;
+      case REAL:
+        return Types.DOUBLE;
+      case BOOLEAN:
+        return Types.BOOLEAN;
+      case BINARY:
+        return Types.BINARY;
+      default:
+        return Types.OTHER;
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/AbstractArrowVectorConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/AbstractArrowVectorConverter.java
@@ -90,7 +90,8 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
     if (isNull(index)) {
       return null;
     }
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "byteArray", "");
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, "");
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/AbstractArrowVectorConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/AbstractArrowVectorConverter.java
@@ -1,0 +1,149 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Period;
+import java.util.TimeZone;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.ValueVector;
+
+abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
+  protected String logicalTypeStr;
+  private final ValueVector valueVector;
+  protected final DataConversionContext context;
+  protected final int columnIndex;
+
+  AbstractArrowVectorConverter(
+      String logicalTypeStr,
+      ValueVector valueVector,
+      int vectorIndex,
+      DataConversionContext context) {
+    this.logicalTypeStr = logicalTypeStr;
+    this.valueVector = valueVector;
+    this.columnIndex = vectorIndex + 1;
+    this.context = context;
+  }
+
+  @Override
+  public boolean toBoolean(int rowIndex) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, "");
+  }
+
+  @Override
+  public byte toByte(int rowIndex) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, "");
+  }
+
+  @Override
+  public short toShort(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, "");
+  }
+
+  @Override
+  public int toInt(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR);
+  }
+
+  @Override
+  public long toLong(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.LONG_STR, "");
+  }
+
+  @Override
+  public double toDouble(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.DOUBLE_STR, "");
+  }
+
+  @Override
+  public float toFloat(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.FLOAT_STR, "");
+  }
+
+  @Override
+  public byte[] toBytes(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "byteArray", "");
+  }
+
+  @Override
+  public Date toDate(int index, TimeZone jvmTz, boolean useDateFormat) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.DATE_STR, "");
+  }
+
+  @Override
+  public Time toTime(int index) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.TIME_STR, "");
+  }
+
+  @Override
+  public Timestamp toTimestamp(int index, TimeZone tz) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.TIMESTAMP_STR, "");
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, "");
+  }
+
+  @Override
+  public Period toPeriod(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "period", "");
+  }
+
+  @Override
+  public Duration toDuration(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "duration", "");
+  }
+
+  @Override
+  public boolean isNull(int index) {
+    return valueVector.isNull(index);
+  }
+
+  @Override
+  public abstract Object toObject(int index) throws SFException;
+
+  @Override
+  public abstract String toString(int index) throws SFException;
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowResultUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowResultUtil.java
@@ -1,0 +1,24 @@
+package net.snowflake.client.internal.core.arrow;
+
+public class ArrowResultUtil {
+  private static final int[] POWERS_OF_10 = {
+    1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
+  };
+
+  public static final int MAX_SCALE_POWERS_OF_10 = 9;
+
+  public static long powerOfTen(int pow) {
+    long val = 1;
+    while (pow > MAX_SCALE_POWERS_OF_10) {
+      val *= POWERS_OF_10[MAX_SCALE_POWERS_OF_10];
+      pow -= MAX_SCALE_POWERS_OF_10;
+    }
+    return val * POWERS_OF_10[pow];
+  }
+
+  public static String getStringFormat(int scale) {
+    return new StringBuilder().append("%.").append(scale).append('f').toString();
+  }
+
+  private ArrowResultUtil() {}
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowVectorConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowVectorConverter.java
@@ -1,0 +1,47 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Period;
+import java.util.TimeZone;
+import net.snowflake.client.jdbc.SFException;
+
+public interface ArrowVectorConverter {
+
+  boolean isNull(int index);
+
+  boolean toBoolean(int index) throws SFException;
+
+  byte toByte(int index) throws SFException;
+
+  short toShort(int index) throws SFException;
+
+  int toInt(int index) throws SFException;
+
+  long toLong(int index) throws SFException;
+
+  double toDouble(int index) throws SFException;
+
+  float toFloat(int index) throws SFException;
+
+  byte[] toBytes(int index) throws SFException;
+
+  String toString(int index) throws SFException;
+
+  Date toDate(int index, TimeZone jvmTz, boolean useDateFormat) throws SFException;
+
+  Time toTime(int index) throws SFException;
+
+  Timestamp toTimestamp(int index, TimeZone tz) throws SFException;
+
+  BigDecimal toBigDecimal(int index) throws SFException;
+
+  Period toPeriod(int index) throws SFException;
+
+  Duration toDuration(int index) throws SFException;
+
+  Object toObject(int index) throws SFException;
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowVectorConverterUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/ArrowVectorConverterUtil.java
@@ -1,0 +1,95 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.util.Map;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+
+public final class ArrowVectorConverterUtil {
+  private ArrowVectorConverterUtil() {}
+
+  public static SnowflakeType getSnowflakeTypeFromFieldMetadata(Field field) {
+    Map<String, String> customMeta = field.getMetadata();
+    if (customMeta != null && customMeta.containsKey("logicalType")) {
+      return SnowflakeType.valueOf(customMeta.get("logicalType"));
+    }
+    return null;
+  }
+
+  /**
+   * Given an arrow vector (a single column in a single record batch), return an arrow vector
+   * converter. Converter is built on top of arrow vector, so arrow data can be converted back to
+   * java data.
+   */
+  public static ArrowVectorConverter initConverter(
+      ValueVector vector, DataConversionContext context, int idx) throws SnowflakeSQLException {
+    Types.MinorType type = Types.getMinorTypeForArrowType(vector.getField().getType());
+    SnowflakeType st = getSnowflakeTypeFromFieldMetadata(vector.getField());
+
+    if (type == Types.MinorType.DECIMAL) {
+      return new DecimalToScaledFixedConverter(vector, idx, context);
+    }
+
+    if (st != null) {
+      switch (st) {
+        case ANY:
+        case CHAR:
+        case TEXT:
+        case VARIANT:
+          return new VarCharConverter(vector, idx, context);
+
+        case BINARY:
+          return new VarBinaryToBinaryConverter(vector, idx, context);
+
+        case BOOLEAN:
+          return new BitToBooleanConverter(vector, idx, context);
+
+        case FIXED:
+          String scaleStr = vector.getField().getMetadata().get("scale");
+          int sfScale = Integer.parseInt(scaleStr);
+          switch (type) {
+            case TINYINT:
+              if (sfScale == 0) {
+                return new TinyIntToFixedConverter(vector, idx, context);
+              }
+              return new TinyIntToScaledFixedConverter(vector, idx, context, sfScale);
+            case SMALLINT:
+              if (sfScale == 0) {
+                return new SmallIntToFixedConverter(vector, idx, context);
+              }
+              return new SmallIntToScaledFixedConverter(vector, idx, context, sfScale);
+            case INT:
+              if (sfScale == 0) {
+                return new IntToFixedConverter(vector, idx, context);
+              }
+              return new IntToScaledFixedConverter(vector, idx, context, sfScale);
+            case BIGINT:
+              if (sfScale == 0) {
+                return new BigIntToFixedConverter(vector, idx, context);
+              }
+              return new BigIntToScaledFixedConverter(vector, idx, context, sfScale);
+            default:
+              break;
+          }
+          break;
+
+        case REAL:
+          return new DoubleToRealConverter(vector, idx, context);
+
+        default:
+          throw new SnowflakeSQLException("Unsupported Arrow logical type: " + st.name());
+      }
+    }
+
+    throw new SnowflakeSQLException("Unsupported Arrow field type: " + type);
+  }
+
+  public static ArrowVectorConverter initConverter(
+      FieldVector vector, DataConversionContext context, int columnIndex)
+      throws SnowflakeSQLException {
+    return initConverter((ValueVector) vector, context, columnIndex);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToFixedConverter.java
@@ -1,0 +1,127 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.ValueVector;
+
+public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
+  protected final BigIntVector bigIntVector;
+  protected int sfScale;
+  protected ByteBuffer byteBuf = ByteBuffer.allocate(BigIntVector.TYPE_WIDTH);
+
+  public BigIntToFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale")),
+        fieldVector,
+        columnIndex,
+        context);
+    this.bigIntVector = (BigIntVector) fieldVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.putLong(0, getLong(index));
+    return byteBuf.array();
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    long longVal = toLong(index);
+    if (longVal == 0) {
+      return false;
+    } else if (longVal == 1) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, longVal);
+  }
+
+  @Override
+  public byte toByte(int index) throws SFException {
+    long longVal = toLong(index);
+    byte byteVal = (byte) longVal;
+    if (byteVal == longVal) {
+      return byteVal;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, longVal);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    long longVal = toLong(index);
+    short shortVal = (short) longVal;
+    if (shortVal == longVal) {
+      return shortVal;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, longVal);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    long longVal = toLong(index);
+    int intVal = (int) longVal;
+    if (intVal == longVal) {
+      return intVal;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR, longVal);
+  }
+
+  protected long getLong(int index) {
+    return bigIntVector.getDataBuffer().getLong(index * BigIntVector.TYPE_WIDTH);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (bigIntVector.isNull(index)) {
+      return 0;
+    }
+    return getLong(index);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    return toLong(index);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    return toLong(index);
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) {
+    if (bigIntVector.isNull(index)) {
+      return null;
+    }
+    return BigDecimal.valueOf(getLong(index), sfScale);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    if (bigIntVector.isNull(index)) {
+      return null;
+    }
+    return getLong(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    return isNull(index) ? null : Long.toString(getLong(index));
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToScaledFixedConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.ValueVector;
 
 public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
@@ -44,7 +45,10 @@ public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
     }
     BigDecimal val = toBigDecimal(index);
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.SHORT_STR,
+        val.toPlainString());
   }
 
   @Override
@@ -54,7 +58,10 @@ public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
     }
     BigDecimal val = toBigDecimal(index);
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.INT_STR,
+        val.toPlainString());
   }
 
   @Override
@@ -64,7 +71,10 @@ public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
     }
     BigDecimal val = toBigDecimal(index);
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.LONG_STR,
+        val.toPlainString());
   }
 
   @Override
@@ -89,7 +99,10 @@ public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
       return true;
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.BOOLEAN_STR,
+        val.toPlainString());
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BigIntToScaledFixedConverter.java
@@ -1,0 +1,103 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.ValueVector;
+
+public class BigIntToScaledFixedConverter extends BigIntToFixedConverter {
+  public BigIntToScaledFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context, int scale) {
+    super(fieldVector, columnIndex, context);
+    logicalTypeStr =
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale"));
+    sfScale = scale;
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    return (float) toDouble(index);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    if (sfScale > 9) {
+      return toBigDecimal(index).doubleValue();
+    }
+    double res = getLong(index);
+    res = res / ArrowResultUtil.powerOfTen(sfScale);
+    return res;
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal val = toBigDecimal(index);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val.toPlainString());
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal val = toBigDecimal(index);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val.toPlainString());
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal val = toBigDecimal(index);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val.toPlainString());
+  }
+
+  @Override
+  public Object toObject(int index) {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    return isNull(index) ? null : BigDecimal.valueOf(getLong(index), sfScale).toPlainString();
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    BigDecimal val = toBigDecimal(index);
+    if (val.compareTo(BigDecimal.ZERO) == 0) {
+      return false;
+    } else if (val.compareTo(BigDecimal.ONE) == 0) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.putLong(0, getLong(index));
+    return byteBuf.array();
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverter.java
@@ -1,0 +1,40 @@
+package net.snowflake.client.internal.core.arrow;
+
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.ValueVector;
+
+public class BitToBooleanConverter extends AbstractArrowVectorConverter {
+  private final BitVector bitVector;
+
+  public BitToBooleanConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(SnowflakeType.BOOLEAN.name(), fieldVector, columnIndex, context);
+    this.bitVector = (BitVector) fieldVector;
+  }
+
+  @Override
+  public boolean toBoolean(int index) {
+    return !isNull(index) && bitVector.get(index) == 1;
+  }
+
+  @Override
+  public Object toObject(int index) {
+    return isNull(index) ? null : toBoolean(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    return isNull(index) ? null : Boolean.toString(toBoolean(index));
+  }
+
+  @Override
+  public byte toByte(int index) throws SFException {
+    boolean val = toBoolean(index);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, val);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverter.java
@@ -1,24 +1,54 @@
 package net.snowflake.client.internal.core.arrow;
 
-import net.snowflake.client.jdbc.ErrorCode;
+import java.math.BigDecimal;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.ValueVector;
 
 public class BitToBooleanConverter extends AbstractArrowVectorConverter {
-  private final BitVector bitVector;
+  private BitVector bitVector;
 
+  /**
+   * @param fieldVector ValueVector
+   * @param columnIndex column index
+   * @param context DataConversionContext
+   */
   public BitToBooleanConverter(
       ValueVector fieldVector, int columnIndex, DataConversionContext context) {
     super(SnowflakeType.BOOLEAN.name(), fieldVector, columnIndex, context);
     this.bitVector = (BitVector) fieldVector;
   }
 
+  private int getBit(int index) {
+    // read a bit from the bitVector
+    // first find the byte value
+    final int byteIndex = index >> 3;
+    final byte b = bitVector.getDataBuffer().getByte(byteIndex);
+    // then get the bit value
+    final int bitIndex = index & 7;
+    return (b >> bitIndex) & 0x01;
+  }
+
   @Override
   public boolean toBoolean(int index) {
-    return !isNull(index) && bitVector.get(index) == 1;
+    if (isNull(index)) {
+      return false;
+    } else {
+      return getBit(index) != 0;
+    }
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    if (isNull(index)) {
+      return null;
+    } else if (toBoolean(index)) {
+
+      return new byte[] {1};
+    } else {
+      return new byte[] {0};
+    }
   }
 
   @Override
@@ -28,13 +58,36 @@ public class BitToBooleanConverter extends AbstractArrowVectorConverter {
 
   @Override
   public String toString(int index) {
-    return isNull(index) ? null : Boolean.toString(toBoolean(index));
+    return isNull(index) ? null : toBoolean(index) ? "TRUE" : "FALSE";
   }
 
   @Override
-  public byte toByte(int index) throws SFException {
-    boolean val = toBoolean(index);
-    throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, val);
+  public short toShort(int rowIndex) throws SFException {
+    return (short) (toBoolean(rowIndex) ? 1 : 0);
+  }
+
+  @Override
+  public int toInt(int rowIndex) throws SFException {
+    return toBoolean(rowIndex) ? 1 : 0;
+  }
+
+  @Override
+  public long toLong(int rowIndex) throws SFException {
+    return toBoolean(rowIndex) ? 1 : 0;
+  }
+
+  @Override
+  public float toFloat(int rowIndex) throws SFException {
+    return toBoolean(rowIndex) ? 1 : 0;
+  }
+
+  @Override
+  public double toDouble(int rowIndex) throws SFException {
+    return toBoolean(rowIndex) ? 1 : 0;
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int rowIndex) throws SFException {
+    return isNull(rowIndex) ? null : toBoolean(rowIndex) ? BigDecimal.ONE : BigDecimal.ZERO;
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DataConversionContext.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DataConversionContext.java
@@ -1,0 +1,3 @@
+package net.snowflake.client.internal.core.arrow;
+
+public interface DataConversionContext {}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DecimalToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DecimalToScaledFixedConverter.java
@@ -1,0 +1,156 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * Data vector whose snowflake logical type is fixed while represented as a BigDecimal value vector.
+ */
+public class DecimalToScaledFixedConverter extends AbstractArrowVectorConverter {
+  protected final DecimalVector decimalVector;
+
+  public DecimalToScaledFixedConverter(
+      ValueVector fieldVector, int vectorIndex, DataConversionContext context) {
+    super(
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale")),
+        fieldVector,
+        vectorIndex,
+        context);
+    decimalVector = (DecimalVector) fieldVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    if (isNull(index)) {
+      return null;
+    }
+    return toBigDecimal(index).toBigInteger().toByteArray();
+  }
+
+  @Override
+  public byte toByte(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(index);
+    if (bigDecimal.scale() == 0) {
+      byte byteVal = bigDecimal.byteValue();
+      if (byteVal == bigDecimal.longValue()) {
+        return byteVal;
+      }
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Byte", bigDecimal.toPlainString());
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Byte", bigDecimal.toPlainString());
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(index);
+    if (bigDecimal.scale() == 0) {
+      short shortValue = bigDecimal.shortValue();
+      if (bigDecimal.compareTo(BigDecimal.valueOf((long) shortValue)) == 0) {
+        return shortValue;
+      }
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(index);
+    if (bigDecimal.scale() == 0) {
+      int intValue = bigDecimal.intValue();
+      if (bigDecimal.compareTo(BigDecimal.valueOf((long) intValue)) == 0) {
+        return intValue;
+      }
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", bigDecimal.toPlainString());
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", bigDecimal.toPlainString());
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(index);
+    if (bigDecimal.scale() == 0) {
+      long longValue = bigDecimal.longValue();
+      if (bigDecimal.compareTo(BigDecimal.valueOf(longValue)) == 0) {
+        return longValue;
+      }
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return toBigDecimal(index).floatValue();
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return toBigDecimal(index).doubleValue();
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) {
+    return decimalVector.getObject(index);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    BigDecimal bigDecimal = toBigDecimal(index);
+    return bigDecimal == null ? null : bigDecimal.toPlainString();
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    BigDecimal val = toBigDecimal(index);
+    if (val.compareTo(BigDecimal.ZERO) == 0) {
+      return false;
+    } else if (val.compareTo(BigDecimal.ONE) == 0) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DecimalToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DecimalToScaledFixedConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.ValueVector;
 
@@ -61,14 +62,20 @@ public class DecimalToScaledFixedConverter extends AbstractArrowVectorConverter 
     BigDecimal bigDecimal = toBigDecimal(index);
     if (bigDecimal.scale() == 0) {
       short shortValue = bigDecimal.shortValue();
-      if (bigDecimal.compareTo(BigDecimal.valueOf((long) shortValue)) == 0) {
+      if (bigDecimal.compareTo(BigDecimal.valueOf(shortValue)) == 0) {
         return shortValue;
       }
       throw new SFException(
-          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.SHORT_STR,
+          bigDecimal.toPlainString());
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.SHORT_STR,
+        bigDecimal.toPlainString());
   }
 
   @Override
@@ -79,14 +86,20 @@ public class DecimalToScaledFixedConverter extends AbstractArrowVectorConverter 
     BigDecimal bigDecimal = toBigDecimal(index);
     if (bigDecimal.scale() == 0) {
       int intValue = bigDecimal.intValue();
-      if (bigDecimal.compareTo(BigDecimal.valueOf((long) intValue)) == 0) {
+      if (bigDecimal.compareTo(BigDecimal.valueOf(intValue)) == 0) {
         return intValue;
       }
       throw new SFException(
-          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", bigDecimal.toPlainString());
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.INT_STR,
+          bigDecimal.toPlainString());
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", bigDecimal.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.INT_STR,
+        bigDecimal.toPlainString());
   }
 
   @Override
@@ -101,10 +114,16 @@ public class DecimalToScaledFixedConverter extends AbstractArrowVectorConverter 
         return longValue;
       }
       throw new SFException(
-          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.LONG_STR,
+          bigDecimal.toPlainString());
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.LONG_STR,
+        bigDecimal.toPlainString());
   }
 
   @Override
@@ -151,6 +170,9 @@ public class DecimalToScaledFixedConverter extends AbstractArrowVectorConverter 
       return true;
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.BOOLEAN_STR,
+        val.toPlainString());
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DoubleToRealConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/DoubleToRealConverter.java
@@ -1,0 +1,120 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.ValueVector;
+
+/** Convert from Arrow Float8Vector to Real. */
+public class DoubleToRealConverter extends AbstractArrowVectorConverter {
+  private final Float8Vector float8Vector;
+  private final ByteBuffer byteBuf = ByteBuffer.allocate(Float8Vector.TYPE_WIDTH);
+
+  public DoubleToRealConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(SnowflakeType.REAL.name(), fieldVector, columnIndex, context);
+    this.float8Vector = (Float8Vector) fieldVector;
+  }
+
+  @Override
+  public double toDouble(int index) {
+    if (float8Vector.isNull(index)) {
+      return 0;
+    }
+    return float8Vector.getDataBuffer().getDouble(index * Float8Vector.TYPE_WIDTH);
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.putDouble(0, toDouble(index));
+    return byteBuf.array();
+  }
+
+  @Override
+  public float toFloat(int index) {
+    return (float) toDouble(index);
+  }
+
+  @Override
+  public Object toObject(int index) {
+    return isNull(index) ? null : toDouble(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    return isNull(index) ? null : String.valueOf(toDouble(index));
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    double val = toDouble(index);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, val);
+  }
+
+  @Override
+  public short toShort(int rowIndex) throws SFException {
+    try {
+      if (isNull(rowIndex)) {
+        return 0;
+      }
+      return (short) toDouble(rowIndex);
+    } catch (ClassCastException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.SHORT_STR,
+          toObject(rowIndex));
+    }
+  }
+
+  @Override
+  public int toInt(int rowIndex) throws SFException {
+    try {
+      if (isNull(rowIndex)) {
+        return 0;
+      }
+      return (int) toDouble(rowIndex);
+    } catch (ClassCastException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.INT_STR,
+          toObject(rowIndex));
+    }
+  }
+
+  @Override
+  public long toLong(int rowIndex) throws SFException {
+    try {
+      if (isNull(rowIndex)) {
+        return 0;
+      }
+      return (long) toDouble(rowIndex);
+    } catch (ClassCastException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT,
+          logicalTypeStr,
+          SnowflakeUtil.LONG_STR,
+          toObject(rowIndex));
+    }
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int rowIndex) {
+    if (isNull(rowIndex)) {
+      return null;
+    }
+    return BigDecimal.valueOf(toDouble(rowIndex));
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToFixedConverter.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.ValueVector;
 
@@ -112,6 +113,7 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
     } else if (val == 1) {
       return true;
     }
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, val);
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToFixedConverter.java
@@ -1,0 +1,117 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.ValueVector;
+
+public class IntToFixedConverter extends AbstractArrowVectorConverter {
+  protected final IntVector intVector;
+  protected int sfScale;
+  protected ByteBuffer byteBuf = ByteBuffer.allocate(IntVector.TYPE_WIDTH);
+
+  public IntToFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale")),
+        fieldVector,
+        columnIndex,
+        context);
+    this.intVector = (IntVector) fieldVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.putInt(0, getInt(index));
+    return byteBuf.array();
+  }
+
+  @Override
+  public byte toByte(int index) throws SFException {
+    int intVal = toInt(index);
+    byte byteVal = (byte) intVal;
+    if (byteVal == intVal) {
+      return byteVal;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "byte", intVal);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    int intVal = toInt(index);
+    short shortVal = (short) intVal;
+    if (shortVal == intVal) {
+      return shortVal;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "short", intVal);
+  }
+
+  protected int getInt(int index) {
+    return intVector.getDataBuffer().getInt(index * IntVector.TYPE_WIDTH);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (intVector.isNull(index)) {
+      return 0;
+    }
+    return getInt(index);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    return (long) toInt(index);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    return toInt(index);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    return toInt(index);
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) throws SFException {
+    if (intVector.isNull(index)) {
+      return null;
+    }
+    return BigDecimal.valueOf((long) getInt(index), sfScale);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    return (long) getInt(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    return isNull(index) ? null : Integer.toString(getInt(index));
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    int val = toInt(index);
+    if (val == 0) {
+      return false;
+    } else if (val == 1) {
+      return true;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToScaledFixedConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.ValueVector;
 
 public class IntToScaledFixedConverter extends IntToFixedConverter {
@@ -44,7 +45,8 @@ public class IntToScaledFixedConverter extends IntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "short", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, val);
   }
 
   @Override
@@ -53,7 +55,8 @@ public class IntToScaledFixedConverter extends IntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "int", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR, val);
   }
 
   @Override
@@ -62,7 +65,8 @@ public class IntToScaledFixedConverter extends IntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "long", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.LONG_STR, val);
   }
 
   @Override
@@ -89,6 +93,9 @@ public class IntToScaledFixedConverter extends IntToFixedConverter {
       return true;
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.BOOLEAN_STR,
+        val.toPlainString());
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/IntToScaledFixedConverter.java
@@ -1,0 +1,94 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.ValueVector;
+
+public class IntToScaledFixedConverter extends IntToFixedConverter {
+  private final String format;
+
+  public IntToScaledFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context, int sfScale) {
+    super(fieldVector, columnIndex, context);
+    logicalTypeStr =
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale"));
+    this.format = ArrowResultUtil.getStringFormat(sfScale);
+    this.sfScale = sfScale;
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return ((float) getInt(index)) / ArrowResultUtil.powerOfTen(sfScale);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return ((double) getInt(index)) / ArrowResultUtil.powerOfTen(sfScale);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "short", val);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "int", val);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "long", val);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    return isNull(index)
+        ? null
+        : String.format(format, (double) getInt(index) / ArrowResultUtil.powerOfTen(sfScale));
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    BigDecimal val = toBigDecimal(index);
+    if (val.compareTo(BigDecimal.ZERO) == 0) {
+      return false;
+    } else if (val.compareTo(BigDecimal.ONE) == 0) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverter.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.ValueVector;
 
@@ -47,7 +48,8 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
     if (byteVal == shortVal) {
       return byteVal;
     }
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "byte", shortVal);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTE_STR, shortVal);
   }
 
   @Override
@@ -107,6 +109,7 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
     } else if (val == 1) {
       return true;
     }
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, val);
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverter.java
@@ -1,0 +1,112 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.ValueVector;
+
+public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
+  protected final SmallIntVector smallIntVector;
+  protected int sfScale;
+  protected ByteBuffer byteBuf = ByteBuffer.allocate(SmallIntVector.TYPE_WIDTH);
+
+  public SmallIntToFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale")),
+        fieldVector,
+        columnIndex,
+        context);
+    this.smallIntVector = (SmallIntVector) fieldVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.putShort(0, getShort(index));
+    return byteBuf.array();
+  }
+
+  protected short getShort(int index) {
+    return smallIntVector.getDataBuffer().getShort(index * SmallIntVector.TYPE_WIDTH);
+  }
+
+  @Override
+  public byte toByte(int index) throws SFException {
+    short shortVal = toShort(index);
+    byte byteVal = (byte) shortVal;
+    if (byteVal == shortVal) {
+      return byteVal;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "byte", shortVal);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (smallIntVector.isNull(index)) {
+      return 0;
+    }
+    return getShort(index);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    return (int) toShort(index);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    return (long) toShort(index);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    return toShort(index);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    return toShort(index);
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) throws SFException {
+    if (smallIntVector.isNull(index)) {
+      return null;
+    }
+    return BigDecimal.valueOf(getShort(index), sfScale);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    if (smallIntVector.isNull(index)) {
+      return null;
+    }
+    return (long) getShort(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    return isNull(index) ? null : Short.toString(getShort(index));
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    short val = toShort(index);
+    if (val == 0) {
+      return false;
+    } else if (val == 1) {
+      return true;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToScaledFixedConverter.java
@@ -1,0 +1,88 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.ValueVector;
+
+public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
+  private final String format;
+
+  public SmallIntToScaledFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context, int sfScale) {
+    super(fieldVector, columnIndex, context);
+    logicalTypeStr =
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale"));
+    this.format = ArrowResultUtil.getStringFormat(sfScale);
+    this.sfScale = sfScale;
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return ((float) getShort(index)) / ArrowResultUtil.powerOfTen(sfScale);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    float f = ((float) getShort(index)) / ArrowResultUtil.powerOfTen(sfScale);
+    return String.format(format, f);
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    BigDecimal val = toBigDecimal(index);
+    if (val.compareTo(BigDecimal.ZERO) == 0) {
+      return false;
+    } else if (val.compareTo(BigDecimal.ONE) == 0) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/SmallIntToScaledFixedConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.ValueVector;
 
 public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
@@ -28,7 +29,8 @@ public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, val);
   }
 
   @Override
@@ -37,7 +39,8 @@ public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR, val);
   }
 
   @Override
@@ -54,7 +57,8 @@ public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.LONG_STR, val);
   }
 
   @Override
@@ -83,6 +87,9 @@ public class SmallIntToScaledFixedConverter extends SmallIntToFixedConverter {
       return true;
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.BOOLEAN_STR,
+        val.toPlainString());
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverter.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.ValueVector;
 
@@ -99,6 +100,7 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
     } else if (val == 1) {
       return true;
     }
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, val);
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverter.java
@@ -1,0 +1,104 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.ValueVector;
+
+public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
+  protected final TinyIntVector tinyIntVector;
+  protected int sfScale;
+  protected ByteBuffer byteBuf = ByteBuffer.allocate(TinyIntVector.TYPE_WIDTH);
+
+  public TinyIntToFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale")),
+        fieldVector,
+        columnIndex,
+        context);
+    this.tinyIntVector = (TinyIntVector) fieldVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    byteBuf.put(0, getByte(index));
+    return byteBuf.array();
+  }
+
+  @Override
+  public byte toByte(int index) {
+    return getByte(index);
+  }
+
+  protected byte getByte(int index) {
+    return tinyIntVector.getDataBuffer().getByte(index * TinyIntVector.TYPE_WIDTH);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    return (short) toByte(index);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    return (int) toByte(index);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    return (long) toByte(index);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    return toByte(index);
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    return toByte(index);
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    return BigDecimal.valueOf(getByte(index), sfScale);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    return (long) getByte(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    return isNull(index) ? null : Byte.toString(getByte(index));
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    byte val = toByte(index);
+    if (val == 0) {
+      return false;
+    } else if (val == 1) {
+      return true;
+    }
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToScaledFixedConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SFException;
 import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import org.apache.arrow.vector.ValueVector;
 
 public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
@@ -28,7 +29,8 @@ public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, val);
   }
 
   @Override
@@ -37,7 +39,8 @@ public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR, val);
   }
 
   @Override
@@ -54,7 +57,8 @@ public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
       return 0;
     }
     float val = toFloat(index);
-    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val);
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.LONG_STR, val);
   }
 
   @Override
@@ -83,6 +87,9 @@ public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
       return true;
     }
     throw new SFException(
-        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+        ErrorCode.INVALID_VALUE_CONVERT,
+        logicalTypeStr,
+        SnowflakeUtil.BOOLEAN_STR,
+        val.toPlainString());
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToScaledFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/TinyIntToScaledFixedConverter.java
@@ -1,0 +1,88 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import org.apache.arrow.vector.ValueVector;
+
+public class TinyIntToScaledFixedConverter extends TinyIntToFixedConverter {
+  private final String format;
+
+  public TinyIntToScaledFixedConverter(
+      ValueVector fieldVector, int columnIndex, DataConversionContext context, int sfScale) {
+    super(fieldVector, columnIndex, context);
+    logicalTypeStr =
+        String.format(
+            "%s(%s,%s)",
+            SnowflakeType.FIXED,
+            fieldVector.getField().getMetadata().get("precision"),
+            fieldVector.getField().getMetadata().get("scale"));
+    this.format = ArrowResultUtil.getStringFormat(sfScale);
+    this.sfScale = sfScale;
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", val);
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Int", val);
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    return ((float) getByte(index)) / ArrowResultUtil.powerOfTen(sfScale);
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    if (isNull(index)) {
+      return 0;
+    }
+    float val = toFloat(index);
+    throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", val);
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    float f = ((float) getByte(index)) / ArrowResultUtil.powerOfTen(sfScale);
+    return String.format(format, f);
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    if (isNull(index)) {
+      return false;
+    }
+    BigDecimal val = toBigDecimal(index);
+    if (val.compareTo(BigDecimal.ZERO) == 0) {
+      return false;
+    } else if (val.compareTo(BigDecimal.ONE) == 0) {
+      return true;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Boolean", val.toPlainString());
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/VarBinaryToBinaryConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/VarBinaryToBinaryConverter.java
@@ -1,0 +1,44 @@
+package net.snowflake.client.internal.core.arrow;
+
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+
+public class VarBinaryToBinaryConverter extends AbstractArrowVectorConverter {
+  private final VarBinaryVector varBinaryVector;
+
+  public VarBinaryToBinaryConverter(
+      ValueVector valueVector, int columnIndex, DataConversionContext context) {
+    super(SnowflakeType.BINARY.name(), valueVector, columnIndex, context);
+    this.varBinaryVector = (VarBinaryVector) valueVector;
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    return isNull(index) ? null : varBinaryVector.get(index);
+  }
+
+  @Override
+  public Object toObject(int index) {
+    return toBytes(index);
+  }
+
+  @Override
+  public String toString(int index) {
+    byte[] bytes = toBytes(index);
+    return bytes == null ? null : new String(bytes);
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    String str = toString(index);
+    if (str == null) {
+      return false;
+    }
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, str);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/VarCharConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/VarCharConverter.java
@@ -1,0 +1,134 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SFException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarCharVector;
+
+public class VarCharConverter extends AbstractArrowVectorConverter {
+  private final VarCharVector varCharVector;
+
+  public VarCharConverter(ValueVector valueVector, int columnIndex, DataConversionContext context) {
+    super(SnowflakeType.TEXT.name(), valueVector, columnIndex, context);
+    this.varCharVector = (VarCharVector) valueVector;
+  }
+
+  @Override
+  public String toString(int index) {
+    byte[] bytes = toBytes(index);
+    return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public byte[] toBytes(int index) {
+    return isNull(index) ? null : varCharVector.get(index);
+  }
+
+  @Override
+  public Object toObject(int index) {
+    return toString(index);
+  }
+
+  @Override
+  public short toShort(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return 0;
+      }
+      return Short.parseShort(str);
+    } catch (NumberFormatException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.SHORT_STR, str);
+    }
+  }
+
+  @Override
+  public int toInt(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return 0;
+      }
+      return Integer.parseInt(str);
+    } catch (NumberFormatException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.INT_STR, str);
+    }
+  }
+
+  @Override
+  public long toLong(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return 0;
+      }
+      return Long.parseLong(str);
+    } catch (NumberFormatException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.LONG_STR, str);
+    }
+  }
+
+  @Override
+  public float toFloat(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return 0;
+      }
+      return Float.parseFloat(str);
+    } catch (NumberFormatException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.FLOAT_STR, str);
+    }
+  }
+
+  @Override
+  public double toDouble(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return 0;
+      }
+      return Double.parseDouble(str);
+    } catch (NumberFormatException ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.DOUBLE_STR, str);
+    }
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) throws SFException {
+    String str = toString(index);
+    try {
+      if (str == null) {
+        return null;
+      }
+      return new BigDecimal(str);
+    } catch (Exception ex) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, str);
+    }
+  }
+
+  @Override
+  public boolean toBoolean(int index) throws SFException {
+    String str = toString(index);
+    if (str == null) {
+      return false;
+    } else if ("0".equals(str) || Boolean.FALSE.toString().equalsIgnoreCase(str)) {
+      return false;
+    } else if ("1".equals(str) || Boolean.TRUE.toString().equalsIgnoreCase(str)) {
+      return true;
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, str);
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/jdbc/ErrorCode.java
+++ b/jdbc/src/main/java/net/snowflake/client/jdbc/ErrorCode.java
@@ -1,0 +1,16 @@
+package net.snowflake.client.jdbc;
+
+public enum ErrorCode {
+  INTERNAL_ERROR(200001),
+  INVALID_VALUE_CONVERT(200038);
+
+  private final int messageCode;
+
+  ErrorCode(int messageCode) {
+    this.messageCode = messageCode;
+  }
+
+  public int getMessageCode() {
+    return messageCode;
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/jdbc/SFException.java
+++ b/jdbc/src/main/java/net/snowflake/client/jdbc/SFException.java
@@ -1,0 +1,25 @@
+package net.snowflake.client.jdbc;
+
+import java.util.Arrays;
+
+public class SFException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  private final ErrorCode errorCode;
+
+  public SFException(ErrorCode errorCode, Object... params) {
+    super(buildMessage(errorCode, params));
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+  private static String buildMessage(ErrorCode errorCode, Object... params) {
+    if (params == null || params.length == 0) {
+      return String.valueOf(errorCode);
+    }
+    return String.format("%s: %s", errorCode, Arrays.toString(params));
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -1,0 +1,11 @@
+package net.snowflake.client.jdbc;
+
+import java.sql.SQLException;
+
+public class SnowflakeSQLException extends SQLException {
+  private static final long serialVersionUID = 1L;
+
+  public SnowflakeSQLException(String message) {
+    super(message);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -1,0 +1,32 @@
+package net.snowflake.client.jdbc;
+
+public enum SnowflakeType {
+  ANY,
+  ARRAY,
+  BINARY,
+  BOOLEAN,
+  CHAR,
+  DATE,
+  DECFLOAT,
+  FIXED,
+  INTEGER,
+  OBJECT,
+  MAP,
+  REAL,
+  TEXT,
+  TIME,
+  TIMESTAMP,
+  TIMESTAMP_LTZ,
+  TIMESTAMP_NTZ,
+  TIMESTAMP_TZ,
+  INTERVAL_YEAR_MONTH,
+  INTERVAL_DAY_TIME,
+  VARIANT,
+  GEOGRAPHY,
+  GEOMETRY,
+  VECTOR;
+
+  public static SnowflakeType fromString(String name) {
+    return SnowflakeType.valueOf(name.toUpperCase());
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -1,0 +1,18 @@
+package net.snowflake.client.jdbc;
+
+public class SnowflakeUtil {
+  public static final String BIG_DECIMAL_STR = "big decimal";
+  public static final String FLOAT_STR = "float";
+  public static final String DOUBLE_STR = "double";
+  public static final String BOOLEAN_STR = "boolean";
+  public static final String SHORT_STR = "short";
+  public static final String INT_STR = "int";
+  public static final String LONG_STR = "long";
+  public static final String TIME_STR = "time";
+  public static final String TIMESTAMP_STR = "timestamp";
+  public static final String DATE_STR = "date";
+  public static final String BYTE_STR = "byte";
+  public static final String BYTES_STR = "byte array";
+
+  private SnowflakeUtil() {}
+}

--- a/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeDriverTest.java
+++ b/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeDriverTest.java
@@ -1,16 +1,17 @@
 package com.snowflake.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Basic tests for the Snowflake JDBC Driver */
 public class SnowflakeDriverTest {
@@ -19,8 +20,8 @@ public class SnowflakeDriverTest {
   public void testDriverRegistration() throws SQLException {
     // Test that the driver is properly registered
     Driver driver = DriverManager.getDriver("jdbc:snowflake://test.snowflakecomputing.com");
-    assertNotNull("Driver should be registered", driver);
-    assertTrue("Driver should be instance of SnowflakeDriver", driver instanceof SnowflakeDriver);
+    assertNotNull(driver, "Driver should be registered");
+    assertTrue(driver instanceof SnowflakeDriver, "Driver should be instance of SnowflakeDriver");
   }
 
   @Test
@@ -29,32 +30,35 @@ public class SnowflakeDriverTest {
 
     // Test valid URLs
     assertTrue(
-        "Should accept snowflake URL",
-        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com"));
+        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com"),
+        "Should accept snowflake URL");
     assertTrue(
-        "Should accept snowflake URL with parameters",
-        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com?db=test"));
+        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com?db=test"),
+        "Should accept snowflake URL with parameters");
 
     // Test invalid URLs
-    assertFalse("Should not accept null URL", driver.acceptsURL(null));
+    assertFalse(driver.acceptsURL(null), "Should not accept null URL");
     assertFalse(
-        "Should not accept non-snowflake URL",
-        driver.acceptsURL("jdbc:mysql://localhost:3306/test"));
-    assertFalse("Should not accept malformed URL", driver.acceptsURL("not-a-url"));
+        driver.acceptsURL("jdbc:mysql://localhost:3306/test"),
+        "Should not accept non-snowflake URL");
+    assertFalse(driver.acceptsURL("not-a-url"), "Should not accept malformed URL");
   }
 
   @Test
   public void testDriverVersion() {
     SnowflakeDriver driver = new SnowflakeDriver();
-    assertEquals("Major version should be 0", 0, driver.getMajorVersion());
-    assertEquals("Minor version should be 1", 1, driver.getMinorVersion());
-    assertFalse("Driver should not claim JDBC compliance in stub", driver.jdbcCompliant());
+    assertEquals(0, driver.getMajorVersion(), "Major version should be 0");
+    assertEquals(1, driver.getMinorVersion(), "Minor version should be 1");
+    assertFalse(driver.jdbcCompliant(), "Driver should not claim JDBC compliance in stub");
   }
 
-  @Test(expected = SQLFeatureNotSupportedException.class)
+  @Test
   public void testGetParentLogger() throws SQLException {
     SnowflakeDriver driver = new SnowflakeDriver();
-    driver.getParentLogger(); // Should throw SQLFeatureNotSupportedException
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        driver::getParentLogger,
+        "Expected getParentLogger to throw");
   }
 
   @Test
@@ -62,7 +66,7 @@ public class SnowflakeDriverTest {
     SnowflakeDriver driver = new SnowflakeDriver();
     DriverPropertyInfo[] props =
         driver.getPropertyInfo("jdbc:snowflake://test.snowflakecomputing.com", null);
-    assertNotNull("Property info should not be null", props);
-    assertEquals("Should return empty array in stub", 0, props.length);
+    assertNotNull(props, "Property info should not be null");
+    assertEquals(0, props.length, "Should return empty array in stub");
   }
 }

--- a/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeQueryTest.java
+++ b/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeQueryTest.java
@@ -1,8 +1,8 @@
 package com.snowflake.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -13,7 +13,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for executing queries through the Snowflake JDBC Driver */
 public class SnowflakeQueryTest {
@@ -85,9 +85,9 @@ public class SnowflakeQueryTest {
       ResultSet rs = stmt.executeQuery("SELECT 1");
 
       // Verify result
-      assertNotNull("ResultSet should not be null", rs);
-      assertTrue("ResultSet should have one row", rs.next());
-      assertEquals("Result should be 1", 1, rs.getInt(1));
+      assertNotNull(rs, "ResultSet should not be null");
+      assertTrue(rs.next(), "ResultSet should have one row");
+      assertEquals(1, rs.getInt(1), "Result should be 1");
 
       // Clean up
       rs.close();

--- a/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeResultSetGettersTest.java
+++ b/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeResultSetGettersTest.java
@@ -1,0 +1,169 @@
+package com.snowflake.jdbc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.Test;
+
+public class SnowflakeResultSetGettersTest {
+
+  private Properties loadConnectionProperties() throws Exception {
+    // Load parameters.json from test resources
+    String paramPath = System.getenv("PARAMETER_PATH");
+    if (paramPath == null) {
+      paramPath = "/parameters.json";
+    }
+    InputStream input = new java.io.FileInputStream(paramPath);
+    if (input == null) {
+      throw new RuntimeException("Could not find parameters.json in test resources");
+    }
+
+    JSONObject params = new JSONObject(new JSONTokener(new InputStreamReader(input)));
+    params = params.getJSONObject("testconnection");
+
+    Properties props = new Properties();
+    props.setProperty("user", params.getString("SNOWFLAKE_TEST_USER"));
+    props.setProperty("password", params.getString("SNOWFLAKE_TEST_PASSWORD"));
+    props.setProperty("db", params.getString("SNOWFLAKE_TEST_DATABASE"));
+    props.setProperty("schema", params.getString("SNOWFLAKE_TEST_SCHEMA"));
+    props.setProperty("warehouse", params.getString("SNOWFLAKE_TEST_WAREHOUSE"));
+    props.setProperty("account", params.getString("SNOWFLAKE_TEST_ACCOUNT"));
+
+    // Add optional parameters if specified
+    if (params.has("SNOWFLAKE_TEST_PORT")) {
+      props.setProperty("port", String.valueOf(params.getInt("SNOWFLAKE_TEST_PORT")));
+    }
+
+    if (params.has("SNOWFLAKE_TEST_ROLE")) {
+      props.setProperty("role", params.getString("SNOWFLAKE_TEST_ROLE"));
+    }
+
+    if (params.has("SNOWFLAKE_TEST_SERVER_URL")) {
+      props.setProperty("server_url", params.getString("SNOWFLAKE_TEST_SERVER_URL"));
+    }
+
+    if (params.has("SNOWFLAKE_TEST_HOST")) {
+      props.setProperty("host", params.getString("SNOWFLAKE_TEST_HOST"));
+    }
+
+    if (params.has("SNOWFLAKE_TEST_PROTOCOL")) {
+      props.setProperty("protocol", params.getString("SNOWFLAKE_TEST_PROTOCOL"));
+    }
+
+    return props;
+  }
+
+  private Connection openConnection() throws Exception {
+    Properties props = loadConnectionProperties();
+    String defaultUrl =
+        "jdbc:snowflake://" + props.getProperty("account") + ".snowflakecomputing.com";
+    if (props.getProperty("port") != null) {
+      defaultUrl += ":" + props.getProperty("port");
+    }
+    String url = props.getProperty("url", defaultUrl);
+    SnowflakeDriver.empty();
+    return DriverManager.getConnection(url, props);
+  }
+
+  @Test
+  public void testGetInt() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 42")) {
+      assertTrue(rs.next());
+      assertEquals(42, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testGetFloat() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 12.5::FLOAT")) {
+      assertTrue(rs.next());
+      assertEquals(12.5f, rs.getFloat(1), 0.0001f);
+    }
+  }
+
+  @Test
+  public void testGetDouble() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 12345.6789::DOUBLE")) {
+      assertTrue(rs.next());
+      assertEquals(12345.6789, rs.getDouble(1), 0.0000001);
+    }
+  }
+
+  @Test
+  public void testGetString() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 'hello'")) {
+      assertTrue(rs.next());
+      assertEquals("hello", rs.getString(1));
+    }
+  }
+
+  @Test
+  public void testGetObject() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 7::NUMBER(10,0)")) {
+      assertTrue(rs.next());
+      Object value = rs.getObject(1);
+      assertNotNull(value);
+      assertTrue(value instanceof Long);
+      assertEquals(7L, value);
+    }
+  }
+
+  @Test
+  public void testGetBytes() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT TO_BINARY('0102', 'HEX')")) {
+      assertTrue(rs.next());
+      assertArrayEquals(new byte[] {0x01, 0x02}, rs.getBytes(1));
+    }
+  }
+
+  @Test
+  public void testGetBigDecimal() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 123.45::NUMBER(10,2)")) {
+      assertTrue(rs.next());
+      BigDecimal value = rs.getBigDecimal(1);
+      assertNotNull(value);
+      assertEquals(0, value.compareTo(new BigDecimal("123.45")));
+    }
+  }
+
+  @Test
+  public void testFloatSpecialValues() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 'inf'::FLOAT, '-inf'::FLOAT, 'nan'::FLOAT")) {
+      assertTrue(rs.next());
+      float posInf = rs.getFloat(1);
+      float negInf = rs.getFloat(2);
+      float nanVal = rs.getFloat(3);
+      assertTrue(Float.isInfinite(posInf) && posInf > 0);
+      assertTrue(Float.isInfinite(negInf) && negInf < 0);
+      assertTrue(Float.isNaN(nanVal));
+    }
+  }
+}

--- a/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeResultSetGettersTest.java
+++ b/jdbc/src/test/java/com/snowflake/jdbc/SnowflakeResultSetGettersTest.java
@@ -1,9 +1,9 @@
 package com.snowflake.jdbc;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -15,7 +15,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SnowflakeResultSetGettersTest {
 

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BaseConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BaseConverterTest.java
@@ -1,0 +1,23 @@
+package net.snowflake.client.internal.core.arrow;
+
+import java.nio.ByteOrder;
+import net.snowflake.client.jdbc.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+
+public class BaseConverterTest implements DataConversionContext {
+  protected final int invalidConversionErrorCode = ErrorCode.INVALID_VALUE_CONVERT.getMessageCode();
+
+  @AfterEach
+  public void clearTimeZone() {
+    System.clearProperty("user.timezone");
+  }
+
+  @BeforeEach
+  public void assumeLittleEndian() {
+    Assumptions.assumeTrue(
+        ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN),
+        "Arrow doesn't support cross endianness");
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BigIntToFixedConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BigIntToFixedConverterTest.java
@@ -1,0 +1,262 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class BigIntToFixedConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  /** Random seed */
+  private final Random random = new Random();
+
+  @Test
+  public void testFixedNoScale() {
+    final int rowCount = 1000;
+    List<Long> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextLong());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    BigIntVector vector = new BigIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new BigIntToFixedConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      long longVal = converter.toLong(i);
+      Object longObject = converter.toObject(i);
+      String longString = converter.toString(i);
+
+      if (longString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertEquals(0L, longVal);
+        assertNull(longObject);
+        assertNull(longString);
+        assertNull(converter.toBytes(i));
+      } else {
+        assertEquals(expectedValues.get(i), longVal);
+        assertEquals(expectedValues.get(i), longObject);
+        assertEquals(expectedValues.get(i).toString(), longString);
+        ByteBuffer bb = ByteBuffer.wrap(converter.toBytes(i));
+        assertEquals(longVal, bb.getLong());
+      }
+    }
+    vector.clear();
+  }
+
+  @Test
+  public void testFixedWithScale() {
+    final int rowCount = 1000;
+    List<Long> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextLong());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    BigIntVector vector = new BigIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new BigIntToScaledFixedConverter(vector, 0, this, 3);
+
+    for (int i = 0; i < rowCount; i++) {
+      BigDecimal bigDecimalVal = converter.toBigDecimal(i);
+      Object objectVal = converter.toObject(i);
+      String stringVal = converter.toString(i);
+
+      if (nullValIndex.contains(i)) {
+        assertNull(bigDecimalVal);
+        assertNull(objectVal);
+        assertNull(stringVal);
+        assertNull(converter.toBytes(i));
+      } else {
+        BigDecimal expectedVal = BigDecimal.valueOf(expectedValues.get(i), 3);
+        assertEquals(expectedVal, bigDecimalVal);
+        assertEquals(expectedVal, objectVal);
+        assertEquals(expectedVal.toPlainString(), stringVal);
+        assertNotNull(converter.toBytes(i));
+      }
+    }
+
+    vector.clear();
+  }
+
+  @Test
+  public void testInvalidConversion() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    BigIntVector vector = new BigIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 123456789L);
+
+    final ArrowVectorConverter converter = new BigIntToScaledFixedConverter(vector, 0, this, 3);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toByte(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(0, TimeZone.getDefault(), false));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toTime(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toTimestamp(0, TimeZone.getDefault()));
+    vector.clear();
+  }
+
+  @Test
+  public void testGetSmallerIntegralType() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    // test value which is out of range of int/short/byte
+    BigIntVector vectorFoo = new BigIntVector("col_one", fieldType, allocator);
+    vectorFoo.setSafe(0, 2147483650L);
+    vectorFoo.setSafe(1, -2147483650L);
+
+    final ArrowVectorConverter converterFoo = new BigIntToFixedConverter(vectorFoo, 0, this);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toInt(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toShort(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toInt(1));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toShort(1));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(1));
+    vectorFoo.clear();
+
+    // test value which is in range of byte, all get method should return
+    BigIntVector vectorBar = new BigIntVector("col_one", fieldType, allocator);
+    vectorBar.setSafe(0, 10L);
+    vectorBar.setSafe(1, -10L);
+
+    final ArrowVectorConverter converterBar = new BigIntToFixedConverter(vectorBar, 0, this);
+
+    assertEquals((byte) 10, converterBar.toByte(0));
+    assertEquals((byte) -10, converterBar.toByte(1));
+    assertEquals((short) 10, converterBar.toShort(0));
+    assertEquals((short) -10, converterBar.toShort(1));
+    assertEquals(10, converterBar.toInt(0));
+    assertEquals(-10, converterBar.toInt(1));
+    vectorBar.clear();
+  }
+
+  @Test
+  public void testGetBooleanNoScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    BigIntVector vector = new BigIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    ArrowVectorConverter converter = new BigIntToFixedConverter(vector, 0, this);
+
+    assertFalse(converter.toBoolean(0));
+    assertTrue(converter.toBoolean(1));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+
+  @Test
+  public void testGetBooleanWithScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.BIGINT.getType(), null, customFieldMeta);
+
+    BigIntVector vector = new BigIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    final ArrowVectorConverter converter = new BigIntToScaledFixedConverter(vector, 0, this, 3);
+
+    assertFalse(converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverterTest.java
@@ -1,0 +1,81 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class BitToBooleanConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  private final Random random = new Random();
+
+  @Test
+  public void testConvertToString() {
+    final int rowCount = 1000;
+    List<Boolean> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextBoolean());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "BOOLEAN");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.BIT.getType(), null, customFieldMeta);
+
+    BitVector vector = new BitVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i) ? 1 : 0);
+      }
+    }
+
+    ArrowVectorConverter converter = new BitToBooleanConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      boolean boolVal = converter.toBoolean(i);
+      Object objectVal = converter.toObject(i);
+      String stringVal = converter.toString(i);
+
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertFalse(boolVal);
+        assertNull(objectVal);
+        assertNull(stringVal);
+        assertNull(converter.toBytes(i));
+      } else {
+        assertEquals(expectedValues.get(i), boolVal);
+        assertEquals(expectedValues.get(i), objectVal);
+        assertEquals(Boolean.toString(expectedValues.get(i)), stringVal);
+        int index = i;
+        TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBytes(index));
+      }
+    }
+    vector.clear();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/BitToBooleanConverterTest.java
@@ -71,9 +71,12 @@ public class BitToBooleanConverterTest extends BaseConverterTest {
       } else {
         assertEquals(expectedValues.get(i), boolVal);
         assertEquals(expectedValues.get(i), objectVal);
-        assertEquals(Boolean.toString(expectedValues.get(i)), stringVal);
-        int index = i;
-        TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBytes(index));
+        assertEquals(Boolean.toString(expectedValues.get(i)).toUpperCase(), stringVal);
+        if (boolVal) {
+          assertEquals((byte) 0x1, converter.toBytes(i)[0]);
+        } else {
+          assertEquals((byte) 0x0, converter.toBytes(i)[0]);
+        }
       }
     }
     vector.clear();

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/DoubleToRealConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/DoubleToRealConverterTest.java
@@ -1,0 +1,89 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class DoubleToRealConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  /** Random seed */
+  private final Random random = new Random();
+
+  @Test
+  public void testConvertToDouble() {
+    final int rowCount = 1000;
+    List<Double> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextDouble());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "REAL");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.FLOAT8.getType(), null, customFieldMeta);
+
+    Float8Vector vector = new Float8Vector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new DoubleToRealConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      double doubleVal = converter.toDouble(i);
+      float floatVal = converter.toFloat(i);
+      Object doubleObject = converter.toObject(i);
+      String doubleString = converter.toString(i);
+      if (doubleObject != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertEquals(0.0d, doubleVal);
+        assertEquals(0.0f, floatVal);
+        assertNull(doubleObject);
+        assertNull(doubleString);
+        assertFalse(converter.toBoolean(i));
+        assertNull(converter.toBytes(i));
+      } else {
+        assertEquals(expectedValues.get(i), doubleVal);
+        assertEquals(expectedValues.get(i).floatValue(), floatVal);
+        assertEquals(expectedValues.get(i), doubleObject);
+        assertEquals(expectedValues.get(i).toString(), doubleString);
+        int index = i;
+        TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(index));
+        ByteBuffer bb = ByteBuffer.wrap(converter.toBytes(i));
+        assertEquals(doubleVal, bb.getDouble());
+      }
+    }
+    vector.clear();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/IntToFixedConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/IntToFixedConverterTest.java
@@ -1,0 +1,259 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class IntToFixedConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  /** Random seed */
+  private final Random random = new Random();
+
+  @Test
+  public void testFixedNoScale() {
+    final int rowCount = 1000;
+    List<Integer> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextInt());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    IntVector vector = new IntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new IntToFixedConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      int intVal = converter.toInt(i);
+      Object longObj = converter.toObject(i);
+      String intString = converter.toString(i);
+      if (intString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertEquals(0, intVal);
+        assertNull(longObj);
+        assertNull(intString);
+        assertNull(converter.toBytes(i));
+      } else {
+        assertEquals(expectedValues.get(i), intVal);
+        assertEquals((long) expectedValues.get(i), longObj);
+        assertEquals(expectedValues.get(i).toString(), intString);
+        ByteBuffer bb = ByteBuffer.wrap(converter.toBytes(i));
+        assertEquals(intVal, bb.getInt());
+      }
+    }
+    vector.clear();
+  }
+
+  @Test
+  public void testFixedWithScale() {
+    final int rowCount = 1000;
+    List<Integer> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(random.nextInt());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    IntVector vector = new IntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new IntToScaledFixedConverter(vector, 0, this, 3);
+    String format = ArrowResultUtil.getStringFormat(3);
+
+    for (int i = 0; i < rowCount; i++) {
+      BigDecimal bigDecimalVal = converter.toBigDecimal(i);
+      Object objectVal = converter.toObject(i);
+      String stringVal = converter.toString(i);
+
+      if (nullValIndex.contains(i)) {
+        assertNull(bigDecimalVal);
+        assertNull(objectVal);
+        assertNull(stringVal);
+        assertNull(converter.toBytes(i));
+      } else {
+        BigDecimal expectedVal = BigDecimal.valueOf(expectedValues.get(i), 3);
+        assertEquals(expectedVal, bigDecimalVal);
+        assertEquals(expectedVal, objectVal);
+        String expectedString =
+            String.format(format, (double) expectedValues.get(i) / ArrowResultUtil.powerOfTen(3));
+        assertEquals(expectedString, stringVal);
+        assertNotNull(converter.toBytes(i));
+      }
+    }
+
+    vector.clear();
+  }
+
+  @Test
+  public void testInvalidConversion() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    IntVector vector = new IntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 33000);
+
+    final ArrowVectorConverter converter = new IntToScaledFixedConverter(vector, 0, this, 3);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toByte(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(0, TimeZone.getDefault(), false));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toTime(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toTimestamp(0, TimeZone.getDefault()));
+    vector.clear();
+  }
+
+  @Test
+  public void testGetSmallerIntegralType() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    // test value which is out of range of short/byte
+    IntVector vectorFoo = new IntVector("col_one", fieldType, allocator);
+    vectorFoo.setSafe(0, 33000);
+    vectorFoo.setSafe(1, -33000);
+
+    final ArrowVectorConverter converterFoo = new IntToFixedConverter(vectorFoo, 0, this);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toShort(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toShort(1));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(1));
+
+    assertEquals(33000L, converterFoo.toLong(0));
+    assertEquals(-33000L, converterFoo.toLong(1));
+    vectorFoo.clear();
+
+    // test value which is in range of byte
+    IntVector vectorBar = new IntVector("col_one", fieldType, allocator);
+    vectorBar.setSafe(0, 10);
+    vectorBar.setSafe(1, -10);
+
+    final ArrowVectorConverter converterBar = new IntToFixedConverter(vectorBar, 0, this);
+
+    assertEquals((byte) 10, converterBar.toByte(0));
+    assertEquals((byte) -10, converterBar.toByte(1));
+    assertEquals((short) 10, converterBar.toShort(0));
+    assertEquals((short) -10, converterBar.toShort(1));
+    assertEquals(10L, converterBar.toLong(0));
+    assertEquals(-10L, converterBar.toLong(1));
+    vectorBar.clear();
+  }
+
+  @Test
+  public void testGetBooleanNoScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    IntVector vector = new IntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    ArrowVectorConverter converter = new IntToFixedConverter(vector, 0, this);
+
+    assertFalse(converter.toBoolean(0));
+    assertTrue(converter.toBoolean(1));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+
+  @Test
+  public void testGetBooleanWithScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType = new FieldType(true, Types.MinorType.INT.getType(), null, customFieldMeta);
+
+    IntVector vector = new IntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    final ArrowVectorConverter converter = new IntToScaledFixedConverter(vector, 0, this, 3);
+
+    assertFalse(converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/SmallIntToFixedConverterTest.java
@@ -1,0 +1,264 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class SmallIntToFixedConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  /** Random seed */
+  private final Random random = new Random();
+
+  @Test
+  public void testFixedNoScale() {
+    final int rowCount = 1000;
+    List<Short> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add((short) random.nextInt(1 << 16));
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    SmallIntVector vector = new SmallIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new SmallIntToFixedConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      short shortVal = converter.toShort(i);
+      Object longObject = converter.toObject(i); // the logical type is long
+      String shortString = converter.toString(i);
+      if (shortString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertEquals((short) 0, shortVal);
+        assertNull(longObject);
+        assertNull(shortString);
+        assertNull(converter.toBytes(i));
+      } else {
+        assertEquals(expectedValues.get(i), shortVal);
+        assertEquals((long) expectedValues.get(i), longObject);
+        assertEquals(expectedValues.get(i).toString(), shortString);
+        ByteBuffer bb = ByteBuffer.wrap(converter.toBytes(i));
+        assertEquals(shortVal, bb.getShort());
+      }
+    }
+    vector.clear();
+  }
+
+  @Test
+  public void testFixedWithScale() {
+    final int rowCount = 1000;
+    List<Short> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add((short) random.nextInt(1 << 16));
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    SmallIntVector vector = new SmallIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new SmallIntToScaledFixedConverter(vector, 0, this, 3);
+    String format = ArrowResultUtil.getStringFormat(3);
+
+    for (int i = 0; i < rowCount; i++) {
+      BigDecimal bigDecimalVal = converter.toBigDecimal(i);
+      Object objectVal = converter.toObject(i);
+      String stringVal = converter.toString(i);
+
+      if (nullValIndex.contains(i)) {
+        assertNull(bigDecimalVal);
+        assertNull(objectVal);
+        assertNull(stringVal);
+        assertNull(converter.toBytes(i));
+      } else {
+        BigDecimal expectedVal = BigDecimal.valueOf(expectedValues.get(i), 3);
+        assertEquals(expectedVal, bigDecimalVal);
+        assertEquals(expectedVal, objectVal);
+        String expectedString =
+            String.format(format, (float) expectedValues.get(i) / ArrowResultUtil.powerOfTen(3));
+        assertEquals(expectedString, stringVal);
+        assertNotNull(converter.toBytes(i));
+      }
+    }
+
+    vector.clear();
+  }
+
+  @Test
+  public void testInvalidConversion() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    SmallIntVector vector = new SmallIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 200);
+
+    final ArrowVectorConverter converter = new SmallIntToScaledFixedConverter(vector, 0, this, 3);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toByte(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(0, TimeZone.getDefault(), false));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toTime(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toTimestamp(0, TimeZone.getDefault()));
+    vector.clear();
+  }
+
+  @Test
+  public void testGetSmallerIntegralType() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    // test value which is out of range of byte
+    SmallIntVector vectorFoo = new SmallIntVector("col_one", fieldType, allocator);
+    vectorFoo.setSafe(0, 200);
+    vectorFoo.setSafe(1, -200);
+
+    final ArrowVectorConverter converterFoo = new SmallIntToFixedConverter(vectorFoo, 0, this);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converterFoo.toByte(1));
+    vectorFoo.clear();
+
+    // test value which is in range of byte, all get method should return
+    SmallIntVector vectorBar = new SmallIntVector("col_one", fieldType, allocator);
+    vectorBar.setSafe(0, 10);
+    vectorBar.setSafe(1, -10);
+
+    final ArrowVectorConverter converterBar = new SmallIntToFixedConverter(vectorBar, 0, this);
+
+    assertEquals((byte) 10, converterBar.toByte(0));
+    assertEquals((byte) -10, converterBar.toByte(1));
+    assertEquals(10, converterBar.toInt(0));
+    assertEquals(-10, converterBar.toInt(1));
+    assertEquals(10L, converterBar.toLong(0));
+    assertEquals(-10L, converterBar.toLong(1));
+    vectorBar.clear();
+  }
+
+  @Test
+  public void testGetBooleanNoScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    SmallIntVector vector = new SmallIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    ArrowVectorConverter converter = new SmallIntToFixedConverter(vector, 0, this);
+
+    assertFalse(converter.toBoolean(0));
+    assertTrue(converter.toBoolean(1));
+    assertFalse(converter.toBoolean(2));
+    assertFalse(converter.isNull(0));
+    assertFalse(converter.isNull(1));
+    assertTrue(converter.isNull(2));
+    assertFalse(converter.isNull(3));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+
+  @Test
+  public void testGetBooleanWithScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    SmallIntVector vector = new SmallIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    final ArrowVectorConverter converter = new SmallIntToScaledFixedConverter(vector, 0, this, 3);
+
+    assertFalse(converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/TestHelper.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/TestHelper.java
@@ -1,0 +1,28 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Random;
+import net.snowflake.client.jdbc.SFException;
+import org.junit.jupiter.api.function.Executable;
+
+public final class TestHelper {
+  private static final char[] ALPHANUM =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+
+  private TestHelper() {}
+
+  public static void assertSFException(int expectedErrorCode, Executable executable) {
+    SFException ex = assertThrows(SFException.class, executable);
+    assertEquals(expectedErrorCode, ex.getErrorCode().getMessageCode());
+  }
+
+  public static String randomString(Random random, int length) {
+    char[] chars = new char[length];
+    for (int i = 0; i < length; i++) {
+      chars[i] = ALPHANUM[random.nextInt(ALPHANUM.length)];
+    }
+    return new String(chars);
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/TinyIntToFixedConverterTest.java
@@ -1,0 +1,240 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class TinyIntToFixedConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  /** Random seed */
+  private final Random random = new Random();
+
+  @Test
+  public void testFixedNoScale() {
+    final int rowCount = 1000;
+    List<Byte> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add((byte) random.nextInt(1 << 8));
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new TinyIntToFixedConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      byte byteVal = converter.toByte(i);
+      Object longObject = converter.toObject(i); // the logical type is long
+      String byteString = converter.toString(i);
+
+      if (nullValIndex.contains(i)) {
+        assertEquals((byte) 0, byteVal);
+        assertNull(longObject);
+        assertNull(byteString);
+      } else {
+        assertEquals(expectedValues.get(i), byteVal);
+        assertEquals((long) expectedValues.get(i), longObject);
+        assertEquals(expectedValues.get(i).toString(), byteString);
+      }
+    }
+    vector.clear();
+  }
+
+  @Test
+  public void testFixedWithScale() {
+    final int rowCount = 1000;
+    List<Byte> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add((byte) random.nextInt(1 << 8));
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "1");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new TinyIntToScaledFixedConverter(vector, 0, this, 1);
+    String format = ArrowResultUtil.getStringFormat(1);
+
+    for (int i = 0; i < rowCount; i++) {
+      BigDecimal bigDecimalVal = converter.toBigDecimal(i);
+      Object objectVal = converter.toObject(i);
+      String stringVal = converter.toString(i);
+
+      if (nullValIndex.contains(i)) {
+        assertNull(bigDecimalVal);
+        assertNull(objectVal);
+        assertNull(stringVal);
+      } else {
+        BigDecimal expectedVal = BigDecimal.valueOf(expectedValues.get(i), 1);
+        assertEquals(expectedVal, bigDecimalVal);
+        assertEquals(expectedVal, objectVal);
+        String expectedString =
+            String.format(format, (float) expectedValues.get(i) / ArrowResultUtil.powerOfTen(1));
+        assertEquals(expectedString, stringVal);
+      }
+    }
+
+    vector.clear();
+  }
+
+  @Test
+  public void testInvalidConversion() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "1");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 200);
+
+    final ArrowVectorConverter converter = new TinyIntToScaledFixedConverter(vector, 0, this, 1);
+
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(0, TimeZone.getDefault(), false));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toTime(0));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toTimestamp(0, TimeZone.getDefault()));
+    vector.clear();
+  }
+
+  @Test
+  public void testGetSmallerIntegralType() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    // test value which is in range of byte, all get method should return
+    TinyIntVector vectorBar = new TinyIntVector("col_one", fieldType, allocator);
+    vectorBar.setSafe(0, 10);
+    vectorBar.setSafe(1, -10);
+
+    final ArrowVectorConverter converterBar = new TinyIntToFixedConverter(vectorBar, 0, this);
+
+    assertEquals((short) 10, converterBar.toShort(0));
+    assertEquals((short) -10, converterBar.toShort(1));
+    assertEquals(10, converterBar.toInt(0));
+    assertEquals(-10, converterBar.toInt(1));
+    assertEquals(10L, converterBar.toLong(0));
+    assertEquals(-10L, converterBar.toLong(1));
+    vectorBar.clear();
+  }
+
+  @Test
+  public void testGetBooleanNoScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    ArrowVectorConverter converter = new TinyIntToFixedConverter(vector, 0, this);
+
+    assertFalse(converter.toBoolean(0));
+    assertTrue(converter.toBoolean(1));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+
+  @Test
+  public void testGetBooleanWithScale() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "3");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 0);
+    vector.setSafe(1, 1);
+    vector.setNull(2);
+    vector.setSafe(3, 5);
+
+    final ArrowVectorConverter converter = new TinyIntToScaledFixedConverter(vector, 0, this, 3);
+
+    assertFalse(converter.toBoolean(0));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    assertFalse(converter.isNull(0));
+    assertFalse(converter.isNull(1));
+    assertTrue(converter.isNull(2));
+    assertFalse(converter.isNull(3));
+    vector.close();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/VarBinaryToBinaryConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/VarBinaryToBinaryConverterTest.java
@@ -1,0 +1,83 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class VarBinaryToBinaryConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  private final Random random = new Random();
+
+  @Test
+  public void testConvertToString() {
+    final int rowCount = 1000;
+    List<byte[]> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(TestHelper.randomString(random, 20).getBytes());
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "BINARY");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.VARBINARY.getType(), null, customFieldMeta);
+
+    VarBinaryVector vector = new VarBinaryVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i));
+      }
+    }
+
+    ArrowVectorConverter converter = new VarBinaryToBinaryConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      String stringVal = converter.toString(i);
+      Object objectVal = converter.toObject(i);
+      byte[] bytesVal = converter.toBytes(i);
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertNull(stringVal);
+        assertNull(objectVal);
+        assertNull(bytesVal);
+        assertFalse(converter.toBoolean(i));
+      } else {
+        String expectedString = new String(expectedValues.get(i));
+        assertEquals(expectedString, stringVal);
+        assertArrayEquals(expectedValues.get(i), bytesVal);
+        assertArrayEquals(expectedValues.get(i), (byte[]) objectVal);
+        int index = i;
+        TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(index));
+      }
+    }
+    vector.clear();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/VarCharConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/VarCharConverterTest.java
@@ -1,0 +1,128 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class VarCharConverterTest extends BaseConverterTest {
+  /** allocator for arrow */
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  private final Random random = new Random();
+
+  @Test
+  public void testConvertToString() {
+    final int rowCount = 1000;
+    List<String> expectedValues = new ArrayList<>();
+    Set<Integer> nullValIndex = new HashSet<>();
+    for (int i = 0; i < rowCount; i++) {
+      expectedValues.add(TestHelper.randomString(random, 20));
+    }
+
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.VARCHAR.getType(), null, customFieldMeta);
+
+    VarCharVector vector = new VarCharVector("col_one", fieldType, allocator);
+    for (int i = 0; i < rowCount; i++) {
+      boolean isNull = random.nextBoolean();
+      if (isNull) {
+        vector.setNull(i);
+        nullValIndex.add(i);
+      } else {
+        vector.setSafe(i, expectedValues.get(i).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    ArrowVectorConverter converter = new VarCharConverter(vector, 0, this);
+
+    for (int i = 0; i < rowCount; i++) {
+      String stringVal = converter.toString(i);
+      Object objectVal = converter.toObject(i);
+      byte[] bytesVal = converter.toBytes(i);
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
+
+      if (nullValIndex.contains(i)) {
+        assertNull(stringVal);
+        assertNull(objectVal);
+        assertNull(bytesVal);
+      } else {
+        assertEquals(expectedValues.get(i), stringVal);
+        assertEquals(expectedValues.get(i), objectVal);
+        assertArrayEquals(expectedValues.get(i).getBytes(StandardCharsets.UTF_8), bytesVal);
+      }
+    }
+    vector.clear();
+  }
+
+  @Test
+  public void testGetBoolean() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.VARCHAR.getType(), null, customFieldMeta);
+
+    VarCharVector vector = new VarCharVector("col_one", fieldType, allocator);
+    vector.setSafe(0, "0".getBytes(StandardCharsets.UTF_8));
+    vector.setSafe(1, "1".getBytes(StandardCharsets.UTF_8));
+    vector.setNull(2);
+    vector.setSafe(3, "5".getBytes(StandardCharsets.UTF_8));
+
+    ArrowVectorConverter converter = new VarCharConverter(vector, 0, this);
+
+    assertFalse(converter.toBoolean(0));
+    assertTrue(converter.toBoolean(1));
+    assertFalse(converter.toBoolean(2));
+    TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
+
+    vector.close();
+  }
+
+  @Test
+  public void testGetDate() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.VARCHAR.getType(), null, customFieldMeta);
+
+    VarCharVector vector = new VarCharVector("col_one", fieldType, allocator);
+    vector.setNull(0);
+    vector.setSafe(1, "2023-10-26".getBytes(StandardCharsets.UTF_8));
+    vector.setSafe(2, "abc".getBytes(StandardCharsets.UTF_8));
+
+    ArrowVectorConverter converter = new VarCharConverter(vector, 0, this);
+
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(1, TimeZone.getDefault(), false));
+    TestHelper.assertSFException(
+        invalidConversionErrorCode, () -> converter.toDate(2, TimeZone.getDefault(), false));
+
+    vector.close();
+  }
+}


### PR DESCRIPTION
Arrow converter layer is now integrated into `universal-driver/jdbc` (Arrow-only, no JSON/common). Migrated converters with their unit tests include:
- VarCharConverter
- VarBinaryToBinaryConverter
- BitToBooleanConverter
- DoubleToRealConverter
- TinyIntToFixedConverter + TinyIntToScaledFixedConverter
- SmallIntToFixedConverter + SmallIntToScaledFixedConverter
- IntToFixedConverter + IntToScaledFixedConverter
- BigIntToFixedConverter + BigIntToScaledFixedConverter
- DecimalToScaledFixedConverter
- ArrowVectorConverterUtil and minimal ArrowResultUtil
(no time, date and timestamp)

Other:
- Added integration tests in `SnowflakeResultSetGettersTest` to validate `getInt, getFloat, getDouble, getString, getObject, getBytes, getBigDecimal`, and float special values (inf, -inf, nan).
- `SnowflakeResultSet` now routes getters through Arrow converters (still using row index 0, no batch/row rework).
- Arrow schema metadata is read to populate columnNames/columnTypes using logicalType metadata.