### PR TITLE
Enable catch2 cmake integration

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -16,3 +16,6 @@ behavior_differences:
   
   6:
     name: "Unsupported compression type returns error instead of being silently ignored"
+
+  8:
+    name: "Old driver doesn't return result set for some queries (based on query type determined by inspecting query text)"

--- a/odbc_tests/CMakeLists.txt
+++ b/odbc_tests/CMakeLists.txt
@@ -34,22 +34,6 @@ if (NOT DEFINED DRIVER_TYPE)
   set(DRIVER_TYPE "NEW")
 endif()
 
-set(CATCH_TAGS "")
-
-if (DRIVER_TYPE STREQUAL "OLD")
-  set(CATCH_TAGS "~[new_odbc]")
-endif()
-
-if (DRIVER_TYPE STREQUAL "NEW")
-  set(CATCH_TAGS "")
-endif()
-
-if (DEFINED ENV{CATCH_TAGS})
-  set(CATCH_TAGS $ENV{CATCH_TAGS})
-endif()
-
-message(STATUS "CATCH_TAGS: ${CATCH_TAGS}")
-
 # Find odbc library
 find_package(ODBC REQUIRED)
 message(STATUS "ODBC_INCLUDE_DIRS: ${ODBC_INCLUDE_DIRS}")

--- a/odbc_tests/CMakeLists.txt
+++ b/odbc_tests/CMakeLists.txt
@@ -17,6 +17,10 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+include(CTest)
+include(Catch)
+
 FetchContent_Declare(
   picojson
   GIT_REPOSITORY https://github.com/kazuho/picojson.git
@@ -57,8 +61,7 @@ function(add_odbc_test name)
   add_executable(${name} ${ARGN})
   target_link_libraries(${name} PRIVATE Catch2::Catch2WithMain ODBC::ODBC common)
   target_include_directories(${name} PRIVATE ${picojson_SOURCE_DIR})
-  add_test(NAME ${name} COMMAND ${name} ${CATCH_TAGS})
-  set_property(TEST ${name} PROPERTY SKIP_RETURN_CODE 4)
+  catch_discover_tests(${name} TEST_PREFIX "${name}: ")
 endfunction()
 
 add_subdirectory(tests)

--- a/odbc_tests/common/include/compatibility.hpp
+++ b/odbc_tests/common/include/compatibility.hpp
@@ -9,3 +9,13 @@ extern DRIVER_TYPE get_driver_type();
 #define NEW_DRIVER_ONLY(x) if (get_driver_type() == DRIVER_TYPE::NEW)
 
 #define OLD_DRIVER_ONLY(x) if (get_driver_type() == DRIVER_TYPE::OLD)
+
+#define SKIP_OLD_DRIVER(bd, message)                            \
+  if (get_driver_type() == DRIVER_TYPE::OLD) {                  \
+    SKIP("Skipping for old driver: " << bd << ": " << message); \
+  }
+
+#define SKIP_NEW_DRIVER(bd, message)                            \
+  if (get_driver_type() == DRIVER_TYPE::NEW) {                  \
+    SKIP("Skipping for new driver: " << bd << ": " << message); \
+  }

--- a/odbc_tests/tests/auth_tests/pat.cpp
+++ b/odbc_tests/tests/auth_tests/pat.cpp
@@ -104,7 +104,8 @@ std::string get_pat_as_token_connection_string(const std::string& pat_secret) {
 }
 
 // PAT Setup doesn't work with old ODBC driver.
-TEST_CASE("PAT Authentication - As Password", "[pat_auth][new_odbc]") {
+TEST_CASE("PAT Authentication - As Password", "[pat_auth]") {
+  SKIP_OLD_DRIVER("BD#8", "Old driver cannot create PATs - cannot retrieve token secret");
   INFO("Testing PAT authentication using token as password");
 
   Pat pat;
@@ -127,7 +128,8 @@ TEST_CASE("PAT Authentication - As Password", "[pat_auth][new_odbc]") {
 }
 
 // PAT Setup doesn't work with old ODBC driver.
-TEST_CASE("PAT Authentication - As Token", "[pat_auth][new_odbc]") {
+TEST_CASE("PAT Authentication - As Token", "[pat_auth]") {
+  SKIP_OLD_DRIVER("BD#8", "Old driver cannot create PATs - cannot retrieve token secret");
   INFO("Testing PAT authentication using PROGRAMMATIC_ACCESS_TOKEN authenticator");
 
   Pat pat;


### PR DESCRIPTION
Enable catch2 cmake integration:
- Enable test level filtering on cmake level
- Retire catch tag filtering for reference tests, use SKIP macro instead