### PR TITLE
SNOW-2881862: Add ODBC wrapper for native Okta authentication

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -563,7 +563,9 @@ pub fn get_connect_attr(
                     );
                     DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap()
                 }),
-                None => 0,
+                None => DEFAULT_LOGIN_TIMEOUT_SECS
+                    .parse()
+                    .unwrap(),
             };
             if !value_ptr.is_null() {
                 unsafe {

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -64,6 +64,8 @@ pub fn driver_connect(
             .pre_connection_attrs
             .contains_key(&ConnectionAttribute::PrivKeyBase64);
 
+    let mut login_timeout_set = false;
+
     for (key, value) in connection_string_map {
         match key.as_str() {
             // TODO: Do it more generically
@@ -237,6 +239,25 @@ pub fn driver_connect(
                     },
                 )?;
             }
+            "DISABLE_SAML_URL_CHECK" => {
+                DatabaseDriverClient::connection_set_option_string(
+                    ConnectionSetOptionStringRequest {
+                        conn_handle: Some(conn_handle),
+                        key: "disable_saml_url_check".to_owned(),
+                        value,
+                    },
+                )?;
+            }
+            "LOGIN_TIMEOUT" => {
+                login_timeout_set = true;
+                DatabaseDriverClient::connection_set_option_string(
+                    ConnectionSetOptionStringRequest {
+                        conn_handle: Some(conn_handle),
+                        key: "authentication_timeout".to_owned(),
+                        value,
+                    },
+                )?;
+            }
             "TLS_VERIFY_HOSTNAME" => {
                 DatabaseDriverClient::connection_set_option_string(
                     ConnectionSetOptionStringRequest {
@@ -281,7 +302,18 @@ pub fn driver_connect(
     }
 
     // Apply SQLSetConnectAttr values (override connection string parameters).
-    apply_pre_connection_attrs(connection, conn_handle)?;
+    let login_timeout_from_attr = apply_pre_connection_attrs(connection, conn_handle)?;
+
+    // Old driver defaults LOGIN_TIMEOUT to 300 s (S_DEFAULT_LOGIN_TIMEOUT).
+    // If neither the connection string nor SQLSetConnectAttr provided a value,
+    // apply the same default so sf_core's Okta SAML retry budget matches.
+    if !login_timeout_set && !login_timeout_from_attr {
+        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
+            conn_handle: Some(conn_handle),
+            key: "authentication_timeout".to_owned(),
+            value: "300".to_owned(),
+        })?;
+    }
 
     DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
         conn_handle: Some(conn_handle),
@@ -304,10 +336,11 @@ pub fn driver_connect(
 
 /// Apply pre-connection attributes to sf_core. SQLSetConnectAttr values override
 /// connection string parameters. PrivKeyContent takes priority over PrivKeyBase64.
+/// Returns `true` if LoginTimeout was set via attributes.
 fn apply_pre_connection_attrs(
     connection: &mut crate::api::Connection,
     conn_handle: ConnectionHandle,
-) -> OdbcResult<()> {
+) -> OdbcResult<bool> {
     let attrs = &connection.pre_connection_attrs;
 
     if let Some(content) = attrs.get(&ConnectionAttribute::PrivKeyContent) {
@@ -346,7 +379,17 @@ fn apply_pre_connection_attrs(
         })?;
     }
 
-    Ok(())
+    // LoginTimeout -> authentication_timeout (matches old driver: used as Okta SAML budget)
+    if let Some(timeout) = attrs.get(&ConnectionAttribute::LoginTimeout) {
+        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
+            conn_handle: Some(conn_handle),
+            key: "authentication_timeout".to_owned(),
+            value: timeout.clone(),
+        })?;
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 /// Simple connect function (SQLConnect) - currently a placeholder
@@ -400,7 +443,20 @@ pub fn set_connect_attr(
     match attr {
         // Standard ODBC attributes
         ConnectionAttribute::LoginTimeout => {
-            tracing::debug!("set_connect_attr: LoginTimeout (ignored)");
+            // Matches old driver: LOGIN_TIMEOUT is reused as the Okta SAML retry budget.
+            // SQL_ATTR_LOGIN_TIMEOUT is an integer attribute: the value is passed as
+            // (SQLPOINTER)(uintptr_t)seconds, not as a string pointer.
+            if matches!(connection.state, ConnectionState::Connected { .. }) {
+                return AttributeCannotBeSetNowSnafu {
+                    attribute: attr.as_raw(),
+                }
+                .fail();
+            }
+            let seconds = value_ptr as usize;
+            tracing::debug!("set_connect_attr: LoginTimeout={}", seconds);
+            connection
+                .pre_connection_attrs
+                .insert(attr, seconds.to_string());
             Ok(())
         }
         ConnectionAttribute::ConnectionTimeout => {
@@ -491,8 +547,20 @@ pub fn get_connect_attr(
             }
             Ok(())
         }
-        ConnectionAttribute::LoginTimeout | ConnectionAttribute::ConnectionTimeout => {
-            // These are accepted but not stored; return 0
+        ConnectionAttribute::LoginTimeout => {
+            let timeout: sql::ULen = connection
+                .pre_connection_attrs
+                .get(&attr)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut sql::ULen) = timeout;
+                }
+            }
+            Ok(())
+        }
+        ConnectionAttribute::ConnectionTimeout => {
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::ULen) = 0;

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -558,6 +558,12 @@ pub fn get_connect_attr(
                     *(value_ptr as *mut sql::ULen) = timeout;
                 }
             }
+            if !string_length_ptr.is_null() {
+                unsafe {
+                    *string_length_ptr =
+                        std::mem::size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
             Ok(())
         }
         ConnectionAttribute::ConnectionTimeout => {

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -19,6 +19,11 @@ use tracing;
 
 const SQL_AUTOCOMMIT_ON: sql::ULen = 1;
 
+/// Default login timeout in seconds, matching the old driver's S_DEFAULT_LOGIN_TIMEOUT.
+/// Used as the Okta SAML retry budget when neither the connection string nor
+/// SQLSetConnectAttr provides a value.
+const DEFAULT_LOGIN_TIMEOUT_SECS: &str = "300";
+
 /// Parse connection string into key-value pairs
 fn parse_connection_string(connection_string: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
@@ -311,7 +316,7 @@ pub fn driver_connect(
         DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
             conn_handle: Some(conn_handle),
             key: "authentication_timeout".to_owned(),
-            value: "300".to_owned(),
+            value: DEFAULT_LOGIN_TIMEOUT_SECS.to_owned(),
         })?;
     }
 
@@ -548,11 +553,18 @@ pub fn get_connect_attr(
             Ok(())
         }
         ConnectionAttribute::LoginTimeout => {
-            let timeout: sql::ULen = connection
-                .pre_connection_attrs
-                .get(&attr)
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
+            let timeout: sql::ULen = match connection.pre_connection_attrs.get(&attr) {
+                Some(s) => s.parse().unwrap_or_else(|_| {
+                    tracing::warn!(
+                        "get_connect_attr: LoginTimeout value {:?} is not a valid integer, \
+                         returning default {}",
+                        s,
+                        DEFAULT_LOGIN_TIMEOUT_SECS,
+                    );
+                    DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap()
+                }),
+                None => 0,
+            };
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::ULen) = timeout;

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -560,8 +560,7 @@ pub fn get_connect_attr(
             }
             if !string_length_ptr.is_null() {
                 unsafe {
-                    *string_length_ptr =
-                        std::mem::size_of::<sql::ULen>() as sql::Integer;
+                    *string_length_ptr = std::mem::size_of::<sql::ULen>() as sql::Integer;
                 }
             }
             Ok(())

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -24,6 +24,29 @@ const SQL_AUTOCOMMIT_ON: sql::ULen = 1;
 /// SQLSetConnectAttr provides a value.
 const DEFAULT_LOGIN_TIMEOUT_SECS: &str = "300";
 
+/// Maps ODBC connection string parameter names to their sf_core equivalents.
+/// Parameters listed here are forwarded as-is via `connection_set_option_string`.
+/// Parameters that need special handling (type conversion, conditional skipping,
+/// side-effects) are handled separately in `driver_connect`.
+const PARAM_MAPPINGS: &[(&str, &str)] = &[
+    ("ACCOUNT", "account"),
+    ("SERVER", "host"),
+    ("PWD", "password"),
+    ("UID", "user"),
+    ("PROTOCOL", "protocol"),
+    ("DATABASE", "database"),
+    ("WAREHOUSE", "warehouse"),
+    ("ROLE", "role"),
+    ("SCHEMA", "schema"),
+    ("AUTHENTICATOR", "authenticator"),
+    ("TOKEN", "token"),
+    ("TLS_CUSTOM_ROOT_STORE_PATH", "custom_root_store_path"),
+    ("DISABLE_SAML_URL_CHECK", "disable_saml_url_check"),
+    ("TLS_VERIFY_HOSTNAME", "verify_hostname"),
+    ("TLS_VERIFY_CERTIFICATES", "verify_certificates"),
+    ("CRL_ENABLED", "crl_enabled"),
+];
+
 /// Parse connection string into key-value pairs
 fn parse_connection_string(connection_string: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
@@ -72,47 +95,24 @@ pub fn driver_connect(
     let mut login_timeout_set = false;
 
     for (key, value) in connection_string_map {
+        if key == "DRIVER" {
+            continue;
+        }
+
+        if let Some(core_key) = PARAM_MAPPINGS
+            .iter()
+            .find(|(k, _)| *k == key)
+            .map(|(_, v)| *v)
+        {
+            DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: core_key.to_owned(),
+                value,
+            })?;
+            continue;
+        }
+
         match key.as_str() {
-            // TODO: Do it more generically
-            "DRIVER" => {
-                // ignore
-            }
-            "ACCOUNT" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "account".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "SERVER" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "host".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "PWD" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "password".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "UID" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "user".to_owned(),
-                        value,
-                    },
-                )?;
-            }
             "PORT" => {
                 let port_int: i64 = value.parse().context(InvalidPortSnafu {
                     port: value.clone(),
@@ -123,47 +123,21 @@ pub fn driver_connect(
                     value: port_int,
                 })?;
             }
-            "PROTOCOL" => {
+            "CRL_MODE" => {
                 DatabaseDriverClient::connection_set_option_string(
                     ConnectionSetOptionStringRequest {
                         conn_handle: Some(conn_handle),
-                        key: "protocol".to_owned(),
-                        value,
+                        key: "crl_mode".to_owned(),
+                        value: value.to_uppercase(),
                     },
                 )?;
             }
-            "DATABASE" => {
+            "LOGIN_TIMEOUT" => {
+                login_timeout_set = true;
                 DatabaseDriverClient::connection_set_option_string(
                     ConnectionSetOptionStringRequest {
                         conn_handle: Some(conn_handle),
-                        key: "database".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "WAREHOUSE" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "warehouse".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "ROLE" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "role".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "SCHEMA" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "schema".to_owned(),
+                        key: "authentication_timeout".to_owned(),
                         value,
                     },
                 )?;
@@ -178,34 +152,6 @@ pub fn driver_connect(
                         ConnectionSetOptionStringRequest {
                             conn_handle: Some(conn_handle),
                             key: "private_key_file".to_owned(),
-                            value,
-                        },
-                    )?;
-                }
-            }
-            "AUTHENTICATOR" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "authenticator".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
-                if connection
-                    .pre_connection_attrs
-                    .contains_key(&ConnectionAttribute::PrivKeyPassword)
-                {
-                    tracing::debug!(
-                        "driver_connect: skipping {} — attribute-based password takes priority",
-                        key
-                    );
-                } else {
-                    DatabaseDriverClient::connection_set_option_string(
-                        ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "private_key_password".to_owned(),
                             value,
                         },
                     )?;
@@ -226,79 +172,24 @@ pub fn driver_connect(
                     )?;
                 }
             }
-            "TOKEN" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "token".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "TLS_CUSTOM_ROOT_STORE_PATH" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "custom_root_store_path".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "DISABLE_SAML_URL_CHECK" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "disable_saml_url_check".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "LOGIN_TIMEOUT" => {
-                login_timeout_set = true;
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "authentication_timeout".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "TLS_VERIFY_HOSTNAME" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "verify_hostname".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "TLS_VERIFY_CERTIFICATES" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "verify_certificates".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            // CRL settings via options
-            "CRL_ENABLED" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "crl_enabled".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "CRL_MODE" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "crl_mode".to_owned(),
-                        value: value.to_uppercase(),
-                    },
-                )?;
+            "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
+                if connection
+                    .pre_connection_attrs
+                    .contains_key(&ConnectionAttribute::PrivKeyPassword)
+                {
+                    tracing::debug!(
+                        "driver_connect: skipping {} — attribute-based password takes priority",
+                        key
+                    );
+                } else {
+                    DatabaseDriverClient::connection_set_option_string(
+                        ConnectionSetOptionStringRequest {
+                            conn_handle: Some(conn_handle),
+                            key: "private_key_password".to_owned(),
+                            value,
+                        },
+                    )?;
+                }
             }
             _ => {
                 tracing::warn!("driver_connect: unknown connection string key: {:?}", key);
@@ -563,9 +454,7 @@ pub fn get_connect_attr(
                     );
                     DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap()
                 }),
-                None => DEFAULT_LOGIN_TIMEOUT_SECS
-                    .parse()
-                    .unwrap(),
+                None => DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap(),
             };
             if !value_ptr.is_null() {
                 unsafe {

--- a/odbc_tests/common/include/compatibility.hpp
+++ b/odbc_tests/common/include/compatibility.hpp
@@ -1,8 +1,9 @@
 #ifndef COMPATIBILITY_HPP
 #define COMPATIBILITY_HPP
 
-#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
+
+#include <catch2/catch_test_macros.hpp>
 
 // Cross-platform process ID
 #ifdef _WIN32
@@ -41,11 +42,11 @@ extern DRIVER_TYPE get_driver_type();
     }                                            \
   } while (0)
 
-#define REQUIRE_VPN(message)                                          \
-  do {                                                                \
-    if (std::getenv("JENKINS_URL") == nullptr) {                      \
-      SKIP("Requires VPN (run on Jenkins): " << message);             \
-    }                                                                 \
+#define REQUIRE_VPN(message)                              \
+  do {                                                    \
+    if (std::getenv("JENKINS_URL") == nullptr) {          \
+      SKIP("Requires VPN (run on Jenkins): " << message); \
+    }                                                     \
   } while (0)
 
 #endif  // COMPATIBILITY_HPP

--- a/odbc_tests/common/include/compatibility.hpp
+++ b/odbc_tests/common/include/compatibility.hpp
@@ -2,6 +2,7 @@
 #define COMPATIBILITY_HPP
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 
 // Cross-platform process ID
 #ifdef _WIN32
@@ -38,6 +39,13 @@ extern DRIVER_TYPE get_driver_type();
     if (get_driver_type() == DRIVER_TYPE::NEW) { \
       SKIP("Not implemented for new driver");    \
     }                                            \
+  } while (0)
+
+#define REQUIRE_VPN(message)                                          \
+  do {                                                                \
+    if (std::getenv("JENKINS_URL") == nullptr) {                      \
+      SKIP("Requires VPN (run on Jenkins): " << message);             \
+    }                                                                 \
   } while (0)
 
 #endif  // COMPATIBILITY_HPP

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -104,7 +104,7 @@ TEST_CASE("should fail native okta authentication with wrong credentials", "[nat
   // When Trying to Connect
   auto records = require_connection_failed(connection_string);
 
-  // Then Connection fails with authentication error indicating bad credentials
+  // Then Connection fails with authentication error
   REQUIRE(records.size() >= 1);
   CHECK(records[0].sqlState == "28000");
   CHECK_THAT(records[0].messageText, ContainsSubstring("rejected credentials"));
@@ -128,10 +128,8 @@ TEST_CASE("should fail native okta authentication with wrong okta url", "[native
   // When Trying to Connect
   auto records = require_connection_failed(connection_string);
 
-  // Then Connection fails with IdP URL mismatch (real IdP URLs don't match invalid.okta.com)
+  // Then Connection fails with authentication error
   REQUIRE(records.size() >= 1);
   CHECK(records[0].sqlState == "28000");
-  CHECK_THAT(records[0].messageText,
-             ContainsSubstring("does not match configured Okta URL") ||
-                 ContainsSubstring("Native Okta SSO failed"));
+  CHECK_THAT(records[0].messageText, ContainsSubstring("does not match configured Okta URL") || ContainsSubstring("Native Okta SSO failed"));
 }

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -1,0 +1,133 @@
+#include <picojson.h>
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <sstream>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "HandleWrapper.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "macros.hpp"
+#include "require.hpp"
+#include "test_setup.hpp"
+
+using namespace Catch::Matchers;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+std::string get_okta_connection_string() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  ss << "DRIVER=" << get_driver_path() << ";";
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_USER", "UID");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_PASSWORD", "PWD");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_URL", "AUTHENTICATOR");
+  ss << "ROLE=PUBLIC;";
+  return ss.str();
+}
+
+EnvironmentHandleWrapper setup_okta_environment() {
+  EnvironmentHandleWrapper env;
+  SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+  CHECK_ODBC(ret, env);
+  return env;
+}
+
+ConnectionHandleWrapper get_okta_connection_handle(EnvironmentHandleWrapper& env) {
+  return env.createConnectionHandle();
+}
+
+void attempt_okta_connection(ConnectionHandleWrapper& dbc, const std::string& connection_string) {
+  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,
+                                   SQL_DRIVER_NOPROMPT);
+  CHECK_ODBC(ret, dbc);
+}
+
+void verify_okta_simple_query_execution(ConnectionHandleWrapper& dbc) {
+  StatementHandleWrapper stmt = dbc.createStatementHandle();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+
+  SQLINTEGER result = 0;
+  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &result, sizeof(result), NULL);
+  CHECK_ODBC(ret, stmt);
+  REQUIRE(result == 1);
+}
+
+// =============================================================================
+// E2E Tests
+// =============================================================================
+
+TEST_CASE("should authenticate using native okta", "[native_okta]") {
+  REQUIRE_VPN("Native Okta E2E tests need access to preprod Snowflake account");
+
+  // Given Okta authentication is configured with valid credentials
+  auto env = setup_okta_environment();
+  auto dbc = get_okta_connection_handle(env);
+  std::string connection_string = get_okta_connection_string();
+
+  // When Trying to Connect
+  attempt_okta_connection(dbc, connection_string);
+
+  // Then Login is successful and simple query can be executed
+  verify_okta_simple_query_execution(dbc);
+
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("should fail native okta authentication with wrong credentials", "[native_okta]") {
+  REQUIRE_VPN("Native Okta E2E tests need access to preprod Snowflake account");
+
+  // Given Okta authentication is configured with wrong password
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  ss << "DRIVER=" << get_driver_path() << ";";
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_USER", "UID");
+  ss << "PWD=wrong_password_12345;";
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_URL", "AUTHENTICATOR");
+  ss << "ROLE=PUBLIC;";
+  std::string connection_string = ss.str();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then Connection fails with authentication error
+  REQUIRE(records.size() >= 1);
+  CHECK(!records[0].messageText.empty());
+}
+
+TEST_CASE("should fail native okta authentication with wrong okta url", "[native_okta]") {
+  REQUIRE_VPN("Native Okta E2E tests need access to preprod Snowflake account");
+
+  // Given Okta authentication is configured with invalid okta url
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  ss << "DRIVER=" << get_driver_path() << ";";
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_USER", "UID");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_OKTA_PASSWORD", "PWD");
+  ss << "AUTHENTICATOR=https://invalid.okta.com;";
+  ss << "ROLE=PUBLIC;";
+  std::string connection_string = ss.str();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then Connection fails with authentication error
+  REQUIRE(records.size() >= 1);
+  CHECK(!records[0].messageText.empty());
+}

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -131,5 +131,7 @@ TEST_CASE("should fail native okta authentication with wrong okta url", "[native
   // Then Connection fails with authentication error
   REQUIRE(records.size() >= 1);
   CHECK(records[0].sqlState == "28000");
-  CHECK_THAT(records[0].messageText, ContainsSubstring("does not match configured Okta URL") || ContainsSubstring("Native Okta SSO failed"));
+  CHECK_THAT(records[0].messageText,
+             ContainsSubstring("does not match configured Okta URL") ||
+                 ContainsSubstring("Native Okta SSO failed"));
 }

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -104,9 +104,10 @@ TEST_CASE("should fail native okta authentication with wrong credentials", "[nat
   // When Trying to Connect
   auto records = require_connection_failed(connection_string);
 
-  // Then Connection fails with authentication error
+  // Then Connection fails with authentication error indicating bad credentials
   REQUIRE(records.size() >= 1);
-  CHECK(!records[0].messageText.empty());
+  CHECK(records[0].sqlState == "28000");
+  CHECK_THAT(records[0].messageText, ContainsSubstring("rejected credentials"));
 }
 
 TEST_CASE("should fail native okta authentication with wrong okta url", "[native_okta]") {
@@ -127,7 +128,10 @@ TEST_CASE("should fail native okta authentication with wrong okta url", "[native
   // When Trying to Connect
   auto records = require_connection_failed(connection_string);
 
-  // Then Connection fails with authentication error
+  // Then Connection fails with IdP URL mismatch (real IdP URLs don't match invalid.okta.com)
   REQUIRE(records.size() >= 1);
-  CHECK(!records[0].messageText.empty());
+  CHECK(records[0].sqlState == "28000");
+  CHECK_THAT(records[0].messageText,
+             ContainsSubstring("does not match configured Okta URL") ||
+                 ContainsSubstring("Native Okta SSO failed"));
 }

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -132,6 +132,5 @@ TEST_CASE("should fail native okta authentication with wrong okta url", "[native
   REQUIRE(records.size() >= 1);
   CHECK(records[0].sqlState == "28000");
   CHECK_THAT(records[0].messageText,
-             ContainsSubstring("does not match configured Okta URL") ||
-                 ContainsSubstring("Native Okta SSO failed"));
+             ContainsSubstring("does not match configured Okta URL") || ContainsSubstring("Native Okta SSO failed"));
 }

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -501,4 +501,95 @@ mod tests {
             _ => panic!("Expected Password login method"),
         }
     }
+
+    fn okta_settings(extras: Vec<(&str, Setting)>) -> HashMap<String, Setting> {
+        let mut base = vec![
+            ("user", Setting::String("okta_user".to_string())),
+            ("password", Setting::String("okta_pass".to_string())),
+            ("host", Setting::String("account.snowflakecomputing.com".to_string())),
+            ("account", Setting::String("account".to_string())),
+            (
+                "authenticator",
+                Setting::String("https://myorg.okta.com".to_string()),
+            ),
+        ];
+        base.extend(extras);
+        create_test_settings(base)
+    }
+
+    #[test]
+    fn test_native_okta_uses_default_authentication_timeout() {
+        let settings = okta_settings(vec![]);
+        let method = LoginMethod::from_settings(&settings).unwrap();
+        match method {
+            LoginMethod::NativeOkta(cfg) => {
+                assert_eq!(
+                    cfg.authentication_timeout_secs,
+                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
+                );
+            }
+            _ => panic!("Expected NativeOkta login method"),
+        }
+    }
+
+    #[test]
+    fn test_native_okta_custom_authentication_timeout() {
+        let settings = okta_settings(vec![(
+            "authentication_timeout",
+            Setting::String("60".to_string()),
+        )]);
+        let method = LoginMethod::from_settings(&settings).unwrap();
+        match method {
+            LoginMethod::NativeOkta(cfg) => {
+                assert_eq!(cfg.authentication_timeout_secs, 60);
+            }
+            _ => panic!("Expected NativeOkta login method"),
+        }
+    }
+
+    #[test]
+    fn test_native_okta_invalid_authentication_timeout_uses_default() {
+        let settings = okta_settings(vec![(
+            "authentication_timeout",
+            Setting::String("not_a_number".to_string()),
+        )]);
+        let method = LoginMethod::from_settings(&settings).unwrap();
+        match method {
+            LoginMethod::NativeOkta(cfg) => {
+                assert_eq!(
+                    cfg.authentication_timeout_secs,
+                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
+                    "Invalid timeout should fall back to the default"
+                );
+            }
+            _ => panic!("Expected NativeOkta login method"),
+        }
+    }
+
+    #[test]
+    fn test_native_okta_disable_saml_url_check_defaults_to_false() {
+        let settings = okta_settings(vec![]);
+        let method = LoginMethod::from_settings(&settings).unwrap();
+        match method {
+            LoginMethod::NativeOkta(cfg) => {
+                assert!(!cfg.disable_saml_url_check);
+            }
+            _ => panic!("Expected NativeOkta login method"),
+        }
+    }
+
+    #[test]
+    fn test_native_okta_disable_saml_url_check_true() {
+        let settings = okta_settings(vec![(
+            "disable_saml_url_check",
+            Setting::String("true".to_string()),
+        )]);
+        let method = LoginMethod::from_settings(&settings).unwrap();
+        match method {
+            LoginMethod::NativeOkta(cfg) => {
+                assert!(cfg.disable_saml_url_check);
+            }
+            _ => panic!("Expected NativeOkta login method"),
+        }
+    }
 }

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -506,7 +506,10 @@ mod tests {
         let mut base = vec![
             ("user", Setting::String("okta_user".to_string())),
             ("password", Setting::String("okta_pass".to_string())),
-            ("host", Setting::String("account.snowflakecomputing.com".to_string())),
+            (
+                "host",
+                Setting::String("account.snowflakecomputing.com".to_string()),
+            ),
             ("account", Setting::String("account".to_string())),
             (
                 "authenticator",
@@ -524,7 +527,10 @@ mod tests {
     #[test]
     fn test_native_okta_uses_default_authentication_timeout() {
         let cfg = okta_config(vec![]);
-        assert_eq!(cfg.authentication_timeout_secs, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+        assert_eq!(
+            cfg.authentication_timeout_secs,
+            DEFAULT_AUTHENTICATION_TIMEOUT_SECS
+        );
     }
 
     #[test]
@@ -543,8 +549,7 @@ mod tests {
             Setting::String("not_a_number".to_string()),
         )]);
         assert_eq!(
-            cfg.authentication_timeout_secs,
-            DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
+            cfg.authentication_timeout_secs, DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
             "Invalid timeout should fall back to the default"
         );
     }

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -502,7 +502,7 @@ mod tests {
         }
     }
 
-    fn okta_settings(extras: Vec<(&str, Setting)>) -> HashMap<String, Setting> {
+    fn okta_config(extras: Vec<(&str, Setting)>) -> NativeOktaConfig {
         let mut base = vec![
             ("user", Setting::String("okta_user".to_string())),
             ("password", Setting::String("okta_pass".to_string())),
@@ -514,82 +514,53 @@ mod tests {
             ),
         ];
         base.extend(extras);
-        create_test_settings(base)
+        let settings = create_test_settings(base);
+        match LoginMethod::from_settings(&settings).unwrap() {
+            LoginMethod::NativeOkta(cfg) => cfg,
+            other => panic!("Expected NativeOkta, got {other:?}"),
+        }
     }
 
     #[test]
     fn test_native_okta_uses_default_authentication_timeout() {
-        let settings = okta_settings(vec![]);
-        let method = LoginMethod::from_settings(&settings).unwrap();
-        match method {
-            LoginMethod::NativeOkta(cfg) => {
-                assert_eq!(
-                    cfg.authentication_timeout_secs,
-                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
-                );
-            }
-            _ => panic!("Expected NativeOkta login method"),
-        }
+        let cfg = okta_config(vec![]);
+        assert_eq!(cfg.authentication_timeout_secs, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
     }
 
     #[test]
     fn test_native_okta_custom_authentication_timeout() {
-        let settings = okta_settings(vec![(
+        let cfg = okta_config(vec![(
             "authentication_timeout",
             Setting::String("60".to_string()),
         )]);
-        let method = LoginMethod::from_settings(&settings).unwrap();
-        match method {
-            LoginMethod::NativeOkta(cfg) => {
-                assert_eq!(cfg.authentication_timeout_secs, 60);
-            }
-            _ => panic!("Expected NativeOkta login method"),
-        }
+        assert_eq!(cfg.authentication_timeout_secs, 60);
     }
 
     #[test]
     fn test_native_okta_invalid_authentication_timeout_uses_default() {
-        let settings = okta_settings(vec![(
+        let cfg = okta_config(vec![(
             "authentication_timeout",
             Setting::String("not_a_number".to_string()),
         )]);
-        let method = LoginMethod::from_settings(&settings).unwrap();
-        match method {
-            LoginMethod::NativeOkta(cfg) => {
-                assert_eq!(
-                    cfg.authentication_timeout_secs,
-                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
-                    "Invalid timeout should fall back to the default"
-                );
-            }
-            _ => panic!("Expected NativeOkta login method"),
-        }
+        assert_eq!(
+            cfg.authentication_timeout_secs,
+            DEFAULT_AUTHENTICATION_TIMEOUT_SECS,
+            "Invalid timeout should fall back to the default"
+        );
     }
 
     #[test]
     fn test_native_okta_disable_saml_url_check_defaults_to_false() {
-        let settings = okta_settings(vec![]);
-        let method = LoginMethod::from_settings(&settings).unwrap();
-        match method {
-            LoginMethod::NativeOkta(cfg) => {
-                assert!(!cfg.disable_saml_url_check);
-            }
-            _ => panic!("Expected NativeOkta login method"),
-        }
+        let cfg = okta_config(vec![]);
+        assert!(!cfg.disable_saml_url_check);
     }
 
     #[test]
     fn test_native_okta_disable_saml_url_check_true() {
-        let settings = okta_settings(vec![(
+        let cfg = okta_config(vec![(
             "disable_saml_url_check",
             Setting::String("true".to_string()),
         )]);
-        let method = LoginMethod::from_settings(&settings).unwrap();
-        match method {
-            LoginMethod::NativeOkta(cfg) => {
-                assert!(cfg.disable_saml_url_check);
-            }
-            _ => panic!("Expected NativeOkta login method"),
-        }
+        assert!(cfg.disable_saml_url_check);
     }
 }

--- a/tests/definitions/shared/authentication/native_okta.feature
+++ b/tests/definitions/shared/authentication/native_okta.feature
@@ -1,4 +1,4 @@
-@core
+@core @odbc
 Feature: Native Okta Authentication
 
   Native SSO through Okta (SAML): user configures authenticator as an Okta URL
@@ -8,19 +8,19 @@ Feature: Native Okta Authentication
   # E2E Tests - Real Okta Authentication
   # =============================================================================
 
-  @core_e2e
+  @core_e2e @odbc_e2e
   Scenario: should authenticate using native okta
     Given Okta authentication is configured with valid credentials
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e
+  @core_e2e @odbc_e2e
   Scenario: should fail native okta authentication with wrong credentials
     Given Okta authentication is configured with wrong password
     When Trying to Connect
     Then Connection fails with authentication error
 
-  @core_e2e
+  @core_e2e @odbc_e2e
   Scenario: should fail native okta authentication with wrong okta url
     Given Okta authentication is configured with invalid okta url
     When Trying to Connect

--- a/tests/oldTestsCoverage/odbc.yaml
+++ b/tests/oldTestsCoverage/odbc.yaml
@@ -61,16 +61,19 @@ tests:
     ud_tests:
     - sf_core/tests/e2e/authentication/native_okta.rs - vpn_should_authenticate_using_native_okta
     - sf_core/tests/integration/authentication/native_okta.rs - should_login_with_native_okta_using_saml_flow
+    - odbc_tests/tests/e2e/authentication/native_okta.cpp - should authenticate using native okta
   - test_name: should throw error for wrong okta credentials
     ud_tests:
     - sf_core/tests/e2e/authentication/native_okta.rs - vpn_should_fail_native_okta_authentication_with_wrong_credentials
     - sf_core/tests/integration/authentication/native_okta.rs - should_fail_with_bad_credentials_when_okta_returns_401
     - sf_core/tests/integration/authentication/native_okta.rs - should_fail_with_bad_credentials_when_okta_returns_403
+    - odbc_tests/tests/e2e/authentication/native_okta.cpp - should fail native okta authentication with wrong credentials
   - test_name: should throw error for wrong okta url
     ud_tests:
     - sf_core/tests/e2e/authentication/native_okta.rs - vpn_should_fail_native_okta_authentication_with_wrong_okta_url
     - sf_core/tests/integration/authentication/native_okta.rs - should_fail_when_tokenurl_does_not_match_configured_okta_url_origin
     - sf_core/tests/integration/authentication/native_okta.rs - should_fail_when_ssourl_does_not_match_configured_okta_url_origin
+    - odbc_tests/tests/e2e/authentication/native_okta.cpp - should fail native okta authentication with wrong okta url
   - test_name: should throw error for wrong url without okta path
     ud_tests:
     - sf_core/tests/integration/authentication/native_okta.rs - should_fail_when_tokenurl_does_not_match_configured_okta_url_origin
@@ -683,6 +686,7 @@ tests:
     ud_tests:
     - sf_core/tests/e2e/authentication/native_okta.rs - vpn_should_authenticate_using_native_okta
     - sf_core/tests/integration/authentication/native_okta.rs - should_login_with_native_okta_using_saml_flow
+    - odbc_tests/tests/e2e/authentication/native_okta.cpp - should authenticate using native okta
   - test_name: sso
     ud_tests: []
   UnitTests/InbandTelemetryTest/InbandTelemetryTest.cpp:
@@ -718,6 +722,7 @@ tests:
     ud_tests:
     - sf_core/tests/e2e/authentication/native_okta.rs - vpn_should_authenticate_using_native_okta
     - sf_core/tests/integration/authentication/native_okta.rs - should_login_with_native_okta_using_saml_flow
+    - odbc_tests/tests/e2e/authentication/native_okta.cpp - should authenticate using native okta
   - test_name: testQuery
     ud_tests: []
   - test_name: testQueryType


### PR DESCRIPTION
### Summary

- Wires the ODBC driver layer to support Native Okta authentication
- No new Rust core logic — the AUTHENTICATOR, UID, and PWD connection string keys were already forwarded to `sf_core`; this PR adds the two remaining Okta-specific parameters and E2E test coverage

### Changes

#### ODBC Connection String Parameters

- `DISABLE_SAML_URL_CHECK` — forwarded to `sf_core` as `disable_saml_url_check`
- `LOGIN_TIMEOUT` — forwarded to `sf_core` as `authentication_timeout` (matches old driver behavior: used as the Okta SAML retry budget, default 300 s)
- `SQL_ATTR_LOGIN_TIMEOUT` via `SQLSetConnectAttr` — now stored and forwarded instead of silently ignored; read back as an integer from `SQLGetConnectAttr`

#### Tests

- 3 ODBC E2E tests: successful login, wrong credentials, wrong Okta URL (require VPN + Okta credentials)
- Tagged shared Gherkin scenarios with `@odbc` and `@odbc_e2e`
- Updated old ODBC tests coverage mapping (`odbc.yaml`)