### PR TITLE
SNOW-3098581: Add driver class to META-INF

### DIFF
--- a/jdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/jdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+net.snowflake.client.api.driver.SnowflakeDriver


### PR DESCRIPTION
## Summary

This PR adds JDBC Service Provider configuration to the universal JDBC artifact so Java can auto-discover the driver at runtime.

### Change
- Add `META-INF/services/java.sql.Driver` under `universal-driver/jdbc`
- File content: `net.snowflake.client.api.driver.SnowflakeDriver`

### Why
Without this service file, runtimes that rely on `DriverManager.getConnection("jdbc:snowflake:...")` may throw `No suitable driver found` unless the driver class is explicitly loaded first. This change restores JDBC 4 auto-loading behavior and improves compatibility with existing integrations and test pipelines.
