### PR TITLE
Implement DictCursor with SnowflakeCursorBase pattern from old connector

### DIFF
--- a/python/src/snowflake/connector/__init__.py
+++ b/python/src/snowflake/connector/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from ._internal.api_client.c_api import register_default_logger_callback
 from .connection import Connection
-from .cursor import Cursor
+from .cursor import DictCursor, SnowflakeCursor
 from .errors import (
     DatabaseError,
     DataError,
@@ -74,7 +74,8 @@ __all__ = [
     "connect",
     # Classes
     "Connection",
-    "Cursor",
+    "DictCursor",
+    "SnowflakeCursor",
     # Exceptions
     "Warning",
     "Error",

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -19,7 +19,7 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_services impo
 )
 
 from ._internal.api_client.client_api import database_driver_client
-from .cursor import Cursor
+from .cursor import SnowflakeCursor, SnowflakeCursorBase
 from .errors import InterfaceError, NotSupportedError
 
 
@@ -85,16 +85,20 @@ class Connection:
         """
         raise NotSupportedError("rollback is not implemented")
 
-    def cursor(self) -> Cursor:
+    def cursor(self, cursor_class: type[SnowflakeCursorBase] = SnowflakeCursor) -> SnowflakeCursorBase:
         """
         Return a new Cursor object using the connection.
 
+        Args:
+            cursor_class: The class to use for the cursor (default: SnowflakeCursor).
+                          Pass DictCursor to get results as dictionaries.
+
         Returns:
-            Cursor: A new cursor object
+            SnowflakeCursorBase: A new cursor object
         """
         if self._closed:
             raise InterfaceError("Connection is closed")
-        return Cursor(self)
+        return cursor_class(self)
 
     # Context manager support
     def __enter__(self) -> Connection:

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -1,10 +1,10 @@
 """
 PEP 249 Database API 2.0 Cursor Objects
 
-This module defines the Cursor class as specified in PEP 249.
+This module defines the cursor classes as specified in PEP 249.
 
-Hierarchy (mirrors the old snowflake-connector-python):
-    Cursor (base, like SnowflakeCursorBase)
+Hierarchy:
+    SnowflakeCursorBase
     ├── SnowflakeCursor  — returns tuple rows
     └── DictCursor       — returns dict rows
 """
@@ -14,7 +14,7 @@ from __future__ import annotations
 import abc
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from ._internal.arrow_context import ArrowConverterContext
 from ._internal.arrow_stream_iterator import ArrowStreamIterator  # type: ignore[import-not-found]
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 
 Row = tuple[Any, ...]
 DictRow = dict[str, Any]
-FetchRow = TypeVar("FetchRow", Row, DictRow)
 
 
 class SnowflakeCursorBase(abc.ABC):
@@ -64,7 +63,6 @@ class SnowflakeCursorBase(abc.ABC):
         self._current_row_in_batch = 0
         self.execute_result: Any = None
         self._iterator: Iterator[Row] | Iterator[DictRow] | None = None
-        self.execute_result = None
 
     # ------------------------------------------------------------------
     # PEP 249 attributes
@@ -133,9 +131,7 @@ class SnowflakeCursorBase(abc.ABC):
         """Close the cursor now (rather than whenever __del__ is called)."""
         self._closed = True
 
-    def execute(
-        self, operation: str, parameters: Sequence[Any] | dict[str, Any] | None = None, _is_put_get: bool | None = None
-    ) -> SnowflakeCursorBase:
+    def execute(self, operation: str, parameters: Sequence[Any] | dict[str, Any] | None = None) -> SnowflakeCursorBase:
         """
         Execute a database operation (query or command).
 

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -2,12 +2,19 @@
 PEP 249 Database API 2.0 Cursor Objects
 
 This module defines the Cursor class as specified in PEP 249.
+
+Hierarchy (mirrors the old snowflake-connector-python):
+    Cursor (base, like SnowflakeCursorBase)
+    ├── SnowflakeCursor  — returns tuple rows
+    └── DictCursor       — returns dict rows
 """
 
 from __future__ import annotations
 
+import abc
+
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ._internal.arrow_context import ArrowConverterContext
 from ._internal.arrow_stream_iterator import ArrowStreamIterator  # type: ignore[import-not-found]
@@ -23,12 +30,17 @@ if TYPE_CHECKING:
     from .connection import Connection
 
 Row = tuple[Any, ...]
+DictRow = dict[str, Any]
+FetchRow = TypeVar("FetchRow", Row, DictRow)
 
 
-class Cursor:
+class SnowflakeCursorBase(abc.ABC):
     """
-    Cursor objects represent a database cursor, which is used to manage the context
-    of a fetch operation.
+    Base cursor class for database operations (PEP 249).
+
+    This is the abstract base for all cursor types, equivalent to
+    ``SnowflakeCursorBase`` in the old connector. Concrete subclasses
+    must override :pyattr:`_use_dict_result` and :pymeth:`fetchone`.
     """
 
     # Class attribute for arraysize
@@ -51,8 +63,12 @@ class Cursor:
         self._current_batch = None
         self._current_row_in_batch = 0
         self.execute_result: Any = None
-        self._iterator: Iterator[Row] | None = None
+        self._iterator: Iterator[Row] | Iterator[DictRow] | None = None
         self.execute_result = None
+
+    # ------------------------------------------------------------------
+    # PEP 249 attributes
+    # ------------------------------------------------------------------
 
     @property
     def description(self) -> Any:
@@ -84,6 +100,19 @@ class Cursor:
     def rowcount(self, value: int) -> None:
         self._rowcount = value
 
+    # ------------------------------------------------------------------
+    # Result format control
+    # ------------------------------------------------------------------
+
+    @property
+    @abc.abstractmethod
+    def _use_dict_result(self) -> bool:
+        """Whether fetch methods return dicts instead of tuples."""
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
     def callproc(self, procname: str, parameters: Sequence[Any] | None = None) -> Sequence[Any]:
         """
         Call a stored database procedure with the given name.
@@ -104,7 +133,9 @@ class Cursor:
         """Close the cursor now (rather than whenever __del__ is called)."""
         self._closed = True
 
-    def execute(self, operation: str, parameters: Sequence[Any] | dict[str, Any] | None = None) -> Cursor:
+    def execute(
+        self, operation: str, parameters: Sequence[Any] | dict[str, Any] | None = None, _is_put_get: bool | None = None
+    ) -> SnowflakeCursorBase:
         """
         Execute a database operation (query or command).
 
@@ -138,6 +169,10 @@ class Cursor:
             NotSupportedError: If not implemented
         """
         raise NotSupportedError("executemany is not implemented")
+
+    # ------------------------------------------------------------------
+    # Arrow stream helpers
+    # ------------------------------------------------------------------
 
     def _get_stream_ptr(self) -> int:
         """Get the ArrowArrayStream pointer from execute result.
@@ -174,17 +209,20 @@ class Cursor:
         return ArrowStreamIterator(
             stream_ptr,
             arrow_context,
-            # TODO: SNOW-2997742, SNOW-2997786, temporarily hardcoded
-            use_dict_result=False,
+            use_dict_result=self._use_dict_result,
+            # TODO: SNOW-2997786, temporarily hardcoded
             use_numpy=False,
         )
 
-    def fetchone(self) -> Row | None:
-        """
-        Fetch the next row of a query result set.
+    # ------------------------------------------------------------------
+    # Fetch – shared implementation
+    # ------------------------------------------------------------------
 
-        Returns:
-            sequence: Next row, or None when no more data is available
+    def _fetchone(self) -> Row | DictRow | None:
+        """Fetch the next row internally.
+
+        Return a dict if ``_use_dict_result`` is True, otherwise a tuple.
+        Concrete subclasses expose this through a type-safe ``fetchone``.
         """
         if self._iterator is None:
             self._iterator = self._get_iterator()
@@ -193,7 +231,11 @@ class Cursor:
         except StopIteration:
             return None
 
-    def fetchmany(self, size: int | None = None) -> list[Row]:
+    @abc.abstractmethod
+    def fetchone(self) -> Row | DictRow | None:
+        """Fetch the next row of a query result set."""
+
+    def fetchmany(self, size: int | None = None) -> list[Any]:
         """
         Fetch the next set of rows of a query result.
 
@@ -222,7 +264,7 @@ class Cursor:
 
         return ret
 
-    def fetchall(self) -> list[Row]:
+    def fetchall(self) -> list[Any]:
         """
         Fetch all (remaining) rows of a query result.
 
@@ -232,6 +274,10 @@ class Cursor:
         if self._iterator is None:
             self._iterator = self._get_iterator()
         return list(self._iterator)
+
+    # ------------------------------------------------------------------
+    # PEP 249 optional / no-op methods
+    # ------------------------------------------------------------------
 
     def nextset(self) -> None:
         """
@@ -246,36 +292,27 @@ class Cursor:
         raise NotSupportedError("nextset is not implemented")
 
     def setinputsizes(self, sizes: Sequence[Any]) -> None:
-        """
-        Predefine memory areas for the operation parameters.
-
-        Args:
-            sizes (sequence): Sequence of type objects or integers
-        """
-        # This method is optional and can be implemented as a no-op
-        pass
+        """Not supported."""
+        return None
 
     def setoutputsize(self, size: int, column: int | None = None) -> None:
-        """
-        Set a column buffer size for fetches of large columns.
+        """Not supported."""
+        return None
 
-        Args:
-            size (int): Buffer size
-            column (int): Column index (optional)
-        """
-        # This method is optional and can be implemented as a no-op
-        pass
+    # ------------------------------------------------------------------
+    # Iterator protocol
+    # ------------------------------------------------------------------
 
-    def __iter__(self) -> Cursor:
+    def __iter__(self) -> SnowflakeCursorBase:
         """
         Return the cursor itself as an iterator.
 
         Returns:
-            Cursor: Self
+            SnowflakeCursorBase: Self
         """
         return self
 
-    def __next__(self) -> Row:
+    def __next__(self) -> Row | DictRow:
         """
         Fetch the next row from the currently executed statement.
 
@@ -291,16 +328,20 @@ class Cursor:
         return row
 
     # Python 2 compatibility
-    def next(self) -> Row:
+    def next(self) -> Row | DictRow:
         """Python 2 compatibility method."""
         return self.__next__()
 
-    def __enter__(self) -> Cursor:
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> SnowflakeCursorBase:
         """
         Enter the runtime context for the cursor.
 
         Returns:
-            Cursor: Self
+            SnowflakeCursorBase: Self
         """
         return self
 
@@ -316,3 +357,105 @@ class Cursor:
             bool: True if closed, False otherwise
         """
         return self._closed
+
+
+# ======================================================================
+# Concrete cursor classes
+# ======================================================================
+
+
+class SnowflakeCursor(SnowflakeCursorBase):
+    """Cursor returning results as tuples (default).
+
+    This is the standard cursor returned by ``connection.cursor()``.
+    """
+
+    @property
+    def _use_dict_result(self) -> bool:
+        return False
+
+    def fetchone(self) -> Row | None:
+        """
+        Fetch the next row of a query result set.
+
+        Returns:
+            tuple: Next row, or None when no more data is available
+        """
+        row = self._fetchone()
+        if not (row is None or isinstance(row, tuple)):
+            raise TypeError(f"fetchone got unexpected result: {row}")
+        return row
+
+    def fetchmany(self, size: int | None = None) -> list[Row]:
+        """
+        Fetch the next set of rows of a query result.
+
+        Args:
+            size (int): Number of rows to fetch (defaults to arraysize)
+
+        Returns:
+            list[tuple]: List of rows as tuples
+        """
+        return super().fetchmany(size)
+
+    def fetchall(self) -> list[Row]:
+        """
+        Fetch all (remaining) rows of a query result.
+
+        Returns:
+            list[tuple]: List of all remaining rows as tuples
+        """
+        return super().fetchall()
+
+
+class DictCursor(SnowflakeCursorBase):
+    """Cursor returning results as dictionaries with column names as keys.
+
+    Usage::
+
+        with connection.cursor(DictCursor) as cur:
+            cur.execute("SELECT 1 AS id, 'hello' AS name")
+            row = cur.fetchone()
+            # row == {"ID": 1, "NAME": "hello"}
+    """
+
+    @property
+    def _use_dict_result(self) -> bool:
+        return True
+
+    def fetchone(self) -> DictRow | None:
+        """
+        Fetch the next row of a query result set as a dictionary.
+
+        Returns:
+            dict: Next row as a dictionary with column names as keys,
+                  or None when no more data is available
+        """
+        row = self._fetchone()
+        if not (row is None or isinstance(row, dict)):
+            raise TypeError(f"fetchone got unexpected result: {row}")
+        return row
+
+    def fetchmany(self, size: int | None = None) -> list[DictRow]:
+        """
+        Fetch the next set of rows as dictionaries.
+
+        Args:
+            size (int): Number of rows to fetch (defaults to arraysize)
+
+        Returns:
+            list[dict]: List of rows as dictionaries
+        """
+        return super().fetchmany(size)
+
+    def fetchall(self) -> list[DictRow]:
+        """
+        Fetch all (remaining) rows as dictionaries.
+
+        Returns:
+            list[dict]: List of all remaining rows as dictionaries
+        """
+        return super().fetchall()
+
+
+__all__ = ["SnowflakeCursor", "DictCursor"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -65,7 +65,7 @@ def cursor(connection):
 @pytest.fixture
 def dict_cursor(connection):
     """Create a DictCursor from a connection."""
-    with connection.cursor(cursor_clas=DictCursor) as cursor:
+    with connection.cursor(cursor_class=DictCursor) as cursor:
         yield cursor
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -9,6 +9,8 @@ from urllib.parse import urlparse
 
 import pytest
 
+from snowflake.connector.cursor import DictCursor
+
 from .compatibility import IS_UNIVERSAL_DRIVER
 from .connector_factory import ConnectorFactory, create_connection_with_adapter
 from .private_key_helper import get_test_private_key_path
@@ -57,6 +59,13 @@ def connection_factory(connector_adapter):
 def cursor(connection):
     """Create a test cursor from a connection."""
     with connection.cursor() as cursor:
+        yield cursor
+
+
+@pytest.fixture
+def dict_cursor(connection):
+    """Create a DictCursor from a connection."""
+    with connection.cursor(cursor_clas=DictCursor) as cursor:
         yield cursor
 
 

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -329,23 +329,24 @@ class TestCursorIteration:
 
 
 class TestCursorLargeResults:
-    """Test cursor with large result sets."""
+    """Test cursor with large result sets spanning multiple batches."""
 
-    N_ROWS = 20_000
+    N_ROWS = 5_000
 
-    def test_large_result_fetchall(self, cursor):
+    @pytest.mark.parametrize("data_size", [N_ROWS, 20_000])
+    def test_large_result_fetchall(self, cursor, data_size):
         """Test fetchall with large results."""
         # Use ROW_NUMBER() for consecutive integers; seq4() may skip values in parallel.
         cursor.execute(
             f"""
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as n
-            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            FROM TABLE(GENERATOR(ROWCOUNT => {data_size}))
             ORDER BY 1
         """
         )
         result = cursor.fetchall()
         values = [row[0] for row in result]
-        assert_sequential_values(values, self.N_ROWS)
+        assert_sequential_values(values, data_size)
 
     def test_large_result_iteration(self, cursor):
         """Test iteration over large results."""
@@ -683,19 +684,20 @@ class TestDictCursorIteration:
 class TestDictCursorLargeResults:
     """Test DictCursor with large result sets spanning multiple batches."""
 
-    N_ROWS = 20_000
+    N_ROWS = 5_000
 
-    def test_large_result_fetchall(self, dict_cursor):
+    @pytest.mark.parametrize("data_size", [N_ROWS, 20_000])
+    def test_large_result_fetchall(self, dict_cursor, data_size):
         """Test fetchall with large results returns dicts."""
         dict_cursor.execute(
             f"""
             SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
-            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            FROM TABLE(GENERATOR(ROWCOUNT => {data_size}))
             ORDER BY 1
             """
         )
         result = dict_cursor.fetchall()
-        assert len(result) == self.N_ROWS
+        assert len(result) == data_size
         assert all(isinstance(row, dict) for row in result)
         assert all(row["N"] == i for i, row in enumerate(result))
 

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -12,9 +12,10 @@ from tests.e2e.types.utils import assert_sequential_values
 
 
 if IS_UNIVERSAL_DRIVER:
-    from snowflake.connector import Cursor
+    from snowflake.connector import SnowflakeCursor
+    from snowflake.connector.cursor import SnowflakeCursorBase
 else:
-    from snowflake.connector.cursor import SnowflakeCursor as Cursor
+    from snowflake.connector.cursor import SnowflakeCursor, SnowflakeCursorBase
 
 
 class TestCursorMethods:
@@ -112,7 +113,7 @@ class TestCursorFetch:
     def test_execute_returns_cursor(self, cursor):
         """Test execute returns cursor"""
         r = cursor.execute("SELECT 1")
-        assert isinstance(r, Cursor)
+        assert isinstance(r, SnowflakeCursor)
         assert r is cursor
 
     def test_fetchone_single_value(self, cursor):
@@ -500,52 +501,297 @@ class TestCursorMultipleQueries:
         assert batch3 == [(105,), (106,), (107,)]
 
 
-class TestCursorDictResult:
-    """Test dict result mode.
+class TestDictCursorCreation:
+    """Test DictCursor creation via connection.cursor()."""
 
-    Note: DictCursor is not yet implemented. These tests use ArrowStreamIterator
-    directly to verify dict result functionality works correctly.
-    """
+    def test_create_dict_cursor(self, connection):
+        """Test that DictCursor can be created via connection.cursor()."""
+        if IS_UNIVERSAL_DRIVER:
+            from snowflake.connector import DictCursor
+        else:
+            from snowflake.connector.cursor import DictCursor
 
-    @pytest.mark.skip_reference
-    def test_next_returns_dict(self, cursor):
-        """Test next() returns dict with column names as keys."""
-        # TODO: Replace with DictCursor when implemented
-        from snowflake.connector._internal.arrow_context import ArrowConverterContext
-        from snowflake.connector._internal.arrow_stream_iterator import (
-            ArrowStreamIterator,
-        )
+        with connection.cursor(DictCursor) as cur:
+            assert isinstance(cur, DictCursor)
 
-        cursor.execute("SELECT 1 AS id, 'hello' AS name")
-        stream_ptr = cursor._get_stream_ptr()
-        arrow_context = ArrowConverterContext()
-        iterator = ArrowStreamIterator(stream_ptr, arrow_context, use_dict_result=True)
+    def test_dict_cursor_is_base_cursor_subclass(self):
+        """Test that DictCursor is a subclass of BaseCursor."""
+        if IS_UNIVERSAL_DRIVER:
+            from snowflake.connector import DictCursor
+        else:
+            from snowflake.connector.cursor import DictCursor
 
-        result = next(iterator)
+        assert issubclass(DictCursor, SnowflakeCursorBase)
+
+
+class TestDictCursorFetchOne:
+    """Test DictCursor fetchone operations."""
+
+    def test_fetchone_returns_dict(self, dict_cursor):
+        """Test fetchone returns a dictionary with column names as keys."""
+        dict_cursor.execute("SELECT 1 AS id, 'hello' AS name")
+        result = dict_cursor.fetchone()
+        assert isinstance(result, dict)
         assert result == {"ID": 1, "NAME": "hello"}
 
-    @pytest.mark.skip_reference
-    def test_dict_result_large_result(self, cursor):
-        """Test dict result with large result set spanning multiple batches."""
-        # TODO: Replace with DictCursor when implemented
-        from snowflake.connector._internal.arrow_context import ArrowConverterContext
-        from snowflake.connector._internal.arrow_stream_iterator import (
-            ArrowStreamIterator,
-        )
+    def test_fetchone_multiple_columns(self, dict_cursor):
+        """Test fetchone with multiple columns."""
+        dict_cursor.execute("SELECT 1 AS a, 'hello' AS b, 3.14 AS c")
+        result = dict_cursor.fetchone()
+        assert isinstance(result, dict)
+        assert result["A"] == 1
+        assert result["B"] == "hello"
+        assert result["C"] == Decimal("3.14")
 
-        cursor.execute(
+    def test_fetchone_returns_none_when_exhausted(self, dict_cursor):
+        """Test fetchone returns None when no more rows."""
+        dict_cursor.execute("SELECT 1 AS id")
+        dict_cursor.fetchone()
+        result = dict_cursor.fetchone()
+        assert result is None
+
+    def test_fetchone_sequential_rows(self, dict_cursor):
+        """Test fetchone returns rows sequentially as dicts."""
+        dict_cursor.execute(
             """
-            SELECT
-                seq4() AS id,
-                seq4() * 2 AS doubled
-            FROM TABLE(GENERATOR(ROWCOUNT => 5000))
-        """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 3))
+            ORDER BY 1
+            """
         )
-        stream_ptr = cursor._get_stream_ptr()
-        arrow_context = ArrowConverterContext()
-        iterator = ArrowStreamIterator(stream_ptr, arrow_context, use_dict_result=True)
+        r1 = dict_cursor.fetchone()
+        r2 = dict_cursor.fetchone()
+        r3 = dict_cursor.fetchone()
+        assert r1 == {"N": 0}
+        assert r2 == {"N": 1}
+        assert r3 == {"N": 2}
 
-        result = list(iterator)
-        assert len(result) == 5000
+
+class TestDictCursorFetchMany:
+    """Test DictCursor fetchmany operations."""
+
+    def test_fetchmany_returns_list_of_dicts(self, dict_cursor):
+        """Test fetchmany returns a list of dictionaries."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        result = dict_cursor.fetchmany(3)
+        assert len(result) == 3
         assert all(isinstance(row, dict) for row in result)
-        assert all(len(row) == 2 for row in result)
+        assert result == [{"N": 0}, {"N": 1}, {"N": 2}]
+
+    def test_fetchmany_default_arraysize(self, dict_cursor):
+        """Test fetchmany with default arraysize."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        dict_cursor.arraysize = 2
+        result = dict_cursor.fetchmany()
+        assert result == [{"N": 0}, {"N": 1}]
+
+    def test_fetchmany_returns_empty_after_exhausted(self, dict_cursor):
+        """Test fetchmany returns empty list after all rows consumed."""
+        dict_cursor.execute("SELECT 1 AS id")
+        dict_cursor.fetchmany(10)
+        result = dict_cursor.fetchmany(10)
+        assert result == []
+
+
+class TestDictCursorFetchAll:
+    """Test DictCursor fetchall operations."""
+
+    def test_fetchall_returns_list_of_dicts(self, dict_cursor):
+        """Test fetchall returns a list of dictionaries."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        result = dict_cursor.fetchall()
+        assert len(result) == 5
+        assert all(isinstance(row, dict) for row in result)
+        assert result == [{"N": i} for i in range(5)]
+
+    def test_fetchall_multiple_columns(self, dict_cursor):
+        """Test fetchall with multiple columns returns dicts."""
+        dict_cursor.execute("SELECT 1 AS a, 'hello' AS b UNION ALL SELECT 2, 'world'")
+        result = dict_cursor.fetchall()
+        assert len(result) == 2
+        assert all(isinstance(row, dict) for row in result)
+        assert result[0]["A"] == 1
+        assert result[0]["B"] == "hello"
+        assert result[1]["A"] == 2
+        assert result[1]["B"] == "world"
+
+    def test_fetchall_after_partial_fetchone(self, dict_cursor):
+        """Test fetchall after partial fetchone calls."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        first = dict_cursor.fetchone()
+        assert first == {"N": 0}
+        remaining = dict_cursor.fetchall()
+        assert remaining == [{"N": i} for i in range(1, 5)]
+
+
+class TestDictCursorIteration:
+    """Test DictCursor iteration."""
+
+    def test_dict_cursor_is_iterable(self, dict_cursor):
+        """Test DictCursor can be iterated to get dicts."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        rows = list(dict_cursor)
+        assert len(rows) == 5
+        assert all(isinstance(row, dict) for row in rows)
+        assert rows == [{"N": i} for i in range(5)]
+
+    def test_mixed_fetchone_and_iteration(self, dict_cursor):
+        """Test mixing fetchone and iteration with DictCursor."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        first = dict_cursor.fetchone()
+        assert first == {"N": 0}
+        remaining = list(dict_cursor)
+        assert remaining == [{"N": i} for i in range(1, 5)]
+
+
+class TestDictCursorLargeResults:
+    """Test DictCursor with large result sets spanning multiple batches."""
+
+    N_ROWS = 20_000
+
+    def test_large_result_fetchall(self, dict_cursor):
+        """Test fetchall with large results returns dicts."""
+        dict_cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
+            """
+        )
+        result = dict_cursor.fetchall()
+        assert len(result) == self.N_ROWS
+        assert all(isinstance(row, dict) for row in result)
+        assert all(row["N"] == i for i, row in enumerate(result))
+
+    def test_large_result_iteration(self, dict_cursor):
+        """Test iteration over large results returns dicts."""
+        dict_cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
+            """
+        )
+        rows = list(dict_cursor)
+        assert len(rows) == self.N_ROWS
+        assert all(isinstance(row, dict) for row in rows)
+        assert all(row["N"] == i for i, row in enumerate(rows))
+
+    def test_large_result_multiple_columns(self, dict_cursor):
+        """Test large result with multiple columns as dicts."""
+        dict_cursor.execute(
+            f"""
+            WITH base AS (
+                SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS id
+                FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            )
+            SELECT id, id * 2 AS doubled, id % 10 AS mod10 FROM base
+            ORDER BY 1
+            """
+        )
+        result = dict_cursor.fetchall()
+        assert len(result) == self.N_ROWS
+        assert all(isinstance(row, dict) for row in result)
+        for i, row in enumerate(result):
+            assert row["ID"] == i
+            assert row["DOUBLED"] == i * 2
+            assert row["MOD10"] == i % 10
+
+    def test_partial_batch_consumption(self, dict_cursor):
+        """Test partial consumption of batches with DictCursor."""
+        dict_cursor.execute(
+            f"""
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => {self.N_ROWS}))
+            ORDER BY 1
+            """
+        )
+        consumed = self.N_ROWS // 10
+        for i in range(consumed):
+            row = dict_cursor.fetchone()
+            assert row == {"N": i}
+        remaining = dict_cursor.fetchall()
+        assert len(remaining) == self.N_ROWS - consumed
+        assert all(isinstance(row, dict) for row in remaining)
+
+
+class TestDictCursorMultipleQueries:
+    """Test DictCursor with multiple sequential queries."""
+
+    def test_sequential_queries(self, dict_cursor):
+        """Test sequential queries on same DictCursor."""
+        dict_cursor.execute("SELECT 1 AS val")
+        result1 = dict_cursor.fetchone()
+        assert result1 == {"VAL": 1}
+
+        dict_cursor.execute("SELECT 2 AS a, 3 AS b")
+        result2 = dict_cursor.fetchone()
+        assert result2 == {"A": 2, "B": 3}
+
+    def test_new_query_resets_iterator(self, dict_cursor):
+        """Test new query resets the iterator state for DictCursor."""
+        dict_cursor.execute(
+            """
+            SELECT seq4() AS val FROM TABLE(GENERATOR(ROWCOUNT => 100))
+            """
+        )
+        for _ in range(10):
+            dict_cursor.fetchone()
+
+        dict_cursor.execute("SELECT 42 AS answer")
+        result = dict_cursor.fetchone()
+        assert result == {"ANSWER": 42}
+
+    def test_fetchone_fetchmany_fetchall_sequence(self, dict_cursor):
+        """Test fetchone, fetchmany, and fetchall in sequence with DictCursor."""
+        dict_cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 20))
+            ORDER BY n
+            """
+        )
+        row1 = dict_cursor.fetchone()
+        assert row1 == {"N": 0}
+
+        batch = dict_cursor.fetchmany(5)
+        assert batch == [{"N": i} for i in range(1, 6)]
+
+        remainder = dict_cursor.fetchall()
+        assert remainder == [{"N": i} for i in range(6, 20)]

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from snowflake.connector.cursor import Cursor
+from snowflake.connector.cursor import SnowflakeCursor, SnowflakeCursorBase
 from snowflake.connector.errors import ProgrammingError
 
 
@@ -22,7 +22,7 @@ class TestFetchone:
     @pytest.fixture
     def cursor(self, mock_connection):
         """Create a cursor with a mock connection."""
-        return Cursor(mock_connection)
+        return SnowflakeCursor(mock_connection)
 
     def test_fetchone_returns_single_row(self, cursor):
         """Test fetchone returns a single row tuple."""
@@ -64,7 +64,7 @@ class TestFetchone:
 
     def test_fetchone_calls_get_iterator_if_iterator_is_none(self, cursor):
         """Test fetchone calls _get_iterator."""
-        mock_ensure = MagicMock()
+        mock_ensure = MagicMock(return_value=iter([(1,)]))
 
         with patch.object(cursor, "_get_iterator", mock_ensure):
             cursor.fetchone()
@@ -131,7 +131,7 @@ class TestFetchall:
     @pytest.fixture
     def cursor(self, mock_connection):
         """Create a cursor with a mock connection."""
-        return Cursor(mock_connection)
+        return SnowflakeCursor(mock_connection)
 
     def test_fetchall_returns_all_rows(self, cursor):
         """Test fetchall returns all rows as a list."""
@@ -263,7 +263,7 @@ class TestFetchmany:
     @pytest.fixture
     def cursor(self, mock_connection):
         """Create a cursor with a mock connection."""
-        return Cursor(mock_connection)
+        return SnowflakeCursor(mock_connection)
 
     def test_fetchmany_default_uses_arraysize(self, cursor):
         """Test that fetchmany() without size argument uses arraysize."""
@@ -442,11 +442,11 @@ class TestFetchmanyArraysizeAttribute:
     @pytest.fixture
     def cursor(self, mock_connection):
         """Create a cursor with a mock connection."""
-        return Cursor(mock_connection)
+        return SnowflakeCursor(mock_connection)
 
     def test_arraysize_class_attribute_default(self):
         """Test that Cursor class has default arraysize of 1."""
-        assert Cursor.arraysize == 1
+        assert SnowflakeCursorBase.arraysize == 1
 
     def test_arraysize_instance_attribute_overrides_class(self, cursor):
         """Test instance arraysize overrides class attribute."""
@@ -454,7 +454,7 @@ class TestFetchmanyArraysizeAttribute:
         cursor.arraysize = 10
         assert cursor.arraysize == 10
         # Class attribute unchanged
-        assert Cursor.arraysize == 1
+        assert SnowflakeCursorBase.arraysize == 1
 
     def test_fetchmany_uses_instance_arraysize(self, cursor):
         """Test fetchmany uses instance arraysize, not class attribute."""

--- a/python/tests/unit/test_module.py
+++ b/python/tests/unit/test_module.py
@@ -2,16 +2,18 @@
 Tests for PEP 249 module interface.
 """
 
+import pytest
+
 import snowflake.connector as pep249_dbapi
 
 from snowflake.connector import (
     Binary,
     Connection,
-    Cursor,
     DatabaseError,
     DataError,
     Date,
     DateFromTicks,
+    DictCursor,
     Error,
     IntegrityError,
     InterfaceError,
@@ -19,6 +21,7 @@ from snowflake.connector import (
     NotSupportedError,
     OperationalError,
     ProgrammingError,
+    SnowflakeCursor,
     Time,
     TimeFromTicks,
     Timestamp,
@@ -82,9 +85,9 @@ class TestModuleExports:
         assert pep249_dbapi.Connection is Connection
 
     def test_cursor_class_exported(self):
-        """Test that Cursor class is exported."""
-        assert hasattr(pep249_dbapi, "Cursor")
-        assert pep249_dbapi.Cursor is Cursor
+        """Test that SnowflakeCursor class is exported."""
+        assert hasattr(pep249_dbapi, "SnowflakeCursor")
+        assert pep249_dbapi.SnowflakeCursor is SnowflakeCursor
 
     def test_exception_classes_exported(self):
         """Test that all exception classes are exported."""
@@ -225,7 +228,8 @@ class TestPEP249Compliance:
             assert hasattr(Connection, method), f"Connection missing required method '{method}'"
             assert callable(getattr(Connection, method))
 
-    def test_cursor_interface_compliance(self):
+    @pytest.mark.parametrize("cursor_class", [SnowflakeCursor, DictCursor])
+    def test_cursor_interface_compliance(self, cursor_class):
         """Test that Cursor class has required methods."""
         required_methods = [
             "callproc",
@@ -241,11 +245,11 @@ class TestPEP249Compliance:
         ]
 
         for method in required_methods:
-            assert hasattr(Cursor, method), f"Cursor missing required method '{method}'"
-            assert callable(getattr(Cursor, method))
+            assert hasattr(cursor_class, method), f"Cursor missing required method '{method}'"
+            assert callable(getattr(cursor_class, method))
 
         # Test required attributes
         required_attrs = ["description", "rowcount", "arraysize"]
 
         for attr in required_attrs:
-            assert hasattr(Cursor, attr), f"Cursor missing required attribute '{attr}'"
+            assert hasattr(cursor_class, attr), f"Cursor missing required attribute '{attr}'"


### PR DESCRIPTION
Refactor cursor hierarchy to mirror the old snowflake-connector-python:
- BaseCursor (abstract) with shared logic and abstract _use_dict_result/fetchone
- SnowflakeCursor returns tuples (default from connection.cursor())
- DictCursor returns dicts (via connection.cursor(DictCursor))

Add comprehensive DictCursor integration tests covering fetchone, fetchmany, fetchall, iteration, large results, and multiple queries.