### PR TITLE
NO-SNOW: Refactor reference tests to run in in isolation

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -22,8 +22,17 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
-  # Build Python wheel with compiled extensions for each Python version
+  # For backcompat
   build_rust_core:
+    needs: detect-changes
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Dummy step"
+        run: "echo 'Dummy step to pass required check'"
+
+  # Build Python wheel with compiled extensions for each Python version
+  build_wheel:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     strategy:
@@ -86,7 +95,7 @@ jobs:
 
   # Combined unit + integration tests with universal connector
   python_tests:
-    needs: [detect-changes, build_rust_core, format]
+    needs: [detect-changes, build_wheel, format]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     strategy:
       fail-fast: false
@@ -165,7 +174,7 @@ jobs:
 
   # Integration tests only with reference connector (for comparison)
   python_tests_reference:
-    needs: [detect-changes, build_rust_core, format]
+    needs: [detect-changes, build_wheel, format]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true  # Reference tests expected to fail due to behavioral differences
@@ -264,7 +273,7 @@ jobs:
         working-directory: python
 
   python-status:
-    needs: [detect-changes, build_rust_core, python_tests, python_tests_reference, python_compare_results]
+    needs: [detect-changes, build_wheel, python_tests, python_tests_reference, python_compare_results]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -281,11 +290,11 @@ jobs:
           
           # Check if critical jobs failed or were cancelled
           # Note: python_tests_reference has continue-on-error:true, so we don't fail on it
-          if [[ "${{ needs.build_rust_core.result }}" =~ ^(failure|cancelled)$ ]] || \
+          if [[ "${{ needs.build_wheel.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.python_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.python_compare_results.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Python CI FAILED or CANCELLED"
-            echo "  - build_rust_core: ${{ needs.build_rust_core.result }}"
+            echo "  - build_wheel: ${{ needs.build_wheel.result }}"
             echo "  - python_tests: ${{ needs.python_tests.result }}"
             echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
             echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"
@@ -294,7 +303,7 @@ jobs:
           
           # Tests ran and passed
           echo "✓ Python CI PASSED"
-          echo "  - build_rust_core: ${{ needs.build_rust_core.result }}"
+          echo "  - build_wheel: ${{ needs.build_wheel.result }}"
           echo "  - python_tests: ${{ needs.python_tests.result }}"
           echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
           echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  PYTHON_REFERENCE_DRIVER_VERSION: "3.17.2"
+  PYTHON_REFERENCE_DRIVER_VERSION: "4.2.0"
   # Python version to run reference tests and comparison
   REFERENCE_PYTHON_VERSION: "3.13"
   # OS version for consistent naming across jobs
@@ -22,11 +22,16 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
-  # Build Rust core library once and share across Python jobs
+  # Build Python wheel with compiled extensions for each Python version
   build_rust_core:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        py: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,21 +45,21 @@ jobs:
         with:
           version: "0.5.11"
 
-      - name: Install Hatch
-        run: uv tool install hatch
+      - name: Set up Python ${{ matrix.py }}
+        run: uv python install ${{ matrix.py }}
 
       - name: Build python wheel
         working-directory: ./python
-        run: hatch build
+        run: uv run --python ${{ matrix.py }} --with hatch --with cython --with setuptools hatch build
 
       - name: Inspect wheel
         working-directory: ./python
-        run: python -m zipfile -l dist/*.whl
+        run: uv run --python ${{ matrix.py }} python -m zipfile -l dist/*.whl
 
       - name: Upload Python wheel
         uses: actions/upload-artifact@v4
         with:
-          name: python-wheel
+          name: python-wheel-${{ matrix.os }}-${{ matrix.py }}
           path: python/dist/*.whl
 
   # Format and lint checking
@@ -114,7 +119,7 @@ jobs:
       - name: Download Python wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheel
+          name: python-wheel-${{ matrix.os }}-${{ matrix.py }}
           path: python/dist
 
       - name: Decode secrets
@@ -124,6 +129,10 @@ jobs:
 
       - name: Install Hatch
         run: uv tool install hatch
+
+      - name: Install snowflake ud driver from wheel
+        working-directory: python
+        run: hatch run test.py${{ matrix.py }}:install-wheel
 
       - name: Run all tests with coverage
         env:
@@ -155,109 +164,107 @@ jobs:
           path: python/reports/*-${{ matrix.os }}-${{ matrix.py }}.*
 
   # Integration tests only with reference connector (for comparison)
-#  python_tests_reference:
-#    needs: [detect-changes, build_rust_core, format]
-#    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
-#    runs-on: ubuntu-latest
-#    continue-on-error: true  # Reference tests expected to fail due to behavioral differences
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Install uv
-#        uses: astral-sh/setup-uv@v4
-#        with:
-#          version: "0.5.11"
-#
-#      - name: Restore uv cache
-#        env:
-#          UV_CACHE_DIR: /tmp/.uv-cache
-#        uses: actions/cache@v4
-#        with:
-#          path: /tmp/.uv-cache
-#          key: uv-${{ runner.os }}-${{ env.REFERENCE_PYTHON_VERSION }}-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
-#          restore-keys: |
-#            uv-${{ runner.os }}-${{ env.REFERENCE_PYTHON_VERSION }}-
-#            uv-${{ runner.os }}-
-#
-#      - name: Set up Python ${{ env.REFERENCE_PYTHON_VERSION }}
-#        run: uv python install ${{ env.REFERENCE_PYTHON_VERSION }}
-#
-#      - name: Download Python wheel
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: python-wheel
-#          path: python/dist
-#
-#      - name: Decode secrets
-#        run: ./scripts/decode_secrets.sh
-#        env:
-#          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
-#
-#      - name: Install Hatch
-#        run: uv tool install hatch
-#
-#      - name: Run reference integration tests
-#        env:
-#          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
-#          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
-#        run: |
-#          mkdir -p reports
-#          hatch run reference:run \
-#            --json-report --json-report-file=reports/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
-#            --junitxml=reports/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.xml
-#        working-directory: python
-#
-#      - name: Upload test results as GitHub artifact
-#        uses: actions/upload-artifact@v4
-#        if: always()  # Upload test results even if tests fail (needed for comparison)
-#        with:
-#          name: results-reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
-#          path: python/reports/*-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.*
+  python_tests_reference:
+    needs: [detect-changes, build_rust_core, format]
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Reference tests expected to fail due to behavioral differences
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.11"
+
+      - name: Restore uv cache
+        env:
+          UV_CACHE_DIR: /tmp/.uv-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-${{ runner.os }}-${{ env.REFERENCE_PYTHON_VERSION }}-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ env.REFERENCE_PYTHON_VERSION }}-
+            uv-${{ runner.os }}-
+
+      - name: Set up Python ${{ env.REFERENCE_PYTHON_VERSION }}
+        run: uv python install ${{ env.REFERENCE_PYTHON_VERSION }}
+
+      - name: Download Python wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheel-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
+          path: python/dist
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+
+      - name: Install Hatch
+        run: uv tool install hatch
+
+      - name: Run reference integration tests
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+        run: |
+          mkdir -p reports
+          hatch run reference:test \
+            --json-report --json-report-file=reports/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
+            --junitxml=reports/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.xml
+        working-directory: python
+
+      - name: Upload test results as GitHub artifact
+        uses: actions/upload-artifact@v4
+        if: always()  # Upload test results even if tests fail (needed for comparison)
+        with:
+          name: results-reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
+          path: python/reports/*-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.*
 
   # Compare results between connectors
-#  python_compare_results:
-#    needs: [detect-changes, python_tests, python_tests_reference]
-#    if: |
-#      always() &&
-#      needs.python_tests.result != 'skipped' &&
-#      needs.python_tests_reference.result != 'skipped'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Install uv
-#        uses: astral-sh/setup-uv@v4
-#        with:
-#          version: "0.5.11"
-#
-#      - name: Download universal test results
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: results-universal-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
-#          path: ${{ github.workspace }}/universal-results
-#
-#      - name: Download reference test results
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: results-reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
-#          path: ${{ github.workspace }}/reference-results
-#
-#      - name: Install Hatch
-#        run: uv tool install hatch
-#
-#      - name: Compare integration test results
-#        run: |
-#          hatch run ci:compare \
-#            --py ${{ env.REFERENCE_PYTHON_VERSION }} \
-#            --os ${{ env.REFERENCE_OS_VERSION }} \
-#            --universal ${{ github.workspace }}/universal-results/universal-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
-#            --reference ${{ github.workspace }}/reference-results/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
-#            --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
-#        working-directory: python
+  python_compare_results:
+    needs: [detect-changes, python_tests, python_tests_reference]
+    if: |
+      always() &&
+      needs.python_tests.result != 'skipped' &&
+      needs.python_tests_reference.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.11"
+
+      - name: Download universal test results
+        uses: actions/download-artifact@v4
+        with:
+          name: results-universal-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
+          path: ${{ github.workspace }}/universal-results
+
+      - name: Download reference test results
+        uses: actions/download-artifact@v4
+        with:
+          name: results-reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}
+          path: ${{ github.workspace }}/reference-results
+
+      - name: Install Hatch
+        run: uv tool install hatch
+
+      - name: Compare integration test results
+        run: |
+          hatch run ci:compare \
+            --py ${{ env.REFERENCE_PYTHON_VERSION }} \
+            --os ${{ env.REFERENCE_OS_VERSION }} \
+            --universal ${{ github.workspace }}/universal-results/universal-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
+            --reference ${{ github.workspace }}/reference-results/reference-${{ env.REFERENCE_OS_VERSION }}-${{ env.REFERENCE_PYTHON_VERSION }}.json \
+            --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
+        working-directory: python
 
   python-status:
-#    needs: [detect-changes, build_rust_core, python_tests, python_tests_reference, python_compare_results]
-    needs: [detect-changes, build_rust_core, python_tests]
+    needs: [detect-changes, build_rust_core, python_tests, python_tests_reference, python_compare_results]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -275,12 +282,13 @@ jobs:
           # Check if critical jobs failed or were cancelled
           # Note: python_tests_reference has continue-on-error:true, so we don't fail on it
           if [[ "${{ needs.build_rust_core.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.python_tests.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.python_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.python_compare_results.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Python CI FAILED or CANCELLED"
             echo "  - build_rust_core: ${{ needs.build_rust_core.result }}"
             echo "  - python_tests: ${{ needs.python_tests.result }}"
-            #echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
-            #echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"
+            echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
+            echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"
             exit 1
           fi
           
@@ -288,6 +296,6 @@ jobs:
           echo "✓ Python CI PASSED"
           echo "  - build_rust_core: ${{ needs.build_rust_core.result }}"
           echo "  - python_tests: ${{ needs.python_tests.result }}"
-          #echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
-          #echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"
+          echo "  - python_tests_reference: ${{ needs.python_tests_reference.result }} (continue-on-error)"
+          echo "  - python_compare_results: ${{ needs.python_compare_results.result }}"
           exit 0

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -205,10 +205,16 @@ pipeline {
                                             set +x
                                             RUSTFLAGS="" hatch build -t wheel
                                         '''
+
+                                        sh label: 'Install the wheel', script: '''
+                                            set +x
+                                            hatch run test.py3.9:install-wheel
+                                        '''
                                         
                                         def testExitCode = sh(label: 'Run Tests with Coverage', returnStatus: true, script: '''
                                             set +x
                                             export PARAMETER_PATH=$(pwd)/../parameters.json
+                                            export PYTHONPATH=$(pwd)/src:$PYTHONPATH
                                             mkdir -p reports
                                             hatch run test.py3.9:all -- \
                                                 --cov=src/snowflake \

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -203,14 +203,9 @@ pipeline {
                                     dir('python') {
                                         sh label: 'Build Python Package', script: '''
                                             set +x
-                                            hatch build -t wheel
+                                            RUSTFLAGS="" hatch build -t wheel
                                         '''
-
-                                        sh label: 'Install the wheel', script: '''
-                                            set +x
-                                            hatch run test.py3.9:install-wheel
-                                        '''
-
+                                        
                                         def testExitCode = sh(label: 'Run Tests with Coverage', returnStatus: true, script: '''
                                             set +x
                                             export PARAMETER_PATH=$(pwd)/../parameters.json

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -203,9 +203,14 @@ pipeline {
                                     dir('python') {
                                         sh label: 'Build Python Package', script: '''
                                             set +x
-                                            RUSTFLAGS="" hatch build -t wheel
+                                            hatch build -t wheel
                                         '''
-                                        
+
+                                        sh label: 'Install the wheel', script: '''
+                                            set +x
+                                            hatch run test.py3.9:install-wheel
+                                        '''
+
                                         def testExitCode = sh(label: 'Run Tests with Coverage', returnStatus: true, script: '''
                                             set +x
                                             export PARAMETER_PATH=$(pwd)/../parameters.json

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ flags:
     paths: ["sf_core/**"]
     carryforward: false
   python:
-    paths: ["python/**"]
+    paths: ["src/snowflake/**"]
     carryforward: false
   jdbc:
     paths: ["jdbc/**"]
@@ -58,7 +58,7 @@ component_management:
     - component_id: python
       name: "Python Driver"
       paths:
-        - "python/**"
+        - "src/snowflake/**"
     - component_id: jdbc
       name: "JDBC Driver"
       paths:
@@ -70,7 +70,6 @@ component_management:
 
 fixes:
   - "com/snowflake/::jdbc/src/java/com/snowflake/"
-  - "src/snowflake/::python/src/snowflake/"
 
 ignore:
   # Test files

--- a/codecov.yml
+++ b/codecov.yml
@@ -70,6 +70,7 @@ component_management:
 
 fixes:
   - "com/snowflake/::jdbc/src/java/com/snowflake/"
+  - "src/snowflake/::python/src/snowflake/"
 
 ignore:
   # Test files

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,19 +172,12 @@ fix = [
     'mypy --install-types --non-interactive -p snowflake.connector',
 ]
 
-# Type checking environment
-[tool.hatch.envs.type]
-features = ["dev"]
-scripts.run = "mypy src/snowflake"
-
 # Test environment matrix
 [tool.hatch.envs.test]
 features = ["test"]
+# This skips installing the ud version from sources, installs from wheel via pre-install
+skip-install = true
 dev-mode = false
-
-pre-install-commands = [
-    "pip install {env:WHEEL_PATH:dist/*.whl}",
-]
 
 [tool.hatch.envs.test.env-vars]
 # IMPORTANT: PARAMETER_PATH must be explicitly set
@@ -195,33 +188,31 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.test.scripts]
 # Install from source
-install-wheel = "pip install dist/*.whl"
+install-wheel = "pip install {env:WHEEL_PATH:dist/*.whl}"
 # Unit tests
 unit = "pytest tests/unit {args}"
 # Integration tests
-integ = "pytest tests/integ --connector=universal {args}"
+integ = "pytest tests/integ {args}"
 # End-to-end tests
-e2e = "pytest tests/e2e --connector=universal {args}"
+e2e = "pytest tests/e2e {args}"
 # All tests
-all = "pytest tests/ --connector=universal {args}"
+all = "pytest tests/ {args}"
 # All tests with coverage
-all-cov = "pytest tests/ --connector=universal --cov=src/snowflake --cov-report=xml --cov-report=html {args}"
+all-cov = "pytest tests/ --cov=src/snowflake --cov-report=xml --cov-report=html {args}"
 
-# Reference connector environment (installs local package + reference connector)
+# Reference connector environment installs only reference connector
 [tool.hatch.envs.reference]
 features = ["test"]
-pre-install-commands = [
-    "pip install snowflake-connector-python -t old_driver_src"
-]
+# This skips installing the ud version of driver
+skip-install = true
+dev-mode = false
 
 [tool.hatch.envs.reference.scripts]
-run = "pytest tests/integ tests/e2e --connector=reference {args}"
-
-# CI environment for special CI tasks
-[tool.hatch.envs.ci]
-skip-install = false
-dependencies = [
-    "requests",
+# This environment runs with old driver only. UD driver is not installed.
+test = [
+    "pip uninstall --yes snowflake-connector-python-ud",
+    "pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:3.17.2}",
+    "pytest tests/integ tests/e2e {args}"
 ]
 
 [tool.hatch.envs.ci.scripts]

--- a/python/tests/compatibility.py
+++ b/python/tests/compatibility.py
@@ -1,20 +1,22 @@
-from typing import Optional
+def _check_if_universal():
+    try:
+        # Import universal driver specific code
+        from snowflake.connector._internal.api_client.client_api import database_driver_client  # noqa
+
+        return True
+    except ImportError:
+        return False
 
 
-_current_connector: Optional[str] = None  # "universal" or "reference"
-
-
-def set_current_connector(name: str) -> None:
-    global _current_connector
-    _current_connector = name
+IS_UNIVERSAL_DRIVER = _check_if_universal()
 
 
 def is_new_driver() -> bool:
-    return _current_connector == "universal"
+    return IS_UNIVERSAL_DRIVER
 
 
 def is_old_driver() -> bool:
-    return _current_connector == "reference"
+    return not IS_UNIVERSAL_DRIVER
 
 
 def NEW_DRIVER_ONLY(bc_id: str) -> bool:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -9,9 +9,8 @@ from urllib.parse import urlparse
 
 import pytest
 
-from .compatibility import set_current_connector
+from .compatibility import IS_UNIVERSAL_DRIVER
 from .connector_factory import ConnectorFactory, create_connection_with_adapter
-from .connector_types import ConnectorType
 from .private_key_helper import get_test_private_key_path
 
 
@@ -19,45 +18,14 @@ from .private_key_helper import get_test_private_key_path
 Row = tuple[Any, ...]
 
 
-def pytest_addoption(parser):
-    """Add custom command line options to pytest."""
-    parser.addoption(
-        "--connector",
-        action="store",
-        default="universal",
-        choices=["universal", "reference"],
-        help="Which connector implementation to test against (default: universal)",
-    )
-    parser.addoption(
-        "--reference-package",
-        action="store",
-        default="snowflake.connector",
-        help="Package name for reference connector (default: snowflake.connector)",
-    )
+@pytest.mark.optionalhook
+def pytest_metadata(metadata):
+    metadata["Version of snowflake.connector"] = "Universal" if IS_UNIVERSAL_DRIVER else "Old"
 
 
 @pytest.fixture(scope="session")
-def connector_type(request):
-    """Get the connector type from command line option."""
-    connector_str = request.config.getoption("--connector")
-    return ConnectorType.from_string(connector_str)
-
-
-@pytest.fixture(scope="session")
-def connector_adapter(request, connector_type):
-    """Create the appropriate connector adapter based on command line option."""
-    if connector_type == ConnectorType.REFERENCE:
-        reference_package = request.config.getoption("--reference-package")
-        return ConnectorFactory.create_adapter(connector_type, package_name=reference_package)
-
-    return ConnectorFactory.create_adapter(connector_type)
-
-
-@pytest.fixture(scope="session")
-def reference_connector(request):
-    """Create a reference connector adapter (always uses reference connector)."""
-    reference_package = request.config.getoption("--reference-package")
-    return ConnectorFactory.create_adapter(ConnectorType.REFERENCE, package_name=reference_package)
+def connector_adapter(request):
+    return ConnectorFactory.create_adapter()
 
 
 @pytest.fixture
@@ -153,11 +121,7 @@ def int_test_connection_factory(connector_adapter):
 
 def pytest_runtest_setup(item):
     """Skip tests based on connector type and markers."""
-    connector_type = item.config.getoption("--connector")
-    # Set the current connector for driver-gated helpers
-    set_current_connector(connector_type)
-
-    if connector_type == "universal" and item.get_closest_marker("skip_universal"):
+    if IS_UNIVERSAL_DRIVER and item.get_closest_marker("skip_universal"):
         pytest.skip("Skipping test for universal driver")
-    elif connector_type == "reference" and item.get_closest_marker("skip_reference"):
+    elif not IS_UNIVERSAL_DRIVER and item.get_closest_marker("skip_reference"):
         pytest.skip("Skipping test for reference driver")

--- a/python/tests/connector_factory.py
+++ b/python/tests/connector_factory.py
@@ -5,13 +5,12 @@ This module provides a unified interface to test different Snowflake connector
 implementations with the same test suite.
 """
 
-import importlib.util
-
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any
 
-from .compatibility import is_new_driver, is_old_driver
+from snowflake import connector
+
+from .compatibility import IS_UNIVERSAL_DRIVER, is_new_driver, is_old_driver
 from .config import get_test_parameters
 from .connector_types import ConnectorType
 from .private_key_helper import get_private_key_from_parameters, get_private_key_password
@@ -20,21 +19,13 @@ from .private_key_helper import get_private_key_from_parameters, get_private_key
 class ConnectorAdapter(ABC):
     """Abstract base class for connector adapters."""
 
+    def __init__(self):
+        # All adapters import same connector. Connector version depends on what is installed in environment
+        self.connector = connector
+
     @abstractmethod
     def connect(self, **kwargs) -> Any:
         """Create a connection using this connector implementation."""
-        pass
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Return the name of this connector implementation."""
-        pass
-
-    @property
-    @abstractmethod
-    def version(self) -> str:
-        """Return the version of this connector implementation."""
         pass
 
     @property
@@ -47,26 +38,9 @@ class ConnectorAdapter(ABC):
 class UniversalConnectorAdapter(ConnectorAdapter):
     """Adapter for the universal driver implementation."""
 
-    def __init__(self):
-        # Import the universal connector
-        from snowflake import connector
-
-        self.connector = connector
-
     def connect(self, **kwargs) -> Any:
         """Create a connection using the universal connector."""
         return self.connector.connect(**kwargs)
-
-    @property
-    def name(self) -> str:
-        return "pep249_dbapi"
-
-    @property
-    def version(self) -> str:
-        try:
-            return self.connector.__version__
-        except AttributeError:
-            return "0.1.0"
 
     @property
     def connector_type(self) -> ConnectorType:
@@ -76,37 +50,9 @@ class UniversalConnectorAdapter(ConnectorAdapter):
 class ReferenceConnectorAdapter(ConnectorAdapter):
     """Adapter for the reference Snowflake connector implementation."""
 
-    def __init__(self, package_name: str = "snowflake.connector"):
-        self.package_name = package_name
-        try:
-            self.connector = self._load_from_sources(package_name)
-        except ImportError as e:
-            raise ImportError(f"Could not import reference connector '{package_name}': {e}") from e
-
-    def _load_from_sources(self, package_name: str):
-        legacy_path = Path(__file__).parent.parent / "old_driver_src"
-
-        spec = importlib.util.find_spec(package_name, [legacy_path])
-        if spec is None:
-            raise ImportError(f"Could not find '{package_name}' in {legacy_path}")
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-
     def connect(self, **kwargs) -> Any:
         """Create a connection using the reference connector."""
         return self.connector.connect(**kwargs)
-
-    @property
-    def name(self) -> str:
-        return self.package_name
-
-    @property
-    def version(self) -> str:
-        try:
-            return self.connector.__version__
-        except AttributeError:
-            return "unknown"
 
     @property
     def connector_type(self) -> ConnectorType:
@@ -116,27 +62,12 @@ class ReferenceConnectorAdapter(ConnectorAdapter):
 class ConnectorFactory:
     """Factory for creating connector adapters."""
 
-    _adapters = {
-        ConnectorType.UNIVERSAL: UniversalConnectorAdapter,
-        ConnectorType.REFERENCE: ReferenceConnectorAdapter,
-    }
-
     @classmethod
-    def create_adapter(cls, connector_type: ConnectorType, **kwargs) -> ConnectorAdapter:
-        """Create a connector adapter of the specified type."""
-        if connector_type not in cls._adapters:
-            raise ValueError(f"Unknown connector type: {connector_type}. Available types: {list(cls._adapters.keys())}")
-
-        adapter_class = cls._adapters[connector_type]
-        return adapter_class(**kwargs)
-
-    @classmethod
-    def get_available_connectors(cls) -> dict[ConnectorType, str]:
-        """Get a list of available connector types and their descriptions."""
-        return {
-            ConnectorType.UNIVERSAL: "Universal driver implementation",
-            ConnectorType.REFERENCE: "Old Snowflake connector implementation",
-        }
+    def create_adapter(cls) -> ConnectorAdapter:
+        """Create a connector adapter. It will use connector installed in environment"""
+        if IS_UNIVERSAL_DRIVER:
+            return UniversalConnectorAdapter()
+        return ReferenceConnectorAdapter()
 
 
 def create_connection_with_adapter(adapter: ConnectorAdapter, **override_params):

--- a/python/tests/e2e/authentication/auth_helpers.py
+++ b/python/tests/e2e/authentication/auth_helpers.py
@@ -1,5 +1,3 @@
-from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import DriverException
-
 from ...compatibility import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 
 
@@ -12,13 +10,15 @@ def verify_simple_query_execution(connection):
         assert result[0] == 1
 
 
-def verify_login_error(exception, reference_connector):
+def verify_login_error(exception):
     """Verify that an exception contains a valid login error with code and message."""
     # Debug information about the exception can be seen when tests fail
     assert exception is not None
     assert str(exception).strip() != "", "Login error message should not be empty"
 
     if NEW_DRIVER_ONLY("BD#4"):
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import DriverException
+
         assert isinstance(exception.value.api_error_pb, DriverException), (
             f"Expected DriverException, got: {type(exception.value)}"
         )
@@ -28,9 +28,9 @@ def verify_login_error(exception, reference_connector):
 
     if OLD_DRIVER_ONLY("BD#4"):
         # Reference driver uses DatabaseError from snowflake.connector.errors
-        assert isinstance(exception.value, reference_connector.errors.DatabaseError), (
-            f"Expected DatabaseError, got: {type(exception.value)}"
-        )
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exception.value, DatabaseError), f"Expected DatabaseError, got: {type(exception.value)}"
         # Verify it's specifically an authentication/JWT error
         error_msg = str(exception.value).lower()
         assert "jwt" in error_msg or "token" in error_msg or "invalid" in error_msg, (

--- a/python/tests/e2e/authentication/test_pat.py
+++ b/python/tests/e2e/authentication/test_pat.py
@@ -41,7 +41,7 @@ class TestPATAuthentication:
         with connection:
             verify_simple_query_execution(connection)
 
-    def test_should_fail_pat_authentication_when_invalid_token_provided(self, connection_factory, reference_connector):
+    def test_should_fail_pat_authentication_when_invalid_token_provided(self, connection_factory):
         # Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
         authenticator = "PROGRAMMATIC_ACCESS_TOKEN"
         invalid_token = get_invalid_pat_token()
@@ -51,7 +51,7 @@ class TestPATAuthentication:
             connection_factory(authenticator=authenticator, token=invalid_token)
 
         # Then There is error returned
-        verify_login_error(exception, reference_connector)
+        verify_login_error(exception)
 
 
 class PAT:

--- a/python/tests/e2e/authentication/test_private_key_auth.py
+++ b/python/tests/e2e/authentication/test_private_key_auth.py
@@ -22,9 +22,7 @@ class TestPrivateKeyAuthentication:
         with connection:
             verify_simple_query_execution(connection)
 
-    def test_should_fail_jwt_authentication_when_invalid_private_key_provided(
-        self, connection_factory, reference_connector
-    ):
+    def test_should_fail_jwt_authentication_when_invalid_private_key_provided(self, connection_factory):
         # Given Authentication is set to JWT and invalid private key file is provided
         invalid_private_key_file = get_test_private_key_path()
 
@@ -36,7 +34,7 @@ class TestPrivateKeyAuthentication:
             )
 
         # Then There is error returned
-        verify_login_error(exception, reference_connector)
+        verify_login_error(exception)
 
 
 def create_jwt_connection(connection_factory, private_key_file, private_key_password=None):

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from snowflake.connector.exceptions import NotSupportedError
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+
+
+if IS_UNIVERSAL_DRIVER:
+    from snowflake.connector.exceptions import NotSupportedError
+else:
+    from snowflake.connector.errors import NotSupportedError
 
 
 class TestConnectionMethods:

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -6,8 +6,14 @@ from decimal import Decimal
 
 import pytest
 
-from snowflake.connector.exceptions import NotSupportedError
+from tests.compatibility import IS_UNIVERSAL_DRIVER
 from tests.e2e.types.utils import assert_sequential_values
+
+
+if IS_UNIVERSAL_DRIVER:
+    from snowflake.connector.exceptions import NotSupportedError
+else:
+    from snowflake.connector.errors import NotSupportedError
 
 
 class TestCursorMethods:


### PR DESCRIPTION
This PR refactors the Python reference test infrastructure to run tests in proper isolation. Previously, tests could dynamically load different connector versions at runtime, which could lead to import side effects and cross-contamination between driver implementations.

Now, each test environment has only a single driver installed - either the universal driver or the reference driver (snowflake-connector-python). This ensures complete isolation: when testing the universal driver, no reference driver code is present in the environment, and vice versa.

The `IS_UNIVERSAL_DRIVER` constant in `python/tests/compatibility.py` auto-detects which driver is installed at test runtime by attempting to import a universal-driver-specific module (snowflake.connector._internal.api_client.client_api.database_driver_client). This approach enables:

* Conditional imports: Tests import exceptions from different module paths based on driver type (e.g., snowflake.connector.exceptions vs snowflake.connector.errors)
* Adapter selection: `ConnectorFactory.create_adapter()` returns the appropriate adapter type
* Test skipping: pytest_runtest_setup uses markers (`@pytest.mark.skip_universal`, `@pytest.mark.skip_reference`) to skip tests incompatible with the current driver
* Test metadata: Reports include which driver version was used
* Behavioral differences: NEW_DRIVER_ONLY() and OLD_DRIVER_ONLY() helpers allow test assertions to vary based on known behavioral differences (tracked by BC IDs)

CI runs the same test suite twice in separate jobs - once with the universal driver wheel installed, and once with the reference driver installed - then compares the results to detect regressions or behavioral differences.