### PR TITLE
SNOW-3022768: ODBC API tests for data source connection functions

### DIFF
--- a/odbc_tests/CMakeLists.txt
+++ b/odbc_tests/CMakeLists.txt
@@ -34,8 +34,10 @@ if (NOT DEFINED DRIVER_TYPE)
   set(DRIVER_TYPE "NEW")
 endif()
 
-# Find odbc library
+# Find required libraries
 find_package(ODBC REQUIRED)
+find_package(Threads REQUIRED)
+
 message(STATUS "ODBC_INCLUDE_DIRS: ${ODBC_INCLUDE_DIRS}")
 message(STATUS "ODBC_LIBRARIES: ${ODBC_LIBRARIES}")
 
@@ -43,7 +45,7 @@ add_subdirectory(common)
 
 function(add_odbc_test name)
   add_executable(${name} ${ARGN})
-  target_link_libraries(${name} PRIVATE Catch2::Catch2WithMain ODBC::ODBC common)
+  target_link_libraries(${name} PRIVATE Catch2::Catch2WithMain ODBC::ODBC common Threads::Threads)
   target_include_directories(${name} PRIVATE ${picojson_SOURCE_DIR})
   catch_discover_tests(${name} TEST_PREFIX "${name}: ")
 endfunction()

--- a/odbc_tests/Dockerfile
+++ b/odbc_tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y unixodbc unixodbc-dev curl odbcinst wget build-essential git gdb \
-    zlib1g-dev
+    zlib1g-dev jq
 
 # Install CMake
 RUN wget https://github.com/Kitware/CMake/releases/download/v4.0.3/cmake-4.0.3-linux-aarch64.sh && \

--- a/odbc_tests/common/CMakeLists.txt
+++ b/odbc_tests/common/CMakeLists.txt
@@ -6,6 +6,9 @@ add_library(common STATIC
     src/test_setup.cpp
     src/compatibility.cpp
     src/get_diag_rec.cpp
+    src/ODBCConfig.cpp
+    src/DataSourceConfig.cpp
+    src/ConfigInstallation.cpp
     include/test_setup.hpp
     include/macros.hpp
     include/Connection.hpp
@@ -14,6 +17,9 @@ add_library(common STATIC
     include/MetaOfSqlCTypes.hpp
     include/get_diag_rec.hpp
     include/compatibility.hpp
+    include/ODBCConfig.hpp
+    include/ODBCFixtures.hpp
+    include/EnvOverride.hpp
 )
 
 target_include_directories(common PUBLIC ${picojson_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/odbc_tests/common/include/EnvOverride.hpp
+++ b/odbc_tests/common/include/EnvOverride.hpp
@@ -1,0 +1,79 @@
+#ifndef ENV_OVERRIDE_HPP
+#define ENV_OVERRIDE_HPP
+
+#include <optional>
+#include <string>
+
+// RAII class for temporarily overriding environment variables
+// TODO: Unix-only (uses setenv/unsetenv). Windows requires _putenv_s/_putenv("VAR=")
+class EnvOverride {
+ public:
+  // Sets the environment variable to the new value, saving the original.
+  EnvOverride(const std::string& name, const std::string& value) : name_(name) {
+    // Save original value
+    if (const char* original = std::getenv(name.c_str()); original != nullptr) {
+      original_value_ = std::string(original);
+    }
+    // Set new value
+    setenv(name.c_str(), value.c_str(), 1);
+  }
+
+  // Unsets the environment variable, saving the original.
+  explicit EnvOverride(const std::string& name) : name_(name) {
+    // Save original value
+    if (const char* original = std::getenv(name.c_str()); original != nullptr) {
+      original_value_ = std::string(original);
+    }
+    // Unset the variable
+    unsetenv(name.c_str());
+  }
+
+  ~EnvOverride() {
+    if (original_value_.has_value()) {
+      // Restore original value
+      setenv(name_.c_str(), original_value_->c_str(), 1);
+    } else {
+      // Variable was not set originally, unset it
+      unsetenv(name_.c_str());
+    }
+  }
+
+  // Non-copyable
+  EnvOverride(const EnvOverride&) = delete;
+  EnvOverride& operator=(const EnvOverride&) = delete;
+
+  // Movable
+  EnvOverride(EnvOverride&& other) noexcept
+      : name_(std::move(other.name_)), original_value_(std::move(other.original_value_)) {
+    other.name_.clear();  // Mark as moved-from
+  }
+
+  EnvOverride& operator=(EnvOverride&& other) noexcept {
+    if (this != &other) {
+      // Restore our original value before taking on new responsibility
+      if (!name_.empty()) {
+        if (original_value_.has_value()) {
+          setenv(name_.c_str(), original_value_->c_str(), 1);
+        } else {
+          unsetenv(name_.c_str());
+        }
+      }
+      name_ = std::move(other.name_);
+      original_value_ = std::move(other.original_value_);
+      other.name_.clear();
+    }
+    return *this;
+  }
+
+  // Get the variable name
+  [[nodiscard]] const std::string& name() const { return name_; }
+
+  // Get the original value (if it was set)
+  [[nodiscard]] const std::optional<std::string>& original_value() const { return original_value_; }
+
+ private:
+  std::string name_;
+  std::optional<std::string> original_value_;
+};
+
+#endif  // ENV_OVERRIDE_HPP

--- a/odbc_tests/common/include/ODBCConfig.hpp
+++ b/odbc_tests/common/include/ODBCConfig.hpp
@@ -1,0 +1,115 @@
+#ifndef ODBC_CONFIG_HPP
+#define ODBC_CONFIG_HPP
+
+#include <picojson.h>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "EnvOverride.hpp"
+
+// Forward declarations
+class DriverConfig;
+class DataSourceConfig;
+class ConfigInstallation;
+
+// ============================================================================
+// DriverConfig - Manages ODBC driver configuration
+// ============================================================================
+
+class DriverConfig {
+ public:
+  // Factory method
+  static std::shared_ptr<DriverConfig> Default();
+
+  // Builder methods
+  DriverConfig& set(const std::string& key, const std::string& value);
+  DriverConfig& remove(const std::string& key);
+
+  // Accessors
+  [[nodiscard]] const std::map<std::string, std::string>& parameters() const;
+  [[nodiscard]] static std::string name();
+  static std::string get_driver_path();
+
+ private:
+  std::map<std::string, std::string> parameters_;
+};
+
+// ============================================================================
+// DataSourceConfig - Manages ODBC data source configuration
+// ============================================================================
+
+class DataSourceConfig {
+ public:
+  // Factory methods
+  static DataSourceConfig Snowflake(const std::string& connection_name = "testconnection");
+  static DataSourceConfig SnowflakeNoAuth(const std::string& connection_name = "testconnection");
+
+  // Builder methods
+  DataSourceConfig& set(const std::string& key, const std::string& value);
+  DataSourceConfig& remove(const std::string& key);
+  DataSourceConfig& driver_config(const std::optional<std::shared_ptr<DriverConfig>>& dc);
+  DataSourceConfig& name(const std::string& name);
+
+  // Accessors
+  [[nodiscard]] const std::string& name() const;
+  [[nodiscard]] const std::map<std::string, std::string>& parameters() const;
+  [[nodiscard]] std::optional<std::shared_ptr<DriverConfig>> driver_config() const;
+
+  // Installation
+  ConfigInstallation install();
+
+ private:
+  std::string name_;
+  std::map<std::string, std::string> parameters_;
+  std::optional<std::shared_ptr<DriverConfig>> driver_config_;
+
+  // Helper methods
+  static picojson::object load_parameters(const std::string& connection_name);
+  static std::string get_string(const picojson::object& obj, const std::string& key,
+                                 const std::string& default_value = "");
+};
+
+// ============================================================================
+// ConfigInstallation - RAII class for managing installed ODBC configuration
+// ============================================================================
+
+class ConfigInstallation {
+ public:
+  // Factory method
+  static ConfigInstallation install(const std::vector<DataSourceConfig>& data_sources);
+
+  // Destructor
+  ~ConfigInstallation();
+
+  // Non-copyable
+  ConfigInstallation(const ConfigInstallation&) = delete;
+  ConfigInstallation& operator=(const ConfigInstallation&) = delete;
+
+  // Movable
+  ConfigInstallation(ConfigInstallation&& other) noexcept;
+  ConfigInstallation& operator=(ConfigInstallation&& other) noexcept;
+
+  // Accessors
+  [[nodiscard]] const std::string& config_dir() const;
+  [[nodiscard]] std::string dsn_name(size_t index = 0) const;
+
+ private:
+  // Private constructor (use factory method)
+  explicit ConfigInstallation(const std::vector<DataSourceConfig>& data_sources);
+
+  // Helper methods
+  static std::string create_temp_dir();
+  void write_odbcinst_ini() const;
+  void write_odbc_ini() const;
+
+  // Members
+  std::string config_dir_;
+  std::vector<DataSourceConfig> data_sources_;
+  std::vector<EnvOverride> env_overrides_;
+};
+
+#endif  // ODBC_CONFIG_HPP

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -1,0 +1,91 @@
+#ifndef ODBCFIXTURES_HPP
+#define ODBCFIXTURES_HPP
+
+#include <sql.h>
+#include <sqlext.h>
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+#include <utility>
+#include "HandleWrapper.hpp"
+#include "ODBCConfig.hpp"
+
+// ============================================================================
+// Base Fixtures (Parameterized via Constructor)
+// ============================================================================
+
+class EnvFixture {
+public:
+  std::optional<ConfigInstallation> config;
+  std::optional<EnvironmentHandleWrapper> env_wrapper;
+  SQLHENV env = SQL_NULL_HENV;
+
+  // Constructor with optional DSN configuration
+  explicit EnvFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) {
+    // Install DSN BEFORE creating ENV handle (critical for UnixODBC caching)
+    if (dsn_config.has_value()) {
+      config = dsn_config->install();
+    }
+
+    // Create ENV handle (will see installed DSN)
+    env_wrapper.emplace();
+    env = env_wrapper->getHandle();
+    SQLRETURN ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+
+  // Disable copy and move (RAII resource management)
+  EnvFixture(const EnvFixture&) = delete;
+  EnvFixture& operator=(const EnvFixture&) = delete;
+  EnvFixture(EnvFixture&&) = delete;
+  EnvFixture& operator=(EnvFixture&&) = delete;
+
+  SQLHENV env_handle() const { return env; }
+};
+
+class DbcFixture : public EnvFixture {
+public:
+  std::optional<ConnectionHandleWrapper> dbc_wrapper;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  // Constructor with optional DSN configuration
+  explicit DbcFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt)
+    : EnvFixture(std::move(dsn_config)) {
+    dbc_wrapper.emplace(env_wrapper->createConnectionHandle());
+    dbc = dbc_wrapper->getHandle();
+  }
+
+  // Disable copy and move (RAII resource management)
+  DbcFixture(const DbcFixture&) = delete;
+  DbcFixture& operator=(const DbcFixture&) = delete;
+  DbcFixture(DbcFixture&&) = delete;
+  DbcFixture& operator=(DbcFixture&&) = delete;
+
+  SQLHDBC dbc_handle() const { return dbc; }
+};
+
+// ============================================================================
+// Convenience Fixtures for TEST_CASE_METHOD (Pre-configured DSNs)
+// ============================================================================
+
+class EnvDefaultDSNFixture : public EnvFixture {
+public:
+  EnvDefaultDSNFixture() : EnvFixture(DataSourceConfig::Snowflake()) {}
+};
+
+class DbcDefaultDSNFixture : public DbcFixture {
+public:
+  DbcDefaultDSNFixture() : DbcFixture(DataSourceConfig::Snowflake()) {}
+};
+
+class EnvNoAuthDSNFixture : public EnvFixture {
+public:
+  EnvNoAuthDSNFixture() : EnvFixture(DataSourceConfig::SnowflakeNoAuth()) {}
+};
+
+class DbcNoAuthDSNFixture : public DbcFixture {
+public:
+  DbcNoAuthDSNFixture() : DbcFixture(DataSourceConfig::SnowflakeNoAuth()) {}
+};
+
+#endif // ODBCFIXTURES_HPP

--- a/odbc_tests/common/include/compatibility.hpp
+++ b/odbc_tests/common/include/compatibility.hpp
@@ -1,3 +1,18 @@
+#ifndef COMPATIBILITY_HPP
+#define COMPATIBILITY_HPP
+
+#include "compatibility.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+// Cross-platform process ID
+#ifdef _WIN32
+  #include <process.h>
+  #define GET_PROCESS_ID() _getpid()
+#else
+  #include <unistd.h>
+  #define GET_PROCESS_ID() getpid()
+#endif
 
 enum class DRIVER_TYPE {
   NEW = 0,
@@ -19,3 +34,13 @@ extern DRIVER_TYPE get_driver_type();
   if (get_driver_type() == DRIVER_TYPE::NEW) {                  \
     SKIP("Skipping for new driver: " << bd << ": " << message); \
   }
+
+// Skip test if running against the new Universal Driver
+#define SKIP_NEW_DRIVER_NOT_IMPLEMENTED()                                      \
+  do {                                                                         \
+    if (get_driver_type() == DRIVER_TYPE::NEW) {                               \
+      SKIP("Feature not yet implemented in new Universal Driver");             \
+    }                                                                          \
+  } while (0)
+
+#endif  // COMPATIBILITY_HPP

--- a/odbc_tests/common/include/get_diag_rec.hpp
+++ b/odbc_tests/common/include/get_diag_rec.hpp
@@ -1,9 +1,6 @@
 #ifndef GET_DIAG_REC_HPP
 #define GET_DIAG_REC_HPP
 
-#include <sql.h>
-
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -15,6 +12,10 @@ struct DiagRec {
   std::string messageText;
 };
 
+// Get diagnostic records from a raw ODBC handle
+std::vector<DiagRec> get_diag_rec(SQLSMALLINT handle_type, SQLHANDLE handle);
+
+// Get diagnostic records from a HandleWrapper
 std::vector<DiagRec> get_diag_rec(const HandleWrapper& wrapper);
 
 #endif  // GET_DIAG_REC_HPP

--- a/odbc_tests/common/include/test_macros.hpp
+++ b/odbc_tests/common/include/test_macros.hpp
@@ -1,0 +1,30 @@
+#ifndef TEST_MACROS_HPP
+#define TEST_MACROS_HPP
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "get_diag_rec.hpp"
+
+// Helper macro to check for expected ODBC error with specific SQLSTATE
+#define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType)         \
+  do {                                                                         \
+    REQUIRE(ret == SQL_ERROR);                                                 \
+    const auto __odbc_test_diag_records__ = get_diag_rec(handleType, handle);  \
+    REQUIRE(!__odbc_test_diag_records__.empty());                              \
+    INFO("SQLSTATE: " << __odbc_test_diag_records__[0].sqlState                \
+                      << ", Message: " << __odbc_test_diag_records__[0].messageText); \
+    REQUIRE(__odbc_test_diag_records__[0].sqlState == expectedState);          \
+  } while (0)
+
+// Helper macro to check for expected ODBC warning (SQL_SUCCESS_WITH_INFO) with specific SQLSTATE
+#define REQUIRE_EXPECTED_WARNING(ret, expectedState, handle, handleType)       \
+  do {                                                                         \
+    REQUIRE(ret == SQL_SUCCESS_WITH_INFO);                                     \
+    const auto __odbc_test_diag_records__ = get_diag_rec(handleType, handle);  \
+    REQUIRE(!__odbc_test_diag_records__.empty());                              \
+    INFO("SQLSTATE: " << __odbc_test_diag_records__[0].sqlState                \
+                      << ", Message: " << __odbc_test_diag_records__[0].messageText); \
+    REQUIRE(__odbc_test_diag_records__[0].sqlState == expectedState);          \
+  } while (0)
+
+#endif

--- a/odbc_tests/common/src/ConfigInstallation.cpp
+++ b/odbc_tests/common/src/ConfigInstallation.cpp
@@ -1,0 +1,168 @@
+#include "ODBCConfig.hpp"
+#include "compatibility.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+
+// ============================================================================
+// ConfigInstallation
+// ============================================================================
+
+ConfigInstallation ConfigInstallation::install(const std::vector<DataSourceConfig>& data_sources) {
+  return ConfigInstallation(data_sources);
+}
+
+ConfigInstallation::ConfigInstallation(const std::vector<DataSourceConfig>& data_sources)
+    : data_sources_(data_sources) {
+  // TODO: Windows - Use registry
+  config_dir_ = create_temp_dir();
+  write_odbcinst_ini();
+  write_odbc_ini();
+  env_overrides_.emplace_back("ODBCSYSINI", config_dir_);
+  env_overrides_.emplace_back("ODBCINI", (std::filesystem::path(config_dir_) / "odbc.ini").string());
+}
+
+ConfigInstallation::~ConfigInstallation() {
+  // TODO: Windows - Delete/restore registry keys
+  if (!config_dir_.empty()) {
+    std::error_code ec;
+    std::filesystem::remove_all(config_dir_, ec);
+    if (ec) {
+      std::cerr << "Warning: Failed to remove temporary config directory '"
+                << config_dir_ << "': " << ec.message() << std::endl;
+    }
+  }
+}
+
+ConfigInstallation::ConfigInstallation(ConfigInstallation&& other) noexcept
+    : config_dir_(std::move(other.config_dir_)),
+      data_sources_(std::move(other.data_sources_)),
+      env_overrides_(std::move(other.env_overrides_)) {
+  other.config_dir_.clear();
+}
+
+ConfigInstallation& ConfigInstallation::operator=(ConfigInstallation&& other) noexcept {
+  if (this != &other) {
+    if (!config_dir_.empty()) {
+      std::error_code ec;
+      std::filesystem::remove_all(config_dir_, ec);
+      if (ec) {
+        std::cerr << "Warning: Failed to remove temporary config directory '"
+                  << config_dir_ << "': " << ec.message() << std::endl;
+      }
+    }
+    config_dir_ = std::move(other.config_dir_);
+    data_sources_ = std::move(other.data_sources_);
+    env_overrides_ = std::move(other.env_overrides_);
+    other.config_dir_.clear();
+  }
+  return *this;
+}
+
+const std::string& ConfigInstallation::config_dir() const {
+  return config_dir_;
+}
+
+std::string ConfigInstallation::dsn_name(size_t index) const {
+  if (index >= data_sources_.size()) {
+    throw std::out_of_range("Data source index out of range");
+  }
+  return data_sources_[index].name();
+}
+
+std::string ConfigInstallation::create_temp_dir() {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, 999999);
+
+  // Include process ID to avoid race conditions when multiple test processes run in parallel
+  const int pid = GET_PROCESS_ID();
+  const std::string dir_name = "odbc_dsn_" + std::to_string(pid) + "_" + std::to_string(dis(gen));
+  const std::filesystem::path full_path = std::filesystem::current_path() / dir_name;
+
+  std::error_code ec;
+  if (!std::filesystem::create_directories(full_path, ec) && ec) {
+    throw std::runtime_error("Failed to create temporary config directory '" + 
+                            full_path.string() + "': " + ec.message());
+  }
+  return full_path.string();
+}
+
+void ConfigInstallation::write_odbcinst_ini() const {
+  const std::string file_path = (std::filesystem::path(config_dir_) / "odbcinst.ini").string();
+  std::ofstream file(file_path);
+  
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open odbcinst.ini for writing: " + file_path);
+  }
+
+  file << "[ODBC]\n";
+  file << "Trace=no\n";
+  file << "TraceFile=" << (std::filesystem::path(config_dir_) / "odbc_trace.log").string() << "\n";
+  file << "\n";
+
+  if (!file.good()) {
+    throw std::runtime_error("Failed to write ODBC section to odbcinst.ini");
+  }
+
+  // Collect all unique driver configs
+  std::map<std::string, std::shared_ptr<DriverConfig>> drivers;
+  for (const auto& ds : data_sources_) {
+    if (auto dc = ds.driver_config()) {
+      drivers[dc.value()->name()] = dc.value();
+    }
+  }
+
+  // Write each driver config
+  for (const auto& [name, config] : drivers) {
+    file << "[" << name << "]\n";
+    for (const auto& [key, value] : config->parameters()) {
+      file << key << "=" << value << "\n";
+    }
+    file << "\n";
+
+    if (!file.good()) {
+      throw std::runtime_error("Failed to write driver config for '" + name + "' to odbcinst.ini");
+    }
+  }
+}
+
+void ConfigInstallation::write_odbc_ini() const {
+  const std::string file_path = (std::filesystem::path(config_dir_) / "odbc.ini").string();
+  std::ofstream file(file_path);
+
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open odbc.ini for writing: " + file_path);
+  }
+
+  // Write data sources section
+  file << "[ODBC Data Sources]\n";
+  for (const auto& ds : data_sources_) {
+    if (auto dc = ds.driver_config()) {
+      file << ds.name() << "=" << dc.value()->name() << "\n";
+    }
+  }
+  file << "\n";
+
+  if (!file.good()) {
+    throw std::runtime_error("Failed to write data sources section to odbc.ini");
+  }
+
+  // Write each data source entry
+  for (const auto& ds : data_sources_) {
+    file << "[" << ds.name() << "]\n";
+    for (const auto& [key, value] : ds.parameters()) {
+      if (!value.empty()) {
+        file << key << "=" << value << "\n";
+      }
+    }
+    file << "\n";
+
+    if (!file.good()) {
+      throw std::runtime_error("Failed to write data source config for '" + ds.name() + "' to odbc.ini");
+    }
+  }
+}

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -1,0 +1,130 @@
+#include "ODBCConfig.hpp"
+
+#include <picojson.h>
+
+#include <fstream>
+#include <random>
+#include <stdexcept>
+
+// ============================================================================
+// DataSourceConfig
+// ============================================================================
+
+DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {
+  const auto params = load_parameters(connection_name);
+
+  // Generate unique DSN name for test isolation (parallel execution safety)
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, 999999);
+  const std::string unique_suffix = std::to_string(dis(gen));
+
+  DataSourceConfig config;
+  config.name_ = "Snowflake_" + unique_suffix;
+  config.driver_config_ = DriverConfig::Default();
+  config.parameters_["Description"] = "Snowflake Test DSN";
+  config.parameters_["Driver"] = config.driver_config_.value()->name();
+  config.parameters_["Locale"] = "en-US";
+  config.parameters_["SERVER"] = get_string(params, "SNOWFLAKE_TEST_HOST",
+                                             get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "") +
+                                                 ".snowflakecomputing.com");
+  config.parameters_["PORT"] = "443";
+  config.parameters_["SSL"] = "on";
+  config.parameters_["UID"] = get_string(params, "SNOWFLAKE_TEST_USER", "");
+  config.parameters_["PWD"] = get_string(params, "SNOWFLAKE_TEST_PASSWORD", "");
+  config.parameters_["ACCOUNT"] = get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "");
+
+  // Optional parameters
+  if (auto db = get_string(params, "SNOWFLAKE_TEST_DATABASE", ""); !db.empty()) {
+    config.parameters_["DATABASE"] = db;
+  }
+  if (auto schema = get_string(params, "SNOWFLAKE_TEST_SCHEMA", ""); !schema.empty()) {
+    config.parameters_["SCHEMA"] = schema;
+  }
+  if (auto warehouse = get_string(params, "SNOWFLAKE_TEST_WAREHOUSE", ""); !warehouse.empty()) {
+    config.parameters_["WAREHOUSE"] = warehouse;
+  }
+  if (auto role = get_string(params, "SNOWFLAKE_TEST_ROLE", ""); !role.empty()) {
+    config.parameters_["ROLE"] = role;
+  }
+  config.parameters_["TRACING"] = "0";
+
+  return config;
+}
+
+DataSourceConfig DataSourceConfig::SnowflakeNoAuth(const std::string& connection_name) {
+  return Snowflake(connection_name).remove("UID").remove("PWD");
+}
+
+DataSourceConfig& DataSourceConfig::set(const std::string& key, const std::string& value) {
+  parameters_[key] = value;
+  return *this;
+}
+
+DataSourceConfig& DataSourceConfig::remove(const std::string& key) {
+  parameters_.erase(key);
+  return *this;
+}
+
+DataSourceConfig& DataSourceConfig::driver_config(
+    const std::optional<std::shared_ptr<DriverConfig>>& dc) {
+  driver_config_ = dc;
+  return *this;
+}
+
+DataSourceConfig& DataSourceConfig::name(const std::string& name) {
+  name_ = name;
+  return *this;
+}
+
+const std::string& DataSourceConfig::name() const {
+  return name_;
+}
+
+const std::map<std::string, std::string>& DataSourceConfig::parameters() const {
+  return parameters_;
+}
+
+std::optional<std::shared_ptr<DriverConfig>> DataSourceConfig::driver_config() const {
+  return driver_config_;
+}
+
+ConfigInstallation DataSourceConfig::install() {
+  return ConfigInstallation::install({*this});
+}
+
+picojson::object DataSourceConfig::load_parameters(const std::string& connection_name) {
+  const char* parameter_path_env = std::getenv("PARAMETER_PATH");
+  if (parameter_path_env == nullptr) {
+    throw std::runtime_error("PARAMETER_PATH environment variable not set");
+  }
+
+  std::ifstream params_file(parameter_path_env);
+  if (!params_file.good()) {
+    throw std::runtime_error("Cannot open parameters file: " + std::string(parameter_path_env));
+  }
+
+  picojson::value connections;
+  if (const std::string err = picojson::parse(connections, params_file); !err.empty()) {
+    throw std::runtime_error("Failed to parse parameters: " + err);
+  }
+
+  if (!connections.is<picojson::object>() || !connections.contains(connection_name)) {
+    throw std::runtime_error("Connection '" + connection_name + "' not found in parameters");
+  }
+
+  const picojson::value& params = connections.get<picojson::object>().at(connection_name);
+  if (!params.is<picojson::object>()) {
+    throw std::runtime_error("Connection '" + connection_name + "' is not an object");
+  }
+
+  return params.get<picojson::object>();
+}
+
+std::string DataSourceConfig::get_string(const picojson::object& obj, const std::string& key,
+                                          const std::string& default_value) {
+  if (const auto it = obj.find(key); it != obj.end() && it->second.is<std::string>()) {
+    return it->second.get<std::string>();
+  }
+  return default_value;
+}

--- a/odbc_tests/common/src/ODBCConfig.cpp
+++ b/odbc_tests/common/src/ODBCConfig.cpp
@@ -1,0 +1,43 @@
+#include "ODBCConfig.hpp"
+
+// ============================================================================
+// DriverConfig
+// ============================================================================
+
+std::shared_ptr<DriverConfig> DriverConfig::Default() {
+  auto config = std::make_shared<DriverConfig>();
+  config->parameters_["APILevel"] = "1";
+  config->parameters_["ConnectFunctions"] = "YYY";
+  config->parameters_["Description"] = "Snowflake ODBC Driver";
+  config->parameters_["Driver"] = get_driver_path();
+  config->parameters_["DriverODBCVer"] = "03.52";
+  config->parameters_["SQLLevel"] = "1";
+  config->parameters_["UsageCount"] = "1";
+  return config;
+}
+
+DriverConfig& DriverConfig::set(const std::string& key, const std::string& value) {
+  parameters_[key] = value;
+  return *this;
+}
+
+DriverConfig& DriverConfig::remove(const std::string& key) {
+  parameters_.erase(key);
+  return *this;
+}
+
+const std::map<std::string, std::string>& DriverConfig::parameters() const {
+  return parameters_;
+}
+
+std::string DriverConfig::name() {
+  return "SnowflakeDriver";
+}
+
+std::string DriverConfig::get_driver_path() {
+  if (const char* driver_path_env = std::getenv("DRIVER_PATH");
+      driver_path_env != nullptr && driver_path_env[0] != '\0') {
+    return driver_path_env;
+  }
+  return "/usr/lib/snowflake/odbc/lib/libSnowflake.so";
+}

--- a/odbc_tests/common/src/get_diag_rec.cpp
+++ b/odbc_tests/common/src/get_diag_rec.cpp
@@ -4,32 +4,42 @@
 #include <string>
 #include <vector>
 
-std::vector<DiagRec> get_diag_rec(const HandleWrapper& wrapper) {
-  SQLSMALLINT recNumber = 1;
+// Core implementation: get diagnostic records from raw handle
+std::vector<DiagRec> get_diag_rec(const SQLSMALLINT handle_type, const SQLHANDLE handle) {
   std::vector<DiagRec> records;
+  SQLSMALLINT recNumber = 1;
 
   while (true) {
-    SQLCHAR sqlState[6] = {0};
+    SQLCHAR sqlState[6] = {};
     SQLINTEGER nativeError = 0;
-    SQLCHAR messageText[8096] = {0};
+    SQLCHAR messageText[8096] = {};
     SQLSMALLINT textLength = 0;
 
-    SQLRETURN ret = SQLGetDiagRec(wrapper.getType(), wrapper.getHandle(), recNumber, sqlState, &nativeError,
+    const SQLRETURN ret = SQLGetDiagRec(handle_type, handle, recNumber, sqlState, &nativeError,
                                   messageText, sizeof(messageText), &textLength);
     if (ret == SQL_NO_DATA) {
       break;  // No more data
     }
 
-    REQUIRE(ret == SQL_SUCCESS);
-    std::string messageStr((char*)messageText, textLength);
-    std::string sqlStateStr((char*)sqlState, 5);
+    if (ret != SQL_SUCCESS) {
+      // SQLGetDiagRec itself failed - unable to retrieve diagnostic details
+      // This is rare but can occur with invalid handles or driver issues
+      std::cerr << "Warning: SQLGetDiagRec failed (returned " << ret 
+                << ") when retrieving diagnostic record #" << recNumber << std::endl;
+      break;
+    }
 
-    DiagRec record = {};
-    record.sqlState = sqlStateStr;
+    DiagRec record;
+    record.sqlState = std::string(reinterpret_cast<char*>(sqlState), 5);
     record.nativeError = nativeError;
-    record.messageText = messageStr;
+    record.messageText = std::string(reinterpret_cast<char*>(messageText), textLength);
     records.push_back(record);
     recNumber++;
   }
   return records;
+}
+
+// Overload: get diagnostic records from HandleWrapper
+std::vector<DiagRec> get_diag_rec(const HandleWrapper& wrapper) {
+  return get_diag_rec(wrapper.getType(), wrapper.getHandle());
 }

--- a/odbc_tests/tests/CMakeLists.txt
+++ b/odbc_tests/tests/CMakeLists.txt
@@ -5,4 +5,4 @@ add_subdirectory(integration)
 add_subdirectory(basic_tests)
 add_subdirectory(bindings_tests)
 add_subdirectory(datatype_tests)
-
+add_subdirectory(odbc-api)

--- a/odbc_tests/tests/odbc-api/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_subdirectory(connecting)

--- a/odbc_tests/tests/odbc-api/connecting/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/connecting/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_odbc_test(odbc_api_alloc_handle_tests alloc_handle_tests.cpp)
+add_odbc_test(odbc_api_connect_tests connect_tests.cpp)
+add_odbc_test(odbc_api_driver_connect_tests driver_connect_tests.cpp)
+add_odbc_test(odbc_api_browse_connect_tests browse_connect_tests.cpp)

--- a/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
@@ -1,0 +1,762 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "compatibility.hpp"
+#include "Connection.hpp"
+#include "HandleWrapper.hpp"
+#include "get_diag_rec.hpp"
+#include "macros.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+using namespace Catch::Matchers;
+
+// ============================================================================
+// SQL_HANDLE_ENV - Environment Handle Allocation
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle ENV: Basic allocation succeeds", "[odbc-api][alloc_handle][env][connecting]") {
+  SQLHENV env = SQL_NULL_HENV;
+
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(env != SQL_NULL_HENV);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle ENV: Multiple allocations succeed", "[odbc-api][alloc_handle][env][connecting]") {
+  constexpr int NUM_HANDLES = 5;
+  SQLHENV handles[NUM_HANDLES];
+
+  for (auto & handle : handles) {
+    handle = SQL_NULL_HENV;
+    const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &handle);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(handle != SQL_NULL_HENV);
+  }
+
+  // Note: All handles are unique in Snowflake driver (implementation-specific behavior)
+  for (int i = 0; i < NUM_HANDLES; i++) {
+    for (int j = i + 1; j < NUM_HANDLES; j++) {
+      REQUIRE(handles[i] != handles[j]);
+    }
+  }
+
+  // Clean up
+  for (const auto & handle : handles) {
+    SQLFreeHandle(SQL_HANDLE_ENV, handle);
+  }
+}
+
+TEST_CASE("SQLAllocHandle ENV: HY009 - NULL OutputHandlePtr", "[odbc-api][alloc_handle][env][connecting][error]") {
+  // SQLSTATE HY009: Invalid use of null pointer
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, nullptr);
+
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE("SQLAllocHandle ENV: Non-NULL InputHandle returns error", "[odbc-api][alloc_handle][env][connecting][error]") {
+  SQLHENV env1 = SQL_NULL_HENV;
+  SQLHENV env2 = SQL_NULL_HENV;
+
+  // Allocate first environment
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env1);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate second environment with first environment as InputHandle
+  // Per ODBC spec, InputHandle should be SQL_NULL_HANDLE for ENV
+  ret = SQLAllocHandle(SQL_HANDLE_ENV, env1, &env2);
+
+  // Driver Manager returns SQL_INVALID_HANDLE when InputHandle is not SQL_NULL_HANDLE
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env1);
+}
+
+// ============================================================================
+// SQL_HANDLE_DBC - Connection Handle Allocation
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle DBC: Basic allocation succeeds", "[odbc-api][alloc_handle][dbc][connecting]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DBC: Multiple allocations from same environment", "[odbc-api][alloc_handle][dbc][connecting]") {
+  SQLHENV env = SQL_NULL_HENV;
+  constexpr int NUM_CONNECTIONS = 5;
+  SQLHDBC connections[NUM_CONNECTIONS];
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (auto & connection : connections) {
+    connection = SQL_NULL_HDBC;
+    ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &connection);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(connection != SQL_NULL_HDBC);
+  }
+
+  // All handles should be unique
+  for (int i = 0; i < NUM_CONNECTIONS; i++) {
+    for (int j = i + 1; j < NUM_CONNECTIONS; j++) {
+      REQUIRE(connections[i] != connections[j]);
+    }
+  }
+
+  for (auto & connection : connections) {
+    SQLFreeHandle(SQL_HANDLE_DBC, connection);
+  }
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DBC: HY009 - NULL OutputHandlePtr", "[odbc-api][alloc_handle][dbc][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // SQLSTATE HY009: Invalid use of null pointer
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, nullptr);
+  REQUIRE(ret == SQL_ERROR);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DBC: SQL_INVALID_HANDLE - NULL InputHandle", "[odbc-api][alloc_handle][dbc][connecting][error]") {
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  // SQL_HANDLE_DBC requires valid environment handle
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, SQL_NULL_HANDLE, &dbc);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE(dbc == SQL_NULL_HDBC);
+}
+
+TEST_CASE("SQLAllocHandle DBC: HY010 - Function sequence error (ODBC version not set)",
+          "[odbc-api][alloc_handle][dbc][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Do NOT set SQL_ATTR_ODBC_VERSION - should cause function sequence error
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+
+  // Per ODBC spec, this should return HY010 (Function sequence error)
+  // The Driver Manager enforces this - allocation fails without ODBC version set
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", env, SQL_HANDLE_ENV);
+
+  REQUIRE(dbc == SQL_NULL_HDBC);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DBC: SQL_INVALID_HANDLE - Wrong InputHandle type (STMT handle)",
+          "[odbc-api][alloc_handle][dbc][connecting][error]") {
+  // Using a connected statement handle as InputHandle for DBC allocation
+  Connection conn;
+  const auto stmt = conn.createStatement();
+
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  // Try to allocate DBC with statement handle as parent (should fail)
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, stmt.getHandle(), &dbc);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+// ============================================================================
+// SQL_HANDLE_STMT - Statement Handle Allocation
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle STMT: Basic allocation succeeds", "[odbc-api][alloc_handle][stmt][connecting]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+  // Setup
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Connect
+  const std::string conn_str = get_connection_string();
+  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  // Allocate statement
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(stmt != SQL_NULL_HSTMT);
+
+  // Verify statement is usable
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle STMT: Multiple allocations from same connection", "[odbc-api][alloc_handle][stmt][connecting]") {
+  Connection conn;
+  constexpr int NUM_STATEMENTS = 10;
+  std::vector<StatementHandleWrapper> statements;
+
+  for (int i = 0; i < NUM_STATEMENTS; i++) {
+    statements.push_back(conn.createStatement());
+    REQUIRE(statements[i].getHandle() != SQL_NULL_HSTMT);
+  }
+
+  // All handles should be unique
+  for (int i = 0; i < NUM_STATEMENTS; i++) {
+    for (int j = i + 1; j < NUM_STATEMENTS; j++) {
+      REQUIRE(statements[i].getHandle() != statements[j].getHandle());
+    }
+  }
+
+  // Verify all statements are usable
+  for (int i = 0; i < NUM_STATEMENTS; i++) {
+    const std::string query = "SELECT " + std::to_string(i);
+    SQLRETURN ret = SQLExecDirect(statements[i].getHandle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(query.c_str())), SQL_NTS);
+    CHECK_ODBC(ret, statements[i]);
+  }
+}
+
+TEST_CASE("SQLAllocHandle STMT: HY009 - NULL OutputHandlePtr", "[odbc-api][alloc_handle][stmt][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // SQLSTATE HY009: Invalid use of null pointer
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, nullptr);
+  REQUIRE(ret == SQL_ERROR);
+
+  SQLDisconnect(dbc);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle STMT: SQL_INVALID_HANDLE - NULL InputHandle", "[odbc-api][alloc_handle][stmt][connecting][error]") {
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, SQL_NULL_HANDLE, &stmt);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE(stmt == SQL_NULL_HSTMT);
+}
+
+TEST_CASE("SQLAllocHandle STMT: SQL_INVALID_HANDLE - Wrong InputHandle type (ENV handle)",
+          "[odbc-api][alloc_handle][stmt][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Try to allocate STMT with environment handle (should fail - needs DBC)
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, env, &stmt);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle STMT: 08003 - Connection not open", "[odbc-api][alloc_handle][stmt][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Do NOT connect - try to allocate statement on unconnected DBC
+  // SQLSTATE 08003: Connection not open
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+
+  // Per ODBC spec, this should return 08003
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc, SQL_HANDLE_DBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+// ============================================================================
+// SQL_HANDLE_DESC - Descriptor Handle Allocation
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle DESC: Basic allocation succeeds", "[odbc-api][alloc_handle][desc][connecting]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLHANDLE desc = SQL_NULL_HANDLE;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const std::string conn_str = get_connection_string();
+  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  // Allocate descriptor handle - should succeed on ODBC 3.x compliant drivers
+  ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc, &desc);
+
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(desc != SQL_NULL_HANDLE);
+
+  SQLFreeHandle(SQL_HANDLE_DESC, desc);
+  SQLDisconnect(dbc);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DESC: Multiple allocations from same connection", "[odbc-api][alloc_handle][desc][connecting]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  constexpr int NUM_DESCS = 3;
+  SQLHANDLE descs[NUM_DESCS];
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const std::string conn_str = get_connection_string();
+  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  for (auto & desc : descs) {
+    desc = SQL_NULL_HANDLE;
+    ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc, &desc);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(desc != SQL_NULL_HANDLE);
+  }
+
+  // All handles should be unique
+  for (int i = 0; i < NUM_DESCS; i++) {
+    for (int j = i + 1; j < NUM_DESCS; j++) {
+      REQUIRE(descs[i] != descs[j]);
+    }
+  }
+
+  for (auto & desc : descs) {
+    SQLFreeHandle(SQL_HANDLE_DESC, desc);
+  }
+
+  SQLDisconnect(dbc);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DESC: HY009 - NULL OutputHandlePtr", "[odbc-api][alloc_handle][desc][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const std::string conn_str = get_connection_string();
+  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc, nullptr);
+  REQUIRE(ret == SQL_ERROR);
+
+  SQLDisconnect(dbc);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle DESC: SQL_INVALID_HANDLE - NULL InputHandle", "[odbc-api][alloc_handle][desc][connecting][error]") {
+  SQLHANDLE desc = SQL_NULL_HANDLE;
+
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, SQL_NULL_HANDLE, &desc);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE("SQLAllocHandle DESC: 08003 - Connection not open", "[odbc-api][alloc_handle][desc][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLHANDLE desc = SQL_NULL_HANDLE;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Do NOT connect - try to allocate descriptor on unconnected DBC
+  ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc, &desc);
+
+  // Per ODBC spec, this should return 08003: Connection not open
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc, SQL_HANDLE_DBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+// ============================================================================
+// Invalid Handle Types - HY092
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle: HY092 - Invalid HandleType (negative)", "[odbc-api][alloc_handle][connecting][error]") {
+  SQLHANDLE handle = SQL_NULL_HANDLE;
+
+  const SQLRETURN ret = SQLAllocHandle(-1, SQL_NULL_HANDLE, &handle);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE("SQLAllocHandle: HY092 - Invalid HandleType (zero)", "[odbc-api][alloc_handle][connecting][error]") {
+  SQLHANDLE handle = SQL_NULL_HANDLE;
+
+  const SQLRETURN ret = SQLAllocHandle(0, SQL_NULL_HANDLE, &handle);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE("SQLAllocHandle: HY092 - Invalid HandleType (large number)", "[odbc-api][alloc_handle][connecting][error]") {
+  SQLHANDLE handle = SQL_NULL_HANDLE;
+
+  const SQLRETURN ret = SQLAllocHandle(9999, SQL_NULL_HANDLE, &handle);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+
+// ============================================================================
+// ODBC Version Compatibility
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle: Works with SQL_OV_ODBC3", "[odbc-api][alloc_handle][connecting][version]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle: Works with SQL_OV_ODBC3_80", "[odbc-api][alloc_handle][connecting][version]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3_80), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle: Works with SQL_OV_ODBC2", "[odbc-api][alloc_handle][connecting][version]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC2), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+// ============================================================================
+// Handle Hierarchy and Lifecycle
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle: Complete ENV -> DBC -> STMT hierarchy", "[odbc-api][alloc_handle][connecting][hierarchy]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+  // Allocate environment
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(env != SQL_NULL_HENV);
+
+  // Set ODBC version
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate connection
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  // Connect
+  const std::string conn_str = get_connection_string();
+  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  // Allocate statement
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(stmt != SQL_NULL_HSTMT);
+
+  // Execute a query to verify the hierarchy works
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 42")), SQL_NTS);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+  ret = SQLFetch(stmt);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+  SQLINTEGER value;
+  ret = SQLGetData(stmt, 1, SQL_C_LONG, &value, sizeof(value), nullptr);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+  REQUIRE(value == 42);
+
+  // Clean up in reverse order
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc);
+  CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
+
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE("SQLAllocHandle: Handle reuse after free", "[odbc-api][alloc_handle][connecting][lifecycle]") {
+  SQLHENV env = SQL_NULL_HENV;
+
+  // First allocation
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(env != SQL_NULL_HENV);
+
+  // Free
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second allocation - variable can be reused after free
+  env = SQL_NULL_HENV;
+  ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(env != SQL_NULL_HENV);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle: Overwriting existing handle variable", "[odbc-api][alloc_handle][connecting][lifecycle]") {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHENV first_handle = SQL_NULL_HENV;
+
+  // First allocation
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  first_handle = env;
+
+  // Allocate again WITHOUT freeing first - this overwrites the variable
+  // This is incorrect usage per ODBC spec but should not crash
+  ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // env now contains new handle, first_handle still holds the original
+  REQUIRE(env != first_handle);
+
+  // Clean up both handles
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+  SQLFreeHandle(SQL_HANDLE_ENV, first_handle);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle: Rapid allocation and deallocation", "[odbc-api][alloc_handle][connecting][stress]") {
+  constexpr int ITERATIONS = 100;
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    SQLHENV env = SQL_NULL_HENV;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(env != SQL_NULL_HENV);
+
+    ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+}
+
+TEST_CASE("SQLAllocHandle: Mixed handle type allocations", "[odbc-api][alloc_handle][connecting]") {
+  SQLHENV env1 = SQL_NULL_HENV;
+  SQLHENV env2 = SQL_NULL_HENV;
+  SQLHDBC dbc1 = SQL_NULL_HDBC;
+  SQLHDBC dbc2 = SQL_NULL_HDBC;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env1, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env2);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetEnvAttr(env2, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate connection from each environment
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env1, &dbc1);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env2, &dbc2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: All handles are unique in Snowflake driver (implementation-specific behavior)
+  REQUIRE(env1 != env2);
+  REQUIRE(dbc1 != dbc2);
+  REQUIRE(reinterpret_cast<SQLHANDLE>(env1) != reinterpret_cast<SQLHANDLE>(dbc1));
+  REQUIRE(reinterpret_cast<SQLHANDLE>(env2) != reinterpret_cast<SQLHANDLE>(dbc2));
+
+  // Clean up
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc1);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc2);
+  SQLFreeHandle(SQL_HANDLE_ENV, env1);
+  SQLFreeHandle(SQL_HANDLE_ENV, env2);
+}
+
+// ============================================================================
+// Return Value Verification
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle: Returns SQL_SUCCESS on successful allocation", "[odbc-api][alloc_handle][connecting][return]") {
+  SQLHENV env = SQL_NULL_HENV;
+
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+
+  // Must be exactly SQL_SUCCESS (not SQL_SUCCESS_WITH_INFO for basic allocation)
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+TEST_CASE("SQLAllocHandle: Fails with invalid parent handle", "[odbc-api][alloc_handle][connecting][return]") {
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  // This should fail (DBC without valid ENV parent)
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, SQL_NULL_HANDLE, &dbc);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+// ============================================================================
+// Implicit Descriptor Allocation (via Statement)
+// ============================================================================
+
+TEST_CASE("SQLAllocHandle STMT: Implicit descriptor handles are allocated", "[odbc-api][alloc_handle][stmt][connecting][desc]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a statement is allocated, four descriptor handles are implicitly allocated:
+  // SQL_ATTR_APP_ROW_DESC, SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_IMP_ROW_DESC, SQL_ATTR_IMP_PARAM_DESC
+
+  SQLHANDLE ard = SQL_NULL_HANDLE;
+  SQLHANDLE apd = SQL_NULL_HANDLE;
+  SQLHANDLE ird = SQL_NULL_HANDLE;
+  SQLHANDLE ipd = SQL_NULL_HANDLE;
+
+  // Get the implicit descriptor handles - these should always succeed
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(ard != SQL_NULL_HANDLE);
+
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(apd != SQL_NULL_HANDLE);
+
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(ird != SQL_NULL_HANDLE);
+
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_PARAM_DESC, &ipd, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(ipd != SQL_NULL_HANDLE);
+
+  // All four descriptors should be unique
+  REQUIRE(ard != apd);
+  REQUIRE(ard != ird);
+  REQUIRE(ard != ipd);
+  REQUIRE(apd != ird);
+  REQUIRE(apd != ipd);
+  REQUIRE(ird != ipd);
+}

--- a/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
@@ -1,0 +1,428 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <string>
+
+#include "compatibility.hpp"
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLBrowseConnect - Basic API Tests
+// ============================================================================
+
+TEST_CASE("SQLBrowseConnect: SQL_INVALID_HANDLE with NULL connection",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=Test";
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(SQL_NULL_HDBC,
+                                    reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                                    SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: IM002 - Non-existent DSN",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=NonExistentDSN_12345";
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: NULL OutConnectionString returns error",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=Test";
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 1024, &outLen);
+
+  // Note: Snowflake driver returns ERROR when OutConnectionString is NULL
+  // DM may return IM002 (DSN not found) before checking output buffer, or HY009
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  REQUIRE((records[0].sqlState == "IM002" || records[0].sqlState == "HY009"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: NULL InConnectionString returns error",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), nullptr, SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Note: unixODBC DM treats NULL as empty string → IM002 (no DSN found)
+  // ODBC spec says HY009, but DM behavior varies
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: Empty InConnectionString returns error",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "";
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // IM002: Data source not found (empty string has no DSN/DRIVER)
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: HY090 - Negative StringLength",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=Test";
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         -5,  // Invalid negative length
+                         outConnStr, sizeof(outConnStr), &outLen);
+
+  // HY090: Invalid string or buffer length
+  // Note: DM-dependent - unixODBC may return HY090 or pass to driver which returns IM002
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: HY090 - Negative BufferLength",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=Test";
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr,
+                         -1,  // Invalid negative buffer length
+                         &outLen);
+
+  // HY090: Invalid string or buffer length
+  // Note: DM-dependent - may return HY090 or IM002 (if DSN lookup happens first)
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Zero BufferLength returns SQL_NEED_DATA",
+          "[odbc-api][browse_connect][connecting]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024] = {};
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr,
+                         0,  // Zero buffer length
+                         &outLen);
+
+  // Note: Snowflake driver returns SQL_NEED_DATA when BufferLength is 0
+  // This is because it cannot write the output connection string
+  // Per ODBC spec, 01004 truncation should return SQL_NEED_DATA for SQLBrowseConnect
+  REQUIRE(ret == SQL_NEED_DATA);
+  
+  // outLen should indicate actual string length needed
+  REQUIRE(outLen > 0);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 08002 - Connection already open",
+          "[odbc-api][browse_connect][connecting][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // First connect using SQLDriverConnect
+  const std::string connStr1 = get_connection_string();
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr1.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Try to connect again using SQLBrowseConnect
+  const std::string connStr2 = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr2.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // 08002: Connection name in use
+  REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
+
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLBrowseConnect - Iterative Connection Process
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Initial call with DSN",
+          "[odbc-api][browse_connect][connecting][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Initial browse with just DSN
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024] = {};
+  SQLSMALLINT outLen = 0;
+
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Note: Snowflake driver supports SQLBrowseConnect and completes connection if DSN has all info
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  // Verify OutConnectionString is populated
+  REQUIRE(outLen > 0);
+  REQUIRE(outConnStr[0] != '\0');
+
+  // Verify connection works
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Reconnect after disconnect",
+          "[odbc-api][browse_connect][connecting][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024] = {};
+  SQLSMALLINT outLen = 0;
+
+  // First connection
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  // Disconnect
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  // Reconnect using same handle
+  outLen = 0;
+  std::memset(outConnStr, 0, sizeof(outConnStr));
+  
+  ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  // Verify second connection works
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLBrowseConnect - Authentication Errors
+// ============================================================================
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLBrowseConnect: 28000 - Invalid credentials",
+          "[odbc-api][browse_connect][connecting][integration][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Use DSN without auth but provide invalid credentials
+  const std::string connStr = "DSN=" + config.value().dsn_name() + 
+                               ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
+  SQLCHAR outConnStr[1024] = {};
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLBrowseConnect - Buffer Handling
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 01004 - OutConnectionString truncation",
+          "[odbc-api][browse_connect][connecting]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[10];  // Very small buffer to force truncation
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Per ODBC spec, buffer truncation in SQLBrowseConnect should return SQL_NEED_DATA (99)
+  // not SQL_SUCCESS_WITH_INFO. This is different from other ODBC functions.
+  REQUIRE(ret == SQL_NEED_DATA);
+  
+  // outLen should indicate actual string length needed (larger than our buffer)
+  REQUIRE(outLen >= static_cast<SQLSMALLINT>(sizeof(outConnStr)));
+  
+  // Cannot disconnect - connection is in browsing state, not connected
+  // Fixture will cleanup handles automatically
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: NULL StringLength2Ptr is allowed",
+          "[odbc-api][browse_connect][connecting]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024] = {};
+
+  // NULL StringLength2Ptr is allowed per ODBC spec - caller doesn't need length
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr),
+                         nullptr);  // NULL length pointer
+
+  // Should succeed - NULL length pointer is valid
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  // OutConnectionString should still be populated
+  REQUIRE(outConnStr[0] != '\0');
+  
+  // Connection should work
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+// ============================================================================
+// SQLBrowseConnect - Cancellation
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Disconnecting after successful browse",
+          "[odbc-api][browse_connect][connecting][lifecycle]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Browse and connect
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outLen = 0;
+
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Disconnect after successful connection
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+// ============================================================================
+// SQLBrowseConnect - Driver Support Detection
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Driver support with complete output verification",
+          "[odbc-api][browse_connect][connecting][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLCHAR outConnStr[2048] = {};
+  SQLSMALLINT outLen = 0;
+
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Note: Snowflake driver SUPPORTS SQLBrowseConnect
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  // Verify OutConnectionString contains the complete connection info
+  std::string outStr = reinterpret_cast<char*>(outConnStr);
+  REQUIRE(!outStr.empty());
+  REQUIRE(outLen > 0);
+  
+  // OutConnectionString should be properly null-terminated
+  REQUIRE(static_cast<size_t>(outLen) <= outStr.length());
+  
+  // Verify connection is usable
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLBrowseConnect - Iterative Browsing Tests
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Iterative browse with incomplete connection string",
+          "[odbc-api][browse_connect][connecting][integration][iterative]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Provide ONLY the driver path (no server, no credentials)
+  // True iterative browsing would return SQL_NEED_DATA with required attributes
+  const std::string driverPath = DriverConfig::get_driver_path();
+  const std::string connStr = "DRIVER=" + driverPath;
+  SQLCHAR outConnStr[2048] = {};
+  SQLSMALLINT outLen = 0;
+
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(),
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+
+  // Note: Snowflake driver does NOT support iterative browsing.
+  // It requires a complete connection string and returns SQL_ERROR when given incomplete info.
+  REQUIRE(ret == SQL_ERROR);
+  
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+}

--- a/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
@@ -1,0 +1,567 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "compatibility.hpp"
+#include "Connection.hpp"
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "get_diag_rec.hpp"
+#include "macros.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+using namespace Catch::Matchers;
+
+// ============================================================================
+// SQLConnect - Success Cases
+// ============================================================================
+// NOTE: SQLConnect requires a configured DSN in odbc.ini, not a raw hostname
+// Most tests focus on error conditions that don't require a real DSN
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Completes without crashing with valid parameters", "[odbc-api][connect][connecting]") {
+  // Use a non-existent DSN - should fail gracefully with IM002
+  const std::string dsn = "NonExistentDSN";
+  const std::string uid = "testuser";
+  const std::string pwd = "testpwd";
+
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())), SQL_NTS);
+
+  // Should fail with IM002 (DSN not found)
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Accepts explicit string lengths", "[odbc-api][connect][connecting]") {
+  const std::string dsn = "TestDSN";
+  const std::string uid = "user";
+  const std::string pwd = "cred";
+
+  // Connect with explicit lengths instead of SQL_NTS
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())),
+                   static_cast<SQLSMALLINT>(dsn.length()),
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())),
+                   static_cast<SQLSMALLINT>(uid.length()),
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())),
+                   static_cast<SQLSMALLINT>(pwd.length()));
+
+  // Should fail with IM002 (DSN not found) - the important thing is it doesn't crash with explicit lengths
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Accepts NULL credentials", "[odbc-api][connect][connecting]") {
+  const std::string dsn = "TestDSN";
+
+  // Connect with NULL UID and PWD parameters
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+
+  // Should fail (DSN doesn't exist) but accepts NULL credentials
+  REQUIRE(ret == SQL_ERROR);
+}
+
+// ============================================================================
+// SQLConnect - Error Cases: Invalid Handle
+// ============================================================================
+
+TEST_CASE("SQLConnect: SQL_INVALID_HANDLE - NULL connection handle", "[odbc-api][connect][connecting][error]") {
+  const auto params = get_test_parameters("testconnection");
+  const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
+
+  const SQLRETURN ret =
+      SQLConnect(SQL_NULL_HDBC, reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE("SQLConnect: SQL_INVALID_HANDLE - Invalid handle type", "[odbc-api][connect][connecting][error]") {
+  SQLHENV env = SQL_NULL_HENV;
+
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const auto params = get_test_parameters("testconnection");
+  const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
+
+  // Try to use ENV handle as DBC handle
+  ret = SQLConnect(env, reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+// ============================================================================
+// SQLConnect - Error Cases: IM002 Data Source Not Found
+// ============================================================================
+// NOTE: Most connection errors with SQLConnect will be IM002 (DSN not found)
+// unless a real DSN is configured. Testing 28000 would require a configured DSN.
+
+// ============================================================================
+// SQLConnect - Error Cases: IM002 Data Source Not Found
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: IM002 - Non-existent DSN", "[odbc-api][connect][connecting][error]") {
+  // Use non-existent DSN
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("INVALID_DSN_DOES_NOT_EXIST")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("user")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("pwd")), SQL_NTS);
+
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLConnect - Error Cases: HY090 Invalid String or Buffer Length
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative server name length", "[odbc-api][connect][connecting][error]") {
+  const auto params = get_test_parameters("testconnection");
+  const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
+
+  // Use negative length (invalid, should be >= 0 or SQL_NTS)
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())), -5, nullptr, 0, nullptr, 0);
+
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative username length", "[odbc-api][connect][connecting][error]") {
+  const std::string dsn = "TestDSN";
+  const std::string user = "testuser";
+
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(user.c_str())), -3, nullptr, 0);
+
+  REQUIRE(ret == SQL_ERROR);
+
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: unixODBC may validate lengths first (HY090) or check DSN first (IM002)
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative PWD length", "[odbc-api][connect][connecting][error]") {
+  const std::string dsn = "TestDSN";
+  const std::string uid = "testuser";
+  const std::string pwd = "testpwd";
+
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())), -2);
+
+  REQUIRE(ret == SQL_ERROR);
+
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: unixODBC may validate lengths first (HY090) or check DSN first (IM002)
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+// ============================================================================
+// SQLConnect - Error Cases: IM010 or HY090 Data Source Name Too Long
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: IM010/HY090 - Data source name too long", "[odbc-api][connect][connecting][error]") {
+  // Create a very long data source name (> SQL_MAX_DSN_LENGTH which is typically 32)
+  // Per ODBC spec: IM010 = "*ServerName was longer than SQL_MAX_DSN_LENGTH characters"
+  const std::string long_dsn(300, 'A');
+
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(long_dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+
+  REQUIRE(ret == SQL_ERROR);
+
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: IM010 (DSN too long per ODBC spec) or HY090 (generic invalid length)
+  REQUIRE((records[0].sqlState == "IM010" || records[0].sqlState == "HY090"));
+}
+
+// ============================================================================
+// SQLConnect - Error Cases: Default DSN Handling
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: NULL DSN uses default data source", "[odbc-api][connect][connecting][error]") {
+  // NULL DSN triggers default data source lookup per ODBC spec
+  const SQLRETURN ret = SQLConnect(dbc_handle(), nullptr, 0, nullptr, 0, nullptr, 0);
+
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLConnect - API Validation (Lifecycle)
+// ============================================================================
+// NOTE: These tests validate API behavior without requiring configured DSNs
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Can be called multiple times on same handle after disconnect",
+          "[odbc-api][connect][connecting][lifecycle]") {
+  const std::string dsn = "TestDSN";
+
+  // Multiple attempts (all will fail with IM002, but the API should handle it)
+  for (int i = 0; i < 3; i++) {
+    const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+    REQUIRE(ret == SQL_ERROR);  // DSN doesn't exist
+  }
+}
+
+TEST_CASE_METHOD(EnvFixture, "SQLConnect: Multiple connection handles from same environment",
+          "[odbc-api][connect][connecting][concurrent]") {
+  constexpr int NUM_CONNECTIONS = 3;
+  SQLHDBC connections[NUM_CONNECTIONS];
+
+  const std::string dsn = "TestDSN";
+
+  // Allocate multiple connection handles
+  for (auto & connection : connections) {
+    connection = SQL_NULL_HDBC;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &connection);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    // Try to connect (will fail, but validates API accepts multiple handles)
+    ret = SQLConnect(connection, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
+                     nullptr, 0);
+    REQUIRE(ret == SQL_ERROR);  // DSN doesn't exist
+  }
+
+  // Clean up
+  for (const auto & connection : connections) {
+    SQLFreeHandle(SQL_HANDLE_DBC, connection);
+  }
+}
+
+// ============================================================================
+// SQLConnect - Edge Cases
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Empty string parameters", "[odbc-api][connect][connecting][edge]") {
+  // Connect with empty server name
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), 0, nullptr, 0, nullptr, 0);
+
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Zero-length strings with SQL_NTS", "[odbc-api][connect][connecting][edge]") {
+  // Empty strings with SQL_NTS should be treated as empty
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+
+  REQUIRE(ret == SQL_ERROR);
+}
+
+// ============================================================================
+// SQLConnect - Connection Attribute Tests
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: SQL_ATTR_LOGIN_TIMEOUT can be set before connect", "[odbc-api][connect][connecting][attributes]") {
+  // Set login timeout to 5 seconds per Microsoft example code
+  SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_LOGIN_TIMEOUT, reinterpret_cast<SQLPOINTER>(5), 0);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify the attribute was set
+  SQLUINTEGER timeout = 0;
+  ret = SQLGetConnectAttr(dbc_handle(), SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  REQUIRE(timeout == 5);
+
+  // Connect attempt (will fail with IM002, validates attribute setting doesn't break connect)
+  const std::string dsn = "NonExistentDSN";
+  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_ERROR);
+}
+
+// ============================================================================
+// SQLConnect - Handle Cleanup Verification
+// ============================================================================
+
+TEST_CASE_METHOD(DbcFixture, "SQLConnect: Verify proper cleanup after failed connection", "[odbc-api][connect][connecting][cleanup]") {
+  const std::string dsn = "NonExistentDSN";
+
+  // Attempt connection that will fail
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_ERROR);
+
+  // Per ODBC spec: SQLDisconnect should not be called if connection was never established
+  // But SQLFreeHandle should still work (fixture will handle cleanup)
+}
+
+// ============================================================================
+// SQLConnect - DSN-Based Integration Tests
+// ============================================================================
+// These tests require a configured DSN (set up via scripts/setup_test_dsn.sh)
+// Tag with [.integration] to skip by default - run with: ctest -R integration
+// Or set ODBCSYSINI/ODBCINI to enable these tests
+
+// This test verifies DSN configuration and acts as a gate for other integration tests
+TEST_CASE("SQLConnect: DSN configuration check", "[odbc-api][connect][dsn][integration][!mayfail]") {
+  // This test explicitly checks if DSN is configured and reports clearly
+
+  const auto config = DataSourceConfig::Snowflake().install();
+
+  // Verify the DSN name has correct format (with unique suffix for parallel isolation)
+  const std::string dsn = config.dsn_name();
+  REQUIRE(dsn.rfind("Snowflake_", 0) == 0);  // C++17 compatible starts_with
+  REQUIRE(dsn.length() > 10);  // Has suffix
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Basic DSN connection succeeds", "[odbc-api][connect][dsn][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string dsn = config.value().dsn_name();
+
+  // Credentials are in odbc.ini, pass NULL for UID/PWD
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection by executing a query
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+  ret = SQLFetch(stmt);
+  CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: 08002 - Connection already open", "[odbc-api][connect][dsn][integration][error]") {
+
+  const std::string dsn = config.value().dsn_name();
+
+  // First connection must succeed
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Try to connect again without disconnecting - should fail with 08002
+  // Per ODBC spec: "The specified ConnectionHandle had already been used to establish
+  // a connection with a data source, and the connection was still open"
+  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLConnect: 28000 - Invalid authorization specification",
+          "[odbc-api][connect][dsn][integration][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Use DSN without credentials and provide invalid ones
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
+  const std::string dsn = config.value().dsn_name();
+  const std::string bad_uid = "invalid_user_xyz";
+  const std::string bad_pwd = "invalid_cred_xyz";
+
+  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(bad_uid.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(bad_pwd.c_str())), SQL_NTS);
+
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: SQL_SUCCESS_WITH_INFO has retrievable diagnostics",
+          "[odbc-api][connect][dsn][integration]") {
+
+  const std::string dsn = config.value().dsn_name();
+
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  if (ret == SQL_SUCCESS_WITH_INFO) {
+    auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+    REQUIRE(!records.empty());
+    // Warning SQLSTATEs start with "01"
+    REQUIRE(records[0].sqlState.substr(0, 2) == "01");
+  }
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Disconnect and reconnect cycle", "[odbc-api][connect][dsn][integration][lifecycle]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string dsn = config.value().dsn_name();
+
+  constexpr int CYCLES = 3;
+  for (int i = 0; i < CYCLES; i++) {
+    SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+    CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+    ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLDisconnect(dbc_handle());
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+}
+
+TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLConnect: Multiple concurrent connections", "[odbc-api][connect][dsn][integration][concurrent]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  constexpr int NUM_CONNECTIONS = 3;
+  SQLHDBC connections[NUM_CONNECTIONS];
+
+  const std::string dsn = config.value().dsn_name();
+
+  // Allocate and connect all connections
+  for (auto & connection : connections) {
+    connection = SQL_NULL_HDBC;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &connection);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLConnect(connection, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
+                     nullptr, 0);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  }
+
+  // Verify all connections are independent by executing queries
+  for (int i = 0; i < NUM_CONNECTIONS; i++) {
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, connections[i], &stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    std::string query = "SELECT " + std::to_string(i + 1);
+    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>(query.c_str())), SQL_NTS);
+    CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
+
+    ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+
+  // Clean up
+  for (auto & connection : connections) {
+    SQLRETURN ret = SQLDisconnect(connection);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLFreeHandle(SQL_HANDLE_DBC, connection);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+}
+
+// Concurrent connection test with threads
+static void dsn_connection_thread(const std::string& dsn, std::atomic<SQLRETURN>* result, const int iterations) {
+  for (int i = 0; i < iterations; i++) {
+    constexpr int MAX_RETRIES = 3;
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
+
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      return;
+    }
+
+    ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    // Retry logic for driver loading issues
+    int retry = 0;
+    do {
+      ret = SQLConnect(dbc, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
+                       nullptr, 0);
+      if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } while (++retry < MAX_RETRIES);
+
+    if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
+      // Verify connection works with a query
+      SQLHSTMT stmt = SQL_NULL_HSTMT;
+      if (SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt) == SQL_SUCCESS) {
+        SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+      }
+      SQLDisconnect(dbc);
+      // Don't overwrite previous success - only store on last iteration or failure
+      if (i == iterations - 1) {
+        result->store(SQL_SUCCESS, std::memory_order_relaxed);
+      }
+    } else {
+      // Connection failed, store the error and stop
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    SQLFreeHandle(SQL_HANDLE_ENV, env);
+  }
+}
+
+TEST_CASE("SQLConnect: Threaded concurrent connections", "[odbc-api][connect][dsn][integration][concurrent][threads]") {
+  const auto config = DataSourceConfig::Snowflake().install();
+
+  const std::string dsn = config.dsn_name();
+  constexpr int NUM_THREADS = 3;
+
+  // First, make a single connection to ensure driver is loaded
+  {
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
+
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLConnect(dbc, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+    SQLDisconnect(dbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    SQLFreeHandle(SQL_HANDLE_ENV, env);
+  }
+
+  // Now run threaded connections
+  std::atomic<SQLRETURN> results[NUM_THREADS];
+  std::vector<std::thread> threads;
+
+  for (std::atomic<SQLRETURN>& result : results) {
+    constexpr int ITERATIONS_PER_THREAD = 2;
+    result.store(SQL_SUCCESS, std::memory_order_relaxed);
+    threads.emplace_back(dsn_connection_thread, dsn, &result, ITERATIONS_PER_THREAD);
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Verify all threads completed successfully
+  for (const std::atomic<SQLRETURN>& result : results) {
+    const SQLRETURN value = result.load(std::memory_order_acquire);
+    REQUIRE((value == SQL_SUCCESS || value == SQL_SUCCESS_WITH_INFO));
+  }
+}

--- a/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
@@ -1,0 +1,925 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include <atomic>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "compatibility.hpp"
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+using namespace Catch::Matchers;
+
+// Helper to build connection string from DSN
+std::string build_dsn_connection_string(const std::string& dsn) {
+  return "DSN=" + dsn;
+}
+
+// ============================================================================
+// SQLDriverConnect - API Validation Tests (No DSN Required)
+// ============================================================================
+// These tests validate API behavior and error handling without needing a
+// configured DSN. They test the Driver Manager's parameter validation.
+
+TEST_CASE("SQLDriverConnect: SQL_INVALID_HANDLE - NULL connection handle",
+          "[odbc-api][driverconnect][connecting][error]") {
+  const SQLRETURN ret = SQLDriverConnect(SQL_NULL_HDBC, nullptr,
+                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
+                                   SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+// NOTE: Testing with fake/garbage handle pointers (e.g., 0xDEADBEEF) is unsafe
+// and will cause segfaults as the driver manager dereferences the pointer.
+// Such tests are intentionally omitted - ODBC does not validate pointer contents.
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY090 - Negative string length",
+          "[odbc-api][driverconnect][connecting][error]") {
+  // Negative StringLength1 (not SQL_NTS) should return HY090
+  // Note: DM-dependent - some DMs validate length first (HY090), others pass to DSN lookup (IM002)
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
+                         -5,  // Invalid negative length
+                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: unixODBC may return HY090 (validates length) or IM002 (passes to DSN lookup)
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY090 - Negative buffer length",
+          "[odbc-api][driverconnect][connecting][error]") {
+  SQLCHAR outConnStr[256];
+  SQLSMALLINT outConnStrLen = 0;
+
+  // Negative BufferLength - DM-dependent validation
+  // Most DMs will fail with HY090, but some may pass through to DSN lookup (IM002)
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN")),
+                         SQL_NTS, outConnStr, -1,  // Invalid negative buffer length
+                         &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: HY090 (invalid buffer length) or IM002 (if passed to DSN lookup)
+  REQUIRE((records[0].sqlState == "HY090" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY110 - Invalid DriverCompletion value",
+          "[odbc-api][driverconnect][connecting][error]") {
+  // Invalid DriverCompletion value (not one of the valid constants)
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
+                         SQL_NTS, nullptr, 0, nullptr, 999);  // Invalid value
+  // Should return HY110 (Invalid driver completion)
+  REQUIRE_EXPECTED_ERROR(ret, "HY110", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: IM002 - Data source not found (non-existent DSN)",
+          "[odbc-api][driverconnect][connecting][error]") {
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN12345")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: IM007 - No data source or driver specified with NOPROMPT",
+          "[odbc-api][driverconnect][connecting][error]") {
+  // Empty connection string with SQL_DRIVER_NOPROMPT
+  // Note: DM-dependent - spec says IM007, but some DMs return IM002
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  // DM-dependent: IM007 (per spec) or IM002 (unixODBC behavior)
+  REQUIRE((records[0].sqlState == "IM007" || records[0].sqlState == "IM002"));
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Empty connection string",
+          "[odbc-api][driverconnect][connecting][error]") {
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("")),
+                         0, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: NULL connection string",
+          "[odbc-api][driverconnect][connecting][error]") {
+  // NULL InConnectionString should be an error
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, nullptr, SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Driver Manager behavior varies, but should always fail (not crash)
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Explicit string length with SQL_NTS",
+          "[odbc-api][driverconnect][connecting]") {
+  // Use SQL_NTS for connection string
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Should fail with IM002 (data source not found)
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Explicit byte count for string length",
+          "[odbc-api][driverconnect][connecting]") {
+  const std::string connStr = "DSN=NonExistentDSN";
+
+  // Use explicit length
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         static_cast<SQLSMALLINT>(connStr.length()),
+                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Zero string length (empty string)",
+          "[odbc-api][driverconnect][connecting][edge]") {
+  // Zero length string
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
+                         0,  // Zero length - treats as empty
+                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mode with complete DSN",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_NOPROMPT: Never prompt, fail if info missing
+  // With complete DSN (has credentials), should succeed
+  std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mode with incomplete info fails",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_NOPROMPT: With DSN that has no credentials, should fail
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
+  std::string connStr = "DSN=" + config->dsn_name();
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mode with complete DSN",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_COMPLETE: Prompt only if info is missing
+  // With complete DSN, no prompting needed, should succeed
+  std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mode with incomplete info",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_COMPLETE: Would prompt for missing credentials,
+  // but fails with NULL window handle in headless environment
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
+  std::string connStr = "DSN=" + config->dsn_name();
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_REQUIRED mode with complete DSN",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_COMPLETE_REQUIRED: Only prompt for required info
+  // With complete DSN, no prompting needed, should succeed
+  std::string connStr = "DSN=" + config.value().dsn_name();
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_REQUIRED mode with incomplete info",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // SQL_DRIVER_COMPLETE_REQUIRED: Would prompt for required credentials,
+  // but fails with NULL window handle in headless environment
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
+  std::string connStr = "DSN=" + config->dsn_name();
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_PROMPT mode always requires window handle",
+          "[odbc-api][driverconnect][dsn][integration][drivercompletion][error]") {
+
+  // SQL_DRIVER_PROMPT: Always display dialog, even with complete DSN
+  // Per ODBC spec, with NULL window handle should return HY092 or fail
+  // Even though DSN is complete, PROMPT mode MUST show dialog
+  std::string connStr = "DSN=" + config.value().dsn_name();
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_PROMPT);
+  
+  // Per ODBC spec: SQL_DRIVER_PROMPT with NULL window handle returns HY092
+  // unixODBC follows spec and returns HY092
+  REQUIRE_EXPECTED_ERROR(ret, "HY092", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: 08002 - Connection already in use",
+          "[odbc-api][driverconnect][dsn][integration][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  // First connection
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Second connection on same handle should fail with 08002
+  ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Connection string keyword=value parsing",
+          "[odbc-api][driverconnect][connecting][parsing]") {
+  // Valid format but non-existent DSN
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test;UID=user;PWD=pass")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Should be IM002 (DSN not found), not a parsing error
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString buffer handling",
+          "[odbc-api][driverconnect][dsn][integration][buffer]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  // Test with output buffer
+  SQLCHAR outConnStr[1024];
+  SQLSMALLINT outConnStrLen = 0;
+  std::memset(outConnStr, 0, sizeof(outConnStr));
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Output connection string should be populated
+  REQUIRE(outConnStrLen > 0);
+  REQUIRE(outConnStr[0] != '\0');
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString truncation (01004)",
+          "[odbc-api][driverconnect][dsn][integration][buffer]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  // Very small buffer to force truncation
+  SQLCHAR outConnStr[10];
+  SQLSMALLINT outConnStrLen = 0;
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  // Should succeed (connection made) but possibly with INFO for truncation
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // outConnStrLen should indicate the full length needed
+  if (ret == SQL_SUCCESS_WITH_INFO) {
+    auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+    // May have 01004 (string truncated) or other info
+    const bool found_truncation_or_other = !records.empty();
+    REQUIRE(found_truncation_or_other);
+  }
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL OutConnectionString with non-NULL length pointer",
+          "[odbc-api][driverconnect][dsn][integration][buffer]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  SQLSMALLINT outConnStrLen = 0;
+
+  // NULL buffer but valid length pointer - should report required length
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Length should indicate how much space is needed
+  REQUIRE(outConnStrLen > 0);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL StringLength2Ptr pointer",
+          "[odbc-api][driverconnect][dsn][integration][buffer]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  SQLCHAR outConnStr[1024];
+
+  // Valid buffer but NULL length pointer - should still succeed
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, outConnStr, sizeof(outConnStr), nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Buffer should still be populated
+  REQUIRE(outConnStr[0] != '\0');
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Both OutConnectionString and StringLength2Ptr NULL",
+          "[odbc-api][driverconnect][dsn][integration][buffer]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  // Both NULL - should still connect, just no output
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection works
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Connection string with special characters",
+          "[odbc-api][driverconnect][connecting][parsing]") {
+  // Connection string with braces (should be parsed correctly)
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN={Test DSN With Spaces}")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Will fail with IM002 but shouldn't crash or have parsing error
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Multiple semicolons in connection string",
+          "[odbc-api][driverconnect][connecting][parsing]") {
+  // Multiple semicolons should be handled gracefully
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test;;UID=user;;;")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Should parse correctly and fail with IM002
+  REQUIRE(ret == SQL_ERROR);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Case insensitivity of keywords",
+          "[odbc-api][driverconnect][connecting][parsing]") {
+  // Keywords are case-insensitive per ODBC spec
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("dsn=test;uid=user;pwd=pass")),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  // Should parse correctly (same as DSN=test) - DSN not found, not parsing error
+  REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLDriverConnect - DSN-Based Integration Tests
+// ============================================================================
+// These tests require a configured DSN. They will FAIL if DSN is not set up.
+
+TEST_CASE("SQLDriverConnect: DSN configuration check",
+          "[odbc-api][driverconnect][dsn][integration][!mayfail]") {
+  const auto config = DataSourceConfig::Snowflake().install();
+
+  const std::string dsn = config.dsn_name();
+  // DSN name has unique suffix for parallel test isolation
+  REQUIRE(dsn.rfind("Snowflake_", 0) == 0);  // C++17 compatible starts_with
+  REQUIRE(dsn.length() > 10);  // Has suffix
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Basic DSN connection succeeds",
+          "[odbc-api][driverconnect][dsn][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection by executing a query
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLFetch(stmt);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Connection with additional parameters",
+          "[odbc-api][driverconnect][dsn][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // DSN with additional Snowflake-specific parameters
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";TRACING=0";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: 01S00 - Invalid connection string attribute (unrecognized keyword)",
+          "[odbc-api][driverconnect][dsn][integration]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Per ODBC spec, unrecognized keywords return SQL_SUCCESS_WITH_INFO with 01S00
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";INVALIDKEY=abc";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+
+  auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(!records.empty());
+  REQUIRE(records[0].sqlState == "01S00");
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: 28000 - Invalid authorization specification",
+          "[odbc-api][driverconnect][dsn][integration][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Use DSN without auth but provide invalid credentials
+  // Note: Snowflake driver returns 28000 for authentication failures.
+  // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
+  const std::string connStr = "DSN=" + config.value().dsn_name() +
+                        ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
+
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Disconnect and reconnect cycle",
+          "[odbc-api][driverconnect][dsn][integration][lifecycle]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+
+  for (int i = 0; i < 3; i++) {
+    SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                           SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+    // Verify connection with query
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+    ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLDisconnect(dbc_handle());
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+}
+
+TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLDriverConnect: Multiple concurrent connections",
+          "[odbc-api][driverconnect][dsn][integration][concurrent]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  constexpr int NUM_CONNECTIONS = 4;
+  SQLHDBC connections[NUM_CONNECTIONS];
+
+  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  int successful_connections = 0;
+
+  // Allocate and connect all handles
+  for (auto & connection : connections) {
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &connection);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLDriverConnect(connection, nullptr,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                           SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
+      successful_connections++;
+    }
+  }
+
+  REQUIRE(successful_connections == NUM_CONNECTIONS);
+
+  // Cleanup all connections
+  for (auto & connection : connections) {
+    SQLRETURN ret = SQLDisconnect(connection);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLFreeHandle(SQL_HANDLE_DBC, connection);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+}
+
+// ============================================================================
+// SQLDriverConnect - Snowflake-Specific Connection String Parameters
+// ============================================================================
+// Note: These tests document and verify Snowflake ODBC driver-specific parameters
+// that are not part of the standard ODBC specification. These parameters are
+// extensions provided by the Snowflake driver for driver-specific functionality.
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake TRACING parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Note: TRACING is a Snowflake-specific parameter that controls logging level (0-6)
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";TRACING=0";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake CLIENT_SESSION_KEEP_ALIVE parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Note: CLIENT_SESSION_KEEP_ALIVE is a Snowflake-specific parameter that enables heartbeat to keep session alive
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";CLIENT_SESSION_KEEP_ALIVE=true";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection is usable
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake LOGIN_TIMEOUT parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // LOGIN_TIMEOUT sets connection timeout in seconds
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";LOGIN_TIMEOUT=120";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake APPLICATION parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // APPLICATION parameter sets client application name
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";APPLICATION=ODBCTestSuite";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection is usable
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake QUERY_TIMEOUT parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // QUERY_TIMEOUT sets query execution timeout (0 = no timeout)
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";QUERY_TIMEOUT=0";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake NETWORK_TIMEOUT parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // NETWORK_TIMEOUT sets network operation timeout
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";NETWORK_TIMEOUT=0";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DisableOCSPCheck parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake][security]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Note: DisableOCSPCheck is a Snowflake-specific parameter that controls OCSP certificate validation
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";DisableOCSPCheck=true";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DATABASE and SCHEMA parameters",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // DATABASE and SCHEMA can override default namespace
+  // Empty values should not break connection
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";DATABASE=;SCHEMA=";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake WAREHOUSE parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // WAREHOUSE can override default warehouse (empty = use default)
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";WAREHOUSE=";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake ROLE parameter",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // ROLE can override default role (empty = use default)
+  const std::string connStr = "DSN=" + config.value().dsn_name() + ";ROLE=";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake multiple parameters combined",
+          "[odbc-api][driverconnect][dsn][integration][snowflake]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Combination of multiple Snowflake-specific parameters
+  const std::string connStr = "DSN=" + config.value().dsn_name() +
+                        ";APPLICATION=ODBCTest"
+                        ";TRACING=0"
+                        ";LOGIN_TIMEOUT=60"
+                        ";QUERY_TIMEOUT=0"
+                        ";NETWORK_TIMEOUT=0"
+                        ";CLIENT_SESSION_KEEP_ALIVE=false";
+
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+
+  // Verify connection works
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT CURRENT_TIMESTAMP()")), SQL_NTS);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+// ============================================================================
+// SQLDriverConnect - Threaded/Concurrent Tests
+// ============================================================================
+
+static void driver_connect_thread(const std::string& connStr, std::atomic<SQLRETURN>* result, const int iterations) {
+  for (int i = 0; i < iterations; i++) {
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
+
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      return;
+    }
+
+    ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+    if (ret != SQL_SUCCESS) {
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    ret = SQLDriverConnect(dbc, nullptr,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                           SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
+      // Verify with simple query
+      SQLHSTMT stmt = SQL_NULL_HSTMT;
+      if (SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt) == SQL_SUCCESS) {
+        SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+      }
+      SQLDisconnect(dbc);
+      // Don't overwrite previous success - only store on last iteration or failure
+      if (i == iterations - 1) {
+        result->store(SQL_SUCCESS, std::memory_order_relaxed);
+      }
+    } else {
+      // Connection failed, store the error and stop
+      result->store(ret, std::memory_order_relaxed);
+      SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    SQLFreeHandle(SQL_HANDLE_ENV, env);
+  }
+}
+
+TEST_CASE("SQLDriverConnect: Threaded concurrent connections",
+          "[odbc-api][driverconnect][dsn][integration][concurrent][threads]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  const auto config = DataSourceConfig::Snowflake().install();
+
+  constexpr int NUM_THREADS = 4;
+
+  const std::string connStr = build_dsn_connection_string(config.dsn_name());
+
+  // Pre-connect to ensure driver is loaded
+  {
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLDriverConnect(dbc, nullptr,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+                           SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+    SQLDisconnect(dbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    SQLFreeHandle(SQL_HANDLE_ENV, env);
+  }
+
+  std::atomic<SQLRETURN> results[NUM_THREADS];
+  std::vector<std::thread> threads;
+
+  for (std::atomic<SQLRETURN>& result : results) {
+    constexpr int ITERATIONS_PER_THREAD = 2;
+    result.store(SQL_SUCCESS, std::memory_order_relaxed);
+    threads.emplace_back(driver_connect_thread, connStr, &result, ITERATIONS_PER_THREAD);
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  int successful = 0;
+  for (const std::atomic<SQLRETURN>& result : results) {
+    const SQLRETURN value = result.load(std::memory_order_acquire);
+    if (value == SQL_SUCCESS) {
+      successful++;
+    }
+  }
+  REQUIRE(successful == NUM_THREADS);
+}


### PR DESCRIPTION
Added granular ODBC unit and integration tests to verify compliance of ODBC wrapper with the ODBC 3.x and 2.x specs and consistent behaviour with existing ODBC driver.

This PR only contains ["Connecting to data sources" category functions](https://docs.google.com/spreadsheets/d/1BjOHFnLQ2AooXGqWncsaqCLIw8z9XD0v3fwwF-S-E3g/edit?gid=999869428#gid=999869428).