### PR TITLE
NO-SNOW: Run python test in parallel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,6 +69,8 @@ test = [
     "pytest-json-report",
     "pytest-split",
     "pytest-cov",
+    "pytest-randomly",
+    "pytest-xdist",
     "hypothesis",
     "requests",
     "brotli",
@@ -89,6 +91,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "-v",
+    "-n 8",
 ]
 markers = [
     "skip_reference(reason: str=''): skip when --connector=reference",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,7 +89,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "-vv",
-    "-n 0",
+    "-n 16",
     "--durations=0",
 ]
 markers = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,6 +69,8 @@ test = [
     "pytest-split",
     "pytest-cov",
     "pytest-xdist",
+    "pytest-randomly",
+    "pytest-timeout",
     "hypothesis",
     "requests",
     "brotli",
@@ -92,6 +94,8 @@ addopts = [
     "-n 16",
     "--durations=0",
 ]
+# Default timeout for tests (2 minutes) - prevents hanging tests on CI
+timeout = 120
 markers = [
     "skip_reference(reason: str=''): skip when --connector=reference",
     "skip_universal(reason: str=''): skip when --connector=universal",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,6 @@ test = [
     "pytest-split",
     "pytest-cov",
     "pytest-randomly",
-    "pytest-xdist",
     "hypothesis",
     "requests",
     "brotli",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,7 +89,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "-vv",
-    "-n 16",
+    "-n 0",
     "--durations=0",
 ]
 markers = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,7 +65,6 @@ path = "hatch_build.py"
 [project.optional-dependencies]
 test = [
     "pytest>=8",
-    "pytest-xdist",
     "pytest-json-report",
     "pytest-split",
     "pytest-cov",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -88,8 +88,9 @@ python_functions = ["test_*"]
 addopts = [
     "--strict-markers",
     "--strict-config",
-    "-v",
-    "-n 8",
+    "-vv",
+    "-n 16",
+    "--durations=0",
 ]
 markers = [
     "skip_reference(reason: str=''): skip when --connector=reference",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -68,7 +68,7 @@ test = [
     "pytest-json-report",
     "pytest-split",
     "pytest-cov",
-    "pytest-randomly",
+    "pytest-xdist",
     "hypothesis",
     "requests",
     "brotli",

--- a/python/tests/config.py
+++ b/python/tests/config.py
@@ -1,7 +1,11 @@
 import json
 import os
 
+from pathlib import Path
 from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 
 def get_test_parameters() -> dict[str, Any]:
@@ -12,7 +16,7 @@ def get_test_parameters() -> dict[str, Any]:
         or environment variables as fallback.
     """
     # First try environment variable
-    parameter_path = os.environ.get("PARAMETER_PATH")
+    parameter_path = os.environ.get("PARAMETER_PATH", PROJECT_ROOT / "parameters.json")
     if parameter_path and os.path.exists(parameter_path):
         with open(parameter_path) as f:
             parameters = json.load(f)

--- a/python/tests/e2e/query/test_large_result_set.py
+++ b/python/tests/e2e/query/test_large_result_set.py
@@ -7,6 +7,7 @@ class TestLargeResultSet:
         assert not cursor.connection.is_closed(), "Connection should be open"
 
         # When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
+
         # Note: We use ROW_NUMBER() for actual query to ensure sequential integers.
         sql = (
             "SELECT ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) ORDER BY 1"

--- a/python/tests/e2e/query/test_large_result_set.py
+++ b/python/tests/e2e/query/test_large_result_set.py
@@ -1,15 +1,19 @@
+from tests.e2e.types.utils import assert_sequential_values
+
+
 class TestLargeResultSet:
     def test_should_process_one_million_row_result_set(self, cursor):
         # Given Snowflake client is logged in
         assert not cursor.connection.is_closed(), "Connection should be open"
 
         # When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
-        sql = "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id"
+        # Note: We use ROW_NUMBER() for actual query to ensure sequential integers.
+        sql = (
+            "SELECT ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) ORDER BY 1"
+        )
         cursor.execute(sql)
         rows = cursor.fetchall()
 
         # Then there are 1000000 numbered sequentially rows returned
-        expected_count = 1000000
-        assert len(rows) == expected_count
-        for i, row in enumerate(rows):
-            assert row[0] == i
+        values = [row[0] for row in rows]
+        assert_sequential_values(values, 1000000)

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -136,6 +136,7 @@ class TestDecfloatLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
@@ -244,6 +245,7 @@ class TestDecfloatTable:
         # Given Snowflake client is logged in
 
         # And Table with DECFLOAT column exists with values from 0 to 999999
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_table"

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -136,15 +136,20 @@ class TestDecfloatLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-        sql = f"SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v"
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
+        sql = (
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::DECFLOAT as id "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
+            f"ORDER BY 1"
+        )
         rows = execute_query(sql)
 
         # Then Result should contain consecutive numbers from 0 to 999999
         values = [row[0] for row in rows]
-        assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
-
         # And All values should be returned as appropriate type
         assert_type(values, Decimal)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=Decimal)
 
 
 class TestDecfloatTable:
@@ -239,10 +244,13 @@ class TestDecfloatTable:
         # Given Snowflake client is logged in
 
         # And Table with DECFLOAT column exists with values from 0 to 999999
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_table"
         execute_query(f"CREATE TABLE {table_name} (col DECFLOAT)")
         execute_query(
-            f"INSERT INTO {table_name} SELECT seq8()::DECFLOAT "
+            f"INSERT INTO {table_name} "
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::DECFLOAT "
             f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
@@ -251,10 +259,9 @@ class TestDecfloatTable:
 
         # Then Result should contain consecutive numbers from 0 to 999999
         values = [row[0] for row in rows]
-        assert values == [Decimal(i) for i in range(LARGE_RESULT_SET_SIZE)]
-
         # And All values should be returned as appropriate type
         assert_type(values, Decimal)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=Decimal)
 
 
 class TestDecfloatBinding:

--- a/python/tests/e2e/types/test_float.py
+++ b/python/tests/e2e/types/test_float.py
@@ -12,7 +12,13 @@ from math import inf, nan
 
 import pytest
 
-from .utils import FLOAT_MIN_NORMAL, assert_floats_equal, assert_type
+from .utils import (
+    FLOAT_MIN_NORMAL,
+    assert_floats_equal,
+    assert_sequential_values,
+    assert_type,
+    floats_equal,
+)
 
 
 # =============================================================================
@@ -150,19 +156,20 @@ class TestFloatLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
-            f"SELECT seq8()::{float_type} as id "
-            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v ORDER BY id"
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::{float_type} as id "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
+            f"ORDER BY 1"
         )
         rows = execute_query(sql)
 
         # Then Result should contain 1000000 rows
-        assert len(rows) == LARGE_RESULT_SET_SIZE, f"Expected {LARGE_RESULT_SET_SIZE} rows, got {len(rows)}"
-
         # And All values should be returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)
-        assert_floats_equal(values, [float(i) for i in range(LARGE_RESULT_SET_SIZE)])
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=float, compare=floats_equal)
 
 
 class TestFloatTable:
@@ -265,10 +272,13 @@ class TestFloatTable:
         # Given Snowflake client is logged in
 
         # And Table with <type> column exists with 1000000 sequential values
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_float_table_{float_type.replace(' ', '_').lower()}"
         execute_query(f"CREATE TABLE {table_name} (col {float_type})")
         execute_query(
-            f"INSERT INTO {table_name} SELECT seq8()::{float_type} "
+            f"INSERT INTO {table_name} "
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::{float_type} "
             f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
@@ -276,12 +286,10 @@ class TestFloatTable:
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
         # Then Result should contain 1000000 rows
-        assert len(rows) == LARGE_RESULT_SET_SIZE, f"Expected {LARGE_RESULT_SET_SIZE} rows, got {len(rows)}"
-
         # And All values should be returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)
-        assert_floats_equal(values, [float(i) for i in range(LARGE_RESULT_SET_SIZE)])
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=float, compare=floats_equal)
 
 
 class TestFloatBinding:

--- a/python/tests/e2e/types/test_float.py
+++ b/python/tests/e2e/types/test_float.py
@@ -156,6 +156,7 @@ class TestFloatLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
@@ -272,6 +273,7 @@ class TestFloatTable:
         # Given Snowflake client is logged in
 
         # And Table with <type> column exists with 1000000 sequential values
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_float_table_{float_type.replace(' ', '_').lower()}"

--- a/python/tests/e2e/types/test_int.py
+++ b/python/tests/e2e/types/test_int.py
@@ -179,6 +179,7 @@ class TestIntLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
@@ -292,6 +293,7 @@ class TestIntTable:
         # Given Snowflake client is logged in
 
         # And Table with <type> column exists with 1000000 sequential values
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_int_table_{int_type.lower()}"

--- a/python/tests/e2e/types/test_int.py
+++ b/python/tests/e2e/types/test_int.py
@@ -9,7 +9,7 @@ All tests are parameterized to run with each type synonym to verify they behave 
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -179,17 +179,19 @@ class TestIntLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
-            f"SELECT seq8()::{int_type} as id FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v ORDER BY id"
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::{int_type} as id "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
+            f"ORDER BY 1"
         )
         rows = execute_query(sql)
 
         # Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
-        assert len(rows) == LARGE_RESULT_SET_SIZE, f"Expected {LARGE_RESULT_SET_SIZE} rows, got {len(rows)}"
-
         values = [row[0] for row in rows]
         assert_type(values, int)
-        assert values == list(range(LARGE_RESULT_SET_SIZE))
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE)
 
 
 class TestIntTable:
@@ -290,10 +292,13 @@ class TestIntTable:
         # Given Snowflake client is logged in
 
         # And Table with <type> column exists with 1000000 sequential values
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_int_table_{int_type.lower()}"
         execute_query(f"CREATE TABLE {table_name} (col {int_type})")
         execute_query(
-            f"INSERT INTO {table_name} SELECT seq8()::{int_type} "
+            f"INSERT INTO {table_name} "
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::{int_type} "
             f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
         )
 
@@ -301,11 +306,9 @@ class TestIntTable:
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
         # Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
-        assert len(rows) == LARGE_RESULT_SET_SIZE, f"Expected {LARGE_RESULT_SET_SIZE} rows, got {len(rows)}"
-
         values = [row[0] for row in rows]
         assert_type(values, int)
-        assert values == list(range(LARGE_RESULT_SET_SIZE))
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE)
 
 
 class TestIntBinding:

--- a/python/tests/e2e/types/test_number.py
+++ b/python/tests/e2e/types/test_number.py
@@ -191,7 +191,10 @@ class TestNumberLiteral:
     ):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5)
+        # When Query
+        # "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v"
+        # is executed
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
@@ -418,6 +421,7 @@ class TestNumberTable:
 
         # And Table with columns (<type>(38,0), <type>(20,5)) exists with 1000000 sequential rows,
         # from 0 to 999999 in the first column and from 0.12345 to 999999.12345 in the second column
+
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_table_{num_type.lower()}"

--- a/python/tests/e2e/types/test_number.py
+++ b/python/tests/e2e/types/test_number.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -192,26 +192,33 @@ class TestNumberLiteral:
         # Given Snowflake client is logged in
 
         # When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5)
-        # FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         sql = (
-            f"SELECT seq8()::{num_type}(38,0), (seq8() + 0.12345)::{num_type}(20,5) "
-            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) v"
+            f"WITH base AS ("
+            f"  SELECT ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as rn "
+            f"  FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+            f") "
+            f"SELECT rn::{num_type}(38,0), (rn + 0.12345)::{num_type}(20,5) FROM base "
+            f"ORDER BY 1"
         )
         rows = execute_query(sql)
 
         # Then Column 1 should contain sequential integers from 0 to 999999
-        assert len(rows) == LARGE_RESULT_SET_SIZE
         col0_values = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col0_values, int)
-        assert col0_values == list(range(LARGE_RESULT_SET_SIZE))
+        assert_sequential_values(col0_values, LARGE_RESULT_SET_SIZE)
 
         # And Column 2 should contain sequential decimals starting from 0.12345
         col1_values = [row[1] for row in rows]
         # Python: scale>0 -> Decimal
         assert_type(col1_values, Decimal)
-        expected = [Decimal(str(i)) + Decimal("0.12345") for i in range(LARGE_RESULT_SET_SIZE)]
-        assert col1_values == expected
+        assert_sequential_values(
+            col1_values,
+            LARGE_RESULT_SET_SIZE,
+            transform=lambda i: Decimal(str(i)) + Decimal("0.12345"),
+        )
 
 
 class TestNumberTable:
@@ -411,29 +418,37 @@ class TestNumberTable:
 
         # And Table with columns (<type>(38,0), <type>(20,5)) exists with 1000000 sequential rows,
         # from 0 to 999999 in the first column and from 0.12345 to 999999.12345 in the second column
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
         table_name = f"{tmp_schema}.large_table_{num_type.lower()}"
         execute_query(f"CREATE TABLE {table_name} (col1 {num_type}(38,0), col2 {num_type}(20,5))")
         execute_query(
-            f"INSERT INTO {table_name} SELECT seq8()::{num_type}(38,0), (seq8() + 0.12345)::{num_type}(20,5) "
-            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+            f"INSERT INTO {table_name} "
+            f"WITH base AS ("
+            f"  SELECT ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as rn "
+            f"  FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+            f") "
+            f"SELECT rn::{num_type}(38,0), (rn + 0.12345)::{num_type}(20,5) FROM base"
         )
 
         # When Query "SELECT * FROM <table>" is executed
-        rows = execute_query(f"SELECT * FROM {table_name}")
+        rows = execute_query(f"SELECT * FROM {table_name} ORDER BY 1")
 
         # Then Column 1 should contain sequential integers from 0 to 999999
-        assert len(rows) == LARGE_RESULT_SET_SIZE
         col1 = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col1, int)
-        assert col1 == list(range(LARGE_RESULT_SET_SIZE))
+        assert_sequential_values(col1, LARGE_RESULT_SET_SIZE)
 
         # And Column 2 should contain sequential decimals starting from 0.12345
         col2 = [row[1] for row in rows]
         # Python: scale>0 -> Decimal
         assert_type(col2, Decimal)
-        expected = [Decimal(f"{i}.12345") for i in range(LARGE_RESULT_SET_SIZE)]
-        assert col2 == expected
+        assert_sequential_values(
+            col2,
+            LARGE_RESULT_SET_SIZE,
+            transform=lambda i: Decimal(f"{i}.12345"),
+        )
 
 
 class TestNumberBinding:

--- a/python/tests/e2e/types/utils.py
+++ b/python/tests/e2e/types/utils.py
@@ -64,6 +64,29 @@ def assert_float_equal(actual: float, expected: float | None, msg: str = "") -> 
         assert diff < 1e-10, error_msg
 
 
+def floats_equal(actual: float, expected: float) -> bool:
+    """Check if two float values are equal within appropriate tolerance.
+
+    This is a non-asserting version of assert_float_equal for use as a comparator.
+    """
+    if expected is None:
+        return actual is None
+    if isnan(expected):
+        return isnan(actual)
+    if isinf(expected):
+        return actual == expected
+
+    abs_expected = abs(expected)
+    diff = abs(actual - expected)
+
+    if abs_expected < FLOAT_MIN_NORMAL:
+        return diff <= 1e-325
+    elif abs_expected > 1e10:
+        return diff <= abs_expected * 1e-14
+    else:
+        return diff < 1e-10
+
+
 def assert_floats_equal(actual: Iterable[float], expected: Iterable[float]) -> None:
     """Assert two iterables of float values are equal element-wise.
 
@@ -74,3 +97,43 @@ def assert_floats_equal(actual: Iterable[float], expected: Iterable[float]) -> N
     assert len(actual_list) == len(expected_list), f"Length mismatch: {len(actual_list)} != {len(expected_list)}"
     for i, (a, e) in enumerate(zip(actual_list, expected_list)):
         assert_float_equal(a, e, f"Mismatch at index {i}: expected {e}, got {a}")
+
+
+def assert_sequential_values(
+    values: list,
+    expected_count: int,
+    start: int = 0,
+    transform=None,
+    compare=None,
+) -> None:
+    """Assert values are sequential integers, optionally transformed.
+
+    This is an efficient alternative to `assert values == [transform(i) for i in range(count)]`
+    which avoids pytest's expensive diff computation on large lists.
+
+    Args:
+        values: List of values to check.
+        expected_count: Expected number of elements.
+        start: Starting value for the sequence (default 0).
+        transform: Optional function to transform expected values (e.g., float, Decimal).
+                   If None, compares against raw integers.
+        compare: Optional comparison function (actual, expected) -> bool.
+                 If None, uses equality (==). Use for float tolerance comparisons.
+
+    Raises:
+        AssertionError: If length doesn't match or any value doesn't match expected.
+    """
+    assert len(values) == expected_count, f"Length mismatch: expected {expected_count}, got {len(values)}"
+
+    for i, actual in enumerate(values):
+        expected = start + i
+        if transform is not None:
+            expected = transform(expected)
+
+        if compare is not None:
+            is_equal = compare(actual, expected)
+        else:
+            is_equal = actual == expected
+
+        if not is_equal:
+            raise AssertionError(f"Value mismatch at index {i}: expected {expected!r}, got {actual!r}")

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 import pytest
 
 from snowflake.connector.exceptions import NotSupportedError
+from tests.e2e.types.utils import assert_sequential_values
 
 
 class TestCursorMethods:
@@ -150,6 +151,7 @@ class TestCursorFetch:
             """
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
             FROM TABLE(GENERATOR(ROWCOUNT => 10))
+            ORDER BY 1
         """
         )
         result = cursor.fetchall()
@@ -179,6 +181,7 @@ class TestCursorIteration:
             """
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
             FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
         """
         )
         rows = list(cursor)
@@ -228,10 +231,12 @@ class TestCursorLargeResults:
             f"""
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
             FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
         """
         )
         result = cursor.fetchall()
-        assert result == [(i,) for i in range(self.N_ROWS)]
+        values = [row[0] for row in result]
+        assert_sequential_values(values, self.N_ROWS)
 
     def test_large_result_iteration(self, cursor):
         """Test iteration over large results."""
@@ -240,12 +245,13 @@ class TestCursorLargeResults:
             f"""
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
             FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
         """
         )
         rows = list(cursor)
-        assert rows == [(i,) for i in range(self.N_ROWS)]
+        values = [row[0] for row in rows]
+        assert_sequential_values(values, self.N_ROWS)
 
-    @pytest.mark.skip("Test does not complete on CI")
     def test_large_result_with_multiple_columns(self, cursor):
         """Test large result with multiple columns."""
         # Use ROW_NUMBER() in a CTE to get consecutive integers starting from 0.
@@ -258,10 +264,15 @@ class TestCursorLargeResults:
                 FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
             )
             SELECT id, id * 2 as doubled, id % 10 as mod10 FROM base
+            ORDER BY 1
         """
         )
         result = cursor.fetchall()
-        assert result == [(i, i * 2, i % 10) for i in range(self.N_ROWS)]
+        assert_sequential_values(
+            result,
+            self.N_ROWS,
+            transform=lambda i: (i, i * 2, i % 10),
+        )
 
     def test_partial_batch_consumption(self, cursor):
         """Test partial consumption of batches."""
@@ -270,6 +281,7 @@ class TestCursorLargeResults:
             f"""
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
             FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
         """
         )
         # Fetch only some rows
@@ -277,7 +289,8 @@ class TestCursorLargeResults:
             cursor.fetchone()
         # Fetch remaining
         remaining = cursor.fetchall()
-        assert remaining == [(i,) for i in range(self.N_ROWS // 10, self.N_ROWS)]
+        values = [row[0] for row in remaining]
+        assert_sequential_values(values, self.N_ROWS - self.N_ROWS // 10, start=self.N_ROWS // 10)
 
 
 class TestCursorMultipleQueries:

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -145,7 +145,13 @@ class TestCursorFetch:
 
     def test_fetchall_multiple_rows(self, cursor):
         """Test fetchall with multiple rows."""
-        cursor.execute("SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => 10))")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => 10))
+        """
+        )
         result = cursor.fetchall()
         assert result == [(i,) for i in range(10)]
 
@@ -168,20 +174,40 @@ class TestCursorIteration:
 
     def test_cursor_is_iterable(self, cursor):
         """Test cursor can be iterated."""
-        cursor.execute("SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => 5))")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+        """
+        )
         rows = list(cursor)
         assert rows == [(i,) for i in range(5)]
 
     def test_cursor_iteration_order(self, cursor):
         """Test cursor iteration maintains order."""
-        cursor.execute("SELECT seq4() as n FROM TABLE(GENERATOR(ROWCOUNT => 100)) ORDER BY n DESC")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => 100))
+            ORDER BY n DESC
+        """
+        )
         rows = list(cursor)
         for i, row in enumerate(rows):
             assert row == (99 - i,), f"Expected ({99 - i},), got {row}"
 
     def test_mixed_fetchone_and_iteration(self, cursor):
         """Test mixing fetchone and iteration."""
-        cursor.execute("SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY 1")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+        """
+        )
         # Fetch first row
         first = cursor.fetchone()
         assert first == (0,)
@@ -197,25 +223,41 @@ class TestCursorLargeResults:
 
     def test_large_result_fetchall(self, cursor):
         """Test fetchall with large results."""
-        cursor.execute(f"SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+        """
+        )
         result = cursor.fetchall()
         assert result == [(i,) for i in range(self.N_ROWS)]
 
     def test_large_result_iteration(self, cursor):
         """Test iteration over large results."""
-        cursor.execute(f"SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+        """
+        )
         rows = list(cursor)
         assert rows == [(i,) for i in range(self.N_ROWS)]
 
+    @pytest.mark.skip("Test does not complete on CI")
     def test_large_result_with_multiple_columns(self, cursor):
         """Test large result with multiple columns."""
+        # Use ROW_NUMBER() in a CTE to get consecutive integers starting from 0.
+        # seq4() doesn't guarantee consecutive values in parallel execution,
+        # and window functions need to be computed once then reused.
         cursor.execute(
             f"""
-            SELECT
-                seq4() as id,
-                seq4() * 2 as doubled,
-                seq4() % 10 as mod10
-            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            WITH base AS (
+                SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as id
+                FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            )
+            SELECT id, id * 2 as doubled, id % 10 as mod10 FROM base
         """
         )
         result = cursor.fetchall()
@@ -223,7 +265,13 @@ class TestCursorLargeResults:
 
     def test_partial_batch_consumption(self, cursor):
         """Test partial consumption of batches."""
-        cursor.execute(f"SELECT seq4() FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+        """
+        )
         # Fetch only some rows
         for _ in range(self.N_ROWS // 10):
             cursor.fetchone()
@@ -259,7 +307,14 @@ class TestCursorMultipleQueries:
 
     def test_fetchall_after_partial_fetch(self, cursor):
         """Test fetchall after partial fetchone calls."""
-        cursor.execute("SELECT seq4() as n FROM TABLE(GENERATOR(ROWCOUNT => 10)) ORDER BY n")
+        # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
+            FROM TABLE(GENERATOR(ROWCOUNT => 10))
+            ORDER BY n
+        """
+        )
         # Fetch first 3
         r1 = cursor.fetchone()
         r2 = cursor.fetchone()


### PR DESCRIPTION
As per note in [seq docs](https://docs.snowflake.com/en/sql-reference/functions/seq) following query does not produce deterministic result:
`"SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id"`
additionally, any `select * from table` is not deterministic. [Snowflake does not guarantee](https://docs.snowflake.com/en/sql-reference/sql/select#usage-notes) that rows will be sorted. To have deterministic result `ORDER BY` must be used.

