### PR TITLE
SNOW-3067168: Improve Python error handling

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverV1.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverV1.java
@@ -7025,6 +7025,91 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
      */
     net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ErrorTraceEntryOrBuilder getErrorTraceOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+     * Present when the error originated from a Snowflake server response.
+     * </pre>
+     *
+     * <code>optional int32 vendor_code = 5;</code>
+     * @return Whether the vendorCode field is set.
+     */
+    boolean hasVendorCode();
+    /**
+     * <pre>
+     * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+     * Present when the error originated from a Snowflake server response.
+     * </pre>
+     *
+     * <code>optional int32 vendor_code = 5;</code>
+     * @return The vendorCode.
+     */
+    int getVendorCode();
+
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return Whether the sqlState field is set.
+     */
+    boolean hasSqlState();
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return The sqlState.
+     */
+    java.lang.String getSqlState();
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return The bytes for sqlState.
+     */
+    com.google.protobuf.ByteString
+        getSqlStateBytes();
+
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return Whether the rootCause field is set.
+     */
+    boolean hasRootCause();
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return The rootCause.
+     */
+    java.lang.String getRootCause();
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return The bytes for rootCause.
+     */
+    com.google.protobuf.ByteString
+        getRootCauseBytes();
   }
   /**
    * <pre>
@@ -7055,6 +7140,8 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       message_ = "";
       statusCode_ = 0;
       errorTrace_ = java.util.Collections.emptyList();
+      sqlState_ = "";
+      rootCause_ = "";
     }
 
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -7195,6 +7282,159 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       return errorTrace_.get(index);
     }
 
+    public static final int VENDOR_CODE_FIELD_NUMBER = 5;
+    private int vendorCode_ = 0;
+    /**
+     * <pre>
+     * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+     * Present when the error originated from a Snowflake server response.
+     * </pre>
+     *
+     * <code>optional int32 vendor_code = 5;</code>
+     * @return Whether the vendorCode field is set.
+     */
+    @java.lang.Override
+    public boolean hasVendorCode() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+     * Present when the error originated from a Snowflake server response.
+     * </pre>
+     *
+     * <code>optional int32 vendor_code = 5;</code>
+     * @return The vendorCode.
+     */
+    @java.lang.Override
+    public int getVendorCode() {
+      return vendorCode_;
+    }
+
+    public static final int SQL_STATE_FIELD_NUMBER = 6;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object sqlState_ = "";
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return Whether the sqlState field is set.
+     */
+    @java.lang.Override
+    public boolean hasSqlState() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return The sqlState.
+     */
+    @java.lang.Override
+    public java.lang.String getSqlState() {
+      java.lang.Object ref = sqlState_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        sqlState_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ANSI SQL state code (e.g. "42000" for syntax error).
+     * Present when the server provides a sqlState in its response.
+     * </pre>
+     *
+     * <code>optional string sql_state = 6;</code>
+     * @return The bytes for sqlState.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getSqlStateBytes() {
+      java.lang.Object ref = sqlState_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        sqlState_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ROOT_CAUSE_FIELD_NUMBER = 7;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object rootCause_ = "";
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return Whether the rootCause field is set.
+     */
+    @java.lang.Override
+    public boolean hasRootCause() {
+      return ((bitField0_ & 0x00000008) != 0);
+    }
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return The rootCause.
+     */
+    @java.lang.Override
+    public java.lang.String getRootCause() {
+      java.lang.Object ref = rootCause_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        rootCause_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The deepest cause in the error chain (root cause).
+     * More informative than the top-level message for end users.
+     * </pre>
+     *
+     * <code>optional string root_cause = 7;</code>
+     * @return The bytes for rootCause.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRootCauseBytes() {
+      java.lang.Object ref = rootCause_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        rootCause_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -7221,6 +7461,15 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       for (int i = 0; i < errorTrace_.size(); i++) {
         output.writeMessage(4, errorTrace_.get(i));
       }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeInt32(5, vendorCode_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 6, sqlState_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 7, rootCause_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -7244,6 +7493,16 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       for (int i = 0; i < errorTrace_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, errorTrace_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(5, vendorCode_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(6, sqlState_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(7, rootCause_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -7270,6 +7529,21 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       }
       if (!getErrorTraceList()
           .equals(other.getErrorTraceList())) return false;
+      if (hasVendorCode() != other.hasVendorCode()) return false;
+      if (hasVendorCode()) {
+        if (getVendorCode()
+            != other.getVendorCode()) return false;
+      }
+      if (hasSqlState() != other.hasSqlState()) return false;
+      if (hasSqlState()) {
+        if (!getSqlState()
+            .equals(other.getSqlState())) return false;
+      }
+      if (hasRootCause() != other.hasRootCause()) return false;
+      if (hasRootCause()) {
+        if (!getRootCause()
+            .equals(other.getRootCause())) return false;
+      }
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -7292,6 +7566,18 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
       if (getErrorTraceCount() > 0) {
         hash = (37 * hash) + ERROR_TRACE_FIELD_NUMBER;
         hash = (53 * hash) + getErrorTraceList().hashCode();
+      }
+      if (hasVendorCode()) {
+        hash = (37 * hash) + VENDOR_CODE_FIELD_NUMBER;
+        hash = (53 * hash) + getVendorCode();
+      }
+      if (hasSqlState()) {
+        hash = (37 * hash) + SQL_STATE_FIELD_NUMBER;
+        hash = (53 * hash) + getSqlState().hashCode();
+      }
+      if (hasRootCause()) {
+        hash = (37 * hash) + ROOT_CAUSE_FIELD_NUMBER;
+        hash = (53 * hash) + getRootCause().hashCode();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -7449,6 +7735,9 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
           errorTraceBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000008);
+        vendorCode_ = 0;
+        sqlState_ = "";
+        rootCause_ = "";
         return this;
       }
 
@@ -7508,6 +7797,18 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
               : errorBuilder_.build();
           to_bitField0_ |= 0x00000001;
         }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.vendorCode_ = vendorCode_;
+          to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000020) != 0)) {
+          result.sqlState_ = sqlState_;
+          to_bitField0_ |= 0x00000004;
+        }
+        if (((from_bitField0_ & 0x00000040) != 0)) {
+          result.rootCause_ = rootCause_;
+          to_bitField0_ |= 0x00000008;
+        }
         result.bitField0_ |= to_bitField0_;
       }
 
@@ -7559,6 +7860,19 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
               errorTraceBuilder_.addAllMessages(other.errorTrace_);
             }
           }
+        }
+        if (other.hasVendorCode()) {
+          setVendorCode(other.getVendorCode());
+        }
+        if (other.hasSqlState()) {
+          sqlState_ = other.sqlState_;
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
+        if (other.hasRootCause()) {
+          rootCause_ = other.rootCause_;
+          bitField0_ |= 0x00000040;
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -7616,6 +7930,21 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
                 }
                 break;
               } // case 34
+              case 40: {
+                vendorCode_ = input.readInt32();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 50: {
+                sqlState_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 50
+              case 58: {
+                rootCause_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 58
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -8115,6 +8444,284 @@ public final class DatabaseDriverV1 extends com.google.protobuf.GeneratedFile {
           errorTrace_ = null;
         }
         return errorTraceBuilder_;
+      }
+
+      private int vendorCode_ ;
+      /**
+       * <pre>
+       * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+       * Present when the error originated from a Snowflake server response.
+       * </pre>
+       *
+       * <code>optional int32 vendor_code = 5;</code>
+       * @return Whether the vendorCode field is set.
+       */
+      @java.lang.Override
+      public boolean hasVendorCode() {
+        return ((bitField0_ & 0x00000010) != 0);
+      }
+      /**
+       * <pre>
+       * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+       * Present when the error originated from a Snowflake server response.
+       * </pre>
+       *
+       * <code>optional int32 vendor_code = 5;</code>
+       * @return The vendorCode.
+       */
+      @java.lang.Override
+      public int getVendorCode() {
+        return vendorCode_;
+      }
+      /**
+       * <pre>
+       * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+       * Present when the error originated from a Snowflake server response.
+       * </pre>
+       *
+       * <code>optional int32 vendor_code = 5;</code>
+       * @param value The vendorCode to set.
+       * @return This builder for chaining.
+       */
+      public Builder setVendorCode(int value) {
+
+        vendorCode_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+       * Present when the error originated from a Snowflake server response.
+       * </pre>
+       *
+       * <code>optional int32 vendor_code = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearVendorCode() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        vendorCode_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object sqlState_ = "";
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @return Whether the sqlState field is set.
+       */
+      public boolean hasSqlState() {
+        return ((bitField0_ & 0x00000020) != 0);
+      }
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @return The sqlState.
+       */
+      public java.lang.String getSqlState() {
+        java.lang.Object ref = sqlState_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          sqlState_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @return The bytes for sqlState.
+       */
+      public com.google.protobuf.ByteString
+          getSqlStateBytes() {
+        java.lang.Object ref = sqlState_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          sqlState_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @param value The sqlState to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSqlState(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        sqlState_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSqlState() {
+        sqlState_ = getDefaultInstance().getSqlState();
+        bitField0_ = (bitField0_ & ~0x00000020);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ANSI SQL state code (e.g. "42000" for syntax error).
+       * Present when the server provides a sqlState in its response.
+       * </pre>
+       *
+       * <code>optional string sql_state = 6;</code>
+       * @param value The bytes for sqlState to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSqlStateBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        sqlState_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object rootCause_ = "";
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @return Whether the rootCause field is set.
+       */
+      public boolean hasRootCause() {
+        return ((bitField0_ & 0x00000040) != 0);
+      }
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @return The rootCause.
+       */
+      public java.lang.String getRootCause() {
+        java.lang.Object ref = rootCause_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          rootCause_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @return The bytes for rootCause.
+       */
+      public com.google.protobuf.ByteString
+          getRootCauseBytes() {
+        java.lang.Object ref = rootCause_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          rootCause_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @param value The rootCause to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRootCause(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        rootCause_ = value;
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRootCause() {
+        rootCause_ = getDefaultInstance().getRootCause();
+        bitField0_ = (bitField0_ & ~0x00000040);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The deepest cause in the error chain (root cause).
+       * More informative than the top-level message for end users.
+       * </pre>
+       *
+       * <code>optional string root_cause = 7;</code>
+       * @param value The bytes for rootCause to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRootCauseBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        rootCause_ = value;
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:database_driver_v1.DriverException)
@@ -64326,12 +64933,15 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
       "ueH\000\0225\n\013login_error\030\006 \001(\0132\036.database_dri" +
       "ver_v1.LoginErrorH\000B\014\n\nerror_type\"N\n\017Err" +
       "orTraceEntry\022\014\n\004file\030\001 \001(\t\022\014\n\004line\030\002 \001(\r" +
-      "\022\016\n\006column\030\003 \001(\r\022\017\n\007message\030\004 \001(\t\"\301\001\n\017Dr" +
+      "\022\016\n\006column\030\003 \001(\r\022\017\n\007message\030\004 \001(\t\"\271\002\n\017Dr" +
       "iverException\022\017\n\007message\030\001 \001(\t\0223\n\013status" +
       "_code\030\002 \001(\0162\036.database_driver_v1.StatusC" +
       "ode\022.\n\005error\030\003 \001(\0132\037.database_driver_v1." +
       "DriverError\0228\n\013error_trace\030\004 \003(\0132#.datab" +
-      "ase_driver_v1.ErrorTraceEntry\"\314\001\n\016Column" +
+      "ase_driver_v1.ErrorTraceEntry\022\030\n\013vendor_" +
+      "code\030\005 \001(\005H\000\210\001\001\022\026\n\tsql_state\030\006 \001(\tH\001\210\001\001\022" +
+      "\027\n\nroot_cause\030\007 \001(\tH\002\210\001\001B\016\n\014_vendor_code" +
+      "B\014\n\n_sql_stateB\r\n\013_root_cause\"\314\001\n\016Column" +
       "Metadata\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\026\n\t" +
       "precision\030\003 \001(\003H\000\210\001\001\022\022\n\005scale\030\004 \001(\003H\001\210\001\001" +
       "\022\023\n\006length\030\005 \001(\003H\002\210\001\001\022\030\n\013byte_length\030\006 \001" +
@@ -64745,7 +65355,7 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
     internal_static_database_driver_v1_DriverException_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_DriverException_descriptor,
-        new java.lang.String[] { "Message", "StatusCode", "Error", "ErrorTrace", });
+        new java.lang.String[] { "Message", "StatusCode", "Error", "ErrorTrace", "VendorCode", "SqlState", "RootCause", });
     internal_static_database_driver_v1_ColumnMetadata_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_database_driver_v1_ColumnMetadata_fieldAccessorTable = new

--- a/proto_generator/src/generators/python_generator.rs
+++ b/proto_generator/src/generators/python_generator.rs
@@ -250,8 +250,14 @@ class ProtoError(Exception):
 
         let mut content = format!(
             r#"class {service_name}Client:
-    def __init__(self, transport):
+    def __init__(self, transport, error_handler=None):
         self._transport = transport
+        self._error_handler = error_handler
+
+    def _raise_error(self, exc):
+        if self._error_handler is not None:
+            raise self._error_handler(exc) from None
+        raise exc
 
 "#
         );
@@ -287,12 +293,11 @@ class ProtoError(Exception):
         elif code == 1:
             error = {error_type}()
             error.ParseFromString(response_bytes)
-            raise ProtoApplicationException(error)
+            self._raise_error(ProtoApplicationException(error))
         elif code == 2:
-            raise ProtoTransportException(str(response_bytes))
+            self._raise_error(ProtoTransportException(str(response_bytes)))
         else:
-            raise ProtoTransportException(f"Unknown error code: %s", code)
-
+            self._raise_error(ProtoTransportException(f"Unknown error code: %s", code))
 "#
             );
         }

--- a/proto_generator/src/generators/python_generator.rs
+++ b/proto_generator/src/generators/python_generator.rs
@@ -251,6 +251,13 @@ class ProtoError(Exception):
         let mut content = format!(
             r#"class {service_name}Client:
     def __init__(self, transport, error_handler=None):
+        """
+        Args:
+            transport: Transport layer that handles message serialization.
+            error_handler: Optional callable that converts a proto-layer exception
+                into a public exception.  Must **return** the converted exception
+                (not raise it); ``_raise_error`` takes care of raising.
+        """
         self._transport = transport
         self._error_handler = error_handler
 

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -114,6 +114,15 @@ message DriverException {
   StatusCode status_code = 2;
   DriverError error = 3;
   repeated ErrorTraceEntry error_trace = 4;
+  // Snowflake server error code (e.g. 1003 for syntax error, 904 for invalid identifier).
+  // Present when the error originated from a Snowflake server response.
+  optional int32 vendor_code = 5;
+  // ANSI SQL state code (e.g. "42000" for syntax error).
+  // Present when the server provides a sqlState in its response.
+  optional string sql_state = 6;
+  // The deepest cause in the error chain (root cause).
+  // More informative than the top-level message for end users.
+  optional string root_cause = 7;
 }
 
 // Column metadata for description

--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -8,9 +8,6 @@ behavior_differences:
   3:
     name: "BROTLI compression type option is now supported"
 
-  4:
-    name: "Error structure changed"
-
   5:
     name: "Private key password parameter name changed"
     description: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -263,7 +263,7 @@ template = "test"
 # This environment runs with old driver only. UD driver is not installed.
 test = [
     "uv pip uninstall snowflake-connector-python-ud",
-    "uv pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:3.17.2}",
+    "uv pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.2.0}",
     "pytest tests/integ tests/e2e {args}"
 ]
 compare = "python ci/reference_tests/compare_reports.py {args}"

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -3,10 +3,160 @@ from __future__ import annotations
 import ctypes
 
 from ctypes import c_char_p
+from typing import Any
 
+from ..protobuf_gen.database_driver_v1_pb2 import (
+    AuthenticationError as ProtoAuthenticationError,
+)
+from ..protobuf_gen.database_driver_v1_pb2 import (
+    InvalidParameterValue as ProtoInvalidParameterValue,
+)
+from ..protobuf_gen.database_driver_v1_pb2 import (
+    LoginError as ProtoLoginError,
+)
+from ..protobuf_gen.database_driver_v1_pb2 import (
+    MissingParameter as ProtoMissingParameter,
+)
 from ..protobuf_gen.database_driver_v1_services import DatabaseDriverClient
-from ..protobuf_gen.proto_exception import ProtoTransportException
+from ..protobuf_gen.proto_exception import (
+    ProtoApplicationException,
+    ProtoTransportException,
+)
 from .c_api import sf_core_api_call_proto, sf_core_free_buffer
+
+
+# ---------------------------------------------------------------------------
+# Proto-to-PEP-249 error conversion (kept here, at the transport boundary)
+# ---------------------------------------------------------------------------
+
+
+def _extract_error_detail(driver_exception: Any) -> str | None:
+    error = getattr(driver_exception, "error", None)
+    if error is None:
+        return None
+
+    error_type = error.WhichOneof("error_type")
+    if error_type is None:
+        return None
+
+    inner = getattr(error, error_type, None)
+    if inner is None:
+        return None
+
+    if isinstance(inner, ProtoAuthenticationError):
+        return inner.detail or None
+    if isinstance(inner, ProtoLoginError):
+        if inner.message and inner.code:
+            return f"{inner.message} (code={inner.code})"
+        return inner.message or None
+    if isinstance(inner, ProtoMissingParameter):
+        return f"Missing required parameter: {inner.parameter}" if inner.parameter else None
+    if isinstance(inner, ProtoInvalidParameterValue):
+        parts = [f"Invalid value {inner.value!r} for parameter {inner.parameter!r}"]
+        if inner.explanation:
+            parts.append(inner.explanation)
+        return ". ".join(parts)
+    # GenericError, InternalError have no extra fields
+    return None
+
+
+def _append_detail(base: str, detail: str) -> str:
+    """Append *detail* to *base* with `. ` separator, avoiding double punctuation."""
+    if not base:
+        return detail
+    base = base.rstrip(".")
+    return f"{base}. {detail}"
+
+
+def _convert_application_error(proto_exc: ProtoApplicationException) -> Any:
+    from snowflake.connector.errors import (
+        _STATUS_CODE_LABELS,
+        _STATUS_TO_ERRNO,
+        _STATUS_TO_EXCEPTION,
+        DatabaseError,
+    )
+
+    driver_exc = getattr(proto_exc, "api_error_pb", None)
+    if driver_exc is None:
+        return DatabaseError(str(proto_exc))
+
+    status_code = getattr(driver_exc, "status_code", 0)
+    message = getattr(driver_exc, "message", "") or ""
+
+    # The root_cause field carries the deepest error in the chain from the
+    # Rust core, which is typically the most informative for end users.
+    root_cause = _get_optional_str(driver_exc, "root_cause")
+    if root_cause and root_cause not in message:
+        message = _append_detail(message, root_cause)
+
+    detail = _extract_error_detail(driver_exc)
+    if detail and detail not in message:
+        message = _append_detail(message, detail)
+
+    if not message:
+        message = _STATUS_CODE_LABELS.get(status_code, "Unknown error")
+
+    exc_class = _STATUS_TO_EXCEPTION.get(status_code, DatabaseError)
+
+    # Prefer the Snowflake server vendor_code when the core driver provides it
+    # (e.g. 1003 for syntax error, 904 for invalid identifier).
+    # Fall back to the old-driver-compatible errno mapping, then to the raw
+    # proto status code.
+    vendor_code = _get_optional_int(driver_exc, "vendor_code")
+    errno = vendor_code if vendor_code is not None else _STATUS_TO_ERRNO.get(status_code, status_code)
+
+    # Prefer the server-provided sql_state; fall back to a type-derived value.
+    sqlstate = _get_optional_str(driver_exc, "sql_state") or _derive_sqlstate(driver_exc)
+
+    return exc_class(message, errno=errno, sqlstate=sqlstate)
+
+
+def _get_optional_int(msg: Any, field: str) -> int | None:
+    """Read an optional int32 proto field, returning None if not set."""
+    try:
+        if msg.HasField(field):
+            return int(getattr(msg, field))
+    except (ValueError, TypeError, AttributeError):
+        # Field missing from the proto schema or cannot be coerced to int; treat as unset.
+        pass
+    return None
+
+
+def _get_optional_str(msg: Any, field: str) -> str | None:
+    """Read an optional string proto field, returning None if not set."""
+    try:
+        if msg.HasField(field):
+            return str(getattr(msg, field)) or None
+    except (ValueError, TypeError, AttributeError):
+        # Field missing from the proto schema or cannot be coerced to string; treat as unset.
+        pass
+    return None
+
+
+def _derive_sqlstate(driver_exception: Any) -> str | None:
+    """Derive sqlstate from the error type when the proto does not carry it."""
+    error = getattr(driver_exception, "error", None)
+    if error is None:
+        return None
+    error_type = error.WhichOneof("error_type")
+    if error_type in ("login_error", "auth_error"):
+        return "08001"  # SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
+    return None
+
+
+def _convert_proto_error(proto_exc: Exception) -> Any:
+    from snowflake.connector.errors import DatabaseError, OperationalError
+
+    if isinstance(proto_exc, ProtoApplicationException):
+        return _convert_application_error(proto_exc)
+    if isinstance(proto_exc, ProtoTransportException):
+        return OperationalError(f"Driver communication error: {proto_exc}")
+    return DatabaseError(str(proto_exc))
+
+
+# ---------------------------------------------------------------------------
+# Transport + singleton
+# ---------------------------------------------------------------------------
 
 
 class ProtoTransport:
@@ -39,5 +189,5 @@ _DATABASE_DRIVER_CLIENT: DatabaseDriverClient | None = None
 def database_driver_client() -> DatabaseDriverClient:
     global _DATABASE_DRIVER_CLIENT
     if _DATABASE_DRIVER_CLIENT is None:
-        _DATABASE_DRIVER_CLIENT = DatabaseDriverClient(ProtoTransport())
+        _DATABASE_DRIVER_CLIENT = DatabaseDriverClient(ProtoTransport(), error_handler=_convert_proto_error)
     return _DATABASE_DRIVER_CLIENT

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import ctypes
 
 from ctypes import c_char_p
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from snowflake.connector.errors import Error
 
 from ..protobuf_gen.database_driver_v1_pb2 import (
     AuthenticationError as ProtoAuthenticationError,
@@ -68,13 +72,29 @@ def _append_detail(base: str, detail: str) -> str:
     return f"{base}. {detail}"
 
 
-def _convert_application_error(proto_exc: ProtoApplicationException) -> Any:
-    from snowflake.connector.errors import (
-        _STATUS_CODE_LABELS,
-        _STATUS_TO_ERRNO,
-        _STATUS_TO_EXCEPTION,
-        DatabaseError,
+def _proto_to_public_error(proto_exc: Exception) -> Error:
+    """Convert a proto-layer exception into a PEP 249 ``Error`` subclass.
+
+    This function **returns** the converted exception; it does not raise it.
+    The caller (``_raise_error`` in the generated client) is responsible for
+    raising the returned value.
+    """
+    from snowflake.connector.errors import DatabaseError, OperationalError
+
+    if isinstance(proto_exc, ProtoApplicationException):
+        return _convert_application_error(proto_exc)
+    if isinstance(proto_exc, ProtoTransportException):
+        return OperationalError(f"Driver communication error: {proto_exc}")
+    return DatabaseError(str(proto_exc))
+
+
+def _convert_application_error(proto_exc: ProtoApplicationException) -> Error:
+    from snowflake.connector._internal.status_codes import (
+        STATUS_CODE_LABELS,
+        STATUS_TO_ERRNO,
+        STATUS_TO_EXCEPTION,
     )
+    from snowflake.connector.errors import DatabaseError
 
     driver_exc = getattr(proto_exc, "api_error_pb", None)
     if driver_exc is None:
@@ -94,16 +114,16 @@ def _convert_application_error(proto_exc: ProtoApplicationException) -> Any:
         message = _append_detail(message, detail)
 
     if not message:
-        message = _STATUS_CODE_LABELS.get(status_code, "Unknown error")
+        message = STATUS_CODE_LABELS.get(status_code, "Unknown error")
 
-    exc_class = _STATUS_TO_EXCEPTION.get(status_code, DatabaseError)
+    exc_class = STATUS_TO_EXCEPTION.get(status_code, DatabaseError)
 
     # Prefer the Snowflake server vendor_code when the core driver provides it
     # (e.g. 1003 for syntax error, 904 for invalid identifier).
     # Fall back to the old-driver-compatible errno mapping, then to the raw
     # proto status code.
     vendor_code = _get_optional_int(driver_exc, "vendor_code")
-    errno = vendor_code if vendor_code is not None else _STATUS_TO_ERRNO.get(status_code, status_code)
+    errno = vendor_code if vendor_code is not None else STATUS_TO_ERRNO.get(status_code, status_code)
 
     # Prefer the server-provided sql_state; fall back to a type-derived value.
     sqlstate = _get_optional_str(driver_exc, "sql_state") or _derive_sqlstate(driver_exc)
@@ -134,7 +154,12 @@ def _get_optional_str(msg: Any, field: str) -> str | None:
 
 
 def _derive_sqlstate(driver_exception: Any) -> str | None:
-    """Derive sqlstate from the error type when the proto does not carry it."""
+    """Derive sqlstate from the error type when the proto does not carry it.
+
+    Only login/auth errors have an obvious ANSI SQL state mapping today.
+    Other error types (missing_parameter, invalid_parameter_value, etc.)
+    will return ``None``; extend this function as mappings become clear.
+    """
     error = getattr(driver_exception, "error", None)
     if error is None:
         return None
@@ -142,16 +167,6 @@ def _derive_sqlstate(driver_exception: Any) -> str | None:
     if error_type in ("login_error", "auth_error"):
         return "08001"  # SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
     return None
-
-
-def _convert_proto_error(proto_exc: Exception) -> Any:
-    from snowflake.connector.errors import DatabaseError, OperationalError
-
-    if isinstance(proto_exc, ProtoApplicationException):
-        return _convert_application_error(proto_exc)
-    if isinstance(proto_exc, ProtoTransportException):
-        return OperationalError(f"Driver communication error: {proto_exc}")
-    return DatabaseError(str(proto_exc))
 
 
 # ---------------------------------------------------------------------------
@@ -189,5 +204,5 @@ _DATABASE_DRIVER_CLIENT: DatabaseDriverClient | None = None
 def database_driver_client() -> DatabaseDriverClient:
     global _DATABASE_DRIVER_CLIENT
     if _DATABASE_DRIVER_CLIENT is None:
-        _DATABASE_DRIVER_CLIENT = DatabaseDriverClient(ProtoTransport(), error_handler=_convert_proto_error)
+        _DATABASE_DRIVER_CLIENT = DatabaseDriverClient(ProtoTransport(), error_handler=_proto_to_public_error)
     return _DATABASE_DRIVER_CLIENT

--- a/python/src/snowflake/connector/_internal/errorcode.py
+++ b/python/src/snowflake/connector/_internal/errorcode.py
@@ -1,0 +1,22 @@
+"""
+Snowflake error codes.
+
+These codes are intentionally aligned with the reference snowflake-connector-python
+so that users can rely on stable, documented error numbers across driver implementations.
+"""
+
+from __future__ import annotations
+
+
+# network
+ER_FAILED_TO_CONNECT_TO_DB = 250001
+ER_CONNECTION_IS_CLOSED = 250002
+
+# connection
+ER_NO_ACCOUNT_NAME = 251001
+ER_NO_USER = 251005
+ER_NO_PASSWORD = 251006
+ER_INVALID_VALUE = 251007
+
+# cursor
+ER_CURSOR_IS_CLOSED = 252006

--- a/python/src/snowflake/connector/_internal/status_codes.py
+++ b/python/src/snowflake/connector/_internal/status_codes.py
@@ -1,0 +1,119 @@
+"""
+Internal proto StatusCode enum values (from database_driver_v1.proto).
+
+These are implementation details of the proto-to-PEP-249 error conversion
+layer and are NOT part of the public API.  External code should not depend
+on them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from snowflake.connector._internal.errorcode import ER_FAILED_TO_CONNECT_TO_DB, ER_INVALID_VALUE
+
+
+if TYPE_CHECKING:
+    from snowflake.connector.errors import Error
+
+
+STATUS_CODE_GENERIC_ERROR = 1
+STATUS_CODE_AUTHENTICATION_ERROR = 2
+STATUS_CODE_INVALID_ARGUMENT = 3
+STATUS_CODE_TIMEOUT = 4
+STATUS_CODE_NOT_FOUND = 5
+STATUS_CODE_ALREADY_EXISTS = 6
+STATUS_CODE_NOT_IMPLEMENTED = 7
+STATUS_CODE_UNAUTHORIZED = 8
+STATUS_CODE_CANCELLED = 9
+STATUS_CODE_INVALID_STATE = 10
+STATUS_CODE_RESOURCE_EXHAUSTED = 11
+STATUS_CODE_ADBC_INTERNAL = 12
+STATUS_CODE_IO = 13
+STATUS_CODE_INTERNAL_ERROR = 14
+STATUS_CODE_MISSING_PARAMETER = 15
+STATUS_CODE_INVALID_PARAMETER_VALUE = 16
+STATUS_CODE_LOGIN_ERROR = 17
+STATUS_CODE_INVALID_DATA = 18
+
+# Human-readable label for each status code (used as fallback message)
+STATUS_CODE_LABELS: dict[int, str] = {
+    STATUS_CODE_GENERIC_ERROR: "Generic error",
+    STATUS_CODE_AUTHENTICATION_ERROR: "Authentication error",
+    STATUS_CODE_INVALID_ARGUMENT: "Invalid argument",
+    STATUS_CODE_TIMEOUT: "Timeout",
+    STATUS_CODE_NOT_FOUND: "Not found",
+    STATUS_CODE_ALREADY_EXISTS: "Already exists",
+    STATUS_CODE_NOT_IMPLEMENTED: "Not implemented",
+    STATUS_CODE_UNAUTHORIZED: "Unauthorized",
+    STATUS_CODE_CANCELLED: "Cancelled",
+    STATUS_CODE_INVALID_STATE: "Invalid state",
+    STATUS_CODE_RESOURCE_EXHAUSTED: "Resource exhausted",
+    STATUS_CODE_ADBC_INTERNAL: "ADBC internal error",
+    STATUS_CODE_IO: "I/O error",
+    STATUS_CODE_INTERNAL_ERROR: "Internal error",
+    STATUS_CODE_MISSING_PARAMETER: "Missing parameter",
+    STATUS_CODE_INVALID_PARAMETER_VALUE: "Invalid parameter value",
+    STATUS_CODE_LOGIN_ERROR: "Login error",
+    STATUS_CODE_INVALID_DATA: "Invalid data",
+}
+
+
+def _build_status_to_exception() -> dict[int, type[Error]]:
+    """Build the status-code-to-exception-class mapping.
+
+    Constructed via a function to avoid a circular import: this module is
+    imported by ``errors.py`` (for errorcode constants), and the mapping
+    needs the exception classes defined there.
+    """
+    from snowflake.connector.errors import (
+        DatabaseError,
+        DataError,
+        InternalError,
+        NotSupportedError,
+        OperationalError,
+        ProgrammingError,
+    )
+
+    return {
+        STATUS_CODE_GENERIC_ERROR: DatabaseError,
+        STATUS_CODE_AUTHENTICATION_ERROR: DatabaseError,
+        STATUS_CODE_INVALID_ARGUMENT: ProgrammingError,
+        STATUS_CODE_TIMEOUT: OperationalError,
+        STATUS_CODE_NOT_FOUND: ProgrammingError,
+        STATUS_CODE_ALREADY_EXISTS: ProgrammingError,
+        STATUS_CODE_NOT_IMPLEMENTED: NotSupportedError,
+        STATUS_CODE_UNAUTHORIZED: OperationalError,
+        STATUS_CODE_CANCELLED: OperationalError,
+        STATUS_CODE_INVALID_STATE: InternalError,
+        STATUS_CODE_RESOURCE_EXHAUSTED: OperationalError,
+        STATUS_CODE_ADBC_INTERNAL: InternalError,
+        STATUS_CODE_IO: OperationalError,
+        # INTERNAL_ERROR maps to ProgrammingError (not InternalError) because
+        # the Rust core uses this status code for Snowflake query failures
+        # (syntax errors, invalid identifiers, etc.) which are SQL programming
+        # mistakes.  The server's vendor_code is surfaced separately via the
+        # proto so the errno seen by users is the server code, not this value.
+        STATUS_CODE_INTERNAL_ERROR: ProgrammingError,
+        STATUS_CODE_MISSING_PARAMETER: ProgrammingError,
+        STATUS_CODE_INVALID_PARAMETER_VALUE: ProgrammingError,
+        STATUS_CODE_LOGIN_ERROR: DatabaseError,
+        STATUS_CODE_INVALID_DATA: DataError,
+    }
+
+
+def _build_status_to_errno() -> dict[int, int]:
+    """Build the status-code-to-errno mapping.
+
+    For query errors (INTERNAL_ERROR) the Snowflake server code is exposed via
+    the proto ``vendor_code`` field and takes precedence in the conversion layer.
+    """
+    return {
+        STATUS_CODE_AUTHENTICATION_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
+        STATUS_CODE_LOGIN_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
+        STATUS_CODE_INVALID_PARAMETER_VALUE: ER_INVALID_VALUE,
+    }
+
+
+STATUS_TO_EXCEPTION: dict[int, type[Error]] = _build_status_to_exception()
+STATUS_TO_ERRNO: dict[int, int] = _build_status_to_errno()

--- a/python/src/snowflake/connector/config_manager.py
+++ b/python/src/snowflake/connector/config_manager.py
@@ -33,6 +33,9 @@ from snowflake.connector.errors import (
     ConfigSourceError,
     MissingConfigOptionError,
 )
+from snowflake.connector.errors import (
+    Error as DriverError,
+)
 
 
 _T = TypeVar("_T")
@@ -75,15 +78,26 @@ def _populate_tomlkit(target: Any, source: dict[str, Any]) -> None:
             target.add(key, value)
 
 
+def _extract_error_msg(exc: Exception) -> str:
+    """Extract the raw error message from a proto or PEP 249 exception."""
+    if hasattr(exc, "message"):
+        return str(exc.message)
+    if hasattr(exc, "raw_msg"):
+        return str(exc.raw_msg)
+    return str(exc)
+
+
 def _translate_core_error(
-    exc: ProtoApplicationException,
+    exc: Exception,
     file_path: Path | None = None,
 ) -> ConfigManagerError:
     """Translate a Rust core DriverException into the appropriate Python error.
 
     Maps sf_core error messages to backward-compatible Python exception types.
+    Accepts both raw ``ProtoApplicationException`` and PEP 249 ``Error``
+    subclasses (produced by the error_handler in the generated client).
     """
-    msg = str(exc.message) if hasattr(exc, "message") else str(exc)
+    msg = _extract_error_msg(exc)
 
     if "parse TOML" in msg or "Failed to parse" in msg or "Failed to read config file" in msg:
         display_path = str(file_path) if file_path else "unknown"
@@ -247,8 +261,8 @@ class ConfigManager:
         try:
             client = database_driver_client()
             response = client.config_load_all_sections(request)
-        except ProtoApplicationException as e:
-            msg = str(e.message) if hasattr(e, "message") else str(e)
+        except (ProtoApplicationException, DriverError) as e:
+            msg = _extract_error_msg(e)
             if "permission" in msg.lower() or "Permission denied" in msg:
                 LOGGER.debug(
                     "Config file '%s' could not be read due to no permission on its parent directory",

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -10,6 +10,7 @@ from collections.abc import Generator, Iterable
 from io import StringIO
 from typing import Any, Callable, Union
 
+from snowflake.connector._internal.errorcode import ER_CONNECTION_IS_CLOSED
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
     ConnectionGetInfoRequest,
     ConnectionGetInfoResponse,
@@ -160,9 +161,12 @@ class Connection:
         Returns:
             SnowflakeCursorBase: A new cursor object
         """
-        if self._closed:
-            raise InterfaceError("Connection is closed")
+        self._check_not_closed()
         return cursor_class(self)
+
+    def _check_not_closed(self) -> None:
+        if self._closed:
+            raise InterfaceError("Connection is closed.", errno=ER_CONNECTION_IS_CLOSED)
 
     # Context manager support
     def __enter__(self) -> Connection:

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -17,6 +17,8 @@ import ctypes
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Union, cast
 
+from snowflake.connector._internal.errorcode import ER_CONNECTION_IS_CLOSED, ER_CURSOR_IS_CLOSED
+
 from ._internal.arrow_context import ArrowConverterContext
 from ._internal.arrow_stream_iterator import ArrowStreamIterator
 from ._internal.binding_converters import (
@@ -240,6 +242,14 @@ class SnowflakeCursorBase(abc.ABC):
         """Close the cursor now (rather than whenever __del__ is called)."""
         self._closed = True
 
+    def _check_not_closed(self) -> None:
+        if self._closed:
+            raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+
+    def _check_connection_open(self) -> None:
+        if self.connection.is_closed():
+            raise InterfaceError("Connection is closed.", errno=ER_CONNECTION_IS_CLOSED)
+
     def _build_query_bindings(self, parameters: Sequence[Any]) -> QueryBindings | None:
         """Serialize parameters and build a QueryBindings protobuf message.
 
@@ -334,8 +344,9 @@ class SnowflakeCursorBase(abc.ABC):
                 For pyformat paramstyle: sequence (%s) or dict (%(name)s)
                 For format paramstyle: sequence (%s)
         """
+        self._check_not_closed()
+        self._check_connection_open()
         query, bindings = self._prepare_query(operation, parameters)
-
         stmt_handle = self._connection.db_api.statement_new(
             StatementNewRequest(conn_handle=self._connection.conn_handle)
         ).stmt_handle
@@ -490,6 +501,7 @@ class SnowflakeCursorBase(abc.ABC):
         Return a dict if ``_use_dict_result`` is True, otherwise a tuple.
         Concrete subclasses expose this through a type-safe ``fetchone``.
         """
+        self._check_not_closed()
         if self._iterator is None:
             self._iterator = self._get_iterator()
         try:
@@ -540,6 +552,7 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             sequence: List of all remaining rows
         """
+        self._check_not_closed()
         if self._iterator is None:
             self._iterator = self._get_iterator()
         return list(self._iterator)

--- a/python/src/snowflake/connector/errors.py
+++ b/python/src/snowflake/connector/errors.py
@@ -4,6 +4,10 @@ PEP 249 Database API 2.0 Exception Classes
 This module defines the exception hierarchy as specified in PEP 249.
 """
 
+from __future__ import annotations
+
+from snowflake.connector._internal.errorcode import ER_FAILED_TO_CONNECT_TO_DB, ER_INVALID_VALUE
+
 
 class Warning(Warning):  # type: ignore[misc]
     """Exception raised for important warnings like data truncations while inserting, etc."""
@@ -14,7 +18,26 @@ class Warning(Warning):  # type: ignore[misc]
 class Error(Exception):
     """Exception that is the base class of all other error exceptions."""
 
-    pass
+    def __init__(
+        self,
+        msg: str = "",
+        errno: int = -1,
+        sqlstate: str | None = None,
+        sfqid: str | None = None,
+        query: str | None = None,
+    ) -> None:
+        self.errno = errno
+        self.sqlstate = sqlstate
+        self.sfqid = sfqid
+        self.query = query
+        self.raw_msg = msg
+        self.msg = self._format_message(msg)
+        super().__init__(self.msg)
+
+    def _format_message(self, msg: str) -> str:
+        code_str = f"{self.errno:06d}" if isinstance(self.errno, int) and self.errno >= 0 else "------"
+        sqlstate_str = f" ({self.sqlstate})" if self.sqlstate else ""
+        return f"{code_str}{sqlstate_str}: {msg}" if msg else ""
 
 
 class InterfaceError(Error):
@@ -117,3 +140,80 @@ class ForbiddenError(Error):
 
 class BadGatewayError(Error):
     """Exception for 502 HTTP error for retry."""
+
+
+# ---------------------------------------------------------------------------
+# Proto status-code → PEP 249 exception class mapping
+# ---------------------------------------------------------------------------
+
+# Internal proto StatusCode enum values (from database_driver_v1.proto)
+_STATUS_CODE_GENERIC_ERROR = 1
+_STATUS_CODE_AUTHENTICATION_ERROR = 2
+_STATUS_CODE_INVALID_ARGUMENT = 3
+_STATUS_CODE_TIMEOUT = 4
+_STATUS_CODE_NOT_FOUND = 5
+_STATUS_CODE_ALREADY_EXISTS = 6
+_STATUS_CODE_NOT_IMPLEMENTED = 7
+_STATUS_CODE_UNAUTHORIZED = 8
+_STATUS_CODE_CANCELLED = 9
+_STATUS_CODE_INVALID_STATE = 10
+_STATUS_CODE_RESOURCE_EXHAUSTED = 11
+_STATUS_CODE_ADBC_INTERNAL = 12
+_STATUS_CODE_IO = 13
+_STATUS_CODE_INTERNAL_ERROR = 14
+_STATUS_CODE_MISSING_PARAMETER = 15
+_STATUS_CODE_INVALID_PARAMETER_VALUE = 16
+_STATUS_CODE_LOGIN_ERROR = 17
+_STATUS_CODE_INVALID_DATA = 18
+
+_STATUS_TO_EXCEPTION: dict[int, type[Error]] = {
+    _STATUS_CODE_GENERIC_ERROR: DatabaseError,
+    _STATUS_CODE_AUTHENTICATION_ERROR: DatabaseError,
+    _STATUS_CODE_INVALID_ARGUMENT: ProgrammingError,
+    _STATUS_CODE_TIMEOUT: OperationalError,
+    _STATUS_CODE_NOT_FOUND: ProgrammingError,
+    _STATUS_CODE_ALREADY_EXISTS: ProgrammingError,
+    _STATUS_CODE_NOT_IMPLEMENTED: NotSupportedError,
+    _STATUS_CODE_UNAUTHORIZED: OperationalError,
+    _STATUS_CODE_CANCELLED: OperationalError,
+    _STATUS_CODE_INVALID_STATE: InternalError,
+    _STATUS_CODE_RESOURCE_EXHAUSTED: OperationalError,
+    _STATUS_CODE_ADBC_INTERNAL: InternalError,
+    _STATUS_CODE_IO: OperationalError,
+    _STATUS_CODE_INTERNAL_ERROR: ProgrammingError,
+    _STATUS_CODE_MISSING_PARAMETER: ProgrammingError,
+    _STATUS_CODE_INVALID_PARAMETER_VALUE: ProgrammingError,
+    _STATUS_CODE_LOGIN_ERROR: DatabaseError,
+    _STATUS_CODE_INVALID_DATA: DataError,
+}
+
+# Human-readable label for each status code (used as fallback message)
+_STATUS_CODE_LABELS: dict[int, str] = {
+    _STATUS_CODE_GENERIC_ERROR: "Generic error",
+    _STATUS_CODE_AUTHENTICATION_ERROR: "Authentication error",
+    _STATUS_CODE_INVALID_ARGUMENT: "Invalid argument",
+    _STATUS_CODE_TIMEOUT: "Timeout",
+    _STATUS_CODE_NOT_FOUND: "Not found",
+    _STATUS_CODE_ALREADY_EXISTS: "Already exists",
+    _STATUS_CODE_NOT_IMPLEMENTED: "Not implemented",
+    _STATUS_CODE_UNAUTHORIZED: "Unauthorized",
+    _STATUS_CODE_CANCELLED: "Cancelled",
+    _STATUS_CODE_INVALID_STATE: "Invalid state",
+    _STATUS_CODE_RESOURCE_EXHAUSTED: "Resource exhausted",
+    _STATUS_CODE_ADBC_INTERNAL: "ADBC internal error",
+    _STATUS_CODE_IO: "I/O error",
+    _STATUS_CODE_INTERNAL_ERROR: "Internal error",
+    _STATUS_CODE_MISSING_PARAMETER: "Missing parameter",
+    _STATUS_CODE_INVALID_PARAMETER_VALUE: "Invalid parameter value",
+    _STATUS_CODE_LOGIN_ERROR: "Login error",
+    _STATUS_CODE_INVALID_DATA: "Invalid data",
+}
+
+# Map proto StatusCode → errno aligned with the reference snowflake-connector-python.
+# For query errors (INTERNAL_ERROR) the Snowflake server code is exposed via the
+# proto vendor_code field and takes precedence in the conversion layer.
+_STATUS_TO_ERRNO: dict[int, int] = {
+    _STATUS_CODE_AUTHENTICATION_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
+    _STATUS_CODE_LOGIN_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
+    _STATUS_CODE_INVALID_PARAMETER_VALUE: ER_INVALID_VALUE,
+}

--- a/python/src/snowflake/connector/errors.py
+++ b/python/src/snowflake/connector/errors.py
@@ -6,8 +6,6 @@ This module defines the exception hierarchy as specified in PEP 249.
 
 from __future__ import annotations
 
-from snowflake.connector._internal.errorcode import ER_FAILED_TO_CONNECT_TO_DB, ER_INVALID_VALUE
-
 
 class Warning(Warning):  # type: ignore[misc]
     """Exception raised for important warnings like data truncations while inserting, etc."""
@@ -140,80 +138,3 @@ class ForbiddenError(Error):
 
 class BadGatewayError(Error):
     """Exception for 502 HTTP error for retry."""
-
-
-# ---------------------------------------------------------------------------
-# Proto status-code → PEP 249 exception class mapping
-# ---------------------------------------------------------------------------
-
-# Internal proto StatusCode enum values (from database_driver_v1.proto)
-_STATUS_CODE_GENERIC_ERROR = 1
-_STATUS_CODE_AUTHENTICATION_ERROR = 2
-_STATUS_CODE_INVALID_ARGUMENT = 3
-_STATUS_CODE_TIMEOUT = 4
-_STATUS_CODE_NOT_FOUND = 5
-_STATUS_CODE_ALREADY_EXISTS = 6
-_STATUS_CODE_NOT_IMPLEMENTED = 7
-_STATUS_CODE_UNAUTHORIZED = 8
-_STATUS_CODE_CANCELLED = 9
-_STATUS_CODE_INVALID_STATE = 10
-_STATUS_CODE_RESOURCE_EXHAUSTED = 11
-_STATUS_CODE_ADBC_INTERNAL = 12
-_STATUS_CODE_IO = 13
-_STATUS_CODE_INTERNAL_ERROR = 14
-_STATUS_CODE_MISSING_PARAMETER = 15
-_STATUS_CODE_INVALID_PARAMETER_VALUE = 16
-_STATUS_CODE_LOGIN_ERROR = 17
-_STATUS_CODE_INVALID_DATA = 18
-
-_STATUS_TO_EXCEPTION: dict[int, type[Error]] = {
-    _STATUS_CODE_GENERIC_ERROR: DatabaseError,
-    _STATUS_CODE_AUTHENTICATION_ERROR: DatabaseError,
-    _STATUS_CODE_INVALID_ARGUMENT: ProgrammingError,
-    _STATUS_CODE_TIMEOUT: OperationalError,
-    _STATUS_CODE_NOT_FOUND: ProgrammingError,
-    _STATUS_CODE_ALREADY_EXISTS: ProgrammingError,
-    _STATUS_CODE_NOT_IMPLEMENTED: NotSupportedError,
-    _STATUS_CODE_UNAUTHORIZED: OperationalError,
-    _STATUS_CODE_CANCELLED: OperationalError,
-    _STATUS_CODE_INVALID_STATE: InternalError,
-    _STATUS_CODE_RESOURCE_EXHAUSTED: OperationalError,
-    _STATUS_CODE_ADBC_INTERNAL: InternalError,
-    _STATUS_CODE_IO: OperationalError,
-    _STATUS_CODE_INTERNAL_ERROR: ProgrammingError,
-    _STATUS_CODE_MISSING_PARAMETER: ProgrammingError,
-    _STATUS_CODE_INVALID_PARAMETER_VALUE: ProgrammingError,
-    _STATUS_CODE_LOGIN_ERROR: DatabaseError,
-    _STATUS_CODE_INVALID_DATA: DataError,
-}
-
-# Human-readable label for each status code (used as fallback message)
-_STATUS_CODE_LABELS: dict[int, str] = {
-    _STATUS_CODE_GENERIC_ERROR: "Generic error",
-    _STATUS_CODE_AUTHENTICATION_ERROR: "Authentication error",
-    _STATUS_CODE_INVALID_ARGUMENT: "Invalid argument",
-    _STATUS_CODE_TIMEOUT: "Timeout",
-    _STATUS_CODE_NOT_FOUND: "Not found",
-    _STATUS_CODE_ALREADY_EXISTS: "Already exists",
-    _STATUS_CODE_NOT_IMPLEMENTED: "Not implemented",
-    _STATUS_CODE_UNAUTHORIZED: "Unauthorized",
-    _STATUS_CODE_CANCELLED: "Cancelled",
-    _STATUS_CODE_INVALID_STATE: "Invalid state",
-    _STATUS_CODE_RESOURCE_EXHAUSTED: "Resource exhausted",
-    _STATUS_CODE_ADBC_INTERNAL: "ADBC internal error",
-    _STATUS_CODE_IO: "I/O error",
-    _STATUS_CODE_INTERNAL_ERROR: "Internal error",
-    _STATUS_CODE_MISSING_PARAMETER: "Missing parameter",
-    _STATUS_CODE_INVALID_PARAMETER_VALUE: "Invalid parameter value",
-    _STATUS_CODE_LOGIN_ERROR: "Login error",
-    _STATUS_CODE_INVALID_DATA: "Invalid data",
-}
-
-# Map proto StatusCode → errno aligned with the reference snowflake-connector-python.
-# For query errors (INTERNAL_ERROR) the Snowflake server code is exposed via the
-# proto vendor_code field and takes precedence in the conversion layer.
-_STATUS_TO_ERRNO: dict[int, int] = {
-    _STATUS_CODE_AUTHENTICATION_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
-    _STATUS_CODE_LOGIN_ERROR: ER_FAILED_TO_CONNECT_TO_DB,
-    _STATUS_CODE_INVALID_PARAMETER_VALUE: ER_INVALID_VALUE,
-}

--- a/python/tests/e2e/authentication/auth_helpers.py
+++ b/python/tests/e2e/authentication/auth_helpers.py
@@ -1,4 +1,4 @@
-from ...compatibility import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
+from snowflake.connector.errors import DatabaseError
 
 
 def verify_simple_query_execution(connection):
@@ -16,23 +16,9 @@ def verify_login_error(exception):
     assert exception is not None
     assert str(exception).strip() != "", "Login error message should not be empty"
 
-    if NEW_DRIVER_ONLY("BD#4"):
-        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import DriverException
-
-        assert isinstance(exception.value.api_error_pb, DriverException), (
-            f"Expected DriverException, got: {type(exception.value)}"
-        )
-        assert exception.value.error.WhichOneof("error_type") == "login_error", "Expected login error"
-        assert exception.value.error.login_error.code != 0, "Login error code should not be zero"
-        assert exception.value.error.login_error.message.strip() != "", "Login error message should not be empty"
-
-    if OLD_DRIVER_ONLY("BD#4"):
-        # Reference driver uses DatabaseError from snowflake.connector.errors
-        from snowflake.connector.errors import DatabaseError
-
-        assert isinstance(exception.value, DatabaseError), f"Expected DatabaseError, got: {type(exception.value)}"
-        # Verify it's specifically an authentication/JWT error
-        error_msg = str(exception.value).lower()
-        assert "jwt" in error_msg or "token" in error_msg or "invalid" in error_msg, (
-            f"Expected authentication-related error, got: {exception.value}"
-        )
+    assert isinstance(exception.value, DatabaseError), f"Expected DatabaseError, got: {type(exception.value)}"
+    # Verify it's specifically an authentication/JWT error
+    error_msg = str(exception.value).lower()
+    assert "jwt" in error_msg or "token" in error_msg or "invalid" in error_msg, (
+        f"Expected authentication-related error, got: {exception.value}"
+    )

--- a/python/tests/e2e/query/test_basic_execute_query.py
+++ b/python/tests/e2e/query/test_basic_execute_query.py
@@ -18,8 +18,6 @@ import pytest
 
 from tests.e2e.types.utils import assert_sequential_values
 
-from ...compatibility import IS_UNIVERSAL_DRIVER
-
 
 class TestSelectQueries:
     """Tests for basic SELECT query execution."""
@@ -150,17 +148,9 @@ class TestErrorHandling:
 
         # When Invalid SQL "SELCT INVALID SYNTAX" is executed
         # Then An error should be returned
-        if IS_UNIVERSAL_DRIVER:
-            # TODO: this is not a desired state. Error type should match after error unification PR.
-            from snowflake.connector._internal.protobuf_gen.proto_exception import ProtoApplicationException
+        from snowflake.connector import ProgrammingError
 
-            expected_error = ProtoApplicationException
-        else:
-            from snowflake.connector import ProgrammingError
-
-            expected_error = ProgrammingError
-
-        with pytest.raises(expected_error):
+        with pytest.raises(ProgrammingError):
             cursor.execute("SELCT INVALID SYNTAX")
 
 

--- a/python/tests/e2e/query/test_parameter_binding.py
+++ b/python/tests/e2e/query/test_parameter_binding.py
@@ -228,18 +228,9 @@ class TestEdgeCases:
 
         # When Query with 3 placeholders is executed with 1 argument
         # Then Error should be raised for too few arguments
-        from ...compatibility import IS_UNIVERSAL_DRIVER
+        from snowflake.connector import DatabaseError
 
-        if IS_UNIVERSAL_DRIVER:
-            from snowflake.connector._internal.protobuf_gen.proto_exception import ProtoApplicationException
-
-            expected_error = ProtoApplicationException
-        else:
-            from snowflake.connector import DatabaseError
-
-            expected_error = DatabaseError
-
-        with pytest.raises(expected_error):
+        with pytest.raises(DatabaseError):
             cursor.execute("SELECT ?, ?, ?", (1,))
 
 

--- a/python/tests/integ/authentication/test_private_key_auth.py
+++ b/python/tests/integ/authentication/test_private_key_auth.py
@@ -1,5 +1,7 @@
 import pytest
 
+from snowflake.connector import ProgrammingError
+
 from ...compatibility import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 
 
@@ -9,25 +11,17 @@ class TestPrivateKeyAuthentication:
         authenticator = "SNOWFLAKE_JWT"
 
         # When Trying to Connect with no private file provided
-        with pytest.raises(Exception) as exception:
+        with pytest.raises(Exception) as exception_info:
             int_test_connection_factory(authenticator=authenticator, private_key_file=None)
 
-        # Then There is error returned
-        self._verify_missing_parameter_error(exception)
+        exception = exception_info.value
 
-    def _verify_missing_parameter_error(self, exception):
+        # Then There is error returned
         assert exception is not None
-        assert str(exception.value).strip() != "", "Missing parameter error message should not be empty"
+
         if NEW_DRIVER_ONLY("BD#4"):
-            assert hasattr(exception.value, "error") and exception.value.error.missing_parameter is not None, (
-                "Expected missing parameter error"
-            )
-            assert exception.value.error.missing_parameter.parameter.strip() != "", (
-                "Missing parameter name should not be empty"
-            )
-        if OLD_DRIVER_ONLY("BD#4"):
-            assert isinstance(exception.value, TypeError), "Old driver throws TypeError for missing private key"
-            error_msg = str(exception.value).lower()
-            assert any(keyword in error_msg for keyword in ["private", "key", "missing"]), (
-                f"Expected error related to missing private key parameters, got: {exception.value}"
-            )
+            assert isinstance(exception, ProgrammingError)
+            assert "Missing required parameter: private_key or private_key_file" in str(exception)
+        elif OLD_DRIVER_ONLY("BD#4"):
+            assert isinstance(exception, TypeError)
+            assert "Expected bytes or RSAPrivateKey" in str(exception)

--- a/python/tests/integ/test_errors.py
+++ b/python/tests/integ/test_errors.py
@@ -1,0 +1,215 @@
+"""
+Integration tests for error handling.
+
+Tests verify that real Snowflake errors are surfaced as proper PEP 249 exceptions
+with meaningful messages and structured attributes.
+
+These tests are designed to pass against both the new (universal) driver and
+the old (reference) snowflake-connector-python driver.
+"""
+
+import uuid
+
+import pytest
+
+from snowflake.connector.errors import DatabaseError, Error, InterfaceError, ProgrammingError
+from tests.compatibility import is_new_driver, is_old_driver
+
+
+# Password authenticator name differs between drivers.
+# Old driver: "snowflake" (DEFAULT_AUTHENTICATOR = "SNOWFLAKE")
+# New driver: "SNOWFLAKE_PASSWORD"
+PASSWORD_AUTH = "SNOWFLAKE_PASSWORD" if is_new_driver() else "snowflake"
+
+
+class TestAuthenticationErrors:
+    """Test that authentication failures raise proper errors."""
+
+    def test_invalid_password(self, connection_factory):
+        """Test that wrong password raises a DatabaseError subclass with descriptive message."""
+        with pytest.raises(DatabaseError) as excinfo:
+            connection_factory(authenticator=PASSWORD_AUTH, password="wrong_password_12345")
+        error = excinfo.value
+        assert "incorrect username or password" in error.msg.lower()
+        assert error.errno == 250001
+
+    def test_invalid_user(self, connection_factory):
+        """Test that a non-existent user raises a DatabaseError subclass."""
+        with pytest.raises(DatabaseError) as excinfo:
+            connection_factory(
+                authenticator=PASSWORD_AUTH,
+                user=f"nonexistent_user_{uuid.uuid4().hex[:8]}",
+                password="dummy",
+            )
+        error = excinfo.value
+        assert error.msg
+        assert error.errno == 250001
+
+    def test_invalid_account(self, connection_factory):
+        """Test that a non-existent account raises an Error subclass."""
+        with pytest.raises(Error) as excinfo:
+            connection_factory(
+                account=f"nonexistent_account_{uuid.uuid4().hex[:8]}",
+                authenticator=PASSWORD_AUTH,
+                password="dummy",
+            )
+        error = excinfo.value
+        assert error.errno != -1
+        if is_new_driver():
+            assert error.errno == 250001
+        else:
+            # Old driver: HttpError (290404) when server returns 404 for unknown account,
+            # or ER_FAILED_TO_CONNECT_TO_DB (250001) for connection-level failures.
+            assert error.errno in (290404, 250001)
+
+    def test_invalid_authenticator_value(self, connection_factory):
+        """Test that an unsupported authenticator value raises ProgrammingError."""
+        with pytest.raises(ProgrammingError) as excinfo:
+            connection_factory(authenticator="INVALID_AUTH_METHOD", password="dummy")
+        error = excinfo.value
+        assert "authenticator" in error.msg.lower()
+        assert error.errno == 251007
+
+
+class TestQuerySyntaxErrors:
+    """Test that SQL syntax errors raise DatabaseError with descriptive messages."""
+
+    def test_invalid_sql_syntax(self, cursor):
+        """Test that malformed SQL raises DatabaseError mentioning the syntax error."""
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute("SELEC 1")
+        error = excinfo.value
+        assert error.errno == 1003
+        assert "sql compilation error" in error.msg.lower()
+        assert "syntax error" in error.msg.lower()
+
+    def test_unclosed_string_literal(self, cursor):
+        """Test that an unclosed string literal raises DatabaseError with parse error."""
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute("SELECT 'unclosed")
+        error = excinfo.value
+        assert error.errno == 1003
+        assert "sql compilation error" in error.msg.lower()
+        assert "parse error" in error.msg.lower()
+
+    def test_invalid_identifier(self, cursor):
+        """Test that referencing a non-existent column raises DatabaseError."""
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute("SELECT nonexistent_column")
+        error = excinfo.value
+        assert error.errno == 904
+        assert "sql compilation error" in error.msg.lower()
+        assert "invalid identifier" in error.msg.lower()
+
+
+class TestObjectNotFoundErrors:
+    """Test that references to non-existent objects raise DatabaseError."""
+
+    def test_select_from_nonexistent_table(self, cursor):
+        """Test that selecting from a non-existent table raises DatabaseError."""
+        table_name = f"nonexistent_table_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute(f"SELECT * FROM {table_name}")
+        error = excinfo.value
+        assert error.errno == 2003
+        assert "does not exist or not authorized" in error.msg.lower()
+
+    def test_drop_nonexistent_table(self, cursor):
+        """Test that dropping a non-existent table (without IF EXISTS) raises DatabaseError."""
+        table_name = f"nonexistent_table_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute(f"DROP TABLE {table_name}")
+        error = excinfo.value
+        assert error.errno == 2003
+        assert "does not exist or not authorized" in error.msg.lower()
+
+    def test_use_nonexistent_database(self, cursor):
+        """Test that USE on a non-existent database raises DatabaseError."""
+        db_name = f"nonexistent_db_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute(f"USE DATABASE {db_name}")
+        error = excinfo.value
+        assert error.errno == 2043
+
+
+class TestClosedCursorErrors:
+    """Test that operations on a closed cursor raise proper errors."""
+
+    def test_execute_on_closed_cursor(self, cursor):
+        """Test that execute on a closed cursor raises InterfaceError."""
+        cursor.close()
+        with pytest.raises(InterfaceError, match="(?i)cursor is closed"):
+            cursor.execute("SELECT 1")
+
+    def test_fetchone_on_closed_cursor(self, cursor):
+        """Test that fetchone on a closed cursor raises an error."""
+        cursor.close()
+        # New driver raises InterfaceError; old driver raises TypeError (no closed-cursor guard on fetch).
+        with pytest.raises((InterfaceError, TypeError)):
+            cursor.fetchone()
+
+    def test_fetchall_on_closed_cursor(self, cursor):
+        """Test that fetchall on a closed cursor raises an error."""
+        cursor.close()
+        # New driver raises InterfaceError; old driver raises TypeError (no closed-cursor guard on fetch).
+        with pytest.raises((InterfaceError, TypeError)):
+            cursor.fetchall()
+
+
+class TestClosedConnectionErrors:
+    """Test that operations on a closed connection raise proper errors."""
+
+    def test_cursor_on_closed_connection(self, connection_factory):
+        """Test that creating a cursor on a closed connection raises an error."""
+        conn = connection_factory()
+        conn.close()
+        # New driver: InterfaceError; old driver: DatabaseError (errno=250002)
+        with pytest.raises(Error, match="(?i)connection is closed"):
+            conn.cursor()
+
+    def test_execute_on_closed_connection(self, connection_factory):
+        """Test that execute via cursor on a closed connection raises an error."""
+        conn = connection_factory()
+        cur = conn.cursor()
+        conn.close()
+        # New driver: InterfaceError("Connection is closed.")
+        # Old driver: InterfaceError("Cursor is closed in execute.") or DatabaseError("Connection is closed")
+        with pytest.raises(Error, match="(?i)(?:connection|cursor) is closed"):
+            cur.execute("SELECT 1")
+
+
+class TestErrorAttributes:
+    """Test that errors raised from real queries carry expected PEP 249 attributes."""
+
+    def test_error_inherits_from_database_error(self, cursor):
+        """Test that a query error is catchable as DatabaseError and Error."""
+        with pytest.raises(DatabaseError):
+            cursor.execute("SELEC 1")
+
+    def test_error_has_errno(self, cursor):
+        """Test that errors from the server carry the Snowflake server error code."""
+        with pytest.raises(Error) as excinfo:
+            cursor.execute("SELEC 1")
+        error = excinfo.value
+        assert error.errno == 1003
+
+    def test_error_has_raw_msg(self, cursor):
+        """Test that errors from the server carry raw_msg."""
+        with pytest.raises(Error) as excinfo:
+            cursor.execute("SELEC 1")
+        assert excinfo.value.raw_msg is not None
+        assert "sql compilation error" in excinfo.value.raw_msg.lower()
+
+    def test_error_has_sqlstate(self, cursor):
+        """Test that errors from the server carry sqlstate."""
+        with pytest.raises(Error) as excinfo:
+            cursor.execute("SELEC 1")
+        assert excinfo.value.sqlstate == "42000"
+
+    def test_error_does_not_leak_internal_cause(self, cursor):
+        """Test that server errors do not expose internal proto exceptions via __cause__."""
+        if is_old_driver():
+            pytest.skip("__cause__ suppression is a new-driver concern")
+        with pytest.raises(Error) as excinfo:
+            cursor.execute("SELEC 1")
+        assert excinfo.value.__cause__ is None

--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -4,7 +4,7 @@ Tests for PEP 249 exception classes.
 
 from unittest.mock import MagicMock
 
-from snowflake.connector._internal.api_client.client_api import _convert_proto_error
+from snowflake.connector._internal.api_client.client_api import _proto_to_public_error
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     DriverError as ProtoDriverError,
 )
@@ -14,18 +14,20 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     LoginError as ProtoLoginError,
 )
+from snowflake.connector._internal.status_codes import (
+    STATUS_CODE_AUTHENTICATION_ERROR,
+    STATUS_CODE_INTERNAL_ERROR,
+    STATUS_CODE_INVALID_ARGUMENT,
+    STATUS_CODE_INVALID_DATA,
+    STATUS_CODE_INVALID_PARAMETER_VALUE,
+    STATUS_CODE_LOGIN_ERROR,
+    STATUS_CODE_MISSING_PARAMETER,
+    STATUS_CODE_NOT_FOUND,
+    STATUS_CODE_NOT_IMPLEMENTED,
+    STATUS_CODE_TIMEOUT,
+    STATUS_TO_EXCEPTION,
+)
 from snowflake.connector.errors import (
-    _STATUS_CODE_AUTHENTICATION_ERROR,
-    _STATUS_CODE_INTERNAL_ERROR,
-    _STATUS_CODE_INVALID_ARGUMENT,
-    _STATUS_CODE_INVALID_DATA,
-    _STATUS_CODE_INVALID_PARAMETER_VALUE,
-    _STATUS_CODE_LOGIN_ERROR,
-    _STATUS_CODE_MISSING_PARAMETER,
-    _STATUS_CODE_NOT_FOUND,
-    _STATUS_CODE_NOT_IMPLEMENTED,
-    _STATUS_CODE_TIMEOUT,
-    _STATUS_TO_EXCEPTION,
     DatabaseError,
     DataError,
     Error,
@@ -135,34 +137,34 @@ class TestStatusCodeMapping:
     """Test that proto status codes map to the correct PEP 249 exception class."""
 
     def test_authentication_error_maps_to_database_error(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_AUTHENTICATION_ERROR] is DatabaseError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_AUTHENTICATION_ERROR] is DatabaseError
 
     def test_internal_error_maps_to_programming(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INTERNAL_ERROR] is ProgrammingError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_INTERNAL_ERROR] is ProgrammingError
 
     def test_login_error_maps_to_database_error(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_LOGIN_ERROR] is DatabaseError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_LOGIN_ERROR] is DatabaseError
 
     def test_timeout_maps_to_operational(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_TIMEOUT] is OperationalError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_TIMEOUT] is OperationalError
 
     def test_not_implemented_maps_to_not_supported(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_NOT_IMPLEMENTED] is NotSupportedError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_NOT_IMPLEMENTED] is NotSupportedError
 
     def test_not_found_maps_to_programming(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_NOT_FOUND] is ProgrammingError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_NOT_FOUND] is ProgrammingError
 
     def test_invalid_argument_maps_to_programming(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_ARGUMENT] is ProgrammingError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_INVALID_ARGUMENT] is ProgrammingError
 
     def test_missing_parameter_maps_to_programming(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_MISSING_PARAMETER] is ProgrammingError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_MISSING_PARAMETER] is ProgrammingError
 
     def test_invalid_parameter_value_maps_to_programming(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_PARAMETER_VALUE] is ProgrammingError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_INVALID_PARAMETER_VALUE] is ProgrammingError
 
     def test_invalid_data_maps_to_data_error(self):
-        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_DATA] is DataError
+        assert STATUS_TO_EXCEPTION[STATUS_CODE_INVALID_DATA] is DataError
 
 
 class TestExtractErrorDetail:
@@ -204,7 +206,7 @@ class TestExtractErrorDetail:
 
 
 class TestConvertProtoError:
-    """Test _convert_proto_error end-to-end conversion."""
+    """Test _proto_to_public_error end-to-end conversion."""
 
     def test_application_exception_with_status_code(self):
         from snowflake.connector._internal.protobuf_gen.proto_exception import (
@@ -213,13 +215,13 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Query failed"
-        driver_exc.status_code = _STATUS_CODE_INVALID_ARGUMENT
+        driver_exc.status_code = STATUS_CODE_INVALID_ARGUMENT
         driver_exc.report = ""
         driver_exc.error = None
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, ProgrammingError)
         assert "Query failed" in str(result)
 
@@ -236,7 +238,7 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Authentication failed"
-        driver_exc.status_code = _STATUS_CODE_AUTHENTICATION_ERROR
+        driver_exc.status_code = STATUS_CODE_AUTHENTICATION_ERROR
         driver_exc.report = ""
         driver_exc.error = ProtoDriverError(
             auth_error=ProtoAuthenticationError(detail="Token expired"),
@@ -244,7 +246,7 @@ class TestConvertProtoError:
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, DatabaseError)
         assert "Authentication failed" in str(result)
         assert "Token expired" in str(result)
@@ -257,13 +259,13 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Feature X not implemented"
-        driver_exc.status_code = _STATUS_CODE_NOT_IMPLEMENTED
+        driver_exc.status_code = STATUS_CODE_NOT_IMPLEMENTED
         driver_exc.report = ""
         driver_exc.error = None
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, NotSupportedError)
 
     def test_transport_exception_becomes_operational(self):
@@ -272,11 +274,11 @@ class TestConvertProtoError:
         )
 
         proto_exc = ProtoTransportException("connection lost")
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, OperationalError)
 
     def test_unknown_exception_type_becomes_database_error(self):
-        result = _convert_proto_error(Exception("something unexpected"))
+        result = _proto_to_public_error(Exception("something unexpected"))
         assert isinstance(result, DatabaseError)
         assert "something unexpected" in str(result)
 
@@ -287,17 +289,17 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Internal"
-        driver_exc.status_code = _STATUS_CODE_INTERNAL_ERROR
+        driver_exc.status_code = STATUS_CODE_INTERNAL_ERROR
         driver_exc.report = ""
         driver_exc.error = None
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, ProgrammingError)
         # INTERNAL_ERROR has no old-driver errno mapping, so proto status code
         # is used as fallback.
-        assert result.errno == _STATUS_CODE_INTERNAL_ERROR
+        assert result.errno == STATUS_CODE_INTERNAL_ERROR
 
     def test_application_exception_login_error_uses_old_errno(self):
         from snowflake.connector._internal.protobuf_gen.proto_exception import (
@@ -306,7 +308,7 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Login failed"
-        driver_exc.status_code = _STATUS_CODE_LOGIN_ERROR
+        driver_exc.status_code = STATUS_CODE_LOGIN_ERROR
         driver_exc.report = ""
         driver_exc.error = ProtoDriverError(
             login_error=ProtoLoginError(
@@ -317,7 +319,7 @@ class TestConvertProtoError:
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, DatabaseError)
         # Login errors use ER_FAILED_TO_CONNECT_TO_DB (250001) to match old driver.
         assert result.errno == 250001
@@ -330,13 +332,13 @@ class TestConvertProtoError:
 
         driver_exc = ProtoDriverException(
             message="SQL compilation error: syntax error",
-            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            status_code=STATUS_CODE_INTERNAL_ERROR,
             vendor_code=1003,
             sql_state="42000",
         )
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, ProgrammingError)
         # vendor_code from proto takes priority over status-code-based mapping
         assert result.errno == 1003
@@ -349,12 +351,12 @@ class TestConvertProtoError:
 
         driver_exc = ProtoDriverException(
             message="Query failed",
-            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            status_code=STATUS_CODE_INTERNAL_ERROR,
             root_cause="division by zero",
         )
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert isinstance(result, ProgrammingError)
         assert "Query failed" in str(result)
         assert "division by zero" in str(result)
@@ -366,12 +368,12 @@ class TestConvertProtoError:
 
         driver_exc = ProtoDriverException(
             message="division by zero",
-            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            status_code=STATUS_CODE_INTERNAL_ERROR,
             root_cause="division by zero",
         )
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         # root_cause should not be appended when it already appears in message
         msg_str = str(result)
         assert msg_str.count("division by zero") == 1
@@ -383,13 +385,13 @@ class TestConvertProtoError:
 
         driver_exc = MagicMock()
         driver_exc.message = "Query failed"
-        driver_exc.status_code = _STATUS_CODE_INVALID_ARGUMENT
+        driver_exc.status_code = STATUS_CODE_INVALID_ARGUMENT
         driver_exc.report = "Diagnostic report:\n  line 1: unexpected token"
         driver_exc.error = None
         driver_exc.HasField.return_value = False
         proto_exc = ProtoApplicationException(driver_exc)
 
-        result = _convert_proto_error(proto_exc)
+        result = _proto_to_public_error(proto_exc)
         assert "Query failed" in str(result)
         assert "Diagnostic report" not in str(result)
 

--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -2,9 +2,30 @@
 Tests for PEP 249 exception classes.
 """
 
-import pytest
+from unittest.mock import MagicMock
 
+from snowflake.connector._internal.api_client.client_api import _convert_proto_error
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    DriverError as ProtoDriverError,
+)
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    DriverException as ProtoDriverException,
+)
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    LoginError as ProtoLoginError,
+)
 from snowflake.connector.errors import (
+    _STATUS_CODE_AUTHENTICATION_ERROR,
+    _STATUS_CODE_INTERNAL_ERROR,
+    _STATUS_CODE_INVALID_ARGUMENT,
+    _STATUS_CODE_INVALID_DATA,
+    _STATUS_CODE_INVALID_PARAMETER_VALUE,
+    _STATUS_CODE_LOGIN_ERROR,
+    _STATUS_CODE_MISSING_PARAMETER,
+    _STATUS_CODE_NOT_FOUND,
+    _STATUS_CODE_NOT_IMPLEMENTED,
+    _STATUS_CODE_TIMEOUT,
+    _STATUS_TO_EXCEPTION,
     DatabaseError,
     DataError,
     Error,
@@ -22,159 +43,367 @@ class TestExceptionHierarchy:
     """Test the exception hierarchy as defined in PEP 249."""
 
     def test_warning_inheritance(self):
-        """Test that Warning inherits from Warning."""
-        # Note: Warning in PEP 249 should inherit from Python's Warning, not Exception
         assert issubclass(Warning, Warning)
 
     def test_error_inheritance(self):
-        """Test that Error inherits from Exception."""
         assert issubclass(Error, Exception)
 
     def test_interface_error_inheritance(self):
-        """Test that InterfaceError inherits from Error."""
         assert issubclass(InterfaceError, Error)
-        assert issubclass(InterfaceError, Exception)
 
     def test_database_error_inheritance(self):
-        """Test that DatabaseError inherits from Error."""
         assert issubclass(DatabaseError, Error)
-        assert issubclass(DatabaseError, Exception)
 
     def test_data_error_inheritance(self):
-        """Test that DataError inherits from DatabaseError."""
         assert issubclass(DataError, DatabaseError)
-        assert issubclass(DataError, Error)
-        assert issubclass(DataError, Exception)
 
     def test_operational_error_inheritance(self):
-        """Test that OperationalError inherits from DatabaseError."""
         assert issubclass(OperationalError, DatabaseError)
-        assert issubclass(OperationalError, Error)
-        assert issubclass(OperationalError, Exception)
 
     def test_integrity_error_inheritance(self):
-        """Test that IntegrityError inherits from DatabaseError."""
         assert issubclass(IntegrityError, DatabaseError)
-        assert issubclass(IntegrityError, Error)
-        assert issubclass(IntegrityError, Exception)
 
     def test_internal_error_inheritance(self):
-        """Test that InternalError inherits from DatabaseError."""
         assert issubclass(InternalError, DatabaseError)
-        assert issubclass(InternalError, Error)
-        assert issubclass(InternalError, Exception)
 
     def test_programming_error_inheritance(self):
-        """Test that ProgrammingError inherits from DatabaseError."""
         assert issubclass(ProgrammingError, DatabaseError)
-        assert issubclass(ProgrammingError, Error)
-        assert issubclass(ProgrammingError, Exception)
 
     def test_not_supported_error_inheritance(self):
-        """Test that NotSupportedError inherits from DatabaseError."""
         assert issubclass(NotSupportedError, DatabaseError)
-        assert issubclass(NotSupportedError, Error)
-        assert issubclass(NotSupportedError, Exception)
 
 
 class TestExceptionInstantiation:
-    """Test that exceptions can be instantiated and raised."""
+    """Test Error attributes (msg, errno, sqlstate, sfqid, query)."""
 
-    def test_warning_instantiation(self):
-        """Test Warning instantiation."""
-        warning = Warning("Test warning")
-        assert str(warning) == "Test warning"
+    def test_error_default_attributes(self):
+        error = Error("something went wrong")
+        assert error.raw_msg == "something went wrong"
+        assert error.errno == -1
+        assert error.sqlstate is None
+        assert error.sfqid is None
+        assert error.query is None
 
-    def test_error_instantiation(self):
-        """Test Error instantiation."""
-        error = Error("Test error")
-        assert str(error) == "Test error"
+    def test_error_full_attributes(self):
+        error = Error("oops", errno=42, sqlstate="HY000", sfqid="abc-123", query="SELECT 1")
+        assert error.raw_msg == "oops"
+        assert error.errno == 42
+        assert error.sqlstate == "HY000"
+        assert error.sfqid == "abc-123"
+        assert error.query == "SELECT 1"
 
-    def test_interface_error_instantiation(self):
-        """Test InterfaceError instantiation."""
-        error = InterfaceError("Interface error")
-        assert str(error) == "Interface error"
+    def test_error_with_errno(self):
+        error = Error("fail", errno=1003)
+        assert "001003" in error.msg
+        assert error.errno == 1003
 
-    def test_database_error_instantiation(self):
-        """Test DatabaseError instantiation."""
-        error = DatabaseError("Database error")
-        assert str(error) == "Database error"
+    def test_interface_error_with_attributes(self):
+        err = InterfaceError("closed", errno=252006)
+        assert err.errno == 252006
+        assert "closed" in str(err)
 
-    def test_data_error_instantiation(self):
-        """Test DataError instantiation."""
-        error = DataError("Data error")
-        assert str(error) == "Data error"
+    def test_operational_error(self):
+        err = OperationalError("timeout", errno=4)
+        assert err.errno == 4
 
-    def test_operational_error_instantiation(self):
-        """Test OperationalError instantiation."""
-        error = OperationalError("Operational error")
-        assert str(error) == "Operational error"
+    def test_subclass_inherits_attributes(self):
+        err = ProgrammingError("bad sql", errno=1003, sqlstate="42000")
+        assert isinstance(err, DatabaseError)
+        assert isinstance(err, Error)
+        assert err.errno == 1003
+        assert err.sqlstate == "42000"
 
-    def test_integrity_error_instantiation(self):
-        """Test IntegrityError instantiation."""
-        error = IntegrityError("Integrity error")
-        assert str(error) == "Integrity error"
+    def test_not_supported_error(self):
+        err = NotSupportedError("not supported")
+        assert isinstance(err, DatabaseError)
 
-    def test_internal_error_instantiation(self):
-        """Test InternalError instantiation."""
-        error = InternalError("Internal error")
-        assert str(error) == "Internal error"
+    def test_error_with_query(self):
+        err = Error("failed", query="SELECT 1")
+        assert err.query == "SELECT 1"
 
-    def test_programming_error_instantiation(self):
-        """Test ProgrammingError instantiation."""
-        error = ProgrammingError("Programming error")
-        assert str(error) == "Programming error"
+    def test_plain_message(self):
+        err = Error("hello")
+        assert err.raw_msg == "hello"
+        assert "hello" in str(err)
 
-    def test_not_supported_error_instantiation(self):
-        """Test NotSupportedError instantiation."""
-        error = NotSupportedError("Not supported error")
-        assert str(error) == "Not supported error"
+    def test_unknown_error_when_no_message(self):
+        err = Error("")
+        assert err.msg == ""
 
 
-class TestExceptionRaising:
-    """Test that exceptions can be raised and caught."""
+class TestStatusCodeMapping:
+    """Test that proto status codes map to the correct PEP 249 exception class."""
 
-    def test_raise_interface_error(self):
-        """Test raising InterfaceError."""
-        with pytest.raises(InterfaceError) as excinfo:
-            raise InterfaceError("Test interface error")
-        assert str(excinfo.value) == "Test interface error"
+    def test_authentication_error_maps_to_database_error(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_AUTHENTICATION_ERROR] is DatabaseError
 
-    def test_raise_database_error(self):
-        """Test raising DatabaseError."""
-        with pytest.raises(DatabaseError) as excinfo:
-            raise DatabaseError("Test database error")
-        assert str(excinfo.value) == "Test database error"
+    def test_internal_error_maps_to_programming(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INTERNAL_ERROR] is ProgrammingError
 
-    def test_catch_database_error_hierarchy(self):
-        """Test catching DatabaseError catches all subclasses."""
-        # Test that we can catch DatabaseError when raising a subclass
-        with pytest.raises(DatabaseError):
-            raise DataError("Data error")
+    def test_login_error_maps_to_database_error(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_LOGIN_ERROR] is DatabaseError
 
-        with pytest.raises(DatabaseError):
-            raise OperationalError("Operational error")
+    def test_timeout_maps_to_operational(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_TIMEOUT] is OperationalError
 
-        with pytest.raises(DatabaseError):
-            raise IntegrityError("Integrity error")
+    def test_not_implemented_maps_to_not_supported(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_NOT_IMPLEMENTED] is NotSupportedError
 
-        with pytest.raises(DatabaseError):
-            raise InternalError("Internal error")
+    def test_not_found_maps_to_programming(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_NOT_FOUND] is ProgrammingError
 
-        with pytest.raises(DatabaseError):
-            raise ProgrammingError("Programming error")
+    def test_invalid_argument_maps_to_programming(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_ARGUMENT] is ProgrammingError
 
-        with pytest.raises(DatabaseError):
-            raise NotSupportedError("Not supported error")
+    def test_missing_parameter_maps_to_programming(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_MISSING_PARAMETER] is ProgrammingError
 
-    def test_catch_error_hierarchy(self):
-        """Test catching Error catches all database errors."""
-        # Test that we can catch Error when raising any database error
-        with pytest.raises(Error):
-            raise InterfaceError("Interface error")
+    def test_invalid_parameter_value_maps_to_programming(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_PARAMETER_VALUE] is ProgrammingError
 
-        with pytest.raises(Error):
-            raise DatabaseError("Database error")
+    def test_invalid_data_maps_to_data_error(self):
+        assert _STATUS_TO_EXCEPTION[_STATUS_CODE_INVALID_DATA] is DataError
 
-        with pytest.raises(Error):
-            raise DataError("Data error")
+
+class TestExtractErrorDetail:
+    """Test _extract_error_detail helper."""
+
+    def test_no_error_field(self):
+        from snowflake.connector._internal.api_client.client_api import _extract_error_detail
+
+        driver_exc = MagicMock()
+        driver_exc.error = None
+        assert _extract_error_detail(driver_exc) is None
+
+    def test_missing_parameter(self):
+        from snowflake.connector._internal.api_client.client_api import _extract_error_detail
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+            MissingParameter as ProtoMissingParameter,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.error.WhichOneof.return_value = "missing_parameter"
+        driver_exc.error.missing_parameter = ProtoMissingParameter(parameter="account")
+        result = _extract_error_detail(driver_exc)
+        assert "account" in result
+
+    def test_invalid_parameter_value(self):
+        from snowflake.connector._internal.api_client.client_api import _extract_error_detail
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+            InvalidParameterValue as ProtoInvalidParameterValue,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.error.WhichOneof.return_value = "invalid_parameter_value"
+        driver_exc.error.invalid_parameter_value = ProtoInvalidParameterValue(
+            parameter="authenticator", value="BAD", explanation="not supported"
+        )
+        result = _extract_error_detail(driver_exc)
+        assert "authenticator" in result
+        assert "BAD" in result
+
+
+class TestConvertProtoError:
+    """Test _convert_proto_error end-to-end conversion."""
+
+    def test_application_exception_with_status_code(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Query failed"
+        driver_exc.status_code = _STATUS_CODE_INVALID_ARGUMENT
+        driver_exc.report = ""
+        driver_exc.error = None
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, ProgrammingError)
+        assert "Query failed" in str(result)
+
+    def test_application_exception_authentication(self):
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+            AuthenticationError as ProtoAuthenticationError,
+        )
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+            DriverError as ProtoDriverError,
+        )
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Authentication failed"
+        driver_exc.status_code = _STATUS_CODE_AUTHENTICATION_ERROR
+        driver_exc.report = ""
+        driver_exc.error = ProtoDriverError(
+            auth_error=ProtoAuthenticationError(detail="Token expired"),
+        )
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, DatabaseError)
+        assert "Authentication failed" in str(result)
+        assert "Token expired" in str(result)
+        assert result.errno == 250001
+
+    def test_application_exception_not_implemented(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Feature X not implemented"
+        driver_exc.status_code = _STATUS_CODE_NOT_IMPLEMENTED
+        driver_exc.report = ""
+        driver_exc.error = None
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, NotSupportedError)
+
+    def test_transport_exception_becomes_operational(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoTransportException,
+        )
+
+        proto_exc = ProtoTransportException("connection lost")
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, OperationalError)
+
+    def test_unknown_exception_type_becomes_database_error(self):
+        result = _convert_proto_error(Exception("something unexpected"))
+        assert isinstance(result, DatabaseError)
+        assert "something unexpected" in str(result)
+
+    def test_application_exception_preserves_errno(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Internal"
+        driver_exc.status_code = _STATUS_CODE_INTERNAL_ERROR
+        driver_exc.report = ""
+        driver_exc.error = None
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, ProgrammingError)
+        # INTERNAL_ERROR has no old-driver errno mapping, so proto status code
+        # is used as fallback.
+        assert result.errno == _STATUS_CODE_INTERNAL_ERROR
+
+    def test_application_exception_login_error_uses_old_errno(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Login failed"
+        driver_exc.status_code = _STATUS_CODE_LOGIN_ERROR
+        driver_exc.report = ""
+        driver_exc.error = ProtoDriverError(
+            login_error=ProtoLoginError(
+                message="Incorrect username or password",
+                code=390100,
+            ),
+        )
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, DatabaseError)
+        # Login errors use ER_FAILED_TO_CONNECT_TO_DB (250001) to match old driver.
+        assert result.errno == 250001
+        assert result.sqlstate == "08001"
+
+    def test_application_exception_uses_vendor_code_and_sqlstate(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = ProtoDriverException(
+            message="SQL compilation error: syntax error",
+            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            vendor_code=1003,
+            sql_state="42000",
+        )
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, ProgrammingError)
+        # vendor_code from proto takes priority over status-code-based mapping
+        assert result.errno == 1003
+        assert result.sqlstate == "42000"
+
+    def test_application_exception_root_cause_appended(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = ProtoDriverException(
+            message="Query failed",
+            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            root_cause="division by zero",
+        )
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert isinstance(result, ProgrammingError)
+        assert "Query failed" in str(result)
+        assert "division by zero" in str(result)
+
+    def test_application_exception_root_cause_not_duplicated(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = ProtoDriverException(
+            message="division by zero",
+            status_code=_STATUS_CODE_INTERNAL_ERROR,
+            root_cause="division by zero",
+        )
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        # root_cause should not be appended when it already appears in message
+        msg_str = str(result)
+        assert msg_str.count("division by zero") == 1
+
+    def test_application_exception_report_not_included(self):
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = MagicMock()
+        driver_exc.message = "Query failed"
+        driver_exc.status_code = _STATUS_CODE_INVALID_ARGUMENT
+        driver_exc.report = "Diagnostic report:\n  line 1: unexpected token"
+        driver_exc.error = None
+        driver_exc.HasField.return_value = False
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _convert_proto_error(proto_exc)
+        assert "Query failed" in str(result)
+        assert "Diagnostic report" not in str(result)
+
+
+class TestErrorAttributes:
+    """Test that errors carry expected PEP 249 attributes."""
+
+    def test_error_has_raw_msg(self):
+        err = Error("test message", errno=42)
+        assert err.raw_msg == "test message"
+        assert "test message" in err.msg
+
+    def test_error_formatting_with_sqlstate(self):
+        err = Error("fail", errno=1003, sqlstate="42000")
+        assert "001003" in err.msg
+        assert "(42000)" in err.msg
+        assert "fail" in err.msg

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -361,6 +361,9 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 /// Only populates vendor_code/sql_state for query errors where the Snowflake server
 /// code is the user-facing error number.  Login errors use client-side error codes
 /// (mapped by the Python layer) so the server code is NOT surfaced here.
+///
+/// NOTE: currently handles `QueryFailed` and `AsyncQuery` variants only.
+/// New query-related error variants should be added here as they are introduced.
 fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
     match error {
         ApiError::Query {

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -22,6 +22,7 @@ use crate::apis::database_driver_v1::{
 use crate::config::config_manager;
 use crate::config::path_resolver;
 use crate::protobuf::generated::database_driver_v1::*;
+use crate::rest::snowflake::error::SfError;
 use arrow::ffi::FFI_ArrowArray;
 use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
@@ -355,6 +356,31 @@ fn to_driver_error(error: &ApiError) -> DriverError {
     }
 }
 
+/// Extract the Snowflake server vendor code and SQL state from an ApiError, if available.
+///
+/// Only populates vendor_code/sql_state for query errors where the Snowflake server
+/// code is the user-facing error number.  Login errors use client-side error codes
+/// (mapped by the Python layer) so the server code is NOT surfaced here.
+fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
+    match error {
+        ApiError::Query {
+            source: RestError::QueryFailed {
+                code, sql_state, ..
+            },
+            ..
+        } => (*code, sql_state.clone()),
+        ApiError::Query {
+            source:
+                RestError::AsyncQuery {
+                    source: SfError::SnowflakeBody { code, .. },
+                    ..
+                },
+            ..
+        } => (Some(*code), None),
+        _ => (None, None),
+    }
+}
+
 fn to_driver_exception(error: ApiError) -> DriverException {
     let status_code = match &error {
         ApiError::GenericError { .. } => StatusCode::GenericError,
@@ -410,7 +436,9 @@ fn to_driver_exception(error: ApiError) -> DriverException {
         ApiError::InvalidRefreshState { .. } => StatusCode::InternalError,
     };
 
+    let (vendor_code, sql_state) = extract_vendor_info(&error);
     let message = error.to_string();
+    let root_cause = extract_root_cause(&error);
     let driver_error = to_driver_error(&error);
     let error_trace = error
         .error_trace()
@@ -427,7 +455,23 @@ fn to_driver_exception(error: ApiError) -> DriverException {
         status_code: status_code as i32,
         error: Some(driver_error),
         error_trace,
+        vendor_code,
+        sql_state,
+        root_cause,
     }
+}
+
+/// Walk the `source()` chain to the deepest error and return its message.
+/// Returns `None` when the error has no source (i.e. the message itself is
+/// already the root cause).
+fn extract_root_cause(error: &dyn std::error::Error) -> Option<String> {
+    let mut deepest: Option<&dyn std::error::Error> = None;
+    let mut current = error.source();
+    while let Some(cause) = current {
+        deepest = Some(cause);
+        current = cause.source();
+    }
+    deepest.map(|e| e.to_string())
 }
 
 #[allow(clippy::result_large_err)]
@@ -437,6 +481,9 @@ fn required<T>(value: Option<T>, message: &str) -> Result<T, DriverException> {
         status_code: StatusCode::InvalidArgument as i32,
         error: None,
         error_trace: vec![],
+        vendor_code: None,
+        sql_state: None,
+        root_cause: None,
     })
 }
 
@@ -446,6 +493,9 @@ fn not_implemented(message: &str) -> DriverException {
         status_code: StatusCode::NotImplemented as i32,
         error: None,
         error_trace: vec![],
+        vendor_code: None,
+        sql_state: None,
+        root_cause: None,
     }
 }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -479,11 +479,7 @@ fn required<T>(value: Option<T>, message: &str) -> Result<T, DriverException> {
     value.ok_or_else(|| DriverException {
         message: message.to_string(),
         status_code: StatusCode::InvalidArgument as i32,
-        error: None,
-        error_trace: vec![],
-        vendor_code: None,
-        sql_state: None,
-        root_cause: None,
+        ..Default::default()
     })
 }
 
@@ -491,11 +487,7 @@ fn not_implemented(message: &str) -> DriverException {
     DriverException {
         message: message.to_string(),
         status_code: StatusCode::NotImplemented as i32,
-        error: None,
-        error_trace: vec![],
-        vendor_code: None,
-        sql_state: None,
-        root_cause: None,
+        ..Default::default()
     }
 }
 
@@ -952,8 +944,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let config_json = serde_json::to_string(&nested_json).map_err(|e| DriverException {
             message: format!("Failed to serialize config to JSON: {e}"),
             status_code: StatusCode::InternalError as i32,
-            error: None,
-            error_trace: vec![],
+            ..Default::default()
         })?;
 
         Ok(ConfigLoadAllSectionsResponse { config_json })
@@ -970,15 +961,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let config_file = paths.config_file.ok_or_else(|| DriverException {
             message: "Configuration path for config file is unavailable".to_string(),
             status_code: StatusCode::InternalError as i32,
-            error: None,
-            error_trace: vec![],
+            ..Default::default()
         })?;
 
         let connections_file = paths.connections_file.ok_or_else(|| DriverException {
             message: "Configuration path for connections file is unavailable".to_string(),
             status_code: StatusCode::InternalError as i32,
-            error: None,
-            error_trace: vec![],
+            ..Default::default()
         })?;
 
         Ok(ConfigGetPathsResponse {

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -791,7 +791,17 @@ async fn execute_sync_query<'a>(
         let message = query_response
             .message
             .unwrap_or_else(|| "Unknown error".to_owned());
-        return QueryFailedSnafu { message }.fail();
+        let code = query_response
+            .code
+            .as_deref()
+            .and_then(|c| c.parse::<i32>().ok());
+        let sql_state = query_response.data.sql_state.clone();
+        return QueryFailedSnafu {
+            message,
+            code,
+            sql_state,
+        }
+        .fail();
     }
     Ok(query_response)
 }
@@ -959,6 +969,10 @@ pub enum RestError {
     #[snafu(display("Query failed: {message}"))]
     QueryFailed {
         message: String,
+        /// Snowflake server error code (e.g. 1003 for syntax error).
+        code: Option<i32>,
+        /// ANSI SQL state code (e.g. "42000" for syntax error).
+        sql_state: Option<String>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -61,7 +61,7 @@ pub struct Data {
     #[serde(rename = "queryId")]
     pub query_id: Option<String>,
     #[serde(rename = "sqlState")]
-    _sql_state: Option<String>,
+    pub sql_state: Option<String>,
     #[serde(rename = "databaseProvider")]
     _database_provider: Option<String>,
     #[serde(rename = "finalDatabaseName")]


### PR DESCRIPTION
Before:
```
/Users/turbaszek/code/universal-driver/python/.venv/bin/python3.13 /Users/turbaszek/Library/Application Support/JetBrains/IntelliJIdea2025.2/scratches/ud/ud_demo.py 
Traceback (most recent call last):
  File "/Users/turbaszek/Library/Application Support/JetBrains/IntelliJIdea2025.2/scratches/ud/ud_demo.py", line 14, in <module>
    r = curr.execute("SELECT foo")
  File "/Users/turbaszek/code/universal-driver/python/src/snowflake/connector/cursor.py", line 204, in execute
    self.execute_result = self.connection.db_api.statement_execute_query(
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        StatementExecuteQueryRequest(stmt_handle=stmt_handle)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).result
    ^
  File "/Users/turbaszek/code/universal-driver/python/src/snowflake/connector/_internal/protobuf_gen/database_driver_v1_services.py", line 831, in statement_execute_query
    raise ProtoApplicationException(error)
snowflake.connector._internal.protobuf_gen.proto_exception.ProtoApplicationException: message: "Query execution failed: Query failed: SQL compilation error: error line 1 at position 7\ninvalid identifier \'FOO\'"
status_code: STATUS_CODE_INTERNAL_ERROR
error {
  internal_error {
  }
}
report: "Query execution failed *\n\nCaused by this error:\n  1: Query failed: SQL compilation error: error line 1 at position 7\ninvalid identifier \'FOO\'\n\nNOTE: Some redundant information has been removed from the lines marked with *. Set SNAFU_RAW_ERROR_MESSAGES=1 to disable this behavior.\n"

```

After
```
/Users/turbaszek/code/universal-driver/python/.venv/bin/python3.13 /Users/turbaszek/Library/Application Support/JetBrains/IntelliJIdea2025.2/scratches/ud/ud_demo.py 
Traceback (most recent call last):
  File "/Users/turbaszek/Library/Application Support/JetBrains/IntelliJIdea2025.2/scratches/ud/ud_demo.py", line 14, in <module>
    r = curr.execute("SELECT foo")
snowflake.connector.errors.ProgrammingError: 000904 (42000): Query execution failed: Query failed: SQL compilation error: error line 1 at position 7
invalid identifier 'FOO'
```