### PR TITLE
SNOW-3022768: ODBC API tests for catalog functions

### DIFF
--- a/odbc_tests/common/CMakeLists.txt
+++ b/odbc_tests/common/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(common STATIC
     src/test_setup.cpp
     src/compatibility.cpp
     src/get_diag_rec.cpp
+    src/query_helpers.cpp
     src/ODBCConfig.cpp
     src/DataSourceConfig.cpp
     src/ConfigInstallation.cpp
@@ -17,6 +18,7 @@ add_library(common STATIC
     include/get_data.hpp
     include/MetaOfSqlCTypes.hpp
     include/get_diag_rec.hpp
+    include/query_helpers.hpp
     include/compatibility.hpp
     include/ODBCConfig.hpp
     include/ODBCFixtures.hpp

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -13,6 +13,7 @@
 #include "HandleWrapper.hpp"
 #include "ODBCConfig.hpp"
 #include "compatibility.hpp"
+#include "odbc_cast.hpp"
 
 // ============================================================================
 // Base Fixtures (Parameterized via Constructor)
@@ -109,8 +110,7 @@ class StmtFixture : public DbcFixture {
     SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
     const std::string dsn = dsn_name();
-    SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                               nullptr, 0, nullptr, 0);
+    SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE(ret == SQL_SUCCESS);
 
     ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -1,30 +1,88 @@
 #ifndef SCHEMA_HPP
 #define SCHEMA_HPP
 
+#include <sql.h>
+#include <sqlext.h>
+
 #include <chrono>
+#include <functional>
 #include <random>
+#include <stdexcept>
 #include <string>
 
 #include "Connection.hpp"
 
 class Schema {
  public:
-  Schema(Connection& conn, const std::string& schema_name) : conn(conn), schema_name(schema_name) {
-    conn.execute("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    conn.execute("USE SCHEMA " + schema_name);
+  Schema(Connection& conn, const std::string& schema_name)
+      : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
+    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
+    execute_fn("USE SCHEMA " + schema_name);
   }
 
-  static Schema use_random_schema(Connection& conn) {
-    std::random_device rd;
-    std::mt19937 gen(std::chrono::steady_clock::now().time_since_epoch().count());
-    const std::string schema_name = "schema_" + std::to_string(gen());
-    return Schema(conn, schema_name);
+  Schema(const SQLHDBC dbc, const std::string& schema_name)
+      : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
+    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
+    execute_fn("USE SCHEMA " + schema_name);
   }
 
-  ~Schema() { conn.execute("DROP SCHEMA IF EXISTS " + schema_name); }
+  static Schema use_random_schema(Connection& conn) { return Schema(conn, generate_random_name()); }
+
+  static Schema use_random_schema(const SQLHDBC dbc) { return Schema(dbc, generate_random_name()); }
+
+  const std::string& name() const { return schema_name; }
+
+  ~Schema() {
+    if (execute_fn) {
+      execute_fn("DROP SCHEMA IF EXISTS " + schema_name + " CASCADE");
+    }
+  }
+
+  Schema(const Schema&) = delete;
+  Schema& operator=(const Schema&) = delete;
+
+  Schema(Schema&& other) noexcept : execute_fn(std::move(other.execute_fn)), schema_name(std::move(other.schema_name)) {
+    other.execute_fn = nullptr;
+    other.schema_name.clear();
+  }
+
+  Schema& operator=(Schema&& other) noexcept {
+    if (this != &other) {
+      if (execute_fn) {
+        execute_fn("DROP SCHEMA IF EXISTS " + schema_name + " CASCADE");
+      }
+      execute_fn = std::move(other.execute_fn);
+      schema_name = std::move(other.schema_name);
+      other.execute_fn = nullptr;
+      other.schema_name.clear();
+    }
+    return *this;
+  }
 
  private:
-  Connection& conn;
+  static std::string generate_random_name() {
+    std::mt19937 gen(std::chrono::steady_clock::now().time_since_epoch().count());
+    return "SCHEMA_" + std::to_string(gen());
+  }
+
+  static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {
+    return [dbc](const std::string& sql) {
+      SQLHSTMT stmt = SQL_NULL_HSTMT;
+      SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+      if (!SQL_SUCCEEDED(ret)) {
+        throw std::runtime_error("Schema: SQLAllocHandle(SQL_HANDLE_STMT) failed for: " + sql);
+      }
+      ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>(sql.c_str())), SQL_NTS);
+      if (!SQL_SUCCEEDED(ret)) {
+        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+        throw std::runtime_error("Schema: SQLExecDirect failed for: " + sql);
+      }
+      SQLFreeStmt(stmt, SQL_CLOSE);
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    };
+  }
+
+  std::function<void(const std::string&)> execute_fn;
   std::string schema_name;
 };
 

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "Connection.hpp"
+#include "odbc_cast.hpp"
 
 class Schema {
  public:
@@ -72,7 +73,7 @@ class Schema {
       if (!SQL_SUCCEEDED(ret)) {
         throw std::runtime_error("Schema: SQLAllocHandle(SQL_HANDLE_STMT) failed for: " + sql);
       }
-      ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>(sql.c_str())), SQL_NTS);
+      ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
       if (!SQL_SUCCEEDED(ret)) {
         SQLFreeHandle(SQL_HANDLE_STMT, stmt);
         throw std::runtime_error("Schema: SQLExecDirect failed for: " + sql);

--- a/odbc_tests/common/include/odbc_cast.hpp
+++ b/odbc_tests/common/include/odbc_cast.hpp
@@ -1,0 +1,9 @@
+#ifndef ODBC_CAST_HPP
+#define ODBC_CAST_HPP
+
+#include <sql.h>
+
+// Cast a C string literal or char* to SQLCHAR* for ODBC API calls.
+inline SQLCHAR* sqlchar(const char* str) { return reinterpret_cast<SQLCHAR*>(const_cast<char*>(str)); }
+
+#endif  // ODBC_CAST_HPP

--- a/odbc_tests/common/include/query_helpers.hpp
+++ b/odbc_tests/common/include/query_helpers.hpp
@@ -1,0 +1,13 @@
+#ifndef QUERY_HELPERS_HPP
+#define QUERY_HELPERS_HPP
+
+#include <sql.h>
+
+#include <string>
+
+// Query the current database name using a temporary statement on the given connection.
+// Allocates and frees its own statement handle so the caller's statement state is not mutated.
+// Throws std::runtime_error if any ODBC call fails.
+std::string get_current_database(SQLHDBC dbc);
+
+#endif  // QUERY_HELPERS_HPP

--- a/odbc_tests/common/include/test_macros.hpp
+++ b/odbc_tests/common/include/test_macros.hpp
@@ -1,9 +1,47 @@
 #ifndef TEST_MACROS_HPP
 #define TEST_MACROS_HPP
 
+#include <sql.h>
+#include <sqlext.h>
+
+#include <stdexcept>
+#include <string>
+
 #include <catch2/catch_test_macros.hpp>
 
-#include "get_diag_rec.hpp"
+// Query the current database name using a temporary statement on the given connection.
+// Allocates and frees its own statement handle so the caller's statement state is not mutated.
+inline std::string get_current_database(SQLHDBC dbc) {
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+  if (!SQL_SUCCEEDED(ret)) {
+    throw std::runtime_error("get_current_database: SQLAllocHandle(SQL_HANDLE_STMT) failed");
+  }
+
+  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT CURRENT_DATABASE()")), SQL_NTS);
+  if (!SQL_SUCCEEDED(ret)) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLExecDirect failed");
+  }
+
+  ret = SQLFetch(stmt);
+  if (!SQL_SUCCEEDED(ret)) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLFetch failed");
+  }
+
+  char db[256] = {};
+  SQLLEN indicator = 0;
+  ret = SQLGetData(stmt, 1, SQL_C_CHAR, db, sizeof(db), &indicator);
+  if (!SQL_SUCCEEDED(ret) || indicator == SQL_NULL_DATA) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLGetData failed or returned NULL");
+  }
+
+  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  return std::string(db);
+}
 
 // Helper macro to check for expected ODBC error with specific SQLSTATE
 #define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType)                \

--- a/odbc_tests/common/include/test_macros.hpp
+++ b/odbc_tests/common/include/test_macros.hpp
@@ -4,44 +4,9 @@
 #include <sql.h>
 #include <sqlext.h>
 
-#include <stdexcept>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
-
-// Query the current database name using a temporary statement on the given connection.
-// Allocates and frees its own statement handle so the caller's statement state is not mutated.
-inline std::string get_current_database(SQLHDBC dbc) {
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
-  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
-  if (!SQL_SUCCEEDED(ret)) {
-    throw std::runtime_error("get_current_database: SQLAllocHandle(SQL_HANDLE_STMT) failed");
-  }
-
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT CURRENT_DATABASE()")), SQL_NTS);
-  if (!SQL_SUCCEEDED(ret)) {
-    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-    throw std::runtime_error("get_current_database: SQLExecDirect failed");
-  }
-
-  ret = SQLFetch(stmt);
-  if (!SQL_SUCCEEDED(ret)) {
-    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-    throw std::runtime_error("get_current_database: SQLFetch failed");
-  }
-
-  char db[256] = {};
-  SQLLEN indicator = 0;
-  ret = SQLGetData(stmt, 1, SQL_C_CHAR, db, sizeof(db), &indicator);
-  if (!SQL_SUCCEEDED(ret) || indicator == SQL_NULL_DATA) {
-    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-    throw std::runtime_error("get_current_database: SQLGetData failed or returned NULL");
-  }
-
-  SQLFreeStmt(stmt, SQL_CLOSE);
-  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  return std::string(db);
-}
 
 // Helper macro to check for expected ODBC error with specific SQLSTATE
 #define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType)                \

--- a/odbc_tests/common/src/query_helpers.cpp
+++ b/odbc_tests/common/src/query_helpers.cpp
@@ -1,0 +1,40 @@
+#include "query_helpers.hpp"
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <stdexcept>
+
+#include "odbc_cast.hpp"
+
+std::string get_current_database(SQLHDBC dbc) {
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+  if (!SQL_SUCCEEDED(ret)) {
+    throw std::runtime_error("get_current_database: SQLAllocHandle(SQL_HANDLE_STMT) failed");
+  }
+
+  ret = SQLExecDirect(stmt, sqlchar("SELECT CURRENT_DATABASE()"), SQL_NTS);
+  if (!SQL_SUCCEEDED(ret)) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLExecDirect failed");
+  }
+
+  ret = SQLFetch(stmt);
+  if (!SQL_SUCCEEDED(ret)) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLFetch failed");
+  }
+
+  char db[256] = {};
+  SQLLEN indicator = 0;
+  ret = SQLGetData(stmt, 1, SQL_C_CHAR, db, sizeof(db), &indicator);
+  if (!SQL_SUCCEEDED(ret) || indicator == SQL_NULL_DATA) {
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    throw std::runtime_error("get_current_database: SQLGetData failed or returned NULL");
+  }
+
+  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  return std::string(db);
+}

--- a/odbc_tests/tests/odbc-api/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 4.0)
 
+add_subdirectory(catalog)
 add_subdirectory(connecting)
 add_subdirectory(driver_info)
 add_subdirectory(preparing)

--- a/odbc_tests/tests/odbc-api/catalog/CMakeLists.txt
+++ b/odbc_tests/tests/odbc-api/catalog/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_odbc_test(odbc_api_column_privileges_tests column_privileges_tests.cpp)
+add_odbc_test(odbc_api_columns_tests columns_tests.cpp)
+add_odbc_test(odbc_api_primary_keys_tests primary_keys_tests.cpp)
+add_odbc_test(odbc_api_foreign_keys_tests foreign_keys_tests.cpp)
+add_odbc_test(odbc_api_procedure_columns_tests procedure_columns_tests.cpp)
+add_odbc_test(odbc_api_procedures_tests procedures_tests.cpp)
+add_odbc_test(odbc_api_special_columns_tests special_columns_tests.cpp)
+add_odbc_test(odbc_api_statistics_tests statistics_tests.cpp)
+add_odbc_test(odbc_api_table_privileges_tests table_privileges_tests.cpp)
+add_odbc_test(odbc_api_tables_tests tables_tests.cpp)

--- a/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,19 +28,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has cor
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_numcols (id INT, name VARCHAR(100))")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_NUMCOLS")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_NUMCOLS"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -51,17 +49,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column 
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_colnames (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_colnames (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_COLNAMES")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_COLNAMES"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME",
@@ -93,18 +88,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty resu
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_empty (id INT, name VARCHAR(100))")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_empty (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_EMPTY")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_EMPTY"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -119,10 +111,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_params (id INT, name VARCHAR(100))")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_params (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
@@ -130,19 +120,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter 
   const std::string& schemaName = schema.name();
 
   // Wildcard % for ColumnName
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_PARAMS")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_PARAMS"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
   // NULL ColumnName (treated as wildcard)
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_PARAMS")), SQL_NTS, nullptr, 0);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_PARAMS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -151,12 +138,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter 
   // Explicit string lengths instead of SQL_NTS
   const std::string tbl = "TEST_CP_PARAMS";
   const std::string col = "%";
-  ret = SQLColumnPrivileges(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(tbl.c_str())),
-      static_cast<SQLSMALLINT>(tbl.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(col.c_str())),
-      static_cast<SQLSMALLINT>(col.length()));
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                            sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
+                            sqlchar(tbl.c_str()), static_cast<SQLSMALLINT>(tbl.length()), sqlchar(col.c_str()),
+                            static_cast<SQLSMALLINT>(col.length()));
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -171,10 +156,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table
   const std::string currentDb = get_current_database(dbc_handle());
 
   SQLRETURN ret =
-      SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+      SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                          sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -189,26 +172,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple 
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_reuse (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_reuse (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_REUSE")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_REUSE"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_REUSE")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_REUSE"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -218,17 +196,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount return
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_rowcount (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_rowcount (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_ROWCOUNT")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_ROWCOUNT"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -243,9 +218,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount return
 
 TEST_CASE("SQLColumnPrivileges: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][catalog][columnprivileges][error]") {
-  const SQLRETURN ret = SQLColumnPrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS,
-                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  const SQLRETURN ret =
+      SQLColumnPrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -258,31 +232,27 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY009 - NULL Table
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative CatalogName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
-      SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("DB")), -999, nullptr, 0,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+      SQLColumnPrivileges(stmt_handle(), sqlchar("DB"), -999, nullptr, 0, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
-      SQLColumnPrivileges(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+      SQLColumnPrivileges(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative TableName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
-  const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, nullptr, 0);
+  const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative ColumnName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
-      SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")),
-                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>("COLUMN")), -999);
+      SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS, sqlchar("COLUMN"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -290,24 +260,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: 24000 - Cursor alr
                  "[odbc-api][catalog][columnprivileges][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_cursor (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_cursor (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_CURSOR")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_CURSOR"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_CURSOR")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_CP_CURSOR"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
@@ -1,0 +1,323 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// Note: SQLColumnPrivileges is not fully supported by the Snowflake reference driver.
+// It always returns an empty result set (SQL_NO_DATA on first fetch) regardless of
+// the table or parameters used. These tests document this behavior.
+
+// ============================================================================
+// SQLColumnPrivileges - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has correct number of columns",
+                 "[odbc-api][catalog][columnprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_numcols (id INT, name VARCHAR(100))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_NUMCOLS")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 8);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][catalog][columnprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_colnames (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_COLNAMES")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME",
+                                    "GRANTOR",   "GRANTEE",     "PRIVILEGE",  "IS_GRANTABLE"};
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLColumnPrivileges - Empty Result Set (Snowflake limitation)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty result set for existing table",
+                 "[odbc-api][catalog][columnprivileges]") {
+  // Note: Snowflake does NOT support traditional SQL column-level GRANT privileges
+  // (e.g., GRANT SELECT(col)). SQLColumnPrivileges always returns an empty result set.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_empty (id INT, name VARCHAR(100))")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_EMPTY")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter combinations return empty",
+                 "[odbc-api][catalog][columnprivileges]") {
+  // Note: Cannot verify actual search pattern/parameter behavior since Snowflake doesn't
+  // support column privileges. These tests only verify that various parameter combinations
+  // are accepted without error and return empty result sets.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_params (id INT, name VARCHAR(100))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // Wildcard % for ColumnName
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_PARAMS")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  // NULL ColumnName (treated as wildcard)
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_PARAMS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  // Explicit string lengths instead of SQL_NTS
+  const std::string tbl = "TEST_CP_PARAMS";
+  const std::string col = "%";
+  ret = SQLColumnPrivileges(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(tbl.c_str())),
+      static_cast<SQLSMALLINT>(tbl.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(col.c_str())),
+      static_cast<SQLSMALLINT>(col.length()));
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table returns empty result set",
+                 "[odbc-api][catalog][columnprivileges]") {
+  // Note: Cannot distinguish between "table doesn't exist" and "no privileges exist"
+  // since Snowflake doesn't support column privileges - both return empty result sets.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret =
+      SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLColumnPrivileges - Statement Reuse & SQLRowCount
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple times after close cursor",
+                 "[odbc-api][catalog][columnprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_reuse (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_REUSE")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_REUSE")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount returns -1",
+                 "[odbc-api][catalog][columnprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_rowcount (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_ROWCOUNT")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLColumnPrivileges - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLColumnPrivileges: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret = SQLColumnPrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS,
+                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY009 - NULL TableName pointer",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative CatalogName length",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret =
+      SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("DB")), -999, nullptr, 0,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative SchemaName length",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret =
+      SQLColumnPrivileges(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative TableName length",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative ColumnName length",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const SQLRETURN ret =
+      SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")),
+                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>("COLUMN")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: 24000 - Cursor already open",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_cp_cursor (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_CURSOR")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLColumnPrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_CP_CURSOR")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLColumnPrivileges: Requires active connection",
+                 "[odbc-api][catalog][columnprivileges][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
@@ -1,0 +1,567 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLColumns - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set has correct number of columns",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns 19 columns (ODBC 3.x spec defines 18, driver adds 1 extra)
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 19);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns 19 columns
+  const char* expectedColNames[] = {"TABLE_CAT",        "TABLE_SCHEM",    "TABLE_NAME",       "COLUMN_NAME",
+                                    "DATA_TYPE",        "TYPE_NAME",      "COLUMN_SIZE",      "BUFFER_LENGTH",
+                                    "DECIMAL_DIGITS",   "NUM_PREC_RADIX", "NULLABLE",         "REMARKS",
+                                    "COLUMN_DEF",       "SQL_DATA_TYPE",  "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH",
+                                    "ORDINAL_POSITION", "IS_NULLABLE",    "USER_DATA_TYPE"};
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLColumns - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column metadata for known table",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE TABLE test_sqlcolumns_meta (id INTEGER, name VARCHAR(100), price FLOAT, active BOOLEAN)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_META")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  std::vector<std::string> columnNames;
+  while (true) {
+    ret = SQLFetch(stmt_handle());
+    if (ret == SQL_NO_DATA) break;
+    REQUIRE(ret == SQL_SUCCESS);
+
+    char tableCat[256] = {};
+    char tableSchem[256] = {};
+    char tableName[256] = {};
+    char columnName[256] = {};
+
+    SQLGetData(stmt_handle(), 1, SQL_C_CHAR, tableCat, sizeof(tableCat), nullptr);
+    SQLGetData(stmt_handle(), 2, SQL_C_CHAR, tableSchem, sizeof(tableSchem), nullptr);
+    SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
+    SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+
+    REQUIRE(std::string(tableCat) == currentDb);
+    REQUIRE(std::string(tableSchem) == schema.name());
+    REQUIRE(std::string(tableName) == "TEST_SQLCOLUMNS_META");
+
+    columnNames.emplace_back(columnName);
+  }
+
+  REQUIRE(columnNames.size() == 4);
+  REQUIRE(columnNames[0] == "ID");
+  REQUIRE(columnNames[1] == "NAME");
+  REQUIRE(columnNames[2] == "PRICE");
+  REQUIRE(columnNames[3] == "ACTIVE");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types for known columns",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_types (id INTEGER, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_TYPES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (true) {
+    ret = SQLFetch(stmt_handle());
+    if (ret == SQL_NO_DATA) break;
+    REQUIRE(ret == SQL_SUCCESS);
+
+    char columnName[256] = {};
+    SQLSMALLINT dataType = 0;
+    char typeName[256] = {};
+    SQLLEN dataTypeInd = 0;
+
+    SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+    SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &dataType, 0, &dataTypeInd);
+    SQLGetData(stmt_handle(), 6, SQL_C_CHAR, typeName, sizeof(typeName), nullptr);
+
+    if (rowCount == 0) {
+      REQUIRE(std::string(columnName) == "ID");
+      REQUIRE(dataType == 3);
+      REQUIRE(std::string(typeName) == "DECIMAL");
+    } else if (rowCount == 1) {
+      REQUIRE(std::string(columnName) == "NAME");
+      REQUIRE(dataType == 12);
+      REQUIRE(std::string(typeName) == "VARCHAR");
+    }
+
+    rowCount++;
+  }
+
+  REQUIRE(rowCount == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequential starting from 1",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_ord (col_a INT, col_b VARCHAR(50), col_c FLOAT)")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_ORD")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (int i = 1; i <= 3; i++) {
+    ret = SQLFetch(stmt_handle());
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQLINTEGER ordinalPos = 0;
+    SQLGetData(stmt_handle(), 17, SQL_C_SLONG, &ordinalPos, 0, nullptr);
+    REQUIRE(ordinalPos == i);
+  }
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports correct nullability",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_null (id INTEGER NOT NULL, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_NULL")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // id INTEGER NOT NULL
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLSMALLINT nullable1 = -1;
+  SQLGetData(stmt_handle(), 11, SQL_C_SSHORT, &nullable1, 0, nullptr);
+  REQUIRE(nullable1 == SQL_NO_NULLS);
+
+  // name VARCHAR(100) - nullable by default
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLSMALLINT nullable2 = -1;
+  SQLGetData(stmt_handle(), 11, SQL_C_SSHORT, &nullable2, 0, nullptr);
+  REQUIRE(nullable2 == SQL_NULLABLE);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLColumns - Search Patterns
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % returns all columns",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_wild (col_x INT, col_y VARCHAR(50), col_z FLOAT)")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_WILD")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    rowCount++;
+  }
+  REQUIRE(rowCount == 3);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all columns",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_nullcol (col_a INT, col_b VARCHAR(50))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_NULLCOL")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    rowCount++;
+  }
+  REQUIRE(rowCount == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters results",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sqlcolumns_specific (id INT, name VARCHAR(50), age INT)")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_SPECIFIC")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("NAME")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char columnName[256] = {};
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+  REQUIRE(std::string(columnName) == "NAME");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard matches single character",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_uscore (ca INT, cb INT, ddd INT)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_USCORE")), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("C_")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // C_ matches CA and CB but not DDD
+  char colName[256] = {};
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(colName) == "CA");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(colName) == "CB");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns empty result set",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret =
+      SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_12345")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLColumns - Parameter Variations
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinations are accepted",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_params (id INT, name VARCHAR(50))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // Explicit catalog and schema with SQL_NTS
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_PARAMS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 2);
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Explicit string lengths instead of SQL_NTS
+  const std::string table = "TEST_SQLCOLUMNS_PARAMS";
+  ret = SQLColumns(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(table.c_str())),
+      static_cast<SQLSMALLINT>(table.length()), nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 2);
+}
+
+// ============================================================================
+// SQLColumns - Statement Reuse
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on same statement after close cursor",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_reuse (id INT)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: SQLRowCount after catalog function call",
+                 "[odbc-api][columns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // SQLRowCount is undefined for catalog functions, reference driver returns -1
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLColumns - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLColumns: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][columns][catalog][error]") {
+  const SQLRETURN ret = SQLColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative CatalogName length",
+                 "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999, nullptr,
+                             0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative SchemaName length",
+                 "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative TableName length",
+                 "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative ColumnName length",
+                 "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS,
+                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("COLUMN")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: 24000 - Cursor already open",
+                 "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")),
+                   SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLColumns: Requires active connection", "[odbc-api][columns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
@@ -12,6 +12,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -23,8 +25,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set has correct numb
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("DATABASES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 19 columns (ODBC 3.x spec defines 18, driver adds 1 extra)
@@ -38,8 +39,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set column names mat
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("DATABASES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 19 columns
@@ -80,17 +80,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column meta
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE TABLE test_sqlcolumns_meta (id INTEGER, name VARCHAR(100), price FLOAT, active BOOLEAN)")),
+      sqlchar("CREATE TABLE test_sqlcolumns_meta (id INTEGER, name VARCHAR(100), price FLOAT, active BOOLEAN)"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_META")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_META"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   std::vector<std::string> columnNames;
@@ -130,17 +128,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_types (id INTEGER, name VARCHAR(100))")),
-                                SQL_NTS);
+                                sqlchar("CREATE TABLE test_sqlcolumns_types (id INTEGER, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_TYPES")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_TYPES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -180,18 +175,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequent
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_ord (col_a INT, col_b VARCHAR(50), col_c FLOAT)")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_ord (col_a INT, col_b VARCHAR(50), col_c FLOAT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_ORD")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_ORD"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (int i = 1; i <= 3; i++) {
@@ -213,18 +205,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports cor
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_null (id INTEGER NOT NULL, name VARCHAR(100))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_null (id INTEGER NOT NULL, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_NULL")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_NULL"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // id INTEGER NOT NULL
@@ -255,19 +244,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % retur
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_wild (col_x INT, col_y VARCHAR(50), col_z FLOAT)")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_wild (col_x INT, col_y VARCHAR(50), col_z FLOAT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_WILD")), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_WILD"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -283,18 +268,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_nullcol (col_a INT, col_b VARCHAR(50))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_nullcol (col_a INT, col_b VARCHAR(50))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_NULLCOL")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_NULLCOL"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -310,19 +292,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sqlcolumns_specific (id INT, name VARCHAR(50), age INT)")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_specific (id INT, name VARCHAR(50), age INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_SPECIFIC")), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("NAME")), SQL_NTS);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_SPECIFIC"), SQL_NTS, sqlchar("NAME"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -342,19 +320,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard match
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_uscore (ca INT, cb INT, ddd INT)")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_uscore (ca INT, cb INT, ddd INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_USCORE")), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("C_")), SQL_NTS);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_USCORE"), SQL_NTS, sqlchar("C_"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // C_ matches CA and CB but not DDD
@@ -382,10 +356,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns 
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret =
-      SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_12345")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
+                             SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_12345"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -402,10 +374,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_params (id INT, name VARCHAR(50))")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_params (id INT, name VARCHAR(50))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
@@ -413,9 +383,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
   const std::string& schemaName = schema.name();
 
   // Explicit catalog and schema with SQL_NTS
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_PARAMS")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_PARAMS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -426,11 +395,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
 
   // Explicit string lengths instead of SQL_NTS
   const std::string table = "TEST_SQLCOLUMNS_PARAMS";
-  ret = SQLColumns(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(table.c_str())),
-      static_cast<SQLSMALLINT>(table.length()), nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                   sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(table.c_str()),
+                   static_cast<SQLSMALLINT>(table.length()), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -448,17 +415,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sqlcolumns_reuse (id INT)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_reuse (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int count1 = 0;
@@ -469,9 +433,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SQLCOLUMNS_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                   sqlchar("TEST_SQLCOLUMNS_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int count2 = 0;
@@ -484,8 +447,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: SQLRowCount after catalog f
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("DATABASES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // SQLRowCount is undefined for catalog functions, reference driver returns -1
@@ -500,8 +462,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: SQLRowCount after catalog f
 // ============================================================================
 
 TEST_CASE("SQLColumns: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][columns][catalog][error]") {
-  const SQLRETURN ret = SQLColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  const SQLRETURN ret = SQLColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -509,8 +470,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative CatalogNam
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999, nullptr,
-                             0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret =
+      SQLColumns(stmt_handle(), sqlchar("SNOWFLAKE"), -999, nullptr, 0, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -518,8 +479,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative SchemaName
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -527,8 +487,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative TableName 
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -536,9 +495,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative ColumnName
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS,
-                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("COLUMN")), -999);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS, sqlchar("COLUMN"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -546,13 +503,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: 24000 - Cursor already open
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                             reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("DATABASES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DATABASES")),
-                   SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("DATABASES"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
@@ -12,6 +12,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -25,16 +27,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_parent (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_parent (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE TABLE test_fk_child (id INT, parent_id INT, FOREIGN KEY (parent_id) REFERENCES test_fk_parent(id))")),
+      sqlchar(
+          "CREATE TABLE test_fk_child (id INT, parent_id INT, FOREIGN KEY (parent_id) REFERENCES test_fk_parent(id))"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -42,10 +42,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // Query FK table to get foreign keys
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CHILD")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_CHILD"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC 3.x spec defines 14 columns for SQLForeignKeys
@@ -61,26 +59,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_p_names (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_p_names (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE TABLE test_fk_c_names (id INT, pid INT, FOREIGN KEY (pid) REFERENCES test_fk_p_names(id))")),
+      sqlchar("CREATE TABLE test_fk_c_names (id INT, pid INT, FOREIGN KEY (pid) REFERENCES test_fk_p_names(id))"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_C_NAMES")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_C_NAMES"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"PKTABLE_CAT",   "PKTABLE_SCHEM", "PKTABLE_NAME",  "PKCOLUMN_NAME", "FKTABLE_CAT",
@@ -116,28 +109,23 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreig
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_orders_parent (order_id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_orders_parent (order_id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_lines (line_id INT, order_id INT, FOREIGN KEY "
-                                                   "(order_id) REFERENCES test_fk_orders_parent(order_id))")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE TABLE test_fk_lines (line_id INT, order_id INT, FOREIGN KEY "
+                              "(order_id) REFERENCES test_fk_orders_parent(order_id))"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // Query by FK table: what foreign keys does test_fk_lines have?
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_LINES")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_LINES"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -171,27 +159,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreig
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_pk_parent (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_pk_parent (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_pk_child (id INT, parent_id INT, FOREIGN KEY "
-                                                   "(parent_id) REFERENCES test_fk_pk_parent(id))")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE TABLE test_fk_pk_child (id INT, parent_id INT, FOREIGN KEY "
+                              "(parent_id) REFERENCES test_fk_pk_parent(id))"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // Query by PK table: what tables reference test_fk_pk_parent's primary key?
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_PK_PARENT")), SQL_NTS, nullptr, 0, nullptr,
-                       0, nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_PK_PARENT"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -222,28 +205,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table sp
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_both_pk (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_both_pk (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE TABLE test_fk_both_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_both_pk(id))")),
+      sqlchar("CREATE TABLE test_fk_both_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_both_pk(id))"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_BOTH_PK")), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_BOTH_FK")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_BOTH_PK"), SQL_NTS, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_BOTH_FK"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -268,35 +245,30 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_parent (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_multi_parent (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_child_a (id INT, parent_id INT, "
-                                                   "FOREIGN KEY (parent_id) REFERENCES test_fk_multi_parent(id))")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE TABLE test_fk_multi_child_a (id INT, parent_id INT, "
+                              "FOREIGN KEY (parent_id) REFERENCES test_fk_multi_parent(id))"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_child_b (id INT, ref_id INT, "
-                                                   "FOREIGN KEY (ref_id) REFERENCES test_fk_multi_parent(id))")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE TABLE test_fk_multi_child_b (id INT, ref_id INT, "
+                              "FOREIGN KEY (ref_id) REFERENCES test_fk_multi_parent(id))"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // Query by PK table: both children should appear
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_MULTI_PARENT")), SQL_NTS, nullptr, 0,
-                       nullptr, 0, nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_MULTI_PARENT"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -314,18 +286,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign k
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_nofk (id INT, name VARCHAR(50))")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_nofk (id INT, name VARCHAR(50))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_NOFK")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_NOFK"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -340,10 +309,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table retu
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS);
+  SQLRETURN ret =
+      SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                     sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -360,26 +328,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_reuse_pk (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_reuse_pk (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE TABLE test_fk_reuse_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_reuse_pk(id))")),
+      sqlchar(
+          "CREATE TABLE test_fk_reuse_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_reuse_pk(id))"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_REUSE_FK")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_REUSE_FK"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -389,10 +353,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_REUSE_FK")), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
+                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_REUSE_FK"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -406,18 +368,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catal
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_rc_pk (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_rc_pk (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_RC_PK")), SQL_NTS, nullptr, 0, nullptr, 0,
-                       nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_RC_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -432,7 +390,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catal
 
 TEST_CASE("SQLForeignKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][foreignkeys][catalog][error]") {
   const SQLRETURN ret = SQLForeignKeys(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0,
-                                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+                                       sqlchar("TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -448,9 +406,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative PKCata
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
-                                 nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr,
-                                 0, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar("SNOWFLAKE"), -999, nullptr, 0, sqlchar("TABLE"), SQL_NTS,
+                                 nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -458,8 +415,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTabl
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  SQLRETURN ret =
+      SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -469,25 +426,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: 24000 - Cursor already 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_cursor_pk (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_cursor_pk (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CURSOR_PK")), SQL_NTS, nullptr, 0, nullptr,
-                       0, nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_CURSOR_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CURSOR_PK")), SQL_NTS, nullptr, 0, nullptr,
-                       0, nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_FK_CURSOR_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
@@ -1,0 +1,502 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLForeignKeys - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct number of columns",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_parent (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE TABLE test_fk_child (id INT, parent_id INT, FOREIGN KEY (parent_id) REFERENCES test_fk_parent(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // Query FK table to get foreign keys
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CHILD")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // ODBC 3.x spec defines 14 columns for SQLForeignKeys
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 14);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_p_names (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE TABLE test_fk_c_names (id INT, pid INT, FOREIGN KEY (pid) REFERENCES test_fk_p_names(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_C_NAMES")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"PKTABLE_CAT",   "PKTABLE_SCHEM", "PKTABLE_NAME",  "PKCOLUMN_NAME", "FKTABLE_CAT",
+                                    "FKTABLE_SCHEM", "FKTABLE_NAME",  "FKCOLUMN_NAME", "KEY_SEQ",       "UPDATE_RULE",
+                                    "DELETE_RULE",   "FK_NAME",       "PK_NAME",       "DEFERRABILITY"};
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLForeignKeys - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreign key referencing PK table",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_orders_parent (order_id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_lines (line_id INT, order_id INT, FOREIGN KEY "
+                                                   "(order_id) REFERENCES test_fk_orders_parent(order_id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // Query by FK table: what foreign keys does test_fk_lines have?
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_LINES")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char pkTableName[256] = {};
+  char pkColumnName[256] = {};
+  char fkTableName[256] = {};
+  char fkColumnName[256] = {};
+  SQLSMALLINT keySeq = 0;
+
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, pkTableName, sizeof(pkTableName), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, pkColumnName, sizeof(pkColumnName), nullptr);
+  SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTableName, sizeof(fkTableName), nullptr);
+  SQLGetData(stmt_handle(), 8, SQL_C_CHAR, fkColumnName, sizeof(fkColumnName), nullptr);
+  SQLGetData(stmt_handle(), 9, SQL_C_SSHORT, &keySeq, 0, nullptr);
+
+  REQUIRE(std::string(pkTableName) == "TEST_FK_ORDERS_PARENT");
+  REQUIRE(std::string(pkColumnName) == "ORDER_ID");
+  REQUIRE(std::string(fkTableName) == "TEST_FK_LINES");
+  REQUIRE(std::string(fkColumnName) == "ORDER_ID");
+  REQUIRE(keySeq == 1);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreign keys referencing it",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_pk_parent (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_pk_child (id INT, parent_id INT, FOREIGN KEY "
+                                                   "(parent_id) REFERENCES test_fk_pk_parent(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // Query by PK table: what tables reference test_fk_pk_parent's primary key?
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_PK_PARENT")), SQL_NTS, nullptr, 0, nullptr,
+                       0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char pkTableName[256] = {};
+  char pkColumnName[256] = {};
+  char fkTableName[256] = {};
+  char fkColumnName[256] = {};
+
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, pkTableName, sizeof(pkTableName), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, pkColumnName, sizeof(pkColumnName), nullptr);
+  SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTableName, sizeof(fkTableName), nullptr);
+  SQLGetData(stmt_handle(), 8, SQL_C_CHAR, fkColumnName, sizeof(fkColumnName), nullptr);
+
+  REQUIRE(std::string(pkTableName) == "TEST_FK_PK_PARENT");
+  REQUIRE(std::string(pkColumnName) == "ID");
+  REQUIRE(std::string(fkTableName) == "TEST_FK_PK_CHILD");
+  REQUIRE(std::string(fkColumnName) == "PARENT_ID");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table specified returns matching relationship",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_both_pk (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE TABLE test_fk_both_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_both_pk(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_BOTH_PK")), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_BOTH_FK")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char pkTableName[256] = {};
+  char fkTableName[256] = {};
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, pkTableName, sizeof(pkTableName), nullptr);
+  SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTableName, sizeof(fkTableName), nullptr);
+
+  REQUIRE(std::string(pkTableName) == "TEST_FK_BOTH_PK");
+  REQUIRE(std::string(fkTableName) == "TEST_FK_BOTH_FK");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLForeignKeys: PK table referenced by multiple children returns all relationships",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_parent (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_child_a (id INT, parent_id INT, "
+                                                   "FOREIGN KEY (parent_id) REFERENCES test_fk_multi_parent(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_multi_child_b (id INT, ref_id INT, "
+                                                   "FOREIGN KEY (ref_id) REFERENCES test_fk_multi_parent(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // Query by PK table: both children should appear
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_MULTI_PARENT")), SQL_NTS, nullptr, 0,
+                       nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    char fkTable[256] = {};
+    SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTable, sizeof(fkTable), nullptr);
+    rowCount++;
+  }
+  REQUIRE(rowCount == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign keys returns empty result set",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_nofk (id INT, name VARCHAR(50))")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_NOFK")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table returns empty result set",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLForeignKeys - Statement Reuse
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times on same statement after close cursor",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_reuse_pk (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE TABLE test_fk_reuse_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_reuse_pk(id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_REUSE_FK")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_REUSE_FK")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catalog function call",
+                 "[odbc-api][foreignkeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_rc_pk (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_RC_PK")), SQL_NTS, nullptr, 0, nullptr, 0,
+                       nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLForeignKeys - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLForeignKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][foreignkeys][catalog][error]") {
+  const SQLRETURN ret = SQLForeignKeys(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0,
+                                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY009 - Both PKTableName and FKTableName are null",
+                 "[odbc-api][foreignkeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative PKCatalogName length",
+                 "[odbc-api][foreignkeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
+                                 nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS, nullptr,
+                                 0, nullptr, 0, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTableName length",
+                 "[odbc-api][foreignkeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: 24000 - Cursor already open",
+                 "[odbc-api][foreignkeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_fk_cursor_pk (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CURSOR_PK")), SQL_NTS, nullptr, 0, nullptr,
+                       0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLForeignKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_FK_CURSOR_PK")), SQL_NTS, nullptr, 0, nullptr,
+                       0, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLForeignKeys: Requires active connection", "[odbc-api][foreignkeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
@@ -1,0 +1,400 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLPrimaryKeys - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct number of columns",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_numcols (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_NUMCOLS")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  // ODBC 3.x spec defines 6 columns for SQLPrimaryKeys
+  REQUIRE(numCols == 6);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_COLNAMES")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"};
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLPrimaryKeys - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for single-column PK",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_pk_single (id INT PRIMARY KEY, name VARCHAR(50))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_SINGLE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char tableCat[256] = {};
+  char tableSchem[256] = {};
+  char tableName[256] = {};
+  char columnName[256] = {};
+  SQLSMALLINT keySeq = 0;
+
+  SQLGetData(stmt_handle(), 1, SQL_C_CHAR, tableCat, sizeof(tableCat), nullptr);
+  SQLGetData(stmt_handle(), 2, SQL_C_CHAR, tableSchem, sizeof(tableSchem), nullptr);
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+  SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
+
+  REQUIRE(std::string(tableCat) == currentDb);
+  REQUIRE(std::string(tableSchem) == schema.name());
+  REQUIRE(std::string(tableName) == "TEST_PK_SINGLE");
+  REQUIRE(std::string(columnName) == "ID");
+  REQUIRE(keySeq == 1);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite primary key with correct KEY_SEQ",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_composite (region_id INT, store_id INT, name "
+                                                   "VARCHAR(50), PRIMARY KEY (region_id, store_id))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_COMPOSITE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char columnName[256] = {};
+  SQLSMALLINT keySeq = 0;
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+  SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
+  REQUIRE(std::string(columnName) == "REGION_ID");
+  REQUIRE(keySeq == 1);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
+  SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
+  REQUIRE(std::string(columnName) == "STORE_ID");
+  REQUIRE(keySeq == 2);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary key returns empty result set",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_none (id INT, name VARCHAR(50))")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_NONE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table returns empty result set",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+                                 SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLPrimaryKeys - Parameter Variations
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combinations are accepted",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_params (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // Explicit catalog, schema, table with SQL_NTS
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_PARAMS")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Explicit string lengths instead of SQL_NTS
+  const std::string table = "TEST_PK_PARAMS";
+  ret = SQLPrimaryKeys(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(table.c_str())),
+      static_cast<SQLSMALLINT>(table.length()));
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+// ============================================================================
+// SQLPrimaryKeys - Statement Reuse
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times on same statement after close cursor",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_reuse (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catalog function call",
+                 "[odbc-api][primarykeys][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_ROWCOUNT")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLPrimaryKeys - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLPrimaryKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][primarykeys][catalog][error]") {
+  const SQLRETURN ret = SQLPrimaryKeys(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative CatalogName length",
+                 "[odbc-api][primarykeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
+                                 nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative SchemaName length",
+                 "[odbc-api][primarykeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")),
+                                 -999, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableName length",
+                 "[odbc-api][primarykeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, nullptr, 0,
+                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: 24000 - Cursor already open",
+                 "[odbc-api][primarykeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_cursor (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_CURSOR")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_CURSOR")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLPrimaryKeys: Requires active connection", "[odbc-api][primarykeys][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
@@ -12,6 +12,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -25,17 +27,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_numcols (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_numcols (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_NUMCOLS")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_NUMCOLS"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -51,17 +50,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_colnames (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_COLNAMES")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_COLNAMES"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"};
@@ -96,17 +92,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_pk_single (id INT PRIMARY KEY, name VARCHAR(50))")),
-                                SQL_NTS);
+                                sqlchar("CREATE TABLE test_pk_single (id INT PRIMARY KEY, name VARCHAR(50))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_SINGLE")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_SINGLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -140,19 +133,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite prima
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_composite (region_id INT, store_id INT, name "
-                                                   "VARCHAR(50), PRIMARY KEY (region_id, store_id))")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE TABLE test_pk_composite (region_id INT, store_id INT, name "
+                                        "VARCHAR(50), PRIMARY KEY (region_id, store_id))"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_COMPOSITE")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_COMPOSITE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   char columnName[256] = {};
@@ -182,17 +173,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary k
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_none (id INT, name VARCHAR(50))")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_none (id INT, name VARCHAR(50))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_NONE")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_NONE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -207,9 +196,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table retu
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-                                 SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
+                                 SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -226,9 +214,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_params (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_params (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
@@ -236,9 +222,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
   const std::string& schemaName = schema.name();
 
   // Explicit catalog, schema, table with SQL_NTS
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_PARAMS")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_PARAMS"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -249,11 +234,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
 
   // Explicit string lengths instead of SQL_NTS
   const std::string table = "TEST_PK_PARAMS";
-  ret = SQLPrimaryKeys(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(table.c_str())),
-      static_cast<SQLSMALLINT>(table.length()));
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                       sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
+                       sqlchar(table.c_str()), static_cast<SQLSMALLINT>(table.length()));
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -271,17 +254,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_reuse (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_reuse (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_REUSE")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -291,9 +271,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_REUSE")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -307,17 +286,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catal
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_ROWCOUNT")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_ROWCOUNT"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -331,8 +307,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catal
 // ============================================================================
 
 TEST_CASE("SQLPrimaryKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][primarykeys][catalog][error]") {
-  const SQLRETURN ret = SQLPrimaryKeys(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  const SQLRETURN ret = SQLPrimaryKeys(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -340,8 +315,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative Catalo
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
-                                 nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar("SNOWFLAKE"), -999, nullptr, 0, sqlchar("TABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -349,8 +323,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative Schema
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")),
-                                 -999, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -358,8 +331,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableN
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, nullptr, 0,
-                                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -369,23 +341,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: 24000 - Cursor already 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_pk_cursor (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_cursor (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_CURSOR")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_CURSOR"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLPrimaryKeys(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                       reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PK_CURSOR")), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                       sqlchar("TEST_PK_CURSOR"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
@@ -12,6 +12,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -27,17 +29,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has cor
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_pc_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_pc_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_NUMCOLS")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_NUMCOLS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 21 columns (ODBC 3.x spec defines 19, driver adds 2 extra)
@@ -55,17 +55,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column 
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_pc_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_pc_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_COLNAMES")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_COLNAMES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 21 columns (19 spec + 2 driver-specific)
@@ -105,19 +103,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_params(p_name VARCHAR, p_age FLOAT)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_params(p_name VARCHAR, p_age FLOAT)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_PARAMS")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_PARAMS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procCat[256] = {};
@@ -161,10 +157,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent proce
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret = SQLProcedureColumns(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_PROC_XYZ_99999")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret =
+      SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                          sqlchar("NONEXISTENT_PROC_XYZ_99999"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -177,20 +172,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnNam
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_filter(p_id INTEGER, p_name VARCHAR)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_filter(p_id INTEGER, p_name VARCHAR)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_FILTER")), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("P_NAME")), SQL_NTS);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_FILTER"), SQL_NTS, sqlchar("P_NAME"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -214,11 +206,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_variations(p1 VARCHAR)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_variations(p1 VARCHAR)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
@@ -227,9 +218,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 
   // Return value + 1 input parameter = 2 rows
   // Explicit catalog, schema, proc with SQL_NTS
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_VARIATIONS")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_VARIATIONS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -240,11 +230,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 
   // Explicit string lengths instead of SQL_NTS
   const std::string proc = "TEST_PC_VARIATIONS";
-  ret = SQLProcedureColumns(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(proc.c_str())),
-      static_cast<SQLSMALLINT>(proc.length()), nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                            sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
+                            sqlchar(proc.c_str()), static_cast<SQLSMALLINT>(proc.length()), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -263,19 +251,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_reuse(p1 VARCHAR)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_reuse(p1 VARCHAR)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   // Return value + 1 input parameter = 2 rows
   int count1 = 0;
@@ -286,9 +272,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -302,19 +287,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after 
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_rowcount(p1 VARCHAR)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_rowcount(p1 VARCHAR)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_ROWCOUNT")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_ROWCOUNT"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -329,8 +312,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after 
 
 TEST_CASE("SQLProcedureColumns: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][procedurecolumns][catalog][error]") {
-  const SQLRETURN ret = SQLProcedureColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+  const SQLRETURN ret =
+      SQLProcedureColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("PROC"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -339,8 +322,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative C
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret =
-      SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999, nullptr, 0,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+      SQLProcedureColumns(stmt_handle(), sqlchar("SNOWFLAKE"), -999, nullptr, 0, sqlchar("PROC"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -349,8 +331,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative S
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret =
-      SQLProcedureColumns(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+      SQLProcedureColumns(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("PROC"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -358,8 +339,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative P
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0,
-                                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), -999, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("PROC"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -368,8 +348,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative C
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret =
-      SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")),
-                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>("COL")), -999);
+      SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("PROC"), SQL_NTS, sqlchar("COL"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -379,25 +358,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: 24000 - Cursor alr
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_cursor(p1 VARCHAR)"
-                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_pc_cursor(p1 VARCHAR)"
+                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_CURSOR")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_CURSOR"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_CURSOR")), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("TEST_PC_CURSOR"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
@@ -1,0 +1,413 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLProcedureColumns - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has correct number of columns",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_pc_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_NUMCOLS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns 21 columns (ODBC 3.x spec defines 19, driver adds 2 extra)
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 21);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_pc_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_COLNAMES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Note: Reference driver returns 21 columns (19 spec + 2 driver-specific)
+  const char* expectedColNames[] = {"PROCEDURE_CAT",     "PROCEDURE_SCHEM",  "PROCEDURE_NAME", "COLUMN_NAME",
+                                    "COLUMN_TYPE",       "DATA_TYPE",        "TYPE_NAME",      "COLUMN_SIZE",
+                                    "BUFFER_LENGTH",     "DECIMAL_DIGITS",   "NUM_PREC_RADIX", "NULLABLE",
+                                    "REMARKS",           "COLUMN_DEF",       "SQL_DATA_TYPE",  "SQL_DATETIME_SUB",
+                                    "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",    "IS RESULT SET COLUMN",
+                                    "USER_DATA_TYPE"};
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLProcedureColumns - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters for known procedure",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_params(p_name VARCHAR, p_age FLOAT)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_PARAMS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char procCat[256] = {};
+  char procSchem[256] = {};
+  char procName[256] = {};
+  char colName[256] = {};
+
+  // Return value is listed first with empty column name
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 1, SQL_C_CHAR, procCat, sizeof(procCat), nullptr);
+  SQLGetData(stmt_handle(), 2, SQL_C_CHAR, procSchem, sizeof(procSchem), nullptr);
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, procName, sizeof(procName), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(procCat) == currentDb);
+  REQUIRE(std::string(procSchem) == schema.name());
+  REQUIRE(std::string(procName) == "TEST_PC_PARAMS");
+  REQUIRE(std::string(colName).empty());
+
+  // Input parameter P_NAME
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(colName) == "P_NAME");
+
+  // Input parameter P_AGE
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(colName) == "P_AGE");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent procedure returns empty result set",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret = SQLProcedureColumns(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_PROC_XYZ_99999")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnName filters results",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_filter(p_id INTEGER, p_name VARCHAR)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_FILTER")), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("P_NAME")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char colName[256] = {};
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
+  REQUIRE(std::string(colName) == "P_NAME");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLProcedureColumns - Parameter Variations
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_variations(p1 VARCHAR)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // Return value + 1 input parameter = 2 rows
+  // Explicit catalog, schema, proc with SQL_NTS
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_VARIATIONS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 2);
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Explicit string lengths instead of SQL_NTS
+  const std::string proc = "TEST_PC_VARIATIONS";
+  ret = SQLProcedureColumns(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(proc.c_str())),
+      static_cast<SQLSMALLINT>(proc.length()), nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 2);
+}
+
+// ============================================================================
+// SQLProcedureColumns - Statement Reuse
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLProcedureColumns: Can call multiple times on same statement after close cursor",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_reuse(p1 VARCHAR)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  // Return value + 1 input parameter = 2 rows
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 2);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after catalog function call",
+                 "[odbc-api][procedurecolumns][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_rowcount(p1 VARCHAR)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_ROWCOUNT")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLProcedureColumns - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLProcedureColumns: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][procedurecolumns][catalog][error]") {
+  const SQLRETURN ret = SQLProcedureColumns(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative CatalogName length",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999, nullptr, 0,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative SchemaName length",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLProcedureColumns(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ProcName length",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0,
+                                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), -999, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ColumnName length",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLProcedureColumns(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")),
+                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>("COL")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: 24000 - Cursor already open",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_pc_cursor(p1 VARCHAR)"
+                                                   " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_CURSOR")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLProcedureColumns(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                            reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PC_CURSOR")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLProcedureColumns: Requires active connection",
+                 "[odbc-api][procedurecolumns][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,17 +28,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct n
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_procs_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_NUMCOLS")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_NUMCOLS"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC 3.x spec defines 8 columns
@@ -54,17 +54,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names 
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar(
+          "CREATE PROCEDURE test_procs_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_COLNAMES")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_COLNAMES"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"PROCEDURE_CAT",     "PROCEDURE_SCHEM", "PROCEDURE_NAME", "NUM_INPUT_PARAMS",
@@ -101,17 +100,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure 
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_meta(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_procs_meta(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_META")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_META"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -145,17 +142,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds pr
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_wildcard(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar(
+          "CREATE PROCEDURE test_procs_wildcard(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_WILD%")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_WILD%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -172,27 +168,24 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returni
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_multi_a(p1 VARCHAR) RETURNS VARCHAR "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_procs_multi_a(p1 VARCHAR) RETURNS VARCHAR "
+                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_multi_b(p1 VARCHAR) RETURNS VARCHAR "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE PROCEDURE test_procs_multi_b(p1 VARCHAR) RETURNS VARCHAR "
+                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_MULTI%")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_MULTI%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -212,27 +205,24 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_dtype_a(p1 VARCHAR) RETURNS VARCHAR "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_procs_dtype_a(p1 VARCHAR) RETURNS VARCHAR "
+                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_dtype_b(p1 INT) RETURNS INT "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE PROCEDURE test_procs_dtype_b(p1 INT) RETURNS INT "
+                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_DTYPE%")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_DTYPE%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -256,27 +246,24 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returnin
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_num_a(p1 INT) RETURNS INT "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE PROCEDURE test_procs_num_a(p1 INT) RETURNS INT "
+                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                                SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_num_b(p1 INT) RETURNS INT "
-                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(),
+                      sqlchar("CREATE PROCEDURE test_procs_num_b(p1 INT) RETURNS INT "
+                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_NUM%")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_NUM%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -299,9 +286,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure r
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-                                SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_PROC_XYZ_99999")), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
+                                SQL_NTS, sqlchar("NONEXISTENT_PROC_XYZ_99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -320,8 +306,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_params(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_procs_params(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -330,9 +315,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
   const std::string& schemaName = schema.name();
 
   // Explicit catalog, schema, proc with SQL_NTS
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_PARAMS")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_PARAMS"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -343,11 +327,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
 
   // Explicit string lengths instead of SQL_NTS
   const std::string proc = "TEST_PROCS_PARAMS";
-  ret = SQLProcedures(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(proc.c_str())),
-      static_cast<SQLSMALLINT>(proc.length()));
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                      sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(proc.c_str()),
+                      static_cast<SQLSMALLINT>(proc.length()));
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -367,17 +349,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times 
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_reuse(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_procs_reuse(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_REUSE")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -387,9 +367,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_REUSE")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -405,17 +384,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalo
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_rowcount(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar(
+          "CREATE PROCEDURE test_procs_rowcount(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_ROWCOUNT")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_ROWCOUNT"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -429,8 +407,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalo
 // ============================================================================
 
 TEST_CASE("SQLProcedures: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][procedures][catalog][error]") {
-  const SQLRETURN ret = SQLProcedures(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  const SQLRETURN ret = SQLProcedures(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("PROC"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -438,8 +415,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative Catalog
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
-                                nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar("SNOWFLAKE"), -999, nullptr, 0, sqlchar("PROC"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -447,8 +423,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative SchemaN
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLProcedures(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")),
-                                -999, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("PROC"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -456,8 +431,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcNam
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLProcedures(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), -999);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("PROC"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -469,23 +443,20 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: 24000 - Cursor already o
 
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-          "CREATE PROCEDURE test_procs_cursor(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      sqlchar("CREATE PROCEDURE test_procs_cursor(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_CURSOR")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_CURSOR"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_CURSOR")), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_PROCS_CURSOR"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
@@ -1,0 +1,500 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLProcedures - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct number of columns",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_NUMCOLS")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // ODBC 3.x spec defines 8 columns
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 8);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_COLNAMES")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"PROCEDURE_CAT",     "PROCEDURE_SCHEM", "PROCEDURE_NAME", "NUM_INPUT_PARAMS",
+                                    "NUM_OUTPUT_PARAMS", "NUM_RESULT_SETS", "REMARKS",        "PROCEDURE_TYPE"};
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLProcedures - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure with correct metadata",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_meta(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_META")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char procCat[256] = {};
+  char procSchem[256] = {};
+  char procName[256] = {};
+  SQLSMALLINT procType = 0;
+
+  SQLGetData(stmt_handle(), 1, SQL_C_CHAR, procCat, sizeof(procCat), nullptr);
+  SQLGetData(stmt_handle(), 2, SQL_C_CHAR, procSchem, sizeof(procSchem), nullptr);
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, procName, sizeof(procName), nullptr);
+  SQLGetData(stmt_handle(), 8, SQL_C_SSHORT, &procType, 0, nullptr);
+
+  REQUIRE(std::string(procCat) == currentDb);
+  REQUIRE(std::string(procSchem) == schema.name());
+  REQUIRE(std::string(procName) == "TEST_PROCS_META");
+  // SQL_PT_FUNCTION since it has RETURNS
+  REQUIRE(procType == SQL_PT_FUNCTION);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds procedure",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_wildcard(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_WILD%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char name[256] = {};
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name, sizeof(name), nullptr);
+  REQUIRE(std::string(name) == "TEST_PROCS_WILDCARD");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returning procs are all returned",
+                 "[odbc-api][procedures][catalog][known-bug]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_multi_a(p1 VARCHAR) RETURNS VARCHAR "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_multi_b(p1 VARCHAR) RETURNS VARCHAR "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_MULTI%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    char name[256] = {};
+    SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name, sizeof(name), nullptr);
+    INFO("Row " << (rowCount + 1) << ": " << name);
+    rowCount++;
+  }
+  // Both procedures should be returned
+  REQUIRE(rowCount == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is skipped by reference driver",
+                 "[odbc-api][procedures][catalog][known-bug]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_dtype_a(p1 VARCHAR) RETURNS VARCHAR "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_dtype_b(p1 INT) RETURNS INT "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_DTYPE%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  std::string foundName;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    char name[256] = {};
+    SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name, sizeof(name), nullptr);
+    INFO("Row " << (rowCount + 1) << ": " << name);
+    if (rowCount == 0) foundName = name;
+    rowCount++;
+  }
+  // Note: One proc has NUMBER(38,0) return types, so it is silently
+  // dropped by a comma-in-type parsing bug in the reference driver.
+  REQUIRE(rowCount == 1);
+  REQUIRE(foundName == "TEST_PROCS_DTYPE_A");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returning procs are all skipped",
+                 "[odbc-api][procedures][catalog][known-bug]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_num_a(p1 INT) RETURNS INT "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE PROCEDURE test_procs_num_b(p1 INT) RETURNS INT "
+                                                   "LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_NUM%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  int rowCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS) {
+    char name[256] = {};
+    SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name, sizeof(name), nullptr);
+    WARN("Unexpected row " << (rowCount + 1) << ": " << name);
+    rowCount++;
+  }
+  // Note: Both procs have NUMBER(38,0) return types, so both are silently
+  // dropped by a comma-in-type parsing bug in the reference driver.
+  REQUIRE(rowCount == 0);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure returns empty result set",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+                                SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_PROC_XYZ_99999")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLProcedures - Parameter Variations
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combinations are accepted",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_params(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // Explicit catalog, schema, proc with SQL_NTS
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_PARAMS")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Explicit string lengths instead of SQL_NTS
+  const std::string proc = "TEST_PROCS_PARAMS";
+  ret = SQLProcedures(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(proc.c_str())),
+      static_cast<SQLSMALLINT>(proc.length()));
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+// ============================================================================
+// SQLProcedures - Statement Reuse
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times on same statement after close cursor",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_reuse(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalog function call",
+                 "[odbc-api][procedures][catalog]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_rowcount(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_ROWCOUNT")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLProcedures - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLProcedures: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][procedures][catalog][error]") {
+  const SQLRETURN ret = SQLProcedures(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative CatalogName length",
+                 "[odbc-api][procedures][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SNOWFLAKE")), -999,
+                                nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative SchemaName length",
+                 "[odbc-api][procedures][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLProcedures(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")),
+                                -999, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcName length",
+                 "[odbc-api][procedures][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret =
+      SQLProcedures(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("PROC")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: 24000 - Cursor already open",
+                 "[odbc-api][procedures][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+          "CREATE PROCEDURE test_procs_cursor(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_CURSOR")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLProcedures(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_PROCS_CURSOR")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLProcedures: Requires active connection", "[odbc-api][procedures][catalog][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,19 +28,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has corre
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sc_numcols (id INT PRIMARY KEY, name VARCHAR(100))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sc_numcols (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_NUMCOLS")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_NUMCOLS"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -51,18 +50,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column na
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_colnames (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COLNAMES")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COLNAMES"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"SCOPE",       "COLUMN_NAME",   "DATA_TYPE",      "TYPE_NAME",
@@ -94,19 +90,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID retur
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sc_bestrowid (id INT PRIMARY KEY, name VARCHAR(100))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sc_bestrowid (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_BESTROWID")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_BESTROWID"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -120,19 +113,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns e
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_sc_rowver (id INT PRIMARY KEY, name VARCHAR(100))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_sc_rowver (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(stmt_handle(), SQL_ROWVER, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_ROWVER")), SQL_NTS, SQL_SCOPE_SESSION,
-                          SQL_NULLABLE);
+  ret =
+      SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
+                        SQL_NTS, sqlchar("TEST_SC_ROWVER"), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -143,29 +133,25 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nu
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_combos (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_combos (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // SQL_SCOPE_CURROW + SQL_NO_NULLS
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COMBOS")), SQL_NTS, SQL_SCOPE_CURROW, SQL_NO_NULLS);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COMBOS"), SQL_NTS, SQL_SCOPE_CURROW,
+                          SQL_NO_NULLS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
   // SQL_SCOPE_TRANSACTION + SQL_NULLABLE
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COMBOS")), SQL_NTS, SQL_SCOPE_TRANSACTION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COMBOS"), SQL_NTS,
+                          SQL_SCOPE_TRANSACTION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -179,27 +165,23 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple ti
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_reuse (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_reuse (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_REUSE")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_REUSE"), SQL_NTS, SQL_SCOPE_SESSION,
+                          SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLSpecialColumns(stmt_handle(), SQL_ROWVER, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_REUSE")), SQL_NTS, SQL_SCOPE_SESSION,
-                          SQL_NULLABLE);
+  ret =
+      SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
+                        SQL_NTS, sqlchar("TEST_SC_REUSE"), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -209,18 +191,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns 
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_ROWCOUNT")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_ROWCOUNT"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -235,17 +214,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns 
 
 TEST_CASE("SQLSpecialColumns: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][catalog][specialcolumns][error]") {
-  const SQLRETURN ret =
-      SQLSpecialColumns(SQL_NULL_HSTMT, SQL_BEST_ROWID, nullptr, 0, nullptr, 0,
-                        reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  const SQLRETURN ret = SQLSpecialColumns(SQL_NULL_HSTMT, SQL_BEST_ROWID, nullptr, 0, nullptr, 0, sqlchar("T"), SQL_NTS,
+                                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: HY090 - Negative TableName length",
                  "[odbc-api][catalog][specialcolumns][error]") {
-  const SQLRETURN ret =
-      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, nullptr, 0, nullptr, 0,
-                        reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  const SQLRETURN ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999,
+                                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -253,25 +230,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: 24000 - Cursor alrea
                  "[odbc-api][catalog][specialcolumns][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_cursor (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_cursor (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_CURSOR")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_CURSOR"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLSpecialColumns(
-      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_CURSOR")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
+                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_CURSOR"), SQL_NTS,
+                          SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
@@ -1,0 +1,287 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// Note: SQLSpecialColumns is not fully supported by the Snowflake reference driver.
+// It always returns an empty result set (SQL_NO_DATA on first fetch) regardless of
+// the table or parameters used. These tests document this behavior.
+
+// ============================================================================
+// SQLSpecialColumns - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has correct number of columns",
+                 "[odbc-api][catalog][specialcolumns]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sc_numcols (id INT PRIMARY KEY, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_NUMCOLS")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 8);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][catalog][specialcolumns]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COLNAMES")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"SCOPE",       "COLUMN_NAME",   "DATA_TYPE",      "TYPE_NAME",
+                                    "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "PSEUDO_COLUMN"};
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLSpecialColumns - Empty Result Set (Snowflake limitation)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID returns empty result set",
+                 "[odbc-api][catalog][specialcolumns]") {
+  // Note: Snowflake does not support row identifiers, so SQLSpecialColumns
+  // always returns an empty result set for SQL_BEST_ROWID.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sc_bestrowid (id INT PRIMARY KEY, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_BESTROWID")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns empty result set",
+                 "[odbc-api][catalog][specialcolumns]") {
+  // Note: Snowflake does not have auto-updated version columns, so
+  // SQLSpecialColumns always returns an empty result set for SQL_ROWVER.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_sc_rowver (id INT PRIMARY KEY, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(stmt_handle(), SQL_ROWVER, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_ROWVER")), SQL_NTS, SQL_SCOPE_SESSION,
+                          SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nullable combinations return empty",
+                 "[odbc-api][catalog][specialcolumns]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_combos (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // SQL_SCOPE_CURROW + SQL_NO_NULLS
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COMBOS")), SQL_NTS, SQL_SCOPE_CURROW, SQL_NO_NULLS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  // SQL_SCOPE_TRANSACTION + SQL_NULLABLE
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_COMBOS")), SQL_NTS, SQL_SCOPE_TRANSACTION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLSpecialColumns - Statement Reuse & SQLRowCount
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple times after close cursor",
+                 "[odbc-api][catalog][specialcolumns]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_reuse (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_REUSE")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  ret = SQLSpecialColumns(stmt_handle(), SQL_ROWVER, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+                          SQL_NTS, reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                          reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_REUSE")), SQL_NTS, SQL_SCOPE_SESSION,
+                          SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns -1",
+                 "[odbc-api][catalog][specialcolumns]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_ROWCOUNT")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLSpecialColumns - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLSpecialColumns: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][catalog][specialcolumns][error]") {
+  const SQLRETURN ret =
+      SQLSpecialColumns(SQL_NULL_HSTMT, SQL_BEST_ROWID, nullptr, 0, nullptr, 0,
+                        reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: HY090 - Negative TableName length",
+                 "[odbc-api][catalog][specialcolumns][error]") {
+  const SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, nullptr, 0, nullptr, 0,
+                        reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: 24000 - Cursor already open",
+                 "[odbc-api][catalog][specialcolumns][error]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_sc_cursor (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_CURSOR")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLSpecialColumns(
+      stmt_handle(), SQL_BEST_ROWID, reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_SC_CURSOR")), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLSpecialColumns: Requires active connection",
+                 "[odbc-api][catalog][specialcolumns][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,19 +28,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct n
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_stat_numcols (id INT PRIMARY KEY, name VARCHAR(100))")),
-                                SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE TABLE test_stat_numcols (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_NUMCOLS")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_NUMCOLS"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -51,18 +49,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names 
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_colnames (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_COLNAMES")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_COLNAMES"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT",   "TABLE_SCHEM", "TABLE_NAME",       "NON_UNIQUE",  "INDEX_QUALIFIER",
@@ -96,17 +91,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Returns empty result set
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
-                                    "CREATE TABLE test_stat_pk (id INT PRIMARY KEY, name VARCHAR(100))")),
-                                SQL_NTS);
+                                sqlchar("CREATE TABLE test_stat_pk (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_PK")), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_PK"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -117,18 +109,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_unique (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_unique (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_UNIQUE")), SQL_NTS, SQL_INDEX_UNIQUE,
-                      SQL_ENSURE);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_UNIQUE"), SQL_NTS, SQL_INDEX_UNIQUE, SQL_ENSURE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -143,27 +131,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times 
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_reuse (id INT PRIMARY KEY)")),
-      SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_reuse (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_REUSE")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_REUSE"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_REUSE")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_REUSE"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -172,18 +154,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1", "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_ROWCOUNT")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_ROWCOUNT"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -198,16 +177,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1",
 
 TEST_CASE("SQLStatistics: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][catalog][statistics][error]") {
   const SQLRETURN ret =
-      SQLStatistics(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS,
-                    SQL_INDEX_ALL, SQL_QUICK);
+      SQLStatistics(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("T"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: HY090 - Negative TableName length",
                  "[odbc-api][catalog][statistics][error]") {
   const SQLRETURN ret =
-      SQLStatistics(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999,
-                    SQL_INDEX_ALL, SQL_QUICK);
+      SQLStatistics(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -215,25 +192,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: 24000 - Cursor already o
                  "[odbc-api][catalog][statistics][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_cursor (id INT PRIMARY KEY)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_cursor (id INT PRIMARY KEY)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_CURSOR")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_CURSOR"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_CURSOR")), SQL_NTS, SQL_INDEX_ALL,
-                      SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                      sqlchar("TEST_STAT_CURSOR"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
@@ -1,0 +1,248 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// Note: SQLStatistics is not fully supported by the Snowflake reference driver.
+// It always returns an empty result set (SQL_NO_DATA on first fetch) regardless of
+// the table or index configuration. These tests document this behavior.
+
+// ============================================================================
+// SQLStatistics - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct number of columns",
+                 "[odbc-api][catalog][statistics]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_stat_numcols (id INT PRIMARY KEY, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_NUMCOLS")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 13);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][catalog][statistics]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_colnames (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_COLNAMES")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"TABLE_CAT",   "TABLE_SCHEM", "TABLE_NAME",       "NON_UNIQUE",  "INDEX_QUALIFIER",
+                                    "INDEX_NAME",  "TYPE",        "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC",
+                                    "CARDINALITY", "PAGES",       "FILTER_CONDITION"};
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLStatistics - Empty Result Set (Snowflake limitation)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Returns empty result set for table with primary key",
+                 "[odbc-api][catalog][statistics]") {
+  // Note: Snowflake does not expose index/statistics metadata through ODBC.
+  // SQLStatistics always returns an empty result set.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                reinterpret_cast<SQLCHAR*>(const_cast<char*>(
+                                    "CREATE TABLE test_stat_pk (id INT PRIMARY KEY, name VARCHAR(100))")),
+                                SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_PK")), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns empty",
+                 "[odbc-api][catalog][statistics]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_unique (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_UNIQUE")), SQL_NTS, SQL_INDEX_UNIQUE,
+                      SQL_ENSURE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLStatistics - Statement Reuse & SQLRowCount
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times after close cursor",
+                 "[odbc-api][catalog][statistics]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_reuse (id INT PRIMARY KEY)")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_REUSE")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_REUSE")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1", "[odbc-api][catalog][statistics]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_rowcount (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_ROWCOUNT")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLStatistics - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLStatistics: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][catalog][statistics][error]") {
+  const SQLRETURN ret =
+      SQLStatistics(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS,
+                    SQL_INDEX_ALL, SQL_QUICK);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: HY090 - Negative TableName length",
+                 "[odbc-api][catalog][statistics][error]") {
+  const SQLRETURN ret =
+      SQLStatistics(stmt_handle(), nullptr, 0, nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999,
+                    SQL_INDEX_ALL, SQL_QUICK);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: 24000 - Cursor already open",
+                 "[odbc-api][catalog][statistics][error]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_stat_cursor (id INT PRIMARY KEY)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_CURSOR")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLStatistics(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                      reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_STAT_CURSOR")), SQL_NTS, SQL_INDEX_ALL,
+                      SQL_QUICK);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLStatistics: Requires active connection", "[odbc-api][catalog][statistics][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
@@ -1,0 +1,211 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// Note: SQLTablePrivileges is not fully supported by the Snowflake reference driver.
+// It always returns an empty result set (SQL_NO_DATA on first fetch) regardless of
+// the table or privilege configuration. These tests document this behavior.
+
+// ============================================================================
+// SQLTablePrivileges - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has correct number of columns",
+                 "[odbc-api][catalog][tableprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_numcols (id INT, name VARCHAR(100))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_NUMCOLS")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 7);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][catalog][tableprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_colnames (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_COLNAMES")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",  "GRANTOR",
+                                    "GRANTEE",   "PRIVILEGE",   "IS_GRANTABLE"};
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLTablePrivileges - Empty Result Set (Snowflake limitation)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty result set for existing table",
+                 "[odbc-api][catalog][tableprivileges]") {
+  // Note: Snowflake does not expose table-level privilege metadata through ODBC.
+  // SQLTablePrivileges always returns an empty result set.
+
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_empty (id INT, name VARCHAR(100))")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_EMPTY")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL parameters return empty",
+                 "[odbc-api][catalog][tableprivileges]") {
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const SQLRETURN fetchRet = SQLFetch(stmt_handle());
+  REQUIRE(fetchRet == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLTablePrivileges - Statement Reuse & SQLRowCount
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple times after close cursor",
+                 "[odbc-api][catalog][tableprivileges]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_reuse (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_REUSE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns -1",
+                 "[odbc-api][catalog][tableprivileges]") {
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  const SQLRETURN rcRet = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(rcRet == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLTablePrivileges - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLTablePrivileges: SQL_INVALID_HANDLE for null statement handle",
+          "[odbc-api][catalog][tableprivileges][error]") {
+  const SQLRETURN ret = SQLTablePrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative TableName length",
+                 "[odbc-api][catalog][tableprivileges][error]") {
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative SchemaName length",
+                 "[odbc-api][catalog][tableprivileges][error]") {
+  const SQLRETURN ret =
+      SQLTablePrivileges(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
+                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: 24000 - Cursor already open",
+                 "[odbc-api][catalog][tableprivileges][error]") {
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                                     reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
+                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLTablePrivileges: Requires active connection",
+                 "[odbc-api][catalog][tableprivileges][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,18 +28,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has corr
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_numcols (id INT, name VARCHAR(100))")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_NUMCOLS")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                           sqlchar("TEST_TP_NUMCOLS"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -50,16 +49,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column n
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_colnames (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_colnames (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_COLNAMES")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                           sqlchar("TEST_TP_COLNAMES"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",  "GRANTOR",
@@ -91,17 +88,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty resul
 
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_empty (id INT, name VARCHAR(100))")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_empty (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_EMPTY")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                           sqlchar("TEST_TP_EMPTY"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -110,8 +105,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty resul
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL parameters return empty",
                  "[odbc-api][catalog][tableprivileges]") {
-  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("%")), SQL_NTS);
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const SQLRETURN fetchRet = SQLFetch(stmt_handle());
@@ -126,24 +120,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple t
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tp_reuse (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_reuse (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_REUSE")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                           sqlchar("TEST_TP_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TP_REUSE")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                           sqlchar("TEST_TP_REUSE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -151,8 +142,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple t
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns -1",
                  "[odbc-api][catalog][tableprivileges]") {
-  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -167,35 +157,30 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns
 
 TEST_CASE("SQLTablePrivileges: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][catalog][tableprivileges][error]") {
-  const SQLRETURN ret = SQLTablePrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS);
+  const SQLRETURN ret = SQLTablePrivileges(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("T"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative TableName length",
                  "[odbc-api][catalog][tableprivileges][error]") {
-  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), -999);
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][tableprivileges][error]") {
   const SQLRETURN ret =
-      SQLTablePrivileges(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SCHEMA")), -999,
-                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+      SQLTablePrivileges(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: 24000 - Cursor already open",
                  "[odbc-api][catalog][tableprivileges][error]") {
-  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                                     reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0,
-                           reinterpret_cast<SQLCHAR*>(const_cast<char*>("ANY_TABLE")), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
@@ -11,6 +11,8 @@
 #include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -22,18 +24,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct numbe
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_numcols (id INT, name VARCHAR(100))")),
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_NUMCOLS")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_NUMCOLS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC spec defines 5 columns
@@ -47,16 +46,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names matc
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_colnames (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_colnames (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_COLNAMES")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_COLNAMES"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS"};
@@ -84,17 +81,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with cor
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_meta (id INT, name VARCHAR(100))")), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_meta (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_META")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_META"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -122,23 +117,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with cor
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE VIEW", "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_base (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_base (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE VIEW test_tbl_view AS SELECT * FROM test_tbl_base")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE VIEW test_tbl_view AS SELECT * FROM test_tbl_base"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_VIEW")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_VIEW"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -157,10 +147,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Non-existent table returns e
   const auto schema = Schema::use_random_schema(dbc_handle());
   const std::string currentDb = get_current_database(dbc_handle());
 
-  SQLRETURN ret =
-      SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                            sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -172,24 +160,20 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   auto schema = Schema::use_random_schema(dbc_handle());
 
   // Create a table and a view with a similar naming pattern
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_filter_t (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_filter_t (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLExecDirect(
-      stmt_handle(),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE VIEW test_tbl_filter_v AS SELECT * FROM test_tbl_filter_t")),
-      SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE VIEW test_tbl_filter_v AS SELECT * FROM test_tbl_filter_t"),
+                      SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
   // No filter - wildcard matches both table and view
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int totalCount = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -198,10 +182,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   SQLCloseCursor(stmt_handle());
 
   // Filter for TABLE - should return only the table
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, sqlchar("TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -217,10 +199,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   SQLCloseCursor(stmt_handle());
 
   // Filter for VIEW - should return only the view
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("VIEW")), SQL_NTS);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, sqlchar("VIEW"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -238,16 +218,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table", "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_wild (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_wild (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_WIL%")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_WIL%"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -266,8 +244,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_params (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_params (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
@@ -275,9 +252,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
   const std::string& schemaName = schema.name();
 
   // SQL_NTS lengths
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_PARAMS")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_PARAMS"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -287,11 +263,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
 
   // Explicit string lengths
   const std::string tbl = "TEST_TBL_PARAMS";
-  ret = SQLTables(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
-      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
-      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(tbl.c_str())),
-      static_cast<SQLSMALLINT>(tbl.length()), nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
+                  sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(tbl.c_str()),
+                  static_cast<SQLSMALLINT>(tbl.length()), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -307,16 +281,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_reuse (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_reuse (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -324,9 +296,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
   REQUIRE(count1 == 1);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_REUSE")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_REUSE"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -337,16 +308,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_rowcount (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_rowcount (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_ROWCOUNT")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_ROWCOUNT"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -360,29 +329,25 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[o
 // ============================================================================
 
 TEST_CASE("SQLTables: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][catalog][tables][error]") {
-  const SQLRETURN ret = SQLTables(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
-                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  const SQLRETURN ret = SQLTables(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0, sqlchar("T"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative CatalogName length",
                  "[odbc-api][catalog][tables][error]") {
-  const SQLRETURN ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("DB")), -999, nullptr, 0,
-                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  const SQLRETURN ret = SQLTables(stmt_handle(), sqlchar("DB"), -999, nullptr, 0, sqlchar("T"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][tables][error]") {
-  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("S")), -999,
-                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, sqlchar("S"), -999, sqlchar("T"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative TableName length",
                  "[odbc-api][catalog][tables][error]") {
-  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, nullptr, 0,
-                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), -999, nullptr, 0);
+  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("T"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -390,22 +355,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: 24000 - Cursor already open"
                  "[odbc-api][catalog][tables][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_cursor (id INT)")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_cursor (id INT)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   const std::string currentDb = get_current_database(dbc_handle());
 
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_CURSOR")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_CURSOR"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
-                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_CURSOR")), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
+                  sqlchar("TEST_TBL_CURSOR"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
@@ -1,0 +1,420 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "test_macros.hpp"
+#include "test_setup.hpp"
+
+// ============================================================================
+// SQLTables - Result Set Structure
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct number of columns",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_numcols (id INT, name VARCHAR(100))")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_NUMCOLS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // ODBC spec defines 5 columns
+  SQLSMALLINT numCols = 0;
+  ret = SQLNumResultCols(stmt_handle(), &numCols);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(numCols == 5);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names match ODBC 3.x spec",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_colnames (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_COLNAMES")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS"};
+
+  for (SQLSMALLINT col = 1; col <= static_cast<SQLSMALLINT>(std::size(expectedColNames)); col++) {
+    char colName[256] = {};
+    SQLSMALLINT nameLen = 0;
+    SQLSMALLINT dataType = 0;
+    SQLULEN colSize = 0;
+    SQLSMALLINT decDigits = 0;
+    SQLSMALLINT nullable = 0;
+
+    ret = SQLDescribeCol(stmt_handle(), col, reinterpret_cast<SQLCHAR*>(colName), sizeof(colName), &nameLen, &dataType,
+                         &colSize, &decDigits, &nullable);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(std::string(colName) == expectedColNames[col - 1]);
+  }
+}
+
+// ============================================================================
+// SQLTables - Data Verification
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with correct metadata",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_meta (id INT, name VARCHAR(100))")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_META")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char tableCat[256] = {};
+  char tableSchem[256] = {};
+  char tableName[256] = {};
+  char tableType[256] = {};
+
+  SQLGetData(stmt_handle(), 1, SQL_C_CHAR, tableCat, sizeof(tableCat), nullptr);
+  SQLGetData(stmt_handle(), 2, SQL_C_CHAR, tableSchem, sizeof(tableSchem), nullptr);
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, tableType, sizeof(tableType), nullptr);
+
+  REQUIRE(std::string(tableCat) == currentDb);
+  REQUIRE(std::string(tableSchem) == schema.name());
+  REQUIRE(std::string(tableName) == "TEST_TBL_META");
+  REQUIRE(std::string(tableType) == "TABLE");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE VIEW", "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_base (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE VIEW test_tbl_view AS SELECT * FROM test_tbl_base")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_VIEW")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char tableType[256] = {};
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, tableType, sizeof(tableType), nullptr);
+  REQUIRE(std::string(tableType) == "VIEW");
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Non-existent table returns empty result set",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  SQLRETURN ret =
+      SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                reinterpret_cast<SQLCHAR*>(const_cast<char*>("NONEXISTENT_TABLE_XYZ_99999")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts results",
+                 "[odbc-api][catalog][tables]") {
+  auto schema = Schema::use_random_schema(dbc_handle());
+
+  // Create a table and a view with a similar naming pattern
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_filter_t (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  ret = SQLExecDirect(
+      stmt_handle(),
+      reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE VIEW test_tbl_filter_v AS SELECT * FROM test_tbl_filter_t")),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  // No filter - wildcard matches both table and view
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int totalCount = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    totalCount++;
+  REQUIRE(totalCount == 2);
+  SQLCloseCursor(stmt_handle());
+
+  // Filter for TABLE - should return only the table
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TABLE")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  char name1[256] = {};
+  char type1[256] = {};
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name1, sizeof(name1), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, type1, sizeof(type1), nullptr);
+  REQUIRE(std::string(name1) == "TEST_TBL_FILTER_T");
+  REQUIRE(std::string(type1) == "TABLE");
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+  SQLCloseCursor(stmt_handle());
+
+  // Filter for VIEW - should return only the view
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_FILTER%")), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("VIEW")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  char name2[256] = {};
+  char type2[256] = {};
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name2, sizeof(name2), nullptr);
+  SQLGetData(stmt_handle(), 4, SQL_C_CHAR, type2, sizeof(type2), nullptr);
+  REQUIRE(std::string(name2) == "TEST_TBL_FILTER_V");
+  REQUIRE(std::string(type2) == "VIEW");
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table", "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_wild (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_WIL%")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char tableName[256] = {};
+  SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
+  REQUIRE(std::string(tableName) == "TEST_TBL_WILD");
+}
+
+// ============================================================================
+// SQLTables - Parameter Variations
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinations are accepted",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_params (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+  const std::string& schemaName = schema.name();
+
+  // SQL_NTS lengths
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_PARAMS")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+  SQLCloseCursor(stmt_handle());
+
+  // Explicit string lengths
+  const std::string tbl = "TEST_TBL_PARAMS";
+  ret = SQLTables(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())),
+      static_cast<SQLSMALLINT>(currentDb.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(schemaName.c_str())),
+      static_cast<SQLSMALLINT>(schemaName.length()), reinterpret_cast<SQLCHAR*>(const_cast<char*>(tbl.c_str())),
+      static_cast<SQLSMALLINT>(tbl.length()), nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+// ============================================================================
+// SQLTables - Statement Reuse & SQLRowCount
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times after close cursor",
+                 "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_reuse (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count1 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count1++;
+  REQUIRE(count1 == 1);
+  SQLCloseCursor(stmt_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_REUSE")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  int count2 = 0;
+  while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
+    count2++;
+  REQUIRE(count2 == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_rowcount (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_ROWCOUNT")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN rowCount = 0;
+  ret = SQLRowCount(stmt_handle(), &rowCount);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(rowCount == -1);
+}
+
+// ============================================================================
+// SQLTables - Error Cases
+// ============================================================================
+
+TEST_CASE("SQLTables: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][catalog][tables][error]") {
+  const SQLRETURN ret = SQLTables(SQL_NULL_HSTMT, nullptr, 0, nullptr, 0,
+                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative CatalogName length",
+                 "[odbc-api][catalog][tables][error]") {
+  const SQLRETURN ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("DB")), -999, nullptr, 0,
+                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative SchemaName length",
+                 "[odbc-api][catalog][tables][error]") {
+  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, reinterpret_cast<SQLCHAR*>(const_cast<char*>("S")), -999,
+                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative TableName length",
+                 "[odbc-api][catalog][tables][error]") {
+  const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, nullptr, 0,
+                                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("T")), -999, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: 24000 - Cursor already open",
+                 "[odbc-api][catalog][tables][error]") {
+  const auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CREATE TABLE test_tbl_cursor (id INT)")), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+
+  const std::string currentDb = get_current_database(dbc_handle());
+
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_CURSOR")), SQL_NTS, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Second call without closing cursor
+  ret = SQLTables(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(currentDb.c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>(schema.name().c_str())), SQL_NTS,
+                  reinterpret_cast<SQLCHAR*>(const_cast<char*>("TEST_TBL_CURSOR")), SQL_NTS, nullptr, 0);
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(DbcFixture, "SQLTables: Requires active connection", "[odbc-api][catalog][tables][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  const SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+
+  // Note: Reference driver refuses to allocate statement on disconnected handle
+  REQUIRE(ret == SQL_ERROR);
+}

--- a/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/alloc_handle_tests.cpp
@@ -9,6 +9,7 @@
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "macros.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -208,8 +209,7 @@ TEST_CASE("SQLAllocHandle STMT: Basic allocation succeeds", "[odbc-api][alloc_ha
 
   // Connect
   const std::string conn_str = get_connection_string();
-  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
 
   // Allocate statement
@@ -218,7 +218,7 @@ TEST_CASE("SQLAllocHandle STMT: Basic allocation succeeds", "[odbc-api][alloc_ha
   REQUIRE(stmt != SQL_NULL_HSTMT);
 
   // Verify statement is usable
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -248,8 +248,7 @@ TEST_CASE("SQLAllocHandle STMT: Multiple allocations from same connection",
   // Verify all statements are usable
   for (int i = 0; i < NUM_STATEMENTS; i++) {
     const std::string query = "SELECT " + std::to_string(i);
-    SQLRETURN ret =
-        SQLExecDirect(statements[i].getHandle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(query.c_str())), SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(statements[i].getHandle(), sqlchar(query.c_str()), SQL_NTS);
     CHECK_ODBC(ret, statements[i]);
   }
 }
@@ -344,8 +343,7 @@ TEST_CASE("SQLAllocHandle DESC: Basic allocation succeeds", "[odbc-api][alloc_ha
   REQUIRE(ret == SQL_SUCCESS);
 
   const std::string conn_str = get_connection_string();
-  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
 
   // Allocate descriptor handle - should succeed on ODBC 3.x compliant drivers
@@ -377,8 +375,7 @@ TEST_CASE("SQLAllocHandle DESC: Multiple allocations from same connection",
   REQUIRE(ret == SQL_SUCCESS);
 
   const std::string conn_str = get_connection_string();
-  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
 
   for (auto& desc : descs) {
@@ -416,8 +413,7 @@ TEST_CASE("SQLAllocHandle DESC: HY009 - NULL OutputHandlePtr", "[odbc-api][alloc
   REQUIRE(ret == SQL_SUCCESS);
 
   const std::string conn_str = get_connection_string();
-  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
 
   ret = SQLAllocHandle(SQL_HANDLE_DESC, dbc, nullptr);
@@ -570,8 +566,7 @@ TEST_CASE("SQLAllocHandle: Complete ENV -> DBC -> STMT hierarchy", "[odbc-api][a
 
   // Connect
   const std::string conn_str = get_connection_string();
-  ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(conn_str.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   CHECK_ODBC_ERROR(ret, dbc, SQL_HANDLE_DBC);
 
   // Allocate statement
@@ -580,7 +575,7 @@ TEST_CASE("SQLAllocHandle: Complete ENV -> DBC -> STMT hierarchy", "[odbc-api][a
   REQUIRE(stmt != SQL_NULL_HSTMT);
 
   // Execute a query to verify the hierarchy works
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 42")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 42"), SQL_NTS);
   CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
 
   ret = SQLFetch(stmt);

--- a/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/browse_connect_tests.cpp
@@ -11,6 +11,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -26,8 +27,8 @@ TEST_CASE("SQLBrowseConnect: SQL_INVALID_HANDLE with NULL connection",
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(SQL_NULL_HDBC, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(SQL_NULL_HDBC, sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
@@ -40,8 +41,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: IM002 - Non-existent DSN",
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -53,8 +54,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: NULL OutConnectionString returns
   const std::string connStr = "DSN=Test";
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, nullptr, 1024, &outLen);
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, nullptr, 1024, &outLen);
 
   // Note: Snowflake driver returns ERROR when OutConnectionString is NULL
   // DM may return IM002 (DSN not found) before checking output buffer, or HY009
@@ -86,8 +86,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: Empty InConnectionString returns
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // IM002: Data source not found (empty string has no DSN/DRIVER)
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
@@ -101,7 +101,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: HY090 - Negative StringLength",
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()),
                                          -5,  // Invalid negative length
                                          outConnStr, sizeof(outConnStr), &outLen);
 
@@ -121,8 +121,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLBrowseConnect: HY090 - Negative BufferLength",
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr,
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr,
                                          -1,  // Invalid negative buffer length
                                          &outLen);
 
@@ -142,8 +141,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Zero BufferLength retu
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr,
+  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr,
                                          0,  // Zero buffer length
                                          &outLen);
 
@@ -162,9 +160,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 08002 - Connection alr
 
   // First connect using SQLDriverConnect
   const std::string connStr1 = get_connection_string();
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr1.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr1.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Try to connect again using SQLBrowseConnect
@@ -172,8 +169,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 08002 - Connection alr
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr2.c_str())), SQL_NTS,
-                         outConnStr, sizeof(outConnStr), &outLen);
+  ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr2.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // 08002: Connection name in use
   REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
@@ -194,8 +190,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Initial call with DSN"
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
-  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                   SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // Note: Snowflake driver supports SQLBrowseConnect and completes connection if DSN has all info
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
@@ -209,7 +205,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Initial call with DSN"
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -225,8 +221,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Reconnect after discon
   SQLSMALLINT outLen = 0;
 
   // First connection
-  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                   SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Disconnect
@@ -237,8 +233,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Reconnect after discon
   outLen = 0;
   std::memset(outConnStr, 0, sizeof(outConnStr));
 
-  ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                         outConnStr, sizeof(outConnStr), &outLen);
+  ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify second connection works
@@ -246,7 +241,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Reconnect after discon
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -266,8 +261,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLBrowseConnect: 28000 - Invalid credent
   SQLCHAR outConnStr[1024] = {};
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // Note: Snowflake driver returns 28000 for authentication failures.
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
@@ -285,8 +280,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: 01004 - OutConnectionS
   SQLCHAR outConnStr[10];  // Very small buffer to force truncation
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // Per ODBC spec, buffer truncation in SQLBrowseConnect should return SQL_NEED_DATA (99)
   // not SQL_SUCCESS_WITH_INFO. This is different from other ODBC functions.
@@ -307,8 +302,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: NULL StringLength2Ptr 
   SQLCHAR outConnStr[1024] = {};
 
   // NULL StringLength2Ptr is allowed per ODBC spec - caller doesn't need length
-  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                   SQL_NTS, outConnStr, sizeof(outConnStr),
+  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr),
                                    nullptr);  // NULL length pointer
 
   // Should succeed - NULL length pointer is valid
@@ -335,8 +329,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Disconnecting after su
   SQLCHAR outConnStr[1024];
   SQLSMALLINT outLen = 0;
 
-  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                   SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
@@ -357,8 +351,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Driver support with co
   SQLCHAR outConnStr[2048] = {};
   SQLSMALLINT outLen = 0;
 
-  SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                   SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // Note: Snowflake driver SUPPORTS SQLBrowseConnect
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
@@ -376,7 +370,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Driver support with co
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -398,8 +392,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLBrowseConnect: Iterative browse with 
   SQLCHAR outConnStr[2048] = {};
   SQLSMALLINT outLen = 0;
 
-  const SQLRETURN ret = SQLBrowseConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                                         SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
+  const SQLRETURN ret =
+      SQLBrowseConnect(dbc_handle(), sqlchar(connStr.c_str()), SQL_NTS, outConnStr, sizeof(outConnStr), &outLen);
 
   // Note: Snowflake driver does NOT support iterative browsing.
   // It requires a complete connection string and returns SQL_ERROR when given incomplete info.

--- a/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/connect_tests.cpp
@@ -14,6 +14,7 @@
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "macros.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -30,9 +31,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: Completes without crashing with valid 
   const std::string uid = "testuser";
   const std::string pwd = "testpwd";
 
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())), SQL_NTS);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, sqlchar(uid.c_str()), SQL_NTS,
+                                   sqlchar(pwd.c_str()), SQL_NTS);
 
   // Should fail with IM002 (DSN not found)
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
@@ -44,10 +44,9 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: Accepts explicit string lengths", "[od
   const std::string pwd = "cred";
 
   // Connect with explicit lengths instead of SQL_NTS
-  const SQLRETURN ret = SQLConnect(
-      dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), static_cast<SQLSMALLINT>(dsn.length()),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())), static_cast<SQLSMALLINT>(uid.length()),
-      reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())), static_cast<SQLSMALLINT>(pwd.length()));
+  const SQLRETURN ret =
+      SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), static_cast<SQLSMALLINT>(dsn.length()), sqlchar(uid.c_str()),
+                 static_cast<SQLSMALLINT>(uid.length()), sqlchar(pwd.c_str()), static_cast<SQLSMALLINT>(pwd.length()));
 
   // Should fail with IM002 (DSN not found) - the important thing is it doesn't crash with explicit lengths
   REQUIRE(ret == SQL_ERROR);
@@ -57,8 +56,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: Accepts NULL credentials", "[odbc-api]
   const std::string dsn = "TestDSN";
 
   // Connect with NULL UID and PWD parameters
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
 
   // Should fail (DSN doesn't exist) but accepts NULL credentials
   REQUIRE(ret == SQL_ERROR);
@@ -72,8 +70,7 @@ TEST_CASE("SQLConnect: SQL_INVALID_HANDLE - NULL connection handle", "[odbc-api]
   const auto params = get_test_parameters("testconnection");
   const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
 
-  const SQLRETURN ret = SQLConnect(SQL_NULL_HDBC, reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())),
-                                   SQL_NTS, nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(SQL_NULL_HDBC, sqlchar(server.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
 
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
@@ -88,7 +85,7 @@ TEST_CASE("SQLConnect: SQL_INVALID_HANDLE - Invalid handle type", "[odbc-api][co
   const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
 
   // Try to use ENV handle as DBC handle
-  ret = SQLConnect(env, reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+  ret = SQLConnect(env, sqlchar(server.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
 
   REQUIRE(ret == SQL_INVALID_HANDLE);
 
@@ -107,10 +104,8 @@ TEST_CASE("SQLConnect: SQL_INVALID_HANDLE - Invalid handle type", "[odbc-api][co
 
 TEST_CASE_METHOD(DbcFixture, "SQLConnect: IM002 - Non-existent DSN", "[odbc-api][connect][connecting][error]") {
   // Use non-existent DSN
-  const SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("INVALID_DSN_DOES_NOT_EXIST")), SQL_NTS,
-                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("user")), SQL_NTS,
-                 reinterpret_cast<SQLCHAR*>(const_cast<char*>("pwd")), SQL_NTS);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar("INVALID_DSN_DOES_NOT_EXIST"), SQL_NTS, sqlchar("user"),
+                                   SQL_NTS, sqlchar("pwd"), SQL_NTS);
 
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -125,8 +120,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative server name length",
   const std::string server = params.at("SNOWFLAKE_TEST_HOST").get<std::string>();
 
   // Use negative length (invalid, should be >= 0 or SQL_NTS)
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(server.c_str())), -5,
-                                   nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(server.c_str()), -5, nullptr, 0, nullptr, 0);
 
   REQUIRE_EXPECTED_ERROR(ret, "HY090", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -135,8 +129,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative username length", "[o
   const std::string dsn = "TestDSN";
   const std::string user = "testuser";
 
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(user.c_str())), -3, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, sqlchar(user.c_str()), -3, nullptr, 0);
 
   REQUIRE(ret == SQL_ERROR);
 
@@ -151,9 +144,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: HY090 - Negative PWD length", "[odbc-a
   const std::string uid = "testuser";
   const std::string pwd = "testpwd";
 
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(uid.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(pwd.c_str())), -2);
+  const SQLRETURN ret =
+      SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, sqlchar(uid.c_str()), SQL_NTS, sqlchar(pwd.c_str()), -2);
 
   REQUIRE(ret == SQL_ERROR);
 
@@ -173,8 +165,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: IM010/HY090 - Data source name too lon
   // Per ODBC spec: IM010 = "*ServerName was longer than SQL_MAX_DSN_LENGTH characters"
   const std::string long_dsn(300, 'A');
 
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(long_dsn.c_str())),
-                                   SQL_NTS, nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(long_dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
 
   REQUIRE(ret == SQL_ERROR);
 
@@ -207,8 +198,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: Can be called multiple times on same h
 
   // Multiple attempts (all will fail with IM002, but the API should handle it)
   for (int i = 0; i < 3; i++) {
-    const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                     nullptr, 0, nullptr, 0);
+    const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE(ret == SQL_ERROR);  // DSN doesn't exist
   }
 }
@@ -227,8 +217,7 @@ TEST_CASE_METHOD(EnvFixture, "SQLConnect: Multiple connection handles from same 
     REQUIRE(ret == SQL_SUCCESS);
 
     // Try to connect (will fail, but validates API accepts multiple handles)
-    ret = SQLConnect(connection, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
-                     nullptr, 0);
+    ret = SQLConnect(connection, sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE(ret == SQL_ERROR);  // DSN doesn't exist
   }
 
@@ -244,17 +233,14 @@ TEST_CASE_METHOD(EnvFixture, "SQLConnect: Multiple connection handles from same 
 
 TEST_CASE_METHOD(DbcFixture, "SQLConnect: Empty string parameters", "[odbc-api][connect][connecting][edge]") {
   // Connect with empty server name
-  const SQLRETURN ret =
-      SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), 0, nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(""), 0, nullptr, 0, nullptr, 0);
 
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
 
 TEST_CASE_METHOD(DbcFixture, "SQLConnect: Zero-length strings with SQL_NTS", "[odbc-api][connect][connecting][edge]") {
   // Empty strings with SQL_NTS should be treated as empty
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(""), SQL_NTS, sqlchar(""), SQL_NTS, sqlchar(""), SQL_NTS);
 
   REQUIRE(ret == SQL_ERROR);
 }
@@ -277,8 +263,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: SQL_ATTR_LOGIN_TIMEOUT can be set befo
 
   // Connect attempt (will fail with IM002, validates attribute setting doesn't break connect)
   const std::string dsn = "NonExistentDSN";
-  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
-                   nullptr, 0);
+  ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_ERROR);
 }
 
@@ -291,8 +276,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLConnect: Verify proper cleanup after failed con
   const std::string dsn = "NonExistentDSN";
 
   // Attempt connection that will fail
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   nullptr, 0, nullptr, 0);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_ERROR);
 
   // Per ODBC spec: SQLDisconnect should not be called if connection was never established
@@ -325,8 +309,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Basic DSN connection succeed
   const std::string dsn = dsn_name();
 
   // Credentials are in odbc.ini, pass NULL for UID/PWD
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
-                             0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection by executing a query
@@ -334,7 +317,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Basic DSN connection succeed
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
 
   ret = SQLFetch(stmt);
@@ -351,15 +334,13 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: 08002 - Connection already o
   const std::string dsn = dsn_name();
 
   // First connection must succeed
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
-                             0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Try to connect again without disconnecting - should fail with 08002
   // Per ODBC spec: "The specified ConnectionHandle had already been used to establish
   // a connection with a data source, and the connection was still open"
-  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
-                   nullptr, 0);
+  ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
 
   ret = SQLDisconnect(dbc_handle());
@@ -377,9 +358,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLConnect: 28000 - Invalid authorization
   const std::string bad_uid = "invalid_user_xyz";
   const std::string bad_pwd = "invalid_cred_xyz";
 
-  const SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(bad_uid.c_str())), SQL_NTS,
-                                   reinterpret_cast<SQLCHAR*>(const_cast<char*>(bad_pwd.c_str())), SQL_NTS);
+  const SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, sqlchar(bad_uid.c_str()), SQL_NTS,
+                                   sqlchar(bad_pwd.c_str()), SQL_NTS);
 
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -388,8 +368,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: SQL_SUCCESS_WITH_INFO has re
                  "[odbc-api][connect][dsn][integration]") {
   const std::string dsn = dsn_name();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
-                             0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   if (ret == SQL_SUCCESS_WITH_INFO) {
@@ -411,15 +390,14 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLConnect: Disconnect and reconnect cyc
 
   constexpr int CYCLES = 3;
   for (int i = 0; i < CYCLES; i++) {
-    SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS,
-                               nullptr, 0, nullptr, 0);
+    SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
     SQLHSTMT stmt = SQL_NULL_HSTMT;
     ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+    ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
     CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
 
     ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -445,8 +423,7 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLConnect: Multiple concurrent connecti
     SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &connection);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLConnect(connection, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0,
-                     nullptr, 0);
+    ret = SQLConnect(connection, sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   }
 
@@ -457,7 +434,7 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLConnect: Multiple concurrent connecti
     REQUIRE(ret == SQL_SUCCESS);
 
     std::string query = "SELECT " + std::to_string(i + 1);
-    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>(query.c_str())), SQL_NTS);
+    ret = SQLExecDirect(stmt, sqlchar(query.c_str()), SQL_NTS);
     CHECK_ODBC_ERROR(ret, stmt, SQL_HANDLE_STMT);
 
     ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -503,8 +480,7 @@ static void dsn_connection_thread(const std::string& dsn, std::atomic<SQLRETURN>
     // Retry logic for driver loading issues
     int retry = 0;
     do {
-      ret =
-          SQLConnect(dbc, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+      ret = SQLConnect(dbc, sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
       if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
         break;
       }
@@ -515,7 +491,7 @@ static void dsn_connection_thread(const std::string& dsn, std::atomic<SQLRETURN>
       // Verify connection works with a query
       SQLHSTMT stmt = SQL_NULL_HSTMT;
       if (SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt) == SQL_SUCCESS) {
-        SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+        SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
         SQLFreeHandle(SQL_HANDLE_STMT, stmt);
       }
       SQLDisconnect(dbc);
@@ -554,7 +530,7 @@ TEST_CASE("SQLConnect: Threaded concurrent connections", "[odbc-api][connect][ds
     ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLConnect(dbc, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr, 0, nullptr, 0);
+    ret = SQLConnect(dbc, sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
     SQLDisconnect(dbc);
     SQLFreeHandle(SQL_HANDLE_DBC, dbc);

--- a/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/driver_connect_tests.cpp
@@ -14,6 +14,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -29,8 +30,7 @@ std::string build_dsn_connection_string(const std::string& dsn) { return "DSN=" 
 TEST_CASE("SQLDriverConnect: SQL_INVALID_HANDLE - NULL connection handle",
           "[odbc-api][driverconnect][connecting][error]") {
   const SQLRETURN ret =
-      SQLDriverConnect(SQL_NULL_HDBC, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+      SQLDriverConnect(SQL_NULL_HDBC, nullptr, sqlchar("DSN=test"), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -42,10 +42,9 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY090 - Negative string length",
                  "[odbc-api][driverconnect][connecting][error]") {
   // Negative StringLength1 (not SQL_NTS) should return HY090
   // Note: DM-dependent - some DMs validate length first (HY090), others pass to DSN lookup (IM002)
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
-                       -5,  // Invalid negative length
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=test"),
+                                         -5,  // Invalid negative length
+                                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
   REQUIRE(!records.empty());
@@ -60,10 +59,9 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY090 - Negative buffer length",
 
   // Negative BufferLength - DM-dependent validation
   // Most DMs will fail with HY090, but some may pass through to DSN lookup (IM002)
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN")),
-                       SQL_NTS, outConnStr, -1,  // Invalid negative buffer length
-                       &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=NonExistentDSN"), SQL_NTS, outConnStr,
+                                         -1,  // Invalid negative buffer length
+                                         &outConnStrLen, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
   REQUIRE(!records.empty());
@@ -75,17 +73,15 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: HY110 - Invalid DriverCompletion
                  "[odbc-api][driverconnect][connecting][error]") {
   // Invalid DriverCompletion value (not one of the valid constants)
   const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")), SQL_NTS,
-                       nullptr, 0, nullptr, 999);  // Invalid value
+      SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=test"), SQL_NTS, nullptr, 0, nullptr, 999);  // Invalid value
   // Should return HY110 (Invalid driver completion)
   REQUIRE_EXPECTED_ERROR(ret, "HY110", dbc_handle(), SQL_HANDLE_DBC);
 }
 
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: IM002 - Data source not found (non-existent DSN)",
                  "[odbc-api][driverconnect][connecting][error]") {
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN12345")),
-                       SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=NonExistentDSN12345"), SQL_NTS, nullptr, 0,
+                                         nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
 
@@ -93,8 +89,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: IM007 - No data source or driver
                  "[odbc-api][driverconnect][connecting][error]") {
   // Empty connection string with SQL_DRIVER_NOPROMPT
   // Note: DM-dependent - spec says IM007, but some DMs return IM002
-  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("")),
-                                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret =
+      SQLDriverConnect(dbc_handle(), nullptr, sqlchar(""), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
   REQUIRE(!records.empty());
@@ -104,8 +100,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: IM007 - No data source or driver
 
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Empty connection string",
                  "[odbc-api][driverconnect][connecting][error]") {
-  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), 0,
-                                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret =
+      SQLDriverConnect(dbc_handle(), nullptr, sqlchar(""), 0, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_ERROR);
 }
 
@@ -121,9 +117,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: NULL connection string",
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Explicit string length with SQL_NTS",
                  "[odbc-api][driverconnect][connecting]") {
   // Use SQL_NTS for connection string
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=NonExistentDSN")),
-                       SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=NonExistentDSN"), SQL_NTS, nullptr, 0,
+                                         nullptr, SQL_DRIVER_NOPROMPT);
   // Should fail with IM002 (data source not found)
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -134,18 +129,17 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Explicit byte count for string l
 
   // Use explicit length
   const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())),
-                       static_cast<SQLSMALLINT>(connStr.length()), nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+      SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), static_cast<SQLSMALLINT>(connStr.length()),
+                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
 
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Zero string length (empty string)",
                  "[odbc-api][driverconnect][connecting][edge]") {
   // Zero length string
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test")),
-                       0,  // Zero length - treats as empty
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=test"),
+                                         0,  // Zero length - treats as empty
+                                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_ERROR);
 }
 
@@ -156,9 +150,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mo
   // SQL_DRIVER_NOPROMPT: Never prompt, fail if info missing
   // With complete DSN (has credentials), should succeed
   std::string connStr = "DSN=" + dsn_name();
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -173,9 +166,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_NOPROMPT mod
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
   std::string connStr = "DSN=" + dsn_name();
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                         SQL_DRIVER_NOPROMPT);
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
 }
 
@@ -186,9 +178,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mo
   // SQL_DRIVER_COMPLETE: Prompt only if info is missing
   // With complete DSN, no prompting needed, should succeed
   std::string connStr = "DSN=" + dsn_name();
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_COMPLETE);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -204,9 +195,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE mod
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
   std::string connStr = "DSN=" + dsn_name();
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_COMPLETE);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                         SQL_DRIVER_COMPLETE);
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
 }
 
@@ -217,9 +207,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_RE
   // SQL_DRIVER_COMPLETE_REQUIRED: Only prompt for required info
   // With complete DSN, no prompting needed, should succeed
   std::string connStr = "DSN=" + dsn_name();
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_COMPLETE_REQUIRED);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -235,9 +224,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: SQL_DRIVER_COMPLETE_REQ
   // Note: Snowflake driver returns 28000 for authentication failures.
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
   std::string connStr = "DSN=" + dsn_name();
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_COMPLETE_REQUIRED);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                         SQL_DRIVER_COMPLETE_REQUIRED);
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
 }
 
@@ -247,9 +235,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: SQL_DRIVER_PROMPT mode
   // Per ODBC spec, with NULL window handle should return HY092 or fail
   // Even though DSN is complete, PROMPT mode MUST show dialog
   std::string connStr = "DSN=" + dsn_name();
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_PROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                         SQL_DRIVER_PROMPT);
 
   // Per ODBC spec: SQL_DRIVER_PROMPT with NULL window handle returns HY092
   // unixODBC follows spec and returns HY092
@@ -263,14 +250,13 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: 08002 - Connection alr
   const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // First connection
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Second connection on same handle should fail with 08002
-  ret = SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                         SQL_DRIVER_NOPROMPT);
   REQUIRE_EXPECTED_ERROR(ret, "08002", dbc_handle(), SQL_HANDLE_DBC);
 
   ret = SQLDisconnect(dbc_handle());
@@ -280,9 +266,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: 08002 - Connection alr
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Connection string keyword=value parsing",
                  "[odbc-api][driverconnect][connecting][parsing]") {
   // Valid format but non-existent DSN
-  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
-                                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test;UID=user;PWD=pass")),
-                                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=test;UID=user;PWD=pass"), SQL_NTS, nullptr,
+                                         0, nullptr, SQL_DRIVER_NOPROMPT);
   // Should be IM002 (DSN not found), not a parsing error
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -298,9 +283,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString bu
   SQLSMALLINT outConnStrLen = 0;
   std::memset(outConnStr, 0, sizeof(outConnStr));
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       outConnStr, sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, outConnStr,
+                                   sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Output connection string should be populated
@@ -321,9 +305,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: OutConnectionString tr
   SQLCHAR outConnStr[10];
   SQLSMALLINT outConnStrLen = 0;
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       outConnStr, sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, outConnStr,
+                                   sizeof(outConnStr), &outConnStrLen, SQL_DRIVER_NOPROMPT);
   // Should succeed (connection made) but possibly with INFO for truncation
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
@@ -347,9 +330,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL OutConnectionStri
   SQLSMALLINT outConnStrLen = 0;
 
   // NULL buffer but valid length pointer - should report required length
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, &outConnStrLen, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, &outConnStrLen,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Length should indicate how much space is needed
@@ -367,9 +349,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: NULL StringLength2Ptr 
   SQLCHAR outConnStr[1024];
 
   // Valid buffer but NULL length pointer - should still succeed
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       outConnStr, sizeof(outConnStr), nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, outConnStr,
+                                   sizeof(outConnStr), nullptr, SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Buffer should still be populated
@@ -386,16 +367,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Both OutConnectionStri
   const std::string connStr = build_dsn_connection_string(dsn_name());
 
   // Both NULL - should still connect, just no output
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection works
   SQLHSTMT stmt = SQL_NULL_HSTMT;
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   REQUIRE(ret == SQL_SUCCESS);
@@ -407,9 +387,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Both OutConnectionStri
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Connection string with special characters",
                  "[odbc-api][driverconnect][connecting][parsing]") {
   // Connection string with braces (should be parsed correctly)
-  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
-                                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN={Test DSN With Spaces}")),
-                                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN={Test DSN With Spaces}"), SQL_NTS, nullptr,
+                                         0, nullptr, SQL_DRIVER_NOPROMPT);
   // Will fail with IM002 but shouldn't crash or have parsing error
   REQUIRE(ret == SQL_ERROR);
 }
@@ -417,9 +396,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Connection string with special c
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Multiple semicolons in connection string",
                  "[odbc-api][driverconnect][connecting][parsing]") {
   // Multiple semicolons should be handled gracefully
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DSN=test;;UID=user;;;")),
-                       SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("DSN=test;;UID=user;;;"), SQL_NTS, nullptr, 0,
+                                         nullptr, SQL_DRIVER_NOPROMPT);
   // Should parse correctly and fail with IM002
   REQUIRE(ret == SQL_ERROR);
 }
@@ -427,9 +405,8 @@ TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Multiple semicolons in connectio
 TEST_CASE_METHOD(DbcFixture, "SQLDriverConnect: Case insensitivity of keywords",
                  "[odbc-api][driverconnect][connecting][parsing]") {
   // Keywords are case-insensitive per ODBC spec
-  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,
-                                         reinterpret_cast<SQLCHAR*>(const_cast<char*>("dsn=test;uid=user;pwd=pass")),
-                                         SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar("dsn=test;uid=user;pwd=pass"), SQL_NTS, nullptr,
+                                         0, nullptr, SQL_DRIVER_NOPROMPT);
   // Should parse correctly (same as DSN=test) - DSN not found, not parsing error
   REQUIRE_EXPECTED_ERROR(ret, "IM002", dbc_handle(), SQL_HANDLE_DBC);
 }
@@ -454,9 +431,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Basic DSN connection s
 
   const std::string connStr = build_dsn_connection_string(dsn_name());
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection by executing a query
@@ -464,7 +440,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Basic DSN connection s
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLFetch(stmt);
@@ -483,9 +459,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Connection with additi
   // DSN with additional Snowflake-specific parameters
   const std::string connStr = "DSN=" + dsn_name() + ";TRACING=0";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -500,9 +475,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   // Per ODBC spec, unrecognized keywords return SQL_SUCCESS_WITH_INFO with 01S00
   const std::string connStr = "DSN=" + dsn_name() + ";INVALIDKEY=abc";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
 
   auto records = get_diag_rec(SQL_HANDLE_DBC, dbc_handle());
@@ -522,9 +496,8 @@ TEST_CASE_METHOD(DbcNoAuthDSNFixture, "SQLDriverConnect: 28000 - Invalid authori
   // ODBC spec allows 28000, 08001, 08004, or HY000, but Snowflake consistently uses 28000.
   const std::string connStr = "DSN=" + dsn_name() + ";UID=invalid_user_xyz;PWD=invalid_cred_xyz";
 
-  const SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  const SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                         SQL_DRIVER_NOPROMPT);
   REQUIRE_EXPECTED_ERROR(ret, "28000", dbc_handle(), SQL_HANDLE_DBC);
 }
 
@@ -535,16 +508,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Disconnect and reconne
   const std::string connStr = build_dsn_connection_string(dsn_name());
 
   for (int i = 0; i < 3; i++) {
-    SQLRETURN ret =
-        SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                     SQL_DRIVER_NOPROMPT);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
     // Verify connection with query
     SQLHSTMT stmt = SQL_NULL_HSTMT;
     ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
     REQUIRE(ret == SQL_SUCCESS);
-    ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+    ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
     ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
     REQUIRE(ret == SQL_SUCCESS);
@@ -569,8 +541,8 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLDriverConnect: Multiple concurrent co
     SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env_handle(), &connection);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLDriverConnect(connection, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                           nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    ret = SQLDriverConnect(connection, nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                           SQL_DRIVER_NOPROMPT);
     if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
       successful_connections++;
     }
@@ -601,9 +573,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake TRACING para
   // Note: TRACING is a Snowflake-specific parameter that controls logging level (0-6)
   const std::string connStr = "DSN=" + dsn_name() + ";TRACING=0";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -617,16 +588,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake CLIENT_SESSI
   // Note: CLIENT_SESSION_KEEP_ALIVE is a Snowflake-specific parameter that enables heartbeat to keep session alive
   const std::string connStr = "DSN=" + dsn_name() + ";CLIENT_SESSION_KEEP_ALIVE=true";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection is usable
   SQLHSTMT stmt = SQL_NULL_HSTMT;
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   REQUIRE(ret == SQL_SUCCESS);
@@ -642,9 +612,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake LOGIN_TIMEOU
   // LOGIN_TIMEOUT sets connection timeout in seconds
   const std::string connStr = "DSN=" + dsn_name() + ";LOGIN_TIMEOUT=120";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -658,16 +627,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake APPLICATION 
   // APPLICATION parameter sets client application name
   const std::string connStr = "DSN=" + dsn_name() + ";APPLICATION=ODBCTestSuite";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection is usable
   SQLHSTMT stmt = SQL_NULL_HSTMT;
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   REQUIRE(ret == SQL_SUCCESS);
@@ -683,9 +651,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake QUERY_TIMEOU
   // QUERY_TIMEOUT sets query execution timeout (0 = no timeout)
   const std::string connStr = "DSN=" + dsn_name() + ";QUERY_TIMEOUT=0";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -699,9 +666,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake NETWORK_TIME
   // NETWORK_TIMEOUT sets network operation timeout
   const std::string connStr = "DSN=" + dsn_name() + ";NETWORK_TIMEOUT=0";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -715,9 +681,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DisableOCSPC
   // Note: DisableOCSPCheck is a Snowflake-specific parameter that controls OCSP certificate validation
   const std::string connStr = "DSN=" + dsn_name() + ";DisableOCSPCheck=true";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -732,9 +697,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake DATABASE and
   // Empty values should not break connection
   const std::string connStr = "DSN=" + dsn_name() + ";DATABASE=;SCHEMA=";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -748,9 +712,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake WAREHOUSE pa
   // WAREHOUSE can override default warehouse (empty = use default)
   const std::string connStr = "DSN=" + dsn_name() + ";WAREHOUSE=";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -764,9 +727,8 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake ROLE paramet
   // ROLE can override default role (empty = use default)
   const std::string connStr = "DSN=" + dsn_name() + ";ROLE=";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   ret = SQLDisconnect(dbc_handle());
@@ -786,16 +748,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDriverConnect: Snowflake multiple par
                               ";NETWORK_TIMEOUT=0"
                               ";CLIENT_SESSION_KEEP_ALIVE=false";
 
-  SQLRETURN ret =
-      SQLDriverConnect(dbc_handle(), nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                       nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+  SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
 
   // Verify connection works
   SQLHSTMT stmt = SQL_NULL_HSTMT;
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT CURRENT_TIMESTAMP()")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT CURRENT_TIMESTAMP()"), SQL_NTS);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   REQUIRE(ret == SQL_SUCCESS);
@@ -833,13 +794,12 @@ static void driver_connect_thread(const std::string& connStr, std::atomic<SQLRET
       return;
     }
 
-    ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                           nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    ret = SQLDriverConnect(dbc, nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
       // Verify with simple query
       SQLHSTMT stmt = SQL_NULL_HSTMT;
       if (SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt) == SQL_SUCCESS) {
-        SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+        SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
         SQLFreeHandle(SQL_HANDLE_STMT, stmt);
       }
       SQLDisconnect(dbc);
@@ -880,8 +840,7 @@ TEST_CASE("SQLDriverConnect: Threaded concurrent connections",
     ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
     REQUIRE(ret == SQL_SUCCESS);
 
-    ret = SQLDriverConnect(dbc, nullptr, reinterpret_cast<SQLCHAR*>(const_cast<char*>(connStr.c_str())), SQL_NTS,
-                           nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    ret = SQLDriverConnect(dbc, nullptr, sqlchar(connStr.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
     SQLDisconnect(dbc);
     SQLFreeHandle(SQL_HANDLE_DBC, dbc);

--- a/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
@@ -7,6 +7,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 
 // ============================================================================
@@ -112,8 +113,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported[SQL_API_ODBC3_ALL_FUNCTIONS_SIZE] = {};
@@ -134,8 +134,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported[100] = {};  // Size must be at least the largest function ID in ALL_ODBC_FUNCTIONS
@@ -157,8 +156,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Correctly reports unsup
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported = SQL_TRUE;
@@ -201,8 +199,7 @@ TEST_CASE_METHOD(EnvFixture, "SQLGetFunctions: SQL_INVALID_HANDLE - Invalid hand
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Accepts NULL output pointer",
                  "[odbc-api][getfunctions][driver_info]") {
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns SUCCESS for NULL pointer (differs from ODBC spec)
@@ -215,8 +212,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Accepts NULL output poi
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: HY095 - Invalid FunctionId",
                  "[odbc-api][getfunctions][driver_info][error]") {
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported = SQL_FALSE;
@@ -247,8 +243,7 @@ TEST_CASE_METHOD(DbcFixture, "SQLGetFunctions: Requires active connection",
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: Can be called after connection established",
                  "[odbc-api][getfunctions][driver_info]") {
   const std::string dsn = dsn_name();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn.c_str())), SQL_NTS, nullptr,
-                             0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT supported = SQL_FALSE;
@@ -268,8 +263,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: All known supported fun
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver requires an active connection
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (const auto& func : ALL_ODBC_FUNCTIONS) {

--- a/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
@@ -10,6 +10,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 
 // ============================================================================
@@ -18,8 +19,7 @@
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACTIVE_ENVIRONMENTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT activeEnv = 0;
@@ -33,8 +33,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACTIVE_ENVIRONMENTS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_DBC_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncDbc = 0;
@@ -48,8 +47,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_DBC_FUNCTIONS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_MODE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncMode = 0;
@@ -63,8 +61,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_MODE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_NOTIFICATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER asyncNotif = 0;
@@ -78,8 +75,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ASYNC_NOTIFICATION", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_ROW_COUNT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER batchRowCount = 0;
@@ -93,8 +89,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_ROW_COUNT", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_SUPPORT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER batchSupport = 0;
@@ -107,8 +102,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BATCH_SUPPORT", "[odbc-a
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_NAME", "[odbc-api][getinfo][driver_info]") {
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dsnName[256];
@@ -125,8 +119,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_NAME", "[odb
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_AWARE_POOLING_SUPPORTED",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER poolingSupport = 0;
@@ -144,8 +137,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_AWARE_POOLING_SUP
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverName[256];
@@ -162,8 +154,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_ODBC_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char odbcVer[256];
@@ -180,8 +171,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_ODBC_VER", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverVer[256];
@@ -198,8 +188,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api]
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -233,8 +222,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -268,8 +256,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DYNAMIC_CURSOR_ATTRIBUTE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -299,8 +286,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTR
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -333,8 +319,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FORWARD_ONLY_CURSOR_ATTR
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FILE_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT fileUsage = 0;
@@ -348,8 +333,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FILE_USAGE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GETDATA_EXTENSIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER getdataExt = 0;
@@ -370,8 +354,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GETDATA_EXTENSIONS", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INFO_SCHEMA_VIEWS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER infoSchemaViews = 0;
@@ -413,8 +396,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INFO_SCHEMA_VIEWS", "[od
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -448,8 +430,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -483,8 +464,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYSET_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ASYNC_CONCURRENT_STATEMENTS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxAsync = 0;
@@ -499,8 +479,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ASYNC_CONCURRENT_STA
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CONCURRENT_ACTIVITIES",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxConcurrent = 0;
@@ -514,8 +493,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CONCURRENT_ACTIVITIE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_DRIVER_CONNECTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxConnections = 0;
@@ -530,8 +508,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_DRIVER_CONNECTIONS",
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_INTERFACE_CONFORMANCE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER interfaceConformance = 0;
@@ -545,8 +522,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_INTERFACE_CONFORMAN
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_VER", "[odbc-api][getinfo][driver_info]") {
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char odbcVer[256];
@@ -562,8 +538,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_VER", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER paramArrayRowCounts = 0;
@@ -578,8 +553,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER paramArraySelects = 0;
@@ -593,8 +567,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ROW_UPDATES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char rowUpdates[8];
@@ -609,8 +582,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ROW_UPDATES", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SEARCH_PATTERN_ESCAPE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char escapeChar[8];
@@ -626,8 +598,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SEARCH_PATTERN_ESCAPE", 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SERVER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char serverName[256];
@@ -643,8 +614,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SERVER_NAME", "[odbc-api
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES1",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -678,8 +648,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES2",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER attrs = 0;
@@ -717,8 +686,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_CURSOR_ATTRIBUTES
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATABASE_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbName[256];
@@ -735,8 +703,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATABASE_NAME", "[odbc-a
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbmsName[256];
@@ -753,8 +720,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_NAME", "[odbc-api][
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char dbmsVer[256];
@@ -774,8 +740,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_PROCEDURES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char accessible[8];
@@ -789,8 +754,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_PROCEDURES", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_TABLES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char accessible[8];
@@ -804,8 +768,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ACCESSIBLE_TABLES", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BOOKMARK_PERSISTENCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER bookmarkPersist = 0;
@@ -827,8 +790,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_BOOKMARK_PERSISTENCE", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char catalogTerm[64];
@@ -843,8 +805,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_TERM", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLLATION_SEQ", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char collSeq[256];
@@ -858,8 +819,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLLATION_SEQ", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONCAT_NULL_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT concatBehavior = 0;
@@ -873,8 +833,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONCAT_NULL_BEHAVIOR", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_COMMIT_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT cursorCommit = 0;
@@ -888,8 +847,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_COMMIT_BEHAVIOR",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_ROLLBACK_BEHAVIOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT cursorRollback = 0;
@@ -903,8 +861,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_ROLLBACK_BEHAVIOR
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_SENSITIVITY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER sensitivity = 0;
@@ -918,8 +875,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CURSOR_SENSITIVITY", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_READ_ONLY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char readOnly[8];
@@ -933,8 +889,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATA_SOURCE_READ_ONLY", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DEFAULT_TXN_ISOLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER txnIsolation = 0;
@@ -953,8 +908,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DEFAULT_TXN_ISOLATION", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DESCRIBE_PARAMETER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char descParam[8];
@@ -968,8 +922,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DESCRIBE_PARAMETER", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULT_RESULT_SETS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char multResults[8];
@@ -983,8 +936,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULT_RESULT_SETS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULTIPLE_ACTIVE_TXN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char multTxn[8];
@@ -998,8 +950,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MULTIPLE_ACTIVE_TXN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NEED_LONG_DATA_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char needLongLen[8];
@@ -1013,8 +964,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NEED_LONG_DATA_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NULL_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT nullColl = 0;
@@ -1029,8 +979,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NULL_COLLATION", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURE_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procTerm[64];
@@ -1047,8 +996,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURE_TERM", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char schemaTerm[64];
@@ -1063,8 +1011,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_TERM", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_OPTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER scrollOpts = 0;
@@ -1085,8 +1032,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_OPTIONS", "[odbc-
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TABLE_TERM", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char tableTerm[64];
@@ -1102,8 +1048,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TABLE_TERM", "[odbc-api]
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_CAPABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT txnCapable = 0;
@@ -1117,8 +1062,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_CAPABLE", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_ISOLATION_OPTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER txnIsoOpts = 0;
@@ -1138,8 +1082,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TXN_ISOLATION_OPTION", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_USER_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char userName[256];
@@ -1159,8 +1102,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_USER_NAME", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_AGGREGATE_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER aggFuncs = 0;
@@ -1180,8 +1122,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_AGGREGATE_FUNCTIONS", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER alterDomain = 0;
@@ -1205,8 +1146,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_DOMAIN", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER alterTable = 0;
@@ -1249,8 +1189,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ALTER_TABLE", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATETIME_LITERALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER datetimeLiterals = 0;
@@ -1281,8 +1220,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DATETIME_LITERALS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_LOCATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT catLoc = 0;
@@ -1296,8 +1234,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_LOCATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char catName[8];
@@ -1312,8 +1249,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME_SEPARATOR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char separator[8];
@@ -1328,8 +1264,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_NAME_SEPARATOR",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER catUsage = 0;
@@ -1351,8 +1286,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CATALOG_USAGE", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLUMN_ALIAS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char colAlias[8];
@@ -1366,8 +1300,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_COLUMN_ALIAS", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CORRELATION_NAME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT corrName = 0;
@@ -1381,8 +1314,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CORRELATION_NAME", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_ASSERTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1402,8 +1334,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_ASSERTION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_CHARACTER_SET", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1421,8 +1352,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_CHARACTER_SET", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1438,8 +1368,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_COLLATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1463,8 +1392,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_DOMAIN", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_SCHEMA", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1482,8 +1410,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_SCHEMA", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1518,8 +1445,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TABLE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TRANSLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1535,8 +1461,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_TRANSLATION", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_VIEW", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER create = 0;
@@ -1554,8 +1479,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CREATE_VIEW", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DDL_INDEX", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER ddlIndex = 0;
@@ -1569,8 +1493,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DDL_INDEX", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_ASSERTION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1586,8 +1509,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_ASSERTION", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_CHARACTER_SET", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1603,8 +1525,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_CHARACTER_SET", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_COLLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1620,8 +1541,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_COLLATION", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_DOMAIN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1639,8 +1559,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_DOMAIN", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_SCHEMA", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1657,8 +1576,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_SCHEMA", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1675,8 +1593,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TABLE", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TRANSLATION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1692,8 +1609,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_TRANSLATION", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_VIEW", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER drop = 0;
@@ -1710,8 +1626,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DROP_VIEW", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_EXPRESSIONS_IN_ORDERBY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char exprOrderBy[8];
@@ -1725,8 +1640,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_EXPRESSIONS_IN_ORDERBY",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GROUP_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT groupBy = 0;
@@ -1741,8 +1655,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_GROUP_BY", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_CASE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT identCase = 0;
@@ -1757,8 +1670,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_CASE", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_QUOTE_CHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char quoteChar[8];
@@ -1774,8 +1686,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_IDENTIFIER_QUOTE_CHAR", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INDEX_KEYWORDS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER indexKeywords = 0;
@@ -1789,8 +1700,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INDEX_KEYWORDS", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INSERT_STATEMENT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER insertStmt = 0;
@@ -1809,8 +1719,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INSERT_STATEMENT", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INTEGRITY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char integrity[8];
@@ -1824,8 +1733,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_INTEGRITY", "[odbc-api][
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYWORDS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char keywords[4096];
@@ -1841,8 +1749,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_KEYWORDS", "[odbc-api][g
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LIKE_ESCAPE_CLAUSE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char likeEscape[8];
@@ -1856,8 +1763,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LIKE_ESCAPE_CLAUSE", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NON_NULLABLE_COLUMNS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT nonNull = 0;
@@ -1871,8 +1777,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NON_NULLABLE_COLUMNS", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_OJ_CAPABILITIES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER ojCaps = 0;
@@ -1894,8 +1799,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_OJ_CAPABILITIES", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ORDER_BY_COLUMNS_IN_SELECT",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char orderByInSelect[8];
@@ -1909,8 +1813,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ORDER_BY_COLUMNS_IN_SELE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procedures[8];
@@ -1924,8 +1827,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PROCEDURES", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_QUOTED_IDENTIFIER_CASE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT quotedCase = 0;
@@ -1939,8 +1841,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_QUOTED_IDENTIFIER_CASE",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_USAGE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER schemaUsage = 0;
@@ -1962,8 +1863,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCHEMA_USAGE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SPECIAL_CHARACTERS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char specialChars[256];
@@ -1981,8 +1881,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SPECIAL_CHARACTERS", "[o
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL_CONFORMANCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER conformance = 0;
@@ -1996,8 +1895,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL_CONFORMANCE", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STANDARD_CLI_CONFORMANCE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER cliConf = 0;
@@ -2011,8 +1909,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STANDARD_CLI_CONFORMANCE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SUBQUERIES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER subqueries = 0;
@@ -2033,8 +1930,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SUBQUERIES", "[odbc-api]
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_UNION", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER unionSupport = 0;
@@ -2051,8 +1947,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_UNION", "[odbc-api][geti
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_DELETE_RULE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rules = 0;
@@ -2071,8 +1966,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_DELETE
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_UPDATE_RULE",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rules = 0;
@@ -2090,8 +1984,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_FOREIGN_KEY_UPDATE
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_GRANT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER grantSupport = 0;
@@ -2124,8 +2017,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_GRANT", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_PREDICATES", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER preds = 0;
@@ -2155,8 +2047,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_PREDICATES", "[odb
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_RELATIONAL_JOIN_OPERATORS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER joinOps = 0;
@@ -2183,8 +2074,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_RELATIONAL_JOIN_OP
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_REVOKE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER revokeSupport = 0;
@@ -2220,8 +2110,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_REVOKE", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_ROW_VALUE_CONSTRUCTOR",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER rowValConstr = 0;
@@ -2242,8 +2131,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_ROW_VALUE_CONSTRUC
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_VALUE_EXPRESSIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER valExprs = 0;
@@ -2261,8 +2149,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_VALUE_EXPRESSIONS"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_XOPEN_CLI_YEAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char year[16];
@@ -2280,8 +2167,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_XOPEN_CLI_YEAR", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_BINARY_LITERAL_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxBinaryLit = 0;
@@ -2295,8 +2181,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_BINARY_LITERAL_LEN",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CATALOG_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxCatLen = 0;
@@ -2310,8 +2195,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CATALOG_NAME_LEN", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CHAR_LITERAL_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxCharLit = 0;
@@ -2325,8 +2209,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CHAR_LITERAL_LEN", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMN_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColLen = 0;
@@ -2340,8 +2223,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMN_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_GROUP_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsGroupBy = 0;
@@ -2355,8 +2237,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_GROUP_BY"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_INDEX", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsIndex = 0;
@@ -2370,8 +2251,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_INDEX", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_ORDER_BY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsOrderBy = 0;
@@ -2385,8 +2265,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_ORDER_BY"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_SELECT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsSelect = 0;
@@ -2400,8 +2279,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_SELECT", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_TABLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxColsTable = 0;
@@ -2415,8 +2293,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_COLUMNS_IN_TABLE", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CURSOR_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxCursorLen = 0;
@@ -2430,8 +2307,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_CURSOR_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_IDENTIFIER_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxIdent = 0;
@@ -2445,8 +2321,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_IDENTIFIER_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_INDEX_SIZE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxIndexSize = 0;
@@ -2460,8 +2335,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_INDEX_SIZE", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_PROCEDURE_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxProcLen = 0;
@@ -2475,8 +2349,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_PROCEDURE_NAME_LEN",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxRowSize = 0;
@@ -2491,8 +2364,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE", "[odbc-ap
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE_INCLUDES_LONG",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char includesLong[8];
@@ -2506,8 +2378,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_ROW_SIZE_INCLUDES_LO
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_SCHEMA_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxSchemaLen = 0;
@@ -2521,8 +2392,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_SCHEMA_NAME_LEN", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_STATEMENT_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER maxStmtLen = 0;
@@ -2536,8 +2406,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_STATEMENT_LEN", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLE_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxTableLen = 0;
@@ -2551,8 +2420,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLE_NAME_LEN", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLES_IN_SELECT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxTables = 0;
@@ -2567,8 +2435,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_TABLES_IN_SELECT", "
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_USER_NAME_LEN", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT maxUserLen = 0;
@@ -2587,8 +2454,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_MAX_USER_NAME_LEN", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NUMERIC_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER numFuncs = 0;
@@ -2626,8 +2492,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_NUMERIC_FUNCTIONS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STRING_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER strFuncs = 0;
@@ -2668,8 +2533,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STRING_FUNCTIONS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SYSTEM_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER sysFuncs = 0;
@@ -2686,8 +2550,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SYSTEM_FUNCTIONS", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_ADD_INTERVALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER intervals = 0;
@@ -2711,8 +2574,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_ADD_INTERVALS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_DIFF_INTERVALS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER intervals = 0;
@@ -2736,8 +2598,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_DIFF_INTERVALS"
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER timedateFuncs = 0;
@@ -2781,8 +2642,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_TIMEDATE_FUNCTIONS", "[o
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_DATETIME_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2801,8 +2661,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_DATETIME_FUNCTIONS
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_NUMERIC_VALUE_FUNCTIONS",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2822,8 +2681,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_NUMERIC_VALUE_FUNC
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_STRING_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER funcs = 0;
@@ -2849,8 +2707,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SQL92_STRING_FUNCTIONS",
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FUNCTIONS", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convertFuncs = 0;
@@ -2866,8 +2723,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FUNCTIONS", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIGINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -2907,8 +2763,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIGINT", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -2945,8 +2800,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BINARY", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -2984,8 +2838,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_BIT", "[odbc-api
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_CHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3023,8 +2876,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_CHAR", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DATE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3061,8 +2913,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DATE", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DECIMAL", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3098,8 +2949,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DECIMAL", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DOUBLE", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3135,8 +2985,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_DOUBLE", "[odbc-
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FLOAT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3172,8 +3021,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_FLOAT", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_GUID", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3211,8 +3059,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_GUID", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTEGER", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3249,8 +3096,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTEGER", "[odbc
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_DAY_TIME",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3298,8 +3144,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_DAY_TIM
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_YEAR_MONTH",
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3348,8 +3193,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_INTERVAL_YEAR_MO
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARBINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3390,8 +3234,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARBINARY", 
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3437,8 +3280,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_LONGVARCHAR", "[
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_NUMERIC", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3474,8 +3316,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_NUMERIC", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_REAL", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3515,8 +3356,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_REAL", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_SMALLINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3557,8 +3397,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_SMALLINT", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIME", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3594,8 +3433,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIME", "[odbc-ap
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIMESTAMP", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3632,8 +3470,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TIMESTAMP", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TINYINT", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3674,8 +3511,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_TINYINT", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARBINARY", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3712,8 +3548,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARBINARY", "[od
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3751,8 +3586,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_VARCHAR", "[odbc
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3794,8 +3628,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WCHAR", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3838,8 +3671,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WVARCHAR", "[odb
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WLONGVARCHAR", "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER convert = 0;
@@ -3891,8 +3723,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_CONVERT_WLONGVARCHAR", "
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FETCH_DIRECTION (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER fetchDir = 0;
@@ -3914,8 +3745,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_FETCH_DIRECTION (depreca
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LOCK_TYPES (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER lockTypes = 0;
@@ -3933,8 +3763,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_LOCK_TYPES (deprecated)"
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_API_CONFORMANCE (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT apiConf = 0;
@@ -3949,8 +3778,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_API_CONFORMANCE (de
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_SQL_CONFORMANCE (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUSMALLINT sqlConf = 0;
@@ -3965,8 +3793,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_SQL_CONFORMANCE (de
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POS_OPERATIONS (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER posOps = 0;
@@ -3987,8 +3814,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POS_OPERATIONS (deprecat
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POSITIONED_STATEMENTS (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER posStmts = 0;
@@ -4007,8 +3833,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_POSITIONED_STATEMENTS (d
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_CONCURRENCY (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER scrollConc = 0;
@@ -4027,8 +3852,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_SCROLL_CONCURRENCY (depr
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_STATIC_SENSITIVITY (deprecated)",
                  "[odbc-api][getinfo][driver_info][deprecated]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLUINTEGER staticSens = 0;
@@ -4057,8 +3881,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Returns SQL_SUCCESS_WITH_INF
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char smallBuffer[4];
@@ -4079,8 +3902,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Can query with NULL StringLe
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char driverName[256];
@@ -4096,8 +3918,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: Can query just the length wi
                  "[odbc-api][getinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT requiredLen = 0;
@@ -4119,8 +3940,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY096/HY000 - Invalid InfoTy
                  "[odbc-api][getinfo][driver_info][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char buffer[256];
@@ -4137,8 +3957,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY096/HY000 - Invalid InfoTy
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY090 - Negative BufferLength",
                  "[odbc-api][getinfo][driver_info][error]") {
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char buffer[256];

--- a/odbc_tests/tests/odbc-api/driver_info/get_type_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_type_info_tests.cpp
@@ -11,6 +11,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 
 // ============================================================================
@@ -872,8 +873,7 @@ TEST_CASE("SQLGetTypeInfo: SQL_INVALID_HANDLE - NULL statement handle", "[odbc-a
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: SQL_INVALID_HANDLE - Invalid handle type",
                  "[odbc-api][gettypeinfo][driver_info][error]") {
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLGetTypeInfo(dbc_handle(), SQL_ALL_TYPES);
@@ -1025,8 +1025,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetTypeInfo: Documents all supported 
                  "[odbc-api][gettypeinfo][driver_info]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (const auto& expected : ALL_TYPE_INFO) {

--- a/odbc_tests/tests/odbc-api/preparing/bind_parameter_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/bind_parameter_tests.cpp
@@ -11,6 +11,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -22,7 +23,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds integer input p
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER param_value = 42;
@@ -48,7 +49,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds string input pa
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   char param_value[] = "hello";
@@ -74,7 +75,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Binds NULL parameter 
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN indicator = SQL_NULL_DATA;
@@ -99,7 +100,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Re-execute with diffe
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER param_value = 10;
@@ -135,7 +136,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Multiple parameters",
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ?, ?")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?, ?"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER param1 = 100;
@@ -193,7 +194,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: Rebinding same parame
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER param1 = 111;
@@ -272,7 +273,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLBindParameter: SQLFreeStmt SQL_RESET
                  "[odbc-api][bindparameter][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Bind and execute successfully

--- a/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/get_cursor_name_tests.cpp
@@ -10,6 +10,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -36,8 +37,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: Different statements h
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT;
@@ -71,7 +71,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Returns exact name se
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("MyCursor")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("MyCursor"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -86,10 +86,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Cursor name persists 
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("PrepCursor")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("PrepCursor"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -104,11 +104,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: Cursor name persists 
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CloseCursor")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("CloseCursor"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLCloseCursor(stmt_handle());
@@ -127,8 +126,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("LongCursorName")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("LongCursorName"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Buffer of 5 bytes = 4 chars + null terminator
@@ -146,7 +144,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("TestName")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("TestName"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // BufferLength of 1 = only null terminator fits, truncation occurs
@@ -163,8 +161,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLGetCursorName: NULL CursorName buffe
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("NullBufTest")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("NullBufTest"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Per spec: "If CursorName is NULL, NameLengthPtr will still return the total number of characters"
@@ -178,8 +175,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: 01004 with BufferLengt
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLHSTMT stmt = SQL_NULL_HSTMT;
@@ -192,7 +188,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetCursorName: 01004 with BufferLengt
   // driver's SQLGetCursorNameW, and the driver reads from the buffer despite
   // BufferLength=0. Using a name >= 10 chars avoids the bug.
   // See: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/1371
-  ret = SQLSetCursorName(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("ZeroBufCursor")), SQL_NTS);
+  ret = SQLSetCursorName(stmt, sqlchar("ZeroBufCursor"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};

--- a/odbc_tests/tests/odbc-api/preparing/prepare_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/prepare_tests.cpp
@@ -11,6 +11,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -22,7 +23,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Successfully prepares a sim
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 }
 
@@ -30,7 +31,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Prepared statement can be e
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLExecute(stmt_handle());
@@ -50,7 +51,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Can be executed multiple ti
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 42")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER value = 0;
@@ -81,10 +82,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Replaces previous prepared 
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 99")), SQL_NTS);
+  ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLExecute(stmt_handle());
@@ -105,8 +106,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: With explicit text length i
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   const auto sql = "SELECT 1";
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(sql)),
-                             static_cast<SQLINTEGER>(strlen(sql)));
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar(sql), static_cast<SQLINTEGER>(strlen(sql)));
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLExecute(stmt_handle());
@@ -127,7 +127,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Explicit length shorter tha
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Pass length 8 for "SELECT 1 AS col" -> only "SELECT 1" is used
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1 AS col")), 8);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS col"), 8);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT num_cols = 0;
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: SQLNumResultCols available 
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1, 2, 3")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1, 2, 3"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT num_cols = 0;
@@ -179,7 +179,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Prepares and executes state
                  "[odbc-api][prepare][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT ? AS val")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER param_value = 77;
@@ -208,7 +208,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: Prepares and executes state
 TEST_CASE("SQLPrepare: SQL_INVALID_HANDLE for null statement handle", "[odbc-api][prepare][preparing][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const SQLRETURN ret = SQLPrepare(SQL_NULL_HSTMT, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  const SQLRETURN ret = SQLPrepare(SQL_NULL_HSTMT, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -216,8 +216,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: 42000 for invalid SQL synta
                  "[odbc-api][prepare][preparing][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret =
-      SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("THIS IS NOT VALID SQL")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("THIS IS NOT VALID SQL"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "42000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -235,7 +234,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for empty SQL string"
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver treats empty string as invalid buffer length (HY090)
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar(""), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -244,7 +243,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for negative TextLeng
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // HY090: Invalid string or buffer length
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), -5);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), -5);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -253,7 +252,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: HY090 for TextLength of zer
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // HY090: Invalid string or buffer length
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), 0);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -262,10 +261,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrepare: 24000 when cursor is alread
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Open a cursor by executing a query
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // 24000: Invalid cursor state - attempt to prepare while cursor is open
-  ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 2")), SQL_NTS);
+  ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 2"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }

--- a/odbc_tests/tests/odbc-api/preparing/set_cursor_name_tests.cpp
+++ b/odbc_tests/tests/odbc-api/preparing/set_cursor_name_tests.cpp
@@ -10,6 +10,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -21,10 +22,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Renaming cursor repla
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CursorA")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("CursorA"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("CursorB")), SQL_NTS);
+  ret = SQLSetCursorName(stmt_handle(), sqlchar("CursorB"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -39,10 +40,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Can rename in prepare
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPrepare(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("PreparedCur")), SQL_NTS);
+  ret = SQLSetCursorName(stmt_handle(), sqlchar("PreparedCur"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -57,13 +58,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Can set after SQLClos
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("AfterClose")), SQL_NTS);
+  ret = SQLSetCursorName(stmt_handle(), sqlchar("AfterClose"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -78,7 +79,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: With explicit name le
                  "[odbc-api][cursorname][preparing]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("ExplicitLen")), 11);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("ExplicitLen"), 11);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -94,7 +95,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Explicit length short
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Pass length 4 for "LongName" -> should only use "Long"
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("LongName")), 4);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("LongName"), 4);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -110,7 +111,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: Empty cursor name suc
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Reference driver accepts empty cursor name
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar(""), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLCHAR cursor_name[128] = {};
@@ -129,8 +130,7 @@ TEST_CASE("SQLSetCursorName: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][cursorname][preparing][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const SQLRETURN ret =
-      SQLSetCursorName(SQL_NULL_HSTMT, reinterpret_cast<SQLCHAR*>(const_cast<char*>("Test")), SQL_NTS);
+  const SQLRETURN ret = SQLSetCursorName(SQL_NULL_HSTMT, sqlchar("Test"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -138,8 +138,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLSetCursorName: 3C000 for duplicate cu
                  "[odbc-api][cursorname][preparing][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLHSTMT stmt1 = SQL_NULL_HSTMT, stmt2 = SQL_NULL_HSTMT;
@@ -148,11 +147,11 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLSetCursorName: 3C000 for duplicate cu
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt2);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLSetCursorName(stmt1, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DupCursor")), SQL_NTS);
+  ret = SQLSetCursorName(stmt1, sqlchar("DupCursor"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // 3C000: Duplicate cursor name
-  ret = SQLSetCursorName(stmt2, reinterpret_cast<SQLCHAR*>(const_cast<char*>("DupCursor")), SQL_NTS);
+  ret = SQLSetCursorName(stmt2, sqlchar("DupCursor"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "3C000", stmt2, SQL_HANDLE_STMT);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt1);
@@ -165,8 +164,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 34000 for cursor name
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // 34000: Invalid cursor name (starting with reserved prefix "SQL_CUR")
-  SQLRETURN ret =
-      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SQL_CUR_TEST")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("SQL_CUR_TEST"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "34000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -175,8 +173,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 34000 for cursor name
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // 34000: Invalid cursor name ("SQLCUR" prefix is also reserved)
-  SQLRETURN ret =
-      SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SQLCUR_TEST")), SQL_NTS);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("SQLCUR_TEST"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "34000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -194,7 +191,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: HY009 for negative Na
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Note: Reference driver returns HY009 instead of ODBC spec-defined HY090 for negative NameLength
-  SQLRETURN ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("Test")), -5);
+  SQLRETURN ret = SQLSetCursorName(stmt_handle(), sqlchar("Test"), -5);
   REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
 }
 
@@ -202,10 +199,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSetCursorName: 24000 when cursor is 
                  "[odbc-api][cursorname][preparing][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // 24000: Invalid cursor state (cursor is open)
-  ret = SQLSetCursorName(stmt_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("AfterExec")), SQL_NTS);
+  ret = SQLSetCursorName(stmt_handle(), sqlchar("AfterExec"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }

--- a/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
@@ -9,6 +9,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -21,8 +22,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Successfully disconnects 
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -39,15 +39,13 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Can reconnect after disco
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect, disconnect, reconnect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS, nullptr, 0,
-                   nullptr, 0);
+  ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLHSTMT stmt = SQL_NULL_HSTMT;
@@ -65,8 +63,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Idempotency of multiple d
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // First disconnect
@@ -89,8 +86,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Closes open statements au
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -116,8 +112,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Handles active transactio
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect with manual commit mode
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Set manual commit mode
@@ -129,7 +124,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Handles active transactio
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -150,8 +145,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With active result sets",
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Execute query with result set
@@ -159,7 +153,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With active result sets",
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver allows disconnecting with active result sets
@@ -210,8 +204,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: After failed connection a
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Attempt to connect with invalid credentials
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>("InvalidDSN")), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar("InvalidDSN"), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_ERROR);
 
   // Note: Reference driver returns error (08003: Connection not open)
@@ -224,8 +217,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With multiple statement h
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate multiple statements
@@ -240,13 +232,13 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With multiple statement h
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt1, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt1, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 
-  ret = SQLExecDirect(stmt2, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt2, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 
-  ret = SQLExecDirect(stmt3, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt3, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
@@ -255,8 +247,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Preserves connection hand
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect, disconnect, verify handle can be reused
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -280,8 +271,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Clears previous diagnosti
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Cause an error to populate diagnostic records
@@ -290,7 +280,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Clears previous diagnosti
   REQUIRE(ret == SQL_SUCCESS);
 
   // Execute invalid SQL
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("INVALID SQL STATEMENT")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("INVALID SQL STATEMENT"), SQL_NTS);
   REQUIRE(ret == SQL_ERROR);
 
   SQLCHAR temp_sqlstate[6];

--- a/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
@@ -9,6 +9,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -110,8 +111,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY010 - Cannot free conne
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Try to free while still connected
@@ -128,8 +128,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free disconnected con
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect and disconnect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLDisconnect(dbc_handle());
@@ -163,8 +162,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Successfully frees statem
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect first
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -193,8 +191,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with p
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate and prepare statement
@@ -202,7 +199,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with p
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLPrepare(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLPrepare(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -216,8 +213,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with a
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Execute query
@@ -225,7 +221,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with a
   ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt, reinterpret_cast<SQLCHAR*>(const_cast<char*>("SELECT 1")), SQL_NTS);
+  ret = SQLExecDirect(stmt, sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -239,8 +235,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with b
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement and bind parameter
@@ -263,8 +258,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free statement with b
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement and bind column
@@ -287,8 +281,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Double free statement han
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate and free statement
@@ -314,8 +307,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free explicitly alloc
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate explicit descriptor
@@ -344,8 +336,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: HY017 - Cannot free impli
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -394,8 +385,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: SQL_INVALID_HANDLE for wr
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate statement
@@ -438,8 +428,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free multiple stateme
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Connect
-  SQLRETURN ret = SQLConnect(dbc_handle(), reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS,
-                             nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Allocate multiple statements
@@ -516,8 +505,7 @@ TEST_CASE_METHOD(EnvDefaultDSNFixture, "SQLFreeHandle: Freeing handle clears att
   REQUIRE(ret == SQL_ERROR);
 
   // Connect and verify the attribute is the default after connecting
-  ret = SQLConnect(dbc2, reinterpret_cast<SQLCHAR*>(const_cast<char*>(dsn_name().c_str())), SQL_NTS, nullptr, 0,
-                   nullptr, 0);
+  ret = SQLConnect(dbc2, sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLGetConnectAttr(dbc2, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr);


### PR DESCRIPTION
Added granular ODBC unit and integration tests to verify compliance of ODBC wrapper with the ODBC 3.x and 2.x specs and consistent behaviour with existing ODBC driver.

This PR only contains ["Obtaining information about the data source's system tables" category functions](https://docs.google.com/spreadsheets/d/1BjOHFnLQ2AooXGqWncsaqCLIw8z9XD0v3fwwF-S-E3g/edit?gid=999869428#gid=999869428).