### PR TITLE
Lower numeric large tests size to 3-4 chunks

### DIFF
--- a/odbc_tests/tests/e2e/types/int.cpp
+++ b/odbc_tests/tests/e2e/types/int.cpp
@@ -68,13 +68,13 @@ TEST_CASE("should download large result set with multiple chunks for int and syn
   // Given Snowflake client is logged in
   Connection conn;
 
-  // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
+  // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id" is executed
   auto stmt = conn.createStatement();
-  const auto sql = "SELECT seq8()::BIGINT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id";
+  const auto sql = "SELECT seq8()::BIGINT as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id";
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+  // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
   int row_count = 0;
   int64_t expected_value = 0;
 
@@ -94,7 +94,7 @@ TEST_CASE("should download large result set with multiple chunks for int and syn
     row_count++;
   }
 
-  REQUIRE(row_count == 1000000);
+  REQUIRE(row_count == 50000);
 }
 
 TEST_CASE("should select integers from table for int and synonyms", "[int]") {
@@ -128,10 +128,10 @@ TEST_CASE("should select large result set from table for int and synonyms", "[in
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  // And Table with <type> column exists with 1000000 sequential values
+  // And Table with <type> column exists with 50000 sequential values
   conn.execute("DROP TABLE IF EXISTS int_large_table");
   conn.execute("CREATE TABLE int_large_table (col BIGINT)");
-  conn.execute("INSERT INTO int_large_table SELECT seq8() FROM TABLE(GENERATOR(ROWCOUNT => 1000000))");
+  conn.execute("INSERT INTO int_large_table SELECT seq8() FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
 
   // When Query "SELECT * FROM <table> ORDER BY col" is executed
   auto stmt = conn.createStatement();
@@ -139,7 +139,7 @@ TEST_CASE("should select large result set from table for int and synonyms", "[in
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+  // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
   int row_count = 0;
   int64_t expected_value = 0;
 
@@ -159,5 +159,5 @@ TEST_CASE("should select large result set from table for int and synonyms", "[in
     row_count++;
   }
 
-  REQUIRE(row_count == 1000000);
+  REQUIRE(row_count == 50000);
 }

--- a/odbc_tests/tests/e2e/types/number.cpp
+++ b/odbc_tests/tests/e2e/types/number.cpp
@@ -60,15 +60,15 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR 
   Connection conn;
 
   // When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT =>
-  // 1000000)) v" is executed
+  // 30000)) v" is executed
   auto stmt = conn.createStatement();
   const auto sql =
-      "SELECT seq8()::NUMBER(38,0), (seq8() + 0.12345)::NUMBER(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v "
+      "SELECT seq8()::NUMBER(38,0), (seq8() + 0.12345)::NUMBER(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v "
       "ORDER BY 1";
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Column 1 should contain sequential integers from 0 to 999999
+  // Then Column 1 should contain sequential integers from 0 to 29999
   // And Column 2 should contain sequential decimals starting from 0.12345
   int row_count = 0;
   int64_t expected_int = 0;
@@ -96,7 +96,7 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR 
     row_count++;
   }
 
-  REQUIRE(row_count == 1000000);
+  REQUIRE(row_count == 30000);
 }
 
 TEST_CASE("should select numbers from table with multiple scales for number and synonyms", "[number]") {
@@ -198,12 +198,12 @@ TEST_CASE("should download large result set from table for number and synonyms",
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  // And Table with columns (<type>(38,0), <type>(20,5)) exists with 1000000 sequential rows, from 0 to 999999 in the
-  // first column and from 0.12345 to 999999.12345 in the second column
+  // And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from 0 to 29999 in the
+  // first column and from 0.12345 to 29999.12345 in the second column
   conn.execute("DROP TABLE IF EXISTS number_large_table");
   conn.execute("CREATE TABLE number_large_table (col1 NUMBER(38,0), col2 NUMBER(20,5))");
   conn.execute(
-      "INSERT INTO number_large_table SELECT seq8(), seq8() + 0.12345 FROM TABLE(GENERATOR(ROWCOUNT => 1000000))");
+      "INSERT INTO number_large_table SELECT seq8(), seq8() + 0.12345 FROM TABLE(GENERATOR(ROWCOUNT => 30000))");
 
   // When Query "SELECT * FROM <table>" is executed
   auto stmt = conn.createStatement();
@@ -211,7 +211,7 @@ TEST_CASE("should download large result set from table for number and synonyms",
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Column 1 should contain sequential integers from 0 to 999999
+  // Then Column 1 should contain sequential integers from 0 to 29999
   // And Column 2 should contain sequential decimals starting from 0.12345
   int row_count = 0;
   int64_t expected_int = 0;
@@ -239,5 +239,5 @@ TEST_CASE("should download large result set from table for number and synonyms",
     row_count++;
   }
 
-  REQUIRE(row_count == 1000000);
+  REQUIRE(row_count == 30000);
 }

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -41,7 +41,7 @@ DECFLOAT_LARGE_NEG_EXPONENT = Decimal("9.876E-8000")
 # =============================================================================
 # LARGE RESULT SET SIZE
 # =============================================================================
-LARGE_RESULT_SET_SIZE = 1_000_000
+LARGE_RESULT_SET_SIZE = 20_000
 
 
 class TestDecfloatTypeCasting:
@@ -135,7 +135,7 @@ class TestDecfloatLiteral:
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -146,7 +146,7 @@ class TestDecfloatLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Result should contain consecutive numbers from 0 to 999999
+        # Then Result should contain consecutive numbers from 0 to 19999
         values = [row[0] for row in rows]
         # And All values should be returned as appropriate type
         assert_type(values, Decimal)
@@ -244,7 +244,7 @@ class TestDecfloatTable:
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
 
-        # And Table with DECFLOAT column exists with values from 0 to 999999
+        # And Table with DECFLOAT column exists with values from 0 to 19999
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -259,7 +259,7 @@ class TestDecfloatTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
-        # Then Result should contain consecutive numbers from 0 to 999999
+        # Then Result should contain consecutive numbers from 0 to 19999
         values = [row[0] for row in rows]
         # And All values should be returned as appropriate type
         assert_type(values, Decimal)

--- a/python/tests/e2e/types/test_float.py
+++ b/python/tests/e2e/types/test_float.py
@@ -57,7 +57,7 @@ FLOAT_16_DIGITS = 1234567890123456.0
 # =============================================================================
 # LARGE RESULT SET SIZE
 # =============================================================================
-LARGE_RESULT_SET_SIZE = 1_000_000
+LARGE_RESULT_SET_SIZE = 50_000
 
 
 class TestFloatTypeCasting:
@@ -155,7 +155,7 @@ class TestFloatLiteral:
     ):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
+        # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -166,7 +166,7 @@ class TestFloatLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Result should contain 1000000 rows
+        # Then Result should contain 50000 rows
         # And All values should be returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)
@@ -272,7 +272,7 @@ class TestFloatTable:
     ):
         # Given Snowflake client is logged in
 
-        # And Table with <type> column exists with 1000000 sequential values
+        # And Table with <type> column exists with 50000 sequential values
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -287,7 +287,7 @@ class TestFloatTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
-        # Then Result should contain 1000000 rows
+        # Then Result should contain 50000 rows
         # And All values should be returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)

--- a/python/tests/e2e/types/test_int.py
+++ b/python/tests/e2e/types/test_int.py
@@ -71,7 +71,7 @@ INT38_MIN = -99999999999999999999999999999999999999
 # =============================================================================
 # LARGE RESULT SET SIZE
 # =============================================================================
-LARGE_RESULT_SET_SIZE = 1_000_000
+LARGE_RESULT_SET_SIZE = 50_000
 
 
 class TestIntTypeCasting:
@@ -178,7 +178,7 @@ class TestIntLiteral:
     def test_should_download_large_result_set_with_multiple_chunks_for_int_and_synonyms(self, execute_query, int_type):
         # Given Snowflake client is logged in
 
-        # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
+        # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id" is executed
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -189,7 +189,7 @@ class TestIntLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+        # Then Result should contain 50000 sequentially numbered rows from 0 to 49999
         values = [row[0] for row in rows]
         assert_type(values, int)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE)
@@ -292,7 +292,7 @@ class TestIntTable:
     def test_should_select_large_result_set_from_table_for_int_and_synonyms(self, execute_query, tmp_schema, int_type):
         # Given Snowflake client is logged in
 
-        # And Table with <type> column exists with 1000000 sequential values
+        # And Table with <type> column exists with 50000 sequential values
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -307,7 +307,7 @@ class TestIntTable:
         # When Query "SELECT * FROM <table> ORDER BY col" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
-        # Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+        # Then Result should contain 50000 sequentially numbered rows from 0 to 49999
         values = [row[0] for row in rows]
         assert_type(values, int)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE)

--- a/python/tests/e2e/types/test_number.py
+++ b/python/tests/e2e/types/test_number.py
@@ -65,7 +65,7 @@ NUMBER_38_37_MIN_POSITIVE = Decimal("0.0000000000000000000000000000000000001")
 # =============================================================================
 # LARGE RESULT SET SIZE
 # =============================================================================
-LARGE_RESULT_SET_SIZE = 1_000_000
+LARGE_RESULT_SET_SIZE = 30_000
 
 
 class TestNumberTypeCasting:
@@ -192,7 +192,7 @@ class TestNumberLiteral:
         # Given Snowflake client is logged in
 
         # When Query
-        # "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v"
+        # "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v"
         # is executed
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
@@ -207,7 +207,7 @@ class TestNumberLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Column 1 should contain sequential integers from 0 to 999999
+        # Then Column 1 should contain sequential integers from 0 to 29999
         col0_values = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col0_values, int)
@@ -419,8 +419,8 @@ class TestNumberTable:
     ):
         # Given Snowflake client is logged in
 
-        # And Table with columns (<type>(38,0), <type>(20,5)) exists with 1000000 sequential rows,
-        # from 0 to 999999 in the first column and from 0.12345 to 999999.12345 in the second column
+        # And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows,
+        # from 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
 
         # Note: seq8() doesn't guarantee consecutive values in parallel execution,
         # so we use ROW_NUMBER() to ensure sequential integers.
@@ -438,7 +438,7 @@ class TestNumberTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY 1")
 
-        # Then Column 1 should contain sequential integers from 0 to 999999
+        # Then Column 1 should contain sequential integers from 0 to 29999
         col1 = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col1, int)

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -46,8 +46,8 @@ Feature: DECFLOAT type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in
-    When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-    Then Result should contain consecutive numbers from 0 to 999999
+    When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
+    Then Result should contain consecutive numbers from 0 to 19999
     And All values should be returned as appropriate type
 
   # =========================================================================== #
@@ -85,9 +85,9 @@ Feature: DECFLOAT type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from table
     Given Snowflake client is logged in
-    And Table with DECFLOAT column exists with values from 0 to 999999
+    And Table with DECFLOAT column exists with values from 0 to 19999
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain consecutive numbers from 0 to 999999
+    Then Result should contain consecutive numbers from 0 to 19999
     And All values should be returned as appropriate type
 
   # =========================================================================== #

--- a/tests/definitions/shared/types/float.feature
+++ b/tests/definitions/shared/types/float.feature
@@ -49,8 +49,8 @@ Feature: FLOAT type support
   @python_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR for float and synonyms
     Given Snowflake client is logged in
-    When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-    Then Result should contain 1000000 rows
+    When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
+    Then Result should contain 50000 rows
     And All values should be returned as appropriate float type
 
   # =========================================================================== #
@@ -89,9 +89,9 @@ Feature: FLOAT type support
   @python_e2e
   Scenario: should select large result set from table for float and synonyms
     Given Snowflake client is logged in
-    And Table with <type> column exists with 1000000 sequential values
+    And Table with <type> column exists with 50000 sequential values
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain 1000000 rows
+    Then Result should contain 50000 rows
     And All values should be returned as appropriate float type
 
   # =========================================================================== #

--- a/tests/definitions/shared/types/int.feature
+++ b/tests/definitions/shared/types/int.feature
@@ -50,8 +50,8 @@ Feature: INT type support
   @python_e2e @odbc_e2e
   Scenario: should download large result set with multiple chunks for int and synonyms
     Given Snowflake client is logged in
-    When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
-    Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+    When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id" is executed
+    Then Result should contain 50000 sequentially numbered rows from 0 to 49999
 
   # =========================================================================== #
   #                             Table operations                                #
@@ -77,9 +77,9 @@ Feature: INT type support
   @python_e2e @odbc_e2e
   Scenario: should select large result set from table for int and synonyms
     Given Snowflake client is logged in
-    And Table with <type> column exists with 1000000 sequential values
+    And Table with <type> column exists with 50000 sequential values
     When Query "SELECT * FROM <table> ORDER BY col" is executed
-    Then Result should contain 1000000 sequentially numbered rows from 0 to 999999
+    Then Result should contain 50000 sequentially numbered rows from 0 to 49999
 
   # =========================================================================== #
   #                            Parameter binding                                #

--- a/tests/definitions/shared/types/number.feature
+++ b/tests/definitions/shared/types/number.feature
@@ -50,8 +50,8 @@ Feature: NUMBER type support
   @python_e2e @odbc_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR for number and synonyms
     Given Snowflake client is logged in
-    When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v" is executed
-    Then Column 1 should contain sequential integers from 0 to 999999
+    When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v" is executed
+    Then Column 1 should contain sequential integers from 0 to 29999
     And Column 2 should contain sequential decimals starting from 0.12345
 
   # =========================================================================== #
@@ -112,9 +112,9 @@ Feature: NUMBER type support
   @python_e2e @odbc_e2e
   Scenario: should download large result set from table for number and synonyms
     Given Snowflake client is logged in
-    And Table with columns (<type>(38,0), <type>(20,5)) exists with 1000000 sequential rows, from 0 to 999999 in the first column and from 0.12345 to 999999.12345 in the second column
+    And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
     When Query "SELECT * FROM <table>" is executed
-    Then Column 1 should contain sequential integers from 0 to 999999
+    Then Column 1 should contain sequential integers from 0 to 29999
     And Column 2 should contain sequential decimals starting from 0.12345
 
   # =========================================================================== #


### PR DESCRIPTION
Lower large test size for numeric types to 3-4 chunks, which is:
- 20k for decfloat
- 30k for number
- 50k for int and float

Values were adjusted experimentally from local machine