### PR TITLE
sf_core: replace per-call tokio runtime creation with a shared global runtime

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -16,8 +16,7 @@ use reqwest;
 pub fn connection_init(conn_handle: Handle, _db_handle: Handle) -> Result<(), ApiError> {
     match CONN_HANDLE_MANAGER.get_obj(conn_handle) {
         Some(conn_ptr) => {
-            // Create a blocking runtime for the login process
-            let rt = tokio::runtime::Runtime::new().context(RuntimeCreationSnafu)?;
+            let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
 
             let settings_guard = conn_ptr
                 .lock()

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -238,8 +238,7 @@ pub fn statement_execute_query(stmt_handle: Handle) -> Result<ExecuteResult, Api
         .build()
     })?;
 
-    // Create a blocking runtime for the async operations
-    let rt = tokio::runtime::Runtime::new().context(RuntimeCreationSnafu)?;
+    let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
 
     let (query_parameters, http_client, retry_policy) = {
         let conn = stmt

--- a/sf_core/src/async_bridge.rs
+++ b/sf_core/src/async_bridge.rs
@@ -1,0 +1,29 @@
+use std::sync::OnceLock;
+
+static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Get the global async runtime, initializing on first access.
+///
+/// # Notes
+/// The returned runtime must not be used with `block_on` from within
+/// an existing tokio runtime context (e.g. `#[tokio::test]`), as that
+/// will panic.
+pub(crate) fn runtime() -> Result<&'static tokio::runtime::Runtime, std::io::Error> {
+    if let Some(rt) = RUNTIME.get() {
+        return Ok(rt);
+    }
+    // Build may be called more than once if multiple threads race here,
+    // but `get_or_init` guarantees only one value is stored; the extra
+    // runtime is simply dropped.
+    let rt = build()?;
+    Ok(RUNTIME.get_or_init(|| rt))
+}
+
+fn build() -> Result<tokio::runtime::Runtime, std::io::Error> {
+    // Multi-thread is required: reqwest/hyper spawn background tasks
+    // that must make progress during block_on.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("sf-core-async-bridge-worker")
+        .build()
+}

--- a/sf_core/src/chunks.rs
+++ b/sf_core/src/chunks.rs
@@ -113,8 +113,7 @@ pub fn get_chunk_data_sync(
     client: &Client,
     chunk: &ChunkDownloadData,
 ) -> Result<Vec<u8>, ChunkError> {
-    // TODO: Find a better way of managing tokio runtimes
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
     rt.block_on(async { get_chunk_data(client, chunk).await })
 }
 
@@ -224,6 +223,12 @@ fn decode_chunk_body(body: Vec<u8>, encoding: Option<&HeaderValue>) -> Result<Ve
 
 #[derive(Snafu, Debug)]
 pub enum ChunkError {
+    #[snafu(display("Failed to create runtime"))]
+    RuntimeCreation {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Invalid header name for {key}"))]
     HeaderName {
         key: String,

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -4,6 +4,7 @@ extern crate tracing_subscriber;
 pub mod apis;
 
 pub mod arrow_utils;
+mod async_bridge;
 mod auth;
 pub mod c_api;
 mod chunks;


### PR DESCRIPTION
Each call to connection_init(), statement_execute_query(), and get_chunk_data_sync() previously created and tore down a full multi-threaded tokio runtime. This was especially wasteful for chunk downloads.

Introduce sf_core/src/async_bridge.rs, which holds a single lazily-initialized tokio runtime. Initialization returns a Result to avoid panics across FFI boundaries.

The CRL background worker runtimes (crl/worker.rs, crl/cache.rs) are intentionally left unchanged -- they run infinite event loops on dedicated threads with single-threaded runtimes and serve a different purpose.