### PR TITLE
NO-SNOW: Fix logging in python

### DIFF
--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -218,6 +218,8 @@ class BuildHook(BuildHookInterface):
     def _build_core(self) -> None:
         """Build the Rust core library in release mode for distribution."""
 
+        if os.environ.get("SKIP_CORE_BUILD", "").lower() in ["true", "1"]:
+            return
         # Get paths relative to the Python wrapper directory
         python_dir = Path(__file__).parent
         cargo_manifest = python_dir.parent / "Cargo.toml"

--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -6,6 +6,8 @@ from enum import Enum
 from importlib import resources
 from typing import Any
 
+from ..logging import get_sf_core_logger
+
 
 _CORE_LIB_NAME = "libsf_core"
 
@@ -89,12 +91,18 @@ level_map = {
 
 
 def logger_callback(level: int, message: bytes, filename: bytes, line: int, function: bytes) -> int:
-    if level not in level_map:
+    py_level = level_map.get(level)
+    if py_level is None:
         return 0
-    logger = logging.getLogger("sf_core")
-    record = logger.makeRecord(
+
+    sf_core_logger = get_sf_core_logger()
+    # Respect the logger's configured level - skip if not enabled
+    if not sf_core_logger.isEnabledFor(py_level):
+        return 0
+
+    record = sf_core_logger.makeRecord(
         "sf_core",
-        level_map[level],
+        py_level,
         filename.decode("utf-8"),
         line,
         message.decode("utf-8"),
@@ -102,7 +110,7 @@ def logger_callback(level: int, message: bytes, filename: bytes, line: int, func
         None,
         func=function.decode("utf-8"),
     )
-    logger.handle(record)
+    sf_core_logger.handle(record)
     return 0
 
 

--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -101,7 +101,7 @@ def logger_callback(level: int, message: bytes, filename: bytes, line: int, func
         return 0
 
     record = sf_core_logger.makeRecord(
-        "sf_core",
+        sf_core_logger.name,
         py_level,
         filename.decode("utf-8"),
         line,

--- a/python/src/snowflake/connector/_internal/logging.py
+++ b/python/src/snowflake/connector/_internal/logging.py
@@ -26,6 +26,18 @@ _connector_logger.propagate = False
 _connector_logger.addHandler(logging.NullHandler())
 
 
+def _needs_handler(logger: logging.Logger) -> bool:
+    """
+    Check if a logger needs a handler to be added.
+
+    Returns True if the logger has no handlers or only has NullHandler(s).
+    """
+    if not logger.handlers:
+        return True
+    # Check if all existing handlers are NullHandlers
+    return all(isinstance(h, logging.NullHandler) for h in logger.handlers)
+
+
 def setup_logging(
     level: int = logging.INFO,
     sf_core_level: int = logging.INFO,
@@ -38,6 +50,10 @@ def setup_logging(
     This function sets up logging handlers and formatters for both the
     snowflake.connector logger and the sf_core logger (which receives
     logs from the native Rust library).
+
+    Handlers are only added if the logger has no handlers or only has
+    NullHandler(s). This prevents duplicate handlers if setup_logging
+    is called multiple times.
 
     Args:
         level: Logging level for the snowflake.connector logger.
@@ -65,11 +81,13 @@ def setup_logging(
 
     # Configure snowflake.connector logger
     _connector_logger.setLevel(level)
-    _connector_logger.addHandler(handler)
+    if _needs_handler(_connector_logger):
+        _connector_logger.addHandler(handler)
 
     # Configure sf_core logger with explicit INFO level
     _sf_core_logger.setLevel(sf_core_level)
-    _sf_core_logger.addHandler(handler)
+    if _needs_handler(_sf_core_logger):
+        _sf_core_logger.addHandler(handler)
 
 
 def get_connector_logger() -> logging.Logger:

--- a/python/src/snowflake/connector/_internal/logging.py
+++ b/python/src/snowflake/connector/_internal/logging.py
@@ -1,0 +1,95 @@
+"""
+Logging configuration for the snowflake.connector module.
+
+This module provides utilities to configure logging for the Snowflake connector,
+including the native sf_core library logs.
+"""
+
+import logging
+
+from typing import Optional
+
+
+# Logger names
+CONNECTOR_LOGGER_NAME = "snowflake.connector"
+SF_CORE_LOGGER_NAME = "snowflake.connector._core"
+
+# Set up loggers once at module load:
+# - Disable propagation to prevent duplicate logs via parent loggers
+# - Add NullHandler as a fallback (good practice for library loggers)
+_sf_core_logger = logging.getLogger(SF_CORE_LOGGER_NAME)
+_sf_core_logger.propagate = False
+_sf_core_logger.addHandler(logging.NullHandler())
+
+_connector_logger = logging.getLogger(CONNECTOR_LOGGER_NAME)
+_connector_logger.propagate = False
+_connector_logger.addHandler(logging.NullHandler())
+
+
+def setup_logging(
+    level: int = logging.INFO,
+    sf_core_level: int = logging.INFO,
+    format_string: Optional[str] = None,
+    stream: Optional[object] = None,
+) -> None:
+    """
+    Configure basic logging for the snowflake.connector module.
+
+    This function sets up logging handlers and formatters for both the
+    snowflake.connector logger and the sf_core logger (which receives
+    logs from the native Rust library).
+
+    Args:
+        level: Logging level for the snowflake.connector logger.
+               Defaults to logging.INFO.
+        sf_core_level: Logging level for the sf_core logger.
+                       Defaults to logging.INFO.
+        format_string: Custom format string for log messages.
+                       If None, uses a default format.
+        stream: Stream to write logs to. If None, uses sys.stderr.
+
+    Example:
+        >>> from snowflake.connector._internal.logging import setup_logging
+        >>> import logging
+        >>> setup_logging(level=logging.DEBUG, sf_core_level=logging.DEBUG)
+    """
+    if format_string is None:
+        format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+    # Create formatter
+    formatter = logging.Formatter(format_string)
+
+    # Create handler
+    handler = logging.StreamHandler(stream)  # type: ignore [arg-type]
+    handler.setFormatter(formatter)
+
+    # Configure snowflake.connector logger
+    _connector_logger.setLevel(level)
+    _connector_logger.addHandler(handler)
+
+    # Configure sf_core logger with explicit INFO level
+    _sf_core_logger.setLevel(sf_core_level)
+    _sf_core_logger.addHandler(handler)
+
+
+def get_connector_logger() -> logging.Logger:
+    """
+    Get the snowflake.connector logger.
+
+    Returns:
+        The logger instance for snowflake.connector.
+    """
+    return _connector_logger
+
+
+def get_sf_core_logger() -> logging.Logger:
+    """
+    Get the sf_core logger.
+
+    This logger receives log messages from the native Rust library
+    via the FFI callback mechanism.
+
+    Returns:
+        The logger instance for sf_core.
+    """
+    return _sf_core_logger

--- a/python/tests/unit/test_logging.py
+++ b/python/tests/unit/test_logging.py
@@ -1,0 +1,203 @@
+"""
+Tests for the snowflake.connector._internal.logging module.
+"""
+
+import io
+import logging
+
+import pytest
+
+from snowflake.connector._internal.logging import (
+    CONNECTOR_LOGGER_NAME,
+    SF_CORE_LOGGER_NAME,
+    get_connector_logger,
+    get_sf_core_logger,
+    setup_logging,
+)
+
+
+class TestLoggerConstants:
+    """Test logger name constants."""
+
+    def test_connector_logger_name(self):
+        """Test that CONNECTOR_LOGGER_NAME is correctly defined."""
+        assert CONNECTOR_LOGGER_NAME == "snowflake.connector"
+
+    def test_sf_core_logger_name(self):
+        """Test that SF_CORE_LOGGER_NAME is correctly defined."""
+        assert SF_CORE_LOGGER_NAME == "snowflake.connector._core"
+
+
+class TestGetLoggers:
+    """Test logger getter functions."""
+
+    def test_get_connector_logger_returns_logger(self):
+        """Test that get_connector_logger returns a Logger instance."""
+        logger = get_connector_logger()
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == CONNECTOR_LOGGER_NAME
+
+    def test_get_sf_core_logger_returns_logger(self):
+        """Test that get_sf_core_logger returns a Logger instance."""
+        logger = get_sf_core_logger()
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == SF_CORE_LOGGER_NAME
+
+    def test_get_connector_logger_same_instance(self):
+        """Test that get_connector_logger returns the same instance each time."""
+        logger1 = get_connector_logger()
+        logger2 = get_connector_logger()
+        assert logger1 is logger2
+
+    def test_get_sf_core_logger_same_instance(self):
+        """Test that get_sf_core_logger returns the same instance each time."""
+        logger1 = get_sf_core_logger()
+        logger2 = get_sf_core_logger()
+        assert logger1 is logger2
+
+
+class TestLoggerConfiguration:
+    """Test that loggers are configured correctly at module load."""
+
+    def test_sf_core_logger_propagate_disabled(self):
+        """Test that sf_core logger has propagation disabled."""
+        logger = get_sf_core_logger()
+        assert logger.propagate is False
+
+    def test_connector_logger_propagate_disabled(self):
+        """Test that connector logger has propagation disabled."""
+        logger = get_connector_logger()
+        assert logger.propagate is False
+
+    def test_sf_core_logger_has_null_handler(self):
+        """Test that sf_core logger has a NullHandler."""
+        logger = get_sf_core_logger()
+        null_handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+        assert len(null_handlers) >= 1
+
+    def test_connector_logger_has_null_handler(self):
+        """Test that connector logger has a NullHandler."""
+        logger = get_connector_logger()
+        null_handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+        assert len(null_handlers) >= 1
+
+
+class TestSetupLogging:
+    """Test the setup_logging function."""
+
+    @pytest.fixture(autouse=True)
+    def cleanup_handlers(self):
+        """Clean up handlers added during tests."""
+        connector_logger = get_connector_logger()
+        sf_core_logger = get_sf_core_logger()
+
+        # Store original handlers
+        original_connector_handlers = list(connector_logger.handlers)
+        original_sf_core_handlers = list(sf_core_logger.handlers)
+        original_connector_level = connector_logger.level
+        original_sf_core_level = sf_core_logger.level
+
+        yield
+
+        # Restore original state
+        connector_logger.handlers = original_connector_handlers
+        sf_core_logger.handlers = original_sf_core_handlers
+        connector_logger.setLevel(original_connector_level)
+        sf_core_logger.setLevel(original_sf_core_level)
+
+    def test_setup_logging_sets_connector_level(self):
+        """Test that setup_logging sets the connector logger level."""
+        setup_logging(level=logging.DEBUG)
+        logger = get_connector_logger()
+        assert logger.level == logging.DEBUG
+
+    def test_setup_logging_sets_sf_core_level(self):
+        """Test that setup_logging sets the sf_core logger level."""
+        setup_logging(sf_core_level=logging.WARNING)
+        logger = get_sf_core_logger()
+        assert logger.level == logging.WARNING
+
+    def test_setup_logging_default_levels(self):
+        """Test that setup_logging uses INFO as default level."""
+        setup_logging()
+        connector_logger = get_connector_logger()
+        sf_core_logger = get_sf_core_logger()
+        assert connector_logger.level == logging.INFO
+        assert sf_core_logger.level == logging.INFO
+
+    def test_setup_logging_adds_stream_handler_to_connector(self):
+        """Test that setup_logging adds a StreamHandler to connector logger."""
+        setup_logging()
+        logger = get_connector_logger()
+        stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler)]
+        assert len(stream_handlers) >= 1
+
+    def test_setup_logging_adds_stream_handler_to_sf_core(self):
+        """Test that setup_logging adds a StreamHandler to sf_core logger."""
+        setup_logging()
+        logger = get_sf_core_logger()
+        stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler)]
+        assert len(stream_handlers) >= 1
+
+    def test_setup_logging_custom_stream(self):
+        """Test that setup_logging uses custom stream."""
+        stream = io.StringIO()
+        setup_logging(stream=stream)
+
+        logger = get_connector_logger()
+        logger.info("test message")
+
+        output = stream.getvalue()
+        assert "test message" in output
+
+    def test_setup_logging_custom_format_string(self):
+        """Test that setup_logging uses custom format string."""
+        stream = io.StringIO()
+        custom_format = "CUSTOM: %(message)s"
+        setup_logging(format_string=custom_format, stream=stream)
+
+        logger = get_connector_logger()
+        logger.info("test message")
+
+        output = stream.getvalue()
+        assert "CUSTOM: test message" in output
+
+    def test_setup_logging_default_format_string(self):
+        """Test that setup_logging uses default format when none provided."""
+        stream = io.StringIO()
+        setup_logging(stream=stream)
+
+        logger = get_connector_logger()
+        logger.info("test message")
+
+        output = stream.getvalue()
+        # Default format includes name and levelname
+        assert "snowflake.connector" in output
+        assert "INFO" in output
+        assert "test message" in output
+
+    def test_setup_logging_sf_core_writes_to_stream(self):
+        """Test that sf_core logger writes to the configured stream."""
+        stream = io.StringIO()
+        setup_logging(stream=stream, sf_core_level=logging.DEBUG)
+
+        logger = get_sf_core_logger()
+        logger.debug("sf_core test message")
+
+        output = stream.getvalue()
+        assert "sf_core test message" in output
+
+    def test_setup_logging_respects_level_filtering(self):
+        """Test that setup_logging respects level filtering."""
+        stream = io.StringIO()
+        setup_logging(level=logging.WARNING, stream=stream)
+
+        logger = get_connector_logger()
+        logger.debug("debug message")
+        logger.info("info message")
+        logger.warning("warning message")
+
+        output = stream.getvalue()
+        assert "debug message" not in output
+        assert "info message" not in output
+        assert "warning message" in output

--- a/python/tests/unit/test_logging.py
+++ b/python/tests/unit/test_logging.py
@@ -10,6 +10,7 @@ import pytest
 from snowflake.connector._internal.logging import (
     CONNECTOR_LOGGER_NAME,
     SF_CORE_LOGGER_NAME,
+    _needs_handler,
     get_connector_logger,
     get_sf_core_logger,
     setup_logging,
@@ -201,3 +202,69 @@ class TestSetupLogging:
         assert "debug message" not in output
         assert "info message" not in output
         assert "warning message" in output
+
+    def test_setup_logging_does_not_add_duplicate_handlers(self):
+        """Test that calling setup_logging multiple times doesn't add duplicate handlers."""
+        stream = io.StringIO()
+
+        # Call setup_logging multiple times
+        setup_logging(stream=stream)
+        connector_handlers_after_first = len(get_connector_logger().handlers)
+        sf_core_handlers_after_first = len(get_sf_core_logger().handlers)
+
+        setup_logging(stream=stream)
+        connector_handlers_after_second = len(get_connector_logger().handlers)
+        sf_core_handlers_after_second = len(get_sf_core_logger().handlers)
+
+        # Handler count should not increase after the second call
+        assert connector_handlers_after_second == connector_handlers_after_first
+        assert sf_core_handlers_after_second == sf_core_handlers_after_first
+
+    def test_setup_logging_skips_handler_if_non_null_handler_exists(self):
+        """Test that setup_logging skips adding handler if a non-NullHandler already exists."""
+        connector_logger = get_connector_logger()
+
+        # Add a custom handler first
+        custom_handler = logging.StreamHandler(io.StringIO())
+        connector_logger.addHandler(custom_handler)
+
+        initial_handler_count = len(connector_logger.handlers)
+
+        # Call setup_logging - should not add another handler
+        setup_logging()
+
+        assert len(connector_logger.handlers) == initial_handler_count
+
+
+class TestNeedsHandler:
+    """Test the _needs_handler helper function."""
+
+    def test_needs_handler_empty_handlers(self):
+        """Test that _needs_handler returns True for logger with no handlers."""
+        logger = logging.getLogger("test_empty_handlers")
+        logger.handlers = []
+        assert _needs_handler(logger) is True
+
+    def test_needs_handler_only_null_handler(self):
+        """Test that _needs_handler returns True for logger with only NullHandler."""
+        logger = logging.getLogger("test_only_null_handler")
+        logger.handlers = [logging.NullHandler()]
+        assert _needs_handler(logger) is True
+
+    def test_needs_handler_multiple_null_handlers(self):
+        """Test that _needs_handler returns True for logger with multiple NullHandlers."""
+        logger = logging.getLogger("test_multiple_null_handlers")
+        logger.handlers = [logging.NullHandler(), logging.NullHandler()]
+        assert _needs_handler(logger) is True
+
+    def test_needs_handler_with_stream_handler(self):
+        """Test that _needs_handler returns False for logger with StreamHandler."""
+        logger = logging.getLogger("test_with_stream_handler")
+        logger.handlers = [logging.StreamHandler()]
+        assert _needs_handler(logger) is False
+
+    def test_needs_handler_with_mixed_handlers(self):
+        """Test that _needs_handler returns False for logger with mixed handlers."""
+        logger = logging.getLogger("test_mixed_handlers")
+        logger.handlers = [logging.NullHandler(), logging.StreamHandler()]
+        assert _needs_handler(logger) is False


### PR DESCRIPTION
## Summary

- Fix duplicate log output from the native Rust library (sf_core)
- Add new `_internal.logging` module with utilities for configuring connector logging
- Add unit tests for the logging module

## Problem

The FFI logging callback was causing logs from the native Rust library to appear multiple times:
1. The `logger.handle(record)` call bypassed the logger's level check
2. Log propagation to parent loggers was enabled by default
3. In pytest, this resulted in the same log appearing in multiple captured sections

## Solution

### 1. Fixed `c_api.py` callback

- Added `isEnabledFor()` check to respect the logger's configured level before processing
- Use centralized logger from the new logging module (with propagation disabled)

### 2. New `_internal/logging.py` module

Provides centralized logging configuration:

- **Logger names**: `snowflake.connector` and `snowflake.connector._core`
- **Propagation disabled** by default to prevent duplicate logs
- **NullHandler** added as fallback (library logging best practice)
- **`setup_logging()`** helper function for easy configuration
- **`get_connector_logger()`** and **`get_sf_core_logger()`** accessors