### PR TITLE
Fix memory leak in python FFI

### DIFF
--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -65,6 +65,12 @@ core.sf_core_api_call_proto.argtypes = [
     ctypes.POINTER(ctypes.c_size_t),  # size_t* response_len
 ]
 
+core.sf_core_free_buffer.restype = None
+core.sf_core_free_buffer.argtypes = [
+    ctypes.POINTER(ctypes.c_ubyte),  # uint8_t* buffer
+    ctypes.c_size_t,  # size_t len
+]
+
 
 def sf_core_api_call_proto(
     api: ctypes.c_char_p,
@@ -75,6 +81,10 @@ def sf_core_api_call_proto(
     response_len: Any,
 ) -> int:
     return core.sf_core_api_call_proto(api, method, request, request_len, response, response_len)  # type: ignore
+
+
+def sf_core_free_buffer(buffer: Any, length: int) -> None:
+    core.sf_core_free_buffer(buffer, length)
 
 
 def sf_core_init_logger(callback: Any) -> None:

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -6,7 +6,7 @@ from ctypes import c_char_p
 
 from ..protobuf_gen.database_driver_v1_services import DatabaseDriverClient
 from ..protobuf_gen.proto_exception import ProtoTransportException
-from .c_api import sf_core_api_call_proto
+from .c_api import sf_core_api_call_proto, sf_core_free_buffer
 
 
 class ProtoTransport:
@@ -26,7 +26,9 @@ class ProtoTransport:
             ctypes.byref(response_len),
         )
         if code == 0 or code == 1 or code == 2:
-            return (code, bytes(response[: response_len.value]))
+            result = bytes(response[: response_len.value])
+            sf_core_free_buffer(response, response_len.value)
+            return (code, result)
 
         raise ProtoTransportException(f"Unknown error code: {code}")
 

--- a/sf_core/exports.def
+++ b/sf_core/exports.def
@@ -5,3 +5,4 @@ LIBRARY sf_core
 EXPORTS
     sf_core_init_logger
     sf_core_api_call_proto
+    sf_core_free_buffer

--- a/sf_core/src/c_api.rs
+++ b/sf_core/src/c_api.rs
@@ -17,10 +17,28 @@ pub extern "C" fn sf_core_init_logger(callback: logging::CLogCallback) -> u32 {
 }
 
 fn write_buffer(vec: Vec<u8>, buffer: *mut *const u8, len: *mut usize) {
+    let boxed = vec.into_boxed_slice();
     unsafe {
-        *buffer = vec.as_ptr();
-        *len = vec.len();
-        std::mem::forget(vec);
+        *len = boxed.len();
+        *buffer = Box::into_raw(boxed) as *const u8;
+    }
+}
+
+/// Frees a buffer previously returned by `sf_core_api_call_proto` via `write_buffer`.
+///
+/// # Safety
+/// The caller must pass the exact `buffer` pointer and `len` that were written by a prior
+/// call to `sf_core_api_call_proto`. Each (buffer, len) pair must be freed at most once.
+/// Passing any other pointer or length is undefined behavior.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sf_core_free_buffer(buffer: *const u8, len: usize) {
+    if !buffer.is_null() {
+        unsafe {
+            drop(Box::from_raw(std::slice::from_raw_parts_mut(
+                buffer as *mut u8,
+                len,
+            )));
+        }
     }
 }
 


### PR DESCRIPTION
When we write protobuf response into the buffer, we allocate the buffer on the core side and never free it - we use `std::mem::forget``  
`  
I added a function to rust c api that allow us to free buffers allocated by core once wrapper it finished reading the data in the buffer.  
Now we are calling this function in python and we free the buffer - we no longer leak memory