### PR TITLE
SNOW-2467780: Add integer feature tests

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -173,6 +173,7 @@ tasks.register('referenceTest', Test) {
     configureCommonTestTask(delegate)
     testClassesDirs = sourceSets.test.output.classesDirs
     include 'net/snowflake/client/api/**'
+    include 'net/snowflake/jdbc/**'
     // Isolate old-driver reference tests from this module's main runtime deps.
     // Keep only test output/resources + test-only runtime deps + old JDBC driver deps.
     classpath = sourceSets.test.output +

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/TinyIntToFixedConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/TinyIntToFixedConverter.java
@@ -39,6 +39,9 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
 
   @Override
   public byte toByte(int index) {
+    if (isNull(index)) {
+      return 0;
+    }
     return getByte(index);
   }
 

--- a/jdbc/src/test/java/net/snowflake/client/SnowflakeIntegrationTestBase.java
+++ b/jdbc/src/test/java/net/snowflake/client/SnowflakeIntegrationTestBase.java
@@ -10,8 +10,38 @@ import java.util.Properties;
 import net.snowflake.client.api.driver.SnowflakeDriver;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SnowflakeIntegrationTestBase {
+  private Connection defaultConnection;
+
+  @BeforeAll
+  protected void setUpDefaultConnection() throws Exception {
+    defaultConnection = openConnection();
+    ensureDatabaseAndSchema(defaultConnection);
+  }
+
+  @AfterAll
+  protected void tearDownDefaultConnection() throws Exception {
+    if (defaultConnection != null && !defaultConnection.isClosed()) {
+      defaultConnection.close();
+    }
+    defaultConnection = null;
+  }
+
+  protected Connection getDefaultConnection() throws Exception {
+    if (defaultConnection == null) {
+      throw new IllegalStateException("Default test connection is not initialized");
+    }
+    if (defaultConnection.isClosed()) {
+      throw new IllegalStateException("Default test connection is closed");
+    }
+    return defaultConnection;
+  }
+
   protected Properties loadConnectionProperties() throws Exception {
     // Load parameters.json from test resources
     String paramPath = System.getenv("PARAMETER_PATH");

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/converters/TinyIntToFixedConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/converters/TinyIntToFixedConverterTest.java
@@ -159,6 +159,28 @@ public class TinyIntToFixedConverterTest extends BaseConverterTest {
   }
 
   @Test
+  public void testNullAfterNonNullDoesNotReturnStaleValue() {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "FIXED");
+    customFieldMeta.put("precision", "10");
+    customFieldMeta.put("scale", "0");
+
+    FieldType fieldType =
+        new FieldType(true, Types.MinorType.TINYINT.getType(), null, customFieldMeta);
+    TinyIntVector vector = new TinyIntVector("col_one", fieldType, allocator);
+    vector.setSafe(0, 42);
+    vector.setNull(1);
+
+    ArrowVectorConverter converter = new TinyIntToFixedConverter(vector, 0, this);
+
+    assertEquals(42L, converter.toLong(0));
+    assertEquals(0L, converter.toLong(1));
+    assertNull(converter.toObject(1));
+
+    vector.clear();
+  }
+
+  @Test
   public void testGetSmallerIntegralType() {
     Map<String, String> customFieldMeta = new HashMap<>();
     customFieldMeta.put("logicalType", "FIXED");

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -1,0 +1,354 @@
+package net.snowflake.jdbc.e2e.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class IntTests extends SnowflakeIntegrationTestBase {
+  static Stream<String> intTypeSynonyms() {
+    return Stream.of("INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "BYTEINT");
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldCastIntegerValuesToAppropriateTypeForIntAndSynonyms(String typeName)
+      throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
+    String sql =
+        String.format("SELECT 0::%1$s, 1000000::%1$s, 9223372036854775807::%1$s", typeName);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+
+      // Then All values should be returned as appropriate type
+      // And No precision loss should occur
+      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + typeName);
+      assertAllIntegerGettersInRange(resultSet, 2, 1_000_000L, "Column 2 mismatch for " + typeName);
+      assertAllIntegerGettersInRange(
+          resultSet, 3, Long.MAX_VALUE, "Column 3 mismatch for " + typeName);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldSelectIntegerLiteralsForIntAndSynonyms(String typeName) throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT 0::<type>, 1::<type>, -1::<type>, 42::<type>" is executed
+    String sql = String.format("SELECT 0::%1$s, 1::%1$s, -1::%1$s, 42::%1$s", typeName);
+
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      // Then Result should contain integers [0, 1, -1, 42]
+      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + typeName);
+      assertAllIntegerGettersInRange(resultSet, 2, 1L, "Column 2 mismatch for " + typeName);
+      assertAllIntegerGettersInRange(resultSet, 3, -1L, "Column 3 mismatch for " + typeName);
+      assertAllIntegerGettersInRange(resultSet, 4, 42L, "Column 4 mismatch for " + typeName);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldHandleIntegerBoundaryValuesForIntAndSynonyms(String typeName) throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT -128::<type>, 127::<type>, 255::<type>" is executed
+    // Then Result should contain integers [-128, 127, 255]
+    assertSingleRow(
+        connection,
+        String.format("SELECT -128::%1$s, 127::%1$s, 255::%1$s", typeName),
+        Arrays.asList(-128L, 127L, 255L),
+        typeName);
+
+    // When Query "SELECT -32768::<type>, 32767::<type>, 65535::<type>" is executed
+    // Then Result should contain integers [-32768, 32767, 65535]
+    assertSingleRow(
+        connection,
+        String.format("SELECT -32768::%1$s, 32767::%1$s, 65535::%1$s", typeName),
+        Arrays.asList((long) Short.MIN_VALUE, (long) Short.MAX_VALUE, 65535L),
+        typeName);
+
+    // When Query "SELECT -2147483648::<type>, 2147483647::<type>, 4294967295::<type>" is executed
+    // Then Result should contain integers [-2147483648, 2147483647, 4294967295]
+    assertSingleRow(
+        connection,
+        String.format("SELECT -2147483648::%1$s, 2147483647::%1$s, 4294967295::%1$s", typeName),
+        Arrays.asList((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, 4294967295L),
+        typeName);
+
+    // When Query "SELECT -9223372036854775808::<type>, 9223372036854775807::<type>" is executed
+    // Then Result should contain integers [-9223372036854775808, 9223372036854775807]
+    assertSingleRow(
+        connection,
+        String.format("SELECT -9223372036854775808::%1$s, 9223372036854775807::%1$s", typeName),
+        Arrays.asList(Long.MIN_VALUE, Long.MAX_VALUE),
+        typeName);
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldHandleLargeIntegerValuesForIntAndSynonyms(String typeName) throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT -99999999999999999999999999999999999999::<type>,
+    // 99999999999999999999999999999999999999::<type>" is executed
+    String sql =
+        String.format(
+            "SELECT -99999999999999999999999999999999999999::%1$s, 99999999999999999999999999999999999999::%1$s",
+            typeName);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      // Then Result should contain integers [-99999999999999999999999999999999999999,
+      // 99999999999999999999999999999999999999]
+      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+      assertEquals(
+          new BigDecimal("-99999999999999999999999999999999999999"),
+          resultSet.getBigDecimal(1),
+          "Column 1 mismatch for " + typeName);
+      assertEquals(
+          new BigDecimal("99999999999999999999999999999999999999"),
+          resultSet.getBigDecimal(2),
+          "Column 2 mismatch for " + typeName);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldHandleNULLValuesForIntAndSynonyms(String typeName) throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
+    String sql = String.format("SELECT NULL::%1$s, 42::%1$s, NULL::%1$s", typeName);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      // Then Result should contain [NULL, 42, NULL]
+      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + typeName);
+      assertEquals(
+          new BigDecimal("42"), resultSet.getBigDecimal(2), "Column 2 mismatch for " + typeName);
+      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + typeName);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldDownloadLargeResultSetWithMultipleChunksForIntAndSynonyms(String typeName)
+      throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY
+    // id" is executed
+    String sql =
+        String.format(
+            "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id",
+            typeName);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
+      int expected = 0;
+      while (resultSet.next()) {
+        assertAllIntegerGettersInRange(
+            resultSet, 1, expected, "Value mismatch for " + typeName + ", row " + expected);
+        expected++;
+      }
+      assertEquals(50000, expected, "Unexpected row count for " + typeName);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldSelectIntegersFromTableForIntAndSynonyms(String typeName) throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    ensureDatabaseAndSchema(connection);
+    // And Table with <type> column exists with values [0, 1, -1, 100]
+    String tableName = createTempTable(connection, "col " + typeName);
+    execute(connection, "INSERT INTO " + tableName + " VALUES (0), (1), (-1), (100)");
+
+    // When Query "SELECT * FROM int_table ORDER BY col" is executed
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
+      // Then Result should contain integers [-1, 0, 1, 100]
+      List<Long> expectedValues = Arrays.asList(-1L, 0L, 1L, 100L);
+      for (int i = 0; i < expectedValues.size(); i++) {
+        assertTrue(resultSet.next(), "Missing row " + i + " for " + typeName);
+        assertAllIntegerGettersInRange(
+            resultSet, 1, expectedValues.get(i), "Value mismatch for " + typeName + ", row " + i);
+      }
+      assertFalse(resultSet.next(), "Expected exactly four rows for " + typeName);
+    }
+  }
+
+  @Test
+  public void shouldSelectCornerCaseValuesFromTableForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    ensureDatabaseAndSchema(connection);
+    // And Table with columns (tinyint_col TINYINT, byteint_col BYTEINT, smallint_col SMALLINT,
+    // int_col INT, integer_col INTEGER, bigint_col BIGINT, int38_col INT) exists
+    String tableName =
+        createTempTable(
+            connection,
+            "tinyint_col TINYINT, byteint_col BYTEINT, smallint_col SMALLINT, int_col INT, "
+                + "integer_col INTEGER, bigint_col BIGINT, int38_col INT");
+
+    // And Row with positive values (127, 255, 32767, 2147483647, 2147483647, 9223372036854775807,
+    // 99999999999999999999999999999999999999) is inserted
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES (127, 255, 32767, 2147483647, 2147483647, 9223372036854775807, 99999999999999999999999999999999999999)");
+
+    // And Row with negative values (-128, -1, -32768, -2147483648, -2147483648,
+    // -9223372036854775808, -99999999999999999999999999999999999999) is inserted
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES (-128, -1, -32768, -2147483648, -2147483648, -9223372036854775808, -99999999999999999999999999999999999999)");
+
+    // And Row with zeroes and nulls (0, NULL, 0, NULL, 0, NULL, 0) is inserted
+    execute(connection, "INSERT INTO " + tableName + " VALUES (0, NULL, 0, NULL, 0, NULL, 0)");
+
+    // When Query "SELECT * FROM corner_case_table" is executed
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY tinyint_col DESC")) {
+      // Then Result should contain 3 rows with expected corner case values for all int type
+      // synonyms
+      assertTrue(resultSet.next(), "Expected first row");
+      assertAllIntegerGettersInRange(resultSet, 1, 127L, "First row, tinyint_col mismatch");
+      assertAllIntegerGettersInRange(resultSet, 2, 255L, "First row, byteint_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 3, Short.MAX_VALUE, "First row, smallint_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 4, Integer.MAX_VALUE, "First row, int_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 5, Integer.MAX_VALUE, "First row, integer_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 6, Long.MAX_VALUE, "First row, bigint_col mismatch");
+      assertEquals(
+          new BigDecimal("99999999999999999999999999999999999999"), resultSet.getBigDecimal(7));
+
+      assertTrue(resultSet.next(), "Expected second row");
+      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Second row, tinyint_col mismatch");
+      assertNull(resultSet.getObject(2));
+      assertAllIntegerGettersInRange(resultSet, 3, 0L, "Second row, smallint_col mismatch");
+      assertNull(resultSet.getObject(4));
+      assertAllIntegerGettersInRange(resultSet, 5, 0L, "Second row, integer_col mismatch");
+      assertNull(resultSet.getObject(6));
+      assertAllIntegerGettersInRange(resultSet, 7, 0L, "Second row, int38_col mismatch");
+
+      assertTrue(resultSet.next(), "Expected third row");
+      assertAllIntegerGettersInRange(resultSet, 1, -128L, "Third row, tinyint_col mismatch");
+      assertAllIntegerGettersInRange(resultSet, 2, -1L, "Third row, byteint_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 3, Short.MIN_VALUE, "Third row, smallint_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 4, Integer.MIN_VALUE, "Third row, int_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 5, Integer.MIN_VALUE, "Third row, integer_col mismatch");
+      assertAllIntegerGettersInRange(
+          resultSet, 6, Long.MIN_VALUE, "Third row, bigint_col mismatch");
+      assertEquals(
+          new BigDecimal("-99999999999999999999999999999999999999"), resultSet.getBigDecimal(7));
+
+      assertFalse(resultSet.next(), "Expected exactly three rows");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intTypeSynonyms")
+  public void shouldSelectLargeResultSetFromTableForIntAndSynonyms(String typeName)
+      throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+    ensureDatabaseAndSchema(connection);
+    // And Table with <type> column exists with 50000 sequential values
+    String tableName = createTempTable(connection, "col " + typeName);
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::"
+            + typeName
+            + " FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
+
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
+      // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
+      int expected = 0;
+      while (resultSet.next()) {
+        assertAllIntegerGettersInRange(
+            resultSet, 1, expected, "Value mismatch for " + typeName + ", row " + expected);
+        expected++;
+      }
+      assertEquals(50000, expected, "Unexpected row count for " + typeName);
+    }
+  }
+
+  private static void assertSingleRow(
+      Connection connection, String sql, List<Long> expected, String typeName) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+      for (int i = 0; i < expected.size(); i++) {
+        assertAllIntegerGettersInRange(
+            resultSet, i + 1, expected.get(i), "Column mismatch for " + typeName);
+      }
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+    }
+  }
+
+  private static String createTempTable(Connection connection, String columns) throws Exception {
+    String tableName = "ud_int_" + UUID.randomUUID().toString().replace("-", "");
+    execute(connection, "CREATE TEMPORARY TABLE " + tableName + " (" + columns + ")");
+    return tableName;
+  }
+
+  private static void execute(Connection connection, String sql) throws Exception {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    }
+  }
+
+  private static void assertAllIntegerGettersInRange(
+      ResultSet resultSet, int columnIndex, long expected, String message) throws Exception {
+    assertEquals(
+        BigDecimal.valueOf(expected),
+        resultSet.getBigDecimal(columnIndex),
+        message + " (getBigDecimal)");
+    assertEquals(expected, resultSet.getLong(columnIndex), message + " (getLong)");
+    if (expected >= Integer.MIN_VALUE && expected <= Integer.MAX_VALUE) {
+      assertEquals((int) expected, resultSet.getInt(columnIndex), message + " (getInt)");
+    }
+    if (expected >= Short.MIN_VALUE && expected <= Short.MAX_VALUE) {
+      assertEquals((short) expected, resultSet.getShort(columnIndex), message + " (getShort)");
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -181,7 +181,6 @@ public class IntTests extends SnowflakeIntegrationTestBase {
   public void shouldSelectIntegersFromTableForIntAndSynonyms(String typeName) throws Exception {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
-    ensureDatabaseAndSchema(connection);
     // And Table with <type> column exists with values [0, 1, -1, 100]
     String tableName = createTempTable(connection, "col " + typeName);
     execute(connection, "INSERT INTO " + tableName + " VALUES (0), (1), (-1), (100)");
@@ -205,7 +204,6 @@ public class IntTests extends SnowflakeIntegrationTestBase {
   public void shouldSelectCornerCaseValuesFromTableForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
-    ensureDatabaseAndSchema(connection);
     // And Table with columns (tinyint_col TINYINT, byteint_col BYTEINT, smallint_col SMALLINT,
     // int_col INT, integer_col INTEGER, bigint_col BIGINT, int38_col INT) exists
     String tableName =
@@ -286,7 +284,6 @@ public class IntTests extends SnowflakeIntegrationTestBase {
       throws Exception {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
-    ensureDatabaseAndSchema(connection);
     // And Table with <type> column exists with 50000 sequential values
     String tableName = createTempTable(connection, "col " + typeName);
     execute(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -3,322 +3,250 @@ package net.snowflake.jdbc.e2e.types;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 public class IntTests extends SnowflakeIntegrationTestBase {
-  static Stream<String> intTypeSynonyms() {
-    return Stream.of("INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "BYTEINT");
-  }
+  private static final String INT_TYPE = "INT";
+  private static final String SMALL_INT = "-99999999999999999999999999999999999999";
+  private static final String LARGE_INT = "99999999999999999999999999999999999999";
+  private static final int LARGE_RESULT_SET_SIZE = 50_000;
 
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldCastIntegerValuesToAppropriateTypeForIntAndSynonyms(String typeName)
-      throws Exception {
+  @Test
+  public void shouldCastIntegerValuesToAppropriateTypeForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
     // When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
+    // Then All values should be returned as appropriate type
+    // And No precision loss should occur
+    Connection connection = getDefaultConnection();
     String sql =
-        String.format("SELECT 0::%1$s, 1000000::%1$s, 9223372036854775807::%1$s", typeName);
+        String.format("SELECT 0::%1$s, 1000000::%1$s, 9223372036854775807::%1$s", INT_TYPE);
     try (Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
-
-      // Then All values should be returned as appropriate type
-      // And No precision loss should occur
-      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + typeName);
-      assertAllIntegerGettersInRange(resultSet, 2, 1_000_000L, "Column 2 mismatch for " + typeName);
+      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + INT_TYPE);
+      assertAllIntegerGettersInRange(resultSet, 2, 1_000_000L, "Column 2 mismatch for " + INT_TYPE);
       assertAllIntegerGettersInRange(
-          resultSet, 3, Long.MAX_VALUE, "Column 3 mismatch for " + typeName);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldSelectIntegerLiteralsForIntAndSynonyms(String typeName) throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // When Query "SELECT 0::<type>, 1::<type>, -1::<type>, 42::<type>" is executed
-    String sql = String.format("SELECT 0::%1$s, 1::%1$s, -1::%1$s, 42::%1$s", typeName);
-
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      // Then Result should contain integers [0, 1, -1, 42]
-      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
-      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + typeName);
-      assertAllIntegerGettersInRange(resultSet, 2, 1L, "Column 2 mismatch for " + typeName);
-      assertAllIntegerGettersInRange(resultSet, 3, -1L, "Column 3 mismatch for " + typeName);
-      assertAllIntegerGettersInRange(resultSet, 4, 42L, "Column 4 mismatch for " + typeName);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldHandleIntegerBoundaryValuesForIntAndSynonyms(String typeName) throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // When Query "SELECT -128::<type>, 127::<type>, 255::<type>" is executed
-    // Then Result should contain integers [-128, 127, 255]
-    assertSingleRow(
-        connection,
-        String.format("SELECT -128::%1$s, 127::%1$s, 255::%1$s", typeName),
-        Arrays.asList(-128L, 127L, 255L),
-        typeName);
-
-    // When Query "SELECT -32768::<type>, 32767::<type>, 65535::<type>" is executed
-    // Then Result should contain integers [-32768, 32767, 65535]
-    assertSingleRow(
-        connection,
-        String.format("SELECT -32768::%1$s, 32767::%1$s, 65535::%1$s", typeName),
-        Arrays.asList((long) Short.MIN_VALUE, (long) Short.MAX_VALUE, 65535L),
-        typeName);
-
-    // When Query "SELECT -2147483648::<type>, 2147483647::<type>, 4294967295::<type>" is executed
-    // Then Result should contain integers [-2147483648, 2147483647, 4294967295]
-    assertSingleRow(
-        connection,
-        String.format("SELECT -2147483648::%1$s, 2147483647::%1$s, 4294967295::%1$s", typeName),
-        Arrays.asList((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, 4294967295L),
-        typeName);
-
-    // When Query "SELECT -9223372036854775808::<type>, 9223372036854775807::<type>" is executed
-    // Then Result should contain integers [-9223372036854775808, 9223372036854775807]
-    assertSingleRow(
-        connection,
-        String.format("SELECT -9223372036854775808::%1$s, 9223372036854775807::%1$s", typeName),
-        Arrays.asList(Long.MIN_VALUE, Long.MAX_VALUE),
-        typeName);
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldHandleLargeIntegerValuesForIntAndSynonyms(String typeName) throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // When Query "SELECT -99999999999999999999999999999999999999::<type>,
-    // 99999999999999999999999999999999999999::<type>" is executed
-    String sql =
-        String.format(
-            "SELECT -99999999999999999999999999999999999999::%1$s, 99999999999999999999999999999999999999::%1$s",
-            typeName);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      // Then Result should contain integers [-99999999999999999999999999999999999999,
-      // 99999999999999999999999999999999999999]
-      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
-      assertEquals(
-          new BigDecimal("-99999999999999999999999999999999999999"),
-          resultSet.getBigDecimal(1),
-          "Column 1 mismatch for " + typeName);
-      assertEquals(
-          new BigDecimal("99999999999999999999999999999999999999"),
-          resultSet.getBigDecimal(2),
-          "Column 2 mismatch for " + typeName);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldHandleNULLValuesForIntAndSynonyms(String typeName) throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
-    String sql = String.format("SELECT NULL::%1$s, 42::%1$s, NULL::%1$s", typeName);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      // Then Result should contain [NULL, 42, NULL]
-      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
-      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + typeName);
-      assertEquals(
-          new BigDecimal("42"), resultSet.getBigDecimal(2), "Column 2 mismatch for " + typeName);
-      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + typeName);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldDownloadLargeResultSetWithMultipleChunksForIntAndSynonyms(String typeName)
-      throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY
-    // id" is executed
-    String sql =
-        String.format(
-            "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id",
-            typeName);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
-      int expected = 0;
-      while (resultSet.next()) {
-        assertAllIntegerGettersInRange(
-            resultSet, 1, expected, "Value mismatch for " + typeName + ", row " + expected);
-        expected++;
-      }
-      assertEquals(50000, expected, "Unexpected row count for " + typeName);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldSelectIntegersFromTableForIntAndSynonyms(String typeName) throws Exception {
-    // Given Snowflake client is logged in
-    Connection connection = getDefaultConnection();
-    // And Table with <type> column exists with values [0, 1, -1, 100]
-    String tableName = createTempTable(connection, "col " + typeName);
-    execute(connection, "INSERT INTO " + tableName + " VALUES (0), (1), (-1), (100)");
-
-    // When Query "SELECT * FROM int_table ORDER BY col" is executed
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      // Then Result should contain integers [-1, 0, 1, 100]
-      List<Long> expectedValues = Arrays.asList(-1L, 0L, 1L, 100L);
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertTrue(resultSet.next(), "Missing row " + i + " for " + typeName);
-        assertAllIntegerGettersInRange(
-            resultSet, 1, expectedValues.get(i), "Value mismatch for " + typeName + ", row " + i);
-      }
-      assertFalse(resultSet.next(), "Expected exactly four rows for " + typeName);
+          resultSet, 3, Long.MAX_VALUE, "Column 3 mismatch for " + INT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
     }
   }
 
   @Test
-  public void shouldSelectCornerCaseValuesFromTableForIntAndSynonyms() throws Exception {
+  public void shouldSelectIntegerValuesForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    // When Query "SELECT <query_values>" is executed
+    // Then Result should contain integers <expected_values>
     Connection connection = getDefaultConnection();
-    // And Table with columns (tinyint_col TINYINT, byteint_col BYTEINT, smallint_col SMALLINT,
-    // int_col INT, integer_col INTEGER, bigint_col BIGINT, int38_col INT) exists
-    String tableName =
-        createTempTable(
-            connection,
-            "tinyint_col TINYINT, byteint_col BYTEINT, smallint_col SMALLINT, int_col INT, "
-                + "integer_col INTEGER, bigint_col BIGINT, int38_col INT");
-
-    // And Row with positive values (127, 255, 32767, 2147483647, 2147483647, 9223372036854775807,
-    // 99999999999999999999999999999999999999) is inserted
-    execute(
+    assertSingleRow(connection, String.format("SELECT 0::%1$s", INT_TYPE), Arrays.asList(0L));
+    assertSingleRow(
         connection,
-        "INSERT INTO "
-            + tableName
-            + " VALUES (127, 255, 32767, 2147483647, 2147483647, 9223372036854775807, 99999999999999999999999999999999999999)");
-
-    // And Row with negative values (-128, -1, -32768, -2147483648, -2147483648,
-    // -9223372036854775808, -99999999999999999999999999999999999999) is inserted
-    execute(
+        String.format("SELECT -128::%1$s, 127::%1$s, 255::%1$s", INT_TYPE),
+        Arrays.asList(-128L, 127L, 255L));
+    assertSingleRow(
         connection,
-        "INSERT INTO "
-            + tableName
-            + " VALUES (-128, -1, -32768, -2147483648, -2147483648, -9223372036854775808, -99999999999999999999999999999999999999)");
+        String.format("SELECT -32768::%1$s, 32767::%1$s, 65535::%1$s", INT_TYPE),
+        Arrays.asList((long) Short.MIN_VALUE, (long) Short.MAX_VALUE, 65535L));
+    assertSingleRow(
+        connection,
+        String.format("SELECT -2147483648::%1$s, 2147483647::%1$s, 4294967295::%1$s", INT_TYPE),
+        Arrays.asList((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, 4294967295L));
+    assertSingleRow(
+        connection,
+        String.format("SELECT -9223372036854775808::%1$s, 9223372036854775807::%1$s", INT_TYPE),
+        Arrays.asList(Long.MIN_VALUE, Long.MAX_VALUE));
+  }
 
-    // And Row with zeroes and nulls (0, NULL, 0, NULL, 0, NULL, 0) is inserted
-    execute(connection, "INSERT INTO " + tableName + " VALUES (0, NULL, 0, NULL, 0, NULL, 0)");
-
-    // When Query "SELECT * FROM corner_case_table" is executed
+  @Test
+  public void shouldHandleLargeIntegerValuesForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT -99999999999999999999999999999999999999::<type>,
+    // 99999999999999999999999999999999999999::<type>" is executed
+    // Then Result should contain integers [-99999999999999999999999999999999999999,
+    // 99999999999999999999999999999999999999]
+    Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT %1$s::%3$s, %2$s::%3$s", SMALL_INT, LARGE_INT, INT_TYPE);
     try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY tinyint_col DESC")) {
-      // Then Result should contain 3 rows with expected corner case values for all int type
-      // synonyms
-      assertTrue(resultSet.next(), "Expected first row");
-      assertAllIntegerGettersInRange(resultSet, 1, 127L, "First row, tinyint_col mismatch");
-      assertAllIntegerGettersInRange(resultSet, 2, 255L, "First row, byteint_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 3, Short.MAX_VALUE, "First row, smallint_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 4, Integer.MAX_VALUE, "First row, int_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 5, Integer.MAX_VALUE, "First row, integer_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 6, Long.MAX_VALUE, "First row, bigint_col mismatch");
-      assertEquals(
-          new BigDecimal("99999999999999999999999999999999999999"), resultSet.getBigDecimal(7));
-
-      assertTrue(resultSet.next(), "Expected second row");
-      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Second row, tinyint_col mismatch");
-      assertNull(resultSet.getObject(2));
-      assertAllIntegerGettersInRange(resultSet, 3, 0L, "Second row, smallint_col mismatch");
-      assertNull(resultSet.getObject(4));
-      assertAllIntegerGettersInRange(resultSet, 5, 0L, "Second row, integer_col mismatch");
-      assertNull(resultSet.getObject(6));
-      assertAllIntegerGettersInRange(resultSet, 7, 0L, "Second row, int38_col mismatch");
-
-      assertTrue(resultSet.next(), "Expected third row");
-      assertAllIntegerGettersInRange(resultSet, 1, -128L, "Third row, tinyint_col mismatch");
-      assertAllIntegerGettersInRange(resultSet, 2, -1L, "Third row, byteint_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 3, Short.MIN_VALUE, "Third row, smallint_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 4, Integer.MIN_VALUE, "Third row, int_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 5, Integer.MIN_VALUE, "Third row, integer_col mismatch");
-      assertAllIntegerGettersInRange(
-          resultSet, 6, Long.MIN_VALUE, "Third row, bigint_col mismatch");
-      assertEquals(
-          new BigDecimal("-99999999999999999999999999999999999999"), resultSet.getBigDecimal(7));
-
-      assertFalse(resultSet.next(), "Expected exactly three rows");
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+      assertInt38NumberGetters(resultSet, 1, SMALL_INT, "Column 1 mismatch for " + INT_TYPE);
+      assertInt38NumberGetters(resultSet, 2, LARGE_INT, "Column 2 mismatch for " + INT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("intTypeSynonyms")
-  public void shouldSelectLargeResultSetFromTableForIntAndSynonyms(String typeName)
-      throws Exception {
+  @Test
+  public void shouldHandleNULLValuesForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    // When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
+    // Then Result should contain [NULL, 42, NULL]
     Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT NULL::%1$s, 42::%1$s, NULL::%1$s", INT_TYPE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + INT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + INT_TYPE);
+      assertEquals(
+          0L, resultSet.getLong(1), "Column 1 getLong should return 0 for NULL " + INT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 1 getLong should set wasNull() for " + INT_TYPE);
+      assertAllIntegerGettersInRange(resultSet, 2, 42L, "Column 2 mismatch for " + INT_TYPE);
+      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + INT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + INT_TYPE);
+      assertEquals(
+          0L, resultSet.getLong(3), "Column 3 getLong should return 0 for NULL " + INT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 3 getLong should set wasNull() for " + INT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldDownloadLargeResultSetWithMultipleChunksForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY
+    // id" is executed
+    // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
+    Connection connection = getDefaultConnection();
+    String sql =
+        String.format(
+            "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => %2$d)) v ORDER BY id",
+            INT_TYPE, LARGE_RESULT_SET_SIZE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      int expected = 0;
+      while (resultSet.next()) {
+        assertAllIntegerGettersInRange(
+            resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + expected);
+        expected++;
+      }
+      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + INT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldSelectValuesFromTableForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with values <insert_values>
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    // Then Result should contain integers <expected_values>
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + INT_TYPE);
+
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES (0), (1), (127), (255), (32767), (65535), (2147483647), (4294967295), (9223372036854775807)");
+    assertSingleColumnRows(
+        connection,
+        tableName,
+        Arrays.asList(
+            0L,
+            1L,
+            127L,
+            255L,
+            (long) Short.MAX_VALUE,
+            65535L,
+            (long) Integer.MAX_VALUE,
+            4294967295L,
+            Long.MAX_VALUE));
+
+    execute(connection, "TRUNCATE TABLE " + tableName);
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES (-1), (-128), (-32768), (-2147483648), (-9223372036854775808)");
+    assertSingleColumnRows(
+        connection,
+        tableName,
+        Arrays.asList(
+            Long.MIN_VALUE, (long) Integer.MIN_VALUE, (long) Short.MIN_VALUE, -128L, -1L));
+
+    execute(connection, "TRUNCATE TABLE " + tableName);
+    execute(connection, "INSERT INTO " + tableName + " VALUES (0), (NULL), (42)");
+    assertSingleColumnRows(connection, tableName, Arrays.asList(0L, 42L, null));
+  }
+
+  @Test
+  public void shouldSelectLargeIntegerValuesFromTableForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with values [-99999999999999999999999999999999999999,
+    // 99999999999999999999999999999999999999]
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    // Then Result should contain integers [-99999999999999999999999999999999999999,
+    // 99999999999999999999999999999999999999]
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + INT_TYPE);
+    execute(
+        connection,
+        "INSERT INTO " + tableName + " VALUES (" + SMALL_INT + "), (" + LARGE_INT + ")");
+
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
+      assertTrue(resultSet.next(), "Expected first row for type: " + INT_TYPE);
+      assertEquals(new BigDecimal(SMALL_INT), resultSet.getBigDecimal(1));
+      assertFalse(resultSet.wasNull(), "First row should not be NULL for " + INT_TYPE);
+      assertTrue(resultSet.next(), "Expected second row for type: " + INT_TYPE);
+      assertEquals(new BigDecimal(LARGE_INT), resultSet.getBigDecimal(1));
+      assertFalse(resultSet.wasNull(), "Second row should not be NULL for " + INT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly two rows for type: " + INT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldSelectLargeResultSetFromTableForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
     // And Table with <type> column exists with 50000 sequential values
-    String tableName = createTempTable(connection, "col " + typeName);
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + INT_TYPE);
     execute(
         connection,
         "INSERT INTO "
             + tableName
             + " SELECT (ROW_NUMBER() OVER (ORDER BY seq8()) - 1)::"
-            + typeName
-            + " FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
+            + INT_TYPE
+            + " FROM TABLE(GENERATOR(ROWCOUNT => "
+            + LARGE_RESULT_SET_SIZE
+            + "))");
 
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
     try (Statement statement = connection.createStatement();
         ResultSet resultSet =
             statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
       int expected = 0;
       while (resultSet.next()) {
         assertAllIntegerGettersInRange(
-            resultSet, 1, expected, "Value mismatch for " + typeName + ", row " + expected);
+            resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + expected);
         expected++;
       }
-      assertEquals(50000, expected, "Unexpected row count for " + typeName);
+      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + INT_TYPE);
     }
   }
 
-  private static void assertSingleRow(
-      Connection connection, String sql, List<Long> expected, String typeName) throws Exception {
+  private static void assertSingleRow(Connection connection, String sql, List<Long> expected)
+      throws Exception {
     try (Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + typeName);
+      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
       for (int i = 0; i < expected.size(); i++) {
         assertAllIntegerGettersInRange(
-            resultSet, i + 1, expected.get(i), "Column mismatch for " + typeName);
+            resultSet, i + 1, expected.get(i), "Column mismatch for " + INT_TYPE);
       }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + typeName);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
     }
   }
 
@@ -334,18 +262,74 @@ public class IntTests extends SnowflakeIntegrationTestBase {
     }
   }
 
+  private static void assertSingleColumnRows(
+      Connection connection, String tableName, List<Long> expectedValues) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
+      for (int i = 0; i < expectedValues.size(); i++) {
+        assertTrue(resultSet.next(), "Missing row " + i + " for " + INT_TYPE);
+        Long expected = expectedValues.get(i);
+        if (expected == null) {
+          assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + INT_TYPE);
+          assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
+          assertEquals(0L, resultSet.getLong(1), "Expected getLong=0 for NULL at row " + i);
+          assertTrue(resultSet.wasNull(), "Expected wasNull() after getLong NULL at row " + i);
+        } else {
+          assertAllIntegerGettersInRange(
+              resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + i);
+        }
+      }
+      assertFalse(resultSet.next(), "Unexpected extra rows for " + INT_TYPE);
+    }
+  }
+
   private static void assertAllIntegerGettersInRange(
       ResultSet resultSet, int columnIndex, long expected, String message) throws Exception {
-    assertEquals(
-        BigDecimal.valueOf(expected),
-        resultSet.getBigDecimal(columnIndex),
-        message + " (getBigDecimal)");
     assertEquals(expected, resultSet.getLong(columnIndex), message + " (getLong)");
+    assertFalse(resultSet.wasNull(), message + " (getLong should not be NULL)");
+
     if (expected >= Integer.MIN_VALUE && expected <= Integer.MAX_VALUE) {
       assertEquals((int) expected, resultSet.getInt(columnIndex), message + " (getInt)");
+      assertFalse(resultSet.wasNull(), message + " (getInt should not be NULL)");
+    } else {
+      assertThrows(
+          SQLException.class,
+          () -> resultSet.getInt(columnIndex),
+          message + " (getInt should fail on overflow)");
+      assertFalse(resultSet.wasNull(), message + " (getInt overflow should not set NULL)");
     }
+
     if (expected >= Short.MIN_VALUE && expected <= Short.MAX_VALUE) {
       assertEquals((short) expected, resultSet.getShort(columnIndex), message + " (getShort)");
+      assertFalse(resultSet.wasNull(), message + " (getShort should not be NULL)");
+    } else {
+      assertThrows(
+          SQLException.class,
+          () -> resultSet.getShort(columnIndex),
+          message + " (getShort should fail on overflow)");
+      assertFalse(resultSet.wasNull(), message + " (getShort overflow should not set NULL)");
     }
+  }
+
+  private static void assertInt38NumberGetters(
+      ResultSet resultSet, int columnIndex, String expected, String message) throws Exception {
+    BigDecimal expectedValue = new BigDecimal(expected);
+    assertEquals(expectedValue, resultSet.getBigDecimal(columnIndex), message + " (getBigDecimal)");
+    assertEquals(expectedValue, resultSet.getObject(columnIndex), message + " (getObject)");
+    assertEquals(expected, resultSet.getString(columnIndex), message + " (getString)");
+
+    assertThrows(
+        SQLException.class,
+        () -> resultSet.getLong(columnIndex),
+        message + " (getLong should fail on overflow)");
+    assertThrows(
+        SQLException.class,
+        () -> resultSet.getInt(columnIndex),
+        message + " (getInt should fail on overflow)");
+    assertThrows(
+        SQLException.class,
+        () -> resultSet.getShort(columnIndex),
+        message + " (getShort should fail on overflow)");
   }
 }

--- a/tests/definitions/shared/types/int.feature
+++ b/tests/definitions/shared/types/int.feature
@@ -1,11 +1,11 @@
-@python @odbc @core_not_needed
+@python @odbc @jdbc @core_not_needed
 Feature: INT type support
 
   # =========================================================================== #
   #                               Type casting                                  #
   # =========================================================================== #
 
-  @python_e2e @odbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should cast integer values to appropriate type for int and synonyms
     # Python: Values should be cast to 'int' type
     Given Snowflake client is logged in
@@ -17,7 +17,7 @@ Feature: INT type support
   #                     SELECT with literals (no tables)                        #
   # =========================================================================== #
 
-  @python_e2e @odbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario Outline: should select integer <values> for int and synonyms
     Given Snowflake client is logged in
     When Query "SELECT <query_values>" is executed
@@ -31,19 +31,19 @@ Feature: INT type support
       | int        | -2147483648::<type>, 2147483647::<type>, 4294967295::<type>         | -2147483648, 2147483647, 4294967295          |
       | bigint     | -9223372036854775808::<type>, 9223372036854775807::<type>           | -9223372036854775808, 9223372036854775807    |
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle large integer values for int and synonyms
     Given Snowflake client is logged in
     When Query "SELECT -99999999999999999999999999999999999999::<type>, 99999999999999999999999999999999999999::<type>" is executed
     Then Result should contain integers [-99999999999999999999999999999999999999, 99999999999999999999999999999999999999]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle NULL values for int and synonyms
     Given Snowflake client is logged in
     When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
     Then Result should contain [NULL, 42, NULL]
 
-  @python_e2e @odbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should download large result set with multiple chunks for int and synonyms
     Given Snowflake client is logged in
     When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY id" is executed
@@ -53,7 +53,7 @@ Feature: INT type support
   #                             Table operations                                #
   # =========================================================================== #
 
-  @python_e2e @odbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario Outline: should select <values> from table for int and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values <insert_values>
@@ -66,14 +66,14 @@ Feature: INT type support
       | negative    | -1, -128, -32768, -2147483648, -9223372036854775808                       | -9223372036854775808, -2147483648, -32768, -128, -1                           |
       | null        | 0, NULL, 42                                                               | 0, 42, NULL                                                                   |
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select large integer values from table for int and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [-99999999999999999999999999999999999999, 99999999999999999999999999999999999999]
     When Query "SELECT * FROM <table> ORDER BY col" is executed
     Then Result should contain integers [-99999999999999999999999999999999999999, 99999999999999999999999999999999999999]
 
-  @python_e2e @odbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select large result set from table for int and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with 50000 sequential values

--- a/tests/tests_format_validator/src/behavior_differences_processor.rs
+++ b/tests/tests_format_validator/src/behavior_differences_processor.rs
@@ -111,7 +111,8 @@ impl BehaviorDifferencesProcessor {
                 .into_iter()
                 .filter_map(|e| e.ok())
                 .filter(|e| {
-                    e.path().is_file() && e.path().to_string_lossy().ends_with(&ext[1..]) // Remove * from *.cpp
+                    e.path().is_file() && e.path().to_string_lossy().ends_with(&ext[1..])
+                    // Remove * from *.cpp
                 })
             {
                 test_files.push(entry.path().to_path_buf());

--- a/tests/tests_format_validator/src/driver_handlers/jdbc_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/jdbc_handler.rs
@@ -63,8 +63,8 @@ impl BaseDriverHandler for JdbcHandler {
         for (line_num, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
 
-            // Look for Java test methods: @Test followed by public void methodName()
-            if trimmed.starts_with("@Test") {
+            // Look for Java test methods: @Test/@ParameterizedTest followed by method declaration
+            if trimmed.starts_with("@Test") || trimmed.starts_with("@ParameterizedTest") {
                 // Look for the method declaration in the next few lines
                 for j in (line_num + 1)..std::cmp::min(line_num + 5, lines.len()) {
                     let method_line = lines[j].trim();

--- a/tests/tests_format_validator/src/step_finder.rs
+++ b/tests/tests_format_validator/src/step_finder.rs
@@ -112,7 +112,10 @@ impl MethodBoundaryFinder {
         let catch2_regex = Regex::new(r#"TEST_CASE\s*\(\s*"([^"]+)""#)?;
         // Rust: support optional async before fn
         let fn_regex = Regex::new(r"(?:async\s+)?fn\s+(\w+)")?;
-        let method_regex = Regex::new(r"(?:public\s+)?(?:void\s+)?(\w+)\s*\(")?;
+        // Match Java method declarations (not annotation lines like @MethodSource(...))
+        let method_regex = Regex::new(
+            r"^(?:public|protected|private)?\s*(?:static\s+)?(?:async\s+)?(?:final\s+)?(?:void|Task(?:<[^>]+>)?)\s+(\w+)\s*\(",
+        )?;
         let rust_test_attr_regex = Regex::new(r"^#\[\s*(?:[a-zA-Z0-9_]+::)?test(?:\(.*\))?\s*\]$")?;
 
         for (i, line) in lines.iter().enumerate() {
@@ -173,8 +176,8 @@ impl MethodBoundaryFinder {
                     }
                 }
                 "@Test" => {
-                    // Java: @Test followed by method declaration
-                    if trimmed == "@Test" {
+                    // Java: @Test/@ParameterizedTest followed by method declaration
+                    if trimmed == "@Test" || trimmed == "@ParameterizedTest" {
                         // Look ahead for the method declaration
                         for (j, method_line) in lines.iter().enumerate().skip(i + 1).take(4) {
                             if let Some(captures) = method_regex.captures(method_line.trim()) {
@@ -233,6 +236,7 @@ impl MethodBoundaryFinder {
             }
             // Look for test annotation
             else if trimmed == self.config.test_annotation
+                || (self.config.test_annotation == "@Test" && trimmed == "@ParameterizedTest")
                 || (self.config.test_annotation == "#[test]"
                     && (trimmed.starts_with("#[rstest") || trimmed.starts_with("#[test_case")))
                 || (self.config.test_annotation.contains("pytest")
@@ -915,5 +919,29 @@ def test_second():
         // Should NOT include the second test
         assert!(!method_content.contains("def test_second"));
         assert!(!method_content.contains("y = 2"));
+    }
+
+    #[test]
+    fn test_jdbc_parameterized_test_with_method_source_extracts_real_method_name() {
+        let finder = MethodBoundaryFinder::new(LanguageConfig::jdbc());
+        let content = r#"
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class IntTests {
+    @ParameterizedTest
+    @MethodSource("intTypeSynonyms")
+    public void shouldSelectIntegerLiteralsForIntAndSynonyms(String typeName) throws Exception {
+        // Given Snowflake client is logged in
+    }
+}
+"#;
+
+        let methods = finder
+            .find_all_test_methods_with_lines(content)
+            .expect("Should parse methods");
+
+        assert_eq!(methods.len(), 1);
+        assert_eq!(methods[0].0, "shouldSelectIntegerLiteralsForIntAndSynonyms");
     }
 }

--- a/tests/tests_format_validator/src/test_discovery.rs
+++ b/tests/tests_format_validator/src/test_discovery.rs
@@ -384,13 +384,13 @@ impl TestDiscovery {
                 let base_path = if let Some(subdir) = subdir {
                     self.workspace_root
                         .join(format!(
-                            "jdbc/src/test/java/com/snowflake/jdbc/{}",
+                            "jdbc/src/test/java/net/snowflake/jdbc/{}",
                             test_dir
                         ))
                         .join(subdir)
                 } else {
                     self.workspace_root.join(format!(
-                        "jdbc/src/test/java/com/snowflake/jdbc/{}",
+                        "jdbc/src/test/java/net/snowflake/jdbc/{}",
                         test_dir
                     ))
                 };
@@ -408,9 +408,9 @@ impl TestDiscovery {
                     // Test workspace paths (for unit tests)
                     simple_base_path.join(format!("{}Test.java", pascal_name)),
                     simple_base_path.join(format!("{}Tests.java", pascal_name)),
-                    // jdbc/src/test/java/com/snowflake/jdbc/[e2e|integration]/[subdir/]FeatureNameTest.java
+                    // jdbc/src/test/java/net/snowflake/jdbc/[e2e|integration]/[subdir/]FeatureNameTest.java
                     base_path.join(format!("{}Test.java", pascal_name)),
-                    // jdbc/src/test/java/com/snowflake/jdbc/[e2e|integration]/[subdir/]FeatureNameTests.java
+                    // jdbc/src/test/java/net/snowflake/jdbc/[e2e|integration]/[subdir/]FeatureNameTests.java
                     base_path.join(format!("{}Tests.java", pascal_name)),
                 ]
             }

--- a/tests/tests_format_validator/src/validator.rs
+++ b/tests/tests_format_validator/src/validator.rs
@@ -464,7 +464,7 @@ impl GherkinValidator {
             Language::Rust => vec![self._workspace_root.join("sf_core/tests/e2e")],
             Language::Jdbc => vec![
                 self._workspace_root
-                    .join("jdbc/src/test/java/com/snowflake/jdbc/e2e"),
+                    .join("jdbc/src/test/java/net/snowflake/jdbc/e2e"),
             ],
             Language::Odbc => vec![self._workspace_root.join("odbc_tests/tests/e2e")],
             Language::Python => vec![self._workspace_root.join("python/tests/e2e")],
@@ -576,8 +576,9 @@ impl GherkinValidator {
                 }
             }
             Language::Jdbc => {
-                let test_regex =
-                    Regex::new(r"@Test\s*(?:\n\s*)?(?:public\s+)?(?:void\s+)?(\w+)\s*\(")?;
+                let test_regex = Regex::new(
+                    r"@(?:Test|ParameterizedTest)\b(?:\s*\n\s*@\w+(?:\([^)]*\))?)*\s*\n\s*(?:public|protected|private)?\s*(?:static\s+)?(?:void|Task(?:<[^>]+>)?)\s+(\w+)\s*\(",
+                )?;
                 for captures in test_regex.captures_iter(content) {
                     methods.push(captures[1].to_string());
                 }

--- a/tests/tests_format_validator/tests/validator_tests.rs
+++ b/tests/tests_format_validator/tests/validator_tests.rs
@@ -1361,7 +1361,7 @@ impl TestWorkspace {
     fn create_java_test(&self, subdir: &str, name: &str, content: &str) -> Result<()> {
         let test_path = self
             .workspace_root
-            .join("jdbc/src/test/java/com/snowflake/jdbc/integration")
+            .join("jdbc/src/test/java/net/snowflake/jdbc/integration")
             .join(subdir)
             .join(format!("{}Test.java", name));
         fs::create_dir_all(test_path.parent().unwrap())?;


### PR DESCRIPTION
## Summary
- Adds a new JDBC E2E test suite for INT type coverage in `IntegerFeatureTest`, boundary values, NULL handling, table-based cases, and large-result scenarios.
- Does not implement parameter binding tests as they are not supported in JDBC yet
- Updates shared Gherkin INT feature definitions to include `@jdbc` / `@jdbc_e2e` tags so JDBC participates in applicable integer scenarios.
- Enables JDBC package discovery in `jdbc/build.gradle` reference tests and introduces reusable default-connection lifecycle setup in `SnowflakeIntegrationTestBase`.
- Fixes tests format validator JDBC path assumptions from `com/snowflake/jdbc` to `net/snowflake/jdbc` in discovery, validation, and validator unit tests.
