### PR TITLE
[PY] string type support

### DIFF
--- a/python/tests/e2e/types/test_string.py
+++ b/python/tests/e2e/types/test_string.py
@@ -1,0 +1,243 @@
+"""STRING type tests for Universal Driver.
+
+This module tests STRING type and its synonyms (VARCHAR, CHAR, CHARACTER, NCHAR, STRING, TEXT,
+VARCHAR2, NVARCHAR, NVARCHAR2, CHAR VARYING, NCHAR VARYING) across various scenarios including
+literals, table operations, corner cases, NULL handling, parameter binding, and large result sets.
+
+All tests are parameterized to run with each type synonym to verify they behave identically.
+
+Snowflake String types: All are synonymous with VARCHAR and store Unicode UTF-8.
+Maximum length: 134,217,728 characters (default 16,777,216 if unspecified)
+Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
+"""
+
+import pytest
+
+from .utils import assert_type
+
+
+# =============================================================================
+# TYPE SYNONYMS
+# =============================================================================
+# https://docs.snowflake.com/en/sql-reference/data-types-text
+STRING_TYPE_SYNONYMS = [
+    "VARCHAR",
+    "CHAR",
+    "CHARACTER",
+    "NCHAR",
+    "STRING",
+    "TEXT",
+    "VARCHAR2",
+    "NVARCHAR",
+    "NVARCHAR2",
+    "CHAR VARYING",
+    "NCHAR VARYING",
+]
+string_type_parametrize = pytest.mark.parametrize("string_type", STRING_TYPE_SYNONYMS)
+
+# =============================================================================
+# CORNER CASE VALUES
+# =============================================================================
+# Corner cases for string testing:
+#   - Empty string: ''
+#   - Single character: 'X'
+#   - Whitespace only: '   '
+#   - Tab character: '\t'
+#   - Newline: '\n'
+#   - Unicode snowman: '\u26c4' (⛄)
+#   - Unicode characters: '日本語テスト' (Japanese)
+#   - Escaped single quote: '\''
+#   - Escaped backslash: '\\'
+#   - NULL value
+#   - Combined character: 'y̆es' (character with combining diacritical mark)
+#   - Surrogate pair: '\U0001D11E' (𝄞 musical G clef)
+
+
+# SQL representations for corner case strings (for INSERT statements)
+CORNER_CASE_SQL_VALUES = [
+    ("", "''"),  # Empty string
+    ("X", "'X'"),  # Single character
+    ("   ", "'   '"),  # Whitespace only
+    ("\t", "'\\t'"),  # Tab character
+    ("\n", "'\\n'"),  # Newline
+    ("⛄", "'⛄'"),  # Unicode snowman
+    ("日本語テスト", "'日本語テスト'"),  # Japanese
+    ("'", "''''"),  # Single quote
+    ("\\", "'\\\\'"),  # Backslash
+    (None, "NULL"),  # NULL value
+    ("y̆es", "'y̆es'"),  # Combined character
+    ("𝄞", "'𝄞'"),  # Musical G clef
+]
+
+# =============================================================================
+# LARGE RESULT SET SIZE
+# =============================================================================
+LARGE_RESULT_SET_SIZE = 10_000
+
+
+class TestStringLiteral:
+    """Tests for STRING type using SELECT with literals (no tables)."""
+
+    @string_type_parametrize
+    def test_should_select_hardcoded_string_literals(self, execute_query, string_type):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3" is executed
+        sql = (
+            f"SELECT 'hello'::{string_type}(32) AS str1, "
+            f"'Hello World'::{string_type}(32) AS str2, "
+            f"'Snowflake Driver Test'::{string_type}(32) AS str3"
+        )
+        result = execute_query(sql, single_row=True)
+
+        # Then the result should contain:
+        assert result == ("hello", "Hello World", "Snowflake Driver Test")
+        assert_type(result, str)
+
+    @string_type_parametrize
+    def test_should_select_string_literals_with_corner_case_values(self, execute_query, string_type):
+        # Corner cases: empty string, single character, whitespace-only, unicode characters, escape sequences
+
+        # Given Snowflake client is logged in
+
+        # When Query selecting corner case string literals is executed
+
+        # Then the result should contain expected corner case string values
+        for expected_val, sql_val in CORNER_CASE_SQL_VALUES:
+            result = execute_query(f"SELECT {sql_val}::{string_type}(32)", single_row=True)
+            assert result == (expected_val,), f"Expected {expected_val!r}, got {result[0]!r}"
+
+
+class TestStringTable:
+    """Tests for STRING type using table operations."""
+
+    @string_type_parametrize
+    def test_should_select_hardcoded_string_values_from_table(self, execute_query, tmp_schema, string_type):
+        # Given Snowflake client is logged in
+
+        # And A temporary table with VARCHAR column is created
+        table_name = f"{tmp_schema}.string_table_test"
+        execute_query(f"CREATE TABLE {table_name} (val {string_type}(32))")
+
+        # And The table is populated with string values
+        test_values = ["hello", "Hello World", "Snowflake Driver Test"]
+        for val in test_values:
+            execute_query(f"INSERT INTO {table_name} VALUES ('{val}')")
+
+        # When Query "SELECT * FROM {table}" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then the result should contain the inserted hardcoded string values
+        result = set(row[0] for row in rows)
+        assert result == set(test_values)
+        assert_type(result, str)
+
+    @string_type_parametrize
+    def test_should_select_corner_case_string_values_from_table(self, execute_query, tmp_schema, string_type):
+        # Given Snowflake client is logged in
+
+        # And A temporary table with VARCHAR column is created
+        table_name = f"{tmp_schema}.string_corner_case_table_test"
+        execute_query(f"CREATE TABLE {table_name} (val {string_type}(32))")
+
+        # And The table is populated with corner case string values
+        for _, sql_val in CORNER_CASE_SQL_VALUES:
+            execute_query(f"INSERT INTO {table_name} VALUES ({sql_val})")
+
+        # When Query "SELECT * FROM {table}" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then the result should contain the inserted corner case string values
+        result = [row[0] for row in rows]
+        expected = [expected_val for expected_val, _ in CORNER_CASE_SQL_VALUES]
+        assert len(result) == len(expected)
+        assert set(result) == set(expected)
+        assert_type(result, str, can_be_none=True)
+
+
+class TestStringBinding:
+    """Tests for STRING type using parameter binding."""
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    @string_type_parametrize
+    def test_should_insert_and_select_back_hardcoded_string_values_using_parameter_binding(
+        self, execute_query, tmp_schema, string_type
+    ):
+        # Given Snowflake client is logged in
+
+        # And A temporary table with VARCHAR column is created
+        table_name = f"{tmp_schema}.string_bind_table_test"
+        execute_query(f"CREATE TABLE {table_name} (val {string_type}(32))")
+
+        # When String value 'Test binding value 日本語' is inserted using parameter binding
+        test_value = "Test binding value 日本語"
+        execute_query(f"INSERT INTO {table_name} VALUES (?)", (test_value,))
+
+        # And Query "SELECT * FROM {table}" is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then the result should contain the bound string value 'Test binding value 日本語'
+        result = [row[0] for row in rows]
+        assert result == [test_value]
+        assert_type(result, str)
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    @string_type_parametrize
+    def test_should_select_string_literals_using_parameter_binding(self, execute_query, string_type):
+        # SELECT binding test: Uses SELECT ?::VARCHAR to bind string values
+
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR" is executed
+        # with bound string values ['hello', 'Hello World', '日本語テスト']
+        result = execute_query(
+            f"SELECT ?::{string_type}(32), ?::{string_type}(32), ?::{string_type}(32)",
+            ("hello", "Hello World", "日本語テスト"),
+            single_row=True,
+        )
+
+        # Then the result should contain:
+        assert result == ("hello", "Hello World", "日本語テスト")
+        assert_type(result, str)
+
+    @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
+    @string_type_parametrize
+    def test_should_select_corner_case_string_values_using_parameter_binding(self, execute_query, string_type):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
+        for corner_case, _ in CORNER_CASE_SQL_VALUES:
+            result = execute_query(f"SELECT ?::{string_type}(32)", (corner_case,), single_row=True)
+
+            # Then the result should match the bound corner case value
+            assert result == (corner_case,)
+
+
+class TestStringMultipleChunks:
+    """Tests for STRING type with multiple chunks downloading."""
+
+    def test_should_download_string_data_in_multiple_chunks(self, execute_query):
+        # This test ensures proper handling of large result sets that span multiple chunks
+        # ~10000 values ensures data is downloaded in at least two chunks
+
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val
+        # FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
+
+        # Note: seq8() doesn't guarantee consecutive values in parallel execution,
+        # so we use ROW_NUMBER() to ensure sequential integers.
+        sql = (
+            f"SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1) AS id, "
+            f"TO_VARCHAR(ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::VARCHAR AS str_val "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE})) "
+            f"ORDER BY id"
+        )
+        rows = execute_query(sql)
+
+        # Then there are 10000 rows returned
+        assert len(rows) == LARGE_RESULT_SET_SIZE
+
+        # And all returned string values should match the generated values in order
+        for i, row in enumerate(rows):
+            assert row[1] == str(i), f"String value mismatch at row {i}: expected '{i}', got '{row[1]}'"

--- a/python/tests/e2e/types/test_string.py
+++ b/python/tests/e2e/types/test_string.py
@@ -86,7 +86,7 @@ class TestStringTypeCasting:
         sql = f"SELECT 'hello'::{string_type}(32), 'Hello World'::{string_type}(32), '日本語テスト'::{string_type}(32)"
         result = execute_query(sql, single_row=True)
 
-        # Then All values should be returned as appropriate type (str)
+        # Then All values should be returned as appropriate type
         assert_type(result, str)
         assert result == ("hello", "Hello World", "日本語テスト")
 

--- a/python/tests/e2e/types/test_string.py
+++ b/python/tests/e2e/types/test_string.py
@@ -13,7 +13,7 @@ Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -54,7 +54,7 @@ string_type_parametrize = pytest.mark.parametrize("string_type", STRING_TYPE_SYN
 
 
 # SQL representations for corner case strings (for INSERT statements)
-CORNER_CASE_SQL_VALUES = [
+CORNER_CASE_VALUES = [
     ("", "''"),  # Empty string
     ("X", "'X'"),  # Single character
     ("   ", "'   '"),  # Whitespace only
@@ -107,8 +107,8 @@ class TestStringLiteral:
         result = execute_query(sql, single_row=True)
 
         # Then the result should contain:
-        assert result == ("hello", "Hello World", "Snowflake Driver Test")
         assert_type(result, str)
+        assert result == ("hello", "Hello World", "Snowflake Driver Test")
 
     @string_type_parametrize
     def test_should_select_string_literals_with_corner_case_values(self, execute_query, string_type):
@@ -119,7 +119,7 @@ class TestStringLiteral:
         # When Query selecting corner case string literals is executed
 
         # Then the result should contain expected corner case string values
-        for expected_val, sql_val in CORNER_CASE_SQL_VALUES:
+        for expected_val, sql_val in CORNER_CASE_VALUES:
             result = execute_query(f"SELECT {sql_val}::{string_type}(32)", single_row=True)
             assert result == (expected_val,), f"Expected {expected_val!r}, got {result[0]!r}"
 
@@ -145,8 +145,8 @@ class TestStringTable:
 
         # Then the result should contain the inserted hardcoded string values
         result = set(row[0] for row in rows)
-        assert result == set(test_values)
         assert_type(result, str)
+        assert result == set(test_values)
 
     @string_type_parametrize
     def test_should_select_corner_case_string_values_from_table(self, execute_query, tmp_schema, string_type):
@@ -157,7 +157,7 @@ class TestStringTable:
         execute_query(f"CREATE TABLE {table_name} (val {string_type}(32))")
 
         # And The table is populated with corner case string values
-        for _, sql_val in CORNER_CASE_SQL_VALUES:
+        for _, sql_val in CORNER_CASE_VALUES:
             execute_query(f"INSERT INTO {table_name} VALUES ({sql_val})")
 
         # When Query "SELECT * FROM {table}" is executed
@@ -165,10 +165,10 @@ class TestStringTable:
 
         # Then the result should contain the inserted corner case string values
         result = [row[0] for row in rows]
-        expected = [expected_val for expected_val, _ in CORNER_CASE_SQL_VALUES]
+        expected = [expected_val for expected_val, _ in CORNER_CASE_VALUES]
         assert len(result) == len(expected)
-        assert set(result) == set(expected)
         assert_type(result, str, can_be_none=True)
+        assert set(result) == set(expected)
 
 
 class TestStringBinding:
@@ -194,8 +194,8 @@ class TestStringBinding:
 
         # Then the result should contain the bound string value 'Test binding value 日本語'
         result = [row[0] for row in rows]
-        assert result == [test_value]
         assert_type(result, str)
+        assert result == [test_value]
 
     @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
     @string_type_parametrize
@@ -213,8 +213,8 @@ class TestStringBinding:
         )
 
         # Then the result should contain:
-        assert result == ("hello", "Hello World", "日本語テスト")
         assert_type(result, str)
+        assert result == ("hello", "Hello World", "日本語テスト")
 
     @pytest.mark.skip("SNOW-3006013 - parameter binding is not yet implemented")
     @string_type_parametrize
@@ -222,7 +222,7 @@ class TestStringBinding:
         # Given Snowflake client is logged in
 
         # When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
-        for corner_case, _ in CORNER_CASE_SQL_VALUES:
+        for corner_case, _ in CORNER_CASE_VALUES:
             result = execute_query(f"SELECT ?::{string_type}(32)", (corner_case,), single_row=True)
 
             # Then the result should match the bound corner case value
@@ -255,5 +255,4 @@ class TestStringMultipleChunks:
         assert len(rows) == LARGE_RESULT_SET_SIZE
 
         # And all returned string values should match the generated values in order
-        for i, row in enumerate(rows):
-            assert row[1] == str(i), f"String value mismatch at row {i}: expected '{i}', got '{row[1]}'"
+        assert_sequential_values(rows, LARGE_RESULT_SET_SIZE, transform=lambda i: (i, str(i)))

--- a/python/tests/e2e/types/test_string.py
+++ b/python/tests/e2e/types/test_string.py
@@ -75,6 +75,22 @@ CORNER_CASE_SQL_VALUES = [
 LARGE_RESULT_SET_SIZE = 10_000
 
 
+class TestStringTypeCasting:
+    """Tests for STRING type casting to appropriate type."""
+
+    @string_type_parametrize
+    def test_should_cast_string_values_to_appropriate_type_for_string_and_synonyms(self, execute_query, string_type):
+        # Given Snowflake client is logged in
+
+        # When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
+        sql = f"SELECT 'hello'::{string_type}(32), 'Hello World'::{string_type}(32), '日本語テスト'::{string_type}(32)"
+        result = execute_query(sql, single_row=True)
+
+        # Then All values should be returned as appropriate type (str)
+        assert_type(result, str)
+        assert result == ("hello", "Hello World", "日本語テスト")
+
+
 class TestStringLiteral:
     """Tests for STRING type using SELECT with literals (no tables)."""
 

--- a/python/tests/e2e/types/test_string_lob.py
+++ b/python/tests/e2e/types/test_string_lob.py
@@ -1,0 +1,89 @@
+"""STRING LOB (Large Object) type tests for Universal Driver.
+
+This module tests large VARCHAR values at the following limits:
+  - Historical limit: 16 MB (16,777,216 bytes) per value
+  - Increased LOB Size feature: up to 128 MB (134,217,728 bytes) per value
+
+Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
+"""
+
+# =============================================================================
+# LOB SIZE LIMITS
+# =============================================================================
+# Historical LOB limit (16 MB)
+LOB_16MB_SIZE = 16_777_216
+
+# Maximum LOB limit with Increased LOB Size feature (128 MB)
+LOB_128MB_SIZE = 134_217_728
+
+# 64 characters to generate strings on Snowflake side
+CHARS64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789()"
+
+
+def assert_strings_equal(result_str, generated_string):
+    chunk_size = 1024
+    len_result_str = len(result_str)
+    len_generated_string = len(generated_string)
+    assert len_result_str == len_generated_string, f"Length mismatch: {len_result_str} != {len_generated_string}"
+    for i in range(0, len(generated_string), chunk_size):
+        generated_chunk = generated_string[i : i + chunk_size]
+        result_chunk = result_str[i : i + chunk_size]
+        assert generated_chunk == result_chunk, (
+            f"Chunk mismatch near index {i * chunk_size}: expected '{generated_chunk}', got '{result_chunk}'"
+        )
+
+
+class TestStringLob:
+    """Tests for STRING LOB (Large Object) handling."""
+
+    def test_should_handle_lob_string_at_historical_16_mb_limit(self, execute_query, tmp_schema):
+        # Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
+
+        # Given Snowflake client is logged in
+
+        # And A temporary table with VARCHAR column is created
+        table_name = f"{tmp_schema}.lob_16mb_table"
+        execute_query(f"CREATE TABLE {table_name} (val VARCHAR)")
+
+        # When A string of 16777216 ASCII characters is generated and inserted
+
+        # (Note: REPEAT() cannot be used in VALUES clause, must use INSERT ... SELECT)
+        N = LOB_16MB_SIZE // len(CHARS64)
+        generated_string = CHARS64 * N
+        execute_query(f"INSERT INTO {table_name} SELECT REPEAT('{CHARS64}', {N})")
+
+        # And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
+        result_str, result_len = execute_query(f"SELECT val, LENGTH(val) as len FROM {table_name}", single_row=True)
+
+        # Then the result should show length 16777216
+        assert result_len == LOB_16MB_SIZE, f"Expected length {LOB_16MB_SIZE}, got {result_len}"
+
+        # And the returned string should exactly match the generated string
+        assert isinstance(result_str, str), f"Expected str, got {type(result_str).__name__}"
+        assert_strings_equal(result_str, generated_string)
+
+    def test_should_handle_lob_string_at_maximum_128_mb_limit_with_increased_lob_size(self, execute_query, tmp_schema):
+        # Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
+
+        # Given Snowflake client is logged in
+
+        # And A temporary table with VARCHAR column is created
+        table_name = f"{tmp_schema}.lob_128mb_table"
+        execute_query(f"CREATE TABLE {table_name} (val VARCHAR(134217728))")
+
+        # When A string of 134217728 ASCII characters is generated and inserted
+
+        # (Note: REPEAT() cannot be used in VALUES clause, must use INSERT ... SELECT)
+        N = LOB_128MB_SIZE // len(CHARS64)
+        generated_string = CHARS64 * N
+        execute_query(f"INSERT INTO {table_name} SELECT REPEAT('{CHARS64}', {N})")
+
+        # And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
+        result_str, result_len = execute_query(f"SELECT val, LENGTH(val) as len FROM {table_name}", single_row=True)
+
+        # Then the result should show length 134217728
+        assert result_len == LOB_128MB_SIZE, f"Expected length {LOB_128MB_SIZE}, got {result_len}"
+
+        # And the returned string should exactly match the generated string
+        assert isinstance(result_str, str), f"Expected str, got {type(result_str).__name__}"
+        assert_strings_equal(result_str, generated_string)

--- a/tests/definitions/shared/types/string.feature
+++ b/tests/definitions/shared/types/string.feature
@@ -15,7 +15,7 @@ Feature: String datatype handling
     # Python: Values should be cast to 'str' type
     Given Snowflake client is logged in
     When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
-    Then All values should be returned as appropriate type (str)
+    Then All values should be returned as appropriate type
 
   # ============================================================================
   # SIMPLE SELECTS - LITERALS (Happy path, Corner cases)

--- a/tests/definitions/shared/types/string.feature
+++ b/tests/definitions/shared/types/string.feature
@@ -1,4 +1,4 @@
-@odbc
+@odbc @python
 Feature: String datatype handling
   # Snowflake String types: VARCHAR, CHAR, CHARACTER, NCHAR, STRING, TEXT, VARCHAR2, NVARCHAR, NVARCHAR2, CHAR VARYING, NCHAR VARYING
   # All are synonymous with VARCHAR and store Unicode UTF-8 characters.
@@ -10,7 +10,7 @@ Feature: String datatype handling
   # SIMPLE SELECTS - LITERALS (Happy path, Corner cases)
   # ============================================================================
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select hardcoded string literals
     Given Snowflake client is logged in
     When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3" is executed
@@ -18,7 +18,7 @@ Feature: String datatype handling
       | str1  | str2        | str3                  |
       | hello | Hello World | Snowflake Driver Test |
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select string literals with corner case values
     # Corner cases: empty string, single character, whitespace-only, unicode characters, escape sequences
     Given Snowflake client is logged in
@@ -42,7 +42,7 @@ Feature: String datatype handling
   # SIMPLE SELECTS - FROM TABLE (Happy path, Corner cases)
   # ============================================================================
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select hardcoded string values from table
     Given Snowflake client is logged in
     And A temporary table with VARCHAR column is created
@@ -50,7 +50,7 @@ Feature: String datatype handling
     When Query "SELECT * FROM {table}" is executed
     Then the result should contain the inserted hardcoded string values
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select corner case string values from table
     Given Snowflake client is logged in
     And A temporary table with VARCHAR column is created
@@ -75,7 +75,7 @@ Feature: String datatype handling
   # BINDING TESTS
   # ============================================================================
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should insert and select back hardcoded string values using parameter binding
     Given Snowflake client is logged in
     And A temporary table with VARCHAR column is created
@@ -84,7 +84,7 @@ Feature: String datatype handling
     Then the result should contain the bound string value 'Test binding value 日本語'
 
   
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select string literals using parameter binding
     # SELECT binding test: Uses SELECT ?::VARCHAR to bind string values
     Given Snowflake client is logged in
@@ -93,7 +93,7 @@ Feature: String datatype handling
       | col1  | col2        | col3       |
       | hello | Hello World | 日本語テスト |
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should select corner case string values using parameter binding
     Given Snowflake client is logged in
     When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
@@ -117,7 +117,7 @@ Feature: String datatype handling
   # MULTIPLE CHUNKS DOWNLOADING
   # ============================================================================
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should download string data in multiple chunks
     # This test ensures proper handling of large result sets that span multiple chunks
     # ~10000 values ensures data is downloaded in at least two chunks

--- a/tests/definitions/shared/types/string.feature
+++ b/tests/definitions/shared/types/string.feature
@@ -7,6 +7,17 @@ Feature: String datatype handling
   # Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
 
   # ============================================================================
+  # TYPE CASTING
+  # ============================================================================
+
+  @python_e2e
+  Scenario: should cast string values to appropriate type for string and synonyms
+    # Python: Values should be cast to 'str' type
+    Given Snowflake client is logged in
+    When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
+    Then All values should be returned as appropriate type (str)
+
+  # ============================================================================
   # SIMPLE SELECTS - LITERALS (Happy path, Corner cases)
   # ============================================================================
 

--- a/tests/definitions/shared/types/string_lob.feature
+++ b/tests/definitions/shared/types/string_lob.feature
@@ -1,10 +1,10 @@
-@odbc
+@odbc @python
 Feature: String LOB (Large Object) handling
   # Snowflake LOB feature supports large VARCHAR values:
   #   - Historical limit: 16 MB (16,777,216 bytes) per value
   #   - Increased LOB Size feature: up to 128 MB (134,217,728 bytes) per value
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should handle LOB string at historical 16 MB limit
     # Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
     Given Snowflake client is logged in
@@ -14,7 +14,7 @@ Feature: String LOB (Large Object) handling
     Then the result should show length 16777216
     And the returned string should exactly match the generated string
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: should handle LOB string at maximum 128 MB limit with increased LOB size
     # Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
     Given Snowflake client is logged in


### PR DESCRIPTION
* Add tests for string according to existing gherkins
* Add gherkin for automatic type casting tests
* Move ODBC-specific tests to `string_odbc.feature` due to conflict on test validation