### PR TITLE
[Draft in progress][POC] Add connection state machine POC

### DIFF
--- a/docs/CONNECTION_STATE_MACHINE.md
+++ b/docs/CONNECTION_STATE_MACHINE.md
@@ -1,27 +1,125 @@
 # Connection State Machine Design
 
-## Overview
+## 1. Motivation & Goal
 
-This document proposes an explicit, type-safe connection state machine for the universal-driver Rust core. The design addresses pain points observed in the Node.js Snowflake connector's state machine implementation while providing a clean, observable, and maintainable foundation for all driver wrappers.
+### The Fundamental Observation
 
-## Motivation: Problems with Node.js Implementation
+Analysis of all Snowflake drivers reveals a consistent pattern: **every driver is inherently stateful**. A connection exists in one of several distinct states, and the behavior of operations fundamentally changes depending on the current state.
 
-The current Node.js driver (`snowflake-connector-nodejs/lib/services/sf.js`) uses a state machine pattern with significant usability issues:
+| Driver | States Observed |
+|--------|-----------------|
+| Node.js | Pristine → Connecting → Connected → Renewing → Disconnected |
+| Python | Uninitialized → Connected → Closed (implicit via `_rest` object) |
+| JDBC | Similar lifecycle managed by connection pool |
+| Go | Connection state via `cn.rest` validity |
+| ODBC/C | Handle-based state (allocated → connected → closed) |
 
-| Problem | Description |
-|---------|-------------|
-| **Callback Mutation** | Options objects are mutated in place, callbacks wrapped inside callbacks |
-| **Hidden State** | `currentState` is a closure variable, not inspectable |
-| **No Observability** | No events/notifications when state changes |
-| **Unbounded Queue** | Pending operations queue has no limits or timeouts |
-| **`scope` Anti-Pattern** | Manual `this` binding via `scope` property |
-| **1600+ Line File** | All states, operations, and helpers in one file |
-| **No Types** | No TypeScript or JSDoc type annotations |
+Despite this universal pattern, **state management is implicit and scattered** across all implementations. Each driver handles state transitions ad-hoc, leading to subtle bugs, race conditions, and undefined behavior at state boundaries.
 
-### Example of Problematic Node.js Code
+### Goal
+
+Design an **explicit, type-safe connection state machine** for the universal-driver Rust core that:
+
+1. Makes connection state **visible and inspectable** at all times
+2. **Validates transitions** before they occur, rejecting invalid operations
+3. Provides **observability** through state change notifications
+4. Handles **concurrent access** safely during transient states
+5. Serves as a **single source of truth** for all language wrappers
+
+## 2. Problems This Design Addresses
+
+### 2.1 Session Renewal Storm
+
+**Problem:** When multiple concurrent queries receive `SessionExpired` errors simultaneously, each may independently attempt to renew the session token.
+
+```
+Query A: SessionExpired → tries to renew
+Query B: SessionExpired → tries to renew  
+Query C: SessionExpired → tries to renew
+                   ↓
+      3 parallel renewal requests to Snowflake
+      (only 1 is needed, 2 are wasted + potential conflicts)
+```
+
+**Solution:** The state machine transitions to `Renewing` atomically. Subsequent queries detecting expiration see the state is already `Renewing` and wait on the pending operations queue instead of initiating their own renewal.
+
+### 2.2 Token Access Race Condition
+
+**Problem:** A critical security issue in multi-tenant pooled environments:
+
+```
+Time T0: User closes connection → close() starts deleting tokens
+Time T1: Renewal goroutine/task completes → assigns NEW tokens to connection
+Time T2: close() completes → connection returned to pool WITH new tokens
+Time T3: New tenant gets connection → authenticates as PREVIOUS user!
+```
+
+**Solution:** The state machine enforces that token operations are only valid in appropriate states:
+- `Renewing` → Can update tokens
+- `Disconnected` → Token updates rejected
+- State transition to `Disconnected` invalidates any in-flight renewal results
+
+### 2.3 Operations During Transient States
+
+**Problem:** What happens when a query is submitted while the connection is:
+- Still connecting?
+- In the middle of token renewal?
+- Being closed?
+
+Current drivers handle this inconsistently—some queue silently, some fail with cryptic errors, some exhibit undefined behavior.
+
+**Solution:** Explicit queuing with visibility:
+- `Connecting` / `Renewing` → Operations queued with timeout
+- `Disconnected` → Operations rejected with clear reason
+- `Pristine` → Operations rejected ("connection not initialized")
+
+### 2.4 Query Execution in Closing Session
+
+**Problem:** A query starts executing, then `close()` is called. The query may:
+- Continue running server-side with no way to cancel
+- Fail with confusing "connection closed" error mid-execution
+- Leave resources dangling
+
+**Solution:** State transition to `Disconnected` propagates to all waiters:
+- Pending operations receive `ConnectionDisconnected` error with reason
+- In-flight operations can check state and abort cleanly
+- Clear distinction between "user initiated close" vs "error disconnection"
+
+## 3. Previous Attempt Analysis: Node.js Driver
+
+The Node.js Snowflake connector (`snowflake-connector-nodejs/lib/services/sf.js`) implemented an explicit state machine pattern. While architecturally sound in concept, the implementation suffered from several issues that made it difficult to work with.
+
+### 3.1 What Was Attempted
+
+The Node.js driver defined explicit states and a `transitionTo()` function:
 
 ```javascript
-// Node.js: Callback mutation hell
+var Pristine = 0, Connecting = 1, Connected = 2, Renewing = 3, Disconnected = 4;
+
+function transitionTo(connection, nextState, args) {
+  var connectionConfig = connection.getConfig();
+  currentState = states[nextState];
+  currentState.enter.apply(currentState, args);
+}
+```
+
+### 3.2 Why It Didn't Work
+
+| Issue | Description | Impact |
+|-------|-------------|--------|
+| **Hidden State** | `currentState` stored in closure, not inspectable | Impossible to debug or observe |
+| **No Transition Validation** | Any state could theoretically transition to any other | Silent corruption |
+| **Callback Mutation** | Options objects mutated in place during operations | Unexpected side effects |
+| **Unbounded Queue** | Pending operations array with no limits or timeouts | Memory leaks, hangs |
+| **`scope` Anti-Pattern** | Manual `this` binding via `scope` property | Confusing, error-prone |
+| **1600+ Line Monolith** | All states, operations, queue logic in one file | Unmaintainable |
+| **No Types** | Pure JavaScript with no type annotations | Runtime errors only |
+| **Callback Hell** | Deep nesting of wrapped callbacks | Unreadable flow |
+
+### 3.3 Example of Problematic Code
+
+```javascript
+// The infamous callback mutation pattern
 StateConnected.prototype.request = function (options) {
   const scopeOrig = options.scope;
   const callbackOrig = options.callback;
@@ -31,71 +129,85 @@ StateConnected.prototype.request = function (options) {
     if (!err) {
       await callbackOrig.apply(scopeOrig, [err, body]);
     } else {
-      options.scope = scopeOrig;           // RESTORES on error!
+      options.scope = scopeOrig;           // RESTORES on error path!
       options.callback = callbackOrig;
-      // ... handle errors
+      // ... complex error handling
     }
   };
 };
 ```
 
-## Proposed Solution: Explicit Rust State Machine
+### 3.4 Lessons Learned
 
-### Design Principles
+1. **Explicit state is necessary but not sufficient** — the implementation must also be clean
+2. **Transition validation must be enforced**, not advisory
+3. **Queuing needs bounds and timeouts** to prevent resource exhaustion
+4. **State must be observable** for debugging and monitoring
+5. **Type safety catches errors early** — before production
 
-1. **Explicit State Enum** - State is a real type, not hidden in closures
-2. **Validated Transitions** - Invalid state changes are compile/runtime errors
-3. **Observable** - Broadcast channel for state change notifications
-4. **Bounded Queuing** - Pending operations have timeouts and limits
-5. **Type-Safe Errors** - `snafu` errors with automatic source location
-6. **Async-First** - Native `async/await`, no callback wrapping
-7. **Reconnection Support** - Can reconnect from certain disconnected states
+## 4. Proposed Solution: Rust State Machine
 
-### State Diagram
+### 4.1 Design Principles
+
+| Principle | Implementation |
+|-----------|----------------|
+| Explicit State | `ConnectionState` enum with variants |
+| Validated Transitions | `Result<(), StateMachineError>` on every transition |
+| Observable | `tokio::sync::broadcast` for state change events |
+| Bounded Queuing | Max queue size + operation timeouts |
+| Type-Safe Errors | `snafu` errors with automatic source location |
+| Async-First | Native `async/await`, no callback wrapping |
+| Reconnection Support | Conditional reconnect based on disconnect reason |
+
+### 4.2 State Diagram
 
 ```
-                                    ┌──────────────────────────────┐
-                                    │                              │
-    ┌──────────┐     connect()     ┌▼───────────┐    success    ┌──────────┐
-    │ Pristine │ ────────────────▶ │ Connecting │ ────────────▶ │Connected │
-    └──────────┘                   └─────────────┘              └──────────┘
-                                         │                       │  │    ▲
-                                         │ failure               │  │    │
-                                         ▼                       │  │    │
-    ┌─────────────────────────────────────────────────────────┐  │  │    │
-    │              Disconnected { reason }                     │◀─┘  │    │
-    │  ┌─────────────────────────────────────────────────┐    │     │    │
-    │  │ UserInitiated      → can_reconnect() = true     │    │     │    │
-    │  │ MasterTokenExpired → can_reconnect() = true     │    │     │    │
-    │  │ LoginFailed        → can_reconnect() = true     │    │     │    │
-    │  │ InternalError      → can_reconnect() = false    │    │     │    │
-    │  └─────────────────────────────────────────────────┘    │     │    │
-    └─────────────────────────────────────────────────────────┘     │    │
-         │                                                          │    │
-         │ connect() if can_reconnect()                             │    │
-         └──────────────────────────────────────────────────────────┼────┘
-                                                                    │
-    ┌──────────┐  session token expired  ◀──────────────────────────┘
-    │ Renewing │────────────────────────────────────────────────────────▶
-    └──────────┘                    success (back to Connected)
+                                    ┌──────────────────────────────────┐
+                                    │                                  │
+    ┌──────────┐     connect()     ┌▼───────────┐    success     ┌──────────┐
+    │ Pristine │ ────────────────▶ │ Connecting │ ─────────────▶ │Connected │ ◀──────────┐  
+    └──────────┘                   └────────────┘                └──────────┘            │
+                                         │                        │  │    ▲              │
+                                         │ failure                │  │    │              │
+                                         ▼                        │  │    │ token        │
+    ┌─────────────────────────────────────────────────────────┐   │  │    │ refresh      │
+    │              Disconnected { reason }                    │◀──┘  │    │ success      │
+    │  ┌─────────────────────────────────────────────────┐    │      │    │              │
+    │  │ UserInitiated      → can_reconnect() = true     │    │      │    │              │
+    │  │ MasterTokenExpired → can_reconnect() = true     │    │      │    │              │
+    │  │ LoginFailed        → can_reconnect() = true     │    │      │    │              │
+    │  │ InternalError      → can_reconnect() = false    │    │      │    │              │
+    │  └─────────────────────────────────────────────────┘    │      │    │              │
+    └─────────────────────────────────────────────────────────┘      │    │              │
+         │                                                           │    │              │
+         │ connect() [if can_reconnect()]                            │    │              │
+         └───────────────────────────────────────────────────────────┼────┘              │
+                                                                     │                   │
+    ┌──────────┐  session token near expiry  ◀───────────────────────┘                   │
+    │ Renewing │ ────────────────────────────────────────────────────────────────────────┘
+    └──────────┘                     success (back to Connected)
+          │
+          │ master token expired / error
+          ▼
+    Disconnected { MasterTokenExpired | InternalError }
 ```
 
-### Valid State Transitions
+### 4.3 Valid State Transitions
 
-| From | To | Condition |
-|------|-----|-----------|
-| `Pristine` | `Connecting` | Always |
-| `Connecting` | `Connected` | Login success |
-| `Connecting` | `Disconnected` | Login failure |
-| `Connected` | `Renewing` | Session token expired |
-| `Connected` | `Disconnected` | User close or error |
-| `Renewing` | `Connected` | Token refresh success |
-| `Renewing` | `Disconnected` | Master token expired or error |
-| `Disconnected` | `Connecting` | **Only if `reason.can_reconnect()`** |
+| From | To | Trigger | Pending Ops Behavior |
+|------|-----|---------|---------------------|
+| `Pristine` | `Connecting` | `connect()` called | Queue starts accepting |
+| `Connecting` | `Connected` | Login success | Queue drained (ready) |
+| `Connecting` | `Disconnected` | Login failure | Queue drained (error) |
+| `Connected` | `Renewing` | Token near expiry | Queue starts accepting |
+| `Connected` | `Disconnected` | User close or error | Queue drained (error) |
+| `Renewing` | `Connected` | Token refresh success | Queue drained (ready) |
+| `Renewing` | `Disconnected` | Master expired / error | Queue drained (error) |
+| `Disconnected` | `Connecting` | `connect()` if `can_reconnect()` | Queue starts accepting |
 
-### Key Components
+### 4.4 Key Components
 
-#### 1. ConnectionState Enum
+#### ConnectionState Enum
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,7 +220,7 @@ pub enum ConnectionState {
 }
 ```
 
-#### 2. DisconnectReason with Reconnection Logic
+#### DisconnectReason with Reconnection Logic
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,55 +232,123 @@ pub enum DisconnectReason {
 }
 
 impl DisconnectReason {
+    /// Only InternalError prevents reconnection
     pub fn can_reconnect(&self) -> bool {
         !matches!(self, DisconnectReason::InternalError { .. })
     }
 }
 ```
 
-#### 3. ConnectionStateMachine
-
-- Holds current state in `Arc<RwLock<ConnectionState>>`
-- Validates transitions before applying
-- Broadcasts state changes via `tokio::sync::broadcast`
-- Manages pending operations queue with timeouts
-
-#### 4. PendingOperation Queue
-
-When in `Connecting` or `Renewing` states, requests are queued:
+#### ConnectionStateMachine
 
 ```rust
-struct PendingOperation {
-    ready_tx: oneshot::Sender<Result<(), ApiError>>,
-    queued_at: Instant,
-    timeout: Duration,
-    description: String,
+pub struct ConnectionStateMachine {
+    /// Current state behind async RwLock
+    state: Arc<RwLock<ConnectionState>>,
+    /// Broadcast channel for state change notifications  
+    state_tx: broadcast::Sender<ConnectionState>,
+    /// Pending operations queue (bounded)
+    pending_ops: Arc<RwLock<PendingOperationsQueue>>,
 }
 ```
 
-- When state becomes `Connected`, all pending ops are signaled
-- When state becomes `Disconnected`, all pending ops receive errors
-- Operations time out if state doesn't change within their deadline
+#### PendingOperation Queue
 
-## Integration with Existing Code
+```rust
+struct PendingOperation {
+    ready_tx: oneshot::Sender<Result<()>>,
+    queued_at: Instant,
+    description: String,
+}
 
-### Current `with_valid_session` Function
+struct PendingOperationsQueue {
+    queue: Vec<PendingOperation>,
+    // MAX_PENDING_OPS = 1000 (configurable)
+}
+```
 
-The existing `connection.rs` already has a `with_valid_session` helper that handles token refresh. The state machine enhances this by:
+## 5. How This Addresses Each Problem
 
-1. Adding explicit state tracking
-2. Providing state change observability
-3. Handling queuing during transient states
+### Session Renewal Storm
 
-### Protobuf API Extension (Optional)
+```rust
+// In with_valid_session():
+match self.state_machine.state().await {
+    ConnectionState::Connected => {
+        // Check if token needs refresh
+        if session_tokens.needs_refresh() {
+            // Atomic transition - only first caller wins
+            self.state_machine.start_renewing().await?;
+            // Others will see Renewing and wait
+        }
+    }
+    ConnectionState::Renewing => {
+        // Already renewing - just wait
+        self.state_machine.wait_ready(timeout).await?;
+    }
+    // ...
+}
+```
+
+### Token Access Race
+
+```rust
+// Renewal completion checks state before applying tokens
+pub async fn complete_renewal(&self, new_tokens: SessionTokens) -> Result<()> {
+    let state = self.state_machine.state().await;
+    match state {
+        ConnectionState::Renewing => {
+            // Safe to apply tokens
+            self.session_tokens.write().await.replace(new_tokens);
+            self.state_machine.renewal_complete().await?;
+        }
+        ConnectionState::Disconnected { .. } => {
+            // Connection was closed during renewal - discard tokens!
+            tracing::warn!("Discarding renewed tokens - connection already closed");
+            return Err(StateMachineError::ConnectionDisconnected { ... });
+        }
+        _ => {
+            return Err(StateMachineError::InvalidStateForRenewal { ... });
+        }
+    }
+}
+```
+
+### Query Execution in Closing Session
+
+```rust
+// Before executing query:
+self.state_machine.wait_ready(timeout).await?;
+
+// If close() is called during execution:
+// - State transitions to Disconnected { UserInitiated }
+// - All pending operations receive ConnectionDisconnected error
+// - Error includes reason, enabling clean abort
+```
+
+## 6. Comparison: Implicit vs. Explicit State Machine
+
+| Aspect | Implicit (Current Drivers) | Explicit (Proposed) |
+|--------|---------------------------|---------------------|
+| State visibility | Hidden in variables/flags | Inspectable enum |
+| Invalid transitions | Silent/undefined behavior | Compile/runtime error |
+| Concurrent access | Race conditions | `Arc<RwLock>` protected |
+| Renewal coordination | Multiple storms possible | Single renewal, others wait |
+| Token lifecycle | Race-prone | State-gated updates |
+| Observability | None | `broadcast::Receiver` |
+| Debugging | "Why did this fail?" | Clear state + transition log |
+
+## 7. Integration with Protobuf API
 
 ```protobuf
+// Expose state to language wrappers
 message ConnectionGetStateRequest {
   ConnectionHandle conn_handle = 1;
 }
 
 message ConnectionGetStateResponse {
   ConnectionState state = 1;
+  optional string disconnect_reason = 2;  // If disconnected
 }
 
 enum ConnectionState {
@@ -181,65 +361,65 @@ enum ConnectionState {
 }
 ```
 
-## Comparison: Node.js vs. Rust
+## 8. Files in This POC
 
-| Aspect | Node.js | Rust (Proposed) |
-|--------|---------|-----------------|
-| State representation | Closure variable | Explicit enum |
-| Transitions | Hidden function calls | Validated Result<> |
-| Invalid transitions | Silent/undefined | Compile/runtime error |
-| Observability | None | `broadcast::Receiver` |
-| Request queuing | Unbounded array | Bounded with timeout |
-| Concurrency | Callback hell | `async/await` |
-| Error handling | Inconsistent | Typed `snafu` |
-| Code organization | 1600-line file | Separate modules |
+| File | Purpose |
+|------|---------|
+| `sf_core/src/connection_state/mod.rs` | Module root and re-exports |
+| `sf_core/src/connection_state/state.rs` | `ConnectionState` and `DisconnectReason` enums |
+| `sf_core/src/connection_state/machine.rs` | `ConnectionStateMachine` implementation |
+| `sf_core/src/connection_state/pending_ops.rs` | Bounded pending operations queue |
+| `sf_core/src/connection_state/error.rs` | `StateMachineError` with `snafu` |
 
-## Files in This POC
-
-- `sf_core/src/connection_state/mod.rs` - Main state machine module
-- `sf_core/src/connection_state/state.rs` - State enum and transitions
-- `sf_core/src/connection_state/machine.rs` - State machine implementation
-- `sf_core/src/connection_state/pending_ops.rs` - Pending operations queue
-- `sf_core/src/connection_state/error.rs` - State-specific errors
-
-## Usage Example
+## 9. Usage Example
 
 ```rust
 use sf_core::connection_state::{ConnectionStateMachine, ConnectionState};
+use std::time::Duration;
 
 // Create state machine
 let sm = ConnectionStateMachine::new();
 
-// Subscribe to state changes
+// Subscribe to state changes (for monitoring/debugging)
 let mut rx = sm.subscribe();
 tokio::spawn(async move {
     while let Ok(state) = rx.recv().await {
-        println!("State changed to: {:?}", state);
+        tracing::info!("Connection state: {:?}", state);
     }
 });
 
-// Transition to Connecting
-sm.transition(ConnectionState::Connecting).await?;
+// Start connecting
+sm.start_connecting().await?;
 
-// Wait for connection to be ready (blocks if Connecting/Renewing)
+// ... perform login ...
+
+// Signal connection established
+sm.connection_established().await?;
+
+// Operations wait if not ready
 sm.wait_ready(Duration::from_secs(30)).await?;
 
-// Check current state
-let state = sm.state().await;
-assert!(state.is_ready());
+// Check state programmatically
+assert!(sm.state().await.is_ready());
+
+// Close connection
+sm.close().await?;
+
+// Can reconnect if reason permits
+sm.start_connecting().await?;  // OK - UserInitiated allows reconnect
 ```
 
-## Next Steps
+## 10. Next Steps
 
-1. Review POC implementation
-2. Integrate with existing `Connection` struct
-3. Update `with_valid_session` to use state machine
-4. Add protobuf API for state queries
-5. Write integration tests
-6. Document migration path for existing code
+1. **Review** - Gather feedback on this design
+2. **Integrate** - Wire `ConnectionStateMachine` into existing `Connection` struct
+3. **Update `with_valid_session`** - Use state machine for renewal coordination
+4. **Protobuf API** - Expose state queries to language wrappers
+5. **Integration Tests** - Test concurrent scenarios (renewal storm, close during query)
+6. **Documentation** - Migration guide for existing code
 
 ## References
 
-- Node.js driver: `drivers/snowflake-connector-nodejs/lib/services/sf.js`
-- Current Rust connection: `sf_core/src/apis/database_driver_v1/connection.rs`
+- Node.js driver analysis: `drivers/snowflake-connector-nodejs/lib/services/sf.js`
 - Python driver reconnection: `drivers/snowflake-connector-python/src/snowflake/connector/connection.py`
+- Current Rust connection: `sf_core/src/apis/database_driver_v1/connection.rs`

--- a/docs/CONNECTION_STATE_MACHINE.md
+++ b/docs/CONNECTION_STATE_MACHINE.md
@@ -26,7 +26,80 @@ Design an **explicit, type-safe connection state machine** for the universal-dri
 4. Handles **concurrent access** safely during transient states
 5. Serves as a **single source of truth** for all language wrappers
 
-## 2. Problems This Design Addresses
+## 2. Architecture Overview
+
+### Internal vs. External API
+
+The `ConnectionStateMachine` is an **internal implementation detail** of the Rust core. Language wrappers and end users interact with a simple, familiar API:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Language Wrapper (Python / Node.js / ODBC / etc.)                          │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │  User Code                                                            │  │
+│  │    conn = snowflake.connect(...)                                      │  │
+│  │    cursor = conn.cursor()                                             │  │
+│  │    cursor.execute("SELECT ...")                                       │  │
+│  │    conn.close()                                                       │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+│                              │                                              │
+│                              ▼                                              │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │  Simple Wrapper API: connect(), execute(), close(), get_state()       │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+                               │
+                               │ Protobuf
+                               ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Rust Core (sf_core)                                                        │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │  ConnectionStateMachine (INTERNAL)                                    │  │
+│  │    - Tracks current state                                             │  │
+│  │    - Validates transitions                                            │  │
+│  │    - Manages pending operations queue                                 │  │
+│  │    - Broadcasts state changes                                         │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+│                              │                                              │
+│                              │ State determines behavior                    │
+│                              ▼                                              │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │  Operation Handlers                                                   │  │
+│  │    - Login flow                                                       │  │
+│  │    - Query execution                                                  │  │
+│  │    - Session token renewal                                            │  │
+│  │    - Connection close                                                 │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Principle: State Determines Behavior
+
+The wrapper API remains simple—users call `connect()`, `execute()`, `close()`. **Internally**, the Rust core uses the state machine to decide **how** to handle each operation:
+
+| Wrapper Call | Internal State | Core Behavior |
+|--------------|----------------|---------------|
+| `execute()` | `Pristine` | Error: "connection not initialized" |
+| `execute()` | `Connecting` | Queue operation, wait until connected (with timeout) |
+| `execute()` | `Connected` | Execute immediately |
+| `execute()` | `Renewing` | Queue operation, wait until renewed (with timeout) |
+| `execute()` | `Disconnected` | Error with disconnect reason |
+| `close()` | Any | Transition to `Disconnected`, drain queues with error |
+| `connect()` | `Pristine` | Start connecting |
+| `connect()` | `Disconnected` | Reconnect if `reason.can_reconnect()` |
+| `connect()` | Other | Error: "already connected/connecting" |
+
+### Optional State Exposure via Protobuf
+
+While the state machine is internal, we expose a **read-only state query** via protobuf. This allows users to:
+
+- Check if a connection is closed before attempting operations
+- Implement connection health monitoring
+- Debug connection lifecycle issues
+
+The exposed API is intentionally limited—users **cannot** directly manipulate state transitions.
+
+## 3. Problems This Design Addresses
 
 ### 2.1 Session Renewal Storm
 
@@ -85,7 +158,7 @@ Current drivers handle this inconsistently—some queue silently, some fail with
 - In-flight operations can check state and abort cleanly
 - Clear distinction between "user initiated close" vs "error disconnection"
 
-## 3. Previous Attempt Analysis: Node.js Driver
+## 4. Previous Attempt Analysis: Node.js Driver
 
 The Node.js Snowflake connector (`snowflake-connector-nodejs/lib/services/sf.js`) implemented an explicit state machine pattern. While architecturally sound in concept, the implementation suffered from several issues that made it difficult to work with.
 
@@ -145,7 +218,7 @@ StateConnected.prototype.request = function (options) {
 4. **State must be observable** for debugging and monitoring
 5. **Type safety catches errors early** — before production
 
-## 4. Proposed Solution: Rust State Machine
+## 5. Proposed Solution: Rust State Machine
 
 ### 4.1 Design Principles
 
@@ -189,7 +262,9 @@ StateConnected.prototype.request = function (options) {
           │
           │ master token expired / error
           ▼
+  ┌──────────────┐ 
     Disconnected { MasterTokenExpired | InternalError }
+  └──────────────┘
 ```
 
 ### 4.3 Valid State Transitions
@@ -267,7 +342,7 @@ struct PendingOperationsQueue {
 }
 ```
 
-## 5. How This Addresses Each Problem
+## 6. How This Addresses Each Problem
 
 ### Session Renewal Storm
 
@@ -326,7 +401,7 @@ self.state_machine.wait_ready(timeout).await?;
 // - Error includes reason, enabling clean abort
 ```
 
-## 6. Comparison: Implicit vs. Explicit State Machine
+## 7. Comparison: Implicit vs. Explicit State Machine
 
 | Aspect | Implicit (Current Drivers) | Explicit (Proposed) |
 |--------|---------------------------|---------------------|
@@ -338,17 +413,37 @@ self.state_machine.wait_ready(timeout).await?;
 | Observability | None | `broadcast::Receiver` |
 | Debugging | "Why did this fail?" | Clear state + transition log |
 
-## 7. Integration with Protobuf API
+## 8. Protobuf API: Read-Only State Exposure
+
+While the state machine is an internal implementation detail, we expose connection state via protobuf as a **read-only query**. This serves specific use cases without exposing internal complexity:
+
+### Use Cases
+
+| Use Case | Example |
+|----------|---------|
+| **Connection Health Check** | Check if connection is still valid before expensive operation |
+| **Pool Management** | Wrapper-level connection pools can check state before returning connections |
+| **Debugging** | Users can inspect why operations fail ("connection was closing") |
+| **Monitoring** | Track connection lifecycle for observability dashboards |
+
+### What Is NOT Exposed
+
+- Direct state transitions (users cannot force state changes)
+- Pending operations queue details
+- Internal broadcast channels
+
+### Protobuf Definition
 
 ```protobuf
-// Expose state to language wrappers
+// Read-only state query - users can check but not modify state
 message ConnectionGetStateRequest {
   ConnectionHandle conn_handle = 1;
 }
 
 message ConnectionGetStateResponse {
   ConnectionState state = 1;
-  optional string disconnect_reason = 2;  // If disconnected
+  optional string disconnect_reason = 2;  // Populated if state == DISCONNECTED
+  bool can_reconnect = 3;                 // Whether reconnect() would succeed
 }
 
 enum ConnectionState {
@@ -361,7 +456,26 @@ enum ConnectionState {
 }
 ```
 
-## 8. Files in This POC
+### Wrapper Usage Example
+
+```python
+# Python wrapper example
+conn = snowflake.connect(...)
+
+# User can check state if needed
+state = conn.get_state()
+if state == ConnectionState.DISCONNECTED:
+    if conn.can_reconnect():
+        conn.connect()  # Reconnect
+    else:
+        raise Error("Connection permanently closed")
+
+# But most users just call operations directly
+# and let the core handle state internally
+cursor.execute("SELECT 1")  # Core handles queuing/errors based on state
+```
+
+## 9. Files in This POC
 
 | File | Purpose |
 |------|---------|
@@ -371,7 +485,7 @@ enum ConnectionState {
 | `sf_core/src/connection_state/pending_ops.rs` | Bounded pending operations queue |
 | `sf_core/src/connection_state/error.rs` | `StateMachineError` with `snafu` |
 
-## 9. Usage Example
+## 10. Usage Example
 
 ```rust
 use sf_core::connection_state::{ConnectionStateMachine, ConnectionState};
@@ -409,7 +523,7 @@ sm.close().await?;
 sm.start_connecting().await?;  // OK - UserInitiated allows reconnect
 ```
 
-## 10. Next Steps
+## 11. Next Steps
 
 1. **Review** - Gather feedback on this design
 2. **Integrate** - Wire `ConnectionStateMachine` into existing `Connection` struct
@@ -417,9 +531,3 @@ sm.start_connecting().await?;  // OK - UserInitiated allows reconnect
 4. **Protobuf API** - Expose state queries to language wrappers
 5. **Integration Tests** - Test concurrent scenarios (renewal storm, close during query)
 6. **Documentation** - Migration guide for existing code
-
-## References
-
-- Node.js driver analysis: `drivers/snowflake-connector-nodejs/lib/services/sf.js`
-- Python driver reconnection: `drivers/snowflake-connector-python/src/snowflake/connector/connection.py`
-- Current Rust connection: `sf_core/src/apis/database_driver_v1/connection.rs`

--- a/docs/CONNECTION_STATE_MACHINE.md
+++ b/docs/CONNECTION_STATE_MACHINE.md
@@ -1,0 +1,245 @@
+# Connection State Machine Design
+
+## Overview
+
+This document proposes an explicit, type-safe connection state machine for the universal-driver Rust core. The design addresses pain points observed in the Node.js Snowflake connector's state machine implementation while providing a clean, observable, and maintainable foundation for all driver wrappers.
+
+## Motivation: Problems with Node.js Implementation
+
+The current Node.js driver (`snowflake-connector-nodejs/lib/services/sf.js`) uses a state machine pattern with significant usability issues:
+
+| Problem | Description |
+|---------|-------------|
+| **Callback Mutation** | Options objects are mutated in place, callbacks wrapped inside callbacks |
+| **Hidden State** | `currentState` is a closure variable, not inspectable |
+| **No Observability** | No events/notifications when state changes |
+| **Unbounded Queue** | Pending operations queue has no limits or timeouts |
+| **`scope` Anti-Pattern** | Manual `this` binding via `scope` property |
+| **1600+ Line File** | All states, operations, and helpers in one file |
+| **No Types** | No TypeScript or JSDoc type annotations |
+
+### Example of Problematic Node.js Code
+
+```javascript
+// Node.js: Callback mutation hell
+StateConnected.prototype.request = function (options) {
+  const scopeOrig = options.scope;
+  const callbackOrig = options.callback;
+
+  options.scope = this;                    // MUTATES input!
+  options.callback = async function (err, body) {  // REPLACES callback!
+    if (!err) {
+      await callbackOrig.apply(scopeOrig, [err, body]);
+    } else {
+      options.scope = scopeOrig;           // RESTORES on error!
+      options.callback = callbackOrig;
+      // ... handle errors
+    }
+  };
+};
+```
+
+## Proposed Solution: Explicit Rust State Machine
+
+### Design Principles
+
+1. **Explicit State Enum** - State is a real type, not hidden in closures
+2. **Validated Transitions** - Invalid state changes are compile/runtime errors
+3. **Observable** - Broadcast channel for state change notifications
+4. **Bounded Queuing** - Pending operations have timeouts and limits
+5. **Type-Safe Errors** - `snafu` errors with automatic source location
+6. **Async-First** - Native `async/await`, no callback wrapping
+7. **Reconnection Support** - Can reconnect from certain disconnected states
+
+### State Diagram
+
+```
+                                    ┌──────────────────────────────┐
+                                    │                              │
+    ┌──────────┐     connect()     ┌▼───────────┐    success    ┌──────────┐
+    │ Pristine │ ────────────────▶ │ Connecting │ ────────────▶ │Connected │
+    └──────────┘                   └─────────────┘              └──────────┘
+                                         │                       │  │    ▲
+                                         │ failure               │  │    │
+                                         ▼                       │  │    │
+    ┌─────────────────────────────────────────────────────────┐  │  │    │
+    │              Disconnected { reason }                     │◀─┘  │    │
+    │  ┌─────────────────────────────────────────────────┐    │     │    │
+    │  │ UserInitiated      → can_reconnect() = true     │    │     │    │
+    │  │ MasterTokenExpired → can_reconnect() = true     │    │     │    │
+    │  │ LoginFailed        → can_reconnect() = true     │    │     │    │
+    │  │ InternalError      → can_reconnect() = false    │    │     │    │
+    │  └─────────────────────────────────────────────────┘    │     │    │
+    └─────────────────────────────────────────────────────────┘     │    │
+         │                                                          │    │
+         │ connect() if can_reconnect()                             │    │
+         └──────────────────────────────────────────────────────────┼────┘
+                                                                    │
+    ┌──────────┐  session token expired  ◀──────────────────────────┘
+    │ Renewing │────────────────────────────────────────────────────────▶
+    └──────────┘                    success (back to Connected)
+```
+
+### Valid State Transitions
+
+| From | To | Condition |
+|------|-----|-----------|
+| `Pristine` | `Connecting` | Always |
+| `Connecting` | `Connected` | Login success |
+| `Connecting` | `Disconnected` | Login failure |
+| `Connected` | `Renewing` | Session token expired |
+| `Connected` | `Disconnected` | User close or error |
+| `Renewing` | `Connected` | Token refresh success |
+| `Renewing` | `Disconnected` | Master token expired or error |
+| `Disconnected` | `Connecting` | **Only if `reason.can_reconnect()`** |
+
+### Key Components
+
+#### 1. ConnectionState Enum
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionState {
+    Pristine,
+    Connecting,
+    Connected,
+    Renewing,
+    Disconnected { reason: DisconnectReason },
+}
+```
+
+#### 2. DisconnectReason with Reconnection Logic
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisconnectReason {
+    UserInitiated,
+    MasterTokenExpired,
+    LoginFailed { code: i32, message: String },
+    InternalError { message: String },
+}
+
+impl DisconnectReason {
+    pub fn can_reconnect(&self) -> bool {
+        !matches!(self, DisconnectReason::InternalError { .. })
+    }
+}
+```
+
+#### 3. ConnectionStateMachine
+
+- Holds current state in `Arc<RwLock<ConnectionState>>`
+- Validates transitions before applying
+- Broadcasts state changes via `tokio::sync::broadcast`
+- Manages pending operations queue with timeouts
+
+#### 4. PendingOperation Queue
+
+When in `Connecting` or `Renewing` states, requests are queued:
+
+```rust
+struct PendingOperation {
+    ready_tx: oneshot::Sender<Result<(), ApiError>>,
+    queued_at: Instant,
+    timeout: Duration,
+    description: String,
+}
+```
+
+- When state becomes `Connected`, all pending ops are signaled
+- When state becomes `Disconnected`, all pending ops receive errors
+- Operations time out if state doesn't change within their deadline
+
+## Integration with Existing Code
+
+### Current `with_valid_session` Function
+
+The existing `connection.rs` already has a `with_valid_session` helper that handles token refresh. The state machine enhances this by:
+
+1. Adding explicit state tracking
+2. Providing state change observability
+3. Handling queuing during transient states
+
+### Protobuf API Extension (Optional)
+
+```protobuf
+message ConnectionGetStateRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionGetStateResponse {
+  ConnectionState state = 1;
+}
+
+enum ConnectionState {
+  CONNECTION_STATE_UNSPECIFIED = 0;
+  CONNECTION_STATE_PRISTINE = 1;
+  CONNECTION_STATE_CONNECTING = 2;
+  CONNECTION_STATE_CONNECTED = 3;
+  CONNECTION_STATE_RENEWING = 4;
+  CONNECTION_STATE_DISCONNECTED = 5;
+}
+```
+
+## Comparison: Node.js vs. Rust
+
+| Aspect | Node.js | Rust (Proposed) |
+|--------|---------|-----------------|
+| State representation | Closure variable | Explicit enum |
+| Transitions | Hidden function calls | Validated Result<> |
+| Invalid transitions | Silent/undefined | Compile/runtime error |
+| Observability | None | `broadcast::Receiver` |
+| Request queuing | Unbounded array | Bounded with timeout |
+| Concurrency | Callback hell | `async/await` |
+| Error handling | Inconsistent | Typed `snafu` |
+| Code organization | 1600-line file | Separate modules |
+
+## Files in This POC
+
+- `sf_core/src/connection_state/mod.rs` - Main state machine module
+- `sf_core/src/connection_state/state.rs` - State enum and transitions
+- `sf_core/src/connection_state/machine.rs` - State machine implementation
+- `sf_core/src/connection_state/pending_ops.rs` - Pending operations queue
+- `sf_core/src/connection_state/error.rs` - State-specific errors
+
+## Usage Example
+
+```rust
+use sf_core::connection_state::{ConnectionStateMachine, ConnectionState};
+
+// Create state machine
+let sm = ConnectionStateMachine::new();
+
+// Subscribe to state changes
+let mut rx = sm.subscribe();
+tokio::spawn(async move {
+    while let Ok(state) = rx.recv().await {
+        println!("State changed to: {:?}", state);
+    }
+});
+
+// Transition to Connecting
+sm.transition(ConnectionState::Connecting).await?;
+
+// Wait for connection to be ready (blocks if Connecting/Renewing)
+sm.wait_ready(Duration::from_secs(30)).await?;
+
+// Check current state
+let state = sm.state().await;
+assert!(state.is_ready());
+```
+
+## Next Steps
+
+1. Review POC implementation
+2. Integrate with existing `Connection` struct
+3. Update `with_valid_session` to use state machine
+4. Add protobuf API for state queries
+5. Write integration tests
+6. Document migration path for existing code
+
+## References
+
+- Node.js driver: `drivers/snowflake-connector-nodejs/lib/services/sf.js`
+- Current Rust connection: `sf_core/src/apis/database_driver_v1/connection.rs`
+- Python driver reconnection: `drivers/snowflake-connector-python/src/snowflake/connector/connection.py`

--- a/docs/QUERY_FLOWS_DD.md
+++ b/docs/QUERY_FLOWS_DD.md
@@ -556,48 +556,262 @@ for {
 
 ## 7. Proposed Service Architecture
 
-### 7.1 Architecture Diagram
+### 7.1 Service Responsibility Matrix
+
+> **Design Question**: Should `login()` be in `SessionService` instead of `AuthService`?
+> 
+> **Analysis**: Looking at the old drivers, login is tightly coupled with session lifecycle:
+> - Login creates a session (returns session token + master token)
+> - Heartbeat maintains the session
+> - Refresh renews the session
+> - Logout destroys the session
+> 
+> **Recommendation**: Merge into a single `SessionService` that manages the full session lifecycle.
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                              Connection                                      │
-│  ┌───────────────────────────────────────────────────────────────────────┐  │
-│  │                        ServiceContainer                                │  │
-│  │   ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │  │
-│  │   │ AuthService │  │SessionService│  │QueryService │  │StorageService│  │
-│  │   └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │  │
-│  └───────────────────────────────────────────────────────────────────────┘  │
-│                                    │                                         │
-│                        ConnectionStateMachine                                │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                       │
-                                       ▼
-                    ┌─────────────────────────────────────┐
-                    │         HttpClient (trait)          │
-                    │  request(method, url, headers, body)│
-                    └─────────────────────────────────────┘
-                                       │
-                    ┌──────────────────┴──────────────────┐
-                    ▼                                     ▼
-         ┌─────────────────────┐              ┌─────────────────────┐
-         │  ReqwestHttpClient  │              │   MockHttpClient    │
-         │    (production)     │              │     (testing)       │
-         └─────────────────────┘              └─────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                              SERVICE RESPONSIBILITY MATRIX                           │
+├─────────────────────┬───────────────────────────────────────────────────────────────┤
+│ SessionService      │ Full session lifecycle management                             │
+│                     │  • login() - Create session (authenticate)                    │
+│                     │  • refresh() - Renew session token                            │
+│                     │  • heartbeat() - Keep session alive                           │
+│                     │  • logout() - Destroy session                                 │
+├─────────────────────┼───────────────────────────────────────────────────────────────┤
+│ QueryService        │ SQL execution and result management                           │
+│                     │  • execute() - Submit query                                   │
+│                     │  • fetchResult() - Get results by queryId                     │
+│                     │  • getStatus() - Check async query status                     │
+│                     │  • cancel() - Cancel running query                            │
+├─────────────────────┼───────────────────────────────────────────────────────────────┤
+│ StorageService      │ Cloud storage operations (PUT/GET)                            │
+│                     │  • upload() - Upload to stage                                 │
+│                     │  • download() - Download from stage                           │
+│                     │  • head() - Check file existence                              │
+└─────────────────────┴───────────────────────────────────────────────────────────────┘
 ```
 
-### 7.2 Service Traits (Aligned with Existing Code)
+### 7.2 Class Diagram (UML-style)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                                   «interface»                                        │
+│                                  SessionService                                      │
+├─────────────────────────────────────────────────────────────────────────────────────┤
+│ + login(params: LoginParameters) -> Result<SessionTokens>                           │
+│ + refresh(tokens: SessionTokens) -> Result<SessionTokens>                           │
+│ + heartbeat(token: String) -> Result<()>                                            │
+│ + logout(token: String, config: LogoutConfig) -> Result<()>                         │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+                                         △
+                                         │ implements
+                                         │
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                              SnowflakeSessionService                                 │
+├─────────────────────────────────────────────────────────────────────────────────────┤
+│ - http_client: Arc<dyn HttpClient>                                                  │
+│ - server_url: String                                                                │
+│ - client_info: ClientInfo                                                           │
+│ - retry_policy: RetryPolicy                                                         │
+├─────────────────────────────────────────────────────────────────────────────────────┤
+│ + new(http_client, server_url, client_info) -> Self                                 │
+│ + login(params) -> Result<SessionTokens>                                            │
+│ + refresh(tokens) -> Result<SessionTokens>                                          │
+│ + heartbeat(token) -> Result<()>                                                    │
+│ + logout(token, config) -> Result<()>                                               │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 7.3 State Machine + Services Interaction (Sequence Diagram)
+
+#### 7.3.1 Login Flow
+
+```
+┌──────────┐     ┌──────────────────┐     ┌────────────────┐     ┌─────────────┐
+│  Client  │     │ConnectionState   │     │SessionService  │     │  Snowflake  │
+│          │     │    Machine       │     │                │     │     API     │
+└────┬─────┘     └────────┬─────────┘     └───────┬────────┘     └──────┬──────┘
+     │                    │                       │                     │
+     │ connect()          │                       │                     │
+     ├───────────────────>│                       │                     │
+     │                    │                       │                     │
+     │                    │ transition(Connecting)│                     │
+     │                    ├──────────┐            │                     │
+     │                    │          │            │                     │
+     │                    │<─────────┘            │                     │
+     │                    │                       │                     │
+     │                    │ login(params)         │                     │
+     │                    ├──────────────────────>│                     │
+     │                    │                       │                     │
+     │                    │                       │ POST /session/v1/   │
+     │                    │                       │   login-request     │
+     │                    │                       ├────────────────────>│
+     │                    │                       │                     │
+     │                    │                       │    SessionTokens    │
+     │                    │                       │<────────────────────┤
+     │                    │                       │                     │
+     │                    │   Ok(SessionTokens)   │                     │
+     │                    │<──────────────────────┤                     │
+     │                    │                       │                     │
+     │                    │ transition(Connected) │                     │
+     │                    ├──────────┐            │                     │
+     │                    │          │            │                     │
+     │                    │<─────────┘            │                     │
+     │                    │                       │                     │
+     │                    │ drain_pending_ops()   │                     │
+     │                    ├──────────┐            │                     │
+     │                    │          │            │                     │
+     │                    │<─────────┘            │                     │
+     │                    │                       │                     │
+     │   Ok(Connection)   │                       │                     │
+     │<───────────────────┤                       │                     │
+     │                    │                       │                     │
+```
+
+#### 7.3.2 Query with Auto-Refresh Flow
+
+```
+┌──────────┐  ┌──────────────────┐  ┌────────────────┐  ┌──────────────┐  ┌───────────┐
+│  Client  │  │ConnectionState   │  │SessionService  │  │QueryService  │  │ Snowflake │
+│          │  │    Machine       │  │                │  │              │  │    API    │
+└────┬─────┘  └────────┬─────────┘  └───────┬────────┘  └──────┬───────┘  └─────┬─────┘
+     │                 │                    │                  │                │
+     │ execute(sql)    │                    │                  │                │
+     ├────────────────>│                    │                  │                │
+     │                 │                    │                  │                │
+     │                 │ wait_ready()       │                  │                │
+     │                 ├────────┐           │                  │                │
+     │                 │        │           │                  │                │
+     │                 │<───────┘           │                  │                │
+     │                 │ [state==Connected] │                  │                │
+     │                 │                    │                  │                │
+     │                 │                    │  execute(sql)    │                │
+     │                 │                    │  ────────────────>                │
+     │                 │                    │                  │                │
+     │                 │                    │                  │ POST /queries/ │
+     │                 │                    │                  ├───────────────>│
+     │                 │                    │                  │                │
+     │                 │                    │                  │  code: 390112  │
+     │                 │                    │                  │ (session expired)
+     │                 │                    │                  │<───────────────┤
+     │                 │                    │                  │                │
+     │                 │                    │ Err(SessionExpired)               │
+     │                 │                    │<─────────────────┤                │
+     │                 │                    │                  │                │
+     │                 │ transition(Renewing)                  │                │
+     │                 ├────────┐           │                  │                │
+     │                 │        │           │                  │                │
+     │                 │<───────┘           │                  │                │
+     │                 │                    │                  │                │
+     │                 │ refresh(tokens)    │                  │                │
+     │                 ├───────────────────>│                  │                │
+     │                 │                    │                  │                │
+     │                 │                    │ POST /session/   │                │
+     │                 │                    │   token-request  │                │
+     │                 │                    ├──────────────────────────────────>│
+     │                 │                    │                  │                │
+     │                 │                    │  new SessionTokens                │
+     │                 │                    │<──────────────────────────────────┤
+     │                 │                    │                  │                │
+     │                 │ Ok(new tokens)     │                  │                │
+     │                 │<───────────────────┤                  │                │
+     │                 │                    │                  │                │
+     │                 │ transition(Connected)                 │                │
+     │                 ├────────┐           │                  │                │
+     │                 │        │           │                  │                │
+     │                 │<───────┘           │                  │                │
+     │                 │                    │                  │                │
+     │                 │                    │  execute(sql)    │ (retry)        │
+     │                 │                    │  ────────────────>                │
+     │                 │                    │                  │                │
+     │                 │                    │                  │ POST /queries/ │
+     │                 │                    │                  ├───────────────>│
+     │                 │                    │                  │                │
+     │                 │                    │                  │   QueryResult  │
+     │                 │                    │                  │<───────────────┤
+     │                 │                    │                  │                │
+     │   QueryResult   │                    │                  │                │
+     │<────────────────┴────────────────────┴──────────────────┤                │
+     │                 │                    │                  │                │
+```
+
+#### 7.3.3 Concurrent Requests During Renewal (Storm Prevention)
+
+```
+┌─────────┐ ┌─────────┐  ┌──────────────────┐  ┌────────────────┐  ┌───────────┐
+│ Query A │ │ Query B │  │ConnectionState   │  │SessionService  │  │ Snowflake │
+│         │ │         │  │    Machine       │  │                │  │    API    │
+└────┬────┘ └────┬────┘  └────────┬─────────┘  └───────┬────────┘  └─────┬─────┘
+     │          │                 │                    │                 │
+     │ execute()│                 │                    │                 │
+     ├─────────────────────────────>                   │                 │
+     │          │                 │                    │                 │
+     │          │                 │ gets 390112        │                 │
+     │          │                 │ transition(Renewing)                 │
+     │          │                 ├────────┐           │                 │
+     │          │                 │        │           │                 │
+     │          │                 │<───────┘           │                 │
+     │          │                 │                    │                 │
+     │          │ execute()       │                    │                 │
+     │          ├────────────────>│                    │                 │
+     │          │                 │                    │                 │
+     │          │                 │ wait_ready()       │                 │
+     │          │                 │ [state==Renewing]  │                 │
+     │          │                 │ enqueue(Query B)   │                 │
+     │          │                 ├────────┐           │                 │
+     │          │                 │        │           │                 │
+     │          │                 │<───────┘           │                 │
+     │          │                 │                    │                 │
+     │          │                 │ refresh()          │                 │
+     │          │                 ├───────────────────>│                 │
+     │          │                 │                    │ POST /session/  │
+     │          │                 │                    │   token-request │
+     │          │                 │                    ├────────────────>│
+     │          │                 │                    │                 │
+     │          │                 │                    │ new tokens      │
+     │          │                 │                    │<────────────────┤
+     │          │                 │                    │                 │
+     │          │                 │ Ok(new tokens)     │                 │
+     │          │                 │<───────────────────┤                 │
+     │          │                 │                    │                 │
+     │          │                 │ transition(Connected)                │
+     │          │                 ├────────┐           │                 │
+     │          │                 │        │           │                 │
+     │          │                 │<───────┘           │                 │
+     │          │                 │                    │                 │
+     │          │                 │ drain_pending_ops()│                 │
+     │          │                 │ notify(Query B)    │                 │
+     │          │                 ├────────┐           │                 │
+     │          │                 │        │           │                 │
+     │          │                 │<───────┘           │                 │
+     │          │                 │                    │                 │
+     │  retry   │  proceed        │                    │                 │
+     │<─────────│<────────────────┤                    │                 │
+     │          │                 │                    │                 │
+     │          │ [Both queries now execute with new token]              │
+     │          │                 │                    │                 │
+
+KEY: Only ONE refresh request is made, even though both Query A and Query B 
+     detected session expiration. Query B waits in pending_ops queue.
+```
+
+### 7.4 Revised Service Traits
 
 ```rust
-/// Authentication operations - wraps existing snowflake_login functions
-pub trait AuthService: Send + Sync {
-    async fn login(&self, params: &LoginParameters) -> Result<SessionTokens, AuthError>;
-    async fn refresh(&self, tokens: &SessionTokens) -> Result<SessionTokens, AuthError>;
-}
-
-/// Session management - NEW, needs implementation
+/// Session lifecycle management (login, refresh, heartbeat, logout)
+/// Combines authentication and session operations into single coherent service
 pub trait SessionService: Send + Sync {
-    async fn logout(&self, token: &str, config: &LogoutConfig) -> Result<(), SessionError>;
+    /// Authenticate and create a new session
+    async fn login(&self, params: &LoginParameters) -> Result<SessionTokens, SessionError>;
+    
+    /// Refresh an expired session token using the master token
+    async fn refresh(&self, tokens: &SessionTokens) -> Result<SessionTokens, SessionError>;
+    
+    /// Send heartbeat to keep session alive
     async fn heartbeat(&self, token: &str) -> Result<(), SessionError>;
+    
+    /// Close session and release resources
+    async fn logout(&self, token: &str, config: &LogoutConfig) -> Result<(), SessionError>;
 }
 
 /// Query execution - wraps existing snowflake_query functions
@@ -890,6 +1104,177 @@ Example mappings for common scenarios:
 3. **Retry policy per-service**: Should each service have its own retry policy, or share a connection-level policy?
 
 4. **Telemetry**: Should telemetry be a separate service or handled as a cross-cutting concern?
+
+---
+
+## 13. TODO: Test Framework Investigation
+
+> **Goal**: Design a test framework that allows running the same test logic across multiple execution flows and configuration settings.
+
+### 13.1 Problem Statement
+
+Currently, tests are written for specific scenarios. However, many tests should work across:
+
+**Multiple Execution Flows:**
+1. Normal synchronous query
+2. Async query (execute_async + get_results_from_sfqid)
+3. Large result set (chunk downloading)
+4. Long-running query (ping-pong polling with code 333333/333334)
+5. PUT/GET file transfer
+
+**Multiple Configuration Settings:**
+1. Different authentication types (password, JWT, OAuth, PAT, etc.)
+2. Different proxy configurations
+3. Different timezone settings
+4. Different timeout configurations
+5. Different TLS/SSL settings
+
+### 13.2 Proposed Solution: Parametrized Test Decorators
+
+```python
+# Example: Python test decorator concept
+
+@parametrize_flow([
+    Flow.SYNC,
+    Flow.ASYNC,
+    Flow.LARGE_RESULT,
+    Flow.LONG_RUNNING,
+    Flow.PUT_GET,
+])
+@parametrize_config([
+    Config.DEFAULT,
+    Config.WITH_PROXY,
+    Config.JWT_AUTH,
+    Config.OAUTH_AUTH,
+    Config.CUSTOM_TIMEOUT,
+])
+def test_select_simple_datatypes(flow: Flow, config: Config):
+    """This test should pass regardless of execution flow or config."""
+    conn = create_connection(config)
+    
+    # The flow wrapper handles HOW the query is executed
+    result = execute_with_flow(conn, "SELECT 1, 'hello', 3.14", flow)
+    
+    assert result[0] == (1, 'hello', 3.14)
+```
+
+```rust
+// Example: Rust test macro concept
+
+#[test_all_flows]  // Generates tests for each flow
+#[test_all_configs]  // Generates tests for each config
+fn test_select_simple_datatypes() {
+    let conn = TestConnection::new(TEST_CONFIG);
+    
+    let result = conn.execute_with_flow("SELECT 1, 'hello', 3.14", CURRENT_FLOW);
+    
+    assert_eq!(result.row(0), (1, "hello", 3.14));
+}
+
+// Expands to:
+// - test_select_simple_datatypes_sync_default
+// - test_select_simple_datatypes_sync_with_proxy
+// - test_select_simple_datatypes_async_default
+// - test_select_simple_datatypes_async_with_proxy
+// - ... (combinatorial expansion)
+```
+
+### 13.3 Flow Abstraction Layer
+
+```rust
+pub enum ExecutionFlow {
+    /// Normal synchronous: POST query-request → wait → return
+    Sync,
+    
+    /// Async: POST query-request (async_exec=true) → return queryId → poll status → fetch
+    Async,
+    
+    /// Force large result: Query with enough rows to trigger chunking
+    LargeResult { min_rows: usize },
+    
+    /// Force long-running: Query with SYSTEM$WAIT or large computation
+    LongRunning { min_duration_secs: u32 },
+    
+    /// File transfer: PUT/GET commands
+    FileTransfer { operation: FileOp },
+}
+
+pub trait FlowExecutor {
+    fn execute(&self, conn: &Connection, sql: &str, flow: ExecutionFlow) -> Result<QueryResult>;
+}
+
+impl FlowExecutor for TestFlowExecutor {
+    fn execute(&self, conn: &Connection, sql: &str, flow: ExecutionFlow) -> Result<QueryResult> {
+        match flow {
+            ExecutionFlow::Sync => {
+                conn.execute(sql)
+            }
+            ExecutionFlow::Async => {
+                let qid = conn.execute_async(sql)?;
+                conn.wait_for_query(qid)?;
+                conn.fetch_result(qid)
+            }
+            ExecutionFlow::LargeResult { min_rows } => {
+                // Wrap SQL to ensure large result
+                let wrapped = format!(
+                    "SELECT * FROM TABLE(GENERATOR(ROWCOUNT => {})) CROSS JOIN ({})",
+                    min_rows, sql
+                );
+                conn.execute(&wrapped)
+            }
+            ExecutionFlow::LongRunning { min_duration_secs } => {
+                // Add delay to force ping-pong
+                let wrapped = format!(
+                    "CALL SYSTEM$WAIT({}, 'SECONDS'); {}",
+                    min_duration_secs, sql
+                );
+                conn.execute(&wrapped)
+            }
+            ExecutionFlow::FileTransfer { operation } => {
+                // Handle PUT/GET
+                unimplemented!("File transfer flow")
+            }
+        }
+    }
+}
+```
+
+### 13.4 Config Abstraction Layer
+
+```rust
+pub struct TestConfig {
+    pub auth: AuthConfig,
+    pub proxy: Option<ProxyConfig>,
+    pub timezone: Option<String>,
+    pub timeout: TimeoutConfig,
+    pub tls: TlsConfig,
+}
+
+pub enum AuthConfig {
+    Password { user: String, password: String },
+    Jwt { user: String, private_key_path: String },
+    OAuth { client_id: String, client_secret: String },
+    Pat { token: String },
+    ExternalBrowser,
+}
+
+impl TestConfig {
+    pub const DEFAULT: Self = Self { /* ... */ };
+    pub const WITH_PROXY: Self = Self { /* ... */ };
+    pub const JWT_AUTH: Self = Self { /* ... */ };
+    // ...
+}
+```
+
+### 13.5 Investigation Tasks
+
+- [ ] **Analyze existing test patterns**: Review how tests are currently structured in sf_core and wrapper tests
+- [ ] **Prototype flow executor**: Implement basic FlowExecutor for sync/async
+- [ ] **Prototype config matrix**: Define common test configurations
+- [ ] **Wiremock mappings per flow**: Create Wiremock mappings that simulate each flow pattern
+- [ ] **Measure test explosion**: Calculate test count impact of combinatorial expansion
+- [ ] **Selective execution**: Design mechanism to run subset (e.g., only sync + default config for CI)
+- [ ] **Failure isolation**: Ensure failures clearly indicate which flow/config combination failed
 
 ---
 

--- a/docs/QUERY_FLOWS_DD.md
+++ b/docs/QUERY_FLOWS_DD.md
@@ -1,0 +1,904 @@
+# Universal Driver Service Architecture Design Document
+
+## Status: Draft
+## Author: Agent
+## Last Updated: 2026-02-01
+
+---
+
+## Overview
+
+This document describes the proposed service-based architecture for the Universal Driver, derived from comprehensive analysis of all existing Snowflake drivers (Go, Python, JDBC, Node.js, .NET, ODBC, libsnowflakeclient). The architecture enables clean separation of concerns, dependency injection, and testability while aligning with the existing `sf_core` Rust implementation.
+
+### Implementation Status
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| REST API (login, query) | Implemented | `sf_core/src/rest/snowflake/mod.rs` |
+| HTTP Retry | Implemented | `sf_core/src/http/retry.rs` |
+| Connection State Machine | Implemented | `sf_core/src/connection_state/` |
+| Chunk Downloads | Implemented | `sf_core/src/chunks.rs` |
+| Protobuf FFI | Implemented | `sf_core/src/protobuf_apis/` |
+| Heartbeat Service | Not Implemented | - |
+| Logout Service | Not Implemented | - |
+| Query Status Monitoring | Not Implemented | - |
+
+---
+
+## 1. Endpoint Reference
+
+### 1.1 Complete Snowflake API Catalog
+
+All Snowflake drivers communicate via the following REST endpoints:
+
+| Endpoint | Method | Purpose | Auth Required |
+|----------|--------|---------|---------------|
+| `/session/v1/login-request` | POST | Authentication | No (credentials in body) |
+| `/session/token-request` | POST | Token refresh | Master Token |
+| `/session/heartbeat` | POST | Keep session alive | Session Token |
+| `/session?delete=true` | POST | Logout/close session | Session Token |
+| `/session/authenticator-request` | POST | OKTA/SSO discovery | No |
+| `/queries/v1/query-request` | POST | Execute SQL | Session Token |
+| `/queries/{qid}/result` | GET | Fetch query results | Session Token |
+| `/monitoring/queries/{qid}` | GET | Query status check | Session Token |
+| `/telemetry/send` | POST | Send telemetry | Session Token |
+
+### 1.2 Driver Endpoint Usage by Operation
+
+All drivers support both endpoints - they use them for different purposes:
+
+| Operation | Endpoint | Purpose |
+|-----------|----------|---------|
+| **Async Status Check** | `GET /monitoring/queries/{qid}` | Check if async query is done (returns status metadata, no data) |
+| **Result Fetch** | `GET /queries/{qid}/result` | Fetch actual query results |
+| **Long-running Poll** | `GET {getResultUrl}` → `/queries/{qid}/result` | Poll for results during ping-pong |
+
+**How drivers use these endpoints:**
+
+| Use Case | Flow |
+|----------|------|
+| Sync query completes quickly | `POST /queries/v1/query-request` → returns data inline |
+| Sync query takes >45s | `POST /queries/v1/query-request` → code 333333 → poll `getResultUrl` (`/queries/{qid}/result`) |
+| Async query | `POST /queries/v1/query-request` → returns queryId → poll `/monitoring/queries/{qid}` until SUCCESS → fetch `/queries/{qid}/result` |
+
+**Key Insight**: The `/monitoring/queries/{qid}` endpoint returns **only status metadata** (RUNNING, SUCCESS, FAILED, etc.), while `/queries/{qid}/result` returns **actual data**. For async queries, drivers first poll monitoring until done, then fetch results.
+
+**Key Insight**: The `/monitoring/queries/{qid}` endpoint returns metadata about query status (running, success, failed), while `/queries/{qid}/result` returns actual data. For async queries, drivers first check status via monitoring, then fetch results.
+
+### 1.3 Request Headers (All SF-Related Requests)
+
+```
+Authorization: Snowflake Token="{session_token}"
+Accept: application/snowflake
+Content-Type: application/json
+User-Agent: {application}/{version} ({os}) {runtime}
+```
+
+### 1.4 Query Parameters
+
+| Parameter | Purpose | Scope |
+|-----------|---------|-------|
+| `requestId` | Idempotency key (static per logical request) | All requests |
+| `request_guid` | Unique per attempt (for tracing) | All requests |
+| `retry` | Indicates retry attempt | Query requests |
+| `clientStartTime` | Client timestamp | Query requests |
+
+---
+
+## 2. Error Code Reference
+
+### 2.1 Session-Related Error Codes
+
+| Code | Constant Name | Meaning | Driver Action |
+|------|--------------|---------|---------------|
+| 390110 | `ID_TOKEN_EXPIRED` | ID token expired | Full re-authentication |
+| 390111 | `SESSION_GONE` | Session no longer exists | Ignore on logout, error otherwise |
+| 390112 | `SESSION_EXPIRED` | Session token expired | Auto-refresh with master token |
+| 390113 | `MASTER_TOKEN_NOT_FOUND` | Master token missing | Full re-authentication |
+| 390114 | `MASTER_TOKEN_EXPIRED` | Master token expired | Full re-authentication |
+| 390115 | `MASTER_TOKEN_INVALID` | Master token invalid | Full re-authentication |
+
+### 2.2 Query-Related Error Codes
+
+| Code | Constant Name | Meaning | Driver Action |
+|------|--------------|---------|---------------|
+| 333333 | `QUERY_IN_PROGRESS` | Sync query still running | Poll via `getResultUrl` |
+| 333334 | `QUERY_IN_PROGRESS_ASYNC` | Async/detached query | Return queryId or poll |
+
+### 2.3 HTTP Status Codes for Retry
+
+| Status | Meaning | Retry? |
+|--------|---------|--------|
+| 408 | Request Timeout | Yes |
+| 429 | Too Many Requests | Yes (with Retry-After) |
+| 500 | Internal Server Error | Yes |
+| 502 | Bad Gateway | Yes |
+| 503 | Service Unavailable | Yes |
+| 504 | Gateway Timeout | Yes |
+
+---
+
+## 3. Current sf_core Architecture
+
+### 3.1 Module Structure
+
+```
+sf_core/src/
+├── apis/database_driver_v1/    # ADBC-style API implementation
+│   ├── connection.rs           # Connection management, login, session refresh
+│   ├── statement.rs            # Statement execution
+│   ├── query.rs                # Query result processing
+│   └── error.rs                # API-level errors
+├── rest/snowflake/             # Snowflake REST API
+│   ├── mod.rs                  # Login, refresh, query functions
+│   ├── async_exec.rs           # Async query execution
+│   ├── query_request.rs        # Request structures
+│   └── query_response.rs       # Response structures
+├── http/
+│   └── retry.rs                # HTTP retry with backoff/jitter
+├── connection_state/           # State machine (see CONNECTION_STATE_MACHINE.md)
+│   ├── machine.rs              # State transitions
+│   ├── state.rs                # State enum definitions
+│   └── pending_ops.rs          # Queued operations
+├── chunks.rs                   # Large result set chunk downloading
+├── protobuf_apis/              # Protobuf FFI layer
+│   ├── mod.rs                  # Transport routing
+│   └── database_driver_v1.rs   # Handler implementations
+└── config/
+    ├── retry.rs                # Retry policy configuration
+    └── rest_parameters.rs      # Login/query parameters
+```
+
+### 3.2 Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph wrappers [Language Wrappers]
+        ODBC[ODBC Driver]
+        JDBC[JDBC Bridge]
+        Python[Python Driver]
+    end
+
+    subgraph proto [Protobuf FFI Layer]
+        Transport["RustTransport
+        call_proto()"]
+        ProtoAPIs["DatabaseDriverImpl
+        handle_message()"]
+    end
+
+    subgraph api [API Layer]
+        ConnAPI["connection.rs
+        connection_init()
+        with_valid_session()"]
+        StmtAPI["statement.rs
+        statement_execute_query()"]
+    end
+
+    subgraph core [Core Services]
+        REST["rest/snowflake/
+        snowflake_login()
+        snowflake_query()
+        refresh_session()"]
+        HTTP["http/retry.rs
+        execute_with_retry()"]
+        State["connection_state/
+        ConnectionStateMachine"]
+        Chunks["chunks.rs
+        ChunkReader"]
+    end
+
+    subgraph external [External]
+        SF[Snowflake API]
+        CSP[Cloud Storage]
+    end
+
+    wrappers --> Transport
+    Transport --> ProtoAPIs
+    ProtoAPIs --> ConnAPI
+    ProtoAPIs --> StmtAPI
+    ConnAPI --> REST
+    StmtAPI --> REST
+    ConnAPI --> State
+    REST --> HTTP
+    REST --> Chunks
+    HTTP --> SF
+    Chunks --> CSP
+```
+
+### 3.3 Existing Function Signatures
+
+The `sf_core` already implements core functionality that can be formalized into service traits:
+
+```rust
+// rest/snowflake/mod.rs - Authentication
+pub async fn snowflake_login(
+    login_parameters: &LoginParameters,
+) -> Result<SessionTokens, RestError>
+
+pub async fn snowflake_login_with_client(
+    client: &reqwest::Client,
+    login_parameters: &LoginParameters,
+) -> Result<SessionTokens, RestError>
+
+// rest/snowflake/mod.rs - Session Refresh  
+pub async fn refresh_session(
+    client: &reqwest::Client,
+    server_url: &str,
+    client_info: &ClientInfo,
+    tokens: &SessionTokens,
+) -> Result<SessionTokens, RestError>
+
+// rest/snowflake/mod.rs - Query Execution
+pub async fn snowflake_query_with_client(
+    client: &reqwest::Client,
+    query_parameters: QueryParameters,
+    session_token: String,
+    sql: String,
+    parameter_bindings: Option<HashMap<String, BindParameter>>,
+    retry_policy: &RetryPolicy,
+    execution_mode: QueryExecutionMode,
+) -> Result<query_response::Response, RestError>
+
+// apis/database_driver_v1/connection.rs - Session Refresh Wrapper
+pub async fn with_valid_session<F, Fut, T>(
+    conn: &Arc<Mutex<Connection>>,
+    f: F,
+) -> Result<T, ApiError>
+```
+
+---
+
+## 4. Main Execution Flows
+
+### 4.1 Normal Request (Synchronous)
+
+```
+cursor.execute(sql) 
+    → POST /queries/v1/query-request 
+    → wait for result 
+    → return data
+```
+
+Standard synchronous query execution. The client blocks until the query completes.
+
+### 4.2 Async Request
+
+```
+cursor.execute_async(sql) 
+    → POST /queries/v1/query-request (async_exec: true)
+    → returns immediately with queryId
+
+cursor.get_results_from_sfqid(qid) 
+    → GET /monitoring/queries/{qid} (poll status)
+    → when SUCCESS: GET /queries/{qid}/result
+    → return data
+```
+
+Fire-and-forget query submission. Results are fetched later by query ID.
+
+### 4.3 Long-Running Query (Ping-Pong)
+
+When a query takes longer than ~45 seconds, Snowflake returns code 333333/333334:
+
+```
+execute()
+    → POST /queries/v1/query-request
+    → response: { code: "333333", data: { getResultUrl: "/queries/{qid}/result" } }
+    → GET {getResultUrl}
+    → response: { code: "333333", data: { getResultUrl: "..." } }
+    → repeat until code != 333333/333334
+    → return final result
+```
+
+**Implementation in drivers:**
+
+```go
+// Go driver (restful.go)
+for respd.Code == queryInProgressCode || respd.Code == queryInProgressAsyncCode {
+    fullURL = sr.getFullURL(respd.Data.GetResultURL, nil)
+    respd, err = getExecResponse(ctx, sr, fullURL, headers, timeout)
+}
+```
+
+```python
+# Python driver (network.py)
+while ret.get("code") in (QUERY_IN_PROGRESS_CODE, QUERY_IN_PROGRESS_ASYNC_CODE):
+    result_url = ret["data"]["getResultUrl"]
+    ret = self._get_request(result_url, headers, token=self.token, timeout=timeout)
+```
+
+### 4.4 Large Result Set (Chunk Fetching)
+
+```
+execute() 
+    → POST /queries/v1/query-request 
+    → initial response with chunk metadata:
+      {
+        "rowsetBase64": "...",  // First chunk (inline)
+        "chunks": [
+          { "url": "https://s3.../chunk1", "rowCount": 10000 },
+          { "url": "https://s3.../chunk2", "rowCount": 10000 }
+        ],
+        "chunkHeaders": { "x-amz-server-side-encryption-customer-key": "..." }
+      }
+    → parallel GET chunk URLs from CSP
+    → decompress and assemble Arrow batches
+```
+
+**Current implementation in sf_core:**
+
+```rust
+// chunks.rs
+pub async fn get_chunk_data(client: &Client, chunk: &ChunkDownloadData) -> Result<Vec<u8>, ChunkError> {
+    let policy = RetryPolicy::default();
+    let ctx = HttpContext::new(Method::GET, url.clone()).with_idempotent(true);
+    
+    let response = execute_with_retry(
+        || client.get(url.clone()).headers(headers.clone()),
+        &ctx,
+        &policy,
+        |r| async move { Ok(r) },
+    ).await?;
+    // decompress and return
+}
+```
+
+### 4.5 PUT/GET (File Transfer)
+
+```
+cursor.execute("PUT @stage ...")
+    → POST /queries/v1/query-request
+    → response contains stage info & credentials:
+      {
+        "command": "UPLOAD",
+        "stageInfo": { "locationType": "S3", "location": "...", "credentials": {...} }
+      }
+    → StorageClient.upload() to CSP (S3/Azure/GCS)
+    
+cursor.execute("GET @stage ...")
+    → similar flow but download
+```
+
+---
+
+## 5. Session Management Flows
+
+### 5.1 Heartbeat
+
+Heartbeat keeps the session alive and is used to detect session expiration early.
+
+**Interval Calculation** (consistent across all drivers):
+
+```go
+// Go driver
+const minHeartBeatInterval = 900 * time.Second   // 15 minutes
+const maxHeartBeatInterval = 3600 * time.Second  // 1 hour
+const defaultHeartBeatInterval = 3600 * time.Second
+```
+
+```cpp
+// ODBC driver
+long HeartbeatBackground::calculateHeartBeatInterval(long master_token_validation_time) {
+    return master_token_validation_time / 4;
+}
+```
+
+**Heartbeat Flow:**
+
+```
+Background thread/task:
+    every {master_token_validity / 4} seconds:
+        → POST /session/heartbeat
+        → if response code == 390112:
+            → refresh_session()
+            → retry heartbeat
+```
+
+**JDBC Pattern** (HeartbeatBackground.java):
+
+```java
+public void run() {
+    for (SFSession session : sessions.keySet()) {
+        session.heartbeat();
+    }
+    if (sessions.size() > 0) {
+        scheduleHeartbeat();
+    }
+}
+```
+
+### 5.2 Session Token Refresh
+
+When session token expires (code 390112), drivers automatically refresh:
+
+```
+Request fails with code 390112
+    → POST /session/token-request
+      Headers: Authorization: Snowflake Token="{master_token}"
+      Body: { "oldSessionToken": "...", "requestType": "RENEW" }
+    → Response: { "sessionToken": "...", "masterToken": "...", "validityInSecondsST": 3600 }
+    → Retry original request with new token
+```
+
+**Current implementation in sf_core:**
+
+```rust
+// rest/snowflake/mod.rs
+pub async fn refresh_session(
+    client: &reqwest::Client,
+    server_url: &str,
+    client_info: &ClientInfo,
+    tokens: &SessionTokens,
+) -> Result<SessionTokens, RestError> {
+    let body = serde_json::json!({
+        "oldSessionToken": tokens.session_token,
+        "requestType": "RENEW"
+    });
+    // POST with master token in Authorization header
+}
+```
+
+**Wrapper with automatic refresh:**
+
+```rust
+// apis/database_driver_v1/connection.rs
+pub async fn with_valid_session<F, Fut, T>(conn: &Arc<Mutex<Connection>>, f: F) -> Result<T, ApiError>
+where
+    F: Fn(String) -> Fut,
+    Fut: Future<Output = Result<T, RestError>>,
+{
+    // First attempt
+    match f(session_token).await {
+        Ok(result) => Ok(result),
+        Err(RestError::InvalidSnowflakeResponse { source: SessionExpired { .. }, .. }) => {
+            // Refresh and retry
+            let new_tokens = refresh_session(...).await?;
+            f(new_tokens.session_token).await
+        }
+        Err(e) => Err(e),
+    }
+}
+```
+
+### 5.3 Logout / Close Session
+
+**Endpoint:** `POST /session?delete=true&requestId={uuid}`
+
+**Behavior across drivers:**
+
+| Driver | On Success | On 390111 (Session Gone) | On Other Error |
+|--------|-----------|-------------------------|----------------|
+| Go | Return success | Log warning, return success | Return error |
+| Python | Return success | Ignore | Return error |
+| JDBC | Return success | Ignore | Return error |
+| Node.js | Return success | Ignore | Return error |
+| .NET | Return success | Ignore | Return error |
+
+**Go implementation:**
+
+```go
+func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Duration) error {
+    // POST /session?delete=true
+    if respd.Code == sessionGoneCode {
+        return nil  // Already gone, not an error
+    }
+    if !respd.Success {
+        return &SnowflakeError{Number: ErrFailedToCloseSession, ...}
+    }
+    return nil
+}
+```
+
+---
+
+## 6. Query Status Monitoring
+
+### 6.1 Monitoring vs Result Endpoints
+
+| Endpoint | Purpose | Returns |
+|----------|---------|---------|
+| `/monitoring/queries/{qid}` | Check status only | Status metadata (no data) |
+| `/queries/{qid}/result` | Fetch results | Full query results |
+
+**When to use each:**
+
+- **Async queries**: First poll `/monitoring/queries/{qid}` until status is SUCCESS, then fetch `/queries/{qid}/result`
+- **Long-running sync**: Follow `getResultUrl` from response (points to `/queries/{qid}/result`)
+
+### 6.2 Query Status Values
+
+```javascript
+// From all drivers (consistent)
+const QueryStatus = {
+    RUNNING: 'RUNNING',
+    ABORTING: 'ABORTING', 
+    SUCCESS: 'SUCCESS',
+    FAILED_WITH_ERROR: 'FAILED_WITH_ERROR',
+    ABORTED: 'ABORTED',
+    QUEUED: 'QUEUED',
+    FAILED_WITH_INCIDENT: 'FAILED_WITH_INCIDENT',
+    DISCONNECTED: 'DISCONNECTED',
+    RESUMING_WAREHOUSE: 'RESUMING_WAREHOUSE',
+    QUEUED_REPAIRING_WAREHOUSE: 'QUEUED_REPARING_WAREHOUSE',  // Note: typo in Snowflake API
+    RESTARTED: 'RESTARTED',
+    BLOCKED: 'BLOCKED',
+    NO_DATA: 'NO_DATA'
+};
+
+// Still running statuses
+const runningStatuses = ['RUNNING', 'RESUMING_WAREHOUSE', 'QUEUED', 'QUEUED_REPARING_WAREHOUSE', 'NO_DATA'];
+
+// Error statuses
+const errorStatuses = ['ABORTING', 'FAILED_WITH_ERROR', 'ABORTED', 'FAILED_WITH_INCIDENT', 'DISCONNECTED', 'BLOCKED'];
+```
+
+### 6.3 Async Query Retry Pattern
+
+All drivers use similar exponential backoff for async status polling:
+
+```go
+// Go driver (async.go)
+retryPattern := []int32{1, 1, 2, 3, 4, 8, 10}  // seconds
+
+for {
+    status := checkQueryStatus(qid)
+    if !status.isRunning() {
+        break
+    }
+    time.Sleep(500 * time.Millisecond * retryPattern[retryPatternIndex])
+    if retryPatternIndex < len(retryPattern)-1 {
+        retryPatternIndex++
+    }
+}
+```
+
+---
+
+## 7. Proposed Service Architecture
+
+### 7.1 Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              Connection                                      │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │                        ServiceContainer                                │  │
+│  │   ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │  │
+│  │   │ AuthService │  │SessionService│  │QueryService │  │StorageService│  │
+│  │   └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+│                                    │                                         │
+│                        ConnectionStateMachine                                │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+                    ┌─────────────────────────────────────┐
+                    │         HttpClient (trait)          │
+                    │  request(method, url, headers, body)│
+                    └─────────────────────────────────────┘
+                                       │
+                    ┌──────────────────┴──────────────────┐
+                    ▼                                     ▼
+         ┌─────────────────────┐              ┌─────────────────────┐
+         │  ReqwestHttpClient  │              │   MockHttpClient    │
+         │    (production)     │              │     (testing)       │
+         └─────────────────────┘              └─────────────────────┘
+```
+
+### 7.2 Service Traits (Aligned with Existing Code)
+
+```rust
+/// Authentication operations - wraps existing snowflake_login functions
+pub trait AuthService: Send + Sync {
+    async fn login(&self, params: &LoginParameters) -> Result<SessionTokens, AuthError>;
+    async fn refresh(&self, tokens: &SessionTokens) -> Result<SessionTokens, AuthError>;
+}
+
+/// Session management - NEW, needs implementation
+pub trait SessionService: Send + Sync {
+    async fn logout(&self, token: &str, config: &LogoutConfig) -> Result<(), SessionError>;
+    async fn heartbeat(&self, token: &str) -> Result<(), SessionError>;
+}
+
+/// Query execution - wraps existing snowflake_query functions
+pub trait QueryService: Send + Sync {
+    async fn execute(
+        &self, 
+        token: &str, 
+        sql: &str, 
+        params: &QueryParams,
+        mode: QueryExecutionMode,
+    ) -> Result<QueryResult, QueryError>;
+    
+    async fn fetch_result(&self, token: &str, query_id: &str) -> Result<QueryResult, QueryError>;
+    async fn get_status(&self, token: &str, query_id: &str) -> Result<QueryStatus, QueryError>;
+    async fn cancel(&self, token: &str, query_id: &str) -> Result<(), QueryError>;
+}
+
+/// Cloud storage operations - wraps existing file_manager
+pub trait StorageService: Send + Sync {
+    async fn upload(&self, meta: &FileMeta, credentials: &StorageCredentials) -> Result<(), StorageError>;
+    async fn download(&self, meta: &FileMeta, credentials: &StorageCredentials) -> Result<Vec<u8>, StorageError>;
+}
+```
+
+### 7.3 Integration with Connection State Machine
+
+The service architecture integrates with the existing `ConnectionStateMachine`:
+
+```rust
+pub struct Connection {
+    // Services
+    auth_service: Arc<dyn AuthService>,
+    session_service: Arc<dyn SessionService>,
+    query_service: Arc<dyn QueryService>,
+    storage_service: Arc<dyn StorageService>,
+    
+    // State (from connection_state module)
+    state_machine: ConnectionStateMachine,
+    tokens: Arc<AsyncRwLock<Option<SessionTokens>>>,
+    
+    // Configuration
+    http_client: reqwest::Client,
+    server_url: String,
+    client_info: ClientInfo,
+}
+
+impl Connection {
+    pub async fn execute_query(&self, sql: &str) -> Result<QueryResult, ApiError> {
+        // Use state machine to wait for ready state
+        self.state_machine.wait_ready(Duration::from_secs(30)).await?;
+        
+        // Execute with automatic session refresh
+        with_valid_session(&self.tokens, |token| {
+            self.query_service.execute(&token, sql, &params, QueryExecutionMode::Blocking)
+        }).await
+    }
+    
+    pub async fn close(&self) -> Result<(), ApiError> {
+        let token = self.tokens.read().await.as_ref()
+            .map(|t| t.session_token.clone())
+            .ok_or(ApiError::NotConnected)?;
+            
+        // Logout (best-effort)
+        let _ = self.session_service.logout(&token, &LogoutConfig::default()).await;
+        
+        // Transition state machine
+        self.state_machine.disconnect(DisconnectReason::UserInitiated).await?;
+        
+        Ok(())
+    }
+}
+```
+
+---
+
+## 8. Protobuf FFI Pattern
+
+### 8.1 Current Architecture
+
+The Universal Driver uses Protobuf for FFI between language wrappers and the Rust core:
+
+```
+┌──────────────┐     Protobuf      ┌──────────────────┐
+│ ODBC/JDBC/   │ ──── Bytes ────▶  │  RustTransport   │
+│ Python       │                   │  call_proto()    │
+└──────────────┘                   └────────┬─────────┘
+                                            │
+                                   ┌────────▼─────────┐
+                                   │DatabaseDriverImpl│
+                                   │ handle_message() │
+                                   └────────┬─────────┘
+                                            │
+                                   ┌────────▼─────────┐
+                                   │  apis/database_  │
+                                   │  driver_v1/      │
+                                   └──────────────────┘
+```
+
+### 8.2 Adding New Services
+
+To add a new service (e.g., Heartbeat):
+
+**Step 1: Define in `database_driver_v1.proto`**
+
+```protobuf
+message ConnectionHeartbeatRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionHeartbeatResponse {
+}
+
+service DatabaseDriver {
+  // ... existing methods ...
+  rpc ConnectionHeartbeat(ConnectionHeartbeatRequest) returns (ConnectionHeartbeatResponse);
+}
+```
+
+**Step 2: Regenerate Rust code**
+
+```bash
+cd proto_generator
+cargo run
+```
+
+**Step 3: Implement handler in `protobuf_apis/database_driver_v1.rs`**
+
+```rust
+impl DatabaseDriverServer for DatabaseDriverImpl {
+    fn connection_heartbeat(
+        &self,
+        request: ConnectionHeartbeatRequest,
+    ) -> Result<ConnectionHeartbeatResponse, DriverException> {
+        let conn = get_connection(request.conn_handle)?;
+        connection::connection_heartbeat(conn.id)?;
+        Ok(ConnectionHeartbeatResponse {})
+    }
+}
+```
+
+**Step 4: Implement core logic in `apis/database_driver_v1/connection.rs`**
+
+```rust
+pub fn connection_heartbeat(conn_handle: Handle) -> Result<(), ApiError> {
+    let conn = CONN_HANDLE_MANAGER.get_obj(conn_handle)
+        .ok_or(ApiError::InvalidHandle)?;
+    
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let guard = conn.lock()?;
+        let token = guard.tokens.read().await
+            .as_ref()
+            .map(|t| t.session_token.clone())
+            .ok_or(ApiError::NotConnected)?;
+        
+        heartbeat_request(&guard.http_client, &guard.server_url, &token).await
+    })
+}
+```
+
+---
+
+## 9. Request Type Taxonomy
+
+### 9.1 Auth-Related Requests
+
+**Endpoints:**
+- `/session/v1/login-request` (various authentication methods)
+- `/session/token-request` (token refresh)
+- `/session/authenticator-request` (OKTA/SSO discovery)
+- External: OAuth providers, OKTA, Browser SSO
+
+**Characteristics:**
+- Pre-session (no session token yet, or special token handling)
+- Special error handling (credentials vs connectivity errors)
+- May involve external redirects (browser auth, OKTA)
+- Different retry semantics (some errors should not retry)
+
+**Authentication Methods Supported:**
+- Default (username/password)
+- External Browser (SSO)
+- Key Pair (JWT)
+- OAuth (Authorization Code, Client Credentials)
+- ID Token
+- Username/Password with MFA
+- Programmatic Access Token (PAT)
+- Workload Identity
+
+### 9.2 SF-Related Requests (Snowflake Core)
+
+**Characteristics:**
+- Session token in `Authorization: Snowflake Token="{token}"` header
+- Error code 390112 triggers automatic session refresh
+- Common retry policy for transient errors (503, 429, 408, etc.)
+- `requestId` and `request_guid` query parameters
+- Gzip compression for POST body
+
+### 9.3 CSP-Related Requests (Cloud Storage Providers)
+
+**Operations:**
+- S3: PUT/GET with presigned URLs, multipart upload
+- Azure Blob: PUT/GET with SAS tokens
+- GCS: PUT/GET with presigned URLs or OAuth
+
+**Characteristics:**
+- Cloud-specific credentials (temporary, refreshable via Snowflake)
+- Chunked transfer for large files
+- Client-side encryption/decryption
+- Different transient error codes: 408, 429, 500, 502, 503, 504
+- Exponential backoff with jitter
+
+---
+
+## 10. Testing Strategy
+
+### 10.1 Testing Matrix
+
+| Test Level | What's Real | What's Mocked | Verifies |
+|------------|-------------|---------------|----------|
+| Unit | `Connection.close()` | `SessionService` | Business logic, state management |
+| Service Integration | `SnowflakeSessionService` | `HttpClient` | Request construction, error handling |
+| HTTP Integration | All Rust code | Wiremock server | Full HTTP flow, headers, body |
+| E2E | All code | Nothing | Real Snowflake behavior |
+
+### 10.2 Wiremock Mappings
+
+Example mappings for common scenarios:
+
+```json
+// Long-running query
+{
+  "request": { "urlPathPattern": "/queries/v1/query-request" },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "success": true,
+      "code": "333334",
+      "data": {
+        "queryId": "01bfd516-0009-ae23-0000-4c390101d1aa",
+        "getResultUrl": "/queries/01bfd516-0009-ae23-0000-4c390101d1aa/result"
+      }
+    }
+  }
+}
+
+// Session expired
+{
+  "request": { "urlPathPattern": "/queries/.*" },
+  "response": {
+    "status": 200,
+    "jsonBody": { "success": false, "code": "390112", "message": "Session expired" }
+  }
+}
+```
+
+---
+
+## 11. Migration Path
+
+### Phase 1: Define Service Traits
+- Define `SessionService`, `QueryService` traits based on existing functions
+- Keep existing implementation working
+
+### Phase 2: Implement Missing Services
+- Implement `SessionService.heartbeat()` 
+- Implement `SessionService.logout()`
+- Implement `QueryService.get_status()` (monitoring endpoint)
+
+### Phase 3: Integrate with State Machine
+- Wire services to use `ConnectionStateMachine`
+- Implement heartbeat background task
+
+### Phase 4: Add Protobuf Methods
+- Add `ConnectionHeartbeat`, `ConnectionLogout` to proto
+- Implement handlers
+
+### Phase 5: Testing
+- Add unit tests with mock services
+- Add Wiremock integration tests
+- Verify against real Snowflake
+
+---
+
+## 12. Open Questions
+
+1. **Heartbeat scheduling**: Should heartbeat run as a background tokio task per-connection, or use a shared scheduler like JDBC's `HeartbeatBackground`?
+
+2. **State machine integration**: Should services have direct access to the state machine, or should the Connection coordinate all state transitions?
+
+3. **Retry policy per-service**: Should each service have its own retry policy, or share a connection-level policy?
+
+4. **Telemetry**: Should telemetry be a separate service or handled as a cross-cutting concern?
+
+---
+
+## References
+
+- Connection State Machine Design: `docs/CONNECTION_STATE_MACHINE.md`
+- Go Driver: `drivers/gosnowflake/`
+- Python Connector: `drivers/snowflake-connector-python/`
+- JDBC Driver: `drivers/snowflake-jdbc/`
+- Node.js Connector: `drivers/snowflake-connector-nodejs/`
+- .NET Connector: `drivers/snowflake-connector-net/`
+- ODBC Driver: `drivers/snowflake-odbc/`

--- a/docs/QUERY_FLOWS_DD.md
+++ b/docs/QUERY_FLOWS_DD.md
@@ -205,6 +205,71 @@ graph TB
     Chunks --> CSP
 ```
 
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml architecture
+skinparam componentStyle uml2
+skinparam linetype ortho
+
+package "Language Wrappers" {
+  [ODBC Driver] as ODBC
+  [JDBC Bridge] as JDBC
+  [Python Driver] as Python
+}
+
+package "Protobuf FFI Layer" {
+  [RustTransport\ncall_proto()] as Transport
+  [DatabaseDriverImpl\nhandle_message()] as ProtoAPIs
+}
+
+package "API Layer" {
+  [connection.rs\nconnection_init()\nwith_valid_session()] as ConnAPI
+  [statement.rs\nstatement_execute_query()] as StmtAPI
+}
+
+package "Core Services" {
+  [rest/snowflake/\nsnowflake_login()\nsnowflake_query()\nrefresh_session()] as REST
+  [http/retry.rs\nexecute_with_retry()] as HTTP
+  [connection_state/\nConnectionStateMachine] as State
+  [chunks.rs\nChunkReader] as Chunks
+}
+
+cloud "External" {
+  [Snowflake API] as SF
+  [Cloud Storage\n(S3/Azure/GCS)] as CSP
+}
+
+ODBC --> Transport
+JDBC --> Transport
+Python --> Transport
+Transport --> ProtoAPIs
+ProtoAPIs --> ConnAPI
+ProtoAPIs --> StmtAPI
+ConnAPI --> REST
+StmtAPI --> REST
+ConnAPI --> State
+REST --> HTTP
+REST --> Chunks
+HTTP --> SF
+Chunks --> CSP
+
+note right of Transport
+  Protobuf serialization/deserialization
+  handles cross-language communication
+end note
+
+note right of State
+  Manages connection lifecycle:
+  Pristine → Connecting → Connected → Renewing
+end note
+
+@enduml
+```
+
+</details>
+
 ### 3.3 Existing Function Signatures
 
 The `sf_core` already implements core functionality that can be formalized into service traits:
@@ -622,6 +687,70 @@ for {
 └─────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml class_diagram
+skinparam classAttributeIconSize 0
+
+interface SessionService <<interface>> {
+  + login(params: LoginParameters): Result<SessionTokens>
+  + refresh(tokens: SessionTokens): Result<SessionTokens>
+  + heartbeat(token: String): Result<()>
+  + logout(token: String, config: LogoutConfig): Result<()>
+}
+
+class SnowflakeSessionService {
+  - http_client: Arc<dyn HttpClient>
+  - server_url: String
+  - client_info: ClientInfo
+  - retry_policy: RetryPolicy
+  --
+  + new(http_client, server_url, client_info): Self
+  + login(params): Result<SessionTokens>
+  + refresh(tokens): Result<SessionTokens>
+  + heartbeat(token): Result<()>
+  + logout(token, config): Result<()>
+}
+
+interface QueryService <<interface>> {
+  + execute(token, sql, params, mode): Result<QueryResult>
+  + fetchResult(token, queryId): Result<QueryResult>
+  + getStatus(token, queryId): Result<QueryStatus>
+  + cancel(token, queryId): Result<()>
+}
+
+interface StorageService <<interface>> {
+  + upload(meta, credentials): Result<()>
+  + download(meta, credentials): Result<Vec<u8>>
+  + head(meta, credentials): Result<FileInfo>
+}
+
+interface HttpClient <<interface>> {
+  + request(method, url, headers, body): Result<Response>
+}
+
+class ReqwestHttpClient {
+  - client: reqwest::Client
+  + request(method, url, headers, body): Result<Response>
+}
+
+class MockHttpClient {
+  - responses: Vec<MockResponse>
+  + request(method, url, headers, body): Result<Response>
+}
+
+SessionService <|.. SnowflakeSessionService
+HttpClient <|.. ReqwestHttpClient
+HttpClient <|.. MockHttpClient
+
+SnowflakeSessionService --> HttpClient : uses
+@enduml
+```
+
+</details>
+
 ### 7.3 State Machine + Services Interaction (Sequence Diagram)
 
 #### 7.3.1 Login Flow
@@ -667,6 +796,49 @@ for {
      │<───────────────────┤                       │                     │
      │                    │                       │                     │
 ```
+
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml login_flow
+skinparam sequenceMessageAlign center
+
+participant "Client" as C
+participant "ConnectionStateMachine" as SM
+participant "SessionService" as SS
+participant "Snowflake API" as SF
+
+C -> SM: connect()
+activate SM
+
+SM -> SM: transition(Connecting)
+note right: State: Pristine → Connecting
+
+SM -> SS: login(params)
+activate SS
+
+SS -> SF: POST /session/v1/login-request
+activate SF
+SF --> SS: SessionTokens
+deactivate SF
+
+SS --> SM: Ok(SessionTokens)
+deactivate SS
+
+SM -> SM: transition(Connected)
+note right: State: Connecting → Connected
+
+SM -> SM: drain_pending_ops()
+note right: Resume any queued operations
+
+SM --> C: Ok(Connection)
+deactivate SM
+
+@enduml
+```
+
+</details>
 
 #### 7.3.2 Query with Auto-Refresh Flow
 
@@ -735,6 +907,73 @@ for {
      │                 │                    │                  │                │
 ```
 
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml query_auto_refresh
+skinparam sequenceMessageAlign center
+
+participant "Client" as C
+participant "ConnectionStateMachine" as SM
+participant "SessionService" as SS
+participant "QueryService" as QS
+participant "Snowflake API" as SF
+
+C -> SM: execute(sql)
+activate SM
+
+SM -> SM: wait_ready()
+note right: State: Connected ✓
+
+SM -> QS: execute(sql, token)
+activate QS
+
+QS -> SF: POST /queries/v1/query-request
+activate SF
+SF --> QS: Error: code 390112\n(session expired)
+deactivate SF
+
+QS --> SM: Err(SessionExpired)
+deactivate QS
+
+SM -> SM: transition(Renewing)
+note right: State: Connected → Renewing
+
+SM -> SS: refresh(tokens)
+activate SS
+
+SS -> SF: POST /session/token-request
+activate SF
+SF --> SS: new SessionTokens
+deactivate SF
+
+SS --> SM: Ok(new tokens)
+deactivate SS
+
+SM -> SM: update_tokens(new)
+SM -> SM: transition(Connected)
+note right: State: Renewing → Connected
+
+SM -> QS: execute(sql, new_token)
+activate QS
+
+QS -> SF: POST /queries/v1/query-request
+activate SF
+SF --> QS: QueryResult
+deactivate SF
+
+QS --> SM: Ok(QueryResult)
+deactivate QS
+
+SM --> C: QueryResult
+deactivate SM
+
+@enduml
+```
+
+</details>
+
 #### 7.3.3 Concurrent Requests During Renewal (Storm Prevention)
 
 ```
@@ -793,6 +1032,176 @@ for {
 
 KEY: Only ONE refresh request is made, even though both Query A and Query B 
      detected session expiration. Query B waits in pending_ops queue.
+```
+
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml concurrent_renewal
+skinparam sequenceMessageAlign center
+
+participant "Query A" as A
+participant "Query B" as B
+participant "ConnectionStateMachine" as SM
+participant "SessionService" as SS
+participant "Snowflake API" as SF
+
+== Query A triggers refresh ==
+
+A -> SM: execute(sql)
+activate SM
+
+SM -> SF: POST /queries/v1/query-request
+SF --> SM: Error: 390112 (session expired)
+
+SM -> SM: transition(Renewing)
+note right: State: Connected → Renewing\nOnly first thread triggers this
+
+== Query B arrives during renewal ==
+
+B -> SM: execute(sql)
+activate SM #LightBlue
+
+SM -> SM: wait_ready()
+note right: State is Renewing\nQuery B must wait
+
+SM -> SM: enqueue(Query B)
+note right: Add to pending_ops queue\nDo NOT trigger another refresh
+
+== Single refresh happens ==
+
+SM -> SS: refresh(tokens)
+activate SS
+
+SS -> SF: POST /session/token-request
+note right #LightGreen: Only ONE refresh request!\nNo "token refresh storm"
+activate SF
+SF --> SS: new SessionTokens
+deactivate SF
+
+SS --> SM: Ok(new tokens)
+deactivate SS
+
+SM -> SM: update_tokens(new)
+SM -> SM: transition(Connected)
+note right: State: Renewing → Connected
+
+== Both queries proceed ==
+
+SM -> SM: drain_pending_ops()
+note right: Notify Query B it can proceed
+
+SM --> A: retry with new token
+deactivate SM
+
+SM --> B: proceed with new token
+deactivate SM
+
+note over A, B: Both queries now execute\nwith the same new token
+
+@enduml
+```
+
+</details>
+
+#### 7.3.4 Connection State Machine (State Diagram)
+
+<details>
+<summary>PlantUML Source</summary>
+
+```plantuml
+@startuml state_machine
+skinparam state {
+  BackgroundColor<<ready>> LightGreen
+  BackgroundColor<<transient>> LightYellow
+  BackgroundColor<<terminal>> LightGray
+}
+
+[*] --> Pristine
+
+state Pristine <<ready>> {
+  Pristine: No connection established
+  Pristine: Allowed: connect()
+}
+
+state Connecting <<transient>> {
+  Connecting: Login in progress
+  Connecting: Requests queued in pending_ops
+}
+
+state Connected <<ready>> {
+  Connected: Session active
+  Connected: Allowed: execute(), heartbeat(), close()
+}
+
+state Renewing <<transient>> {
+  Renewing: Token refresh in progress
+  Renewing: Requests queued in pending_ops
+}
+
+state Disconnected <<terminal>> {
+  Disconnected: Session closed or failed
+  Disconnected: No operations allowed
+}
+
+Pristine --> Connecting : connect()
+Connecting --> Connected : login success
+Connecting --> Disconnected : login failure
+
+Connected --> Renewing : 390112 (session expired)
+Connected --> Disconnected : close() / fatal error
+
+Renewing --> Connected : refresh success
+Renewing --> Disconnected : refresh failure\n(master token expired)
+
+note right of Renewing
+  During Renewing:
+  - All new requests wait in pending_ops
+  - Only ONE refresh request is made
+  - After success, pending_ops are drained
+end note
+
+note right of Connected
+  Operations in Connected state:
+  - execute() → QueryService
+  - heartbeat() → SessionService
+  - close() → SessionService.logout()
+end note
+
+@enduml
+```
+
+</details>
+
+```
+    ┌─────────────┐
+    │   Pristine  │ ─── Initial state, no connection
+    └──────┬──────┘
+           │ connect()
+           ▼
+    ┌─────────────┐
+    │ Connecting  │ ─── Login in progress, ops queued
+    └──────┬──────┘
+           │ success / failure
+     ┌─────┴─────┐
+     ▼           ▼
+┌─────────┐  ┌──────────────┐
+│Connected│  │ Disconnected │ ─── Terminal state
+└────┬────┘  └──────────────┘
+     │                ▲
+     │ 390112         │ close() / fatal error
+     ▼                │
+┌─────────┐           │
+│Renewing │───────────┘
+└────┬────┘  failure
+     │
+     │ success
+     └──────────────────┐
+                        ▼
+                  ┌─────────┐
+                  │Connected│
+                  └─────────┘
 ```
 
 ### 7.4 Revised Service Traits

--- a/sf_core/src/connection_state/error.rs
+++ b/sf_core/src/connection_state/error.rs
@@ -1,0 +1,86 @@
+//! Error types for the connection state machine.
+
+use snafu::{Location, Snafu};
+
+/// Errors that can occur during state machine operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum StateMachineError {
+    /// Attempted an invalid state transition.
+    #[snafu(display("Invalid state transition from {from} to {to}"))]
+    InvalidTransition {
+        /// The current state
+        from: String,
+        /// The attempted target state
+        to: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Operation timed out waiting for state to become ready.
+    #[snafu(display("Operation timed out waiting for connection to become ready"))]
+    OperationTimeout {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Operation was cancelled (sender dropped).
+    #[snafu(display("Operation was cancelled"))]
+    OperationCancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Connection is not initialized (still in Pristine state).
+    #[snafu(display("Connection is not initialized"))]
+    ConnectionNotInitialized {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Connection is disconnected and cannot perform the operation.
+    #[snafu(display("Connection is disconnected: {reason}"))]
+    ConnectionDisconnected {
+        /// The disconnect reason
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Cannot reconnect from the current disconnect reason.
+    #[snafu(display("Cannot reconnect: {reason}"))]
+    CannotReconnect {
+        /// The disconnect reason that prevents reconnection
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// The operation is not valid in the current state.
+    #[snafu(display("Invalid state for operation: current state is {state}"))]
+    InvalidStateForOperation {
+        /// The current state
+        state: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Pending operations queue is full.
+    #[snafu(display("Pending operations queue is full (max: {max_size})"))]
+    QueueFull {
+        /// Maximum queue size
+        max_size: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Failed to acquire lock on state machine.
+    #[snafu(display("Failed to acquire state machine lock"))]
+    LockFailed {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+/// Result type alias for state machine operations.
+pub type Result<T> = std::result::Result<T, StateMachineError>;

--- a/sf_core/src/connection_state/machine.rs
+++ b/sf_core/src/connection_state/machine.rs
@@ -1,0 +1,528 @@
+//! Connection state machine implementation.
+//!
+//! This module provides the core state machine that manages connection lifecycle,
+//! validates state transitions, and coordinates pending operations.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{RwLock, broadcast};
+
+use super::error::{
+    ConnectionDisconnectedSnafu, ConnectionNotInitializedSnafu, InvalidTransitionSnafu,
+    OperationCancelledSnafu, OperationTimeoutSnafu, Result,
+};
+use super::pending_ops::{DEFAULT_MAX_PENDING_OPS, PendingOperation, PendingOpsQueue};
+use super::state::{ConnectionState, DisconnectReason, is_valid_transition};
+
+/// Default timeout for waiting on state transitions.
+pub const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Capacity of the state change broadcast channel.
+const STATE_BROADCAST_CAPACITY: usize = 16;
+
+/// The connection state machine.
+///
+/// This struct manages:
+/// - Current connection state
+/// - State transition validation
+/// - Pending operations queue
+/// - State change notifications
+///
+/// # Thread Safety
+///
+/// The state machine is fully thread-safe and can be cloned. All clones
+/// share the same underlying state via `Arc`.
+#[derive(Clone)]
+pub struct ConnectionStateMachine {
+    /// Current state, protected by async RwLock for concurrent reads.
+    state: Arc<RwLock<ConnectionState>>,
+
+    /// Broadcast channel for state change notifications.
+    state_tx: broadcast::Sender<ConnectionState>,
+
+    /// Queue of operations waiting for connection to become ready.
+    pending_ops: Arc<RwLock<PendingOpsQueue>>,
+}
+
+impl Default for ConnectionStateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConnectionStateMachine {
+    /// Creates a new state machine in the `Pristine` state.
+    pub fn new() -> Self {
+        Self::with_queue_size(DEFAULT_MAX_PENDING_OPS)
+    }
+
+    /// Creates a new state machine with a custom pending ops queue size.
+    pub fn with_queue_size(max_pending_ops: usize) -> Self {
+        let (state_tx, _) = broadcast::channel(STATE_BROADCAST_CAPACITY);
+        Self {
+            state: Arc::new(RwLock::new(ConnectionState::Pristine)),
+            state_tx,
+            pending_ops: Arc::new(RwLock::new(PendingOpsQueue::new(max_pending_ops))),
+        }
+    }
+
+    /// Returns the current connection state.
+    pub async fn state(&self) -> ConnectionState {
+        self.state.read().await.clone()
+    }
+
+    /// Returns the current state synchronously (blocking).
+    ///
+    /// Prefer `state()` for async contexts.
+    pub fn state_blocking(&self) -> ConnectionState {
+        self.state.blocking_read().clone()
+    }
+
+    /// Subscribe to state change notifications.
+    ///
+    /// Returns a receiver that will receive each new state after transitions.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let sm = ConnectionStateMachine::new();
+    /// let mut rx = sm.subscribe();
+    ///
+    /// tokio::spawn(async move {
+    ///     while let Ok(state) = rx.recv().await {
+    ///         println!("State changed to: {:?}", state);
+    ///     }
+    /// });
+    /// ```
+    pub fn subscribe(&self) -> broadcast::Receiver<ConnectionState> {
+        self.state_tx.subscribe()
+    }
+
+    /// Returns the number of pending operations in the queue.
+    pub async fn pending_count(&self) -> usize {
+        self.pending_ops.read().await.len()
+    }
+
+    /// Attempts to transition to a new state.
+    ///
+    /// This method validates that the transition is allowed before applying it.
+    /// If the transition is valid:
+    /// - The state is updated
+    /// - State change is broadcast to subscribers
+    /// - Pending operations are processed as appropriate
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidTransition` if the transition is not allowed.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let sm = ConnectionStateMachine::new();
+    ///
+    /// // Valid: Pristine -> Connecting
+    /// sm.transition(ConnectionState::Connecting).await?;
+    ///
+    /// // Invalid: Connecting -> Pristine (will error)
+    /// sm.transition(ConnectionState::Pristine).await?; // Error!
+    /// ```
+    pub async fn transition(&self, new_state: ConnectionState) -> Result<()> {
+        let mut state_guard = self.state.write().await;
+        let current_state = state_guard.clone();
+
+        // Validate the transition
+        if !is_valid_transition(&current_state, &new_state) {
+            return InvalidTransitionSnafu {
+                from: current_state.to_string(),
+                to: new_state.to_string(),
+            }
+            .fail();
+        }
+
+        // Skip if already in the target state
+        if current_state == new_state {
+            return Ok(());
+        }
+
+        tracing::info!(
+            from = %current_state,
+            to = %new_state,
+            "Connection state transition"
+        );
+
+        // Update state
+        *state_guard = new_state.clone();
+
+        // Broadcast to subscribers (ignore if no receivers)
+        let _ = self.state_tx.send(new_state.clone());
+
+        // Release state lock before processing pending ops
+        drop(state_guard);
+
+        // Process pending operations based on new state
+        match &new_state {
+            ConnectionState::Connected => {
+                // Signal all pending operations that they can proceed
+                self.pending_ops.write().await.drain_ready();
+            }
+            ConnectionState::Disconnected { reason } => {
+                // Signal all pending operations with error
+                let reason_str = reason.description();
+                self.pending_ops.write().await.drain_error(move || {
+                    ConnectionDisconnectedSnafu {
+                        reason: reason_str.clone(),
+                    }
+                    .build()
+                });
+            }
+            _ => {
+                // For other states, just expire any timed-out operations
+                let expired = self.pending_ops.write().await.expire_timed_out();
+                if expired > 0 {
+                    tracing::debug!(expired, "Expired timed-out pending operations");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Waits until the connection is ready to accept requests.
+    ///
+    /// If the connection is already in `Connected` state, returns immediately.
+    /// If in `Connecting` or `Renewing` state, the caller is queued and will
+    /// be notified when the state transitions to `Connected`.
+    ///
+    /// # Arguments
+    ///
+    /// * `timeout` - Maximum time to wait for the connection to become ready.
+    ///
+    /// # Errors
+    ///
+    /// - `ConnectionNotInitialized` - Connection is in `Pristine` state
+    /// - `ConnectionDisconnected` - Connection is in `Disconnected` state
+    /// - `OperationTimeout` - Timeout expired before connection became ready
+    /// - `OperationCancelled` - The wait was cancelled
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let sm = ConnectionStateMachine::new();
+    ///
+    /// // In another task, connection is being established...
+    /// sm.wait_ready(Duration::from_secs(30)).await?;
+    ///
+    /// // Now safe to execute queries
+    /// ```
+    pub async fn wait_ready(&self, timeout: Duration) -> Result<()> {
+        let current_state = self.state().await;
+
+        match current_state {
+            // Already ready
+            ConnectionState::Connected => Ok(()),
+
+            // Not initialized
+            ConnectionState::Pristine => ConnectionNotInitializedSnafu.fail(),
+
+            // Cannot proceed
+            ConnectionState::Disconnected { reason } => ConnectionDisconnectedSnafu {
+                reason: reason.description(),
+            }
+            .fail(),
+
+            // Need to wait
+            ConnectionState::Connecting | ConnectionState::Renewing => {
+                let (op, rx) = PendingOperation::with_timeout("wait_ready", timeout);
+
+                // Enqueue the operation
+                self.pending_ops.write().await.enqueue(op)?;
+
+                // Wait for notification with timeout
+                match tokio::time::timeout(timeout, rx).await {
+                    Ok(Ok(result)) => result,
+                    Ok(Err(_)) => {
+                        // Sender dropped (shouldn't happen normally)
+                        OperationCancelledSnafu.fail()
+                    }
+                    Err(_) => {
+                        // Timeout
+                        OperationTimeoutSnafu.fail()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Waits until the connection is ready, using the default timeout.
+    pub async fn wait_ready_default(&self) -> Result<()> {
+        self.wait_ready(DEFAULT_WAIT_TIMEOUT).await
+    }
+
+    /// Checks if the connection can accept requests right now.
+    ///
+    /// This does not wait - it returns the current ability to accept requests.
+    pub async fn can_accept_requests(&self) -> bool {
+        self.state().await.can_accept_requests()
+    }
+
+    /// Checks if the connection is fully ready.
+    pub async fn is_ready(&self) -> bool {
+        self.state().await.is_ready()
+    }
+
+    /// Checks if a connect/reconnect operation can be performed.
+    pub async fn can_connect(&self) -> bool {
+        self.state().await.can_connect()
+    }
+
+    /// Performs state transition to `Connecting`.
+    ///
+    /// This is a convenience method that validates the transition.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if not in `Pristine` state or a reconnectable `Disconnected` state.
+    pub async fn start_connecting(&self) -> Result<()> {
+        self.transition(ConnectionState::Connecting).await
+    }
+
+    /// Performs state transition to `Connected`.
+    ///
+    /// Call this after successful login or token refresh.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if not in `Connecting` or `Renewing` state.
+    pub async fn connection_established(&self) -> Result<()> {
+        self.transition(ConnectionState::Connected).await
+    }
+
+    /// Performs state transition to `Renewing`.
+    ///
+    /// Call this when the session token has expired and refresh is starting.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if not in `Connected` state.
+    pub async fn start_renewing(&self) -> Result<()> {
+        self.transition(ConnectionState::Renewing).await
+    }
+
+    /// Performs state transition to `Disconnected` with the given reason.
+    ///
+    /// This will signal all pending operations with an error.
+    pub async fn disconnect(&self, reason: DisconnectReason) -> Result<()> {
+        self.transition(ConnectionState::Disconnected { reason })
+            .await
+    }
+
+    /// Closes the connection (user-initiated disconnect).
+    ///
+    /// The connection can be reconnected after this.
+    pub async fn close(&self) -> Result<()> {
+        self.disconnect(DisconnectReason::UserInitiated).await
+    }
+}
+
+impl std::fmt::Debug for ConnectionStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionStateMachine")
+            .field("state", &self.state_blocking())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::error::StateMachineError;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_initial_state_is_pristine() {
+        let sm = ConnectionStateMachine::new();
+        assert_eq!(sm.state().await, ConnectionState::Pristine);
+    }
+
+    #[tokio::test]
+    async fn test_valid_transition_pristine_to_connecting() {
+        let sm = ConnectionStateMachine::new();
+        assert!(sm.start_connecting().await.is_ok());
+        assert_eq!(sm.state().await, ConnectionState::Connecting);
+    }
+
+    #[tokio::test]
+    async fn test_valid_transition_connecting_to_connected() {
+        let sm = ConnectionStateMachine::new();
+        sm.start_connecting().await.unwrap();
+        assert!(sm.connection_established().await.is_ok());
+        assert_eq!(sm.state().await, ConnectionState::Connected);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_transition_pristine_to_connected() {
+        let sm = ConnectionStateMachine::new();
+        let result = sm.connection_established().await;
+        assert!(result.is_err());
+        // State should remain unchanged
+        assert_eq!(sm.state().await, ConnectionState::Pristine);
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_after_user_close() {
+        let sm = ConnectionStateMachine::new();
+
+        // Connect
+        sm.start_connecting().await.unwrap();
+        sm.connection_established().await.unwrap();
+
+        // Close
+        sm.close().await.unwrap();
+        assert!(matches!(
+            sm.state().await,
+            ConnectionState::Disconnected {
+                reason: DisconnectReason::UserInitiated
+            }
+        ));
+
+        // Reconnect
+        assert!(sm.start_connecting().await.is_ok());
+        assert_eq!(sm.state().await, ConnectionState::Connecting);
+    }
+
+    #[tokio::test]
+    async fn test_cannot_reconnect_from_internal_error() {
+        let sm = ConnectionStateMachine::new();
+
+        // Transition to internal error
+        sm.start_connecting().await.unwrap();
+        sm.disconnect(DisconnectReason::InternalError {
+            message: "fatal".to_string(),
+        })
+        .await
+        .unwrap();
+
+        // Cannot reconnect
+        let result = sm.start_connecting().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_state_change_broadcast() {
+        let sm = ConnectionStateMachine::new();
+        let mut rx = sm.subscribe();
+
+        sm.start_connecting().await.unwrap();
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received, ConnectionState::Connecting);
+    }
+
+    #[tokio::test]
+    async fn test_wait_ready_when_already_connected() {
+        let sm = ConnectionStateMachine::new();
+        sm.start_connecting().await.unwrap();
+        sm.connection_established().await.unwrap();
+
+        // Should return immediately
+        let result = sm.wait_ready(Duration::from_millis(10)).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_wait_ready_when_pristine() {
+        let sm = ConnectionStateMachine::new();
+
+        let result = sm.wait_ready(Duration::from_millis(10)).await;
+        assert!(matches!(
+            result,
+            Err(StateMachineError::ConnectionNotInitialized { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_wait_ready_when_disconnected() {
+        let sm = ConnectionStateMachine::new();
+        sm.start_connecting().await.unwrap();
+        sm.disconnect(DisconnectReason::UserInitiated)
+            .await
+            .unwrap();
+
+        let result = sm.wait_ready(Duration::from_millis(10)).await;
+        assert!(matches!(
+            result,
+            Err(StateMachineError::ConnectionDisconnected { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_wait_ready_during_connecting() {
+        let sm = ConnectionStateMachine::new();
+        sm.start_connecting().await.unwrap();
+
+        // Clone for the connecting task
+        let sm_clone = sm.clone();
+
+        // Spawn a task that waits for ready
+        let wait_handle =
+            tokio::spawn(async move { sm_clone.wait_ready(Duration::from_secs(5)).await });
+
+        // Give the wait task time to enqueue
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Now establish connection
+        sm.connection_established().await.unwrap();
+
+        // Wait task should complete successfully
+        let result = wait_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_pending_ops_drained_on_disconnect() {
+        let sm = ConnectionStateMachine::new();
+        sm.start_connecting().await.unwrap();
+
+        let sm_clone = sm.clone();
+
+        // Spawn a task that waits for ready
+        let wait_handle =
+            tokio::spawn(async move { sm_clone.wait_ready(Duration::from_secs(5)).await });
+
+        // Give the wait task time to enqueue
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(sm.pending_count().await, 1);
+
+        // Disconnect instead of connecting
+        sm.disconnect(DisconnectReason::UserInitiated)
+            .await
+            .unwrap();
+
+        // Wait task should receive error
+        let result = wait_handle.await.unwrap();
+        assert!(matches!(
+            result,
+            Err(StateMachineError::ConnectionDisconnected { .. })
+        ));
+
+        // Queue should be empty
+        assert_eq!(sm.pending_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_renewing_state() {
+        let sm = ConnectionStateMachine::new();
+
+        // Connect
+        sm.start_connecting().await.unwrap();
+        sm.connection_established().await.unwrap();
+
+        // Start renewing
+        sm.start_renewing().await.unwrap();
+        assert_eq!(sm.state().await, ConnectionState::Renewing);
+
+        // Complete renewal
+        sm.connection_established().await.unwrap();
+        assert_eq!(sm.state().await, ConnectionState::Connected);
+    }
+}

--- a/sf_core/src/connection_state/mod.rs
+++ b/sf_core/src/connection_state/mod.rs
@@ -1,0 +1,91 @@
+//! Connection state machine for managing Snowflake connection lifecycle.
+//!
+//! This module provides an explicit, type-safe state machine for managing
+//! the connection lifecycle. It addresses issues found in other drivers'
+//! state management implementations by providing:
+//!
+//! - **Explicit state enum**: State is a real type, not hidden in closures
+//! - **Validated transitions**: Invalid state changes return errors
+//! - **Observable state changes**: Subscribe to state transitions via broadcast channel
+//! - **Bounded operation queue**: Pending operations have timeouts and limits
+//! - **Reconnection support**: Can reconnect from most disconnected states
+//!
+//! # States
+//!
+//! The connection can be in one of five states:
+//!
+//! - [`ConnectionState::Pristine`] - Initial state, no connection attempted
+//! - [`ConnectionState::Connecting`] - Login in progress
+//! - [`ConnectionState::Connected`] - Authenticated and ready for requests
+//! - [`ConnectionState::Renewing`] - Session token refresh in progress
+//! - [`ConnectionState::Disconnected`] - Connection closed or in error state
+//!
+//! # Usage Example
+//!
+//! ```ignore
+//! use sf_core::connection_state::{ConnectionStateMachine, ConnectionState, DisconnectReason};
+//! use std::time::Duration;
+//!
+//! // Create a new state machine
+//! let sm = ConnectionStateMachine::new();
+//!
+//! // Subscribe to state changes
+//! let mut rx = sm.subscribe();
+//! tokio::spawn(async move {
+//!     while let Ok(state) = rx.recv().await {
+//!         println!("State: {:?}", state);
+//!     }
+//! });
+//!
+//! // Start connecting
+//! sm.start_connecting().await?;
+//!
+//! // ... perform login ...
+//!
+//! // Mark as connected
+//! sm.connection_established().await?;
+//!
+//! // Check state
+//! assert!(sm.is_ready().await);
+//!
+//! // Wait for connection to be ready (useful from other tasks)
+//! sm.wait_ready(Duration::from_secs(30)).await?;
+//!
+//! // Close connection (can reconnect later)
+//! sm.close().await?;
+//!
+//! // Reconnect
+//! sm.start_connecting().await?;
+//! ```
+//!
+//! # Thread Safety
+//!
+//! The [`ConnectionStateMachine`] is fully thread-safe and can be cloned.
+//! All clones share the same underlying state. Operations during transient
+//! states (Connecting, Renewing) are automatically queued and processed
+//! when the connection becomes ready.
+//!
+//! # Design Rationale
+//!
+//! This design addresses issues observed in the Node.js Snowflake connector:
+//!
+//! | Node.js Problem | This Solution |
+//! |-----------------|---------------|
+//! | Hidden closure state | Explicit [`ConnectionState`] enum |
+//! | Callback mutation | Async/await with [`Result`] |
+//! | No observability | [`broadcast`] channel subscription |
+//! | Unbounded queue | Bounded queue with timeouts |
+//! | No type safety | Strong typing with [`snafu`] errors |
+
+pub mod error;
+pub mod machine;
+pub mod pending_ops;
+pub mod state;
+
+// Re-export main types
+pub use error::{Result, StateMachineError};
+pub use machine::{ConnectionStateMachine, DEFAULT_WAIT_TIMEOUT};
+pub use pending_ops::{
+    DEFAULT_MAX_PENDING_OPS, DEFAULT_PENDING_OP_TIMEOUT, PendingOperation, PendingOpsQueue,
+};
+pub use state::{ConnectionState, DisconnectReason, is_valid_transition};

--- a/sf_core/src/connection_state/pending_ops.rs
+++ b/sf_core/src/connection_state/pending_ops.rs
@@ -1,0 +1,274 @@
+//! Pending operations queue for connection state machine.
+//!
+//! When the connection is in a transient state (Connecting, Renewing),
+//! incoming requests are queued and will be processed once the connection
+//! transitions to Connected.
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::oneshot;
+
+use super::error::{QueueFullSnafu, Result, StateMachineError};
+
+/// Default maximum number of pending operations.
+pub const DEFAULT_MAX_PENDING_OPS: usize = 1000;
+
+/// Default timeout for pending operations.
+pub const DEFAULT_PENDING_OP_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// A pending operation waiting for the connection to become ready.
+pub struct PendingOperation {
+    /// Channel to signal when the operation can proceed.
+    pub ready_tx: oneshot::Sender<Result<()>>,
+    /// When this operation was queued.
+    pub queued_at: Instant,
+    /// Timeout for this operation.
+    pub timeout: Duration,
+    /// Description for debugging/logging.
+    pub description: String,
+}
+
+impl PendingOperation {
+    /// Creates a new pending operation with default timeout.
+    pub fn new(description: impl Into<String>) -> (Self, oneshot::Receiver<Result<()>>) {
+        Self::with_timeout(description, DEFAULT_PENDING_OP_TIMEOUT)
+    }
+
+    /// Creates a new pending operation with custom timeout.
+    pub fn with_timeout(
+        description: impl Into<String>,
+        timeout: Duration,
+    ) -> (Self, oneshot::Receiver<Result<()>>) {
+        let (tx, rx) = oneshot::channel();
+        let op = Self {
+            ready_tx: tx,
+            queued_at: Instant::now(),
+            timeout,
+            description: description.into(),
+        };
+        (op, rx)
+    }
+
+    /// Returns true if this operation has timed out.
+    pub fn is_timed_out(&self) -> bool {
+        self.queued_at.elapsed() > self.timeout
+    }
+
+    /// Returns the remaining time before timeout.
+    pub fn remaining_time(&self) -> Duration {
+        self.timeout.saturating_sub(self.queued_at.elapsed())
+    }
+
+    /// Signals that the operation can proceed (success).
+    pub fn signal_ready(self) {
+        let _ = self.ready_tx.send(Ok(()));
+    }
+
+    /// Signals that the operation failed with an error.
+    pub fn signal_error(self, error: StateMachineError) {
+        let _ = self.ready_tx.send(Err(error));
+    }
+}
+
+/// Queue for pending operations.
+///
+/// Thread-safe queue that holds operations waiting for the connection
+/// to transition to a ready state.
+pub struct PendingOpsQueue {
+    /// The pending operations.
+    ops: Vec<PendingOperation>,
+    /// Maximum queue size.
+    max_size: usize,
+}
+
+impl Default for PendingOpsQueue {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_PENDING_OPS)
+    }
+}
+
+impl PendingOpsQueue {
+    /// Creates a new queue with the specified maximum size.
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            ops: Vec::with_capacity(max_size.min(100)), // Pre-allocate reasonably
+            max_size,
+        }
+    }
+
+    /// Returns the number of pending operations.
+    pub fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// Returns true if there are no pending operations.
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    /// Returns true if the queue is at capacity.
+    pub fn is_full(&self) -> bool {
+        self.ops.len() >= self.max_size
+    }
+
+    /// Adds a pending operation to the queue.
+    ///
+    /// # Errors
+    /// Returns `QueueFull` if the queue is at capacity.
+    pub fn enqueue(&mut self, op: PendingOperation) -> Result<()> {
+        if self.is_full() {
+            // Signal the operation that it was rejected
+            op.signal_error(
+                QueueFullSnafu {
+                    max_size: self.max_size,
+                }
+                .build(),
+            );
+            return QueueFullSnafu {
+                max_size: self.max_size,
+            }
+            .fail();
+        }
+        self.ops.push(op);
+        Ok(())
+    }
+
+    /// Drains all pending operations, signaling each one as ready.
+    ///
+    /// This is called when the connection transitions to `Connected`.
+    pub fn drain_ready(&mut self) {
+        for op in self.ops.drain(..) {
+            if op.is_timed_out() {
+                tracing::warn!(
+                    description = %op.description,
+                    elapsed_ms = op.queued_at.elapsed().as_millis(),
+                    "Pending operation timed out before becoming ready"
+                );
+                op.signal_error(super::error::OperationTimeoutSnafu.build());
+            } else {
+                tracing::debug!(
+                    description = %op.description,
+                    wait_ms = op.queued_at.elapsed().as_millis(),
+                    "Signaling pending operation as ready"
+                );
+                op.signal_ready();
+            }
+        }
+    }
+
+    /// Drains all pending operations, signaling each one with an error.
+    ///
+    /// This is called when the connection transitions to `Disconnected`.
+    pub fn drain_error(&mut self, error_factory: impl Fn() -> StateMachineError) {
+        for op in self.ops.drain(..) {
+            tracing::debug!(
+                description = %op.description,
+                wait_ms = op.queued_at.elapsed().as_millis(),
+                "Signaling pending operation with error"
+            );
+            op.signal_error(error_factory());
+        }
+    }
+
+    /// Removes and returns timed-out operations.
+    ///
+    /// Call this periodically to clean up stale operations.
+    pub fn expire_timed_out(&mut self) -> usize {
+        let before = self.ops.len();
+        let ops = std::mem::take(&mut self.ops);
+
+        for op in ops {
+            if op.is_timed_out() {
+                tracing::warn!(
+                    description = %op.description,
+                    elapsed_ms = op.queued_at.elapsed().as_millis(),
+                    "Expiring timed out pending operation"
+                );
+                op.signal_error(super::error::OperationTimeoutSnafu.build());
+            } else {
+                self.ops.push(op);
+            }
+        }
+
+        before - self.ops.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pending_op_ready() {
+        let (op, rx) = PendingOperation::new("test");
+        op.signal_ready();
+        assert!(rx.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_pending_op_error() {
+        let (op, rx) = PendingOperation::new("test");
+        op.signal_error(super::super::error::OperationTimeoutSnafu.build());
+        assert!(rx.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_queue_drain_ready() {
+        let mut queue = PendingOpsQueue::new(10);
+
+        let (op1, rx1) = PendingOperation::new("op1");
+        let (op2, rx2) = PendingOperation::new("op2");
+
+        queue.enqueue(op1).unwrap();
+        queue.enqueue(op2).unwrap();
+
+        assert_eq!(queue.len(), 2);
+
+        queue.drain_ready();
+
+        assert!(queue.is_empty());
+        assert!(rx1.await.unwrap().is_ok());
+        assert!(rx2.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_queue_drain_error() {
+        let mut queue = PendingOpsQueue::new(10);
+
+        let (op, rx) = PendingOperation::new("test");
+        queue.enqueue(op).unwrap();
+
+        queue.drain_error(|| {
+            super::super::error::ConnectionDisconnectedSnafu {
+                reason: "test".to_string(),
+            }
+            .build()
+        });
+
+        assert!(queue.is_empty());
+        assert!(rx.await.unwrap().is_err());
+    }
+
+    #[test]
+    fn test_queue_full() {
+        let mut queue = PendingOpsQueue::new(2);
+
+        let (op1, _rx1) = PendingOperation::new("op1");
+        let (op2, _rx2) = PendingOperation::new("op2");
+        let (op3, _rx3) = PendingOperation::new("op3");
+
+        assert!(queue.enqueue(op1).is_ok());
+        assert!(queue.enqueue(op2).is_ok());
+        assert!(queue.enqueue(op3).is_err()); // Queue full
+    }
+
+    #[tokio::test]
+    async fn test_pending_op_timeout() {
+        let (op, _rx) = PendingOperation::with_timeout("test", Duration::from_millis(1));
+
+        // Wait for timeout
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(op.is_timed_out());
+    }
+}

--- a/sf_core/src/connection_state/state.rs
+++ b/sf_core/src/connection_state/state.rs
@@ -1,0 +1,334 @@
+//! Connection state definitions and transition validation.
+//!
+//! This module defines the explicit states a connection can be in,
+//! along with the rules for valid state transitions.
+
+use std::fmt;
+
+/// The possible states of a Snowflake connection.
+///
+/// This enum represents an explicit, type-safe state machine for connection lifecycle.
+/// Each state has specific behaviors and valid transitions to other states.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// Initial state - no connection attempted yet.
+    ///
+    /// Valid transitions:
+    /// - `Connecting` (via connect())
+    Pristine,
+
+    /// Login/authentication in progress (async operation).
+    ///
+    /// While in this state, requests are queued and will be processed
+    /// once the connection transitions to `Connected`.
+    ///
+    /// Valid transitions:
+    /// - `Connected` (login success)
+    /// - `Disconnected` (login failure)
+    Connecting,
+
+    /// Successfully authenticated and ready for requests.
+    ///
+    /// This is the normal operating state where queries can be executed.
+    ///
+    /// Valid transitions:
+    /// - `Renewing` (session token expired)
+    /// - `Disconnected` (user close or fatal error)
+    Connected,
+
+    /// Session token refresh in progress.
+    ///
+    /// The session token has expired but the master token is still valid.
+    /// A refresh request is in flight. Requests are queued during this state.
+    ///
+    /// Valid transitions:
+    /// - `Connected` (refresh success)
+    /// - `Disconnected` (master token expired or refresh failed)
+    Renewing,
+
+    /// Connection is closed or in an error state.
+    ///
+    /// Depending on the `reason`, the connection may or may not be
+    /// able to reconnect.
+    ///
+    /// Valid transitions:
+    /// - `Connecting` (only if `reason.can_reconnect()` is true)
+    Disconnected {
+        /// The reason for disconnection
+        reason: DisconnectReason,
+    },
+}
+
+impl ConnectionState {
+    /// Returns true if the connection is ready to execute requests.
+    pub fn is_ready(&self) -> bool {
+        matches!(self, ConnectionState::Connected)
+    }
+
+    /// Returns true if requests can potentially be executed (may be queued).
+    ///
+    /// In `Renewing` state, requests are queued and will be executed
+    /// once the token refresh completes.
+    pub fn can_accept_requests(&self) -> bool {
+        matches!(self, ConnectionState::Connected | ConnectionState::Renewing)
+    }
+
+    /// Returns true if this is a terminal state that cannot transition further.
+    ///
+    /// Note: `Disconnected` is only terminal if `!reason.can_reconnect()`.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            ConnectionState::Disconnected {
+                reason: DisconnectReason::InternalError { .. }
+            }
+        )
+    }
+
+    /// Returns true if requests should be queued in this state.
+    pub fn should_queue_requests(&self) -> bool {
+        matches!(
+            self,
+            ConnectionState::Connecting | ConnectionState::Renewing
+        )
+    }
+
+    /// Returns true if this state can transition to `Connecting`.
+    pub fn can_connect(&self) -> bool {
+        match self {
+            ConnectionState::Pristine => true,
+            ConnectionState::Disconnected { reason } => reason.can_reconnect(),
+            _ => false,
+        }
+    }
+
+    /// Returns the display name for this state.
+    pub fn name(&self) -> &'static str {
+        match self {
+            ConnectionState::Pristine => "Pristine",
+            ConnectionState::Connecting => "Connecting",
+            ConnectionState::Connected => "Connected",
+            ConnectionState::Renewing => "Renewing",
+            ConnectionState::Disconnected { .. } => "Disconnected",
+        }
+    }
+}
+
+impl fmt::Display for ConnectionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectionState::Pristine => write!(f, "Pristine"),
+            ConnectionState::Connecting => write!(f, "Connecting"),
+            ConnectionState::Connected => write!(f, "Connected"),
+            ConnectionState::Renewing => write!(f, "Renewing"),
+            ConnectionState::Disconnected { reason } => write!(f, "Disconnected({reason})"),
+        }
+    }
+}
+
+/// The reason why a connection entered the `Disconnected` state.
+///
+/// Some reasons allow reconnection, others are terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisconnectReason {
+    /// User explicitly called close() - CAN reconnect.
+    UserInitiated,
+
+    /// Master token expired, full re-authentication needed - CAN reconnect.
+    MasterTokenExpired,
+
+    /// Initial login failed - CAN retry with different credentials.
+    LoginFailed {
+        /// Snowflake error code
+        code: i32,
+        /// Error message
+        message: String,
+    },
+
+    /// Session refresh failed - CAN reconnect with fresh login.
+    SessionRefreshFailed {
+        /// Error message
+        message: String,
+    },
+
+    /// Unrecoverable internal error - CANNOT reconnect.
+    ///
+    /// This indicates a bug or fundamental issue that won't be fixed
+    /// by simply reconnecting.
+    InternalError {
+        /// Error description
+        message: String,
+    },
+}
+
+impl DisconnectReason {
+    /// Returns true if the connection can attempt to reconnect from this state.
+    ///
+    /// Most disconnect reasons allow reconnection. Only `InternalError`
+    /// is considered unrecoverable.
+    pub fn can_reconnect(&self) -> bool {
+        !matches!(self, DisconnectReason::InternalError { .. })
+    }
+
+    /// Returns a user-friendly description of this disconnect reason.
+    pub fn description(&self) -> String {
+        match self {
+            DisconnectReason::UserInitiated => "Connection closed by user".to_string(),
+            DisconnectReason::MasterTokenExpired => {
+                "Master token expired, re-authentication required".to_string()
+            }
+            DisconnectReason::LoginFailed { code, message } => {
+                format!("Login failed (code {code}): {message}")
+            }
+            DisconnectReason::SessionRefreshFailed { message } => {
+                format!("Session refresh failed: {message}")
+            }
+            DisconnectReason::InternalError { message } => {
+                format!("Internal error: {message}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DisconnectReason::UserInitiated => write!(f, "UserInitiated"),
+            DisconnectReason::MasterTokenExpired => write!(f, "MasterTokenExpired"),
+            DisconnectReason::LoginFailed { code, .. } => write!(f, "LoginFailed(code={code})"),
+            DisconnectReason::SessionRefreshFailed { .. } => write!(f, "SessionRefreshFailed"),
+            DisconnectReason::InternalError { .. } => write!(f, "InternalError"),
+        }
+    }
+}
+
+/// Checks if a transition from one state to another is valid.
+///
+/// # Arguments
+/// * `from` - The current state
+/// * `to` - The desired target state
+///
+/// # Returns
+/// `true` if the transition is valid, `false` otherwise.
+pub fn is_valid_transition(from: &ConnectionState, to: &ConnectionState) -> bool {
+    use ConnectionState::*;
+
+    match (from, to) {
+        // From Pristine: can only start connecting
+        (Pristine, Connecting) => true,
+
+        // From Connecting: success or failure
+        (Connecting, Connected) => true,
+        (Connecting, Disconnected { .. }) => true,
+
+        // From Connected: can renew token or disconnect
+        (Connected, Renewing) => true,
+        (Connected, Disconnected { .. }) => true,
+
+        // From Renewing: success or failure
+        (Renewing, Connected) => true,
+        (Renewing, Disconnected { .. }) => true,
+
+        // From Disconnected: can reconnect if reason allows
+        (Disconnected { reason }, Connecting) => reason.can_reconnect(),
+
+        // Same state is always valid (idempotent)
+        _ if from == to => true,
+
+        // Everything else is invalid
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pristine_can_connect() {
+        assert!(ConnectionState::Pristine.can_connect());
+    }
+
+    #[test]
+    fn test_connected_is_ready() {
+        assert!(ConnectionState::Connected.is_ready());
+        assert!(!ConnectionState::Connecting.is_ready());
+        assert!(!ConnectionState::Renewing.is_ready());
+    }
+
+    #[test]
+    fn test_renewing_can_accept_requests() {
+        assert!(ConnectionState::Renewing.can_accept_requests());
+        assert!(ConnectionState::Connected.can_accept_requests());
+        assert!(!ConnectionState::Connecting.can_accept_requests());
+    }
+
+    #[test]
+    fn test_disconnected_user_initiated_can_reconnect() {
+        let state = ConnectionState::Disconnected {
+            reason: DisconnectReason::UserInitiated,
+        };
+        assert!(state.can_connect());
+    }
+
+    #[test]
+    fn test_disconnected_internal_error_cannot_reconnect() {
+        let state = ConnectionState::Disconnected {
+            reason: DisconnectReason::InternalError {
+                message: "fatal".to_string(),
+            },
+        };
+        assert!(!state.can_connect());
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn test_valid_transitions() {
+        use ConnectionState::*;
+
+        // Pristine -> Connecting
+        assert!(is_valid_transition(&Pristine, &Connecting));
+
+        // Connecting -> Connected
+        assert!(is_valid_transition(&Connecting, &Connected));
+
+        // Connected -> Renewing
+        assert!(is_valid_transition(&Connected, &Renewing));
+
+        // Renewing -> Connected
+        assert!(is_valid_transition(&Renewing, &Connected));
+
+        // Disconnected(UserInitiated) -> Connecting (reconnect)
+        let disconnected = Disconnected {
+            reason: DisconnectReason::UserInitiated,
+        };
+        assert!(is_valid_transition(&disconnected, &Connecting));
+    }
+
+    #[test]
+    fn test_invalid_transitions() {
+        use ConnectionState::*;
+
+        // Cannot go from Pristine directly to Connected
+        assert!(!is_valid_transition(&Pristine, &Connected));
+
+        // Cannot go from Connected directly to Connecting
+        assert!(!is_valid_transition(&Connected, &Connecting));
+
+        // Cannot reconnect from InternalError
+        let internal_error = Disconnected {
+            reason: DisconnectReason::InternalError {
+                message: "fatal".to_string(),
+            },
+        };
+        assert!(!is_valid_transition(&internal_error, &Connecting));
+    }
+
+    #[test]
+    fn test_same_state_transition_is_valid() {
+        assert!(is_valid_transition(
+            &ConnectionState::Connected,
+            &ConnectionState::Connected
+        ));
+    }
+}

--- a/sf_core/src/crl/config.rs
+++ b/sf_core/src/crl/config.rs
@@ -3,9 +3,10 @@ use crate::config::settings::Settings;
 use chrono::Duration;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum CertRevocationCheckMode {
     /// Default - disables CRL checking (TLS handshake still in place)
+    #[default]
     Disabled,
     /// Fails the connection if certificate is revoked or there is other revocation status check issue
     Enabled,
@@ -13,12 +14,6 @@ pub enum CertRevocationCheckMode {
     /// (like connection issues with CRL endpoints, CRL parsing errors etc) assumes
     /// that the certificate is not revoked and allows to connect.
     Advisory,
-}
-
-impl Default for CertRevocationCheckMode {
-    fn default() -> Self {
-        Self::Disabled
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -10,6 +10,7 @@ mod chunks;
 mod compression;
 mod compression_types;
 pub mod config;
+pub mod connection_state;
 pub mod crl;
 mod file_manager;
 pub mod handle_manager;


### PR DESCRIPTION
This commit introduces an explicit, type-safe connection state machine for managing Snowflake connection lifecycle. The design addresses pain points observed in the Node.js driver's state machine implementation.

Key features:
- Explicit ConnectionState enum (Pristine, Connecting, Connected, Renewing, Disconnected)
- Validated state transitions with compile/runtime errors for invalid transitions
- Observable state changes via tokio broadcast channel
- Bounded pending operations queue with timeouts
- Reconnection support from recoverable disconnect states
- Comprehensive test coverage (27 unit tests)

Files added:
- docs/CONNECTION_STATE_MACHINE.md - Design documentation
- sf_core/src/connection_state/mod.rs - Module root
- sf_core/src/connection_state/state.rs - State enum and transitions
- sf_core/src/connection_state/machine.rs - State machine implementation
- sf_core/src/connection_state/pending_ops.rs - Pending operations queue
- sf_core/src/connection_state/error.rs - State-specific errors

Also fixes:
- sf_core/src/crl/config.rs - Use derive(Default) instead of manual impl (clippy)