### PR TITLE
replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,6 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "chrono",
- "lazy_static",
  "odbc-sys",
  "proto_utils",
  "sf_core",
@@ -3161,7 +3160,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
- "lazy_static",
  "log",
  "prost 0.12.6",
  "prost-build",
@@ -3757,7 +3755,6 @@ dependencies = [
  "hex",
  "infer",
  "jwt",
- "lazy_static",
  "lru",
  "num-traits",
  "once_cell",

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -13,7 +13,6 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 snafu = "0.8.7"
 odbc-sys = "0.25.1"
-lazy_static = "1.5.0"
 arrow = { version = "56.0.0", features = ["ffi"] }
 chrono = "0.4.43"
 

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashSet,
     str::Utf8Error,
     string::{FromUtf8Error, FromUtf16Error},
+    sync::LazyLock,
 };
 
 use crate::{
@@ -10,7 +11,6 @@ use crate::{
     write_arrow::ArrowBindingError,
 };
 use arrow::error::ArrowError;
-use lazy_static::lazy_static;
 use odbc_sys as sql;
 use proto_utils::ProtoError;
 use sf_core::protobuf_gen::database_driver_v1::{
@@ -231,19 +231,17 @@ impl<T> Required<T> for Option<T> {
     }
 }
 
-lazy_static! {
-    static ref AUTHENTICATOR_PARAMETERS: HashSet<String> = {
-        let mut set = HashSet::new();
-        set.insert("PRIV_KEY_FILE".to_string());
-        set.insert("PRIVATE_KEY_FILE".to_string());
-        set.insert("PRIV_KEY_FILE_PWD".to_string());
-        set.insert("TOKEN".to_string());
-        set.insert("AUTHENTICATOR".to_string());
-        set.insert("USER".to_string());
-        set.insert("PASSWORD".to_string());
-        set
-    };
-}
+static AUTHENTICATOR_PARAMETERS: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    let mut set = HashSet::new();
+    set.insert("PRIV_KEY_FILE".to_string());
+    set.insert("PRIVATE_KEY_FILE".to_string());
+    set.insert("PRIV_KEY_FILE_PWD".to_string());
+    set.insert("TOKEN".to_string());
+    set.insert("AUTHENTICATOR".to_string());
+    set.insert("USER".to_string());
+    set.insert("PASSWORD".to_string());
+    set
+});
 
 impl OdbcError {
     pub fn to_diagnostic_record(&self) -> DiagnosticRecord {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -103,13 +103,17 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
 
 /// Initialize logging (helper function for allocation)
 pub fn init_logging() {
-    use lazy_static::lazy_static;
+    use std::sync::LazyLock;
 
-    lazy_static! {
-        // TODO: This is a hack to initialize the logging system.
-        // We should find a better way to do this.
-        static ref LOGGING_RESULT: Result<(), sf_core::logging::LogError> = sf_core::logging::init(sf_core::logging::LoggingConfig::new(Some("odbc.log".into()), true, false));
-    }
+    // TODO: This is a hack to initialize the logging system.
+    // We should find a better way to do this.
+    static LOGGING_RESULT: LazyLock<Result<(), sf_core::logging::LogError>> = LazyLock::new(|| {
+        sf_core::logging::init(sf_core::logging::LoggingConfig::new(
+            Some("odbc.log".into()),
+            true,
+            false,
+        ))
+    });
 
     if let Err(e) = LOGGING_RESULT.as_ref() {
         eprintln!("Failed to initialize logging: {e:?}");

--- a/proto_generator/Cargo.toml
+++ b/proto_generator/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 prost-build = "0.14"
 tempfile = "3.22.0"
-lazy_static = "1.5.0" 
 log = "0.4.28"
 env_logger="0.11.8"
 walkdir = "2.5"

--- a/proto_generator/src/main.rs
+++ b/proto_generator/src/main.rs
@@ -3,17 +3,16 @@ use proto_generator::{CodeGenerator, GenerationResult, GeneratorContext};
 use proto_generator::{JavaGenerator, JsonGenerator, PythonGenerator, RustGenerator};
 use snafu::Whatever;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref generators: Vec<Box<dyn CodeGenerator + Sync>> = vec![
+static GENERATORS: LazyLock<Vec<Box<dyn CodeGenerator + Sync + Send>>> = LazyLock::new(|| {
+    vec![
         Box::new(RustGenerator::new()),
         Box::new(JsonGenerator::new()),
         Box::new(PythonGenerator::new()),
-        Box::new(JavaGenerator::new())
-    ];
-}
+        Box::new(JavaGenerator::new()),
+    ]
+});
 
 fn main() -> Result<(), Whatever> {
     env_logger::init();
@@ -98,7 +97,7 @@ fn handle_generate_command(matches: &ArgMatches) -> Result<(), Whatever> {
     }
 
     // Create registry with built-in generators
-    let generator_opt = generators.iter().find(|g| g.name() == generator_name);
+    let generator_opt = GENERATORS.iter().find(|g| g.name() == generator_name);
 
     if generator_opt.is_none() {
         eprintln!("Generator not found: {}", generator_name);

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -29,7 +29,6 @@ flate2 = "1.1.2"
 openssl = "0.10.73"
 jwt = { version = "0.16.0", features = ["openssl"] }
 infer = "0.19.0"
-lazy_static = "1.5.0"
 
 # Proto
 prost = "0.14.1"

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,10 +1,10 @@
 use super::{connection::Connection, database::Database, statement::Statement};
 use crate::handle_manager::HandleManager;
-use lazy_static::lazy_static;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-lazy_static! {
-    pub static ref DB_HANDLE_MANAGER: HandleManager<Mutex<Database>> = HandleManager::new();
-    pub static ref CONN_HANDLE_MANAGER: HandleManager<Mutex<Connection>> = HandleManager::new();
-    pub static ref STMT_HANDLE_MANAGER: HandleManager<Mutex<Statement>> = HandleManager::new();
-}
+pub static DB_HANDLE_MANAGER: LazyLock<HandleManager<Mutex<Database>>> =
+    LazyLock::new(HandleManager::new);
+pub static CONN_HANDLE_MANAGER: LazyLock<HandleManager<Mutex<Connection>>> =
+    LazyLock::new(HandleManager::new);
+pub static STMT_HANDLE_MANAGER: LazyLock<HandleManager<Mutex<Statement>>> =
+    LazyLock::new(HandleManager::new);

--- a/tests/tests_format_validator/Cargo.lock
+++ b/tests/tests_format_validator/Cargo.lock
@@ -203,12 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +395,6 @@ dependencies = [
  "anyhow",
  "clap",
  "convert_case",
- "lazy_static",
  "regex",
  "serde",
  "serde_json",

--- a/tests/tests_format_validator/Cargo.toml
+++ b/tests/tests_format_validator/Cargo.toml
@@ -23,7 +23,6 @@ convert_case = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-lazy_static = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3.21"

--- a/tests/tests_format_validator/src/feature_parser.rs
+++ b/tests/tests_format_validator/src/feature_parser.rs
@@ -1,12 +1,11 @@
 use anyhow::{Context, Result};
-use lazy_static::lazy_static;
 use regex::Regex;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref TAG_REGEX: Regex = Regex::new(r"@(\w+)").unwrap();
-    static ref STEP_REGEX: Regex = Regex::new(r"^\s*(Given|When|Then|And|But)\s+(.+)$").unwrap();
-}
+static TAG_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"@(\w+)").unwrap());
+static STEP_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(Given|When|Then|And|But)\s+(.+)$").unwrap());
 
 #[derive(Debug, Clone)]
 pub struct Feature {


### PR DESCRIPTION
Replacing `lazy_static` with `std::sync::LazyLock` allows us to drop a (small) dependency by using the standard library instead. Behaviour remains unchanged.