### PR TITLE
SNOW-3022768: ODBC API tests for statement preparation functions

### DIFF
--- a/odbc_tests/Dockerfile
+++ b/odbc_tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y unixodbc unixodbc-dev curl odbcinst wget build-essential git gdb \
-    zlib1g-dev jq
+    zlib1g-dev libssl-dev jq
 
 # Install CMake
 RUN wget https://github.com/Kitware/CMake/releases/download/v4.0.3/cmake-4.0.3-linux-aarch64.sh && \

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -5,22 +5,24 @@
 #include <sqlext.h>
 
 #include <optional>
+#include <string>
 #include <utility>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "HandleWrapper.hpp"
 #include "ODBCConfig.hpp"
+#include "compatibility.hpp"
 
 // ============================================================================
 // Base Fixtures (Parameterized via Constructor)
 // ============================================================================
 
 class EnvFixture {
- public:
   std::optional<ConfigInstallation> config;
   std::optional<EnvironmentHandleWrapper> env_wrapper;
 
+ public:
   // Constructor with optional DSN configuration
   explicit EnvFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) {
     // Install DSN BEFORE creating ENV handle (critical for UnixODBC caching)
@@ -42,15 +44,19 @@ class EnvFixture {
   EnvFixture& operator=(EnvFixture&&) = delete;
 
   [[nodiscard]] SQLHENV env_handle() const { return env_wrapper->getHandle(); }
+  [[nodiscard]] std::string dsn_name() const { return config.value().dsn_name(); }
+
+ protected:
+  [[nodiscard]] ConnectionHandleWrapper create_connection_handle() { return env_wrapper->createConnectionHandle(); }
 };
 
 class DbcFixture : public EnvFixture {
- public:
   std::optional<ConnectionHandleWrapper> dbc_wrapper;
 
+ public:
   // Constructor with optional DSN configuration
   explicit DbcFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) : EnvFixture(std::move(dsn_config)) {
-    dbc_wrapper.emplace(env_wrapper->createConnectionHandle());
+    dbc_wrapper.emplace(create_connection_handle());
   }
 
   // Disable copy and move (RAII resource management)
@@ -60,6 +66,10 @@ class DbcFixture : public EnvFixture {
   DbcFixture& operator=(DbcFixture&&) = delete;
 
   [[nodiscard]] SQLHDBC dbc_handle() const { return dbc_wrapper->getHandle(); }
+
+  // Releases the connection handle wrapper, preventing double-free when test
+  // code has already freed the underlying HDBC via SQLFreeHandle.
+  void release_dbc() { dbc_wrapper.reset(); }
 };
 
 // ============================================================================
@@ -84,6 +94,48 @@ class EnvNoAuthDSNFixture : public EnvFixture {
 class DbcNoAuthDSNFixture : public DbcFixture {
  public:
   DbcNoAuthDSNFixture() : DbcFixture(DataSourceConfig::SnowflakeNoAuth()) {}
+};
+
+// ============================================================================
+// Connected Statement Fixtures (ENV + DBC + SQLConnect + STMT)
+// ============================================================================
+
+class StmtFixture : public DbcFixture {
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+ public:
+  explicit StmtFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) : DbcFixture(std::move(dsn_config)) {
+    // SQLConnect is not yet implemented in the new driver
+    SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+    const std::string dsn = dsn_name();
+    SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
+                               nullptr, 0, nullptr, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+    REQUIRE(ret == SQL_SUCCESS);
+  }
+
+  ~StmtFixture() {
+    if (stmt != SQL_NULL_HSTMT) {
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    }
+    SQLDisconnect(dbc_handle());
+  }
+
+  // Disable copy and move (RAII resource management)
+  StmtFixture(const StmtFixture&) = delete;
+  StmtFixture& operator=(const StmtFixture&) = delete;
+  StmtFixture(StmtFixture&&) = delete;
+  StmtFixture& operator=(StmtFixture&&) = delete;
+
+  [[nodiscard]] SQLHSTMT stmt_handle() const { return stmt; }
+};
+
+class StmtDefaultDSNFixture : public StmtFixture {
+ public:
+  StmtDefaultDSNFixture() : StmtFixture(DataSourceConfig::Snowflake()) {}
 };
 
 #endif  // ODBCFIXTURES_HPP

--- a/odbc_tests/tests/odbc-api/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/CMakeLists.txt
@@ -2,4 +2,5 @@ cmake_minimum_required(VERSION 4.0)
 
 add_subdirectory(connecting)
 add_subdirectory(driver_info)
+add_subdirectory(preparing)
 add_subdirectory(terminating_connection)

--- a/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Zero BufferLength retu
                  "[odbc-api][browse_connect][connecting]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
@@ -168,7 +168,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 08002 - Connection alr
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Try to connect again using SQLBrowseConnect
-  const std::string connStr2 = "DSN=" + config.value().dsn_name();
+  const std::string connStr2 = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
@@ -190,7 +190,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Initial call with DSN"
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Initial browse with just DSN
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
@@ -220,7 +220,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Reconnect after discon
                  "[odbc-api][browse_connect][connecting][integration]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
@@ -262,7 +262,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLBrowseConnect: 28000 - Invalid credent
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Use DSN without auth but provide invalid credentials
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
+  const std::string connStr = "DSN=" + dsn_name() + ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
@@ -281,7 +281,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 01004 - OutConnectionS
                  "[odbc-api][browse_connect][connecting]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[10];  // Very small buffer to force truncation
   SQLSMALLINT outLen = 0;
 
@@ -303,7 +303,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: NULL StringLength2Ptr 
                  "[odbc-api][browse_connect][connecting]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024] = {};
 
   // NULL StringLength2Ptr is allowed per ODBC spec - caller doesn't need length
@@ -331,7 +331,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Disconnecting after su
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Browse and connect
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
@@ -353,7 +353,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Driver support with co
                  "[odbc-api][browse_connect][connecting][integration]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = "DSN=" + config.value().dsn_name();
+  const std::string connStr = "DSN=" + dsn_name();
   SQLCHAR outConnStr[2048] = {};
   SQLSMALLINT outLen = 0;
 

--- a/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
@@ -322,7 +322,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Basic DSN connection succeed
                  "[odbc-api][connect][dsn][integration]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
 
   // Credentials are in odbc.ini, pass NULL for UID/PWD
   SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
@@ -348,7 +348,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Basic DSN connection succeed
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: 08002 - Connection already open",
                  "[odbc-api][connect][dsn][integration][error]") {
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
 
   // First connection must succeed
   SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
@@ -373,7 +373,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLConnect: 28000 - Invalid authorization
   // Use DSN without credentials and provide invalid ones
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
   const std::string bad_uid = "invalid_user_xyz";
   const std::string bad_pwd = "invalid_cred_xyz";
 
@@ -386,7 +386,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLConnect: 28000 - Invalid authorization
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: SQL_SUCCESS_WITH_INFO has retrievable diagnostics",
                  "[odbc-api][connect][dsn][integration]") {
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
 
   SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
                              0, nullptr, 0);
@@ -407,7 +407,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Disconnect and reconnect cyc
                  "[odbc-api][connect][dsn][integration][lifecycle]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
 
   constexpr int CYCLES = 3;
   for (int i = 0; i < CYCLES; i++) {
@@ -437,7 +437,7 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLConnect: Multiple concurrent connecti
   constexpr int NUM_CONNECTIONS = 3;
   SQLHDBC connections[NUM_CONNECTIONS];
 
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
 
   // Allocate and connect all connections
   for (auto& connection : connections) {

--- a/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
@@ -155,7 +155,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mo
 
   // SQL_DRIVER_NOPROMPT: Never prompt, fail if info missing
   // With complete DSN (has credentials), should succeed
-  std::string connStr = "DSN=" + config.value().dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
@@ -172,7 +172,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mod
   // SQL_DRIVER_NOPROMPT: With DSN that has no credentials, should fail
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
-  std::string connStr = "DSN=" + config->dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   const SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
@@ -185,7 +185,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mo
 
   // SQL_DRIVER_COMPLETE: Prompt only if info is missing
   // With complete DSN, no prompting needed, should succeed
-  std::string connStr = "DSN=" + config.value().dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
@@ -203,7 +203,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mod
   // but fails with NULL window handle in headless environment
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
-  std::string connStr = "DSN=" + config->dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   const SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
@@ -216,7 +216,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_RE
 
   // SQL_DRIVER_COMPLETE_REQUIRED: Only prompt for required info
   // With complete DSN, no prompting needed, should succeed
-  std::string connStr = "DSN=" + config.value().dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
@@ -234,7 +234,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_REQ
   // but fails with NULL window handle in headless environment
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
-  std::string connStr = "DSN=" + config->dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   const SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
@@ -246,7 +246,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_PROMPT mode
   // SQL_DRIVER_PROMPT: Always display dialog, even with complete DSN
   // Per ODBC spec, with NULL window handle should return HY092 or fail
   // Even though DSN is complete, PROMPT mode MUST show dialog
-  std::string connStr = "DSN=" + config.value().dsn_name();
+  std::string connStr = "DSN=" + dsn_name();
   const SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
                        nullptr, 0, nullptr, SQL_DRIVER_PROMPT);
@@ -260,7 +260,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: 08002 - Connection alr
                  "[odbc-api][driverconnect][dsn][integration][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // First connection
   SQLRETURN ret =
@@ -291,7 +291,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString bu
                  "[odbc-api][driverconnect][dsn][integration][buffer]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // Test with output buffer
   SQLCHAR outConnStr[1024];
@@ -315,7 +315,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString tr
                  "[odbc-api][driverconnect][dsn][integration][buffer]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // Very small buffer to force truncation
   SQLCHAR outConnStr[10];
@@ -343,7 +343,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL OutConnectionStri
                  "[odbc-api][driverconnect][dsn][integration][buffer]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
   SQLSMALLINT outConnStrLen = 0;
 
   // NULL buffer but valid length pointer - should report required length
@@ -363,7 +363,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL StringLength2Ptr 
                  "[odbc-api][driverconnect][dsn][integration][buffer]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
   SQLCHAR outConnStr[1024];
 
   // Valid buffer but NULL length pointer - should still succeed
@@ -383,7 +383,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Both OutConnectionStri
                  "[odbc-api][driverconnect][dsn][integration][buffer]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // Both NULL - should still connect, just no output
   SQLRETURN ret =
@@ -452,7 +452,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Basic DSN connection s
                  "[odbc-api][driverconnect][dsn][integration]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -481,7 +481,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Connection with additi
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // DSN with additional Snowflake-specific parameters
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";TRACING=0";
+  const std::string connStr = "DSN=" + dsn_name() + ";TRACING=0";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -498,7 +498,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Per ODBC spec, unrecognized keywords return SQL_SUCCESS_WITH_INFO with 01S00
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";INVALIDKEY=abc";
+  const std::string connStr = "DSN=" + dsn_name() + ";INVALIDKEY=abc";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -520,7 +520,7 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: 28000 - Invalid authori
   // Use DSN without auth but provide invalid credentials
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
+  const std::string connStr = "DSN=" + dsn_name() + ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
 
   const SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -532,7 +532,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Disconnect and reconne
                  "[odbc-api][driverconnect][dsn][integration][lifecycle]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
 
   for (int i = 0; i < 3; i++) {
     SQLRETURN ret =
@@ -561,7 +561,7 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLDriverConnect: Multiple concurrent co
   constexpr int NUM_CONNECTIONS = 4;
   SQLHDBC connections[NUM_CONNECTIONS];
 
-  const std::string connStr = build_dsn_connection_string(config.value().dsn_name());
+  const std::string connStr = build_dsn_connection_string(dsn_name());
   int successful_connections = 0;
 
   // Allocate and connect all handles
@@ -599,7 +599,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake TRACING para
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: TRACING is a Snowflake-specific parameter that controls logging level (0-6)
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";TRACING=0";
+  const std::string connStr = "DSN=" + dsn_name() + ";TRACING=0";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -615,7 +615,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake CLIENT_SESSI
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: CLIENT_SESSION_KEEP_ALIVE is a Snowflake-specific parameter that enables heartbeat to keep session alive
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";CLIENT_SESSION_KEEP_ALIVE=true";
+  const std::string connStr = "DSN=" + dsn_name() + ";CLIENT_SESSION_KEEP_ALIVE=true";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -640,7 +640,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake LOGIN_TIMEOU
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // LOGIN_TIMEOUT sets connection timeout in seconds
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";LOGIN_TIMEOUT=120";
+  const std::string connStr = "DSN=" + dsn_name() + ";LOGIN_TIMEOUT=120";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -656,7 +656,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake APPLICATION 
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // APPLICATION parameter sets client application name
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";APPLICATION=ODBCTestSuite";
+  const std::string connStr = "DSN=" + dsn_name() + ";APPLICATION=ODBCTestSuite";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -681,7 +681,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake QUERY_TIMEOU
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // QUERY_TIMEOUT sets query execution timeout (0 = no timeout)
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";QUERY_TIMEOUT=0";
+  const std::string connStr = "DSN=" + dsn_name() + ";QUERY_TIMEOUT=0";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -697,7 +697,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake NETWORK_TIME
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // NETWORK_TIMEOUT sets network operation timeout
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";NETWORK_TIMEOUT=0";
+  const std::string connStr = "DSN=" + dsn_name() + ";NETWORK_TIMEOUT=0";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -713,7 +713,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DisableOCSPC
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: DisableOCSPCheck is a Snowflake-specific parameter that controls OCSP certificate validation
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";DisableOCSPCheck=true";
+  const std::string connStr = "DSN=" + dsn_name() + ";DisableOCSPCheck=true";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -730,7 +730,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DATABASE and
 
   // DATABASE and SCHEMA can override default namespace
   // Empty values should not break connection
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";DATABASE=;SCHEMA=";
+  const std::string connStr = "DSN=" + dsn_name() + ";DATABASE=;SCHEMA=";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -746,7 +746,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake WAREHOUSE pa
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // WAREHOUSE can override default warehouse (empty = use default)
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";WAREHOUSE=";
+  const std::string connStr = "DSN=" + dsn_name() + ";WAREHOUSE=";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -762,7 +762,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake ROLE paramet
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // ROLE can override default role (empty = use default)
-  const std::string connStr = "DSN=" + config.value().dsn_name() + ";ROLE=";
+  const std::string connStr = "DSN=" + dsn_name() + ";ROLE=";
 
   SQLRETURN ret =
       SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
@@ -778,7 +778,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake multiple par
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Combination of multiple Snowflake-specific parameters
-  const std::string connStr = "DSN=" + config.value().dsn_name() +
+  const std::string connStr = "DSN=" + dsn_name() +
                               ";APPLICATION=ODBCTest"
                               ";TRACING=0"
                               ";LOGIN_TIMEOUT=60"

--- a/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
@@ -112,9 +112,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported[SQL_API_ODBC3_ALL_FUNCTIONS_SIZE] = {};
@@ -135,9 +134,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported[100] = {};  // Size must be at least the largest function ID in ALL_ODBC_FUNCTIONS
@@ -159,9 +157,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Correctly reports unsup
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported = SQL_TRUE;
@@ -204,9 +201,8 @@ TEST_CASE_METHOD(EnvFixture, "SQLGetFunctions: SQL_INVALID_HANDLE - Invalid hand
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Accepts NULL output pointer",
                  "[odbc-api][getfunctions][driver_info]") {
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns SUCCESS for NULL pointer (differs from ODBC spec)
@@ -219,9 +215,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Accepts NULL output poi
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: HY095 - Invalid FunctionId",
                  "[odbc-api][getfunctions][driver_info][error]") {
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported = SQL_FALSE;
@@ -251,7 +246,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLGetFunctions: Requires active connection",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Can be called after connection established",
                  "[odbc-api][getfunctions][driver_info]") {
-  const std::string dsn = config.value().dsn_name();
+  const std::string dsn = dsn_name();
   SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
                              0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
@@ -273,9 +268,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: All known supported fun
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (const auto& func : ALL_ODBC_FUNCTIONS) {

--- a/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
@@ -18,9 +18,8 @@
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACTIVE_ENVIRONMENTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT activeEnv = 0;
@@ -34,9 +33,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACTIVE_ENVIRONMENTS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_DBC_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncDbc = 0;
@@ -50,9 +48,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_DBC_FUNCTIONS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_MODE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncMode = 0;
@@ -66,9 +63,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_MODE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_NOTIFICATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncNotif = 0;
@@ -82,9 +78,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_NOTIFICATION", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_ROW_COUNT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER batchRowCount = 0;
@@ -98,9 +93,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_ROW_COUNT", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_SUPPORT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER batchSupport = 0;
@@ -113,9 +107,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_SUPPORT", "[odbc-a
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_NAME", "[odbc-api][getinfo][driver_info]") {
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dsnName[256];
@@ -124,7 +117,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_NAME", "[odb
 
   REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(nameLen > 0);
-  REQUIRE(std::string(dsnName) == config.value().dsn_name());
+  REQUIRE(std::string(dsnName) == dsn_name());
 
   SQLDisconnect(dbc_handle());
 }
@@ -132,9 +125,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_NAME", "[odb
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_AWARE_POOLING_SUPPORTED",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER poolingSupport = 0;
@@ -152,9 +144,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_AWARE_POOLING_SUP
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverName[256];
@@ -171,9 +162,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_ODBC_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char odbcVer[256];
@@ -190,9 +180,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_ODBC_VER", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverVer[256];
@@ -209,9 +198,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api]
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -245,9 +233,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -281,9 +268,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -313,9 +299,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTR
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -348,9 +333,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTR
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FILE_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT fileUsage = 0;
@@ -364,9 +348,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FILE_USAGE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GETDATA_EXTENSIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER getdataExt = 0;
@@ -387,9 +370,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GETDATA_EXTENSIONS", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INFO_SCHEMA_VIEWS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER infoSchemaViews = 0;
@@ -431,9 +413,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INFO_SCHEMA_VIEWS", "[od
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -467,9 +448,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -503,9 +483,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ASYNC_CONCURRENT_STATEMENTS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxAsync = 0;
@@ -520,9 +499,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ASYNC_CONCURRENT_STA
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CONCURRENT_ACTIVITIES",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxConcurrent = 0;
@@ -536,9 +514,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CONCURRENT_ACTIVITIE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_DRIVER_CONNECTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxConnections = 0;
@@ -553,9 +530,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_DRIVER_CONNECTIONS",
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_INTERFACE_CONFORMANCE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER interfaceConformance = 0;
@@ -569,9 +545,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_INTERFACE_CONFORMAN
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_VER", "[odbc-api][getinfo][driver_info]") {
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char odbcVer[256];
@@ -587,9 +562,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_VER", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER paramArrayRowCounts = 0;
@@ -604,9 +578,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER paramArraySelects = 0;
@@ -620,9 +593,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ROW_UPDATES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char rowUpdates[8];
@@ -637,9 +609,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ROW_UPDATES", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SEARCH_PATTERN_ESCAPE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char escapeChar[8];
@@ -655,9 +626,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SEARCH_PATTERN_ESCAPE", 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SERVER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char serverName[256];
@@ -673,9 +643,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SERVER_NAME", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -709,9 +678,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -749,9 +717,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATABASE_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbName[256];
@@ -768,9 +735,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATABASE_NAME", "[odbc-a
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbmsName[256];
@@ -787,9 +753,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_NAME", "[odbc-api][
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbmsVer[256];
@@ -809,9 +774,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_PROCEDURES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char accessible[8];
@@ -825,9 +789,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_PROCEDURES", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_TABLES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char accessible[8];
@@ -841,9 +804,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_TABLES", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BOOKMARK_PERSISTENCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER bookmarkPersist = 0;
@@ -865,9 +827,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BOOKMARK_PERSISTENCE", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char catalogTerm[64];
@@ -882,9 +843,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_TERM", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLLATION_SEQ", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char collSeq[256];
@@ -898,9 +858,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLLATION_SEQ", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONCAT_NULL_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT concatBehavior = 0;
@@ -914,9 +873,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONCAT_NULL_BEHAVIOR", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_COMMIT_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT cursorCommit = 0;
@@ -930,9 +888,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_COMMIT_BEHAVIOR",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_ROLLBACK_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT cursorRollback = 0;
@@ -946,9 +903,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_ROLLBACK_BEHAVIOR
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_SENSITIVITY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER sensitivity = 0;
@@ -962,9 +918,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_SENSITIVITY", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_READ_ONLY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char readOnly[8];
@@ -978,9 +933,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_READ_ONLY", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DEFAULT_TXN_ISOLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER txnIsolation = 0;
@@ -999,9 +953,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DEFAULT_TXN_ISOLATION", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DESCRIBE_PARAMETER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char descParam[8];
@@ -1015,9 +968,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DESCRIBE_PARAMETER", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULT_RESULT_SETS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char multResults[8];
@@ -1031,9 +983,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULT_RESULT_SETS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULTIPLE_ACTIVE_TXN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char multTxn[8];
@@ -1047,9 +998,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULTIPLE_ACTIVE_TXN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NEED_LONG_DATA_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char needLongLen[8];
@@ -1063,9 +1013,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NEED_LONG_DATA_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NULL_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT nullColl = 0;
@@ -1080,9 +1029,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NULL_COLLATION", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURE_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procTerm[64];
@@ -1099,9 +1047,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURE_TERM", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char schemaTerm[64];
@@ -1116,9 +1063,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_TERM", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_OPTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER scrollOpts = 0;
@@ -1139,9 +1085,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_OPTIONS", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TABLE_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char tableTerm[64];
@@ -1157,9 +1102,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TABLE_TERM", "[odbc-api]
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_CAPABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT txnCapable = 0;
@@ -1173,9 +1117,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_CAPABLE", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_ISOLATION_OPTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER txnIsoOpts = 0;
@@ -1195,9 +1138,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_ISOLATION_OPTION", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_USER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char userName[256];
@@ -1217,9 +1159,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_USER_NAME", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_AGGREGATE_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER aggFuncs = 0;
@@ -1239,9 +1180,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_AGGREGATE_FUNCTIONS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER alterDomain = 0;
@@ -1265,9 +1205,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_DOMAIN", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER alterTable = 0;
@@ -1310,9 +1249,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_TABLE", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATETIME_LITERALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER datetimeLiterals = 0;
@@ -1343,9 +1281,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATETIME_LITERALS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_LOCATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT catLoc = 0;
@@ -1359,9 +1296,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_LOCATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char catName[8];
@@ -1376,9 +1312,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME_SEPARATOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char separator[8];
@@ -1393,9 +1328,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME_SEPARATOR",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER catUsage = 0;
@@ -1417,9 +1351,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_USAGE", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLUMN_ALIAS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char colAlias[8];
@@ -1433,9 +1366,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLUMN_ALIAS", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CORRELATION_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT corrName = 0;
@@ -1449,9 +1381,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CORRELATION_NAME", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_ASSERTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1471,9 +1402,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_ASSERTION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_CHARACTER_SET", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1491,9 +1421,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_CHARACTER_SET", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1509,9 +1438,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_COLLATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1535,9 +1463,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_DOMAIN", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_SCHEMA", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1555,9 +1482,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_SCHEMA", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1592,9 +1518,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TABLE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TRANSLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1610,9 +1535,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TRANSLATION", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_VIEW", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1630,9 +1554,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_VIEW", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DDL_INDEX", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER ddlIndex = 0;
@@ -1646,9 +1569,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DDL_INDEX", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_ASSERTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1664,9 +1586,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_ASSERTION", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_CHARACTER_SET", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1682,9 +1603,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_CHARACTER_SET", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1700,9 +1620,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_COLLATION", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1720,9 +1639,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_DOMAIN", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_SCHEMA", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1739,9 +1657,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_SCHEMA", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1758,9 +1675,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TABLE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TRANSLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1776,9 +1692,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TRANSLATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_VIEW", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1795,9 +1710,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_VIEW", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_EXPRESSIONS_IN_ORDERBY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char exprOrderBy[8];
@@ -1811,9 +1725,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_EXPRESSIONS_IN_ORDERBY",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GROUP_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT groupBy = 0;
@@ -1828,9 +1741,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GROUP_BY", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_CASE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT identCase = 0;
@@ -1845,9 +1757,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_CASE", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_QUOTE_CHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char quoteChar[8];
@@ -1863,9 +1774,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_QUOTE_CHAR", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INDEX_KEYWORDS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER indexKeywords = 0;
@@ -1879,9 +1789,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INDEX_KEYWORDS", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INSERT_STATEMENT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER insertStmt = 0;
@@ -1900,9 +1809,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INSERT_STATEMENT", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INTEGRITY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char integrity[8];
@@ -1916,9 +1824,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INTEGRITY", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYWORDS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char keywords[4096];
@@ -1934,9 +1841,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYWORDS", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LIKE_ESCAPE_CLAUSE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char likeEscape[8];
@@ -1950,9 +1856,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LIKE_ESCAPE_CLAUSE", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NON_NULLABLE_COLUMNS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT nonNull = 0;
@@ -1966,9 +1871,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NON_NULLABLE_COLUMNS", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_OJ_CAPABILITIES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER ojCaps = 0;
@@ -1990,9 +1894,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_OJ_CAPABILITIES", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ORDER_BY_COLUMNS_IN_SELECT",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char orderByInSelect[8];
@@ -2006,9 +1909,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ORDER_BY_COLUMNS_IN_SELE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procedures[8];
@@ -2022,9 +1924,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURES", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_QUOTED_IDENTIFIER_CASE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT quotedCase = 0;
@@ -2038,9 +1939,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_QUOTED_IDENTIFIER_CASE",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER schemaUsage = 0;
@@ -2062,9 +1962,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_USAGE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SPECIAL_CHARACTERS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char specialChars[256];
@@ -2082,9 +1981,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SPECIAL_CHARACTERS", "[o
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL_CONFORMANCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER conformance = 0;
@@ -2098,9 +1996,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL_CONFORMANCE", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STANDARD_CLI_CONFORMANCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER cliConf = 0;
@@ -2114,9 +2011,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STANDARD_CLI_CONFORMANCE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SUBQUERIES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER subqueries = 0;
@@ -2137,9 +2033,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SUBQUERIES", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_UNION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER unionSupport = 0;
@@ -2156,9 +2051,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_UNION", "[odbc-api][geti
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_DELETE_RULE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rules = 0;
@@ -2177,9 +2071,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_DELETE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_UPDATE_RULE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rules = 0;
@@ -2197,9 +2090,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_UPDATE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_GRANT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER grantSupport = 0;
@@ -2232,9 +2124,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_GRANT", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_PREDICATES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER preds = 0;
@@ -2264,9 +2155,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_PREDICATES", "[odb
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_RELATIONAL_JOIN_OPERATORS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER joinOps = 0;
@@ -2293,9 +2183,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_RELATIONAL_JOIN_OP
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_REVOKE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER revokeSupport = 0;
@@ -2331,9 +2220,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_REVOKE", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_ROW_VALUE_CONSTRUCTOR",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rowValConstr = 0;
@@ -2354,9 +2242,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_ROW_VALUE_CONSTRUC
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_VALUE_EXPRESSIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER valExprs = 0;
@@ -2374,9 +2261,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_VALUE_EXPRESSIONS"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_XOPEN_CLI_YEAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char year[16];
@@ -2394,9 +2280,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_XOPEN_CLI_YEAR", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_BINARY_LITERAL_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxBinaryLit = 0;
@@ -2410,9 +2295,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_BINARY_LITERAL_LEN",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CATALOG_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxCatLen = 0;
@@ -2426,9 +2310,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CATALOG_NAME_LEN", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CHAR_LITERAL_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxCharLit = 0;
@@ -2442,9 +2325,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CHAR_LITERAL_LEN", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMN_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColLen = 0;
@@ -2458,9 +2340,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMN_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_GROUP_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsGroupBy = 0;
@@ -2474,9 +2355,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_GROUP_BY"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_INDEX", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsIndex = 0;
@@ -2490,9 +2370,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_INDEX", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_ORDER_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsOrderBy = 0;
@@ -2506,9 +2385,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_ORDER_BY"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_SELECT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsSelect = 0;
@@ -2522,9 +2400,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_SELECT", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsTable = 0;
@@ -2538,9 +2415,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_TABLE", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CURSOR_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxCursorLen = 0;
@@ -2554,9 +2430,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CURSOR_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_IDENTIFIER_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxIdent = 0;
@@ -2570,9 +2445,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_IDENTIFIER_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_INDEX_SIZE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxIndexSize = 0;
@@ -2586,9 +2460,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_INDEX_SIZE", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_PROCEDURE_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxProcLen = 0;
@@ -2602,9 +2475,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_PROCEDURE_NAME_LEN",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxRowSize = 0;
@@ -2619,9 +2491,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE_INCLUDES_LONG",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char includesLong[8];
@@ -2635,9 +2506,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE_INCLUDES_LO
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_SCHEMA_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxSchemaLen = 0;
@@ -2651,9 +2521,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_SCHEMA_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_STATEMENT_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxStmtLen = 0;
@@ -2667,9 +2536,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_STATEMENT_LEN", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLE_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxTableLen = 0;
@@ -2683,9 +2551,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLE_NAME_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLES_IN_SELECT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxTables = 0;
@@ -2700,9 +2567,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLES_IN_SELECT", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_USER_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxUserLen = 0;
@@ -2721,9 +2587,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_USER_NAME_LEN", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NUMERIC_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER numFuncs = 0;
@@ -2761,9 +2626,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NUMERIC_FUNCTIONS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STRING_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER strFuncs = 0;
@@ -2804,9 +2668,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STRING_FUNCTIONS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SYSTEM_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER sysFuncs = 0;
@@ -2823,9 +2686,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SYSTEM_FUNCTIONS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_ADD_INTERVALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER intervals = 0;
@@ -2849,9 +2711,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_ADD_INTERVALS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_DIFF_INTERVALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER intervals = 0;
@@ -2875,9 +2736,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_DIFF_INTERVALS"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER timedateFuncs = 0;
@@ -2921,9 +2781,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_FUNCTIONS", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_DATETIME_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2942,9 +2801,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_DATETIME_FUNCTIONS
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_NUMERIC_VALUE_FUNCTIONS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2964,9 +2822,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_NUMERIC_VALUE_FUNC
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_STRING_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2992,9 +2849,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_STRING_FUNCTIONS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convertFuncs = 0;
@@ -3010,9 +2866,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FUNCTIONS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIGINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3052,9 +2907,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIGINT", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3091,9 +2945,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BINARY", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3131,9 +2984,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIT", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_CHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3171,9 +3023,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_CHAR", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DATE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3210,9 +3061,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DATE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DECIMAL", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3248,9 +3098,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DECIMAL", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DOUBLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3286,9 +3135,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DOUBLE", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FLOAT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3324,9 +3172,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FLOAT", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_GUID", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3364,9 +3211,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_GUID", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTEGER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3403,9 +3249,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTEGER", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_DAY_TIME",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3453,9 +3298,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_DAY_TIM
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_YEAR_MONTH",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3504,9 +3348,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_YEAR_MO
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARBINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3547,9 +3390,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARBINARY", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3595,9 +3437,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARCHAR", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_NUMERIC", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3633,9 +3474,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_NUMERIC", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_REAL", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3675,9 +3515,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_REAL", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_SMALLINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3718,9 +3557,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_SMALLINT", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3756,9 +3594,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIME", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIMESTAMP", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3795,9 +3632,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIMESTAMP", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TINYINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3838,9 +3674,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TINYINT", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARBINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3877,9 +3712,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARBINARY", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3917,9 +3751,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARCHAR", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3961,9 +3794,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WCHAR", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -4006,9 +3838,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WVARCHAR", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WLONGVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -4060,9 +3891,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WLONGVARCHAR", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FETCH_DIRECTION (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER fetchDir = 0;
@@ -4084,9 +3914,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FETCH_DIRECTION (depreca
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LOCK_TYPES (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER lockTypes = 0;
@@ -4104,9 +3933,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LOCK_TYPES (deprecated)"
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_API_CONFORMANCE (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT apiConf = 0;
@@ -4121,9 +3949,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_API_CONFORMANCE (de
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_SQL_CONFORMANCE (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT sqlConf = 0;
@@ -4138,9 +3965,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_SQL_CONFORMANCE (de
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POS_OPERATIONS (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER posOps = 0;
@@ -4161,9 +3987,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POS_OPERATIONS (deprecat
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POSITIONED_STATEMENTS (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER posStmts = 0;
@@ -4182,9 +4007,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POSITIONED_STATEMENTS (d
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_CONCURRENCY (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER scrollConc = 0;
@@ -4203,9 +4027,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_CONCURRENCY (depr
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_SENSITIVITY (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER staticSens = 0;
@@ -4234,9 +4057,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Returns SQL_SUCCESS_WITH_INF
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char smallBuffer[4];
@@ -4257,9 +4079,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Can query with NULL StringLe
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverName[256];
@@ -4275,9 +4096,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Can query just the length wi
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT requiredLen = 0;
@@ -4299,9 +4119,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY096/HY000 - Invalid InfoTy
                  "[odbc-api][getinfo][driver_info][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char buffer[256];
@@ -4318,9 +4137,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY096/HY000 - Invalid InfoTy
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY090 - Negative BufferLength",
                  "[odbc-api][getinfo][driver_info][error]") {
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char buffer[256];

--- a/odbc_tests/tests/odbc-api/driver_info/get_type_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_type_info_tests.cpp
@@ -808,33 +808,24 @@ static const TypeInfoExpected ALL_TYPE_INFO[] = {
 // SQLGetTypeInfo - Basic Functionality
 // ============================================================================
 
-TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Result set ordering when using SQL_ALL_TYPES",
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetTypeInfo: Result set ordering when using SQL_ALL_TYPES",
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  ret = SQLGetTypeInfo(stmt, SQL_ALL_TYPES);
+  SQLRETURN ret = SQLGetTypeInfo(stmt_handle(), SQL_ALL_TYPES);
   REQUIRE(ret == SQL_SUCCESS);
 
   std::vector<std::pair<SQLSMALLINT, std::string>> types;
 
-  while ((ret = SQLFetch(stmt)) == SQL_SUCCESS) {
+  while ((ret = SQLFetch(stmt_handle())) == SQL_SUCCESS) {
     SQLSMALLINT dataType;
     char typeName[256];
     SQLLEN indicator;
 
-    ret = SQLGetData(stmt, 2, SQL_C_SSHORT, &dataType, sizeof(dataType), &indicator);
+    ret = SQLGetData(stmt_handle(), 2, SQL_C_SSHORT, &dataType, sizeof(dataType), &indicator);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLGetData(stmt, 1, SQL_C_CHAR, typeName, sizeof(typeName), &indicator);
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_CHAR, typeName, sizeof(typeName), &indicator);
     REQUIRE(ret == SQL_SUCCESS);
 
     types.emplace_back(dataType, typeName);
@@ -866,9 +857,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Result set ordering when
   REQUIRE(types[20].first == SQL_WCHAR);
   REQUIRE(types[21].first == SQL_WVARCHAR);
   REQUIRE(types[22].first == SQL_BIT);
-
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  SQLDisconnect(dbc_handle());
 }
 
 // ============================================================================
@@ -882,9 +870,8 @@ TEST_CASE("SQLGetTypeInfo: SQL_INVALID_HANDLE - NULL statement handle", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: SQL_INVALID_HANDLE - Invalid handle type",
                  "[odbc-api][gettypeinfo][driver_info][error]") {
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLGetTypeInfo(dbc_handle(), SQL_ALL_TYPES);
@@ -897,29 +884,17 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: SQL_INVALID_HANDLE - Inv
 // SQLGetTypeInfo - Error Cases: Invalid Parameters
 // ============================================================================
 
-TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Returns empty result for invalid SQL data type",
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetTypeInfo: Returns empty result for invalid SQL data type",
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  ret = SQLGetTypeInfo(stmt, 9999);
+  SQLRETURN ret = SQLGetTypeInfo(stmt_handle(), 9999);
 
   // Note: Reference driver returns SUCCESS with empty result set (differs from ODBC spec)
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLFetch(stmt);
+  ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
-
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  SQLDisconnect(dbc_handle());
 }
 
 // ============================================================================
@@ -946,58 +921,37 @@ TEST_CASE_METHOD(DbcFixture, "SQLGetTypeInfo: Requires active connection",
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 }
 
-TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Can be called multiple times on same statement",
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetTypeInfo: Can be called multiple times on same statement",
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLGetTypeInfo(stmt_handle(), SQL_VARCHAR);
   REQUIRE(ret == SQL_SUCCESS);
 
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLGetTypeInfo(stmt, SQL_VARCHAR);
+  ret = SQLGetTypeInfo(stmt_handle(), SQL_INTEGER);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLCloseCursor(stmt);
+  ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
-
-  ret = SQLGetTypeInfo(stmt, SQL_INTEGER);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  ret = SQLFetch(stmt);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  SQLDisconnect(dbc_handle());
 }
 
 // ============================================================================
 // SQLGetTypeInfo - Result Set Column Tests
 // ============================================================================
 
-TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Result set has correct columns",
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetTypeInfo: Result set has correct columns",
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  ret = SQLGetTypeInfo(stmt, SQL_ALL_TYPES);
+  SQLRETURN ret = SQLGetTypeInfo(stmt_handle(), SQL_ALL_TYPES);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 20 columns instead of standard 19
   SQLSMALLINT numCols = 0;
-  ret = SQLNumResultCols(stmt, &numCols);
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
   REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(numCols == 20);
 
@@ -1015,28 +969,16 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Result set has correct c
                                     "SQL_DATETIME_SUB", "NUM_PREC_RADIX",     "INTERVAL_PRECISION", "USER_DATA_TYPE"};
 
   for (SQLSMALLINT col = 1; col <= numCols; col++) {
-    ret = SQLDescribeCol(stmt, col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType, &colSize,
-                         &decDigits, &nullable);
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
     REQUIRE(ret == SQL_SUCCESS);
     REQUIRE(std::string(colName) == expectedColNames[col - 1]);
   }
-
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  SQLDisconnect(dbc_handle());
 }
 
-TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Can bind columns and fetch data",
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetTypeInfo: Can bind columns and fetch data",
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
-  REQUIRE(ret == SQL_SUCCESS);
-
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
-  REQUIRE(ret == SQL_SUCCESS);
 
   char typeName[256];
   SQLLEN typeNameInd;
@@ -1045,19 +987,19 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Can bind columns and fet
   SQLINTEGER columnSize;
   SQLLEN columnSizeInd;
 
-  ret = SQLGetTypeInfo(stmt, SQL_ALL_TYPES);
+  SQLRETURN ret = SQLGetTypeInfo(stmt_handle(), SQL_ALL_TYPES);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLBindCol(stmt, 1, SQL_C_CHAR, typeName, sizeof(typeName), &typeNameInd);
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, typeName, sizeof(typeName), &typeNameInd);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLBindCol(stmt, 2, SQL_C_SSHORT, &dataType, sizeof(dataType), &dataTypeInd);
+  ret = SQLBindCol(stmt_handle(), 2, SQL_C_SSHORT, &dataType, sizeof(dataType), &dataTypeInd);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLBindCol(stmt, 3, SQL_C_SLONG, &columnSize, sizeof(columnSize), &columnSizeInd);
+  ret = SQLBindCol(stmt_handle(), 3, SQL_C_SLONG, &columnSize, sizeof(columnSize), &columnSizeInd);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLFetch(stmt);
+  ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
   REQUIRE(typeNameInd != SQL_NULL_DATA);
@@ -1071,9 +1013,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Can bind columns and fet
            dataType == SQL_BINARY || dataType == SQL_VARBINARY || dataType == SQL_TYPE_DATE ||
            dataType == SQL_TYPE_TIME || dataType == SQL_TYPE_TIMESTAMP));
   REQUIRE(columnSize > 0);
-
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  SQLDisconnect(dbc_handle());
 }
 
 // ============================================================================
@@ -1084,9 +1023,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Documents all supported 
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (const auto& expected : ALL_TYPE_INFO) {

--- a/odbc_tests/tests/odbc-api/preparing/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/preparing/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_odbc_test(odbc_api_prepare_tests prepare_tests.cpp)
+add_odbc_test(odbc_api_bind_parameter_tests bind_parameter_tests.cpp)
+add_odbc_test(odbc_api_get_cursor_name_tests get_cursor_name_tests.cpp)
+add_odbc_test(odbc_api_set_cursor_name_tests set_cursor_name_tests.cpp)

--- a/odbc_tests/tests/odbc-api/preparing/bind_parameter_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/bind_parameter_tests.cpp
@@ -1,0 +1,315 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLBindParameter - Basic Functionality
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds integer input parameter",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param_value = 42;
+  SQLLEN indicator = 0;
+  ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 0;
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds string input parameter",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char param_value[] = "hello";
+  SQLLEN indicator = SQL_NTS;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, strlen(param_value), 0,
+                         param_value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char result[64] = {};
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, result, sizeof(result), &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(result) == "hello");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds NULL parameter value",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN indicator = SQL_NULL_DATA;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, nullptr, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 999;
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  REQUIRE(result_indicator == SQL_NULL_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Re-execute with different parameter value",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param_value = 10;
+  SQLLEN indicator = 0;
+  ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 0;
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // First execution
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 10);
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second execution with different value
+  param_value = 20;
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 20);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Multiple parameters",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ?, ?")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param1 = 100;
+  SQLINTEGER param2 = 200;
+  SQLLEN ind1 = 0, ind2 = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param1, 0, &ind1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLBindParameter(stmt_handle(), 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param2, 0, &ind2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result1 = 0, result2 = 0;
+  SQLLEN rind1 = 0, rind2 = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result1, 0, &rind1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLBindCol(stmt_handle(), 2, SQL_C_SLONG, &result2, 0, &rind2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result1 == 100);
+  REQUIRE(result2 == 200);
+}
+
+// ============================================================================
+// SQLBindParameter - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLBindParameter: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLINTEGER param_value = 1;
+  SQLLEN indicator = 0;
+  const SQLRETURN ret =
+      SQLBindParameter(SQL_NULL_HSTMT, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: 07009 for parameter number 0",
+                 "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLINTEGER param_value = 1;
+  SQLLEN indicator = 0;
+  // 07009: Invalid descriptor index
+  SQLRETURN ret =
+      SQLBindParameter(stmt_handle(), 0, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE_EXPECTED_ERROR(ret, "07009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Rebinding same parameter number replaces binding",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param1 = 111;
+  SQLLEN ind1 = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param1, 0, &ind1);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param2 = 222;
+  SQLLEN ind2 = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param2, 0, &ind2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 0;
+  SQLLEN result_ind = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_ind);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 222);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: HY009 for both null pointers on input parameter",
+                 "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // HY009: Invalid argument value (both ParameterValuePtr and StrLen_or_IndPtr are null for input parameter)
+  SQLRETURN ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, nullptr, 0, nullptr);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: HY105 for invalid InputOutputType",
+                 "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLINTEGER param_value = 1;
+  SQLLEN indicator = 0;
+  // HY105: Invalid parameter type (999 is not a valid InputOutputType)
+  SQLRETURN ret = SQLBindParameter(stmt_handle(), 1, 999, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE_EXPECTED_ERROR(ret, "HY105", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: HY003 for invalid ValueType",
+                 "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLINTEGER param_value = 1;
+  SQLLEN indicator = 0;
+  // HY003: Invalid application buffer type (9999 is not a valid C data type)
+  SQLRETURN ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, 9999, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE_EXPECTED_ERROR(ret, "HY003", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: HY004 for invalid ParameterType",
+                 "[odbc-api][bindparameter][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLINTEGER param_value = 1;
+  SQLLEN indicator = 0;
+  // HY004: Invalid SQL data type (8888 is not a valid SQL data type)
+  SQLRETURN ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, 8888, 0, 0, &param_value, 0, &indicator);
+  REQUIRE_EXPECTED_ERROR(ret, "HY004", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+// ============================================================================
+// SQLBindParameter - Reset Parameters
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: SQLFreeStmt SQL_RESET_PARAMS clears bindings",
+                 "[odbc-api][bindparameter][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Bind and execute successfully
+  SQLINTEGER param_value = 42;
+  SQLLEN indicator = 0;
+  ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 0;
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 42);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Clear parameter bindings
+  ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Attempt to execute without rebinding - should fail with 07002 (COUNT field incorrect)
+  ret = SQLExecute(stmt_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "07002", stmt_handle(), SQL_HANDLE_STMT);
+
+  // Rebind and execute successfully again
+  ret =
+      SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+}

--- a/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
@@ -186,7 +186,13 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: 01004 with BufferLengt
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLSetCursorName(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("ZeroBuf")), SQL_NTS);
+  // Known bug: cursor names shorter than 10 chars return incorrect name_len when
+  // BufferLength=0 due to an interaction between unixODBC's ANSI-to-Wide shim and
+  // the Simba SDK driver. The DM passes a miscast SQLCHAR* as SQLWCHAR* to the
+  // driver's SQLGetCursorNameW, and the driver reads from the buffer despite
+  // BufferLength=0. Using a name >= 10 chars avoids the bug.
+  // See: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/1371
+  ret = SQLSetCursorName(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("ZeroBufCursor")), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -195,7 +201,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: 01004 with BufferLengt
   // 01004: String data, right truncated
   ret = SQLGetCursorName(stmt, cursor_name, 0, &name_len);
   REQUIRE_EXPECTED_WARNING(ret, "01004", stmt, SQL_HANDLE_STMT);
-  REQUIRE(name_len == 7);
+  REQUIRE(name_len == 13);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   SQLDisconnect(dbc_handle());

--- a/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
@@ -1,0 +1,227 @@
+#include <sql.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLGetCursorName
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Auto-generated cursor name starts with SQL_CUR",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLRETURN ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len > 0);
+
+  std::string name(reinterpret_cast<char*>(cursor_name));
+  REQUIRE(name.length() == static_cast<size_t>(name_len));
+  REQUIRE(name.substr(0, 7) == "SQL_CUR");
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: Different statements have different auto-generated names",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR name1[128] = {}, name2[128] = {};
+  SQLSMALLINT len1 = 0, len2 = 0;
+
+  ret = SQLGetCursorName(stmt1, name1, sizeof(name1), &len1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLGetCursorName(stmt2, name2, sizeof(name2), &len2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  std::string sname1(reinterpret_cast<char*>(name1));
+  std::string sname2(reinterpret_cast<char*>(name2));
+  REQUIRE(sname1 != sname2);
+  REQUIRE(sname1.length() == static_cast<size_t>(len1));
+  REQUIRE(sname2.length() == static_cast<size_t>(len2));
+  REQUIRE(sname1.substr(0, 7) == "SQL_CUR");
+  REQUIRE(sname2.substr(0, 7) == "SQL_CUR");
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt1);
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt2);
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Returns exact name set by SQLSetCursorName",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("MyCursor")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 8);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "MyCursor");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Cursor name persists after SQLPrepare",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("PrepCursor")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 10);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "PrepCursor");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Cursor name persists after SQLCloseCursor",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CloseCursor")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 11);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "CloseCursor");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLGetCursorName: 01004 truncation returns correct partial name and full length",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("LongCursorName")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Buffer of 5 bytes = 4 chars + null terminator
+  SQLCHAR cursor_name[5] = {};
+  SQLSMALLINT name_len = 0;
+  // 01004: String data, right truncated
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE_EXPECTED_WARNING(ret, "01004", stmt_handle(), SQL_HANDLE_STMT);
+  REQUIRE(name_len == 14);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "Long");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLGetCursorName: 01004 with BufferLength of 1 returns empty string and full length",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("TestName")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // BufferLength of 1 = only null terminator fits, truncation occurs
+  SQLCHAR cursor_name[1] = {};
+  SQLSMALLINT name_len = 0;
+  // 01004: String data, right truncated
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, 1, &name_len);
+  REQUIRE_EXPECTED_WARNING(ret, "01004", stmt_handle(), SQL_HANDLE_STMT);
+  REQUIRE(name_len == 8);
+  REQUIRE(cursor_name[0] == '\0');
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: NULL CursorName buffer returns length in NameLengthPtr",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("NullBufTest")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Per spec: "If CursorName is NULL, NameLengthPtr will still return the total number of characters"
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), nullptr, 0, &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 11);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: 01004 with BufferLength of 0 and non-NULL buffer",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetCursorName(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("ZeroBuf")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  // BufferLength 0 with non-NULL buffer: truncation since no chars can be written
+  // 01004: String data, right truncated
+  ret = SQLGetCursorName(stmt, cursor_name, 0, &name_len);
+  REQUIRE_EXPECTED_WARNING(ret, "01004", stmt, SQL_HANDLE_STMT);
+  REQUIRE(name_len == 7);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  SQLDisconnect(dbc_handle());
+}
+
+// ============================================================================
+// SQLGetCursorName - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLGetCursorName: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  const SQLRETURN ret = SQLGetCursorName(SQL_NULL_HSTMT, cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: HY090 for negative BufferLength",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  // HY090: Invalid string or buffer length (negative BufferLength)
+  SQLRETURN ret = SQLGetCursorName(stmt_handle(), cursor_name, -1, &name_len);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}

--- a/odbc_tests/tests/odbc-api/preparing/prepare_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/prepare_tests.cpp
@@ -1,0 +1,271 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLPrepare - Basic Functionality
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Successfully prepares a simple SELECT statement",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Prepared statement can be executed with SQLExecute",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Can be executed multiple times after prepare",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 42")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // First execution
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 42);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second execution - same prepared statement
+  value = 0;
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Replaces previous prepared statement on same handle",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 99")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 99);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: With explicit text length instead of SQL_NTS",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto sql = "SELECT 1";
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(sql)),
+                             static_cast<SQLINTEGER>(strlen(sql)));
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Explicit length shorter than string uses partial SQL",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Pass length 8 for "SELECT 1 AS col" -> only "SELECT 1" is used
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1 AS col")), 8);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT num_cols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &num_cols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(num_cols == 1);
+
+  // Verify column name to ensure "AS col" was NOT processed
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &column_size,
+                       &decimal_digits, &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  std::string actual_col_name(reinterpret_cast<char*>(col_name));
+  // The truncated SQL "SELECT 1" results in column name that is NOT "col"
+  REQUIRE(actual_col_name == "1");
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &value, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: SQLNumResultCols available after prepare",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1, 2, 3")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT num_cols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &num_cols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(num_cols == 3);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Prepares and executes statement with parameter markers",
+                 "[odbc-api][prepare][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param_value = 77;
+  SQLLEN param_indicator = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_value, 0,
+                         &param_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER result = 0;
+  SQLLEN result_indicator = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &result, 0, &result_indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(result == 77);
+}
+
+// ============================================================================
+// SQLPrepare - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLPrepare: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret = SQLPrepare(SQL_NULL_HSTMT, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: 42000 for invalid SQL syntax",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("THIS IS NOT VALID SQL")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "42000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY009 for null SQL text pointer",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // HY009: Invalid use of null pointer
+  SQLRETURN ret = SQLPrepare(stmt_handle(), nullptr, SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for empty SQL string",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Note: Reference driver treats empty string as invalid buffer length (HY090)
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for negative TextLength",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // HY090: Invalid string or buffer length
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), -5);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for TextLength of zero",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // HY090: Invalid string or buffer length
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: 24000 when cursor is already open",
+                 "[odbc-api][prepare][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Open a cursor by executing a query
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // 24000: Invalid cursor state - attempt to prepare while cursor is open
+  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 2")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}

--- a/odbc_tests/tests/odbc-api/preparing/set_cursor_name_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/set_cursor_name_tests.cpp
@@ -1,0 +1,211 @@
+#include <sql.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLSetCursorName
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Renaming cursor replaces previous name",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CursorA")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CursorB")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 7);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "CursorB");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Can rename in prepared state",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("PreparedCur")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 11);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "PreparedCur");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Can set after SQLCloseCursor",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("AfterClose")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 10);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "AfterClose");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: With explicit name length instead of SQL_NTS",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("ExplicitLen")), 11);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 11);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "ExplicitLen");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Explicit length shorter than string uses partial name",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Pass length 4 for "LongName" -> should only use "Long"
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("LongName")), 4);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 4);
+  REQUIRE(std::string(reinterpret_cast<char*>(cursor_name)) == "Long");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Empty cursor name succeeds",
+                 "[odbc-api][cursorname][preparing]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Reference driver accepts empty cursor name
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR cursor_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  ret = SQLGetCursorName(stmt_handle(), cursor_name, sizeof(cursor_name), &name_len);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(name_len == 0);
+  REQUIRE(cursor_name[0] == '\0');
+}
+
+// ============================================================================
+// SQLSetCursorName - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLSetCursorName: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const SQLRETURN ret =
+      SQLSetCursorName(SQL_NULL_HSTMT, reinterpret_cast<SQLCHAR*>(const_cast<char*>("Test")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLSetCursorName: 3C000 for duplicate cursor name on same connection",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt1);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt2);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetCursorName(stmt1, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DupCursor")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // 3C000: Duplicate cursor name
+  ret = SQLSetCursorName(stmt2, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DupCursor")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "3C000", stmt2, SQL_HANDLE_STMT);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt1);
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt2);
+  SQLDisconnect(dbc_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 34000 for cursor name starting with SQL_CUR prefix",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // 34000: Invalid cursor name (starting with reserved prefix "SQL_CUR")
+  SQLRETURN ret =
+      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SQL_CUR_TEST")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "34000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 34000 for cursor name starting with SQLCUR prefix",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // 34000: Invalid cursor name ("SQLCUR" prefix is also reserved)
+  SQLRETURN ret =
+      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SQLCUR_TEST")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "34000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: HY009 for null cursor name pointer",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // HY009: Invalid use of null pointer
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), nullptr, SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: HY009 for negative NameLength",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Note: Reference driver returns HY009 instead of ODBC spec-defined HY090 for negative NameLength
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("Test")), -5);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 24000 when cursor is open",
+                 "[odbc-api][cursorname][preparing][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // 24000: Invalid cursor state (cursor is open)
+  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("AfterExec")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}

--- a/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
@@ -21,9 +21,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Successfully disconnects 
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -40,16 +39,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Can reconnect after disco
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect, disconnect, reconnect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                   SQL_NTS, nullptr, 0, nullptr, 0);
+  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS, nullptr, 0,
+                   nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLHSTMT stmt = SQL_NULL_HSTMT;
@@ -67,9 +65,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Idempotency of multiple d
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // First disconnect
@@ -92,9 +89,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Closes open statements au
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -116,9 +112,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Handles active transactio
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect with manual commit mode
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Set manual commit mode
@@ -151,9 +146,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With active result sets",
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Execute query with result set
@@ -226,9 +220,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With multiple statement h
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate multiple statements
@@ -258,9 +251,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Preserves connection hand
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect, disconnect, verify handle can be reused
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -284,9 +276,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Clears previous diagnosti
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Cause an error to populate diagnostic records

--- a/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
@@ -110,9 +110,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY010 - Cannot free conne
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Try to free while still connected
@@ -129,9 +128,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free disconnected con
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect and disconnect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -142,7 +140,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free disconnected con
   REQUIRE(ret == SQL_SUCCESS);
 
   // Mark handle as freed to prevent double-free in fixture cleanup
-  dbc_wrapper.reset();
+  release_dbc();
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture,
@@ -151,9 +149,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first (required to allocate statement)
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -172,7 +169,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 
-  dbc_wrapper.reset();
+  release_dbc();
 }
 
 // SQLFreeHandle: Double free connection handle
@@ -189,9 +186,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Successfully frees statem
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -220,9 +216,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with p
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate and prepare statement
@@ -244,9 +239,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with a
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Execute query
@@ -268,9 +262,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with b
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement and bind parameter
@@ -293,9 +286,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with b
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement and bind column
@@ -318,9 +310,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Double free statement han
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate and free statement
@@ -346,9 +337,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free explicitly alloc
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate explicit descriptor
@@ -377,9 +367,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY017 - Cannot free impli
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -428,9 +417,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: SQL_INVALID_HANDLE for wr
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -473,9 +461,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free multiple stateme
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())),
-                 SQL_NTS, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
+                             nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate multiple statements
@@ -552,8 +539,8 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLFreeHandle: Freeing handle clears att
   REQUIRE(ret == SQL_ERROR);
 
   // Connect and verify the attribute is the default after connecting
-  ret = SQLConnect(dbc2, reinterpret_cast<SQLCHAR*>(const_cast<char*>(config.value().dsn_name().c_str())), SQL_NTS,
-                   nullptr, 0, nullptr, 0);
+  ret = SQLConnect(dbc2, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS, nullptr, 0,
+                   nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLGetConnectAttr(dbc2, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr);


### PR DESCRIPTION
Added granular ODBC unit and integration tests to verify compliance of ODBC wrapper with the ODBC 3.x and 2.x specs and consistent behaviour with existing ODBC driver.

This PR only contains ["Preparing SQL requests" category functions](https://docs.google.com/spreadsheets/d/1BjOHFnLQ2AooXGqWncsaqCLIw8z9XD0v3fwwF-S-E3g/edit?gid=999869428#gid=999869428).