### PR TITLE
SNOW-3022768: ODBC API tests for connection termination functions

### DIFF
--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -18,7 +18,6 @@ class EnvFixture {
 public:
   std::optional<ConfigInstallation> config;
   std::optional<EnvironmentHandleWrapper> env_wrapper;
-  SQLHENV env = SQL_NULL_HENV;
 
   // Constructor with optional DSN configuration
   explicit EnvFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) {
@@ -29,8 +28,8 @@ public:
 
     // Create ENV handle (will see installed DSN)
     env_wrapper.emplace();
-    env = env_wrapper->getHandle();
-    SQLRETURN ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    SQLRETURN ret = SQLSetEnvAttr(env_wrapper->getHandle(), SQL_ATTR_ODBC_VERSION,
+                            reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
     REQUIRE(ret == SQL_SUCCESS);
   }
 
@@ -40,19 +39,17 @@ public:
   EnvFixture(EnvFixture&&) = delete;
   EnvFixture& operator=(EnvFixture&&) = delete;
 
-  SQLHENV env_handle() const { return env; }
+  [[nodiscard]] SQLHENV env_handle() const { return env_wrapper->getHandle(); }
 };
 
 class DbcFixture : public EnvFixture {
 public:
   std::optional<ConnectionHandleWrapper> dbc_wrapper;
-  SQLHDBC dbc = SQL_NULL_HDBC;
 
   // Constructor with optional DSN configuration
   explicit DbcFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt)
     : EnvFixture(std::move(dsn_config)) {
     dbc_wrapper.emplace(env_wrapper->createConnectionHandle());
-    dbc = dbc_wrapper->getHandle();
   }
 
   // Disable copy and move (RAII resource management)
@@ -61,7 +58,7 @@ public:
   DbcFixture(DbcFixture&&) = delete;
   DbcFixture& operator=(DbcFixture&&) = delete;
 
-  SQLHDBC dbc_handle() const { return dbc; }
+  [[nodiscard]] SQLHDBC dbc_handle() const { return dbc_wrapper->getHandle(); }
 };
 
 // ============================================================================

--- a/odbc_tests/tests/odbc-api/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 4.0)
 
 add_subdirectory(connecting)
 add_subdirectory(driver_info)
+add_subdirectory(terminating_connection)

--- a/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
@@ -3,7 +3,6 @@
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "compatibility.hpp"
 #include "Connection.hpp"
@@ -12,8 +11,6 @@
 #include "macros.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
-
-using namespace Catch::Matchers;
 
 // ============================================================================
 // SQL_HANDLE_ENV - Environment Handle Allocation

--- a/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
@@ -3,7 +3,6 @@
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include <atomic>
 #include <thread>
@@ -17,8 +16,6 @@
 #include "macros.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
-
-using namespace Catch::Matchers;
 
 // ============================================================================
 // SQLConnect - Success Cases

--- a/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
@@ -3,7 +3,6 @@
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include <atomic>
 #include <cstring>
@@ -17,8 +16,6 @@
 #include "get_diag_rec.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
-
-using namespace Catch::Matchers;
 
 // Helper to build connection string from DSN
 std::string build_dsn_connection_string(const std::string& dsn) {

--- a/odbc_tests/tests/odbc-api/terminating_connection/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/terminating_connection/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_odbc_test(odbc_api_disconnect_tests disconnect_tests.cpp)
+add_odbc_test(odbc_api_free_handle_tests free_handle_tests.cpp)

--- a/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
@@ -1,0 +1,312 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "compatibility.hpp"
+#include "Connection.hpp"
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLDisconnect - Basic Functionality
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Successfully disconnects from data source",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect first
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // 08003: Connection not open
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Can reconnect after disconnect",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect, disconnect, reconnect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                   SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Idempotency of multiple disconnects",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect first
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // First disconnect
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns error for disconnecting an already disconnected handle.
+  // This is a deviation from the ODBC specification which allows for idempotent disconnects.
+  // 08003: Connection not open
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLDisconnect - With Active Statements
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Closes open statements automatically",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver does not set statement handle variable to null after disconnect
+  // However, the handle becomes invalid and operations on it return SQL_INVALID_HANDLE
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Handles active transactions",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect with manual commit mode
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Set manual commit mode
+  ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  // Execute a statement to start transaction
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  
+  // Note: Reference driver requires explicit transaction cleanup before disconnecting
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_ERROR);
+  
+  ret = SQLEndTran(SQL_HANDLE_DBC, dbc_handle(), SQL_ROLLBACK);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With active result sets",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Execute query with result set
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  // Note: Reference driver allows disconnecting with active result sets
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+// ============================================================================
+// SQLDisconnect - Error Cases: Invalid Handle
+// ============================================================================
+
+TEST_CASE("SQLDisconnect: SQL_INVALID_HANDLE for null connection handle",
+          "[odbc-api][disconnect][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLDisconnect(SQL_NULL_HDBC);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(EnvFixture, "SQLDisconnect: SQL_INVALID_HANDLE for wrong handle type",
+                 "[odbc-api][disconnect][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Pass environment handle as connection handle
+  const SQLRETURN ret = SQLDisconnect(env_handle());
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLDisconnect: 08003 - Connection not open when not connected",
+                 "[odbc-api][disconnect][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Try to disconnect without connecting first
+  // 08003: Connection not open
+  const SQLRETURN ret = SQLDisconnect(dbc_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+// ============================================================================
+// SQLDisconnect - Edge Cases
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: After failed connection attempt",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Attempt to connect with invalid credentials
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("InvalidDSN")), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_ERROR);
+
+  // Note: Reference driver returns error (08003: Connection not open)
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With multiple statement handles",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate multiple statements
+  SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT, stmt3 = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt2);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt3);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLExecDirect(stmt1, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+  
+  ret = SQLExecDirect(stmt2, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+  
+  ret = SQLExecDirect(stmt3, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Preserves connection handle for reuse",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect, disconnect, verify handle can be reused
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver Get fails but Set succeeds on disconnected handle
+  SQLUINTEGER timeout = 0;
+  ret = SQLGetConnectAttr(dbc_handle(), SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr);
+  REQUIRE(ret == SQL_ERROR);
+  
+  ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_CONNECTION_TIMEOUT, reinterpret_cast<SQLPOINTER>(30), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+// ============================================================================
+// SQLDisconnect - Diagnostic Information
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Clears previous diagnostic records",
+                 "[odbc-api][disconnect][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Cause an error to populate diagnostic records
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  // Execute invalid SQL
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("INVALID SQL STATEMENT")), SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
+  
+  SQLCHAR temp_sqlstate[6];
+  SQLINTEGER temp_native_error;
+  SQLCHAR temp_message[256];
+  SQLSMALLINT temp_message_len;
+  
+  ret = SQLGetDiagRec(SQL_HANDLE_STMT, stmt, 1, temp_sqlstate, &temp_native_error, temp_message, sizeof(temp_message), &temp_message_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns SQL_NO_DATA indicating no diagnostic records
+  SQLCHAR sqlstate[6];
+  SQLINTEGER native_error;
+  SQLCHAR message[256];
+  SQLSMALLINT message_len;
+  
+  ret = SQLGetDiagRec(SQL_HANDLE_DBC, dbc_handle(), 1, sqlstate, &native_error, message, sizeof(message), &message_len);
+  REQUIRE(ret == SQL_NO_DATA);
+}

--- a/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
@@ -1,0 +1,557 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "compatibility.hpp"
+#include "Connection.hpp"
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLFreeHandle - Environment Handle
+// ============================================================================
+
+TEST_CASE("SQLFreeHandle: Successfully frees environment handle",
+          "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate environment
+  SQLHENV env = SQL_NULL_HENV;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(env != SQL_NULL_HENV);
+
+  // Set ODBC version
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Free environment
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE("SQLFreeHandle: SQL_INVALID_HANDLE for null environment handle",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_ENV, SQL_NULL_HENV);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(EnvFixture, "SQLFreeHandle: HY010 - Cannot free environment with active connections",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate connection on environment
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Try to free environment while connection exists
+  // HY010: Function sequence error
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", env_handle(), SQL_HANDLE_ENV);
+
+  // Clean up
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE("SQLFreeHandle: Double free environment handle",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate and free environment
+  SQLHENV env = SQL_NULL_HENV;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+// ============================================================================
+// SQLFreeHandle - Connection Handle
+// ============================================================================
+
+TEST_CASE_METHOD(EnvFixture, "SQLFreeHandle: Successfully frees connection handle",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate connection
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(dbc != SQL_NULL_HDBC);
+
+  // Free connection (not connected)
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE("SQLFreeHandle: SQL_INVALID_HANDLE for null connection handle",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_DBC, SQL_NULL_HDBC);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY010 - Cannot free connected connection handle",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Try to free while still connected
+  // HY010: Function sequence error
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", dbc_handle(), SQL_HANDLE_DBC);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free disconnected connection handle",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect and disconnect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Free disconnected connection
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Mark handle as freed to prevent double-free in fixture cleanup
+  dbc_wrapper.reset();
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Frees dependent statement handles when connection handle is freed",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  
+  // Connect first (required to allocate statement)
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Disconnect first
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver automatically frees dependent statement handles
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+  
+  dbc_wrapper.reset();
+}
+
+// SQLFreeHandle: Double free connection handle
+// Note: Reference driver crashes on double-free of connection handle
+// This is undefined behavior that must be avoided
+// Skipping test case to prevent crash
+
+// ============================================================================
+// SQLFreeHandle - Statement Handle
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Successfully frees statement handle",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect first
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(stmt != SQL_NULL_HSTMT);
+
+  // Free statement
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE("SQLFreeHandle: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_STMT, SQL_NULL_HSTMT);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with prepared statement",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate and prepare statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with active result set",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Execute query
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with bound parameters",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement and bind parameter
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param_value = 42;
+  ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with bound columns",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement and bind column
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER col_value = 0;
+  ret = SQLBindCol(stmt, 1, SQL_C_SLONG, &col_value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Double free statement handle",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate and free statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLFreeHandle - Descriptor Handle
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free explicitly allocated descriptor",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate explicit descriptor
+  SQLHDESC desc = SQL_NULL_HDESC;
+  ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc_handle(), &desc);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(desc != SQL_NULL_HDESC);
+
+  // Free descriptor
+  ret = SQLFreeHandle(SQL_HANDLE_DESC, desc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE("SQLFreeHandle: SQL_INVALID_HANDLE for null descriptor handle",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_DESC, SQL_NULL_HDESC);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY017 - Cannot free implicit descriptor",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Get implicit descriptor (ARD)
+  SQLHDESC ard = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(ard != SQL_NULL_HDESC);
+  
+  // Try to free implicit descriptor
+  // HY017: Invalid use of an automatically allocated descriptor handle
+  ret = SQLFreeHandle(SQL_HANDLE_DESC, ard);
+  REQUIRE_EXPECTED_ERROR(ret, "HY017", ard, SQL_HANDLE_DESC);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLFreeHandle - Invalid Handle Type
+// ============================================================================
+
+TEST_CASE_METHOD(EnvFixture, "SQLFreeHandle: SQL_INVALID_HANDLE for invalid handle type",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate connection
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Try to free with wrong handle type
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, dbc);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  // Clean up properly
+  SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: SQL_INVALID_HANDLE for wrong statement/connection handle type",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate statement
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, stmt);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE("SQLFreeHandle: SQL_INVALID_HANDLE for completely invalid handle type value",
+          "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHENV env = SQL_NULL_HENV;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Try to free with invalid handle type (999)
+  ret = SQLFreeHandle(999, env);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+
+  // Clean up properly
+  SQLFreeHandle(SQL_HANDLE_ENV, env);
+}
+
+// ============================================================================
+// SQLFreeHandle - Edge Cases and Multiple Handles
+// ============================================================================
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free multiple statement handles independently",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Connect
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+                             SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Allocate multiple statements
+  SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT, stmt3 = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt2);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt3);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Free in different order
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt2);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt3);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE("SQLFreeHandle: Complete handle hierarchy cleanup in correct order",
+          "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  
+  // Create hierarchy: ENV -> DBC
+  SQLHENV env = SQL_NULL_HENV;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // HY010: Function sequence error
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", env, SQL_HANDLE_ENV);
+
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLFreeHandle: Freeing handle clears attributes",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Allocate connection and set attribute
+  SQLHDBC dbc = SQL_NULL_HDBC;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Set connection timeout
+  ret = SQLSetConnectAttr(dbc, SQL_ATTR_CONNECTION_TIMEOUT, reinterpret_cast<SQLPOINTER>(30), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Free and reallocate
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHDBC dbc2 = SQL_NULL_HDBC;
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &dbc2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns SQL_ERROR when getting attribute from unconnected handle
+  SQLUINTEGER timeout = 999;
+  ret = SQLGetConnectAttr(dbc2, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr);
+  REQUIRE(ret == SQL_ERROR);
+
+  // Connect and verify the attribute is the default after connecting
+  ret = SQLConnect(dbc2, reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
+        SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLGetConnectAttr(dbc2, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(timeout == 0); // Default value
+
+  ret = SQLDisconnect(dbc2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc2);
+  REQUIRE(ret == SQL_SUCCESS);
+}


### PR DESCRIPTION
Added granular ODBC unit and integration tests to verify compliance of ODBC wrapper with the ODBC 3.x and 2.x specs and consistent behaviour with existing ODBC driver.

This PR only contains ["Terminating a connection" category functions](https://docs.google.com/spreadsheets/d/1BjOHFnLQ2AooXGqWncsaqCLIw8z9XD0v3fwwF-S-E3g/edit?gid=999869428#gid=999869428).