### PR TITLE
Add Snowflake FIXED types to C types conversions

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -283,6 +283,12 @@ pub fn driver_connect(
     // Apply SQLSetConnectAttr values (override connection string parameters).
     apply_pre_connection_attrs(connection, conn_handle)?;
 
+    DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
+        conn_handle: Some(conn_handle),
+        key: "client_app_id".to_owned(),
+        value: "ODBC".to_owned(),
+    })?;
+
     DatabaseDriverClient::connection_init(ConnectionInitRequest {
         conn_handle: Some(conn_handle),
         db_handle: Some(db_handle),

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -9,7 +9,7 @@ use crate::api::{
 };
 use crate::cdata_types::CDataType;
 use crate::conversion::warning::Warnings;
-use crate::conversion::{Binding, ConversionError, make_converter};
+use crate::conversion::{Binding, ConversionError, NumericSettings, make_converter};
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use odbc_sys as sql;
@@ -21,9 +21,10 @@ fn read_arrow_value(
     array_ref: &dyn Array,
     field: &Field,
     batch_idx: usize,
+    numeric_settings: &NumericSettings,
     get_data_offset: &mut Option<usize>,
 ) -> Result<Warnings, ConversionError> {
-    let converter = make_converter(field, array_ref)?;
+    let converter = make_converter(field, array_ref, numeric_settings)?;
     let warnings = converter.convert_arrow_value(batch_idx, binding, get_data_offset)?;
     Ok(warnings)
 }
@@ -383,8 +384,15 @@ fn execute_bindings_for_row(
             }
             let array_ref = record_batch.column(arrow_col);
             let field = schema.field(arrow_col);
-            let w = read_arrow_value(adjusted, array_ref, field, batch_idx, &mut None)
-                .context(ConversionSnafu)?;
+            let w = read_arrow_value(
+                adjusted,
+                array_ref,
+                field,
+                batch_idx,
+                &stmt.conn.numeric_settings,
+                &mut None,
+            )
+            .context(ConversionSnafu)?;
             warnings.extend(w);
         }
     }
@@ -479,17 +487,25 @@ pub fn get_data(
             let schema = record_batch.schema();
             let field = schema.field(col_idx);
 
+            let ard_binding = stmt.ard.bindings.get(&col_or_param_num);
             let binding = Binding {
                 target_type,
                 target_value_ptr,
                 buffer_length,
                 octet_length_ptr: str_len_or_ind_ptr,
                 indicator_ptr: str_len_or_ind_ptr,
-                ..Default::default()
+                precision: ard_binding.and_then(|b| b.precision),
+                scale: ard_binding.and_then(|b| b.scale),
             };
-            let conversion_warnings =
-                read_arrow_value(&binding, array_ref, field, *batch_idx, &mut offset)
-                    .context(ConversionSnafu)?;
+            let conversion_warnings = read_arrow_value(
+                &binding,
+                array_ref,
+                field,
+                *batch_idx,
+                &stmt.conn.numeric_settings,
+                &mut offset,
+            )
+            .context(ConversionSnafu)?;
             warnings.extend(conversion_warnings);
 
             // The write method sets offset to Some(n) on truncation, None when complete.
@@ -542,6 +558,22 @@ mod tests {
     use arrow::datatypes::{DataType, Field};
     use std::collections::HashMap;
 
+    fn read_arrow_value_test(
+        binding: &Binding,
+        array_ref: &dyn arrow::array::Array,
+        field: &Field,
+        batch_idx: usize,
+    ) -> Result<Warnings, ConversionError> {
+        read_arrow_value(
+            binding,
+            array_ref,
+            field,
+            batch_idx,
+            &NumericSettings::default(),
+            &mut None,
+        )
+    }
+
     fn field_with_fixed_meta(data_type: DataType, scale: u32, precision: u32) -> Field {
         let mut metadata = HashMap::new();
         metadata.insert("logicalType".to_string(), "FIXED".to_string());
@@ -583,11 +615,12 @@ mod tests {
                 octet_length_ptr: &mut str_len,
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(str_len, 5);
             assert_eq!(&buffer[..5], b"hello");
+            assert_eq!(buffer[5], 0); // Null terminator
         }
 
         #[test]
@@ -604,11 +637,12 @@ mod tests {
                 octet_length_ptr: &mut str_len,
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(str_len, 6);
             assert_eq!(&buffer[..6], b"123.45");
+            assert_eq!(buffer[6], 0); // Null terminator
         }
 
         #[test]
@@ -625,7 +659,7 @@ mod tests {
                 octet_length_ptr: &mut str_len,
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(str_len, 11); // total character count of "hello world"
@@ -651,7 +685,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 9876543210u64);
@@ -670,7 +704,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 123u64);
@@ -691,7 +725,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 123u64);
@@ -715,7 +749,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, -9876543210i64);
@@ -734,7 +768,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, -123i64);
@@ -758,7 +792,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 123456);
@@ -777,7 +811,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, -123456);
@@ -801,7 +835,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 123456);
@@ -825,7 +859,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 1234);
@@ -844,7 +878,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, -1234);
@@ -868,7 +902,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 1234);
@@ -892,7 +926,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 42);
@@ -911,7 +945,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, -42);
@@ -935,7 +969,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 42);
@@ -959,7 +993,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert!((value - 123.45f32).abs() < 0.01);
@@ -983,7 +1017,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert!((value - 123.45f64).abs() < 0.001);
@@ -1004,7 +1038,7 @@ mod tests {
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert!((value - 123.45f64).abs() < 0.001);
@@ -1022,13 +1056,13 @@ mod tests {
             let mut value: i64 = 0;
 
             let binding = Binding {
-                target_type: CDataType::Binary, // Unsupported
+                target_type: CDataType::TypeDate, // Unsupported for FIXED
                 target_value_ptr: &mut value as *mut i64 as sql::Pointer,
                 buffer_length: 0,
                 octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(matches!(
                 result,
@@ -1050,7 +1084,7 @@ mod tests {
                 octet_length_ptr: &mut str_len,
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(str_len, 10); // "hello" is 5 UTF-16 code units = 10 bytes
@@ -1087,7 +1121,7 @@ mod tests {
                     octet_length_ptr: std::ptr::null_mut(),
                     ..Default::default()
                 };
-                let result = read_arrow_value(&binding, &array, &field, idx, &mut None);
+                let result = read_arrow_value_test(&binding, &array, &field, idx);
 
                 assert!(result.is_ok());
                 assert_eq!(value, expected);
@@ -1110,12 +1144,242 @@ mod tests {
                     octet_length_ptr: &mut str_len,
                     ..Default::default()
                 };
-                let result = read_arrow_value(&binding, &array, &field, idx, &mut None);
+                let result = read_arrow_value_test(&binding, &array, &field, idx);
 
                 assert!(result.is_ok());
                 assert_eq!(str_len, expected.len() as sql::Len);
                 assert_eq!(&buffer[..expected.len()], expected.as_bytes());
             }
+        }
+    }
+
+    // Tests for CDataType::Default (SQL_C_DEFAULT)
+    // Per ODBC spec, SQL_DECIMAL/SQL_NUMERIC default C type is SQL_C_CHAR.
+    mod read_to_default {
+        use super::*;
+
+        #[test]
+        fn default_reads_int64_as_char_for_fixed_type() {
+            let array = Int64Array::from(vec![123i64]);
+            let field = field_with_fixed_meta(DataType::Int64, 0, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 3);
+            assert_eq!(&buffer[..3], b"123");
+        }
+
+        #[test]
+        fn default_reads_int64_with_scale_as_char() {
+            let array = Int64Array::from(vec![12345i64]); // 123.45 with scale 2
+            let field = field_with_fixed_meta(DataType::Int64, 2, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 6);
+            assert_eq!(&buffer[..6], b"123.45");
+        }
+
+        #[test]
+        fn default_reads_negative_int64_with_scale_as_char() {
+            let array = Int64Array::from(vec![-12345i64]); // -123.45 with scale 2
+            let field = field_with_fixed_meta(DataType::Int64, 2, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 7);
+            assert_eq!(&buffer[..7], b"-123.45");
+        }
+
+        #[test]
+        fn default_reads_decimal128_as_char() {
+            let array = Decimal128Array::from(vec![12345i128])
+                .with_precision_and_scale(10, 2)
+                .unwrap();
+            let field = decimal128_field(10, 2);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 6);
+            assert_eq!(&buffer[..6], b"123.45");
+        }
+
+        #[test]
+        fn default_reads_small_value_with_large_scale() {
+            let array = Int64Array::from(vec![5i64]); // 0.05 with scale 2
+            let field = field_with_fixed_meta(DataType::Int64, 2, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 4);
+            assert_eq!(&buffer[..4], b"0.05");
+        }
+
+        #[test]
+        fn default_reads_zero_as_char() {
+            let array = Int64Array::from(vec![0i64]);
+            let field = field_with_fixed_meta(DataType::Int64, 0, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 1);
+            assert_eq!(&buffer[..1], b"0");
+        }
+
+        #[test]
+        fn default_reads_zero_with_scale_as_char() {
+            let array = Int64Array::from(vec![0i64]);
+            let field = field_with_fixed_meta(DataType::Int64, 3, 10);
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(str_len, 5);
+            assert_eq!(&buffer[..5], b"0.000");
+        }
+
+        #[test]
+        fn default_reads_large_decimal128_as_char() {
+            let large_value: i128 = 99999999999999999999999999999999999999;
+            let array = Decimal128Array::from(vec![large_value])
+                .with_precision_and_scale(38, 0)
+                .unwrap();
+            let field = decimal128_field(38, 0);
+            let mut buffer = vec![0u8; 64];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            let expected = b"99999999999999999999999999999999999999";
+            assert_eq!(str_len, expected.len() as sql::Len);
+            assert_eq!(&buffer[..expected.len()], expected);
+        }
+
+        #[test]
+        fn default_reads_large_negative_decimal128_as_char() {
+            let large_value: i128 = -99999999999999999999999999999999999999;
+            let array = Decimal128Array::from(vec![large_value])
+                .with_precision_and_scale(38, 0)
+                .unwrap();
+            let field = decimal128_field(38, 0);
+            let mut buffer = vec![0u8; 64];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            let expected = b"-99999999999999999999999999999999999999";
+            assert_eq!(str_len, expected.len() as sql::Len);
+            assert_eq!(&buffer[..expected.len()], expected);
+        }
+
+        #[test]
+        fn default_reads_decimal128_with_high_scale_as_char() {
+            let value: i128 = 12345678901234567890123456789012345678;
+            let array = Decimal128Array::from(vec![value])
+                .with_precision_and_scale(38, 37)
+                .unwrap();
+            let field = decimal128_field(38, 37);
+            let mut buffer = vec![0u8; 64];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            let expected = b"1.2345678901234567890123456789012345678";
+            assert_eq!(str_len, expected.len() as sql::Len);
+            assert_eq!(&buffer[..expected.len()], expected);
         }
     }
 
@@ -1133,10 +1397,10 @@ mod tests {
                 target_type: CDataType::UBigInt,
                 target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                 buffer_length: 0,
-                octet_length_ptr: std::ptr::null_mut(), // null indicator
+                octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(value, 42u64);
@@ -1152,13 +1416,14 @@ mod tests {
                 target_type: CDataType::Char,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: buffer.len() as sql::Len,
-                octet_length_ptr: std::ptr::null_mut(), // null indicator
+                octet_length_ptr: std::ptr::null_mut(),
                 ..Default::default()
             };
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(&buffer[..5], b"hello");
+            assert_eq!(buffer[5], 0); // Null terminator
         }
     }
 
@@ -1186,7 +1451,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(numeric.sign, 1); // positive
@@ -1217,7 +1482,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(numeric.sign, 0); // negative
@@ -1251,7 +1516,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
 
             assert!(result.is_ok());
             assert_eq!(numeric.sign, 1);
@@ -1267,7 +1532,7 @@ mod tests {
         }
 
         #[test]
-        fn returns_error_without_precision() {
+        fn defaults_precision_and_scale_when_not_set() {
             let array = Int64Array::from(vec![42i64]);
             let field = field_with_fixed_meta(DataType::Int64, 0, 10);
             let mut numeric = sql::Numeric::default();
@@ -1277,13 +1542,17 @@ mod tests {
                 target_value_ptr: &mut numeric as *mut sql::Numeric as sql::Pointer,
                 buffer_length: std::mem::size_of::<sql::Numeric>() as sql::Len,
                 octet_length_ptr: std::ptr::null_mut(),
-                precision: None, // not set
-                scale: Some(0),
+                precision: None,
+                scale: None,
                 ..Default::default()
             };
 
-            let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
-            assert!(result.is_err());
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+            assert!(result.is_ok());
+            assert_eq!(numeric.precision, 10);
+            assert_eq!(numeric.scale, 0);
+            assert_eq!(numeric.sign, 1);
+            assert_eq!(u128::from_le_bytes(numeric.val), 42);
         }
     }
 }

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -395,7 +395,8 @@ impl OdbcError {
                     WriteOdbcError::NumericValueOutOfRange { .. } => {
                         SqlState::NumericValueOutOfRange
                     }
-                    WriteOdbcError::IndicatorRequired { .. } => {
+                    WriteOdbcError::IndicatorRequired { .. }
+                    | WriteOdbcError::IndicatorVariableRequired { .. } => {
                         SqlState::IndicatorVariableRequiredButNotSupplied
                     }
                     WriteOdbcError::UnsupportedOdbcType { .. } => {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -26,6 +26,7 @@ pub fn alloc_connection() -> OdbcResult<*mut Connection> {
         state: ConnectionState::Disconnected,
         diagnostic_info: DiagnosticInfo::default(),
         pre_connection_attrs: Default::default(),
+        numeric_settings: Default::default(),
     });
     Ok(Box::into_raw(dbc))
 }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -12,8 +12,9 @@ use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use odbc_sys as sql;
 use sf_core::protobuf_apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf_gen::database_driver_v1::{
-    ArrowArrayPtr, ArrowSchemaPtr, StatementBindRequest, StatementExecuteQueryRequest,
-    StatementExecuteQueryResponse, StatementPrepareRequest, StatementSetSqlQueryRequest,
+    ArrowArrayPtr, ArrowSchemaPtr, ConnectionGetParameterRequest, ConnectionHandle,
+    StatementBindRequest, StatementExecuteQueryRequest, StatementExecuteQueryResponse,
+    StatementPrepareRequest, StatementSetSqlQueryRequest,
 };
 use snafu::ResultExt;
 use tracing;
@@ -60,7 +61,7 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
     match &mut stmt.conn.state {
         ConnectionState::Connected {
             db_handle: _,
-            conn_handle: _,
+            conn_handle,
         } => {
             DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
                 stmt_handle: Some(stmt.stmt_handle),
@@ -76,6 +77,7 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
             tracing::info!("exec_direct: response={:?}", response);
             let response = response?;
 
+            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings);
             stmt.state = create_execute_state(response)?.into();
             Ok(())
         }
@@ -83,6 +85,40 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
             tracing::error!("exec_direct: connection is disconnected");
             DisconnectedSnafu.fail()
         }
+    }
+}
+
+use crate::conversion::NumericSettings;
+
+fn update_numeric_settings(conn_handle: &ConnectionHandle, settings: &mut NumericSettings) {
+    if let Ok(resp) =
+        DatabaseDriverClient::connection_get_parameter(ConnectionGetParameterRequest {
+            conn_handle: Some(*conn_handle),
+            key: "ODBC_TREAT_DECIMAL_AS_INT".to_string(),
+        })
+        && let Some(value) = resp.value
+    {
+        let bool_value = value.eq_ignore_ascii_case("true");
+        settings.treat_decimal_as_int = bool_value;
+        tracing::info!(
+            "Server parameter ODBC_TREAT_DECIMAL_AS_INT = {}",
+            bool_value
+        );
+    }
+
+    if let Ok(resp) =
+        DatabaseDriverClient::connection_get_parameter(ConnectionGetParameterRequest {
+            conn_handle: Some(*conn_handle),
+            key: "ODBC_TREAT_BIG_NUMBER_AS_STRING".to_string(),
+        })
+        && let Some(value) = resp.value
+    {
+        let bool_value = value.eq_ignore_ascii_case("true");
+        settings.treat_big_number_as_string = bool_value;
+        tracing::info!(
+            "Server parameter ODBC_TREAT_BIG_NUMBER_AS_STRING = {}",
+            bool_value
+        );
     }
 }
 
@@ -132,7 +168,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     match &mut stmt.conn.state {
         ConnectionState::Connected {
             db_handle: _,
-            conn_handle: _,
+            conn_handle,
         } => {
             // If there are bound parameters, we should bind them to the statement
             if !stmt.parameter_bindings.is_empty() {
@@ -162,6 +198,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
                 })?;
 
             tracing::info!("execute: Successfully executed statement");
+            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings);
             stmt.state = create_execute_state(response)?.into();
             Ok(())
         }

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -3,6 +3,7 @@ use crate::api::error::InvalidDescriptorKindSnafu;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::cdata_types::CDataType;
 use crate::conversion::Binding;
+use crate::conversion::NumericSettings;
 use crate::conversion::warning::Warnings;
 use arrow::{array::RecordBatch, ffi_stream::ArrowArrayStreamReader};
 use odbc_sys as sql;
@@ -475,6 +476,7 @@ pub struct Connection {
     pub diagnostic_info: DiagnosticInfo,
     /// Attributes set via SQLSetConnectAttr before the connection is established
     pub pre_connection_attrs: PreConnectionAttributes,
+    pub numeric_settings: NumericSettings,
 }
 
 #[derive(Debug, Clone)]

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -93,7 +93,8 @@ pub fn col_attribute(
 
     match desc_field {
         DescField::Type | DescField::ConciseType => {
-            let sql_type = sql_type_from_field(field).context(ConversionSnafu)?;
+            let sql_type =
+                sql_type_from_field(field, &stmt.conn.numeric_settings).context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provides the C API interface for ODBC functions.
 
+#![allow(non_snake_case)]
+
 use crate::api::{self, ToSqlReturn};
 use crate::cdata_types::CDataType;
 use odbc_sys as sql;

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -44,6 +44,12 @@ pub enum WriteOdbcError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Indicator variable required but not supplied"))]
+    IndicatorVariableRequired {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     /// The target ODBC type is not supported for the given Snowflake/Arrow source type.
     #[snafu(display("Target ODBC type '{target_type:?}' is not supported for this conversion"))]
     UnsupportedOdbcType {

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -9,6 +9,8 @@ mod boolean;
 mod date;
 mod nullable;
 mod number;
+#[cfg(test)]
+mod number_tests;
 mod timestamp;
 mod varchar;
 
@@ -22,6 +24,7 @@ pub use traits::{Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCT
 pub use error::{
     ArrowArrayDowncastSnafu, ConversionError, FieldMetadataParsingSnafu, MissingFieldMetadataSnafu,
 };
+pub use number::NumericSettings;
 
 use crate::conversion::error::{
     IncompatibleFieldMetadataSnafu, ReadArrowValueSnafu, UnsupportedArrowDataTypeSnafu,
@@ -43,7 +46,7 @@ struct GenericConverter<'a, ArrowArrayType, T> {
     arrow_array: &'a ArrowArrayType,
 }
 
-impl<'a, ArrowArrayType, T: SnowflakeType + WriteODBCType + ReadArrowType<ArrowArrayType>>
+impl<'a, ArrowArrayType: Array, T: SnowflakeType + WriteODBCType + ReadArrowType<ArrowArrayType>>
     Converter<'a> for GenericConverter<'a, ArrowArrayType, T>
 {
     fn convert_arrow_value(
@@ -135,7 +138,10 @@ enum SnowflakeFieldType {
 }
 
 impl SnowflakeFieldType {
-    fn from_field(field: &Field) -> Result<Self, ConversionError> {
+    fn from_field(
+        field: &Field,
+        numeric_settings: &NumericSettings,
+    ) -> Result<Self, ConversionError> {
         let logical_type = field
             .metadata()
             .get("logicalType")
@@ -149,7 +155,16 @@ impl SnowflakeFieldType {
             "FIXED" => {
                 let scale = get_field_metadata(field, "scale")?;
                 let precision = get_field_metadata(field, "precision")?;
-                Ok(Self::Number(number::SnowflakeNumber { scale, precision }))
+                let sql_type = number::NumericSqlType::from_scale_and_precision(
+                    scale,
+                    precision,
+                    numeric_settings,
+                );
+                Ok(Self::Number(number::SnowflakeNumber {
+                    scale,
+                    precision,
+                    sql_type,
+                }))
             }
             "DATE" => Ok(Self::Date(date::SnowflakeDate)),
             "TIMESTAMP_NTZ" => Ok(Self::TimestampNtz(timestamp::SnowflakeTimestampNtz)),
@@ -178,8 +193,9 @@ impl SnowflakeFieldType {
 pub fn make_converter<'a>(
     field: &Field,
     arrow_array: &'a dyn Array,
+    numeric_settings: &NumericSettings,
 ) -> Result<Box<dyn Converter<'a> + 'a>, ConversionError> {
-    let field_type = SnowflakeFieldType::from_field(field)?;
+    let field_type = SnowflakeFieldType::from_field(field, numeric_settings)?;
     let nullable = field.is_nullable();
     match field_type {
         SnowflakeFieldType::Varchar(snowflake_type) => {
@@ -247,6 +263,9 @@ pub fn make_converter<'a>(
 }
 
 /// Map a Snowflake Arrow field to the corresponding SQL data type.
-pub fn sql_type_from_field(field: &Field) -> Result<odbc_sys::SqlDataType, ConversionError> {
-    SnowflakeFieldType::from_field(field).map(|ft| ft.sql_type())
+pub fn sql_type_from_field(
+    field: &Field,
+    numeric_settings: &NumericSettings,
+) -> Result<odbc_sys::SqlDataType, ConversionError> {
+    SnowflakeFieldType::from_field(field, numeric_settings).map(|ft| ft.sql_type())
 }

--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -3,17 +3,69 @@ use odbc_sys as sql;
 
 use crate::cdata_types::CDataType;
 use crate::conversion::error::{
-    InvalidValueSnafu, NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu,
-    WriteOdbcError,
+    NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
 use crate::conversion::traits::Binding;
-use crate::conversion::warning::Warnings;
+use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
+
+/// Controls how FIXED numeric columns are reported to ODBC applications.
+/// These settings match the Snowflake server-side session parameters
+/// `ODBC_TREAT_DECIMAL_AS_INT` and `ODBC_TREAT_BIG_NUMBER_AS_STRING`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NumericSettings {
+    /// When true, FIXED columns with scale=0 are reported as SQL_BIGINT
+    /// instead of SQL_DECIMAL. Default C type becomes SQL_C_SBIGINT.
+    /// Can be overridden by `treat_big_number_as_string` for precision > 18.
+    pub treat_decimal_as_int: bool,
+    /// When true, FIXED columns with precision > 18 are reported as SQL_VARCHAR.
+    /// Takes precedence over `treat_decimal_as_int` for high-precision columns.
+    pub treat_big_number_as_string: bool,
+}
+
+/// Represents the SQL numeric data types as defined by the ODBC specification.
+/// Each SQL type has a different default C type used when the application
+/// specifies `SQL_C_DEFAULT`.
+/// Reference: https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/sql-to-c-numeric
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NumericSqlType {
+    Decimal,
+    BigInt,
+    VarChar,
+}
+
+impl NumericSqlType {
+    pub(crate) fn default_c_type(&self) -> CDataType {
+        match self {
+            Self::Decimal => CDataType::Char,
+            Self::BigInt => CDataType::SBigInt,
+            Self::VarChar => CDataType::Char,
+        }
+    }
+
+    pub(crate) fn from_scale_and_precision(
+        scale: u32,
+        precision: u32,
+        settings: &NumericSettings,
+    ) -> Self {
+        let mut result = Self::Decimal;
+
+        if settings.treat_decimal_as_int && scale == 0 {
+            result = Self::BigInt;
+        }
+
+        if precision > 18 && settings.treat_big_number_as_string {
+            result = Self::VarChar;
+        }
+
+        result
+    }
+}
 
 pub(crate) struct SnowflakeNumber {
     pub(crate) scale: u32,
-    #[allow(dead_code)]
     pub(crate) precision: u32,
+    pub(crate) sql_type: NumericSqlType,
 }
 
 impl SnowflakeType for SnowflakeNumber {
@@ -39,6 +91,55 @@ where
     }
 }
 
+impl SnowflakeNumber {
+    fn format_decimal(value: i128, scale: u32) -> String {
+        if scale > 0 {
+            let mut s = value.to_string();
+            let is_negative = s.starts_with('-');
+            if is_negative {
+                s.remove(0);
+            }
+            while s.len() <= scale as usize {
+                s.insert(0, '0');
+            }
+            let decimal_pos = s.len() - scale as usize;
+            s.insert(decimal_pos, '.');
+            if is_negative {
+                s.insert(0, '-');
+            }
+            s
+        } else {
+            value.to_string()
+        }
+    }
+
+    fn check_integer_range(value: i128, min: i128, max: i128) -> Result<(), WriteOdbcError> {
+        if value < min || value > max {
+            NumericValueOutOfRangeSnafu {
+                reason: format!("Value {value} is out of range ({min} to {max})"),
+            }
+            .fail()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn fractional_warning(has_fractional: bool) -> Warnings {
+        if has_fractional {
+            vec![Warning::NumericValueTruncated]
+        } else {
+            vec![]
+        }
+    }
+
+    fn whole_digits_len(num_str: &str) -> usize {
+        match num_str.find('.') {
+            Some(pos) => pos,
+            None => num_str.len(),
+        }
+    }
+}
+
 impl WriteODBCType for SnowflakeNumber {
     fn sql_type(&self) -> sql::SqlDataType {
         sql::SqlDataType::DECIMAL
@@ -50,131 +151,153 @@ impl WriteODBCType for SnowflakeNumber {
         binding: &Binding,
         get_data_offset: &mut Option<usize>,
     ) -> Result<Warnings, WriteOdbcError> {
-        match binding.target_type {
+        let target_type = match binding.target_type {
+            CDataType::Default => self.sql_type.default_c_type(),
+            other => other,
+        };
+
+        let scale_factor = 10i128.pow(self.scale);
+        let int_value = snowflake_value / scale_factor;
+        let has_fractional = self.scale > 0 && snowflake_value % scale_factor != 0;
+
+        match target_type {
             CDataType::Double => {
                 let double_value: f64 = snowflake_value as f64 / 10f64.powi(self.scale as i32);
+                if double_value.is_infinite() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "Value out of range for SQL_C_DOUBLE".to_string(),
+                    }
+                    .fail();
+                }
                 binding.write_fixed(double_value);
                 Ok(vec![])
             }
             CDataType::Float => {
                 let float_value: f32 = snowflake_value as f32 / 10f32.powi(self.scale as i32);
+                if float_value.is_infinite() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "Value out of range for SQL_C_FLOAT".to_string(),
+                    }
+                    .fail();
+                }
                 binding.write_fixed(float_value);
                 Ok(vec![])
             }
             CDataType::Short | CDataType::SShort => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = i16::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_SHORT"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, i16::MIN as i128, i16::MAX as i128)?;
+                binding.write_fixed(int_value as i16);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::UShort => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = u16::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_USHORT"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, 0, u16::MAX as i128)?;
+                binding.write_fixed(int_value as u16);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::TinyInt | CDataType::STinyInt => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = i8::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_TINYINT"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, i8::MIN as i128, i8::MAX as i128)?;
+                binding.write_fixed(int_value as i8);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::UTinyInt => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = u8::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_UTINYINT"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, 0, u8::MAX as i128)?;
+                binding.write_fixed(int_value as u8);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::Long | CDataType::SLong => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = i32::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_LONG"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, i32::MIN as i128, i32::MAX as i128)?;
+                binding.write_fixed(int_value as i32);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::ULong => {
-                let scaled = (snowflake_value as i64) / 10i64.pow(self.scale);
-                let value = u32::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_ULONG"),
-                    }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, 0, u32::MAX as i128)?;
+                binding.write_fixed(int_value as u32);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::SBigInt => {
-                let value = (snowflake_value as i64) / 10i64.pow(self.scale);
-                binding.write_fixed(value);
-                Ok(vec![])
+                Self::check_integer_range(int_value, i64::MIN as i128, i64::MAX as i128)?;
+                binding.write_fixed(int_value as i64);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::UBigInt => {
-                let scaled = (snowflake_value as u128) / 10u128.pow(self.scale);
-                let value = u64::try_from(scaled).map_err(|_| {
-                    NumericValueOutOfRangeSnafu {
-                        reason: format!("{scaled} out of range for SQL_C_UBIGINT"),
+                Self::check_integer_range(int_value, 0, u64::MAX as i128)?;
+                binding.write_fixed(int_value as u64);
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::Bit => {
+                if snowflake_value < 0 || int_value >= 2 {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!(
+                            "Value out of range for SQL_C_BIT (must be 0 or 1, got {})",
+                            int_value
+                        ),
                     }
-                    .build()
-                })?;
-                binding.write_fixed(value);
-                Ok(vec![])
+                    .fail();
+                }
+                binding.write_fixed(int_value as u8);
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::Char => {
+                let num_str = Self::format_decimal(snowflake_value, self.scale);
+                let warnings = binding.write_char_string(&num_str, get_data_offset);
+                if warnings
+                    .iter()
+                    .any(|w| matches!(w, Warning::StringDataTruncated))
+                {
+                    let whole_len = Self::whole_digits_len(&num_str);
+                    if whole_len >= binding.buffer_length as usize {
+                        *get_data_offset = None;
+                        return NumericValueOutOfRangeSnafu {
+                            reason: format!(
+                                "Whole digits of '{num_str}' do not fit in buffer of {} bytes",
+                                binding.buffer_length
+                            ),
+                        }
+                        .fail();
+                    }
+                }
+                Ok(warnings)
+            }
+            CDataType::WChar => {
+                let num_str = Self::format_decimal(snowflake_value, self.scale);
+                let warnings = binding.write_wchar_string(&num_str, get_data_offset);
+                if warnings
+                    .iter()
+                    .any(|w| matches!(w, Warning::StringDataTruncated))
+                {
+                    let whole_len = Self::whole_digits_len(&num_str);
+                    let wchar_capacity = (binding.buffer_length / 2) as usize;
+                    if whole_len >= wchar_capacity {
+                        *get_data_offset = None;
+                        return NumericValueOutOfRangeSnafu {
+                            reason: format!(
+                                "Whole digits of '{num_str}' do not fit in wchar buffer of {wchar_capacity} chars",
+                            ),
+                        }
+                        .fail();
+                    }
+                }
+                Ok(warnings)
             }
             CDataType::Numeric => {
-                // The application must set SQL_DESC_PRECISION and SQL_DESC_SCALE on the ARD
-                // via SQLSetDescField before fetching SQL_C_NUMERIC data.
-                let target_precision = binding.precision.ok_or_else(|| {
-                    InvalidValueSnafu {
-                        reason:
-                            "SQL_DESC_PRECISION must be set on the ARD for SQL_C_NUMERIC bindings"
-                                .to_string(),
-                    }
-                    .build()
-                })?;
-                let target_scale = binding.scale.ok_or_else(|| {
-                    InvalidValueSnafu {
-                        reason: "SQL_DESC_SCALE must be set on the ARD for SQL_C_NUMERIC bindings"
-                            .to_string(),
-                    }
-                    .build()
-                })?;
+                let target_precision = binding.precision.unwrap_or(self.precision as i16);
+                let target_scale = binding.scale.unwrap_or(0);
 
                 let is_negative = snowflake_value < 0;
                 let abs_value = snowflake_value.unsigned_abs();
 
-                // Rescale: convert from Snowflake scale to target scale.
-                // unscaled_target = abs_value * 10^(target_scale - snowflake_scale)
                 let scale_diff = target_scale as i32 - self.scale as i32;
+                let truncated = if scale_diff < 0 {
+                    let divisor = 10u128.pow((-scale_diff) as u32);
+                    abs_value % divisor != 0
+                } else {
+                    false
+                };
                 let unscaled: u128 = if scale_diff >= 0 {
                     abs_value * 10u128.pow(scale_diff as u32)
                 } else {
                     abs_value / 10u128.pow((-scale_diff) as u32)
                 };
 
-                // Build the SQL_NUMERIC_STRUCT (odbc_sys::Numeric)
                 let numeric = sql::Numeric {
                     precision: target_precision as u8,
                     scale: target_scale as i8,
@@ -183,38 +306,46 @@ impl WriteODBCType for SnowflakeNumber {
                 };
 
                 binding.write_fixed(numeric);
+                Ok(Self::fractional_warning(truncated))
+            }
+            CDataType::Binary => {
+                let abs_value = int_value.unsigned_abs();
+                let sign: u8 = if int_value >= 0 { 1 } else { 0 };
+                let numeric = sql::Numeric {
+                    precision: self.precision as u8,
+                    scale: 0,
+                    sign,
+                    val: abs_value.to_le_bytes(),
+                };
+                let numeric_size = std::mem::size_of::<sql::Numeric>();
+                if (binding.buffer_length as usize) < numeric_size {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!(
+                            "Buffer size {} is too small for SQL_C_BINARY (need {numeric_size} bytes)",
+                            binding.buffer_length
+                        ),
+                    }
+                    .fail();
+                }
+                let numeric_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &numeric as *const sql::Numeric as *const u8,
+                        numeric_size,
+                    )
+                };
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        numeric_bytes.as_ptr(),
+                        binding.target_value_ptr as *mut u8,
+                        numeric_size,
+                    );
+                }
+                let _ = binding.write_length_or_null(
+                    crate::conversion::traits::LengthOrNull::Length(numeric_size as sql::Len),
+                );
                 Ok(vec![])
             }
-            CDataType::Default | CDataType::Char => {
-                let num_str = if self.scale > 0 {
-                    let mut s = snowflake_value.to_string();
-                    let is_negative = s.starts_with('-');
-                    if is_negative {
-                        s.remove(0);
-                    }
-
-                    // Pad with leading zeros if necessary
-                    while s.len() <= self.scale as usize {
-                        s.insert(0, '0');
-                    }
-
-                    // Insert decimal point
-                    let decimal_pos = s.len() - self.scale as usize;
-                    s.insert(decimal_pos, '.');
-
-                    if is_negative {
-                        s.insert(0, '-');
-                    }
-                    s
-                } else {
-                    snowflake_value.to_string()
-                };
-                Ok(binding.write_char_string(&num_str, get_data_offset))
-            }
-            _ => UnsupportedOdbcTypeSnafu {
-                target_type: binding.target_type,
-            }
-            .fail(),
+            _ => UnsupportedOdbcTypeSnafu { target_type }.fail(),
         }
     }
 }

--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -1,0 +1,1009 @@
+#[cfg(test)]
+mod tests {
+    use crate::cdata_types::CDataType;
+    use crate::conversion::WriteODBCType;
+    use crate::conversion::number::{NumericSettings, NumericSqlType, SnowflakeNumber};
+    use crate::conversion::traits::Binding;
+    use odbc_sys as sql;
+
+    const SETTINGS_DEFAULT: NumericSettings = NumericSettings {
+        treat_decimal_as_int: false,
+        treat_big_number_as_string: false,
+    };
+
+    const SETTINGS_DECIMAL_AS_INT: NumericSettings = NumericSettings {
+        treat_decimal_as_int: true,
+        treat_big_number_as_string: false,
+    };
+
+    const SETTINGS_BOTH: NumericSettings = NumericSettings {
+        treat_decimal_as_int: true,
+        treat_big_number_as_string: true,
+    };
+
+    const SETTINGS_BIG_NUMBER_AS_STRING: NumericSettings = NumericSettings {
+        treat_decimal_as_int: false,
+        treat_big_number_as_string: true,
+    };
+
+    fn binding_for_value<T>(
+        target_type: CDataType,
+        value: &mut T,
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: value as *mut T as sql::Pointer,
+            buffer_length: 0,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
+    fn binding_for_char_buffer(
+        target_type: CDataType,
+        buffer: &mut [u8],
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: buffer.len() as sql::Len,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
+    fn make_decimal(scale: u32, precision: u32) -> SnowflakeNumber {
+        SnowflakeNumber {
+            scale,
+            precision,
+            sql_type: NumericSqlType::Decimal,
+        }
+    }
+
+    fn make_number(scale: u32, precision: u32, settings: &NumericSettings) -> SnowflakeNumber {
+        SnowflakeNumber {
+            scale,
+            precision,
+            sql_type: NumericSqlType::from_scale_and_precision(scale, precision, settings),
+        }
+    }
+
+    #[test]
+    fn decimal_default_c_type_is_char() {
+        assert_eq!(NumericSqlType::Decimal.default_c_type(), CDataType::Char);
+    }
+
+    #[test]
+    fn bigint_default_c_type_is_sbigint() {
+        assert_eq!(NumericSqlType::BigInt.default_c_type(), CDataType::SBigInt);
+    }
+
+    #[test]
+    fn varchar_default_c_type_is_char() {
+        assert_eq!(NumericSqlType::VarChar.default_c_type(), CDataType::Char);
+    }
+
+    // BD#11: treat_decimal_as_int=true, scale=0 → BigInt for any precision
+    #[test]
+    fn treat_decimal_as_int_scale_zero_resolves_to_bigint() {
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 1, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::BigInt
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 10, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::BigInt
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 18, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::BigInt
+        );
+        // precision > 18 still BigInt when treat_big_number_as_string=false
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 19, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::BigInt
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 38, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::BigInt
+        );
+    }
+
+    // BD#11: treat_decimal_as_int=false → Decimal regardless of scale
+    #[test]
+    fn no_treat_decimal_as_int_stays_decimal() {
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 10, &SETTINGS_DEFAULT),
+            NumericSqlType::Decimal
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 38, &SETTINGS_DEFAULT),
+            NumericSqlType::Decimal
+        );
+    }
+
+    // BD#11 + BD#12: treat_big_number_as_string overrides BigInt for precision > 18
+    #[test]
+    fn big_number_as_string_overrides_bigint() {
+        // precision > 18: BigInt from step 2 is overridden to VarChar by step 3
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 19, &SETTINGS_BOTH),
+            NumericSqlType::VarChar
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 38, &SETTINGS_BOTH),
+            NumericSqlType::VarChar
+        );
+        // precision <= 18: BigInt is NOT overridden
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 18, &SETTINGS_BOTH),
+            NumericSqlType::BigInt
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 10, &SETTINGS_BOTH),
+            NumericSqlType::BigInt
+        );
+    }
+
+    // BD#12: treat_big_number_as_string alone (no treat_decimal_as_int)
+    #[test]
+    fn big_number_as_string_without_decimal_as_int() {
+        // precision > 18 → VarChar
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 19, &SETTINGS_BIG_NUMBER_AS_STRING),
+            NumericSqlType::VarChar
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(5, 20, &SETTINGS_BIG_NUMBER_AS_STRING),
+            NumericSqlType::VarChar
+        );
+        // precision <= 18 → still Decimal
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(0, 18, &SETTINGS_BIG_NUMBER_AS_STRING),
+            NumericSqlType::Decimal
+        );
+    }
+
+    // Non-zero scale → Decimal (treat_decimal_as_int only applies to scale=0)
+    #[test]
+    fn nonzero_scale_resolves_to_decimal() {
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(2, 10, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::Decimal
+        );
+        assert_eq!(
+            NumericSqlType::from_scale_and_precision(1, 18, &SETTINGS_DECIMAL_AS_INT),
+            NumericSqlType::Decimal
+        );
+    }
+
+    // ========================================================================
+    // Integer conversions — success cases
+    // (SQL_C_LONG, SQL_C_SHORT, SQL_C_TINYINT, SQL_C_SBIGINT, etc.)
+    // Per ODBC spec: exact conversion → no warning; fractional truncation → 01S07
+    // ========================================================================
+
+    macro_rules! integer_conversion_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => $expected:expr, truncated=$trunc:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    let warnings = sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert_eq!(value, $expected as $rust_type);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
+                }
+            )*
+        };
+    }
+
+    integer_conversion_tests! {
+        // Basic values — no truncation
+        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                         => 42,                            truncated=false;
+        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                  => 123456789,                     truncated=false;
+        short_integer:                          CDataType::Short,    i16, 0,  5,  300i128                        => 300,                           truncated=false;
+        tinyint_integer:                        CDataType::TinyInt,  i8,  0,  3,  123i128                        => 123,                           truncated=false;
+
+        // Zero across all types
+        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                          => 0,                             truncated=false;
+        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                          => 0,                             truncated=false;
+        short_zero:                             CDataType::Short,    i16, 0,  5,  0i128                          => 0,                             truncated=false;
+        tinyint_zero:                           CDataType::TinyInt,  i8,  0,  3,  0i128                          => 0,                             truncated=false;
+
+        // One and negative one
+        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                          => 1,                             truncated=false;
+        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                         => -1,                            truncated=false;
+
+        // Negative values
+        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                        => -42,                           truncated=false;
+        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                 => -123456789,                    truncated=false;
+
+        // Boundary values — no truncation
+        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128              => 2_147_483_647,                 truncated=false;
+        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128             => -2_147_483_648,                truncated=false;
+        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128  => 9_223_372_036_854_775_807i64,  truncated=false;
+        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128 => -9_223_372_036_854_775_808i64, truncated=false;
+        short_i16_max:                          CDataType::Short,    i16, 0,  5,  32767i128                      => 32767,                         truncated=false;
+        short_i16_min:                          CDataType::Short,    i16, 0,  5,  -32768i128                     => -32768,                        truncated=false;
+        ushort_u16_max:                         CDataType::UShort,   u16, 0,  5,  65535i128                      => 65535,                         truncated=false;
+        tinyint_i8_max:                         CDataType::TinyInt,  i8,  0,  3,  127i128                        => 127,                           truncated=false;
+        tinyint_i8_min:                         CDataType::TinyInt,  i8,  0,  3,  -128i128                       => -128,                          truncated=false;
+        utinyint_u8_max:                        CDataType::UTinyInt, u8,  0,  3,  255i128                        => 255,                           truncated=false;
+
+        // Fractional truncation — should produce 01S07 warning
+        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                        => 9,                             truncated=true;
+        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                       => -9,                            truncated=true;
+        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                          => 0,                             truncated=true;
+        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                         => 0,                             truncated=true;
+        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                      => 12,                            truncated=true;
+        short_truncates_frac:                   CDataType::Short,    i16, 1,  5,  255i128                        => 25,                            truncated=true;
+        tinyint_truncates_frac:                 CDataType::TinyInt,  i8,  1,  3,  99i128                         => 9,                             truncated=true;
+
+        // High scale
+        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                          => 0,                             truncated=false;
+        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                          => 0,                             truncated=false;
+        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128             => 5,                             truncated=false;
+        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128            => -3,                            truncated=false;
+        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                          => 0,                             truncated=false;
+        ulong_zero_scale_10:                    CDataType::ULong,    u32, 10, 38, 0i128                          => 0,                             truncated=false;
+        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                          => 0,                             truncated=false;
+        short_zero_scale_10:                    CDataType::Short,    i16, 10, 38, 0i128                          => 0,                             truncated=false;
+        tinyint_zero_scale_10:                  CDataType::TinyInt,  i8,  10, 38, 0i128                          => 0,                             truncated=false;
+
+        // Type aliases
+        sshort_integer:                         CDataType::SShort,   i16, 0,  5,  300i128                        => 300,                           truncated=false;
+        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                        => 300,                           truncated=false;
+        stinyint_integer:                       CDataType::STinyInt, i8,  0,  3,  100i128                        => 100,                           truncated=false;
+        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                        => 200,                           truncated=false;
+        ubigint_integer:                        CDataType::UBigInt,  u64, 0,  10, 999i128                        => 999,                           truncated=false;
+        ubigint_u64_max:                        CDataType::UBigInt,  u64, 0,  20, 18_446_744_073_709_551_615i128 => 18_446_744_073_709_551_615u64, truncated=false;
+    }
+
+    // ========================================================================
+    // Integer conversions — overflow error cases (SQLSTATE 22003)
+    // ========================================================================
+
+    macro_rules! integer_overflow_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    assert!(sn.write_odbc_type($input, &binding, &mut None).is_err());
+                }
+            )*
+        };
+    }
+
+    integer_overflow_tests! {
+        // i32 overflow
+        slong_overflow_above:               CDataType::SLong,    i32, 0, 10, 2_147_483_648i128;
+        slong_overflow_below:               CDataType::SLong,    i32, 0, 10, -2_147_483_649i128;
+
+        // u32 overflow (ULong)
+        ulong_overflow_above:               CDataType::ULong,    u32, 0, 10, 4_294_967_296i128;
+        ulong_overflow_negative:            CDataType::ULong,    u32, 0, 10, -1i128;
+
+        // i16 overflow
+        short_overflow_above:               CDataType::Short,    i16, 0, 5,  32768i128;
+        short_overflow_below:               CDataType::Short,    i16, 0, 5,  -32769i128;
+
+        // u16 overflow (UShort)
+        ushort_overflow_above:              CDataType::UShort,   u16, 0, 5,  65536i128;
+        ushort_overflow_negative:           CDataType::UShort,   u16, 0, 5,  -1i128;
+
+        // i8 overflow
+        tinyint_overflow_above:             CDataType::TinyInt,  i8,  0, 3,  128i128;
+        tinyint_overflow_below:             CDataType::TinyInt,  i8,  0, 3,  -129i128;
+
+        // u8 overflow (UTinyInt)
+        utinyint_overflow_above:            CDataType::UTinyInt, u8,  0, 3,  256i128;
+        utinyint_overflow_negative:         CDataType::UTinyInt, u8,  0, 3,  -1i128;
+
+        // i64 overflow
+        sbigint_overflow_above:             CDataType::SBigInt,  i64, 0, 20, 9_223_372_036_854_775_808i128;
+        sbigint_overflow_below:             CDataType::SBigInt,  i64, 0, 20, -9_223_372_036_854_775_809i128;
+
+        // u64 overflow (UBigInt)
+        ubigint_overflow_above:             CDataType::UBigInt,  u64, 0, 20, 18_446_744_073_709_551_616i128;
+        ubigint_overflow_negative:          CDataType::UBigInt,  u64, 0, 20, -1i128;
+
+        // Overflow after scale division (value fits in i128 but not in target after division)
+        slong_overflow_after_scale:         CDataType::SLong,    i32, 1, 10, 21_474_836_480i128;
+    }
+
+    // ========================================================================
+    // Char / Default string conversions
+    // ========================================================================
+
+    macro_rules! char_conversion_tests {
+        ($($name:ident: $c_type:expr, $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u8; 128];
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_char_buffer($c_type, &mut buffer, &mut str_len);
+                    sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    let expected: &str = $expected;
+                    assert_eq!(str_len, expected.len() as sql::Len);
+                    assert_eq!(&buffer[..expected.len()], expected.as_bytes());
+                    assert_eq!(buffer[expected.len()], 0);
+                }
+            )*
+        };
+    }
+
+    // Treat_decimal_as_int=true, scale=0, precision<=18 → Default resolves to SBigInt
+    macro_rules! default_bigint_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_number($scale, $precision, &SETTINGS_DECIMAL_AS_INT);
+                    let mut value: i64 = 0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+                    let warnings = sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert!(warnings.is_empty());
+                    assert_eq!(value, $expected);
+                }
+            )*
+        };
+    }
+
+    default_bigint_tests! {
+        default_decimal_as_int_positive:  0, 10, 42i128  => 42i64;
+        default_decimal_as_int_zero:      0, 10, 0i128   => 0i64;
+        default_decimal_as_int_negative:  0, 10, -42i128 => -42i64;
+        default_decimal_as_int_max_prec:  0, 18, 999999999999999999i128 => 999999999999999999i64;
+    }
+
+    // BD#11: treat_decimal_as_int=false → Default still resolves to Char
+    #[test]
+    fn default_without_treat_decimal_as_int_is_char() {
+        let sn = make_number(0, 10, &SETTINGS_DEFAULT);
+        let mut buffer = vec![0u8; 128];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+        sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert_eq!(str_len, 2);
+        assert_eq!(&buffer[..2], b"42");
+    }
+
+    // precision > 18 with treat_decimal_as_int=true (no big_number_as_string)
+    // → BigInt, so Default resolves to SBigInt
+    #[test]
+    fn default_high_precision_decimal_as_int_is_bigint() {
+        let sn = make_number(0, 38, &SETTINGS_DECIMAL_AS_INT);
+        let mut value: i64 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+        let warnings = sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(value, 42);
+    }
+
+    // BD#12: precision > 18 with both settings → VarChar, Default resolves to Char
+    #[test]
+    fn default_high_precision_both_settings_is_char() {
+        let sn = make_number(0, 38, &SETTINGS_BOTH);
+        let mut buffer = vec![0u8; 128];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+        sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert_eq!(str_len, 2);
+        assert_eq!(&buffer[..2], b"42");
+    }
+
+    // BD#12: precision > 18 with only big_number_as_string → VarChar, Default resolves to Char
+    #[test]
+    fn default_high_precision_big_number_as_string_is_char() {
+        let sn = make_number(0, 38, &SETTINGS_BIG_NUMBER_AS_STRING);
+        let mut buffer = vec![0u8; 128];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+        sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert_eq!(str_len, 2);
+        assert_eq!(&buffer[..2], b"42");
+    }
+
+    char_conversion_tests! {
+        // Default type with scale > 0 (maps to Char via Decimal)
+        default_scaled_as_char:                 CDataType::Default, 2, 10, 12345i128            => "123.45";
+        default_negative_scaled_as_char:        CDataType::Default, 3, 10, -50i128              => "-0.050";
+
+        // Explicit Char type
+        char_integer:                           CDataType::Char,    0, 10, 42i128               => "42";
+        char_negative_integer:                  CDataType::Char,    0, 10, -42i128              => "-42";
+        char_one:                               CDataType::Char,    0, 10, 1i128                => "1";
+        char_negative_one:                      CDataType::Char,    0, 10, -1i128               => "-1";
+        char_single_digit:                      CDataType::Char,    0, 1,  5i128                => "5";
+
+        // Leading zeros in fractional part
+        char_leading_zeros_3:                   CDataType::Char,    3, 10, 1i128                => "0.001";
+        char_leading_zeros_3_neg:               CDataType::Char,    3, 10, -1i128               => "-0.001";
+        char_leading_zeros_5:                   CDataType::Char,    5, 10, 1i128                => "0.00001";
+        char_leading_zeros_5_neg:               CDataType::Char,    5, 10, -1i128               => "-0.00001";
+
+        // Zero with various scales
+        char_zero_scale_1:                      CDataType::Char,    1, 10, 0i128                => "0.0";
+        char_zero_scale_3:                      CDataType::Char,    3, 10, 0i128                => "0.000";
+        char_zero_scale_5:                      CDataType::Char,    5, 10, 0i128                => "0.00000";
+
+        // Scale boundary: value digits == scale (entire value is fractional)
+        char_scale_equals_digits:               CDataType::Char,    2, 10, 99i128               => "0.99";
+        char_scale_equals_digits_neg:           CDataType::Char,    2, 10, -99i128              => "-0.99";
+        char_scale_exactly_at_boundary:         CDataType::Char,    2, 10, 100i128              => "1.00";
+        char_trailing_zeros_preserved:          CDataType::Char,    3, 10, 1000i128             => "1.000";
+
+        // Large numbers
+        char_large_integer:                     CDataType::Char,    0, 38, 99999999999999i128   => "99999999999999";
+        char_large_negative:                    CDataType::Char,    0, 38, -99999999999999i128  => "-99999999999999";
+        char_large_with_scale:                  CDataType::Char,    2, 38, 9999999999999900i128 => "99999999999999.00";
+    }
+
+    // ========================================================================
+    // WChar conversions
+    // ========================================================================
+
+    macro_rules! wchar_conversion_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u16; 128];
+                    let mut str_len: sql::Len = 0;
+                    let binding = Binding {
+                        target_type: CDataType::WChar,
+                        target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                        buffer_length: (buffer.len() * 2) as sql::Len,
+                        octet_length_ptr: &mut str_len as *mut sql::Len,
+                        indicator_ptr: &mut str_len as *mut sql::Len,
+                        ..Default::default()
+                    };
+                    sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    let expected_str: &str = $expected;
+                    let expected: Vec<u16> = expected_str.encode_utf16().collect();
+                    assert_eq!(str_len, (expected.len() * 2) as sql::Len);
+                    assert_eq!(&buffer[..expected.len()], &expected[..]);
+                    assert_eq!(buffer[expected.len()], 0);
+                }
+            )*
+        };
+    }
+
+    wchar_conversion_tests! {
+        wchar_integer:              0, 10, 42i128     => "42";
+        wchar_scaled:               2, 10, 12345i128  => "123.45";
+        wchar_zero:                 0, 10, 0i128      => "0";
+        wchar_negative:             0, 10, -42i128    => "-42";
+        wchar_negative_scaled:      2, 10, -12345i128 => "-123.45";
+        wchar_leading_zeros:        3, 10, 1i128      => "0.001";
+        wchar_zero_with_scale:      2, 10, 0i128      => "0.00";
+        wchar_large:                0, 38, 999999i128 => "999999";
+    }
+
+    // ========================================================================
+    // Float / Double conversions (approximate comparison)
+    // ========================================================================
+
+    macro_rules! float_conversion_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => approx $expected:expr, tol $tol:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0.0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert!(
+                        (value - ($expected) as $rust_type).abs() < ($tol) as $rust_type,
+                        "expected approximately {}, got {}", $expected, value
+                    );
+                }
+            )*
+        };
+    }
+
+    float_conversion_tests! {
+        // f64
+        double_integer:             CDataType::Double, f64, 0, 10, 42i128            => approx 42.0,    tol f64::EPSILON;
+        double_zero:                CDataType::Double, f64, 0, 10, 0i128             => approx 0.0,     tol f64::EPSILON;
+        double_negative:            CDataType::Double, f64, 0, 10, -42i128           => approx -42.0,   tol f64::EPSILON;
+        double_one:                 CDataType::Double, f64, 0, 10, 1i128             => approx 1.0,     tol f64::EPSILON;
+        double_neg_one:             CDataType::Double, f64, 0, 10, -1i128            => approx -1.0,    tol f64::EPSILON;
+        double_scaled:              CDataType::Double, f64, 2, 10, 12345i128         => approx 123.45,  tol 0.001;
+        double_negative_scaled:     CDataType::Double, f64, 3, 10, -50i128           => approx -0.05,   tol 0.001;
+        double_large:               CDataType::Double, f64, 0, 15, 1_000_000_000i128 => approx 1e9,     tol 1.0;
+        double_small_fraction:      CDataType::Double, f64, 5, 10, 1i128             => approx 0.00001, tol 1e-8;
+
+        // f32
+        float_scaled:               CDataType::Float,  f32, 3, 10, 123789i128        => approx 123.789, tol 0.01;
+        float_zero:                 CDataType::Float,  f32, 0, 10, 0i128             => approx 0.0,     tol f32::EPSILON;
+        float_negative:             CDataType::Float,  f32, 0, 10, -100i128          => approx -100.0,  tol 0.01;
+        float_small_fraction:       CDataType::Float,  f32, 2, 10, 1i128             => approx 0.01,    tol 0.001;
+        float_one:                  CDataType::Float,  f32, 0, 10, 1i128             => approx 1.0,     tol f32::EPSILON;
+    }
+
+    // ========================================================================
+    // SQL_C_NUMERIC struct conversions
+    // Per ODBC spec: fractional truncation → 01S07
+    // ========================================================================
+
+    macro_rules! numeric_struct_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, val=$val:expr, truncated=$trunc:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value = sql::Numeric {
+                        precision: 0,
+                        scale: 0,
+                        sign: 0,
+                        val: [0u8; 16],
+                    };
+                    let mut str_len: sql::Len = 0;
+                    let mut binding = binding_for_value(CDataType::Numeric, &mut value, &mut str_len);
+                    binding.precision = Some($precision as i16);
+                    binding.scale = Some(0);
+                    let warnings = sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert_eq!(value.precision, $precision as u8);
+                    assert_eq!(value.scale, 0);
+                    assert_eq!(value.sign, $sign);
+                    assert_eq!(u128::from_le_bytes(value.val), $val as u128);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
+                }
+            )*
+        };
+    }
+
+    numeric_struct_tests! {
+        numeric_positive_with_scale:    2,  10, 12345i128           => sign=1, val=123,        truncated=true;
+        numeric_negative:               0,  10, -42i128             => sign=0, val=42,         truncated=false;
+        numeric_zero:                   0,  10, 0i128               => sign=1, val=0,          truncated=false;
+        numeric_one:                    0,  10, 1i128               => sign=1, val=1,          truncated=false;
+        numeric_negative_one:           0,  10, -1i128              => sign=0, val=1,          truncated=false;
+
+        // LE byte boundary values
+        numeric_255:                    0,  10, 255i128             => sign=1, val=255,        truncated=false;
+        numeric_256:                    0,  10, 256i128             => sign=1, val=256,        truncated=false;
+        numeric_65535:                  0,  10, 65535i128           => sign=1, val=65535,      truncated=false;
+        numeric_65536:                  0,  10, 65536i128           => sign=1, val=65536,      truncated=false;
+        numeric_1_000_000:              0,  10, 1_000_000i128       => sign=1, val=1_000_000,  truncated=false;
+
+        // Scale truncation
+        numeric_scale_truncates_frac:   2,  10, 999i128             => sign=1, val=9,          truncated=true;
+        numeric_scale_neg_truncates:    2,  10, -999i128            => sign=0, val=9,          truncated=true;
+        numeric_zero_with_scale:        5,  10, 0i128               => sign=1, val=0,          truncated=false;
+
+        // High scale
+        numeric_high_scale_zero:        10, 38, 0i128               => sign=1, val=0,          truncated=false;
+        numeric_high_scale_positive:    10, 38, 50_000_000_000i128  => sign=1, val=5,          truncated=false;
+        numeric_high_scale_negative:    10, 38, -30_000_000_000i128 => sign=0, val=3,          truncated=false;
+        numeric_scale_37_zero:          37, 38, 0i128               => sign=1, val=0,          truncated=false;
+    }
+
+    // ========================================================================
+    // SQL_C_NUMERIC with explicit target precision and scale
+    // Tests the behavior when SQL_DESC_PRECISION / SQL_DESC_SCALE differ
+    // from the source column's precision/scale.
+    // ========================================================================
+
+    macro_rules! numeric_target_scale_tests {
+        ($($name:ident: src_scale=$src_scale:expr, src_precision=$src_prec:expr, target_precision=$tgt_prec:expr, target_scale=$tgt_scale:expr, $input:expr
+            => sign=$sign:expr, val=$val:expr, out_precision=$out_prec:expr, out_scale=$out_scale:expr, truncated=$trunc:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($src_scale, $src_prec);
+                    let mut value = sql::Numeric {
+                        precision: 0,
+                        scale: 0,
+                        sign: 0,
+                        val: [0u8; 16],
+                    };
+                    let mut str_len: sql::Len = 0;
+                    let mut binding = binding_for_value(CDataType::Numeric, &mut value, &mut str_len);
+                    binding.precision = Some($tgt_prec as i16);
+                    binding.scale = Some($tgt_scale as i16);
+                    let warnings = sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert_eq!(value.precision, $out_prec as u8, "precision mismatch");
+                    assert_eq!(value.scale, $out_scale as i8, "scale mismatch");
+                    assert_eq!(value.sign, $sign, "sign mismatch");
+                    assert_eq!(u128::from_le_bytes(value.val), $val as u128, "val mismatch");
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
+                }
+            )*
+        };
+    }
+
+    numeric_target_scale_tests! {
+        // Target scale == source scale → exact, no truncation
+        numeric_exact_scale_match:
+            src_scale=2, src_precision=10, target_precision=10, target_scale=2, 12345i128
+            => sign=1, val=12345, out_precision=10, out_scale=2, truncated=false;
+
+        // Target scale > source scale → upscale (multiply), no truncation
+        numeric_upscale_integer:
+            src_scale=0, src_precision=10, target_precision=10, target_scale=3, 42i128
+            => sign=1, val=42000, out_precision=10, out_scale=3, truncated=false;
+
+        numeric_upscale_from_scaled:
+            src_scale=2, src_precision=10, target_precision=10, target_scale=5, 12345i128
+            => sign=1, val=12345000, out_precision=10, out_scale=5, truncated=false;
+
+        // Target scale < source scale → downscale (divide), fractional truncation
+        numeric_downscale_truncates:
+            src_scale=3, src_precision=10, target_precision=10, target_scale=1, 12345i128
+            => sign=1, val=123, out_precision=10, out_scale=1, truncated=true;
+
+        numeric_downscale_exact:
+            src_scale=3, src_precision=10, target_precision=10, target_scale=1, 12300i128
+            => sign=1, val=123, out_precision=10, out_scale=1, truncated=false;
+
+        // Target precision differs from source precision → output uses target precision
+        numeric_custom_precision:
+            src_scale=0, src_precision=38, target_precision=5, target_scale=0, 42i128
+            => sign=1, val=42, out_precision=5, out_scale=0, truncated=false;
+
+        // Negative value with upscale
+        numeric_negative_upscale:
+            src_scale=0, src_precision=10, target_precision=10, target_scale=2, -7i128
+            => sign=0, val=700, out_precision=10, out_scale=2, truncated=false;
+
+        // Negative value with downscale truncation
+        numeric_negative_downscale_truncation:
+            src_scale=2, src_precision=10, target_precision=10, target_scale=0, -12345i128
+            => sign=0, val=123, out_precision=10, out_scale=0, truncated=true;
+
+        // Zero with various target scales
+        numeric_zero_target_scale_3:
+            src_scale=0, src_precision=10, target_precision=10, target_scale=3, 0i128
+            => sign=1, val=0, out_precision=10, out_scale=3, truncated=false;
+
+        numeric_zero_downscale:
+            src_scale=5, src_precision=10, target_precision=10, target_scale=0, 0i128
+            => sign=1, val=0, out_precision=10, out_scale=0, truncated=false;
+    }
+
+    // ========================================================================
+    // SQL_C_BINARY conversions (raw SQL_NUMERIC_STRUCT bytes)
+    // ========================================================================
+
+    macro_rules! binary_struct_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, first_val_byte=$byte:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u8; 64];
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_char_buffer(CDataType::Binary, &mut buffer, &mut str_len);
+                    sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    let numeric_size = std::mem::size_of::<sql::Numeric>() as sql::Len;
+                    assert_eq!(str_len, numeric_size);
+                    assert_eq!(buffer[2], $sign);   // sign at offset 2 (after precision + scale)
+                    assert_eq!(buffer[3], $byte);   // val[0] at offset 3
+                }
+            )*
+        };
+    }
+
+    binary_struct_tests! {
+        binary_integer:             0,  10, 42i128             => sign=1, first_val_byte=42;
+        binary_with_scale:          2,  10, 12345i128          => sign=1, first_val_byte=123;
+        binary_zero:                0,  10, 0i128              => sign=1, first_val_byte=0;
+        binary_one:                 0,  10, 1i128              => sign=1, first_val_byte=1;
+        binary_negative:            0,  10, -42i128            => sign=0, first_val_byte=42;
+        binary_255:                 0,  10, 255i128            => sign=1, first_val_byte=255;
+        binary_256_le_low_byte:     0,  10, 256i128            => sign=1, first_val_byte=0;
+        binary_high_scale_zero:     10, 38, 0i128              => sign=1, first_val_byte=0;
+        binary_high_scale_positive: 10, 38, 50_000_000_000i128 => sign=1, first_val_byte=5;
+    }
+
+    // ========================================================================
+    // SQL_C_CHAR truncation: 01004 vs 22003
+    // Per ODBC spec: fractional-only truncation → 01004 (StringDataTruncated),
+    //                whole digits don't fit → 22003 (NumericValueOutOfRange).
+    // ========================================================================
+
+    #[test]
+    fn char_fractional_truncation_returns_01004() {
+        use crate::conversion::warning::Warning;
+        let sn = make_decimal(3, 10);
+        // "12.345" → whole part "12" (2 chars), total 6 chars
+        // Buffer of 4 can hold "12." (3 chars + null). Whole digits fit → 01004.
+        let mut buffer = vec![0u8; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let warnings = sn.write_odbc_type(12345i128, &binding, &mut None).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    #[test]
+    fn char_whole_digit_truncation_returns_22003() {
+        let sn = make_decimal(0, 10);
+        // "123456" → whole part "123456" (6 chars)
+        // Buffer of 4 can only hold "123" + null. Whole digits don't fit → 22003.
+        let mut buffer = vec![0u8; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        assert!(sn.write_odbc_type(123456i128, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn char_negative_whole_digit_truncation_returns_22003() {
+        let sn = make_decimal(0, 10);
+        // "-123" → whole part "-123" (4 chars)
+        // Buffer of 4 can hold "−12" + null. Whole digits don't fit → 22003.
+        let mut buffer = vec![0u8; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        assert!(sn.write_odbc_type(-123i128, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn char_negative_whole_digits_just_fit_returns_01004() {
+        use crate::conversion::warning::Warning;
+        let sn = make_decimal(2, 10);
+        // Value 12345 with scale 2 → "-123.45"
+        // Whole part is "-123" (4 chars). Buffer of 5 can hold "-123" + null.
+        // Total doesn't fit → 01004 (fractional truncation only).
+        let mut buffer = vec![0u8; 5];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let warnings = sn.write_odbc_type(-12345i128, &binding, &mut None).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    #[test]
+    fn char_exact_fit_no_truncation() {
+        let sn = make_decimal(0, 10);
+        // "42" → 2 chars + null = 3 bytes
+        let mut buffer = vec![0u8; 3];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let warnings = sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, 2);
+        assert_eq!(&buffer[..2], b"42");
+    }
+
+    // ========================================================================
+    // SQL_C_WCHAR truncation: 01004 vs 22003
+    // ========================================================================
+
+    #[test]
+    fn wchar_whole_digit_truncation_returns_22003() {
+        let sn = make_decimal(0, 10);
+        // "123456" → 6 wide chars + null = 7 * 2 = 14 bytes
+        // Buffer of 8 bytes = 4 wide chars. Whole digits (6) >= capacity (4) → 22003.
+        let mut buffer = vec![0u16; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = Binding {
+            target_type: CDataType::WChar,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: (buffer.len() * 2) as sql::Len,
+            octet_length_ptr: &mut str_len as *mut sql::Len,
+            indicator_ptr: &mut str_len as *mut sql::Len,
+            ..Default::default()
+        };
+        assert!(sn.write_odbc_type(123456i128, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn wchar_fractional_truncation_returns_01004() {
+        use crate::conversion::warning::Warning;
+        let sn = make_decimal(3, 10);
+        // "12.345" → whole part "12" (2 chars)
+        // Buffer of 4 wide chars. Whole digits (2) < capacity (4) → 01004.
+        let mut buffer = vec![0u16; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = Binding {
+            target_type: CDataType::WChar,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: (buffer.len() * 2) as sql::Len,
+            octet_length_ptr: &mut str_len as *mut sql::Len,
+            indicator_ptr: &mut str_len as *mut sql::Len,
+            ..Default::default()
+        };
+        let warnings = sn.write_odbc_type(12345i128, &binding, &mut None).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    // ========================================================================
+    // SQL_C_BINARY buffer too small → 22003
+    // ========================================================================
+
+    #[test]
+    fn binary_buffer_too_small_returns_22003() {
+        let sn = make_decimal(0, 10);
+        let mut buffer = vec![0u8; 4]; // Too small for SQL_NUMERIC_STRUCT
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Binary, &mut buffer, &mut str_len);
+        assert!(sn.write_odbc_type(42i128, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn binary_buffer_exact_size_succeeds() {
+        let sn = make_decimal(0, 10);
+        let numeric_size = std::mem::size_of::<sql::Numeric>();
+        let mut buffer = vec![0u8; numeric_size];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Binary, &mut buffer, &mut str_len);
+        let warnings = sn.write_odbc_type(42i128, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, numeric_size as sql::Len);
+    }
+
+    // ========================================================================
+    // SQL_C_BIT conversions (per ODBC spec)
+    //   Exact 0 or 1       → ok, no warning
+    //   0 < value < 2, ≠ 1 → truncate, 01S07
+    //   value < 0 or ≥ 2   → 22003 error
+    // ========================================================================
+
+    macro_rules! bit_ok_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr, truncated=$trunc:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: u8 = 0xFF;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+                    let warnings = sn.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert_eq!(value, $expected);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
+                }
+            )*
+        };
+    }
+
+    bit_ok_tests! {
+        // Exact values — no warning
+        bit_exact_zero:                     0,  10, 0i128   => 0, truncated=false;
+        bit_exact_one:                      0,  10, 1i128   => 1, truncated=false;
+        bit_exact_one_via_scale:            2,  10, 100i128 => 1, truncated=false;
+        bit_exact_zero_high_scale:          10, 38, 0i128   => 0, truncated=false;
+
+        // Fractional truncation → 01S07
+        bit_frac_truncates_to_zero:         1,  10, 9i128   => 0, truncated=true;
+        bit_frac_truncates_to_one:          1,  10, 15i128  => 1, truncated=true;
+        bit_frac_099_truncates_to_zero:     2,  10, 99i128  => 0, truncated=true;
+        bit_frac_150_truncates_to_one:      2,  10, 150i128 => 1, truncated=true;
+    }
+
+    macro_rules! bit_error_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: u8 = 0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+                    assert!(sn.write_odbc_type($input, &binding, &mut None).is_err());
+                }
+            )*
+        };
+    }
+
+    bit_error_tests! {
+        // value >= 2
+        bit_rejects_two:                 0, 10, 2i128;
+        bit_rejects_large_positive:      0, 10, 100i128;
+        bit_rejects_frac_truncates_to_2: 1, 10, 25i128;
+
+        // value < 0 (checked on original snowflake_value, not truncated)
+        bit_rejects_negative_one:        0, 10, -1i128;
+        bit_rejects_large_negative:      0, 10, -100i128;
+        bit_rejects_neg_frac:            1, 10, -5i128;
+    }
+
+    // ========================================================================
+    // Nullable NULL handling (SQLSTATE 22002)
+    // When the value is SQL NULL and no indicator pointer is provided,
+    // the driver must return an IndicatorVariableRequired error.
+    // ========================================================================
+
+    mod nullable_null_tests {
+        use super::*;
+        use crate::cdata_types::SQL_NULL_DATA;
+        use crate::conversion::WriteODBCType;
+        use crate::conversion::error::WriteOdbcError;
+        use crate::conversion::nullable::Nullable;
+
+        #[test]
+        fn null_with_indicator_writes_sql_null_data() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 42;
+            let mut str_len: sql::Len = 0;
+            let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+
+            let warnings = nullable
+                .write_odbc_type(None::<i128>, &binding, &mut None)
+                .unwrap();
+
+            assert!(warnings.is_empty());
+            assert_eq!(str_len, SQL_NULL_DATA);
+        }
+
+        #[test]
+        fn null_without_indicator_returns_error() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 42;
+            let binding = Binding {
+                target_type: CDataType::SLong,
+                target_value_ptr: &mut value as *mut i32 as sql::Pointer,
+                ..Default::default()
+            };
+
+            let result = nullable.write_odbc_type(None::<i128>, &binding, &mut None);
+
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                WriteOdbcError::IndicatorRequired { .. }
+            ));
+        }
+
+        #[test]
+        fn non_null_with_null_indicator_still_writes_value() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 0;
+            let binding = Binding {
+                target_type: CDataType::SLong,
+                target_value_ptr: &mut value as *mut i32 as sql::Pointer,
+                ..Default::default()
+            };
+
+            let warnings = nullable
+                .write_odbc_type(Some(42i128), &binding, &mut None)
+                .unwrap();
+
+            assert!(warnings.is_empty());
+            assert_eq!(value, 42);
+        }
+    }
+}

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -16,7 +16,7 @@ behavior_differences:
   
   6:
     name: "Unsupported compression type returns error instead of being silently ignored"
-  
+
   7:
     name: "ALTER USER ADD PROGRAMMATIC ACCESS TOKEN returns result set with token in new driver, old driver returns invalid cursor state (10510)"
 
@@ -32,3 +32,80 @@ behavior_differences:
     description: |
       The old driver accepted raw EVP_PKEY* pointers via SQLSetConnectAttr.
       Not supported across the Rust FFI boundary — use PRIV_KEY_CONTENT or PRIV_KEY_BASE64 instead.
+
+  11:
+    name: "SQL_C_CHAR with small buffer returns SQL_SUCCESS instead of SQL_SUCCESS_WITH_INFO"
+    description: |
+      OLD driver: When SQLGetData is called with a buffer too small to hold the full
+      character representation of a DECIMAL value, the old driver returns SQL_SUCCESS (0)
+      and silently truncates the data without setting a warning.
+      NEW driver: Returns SQL_SUCCESS_WITH_INFO (1) with truncated data in the buffer,
+      a null terminator, and SQL_NO_TOTAL in the indicator, per the ODBC spec
+      for string data right truncation (SQLSTATE 01004).
+      Impact: Applications that check only for SQL_SUCCESS will now also see
+      SQL_SUCCESS_WITH_INFO. The ODBC specification mandates SQL_SUCCESS_WITH_INFO
+      for string truncation, so this is a spec-compliance improvement.
+      Fix for Old Driver is to be merged with SNOW-3120035
+
+  12:
+    name: "SQL_C_BINARY on DECIMAL/NUMERIC columns returns raw internal data size instead of SQL_NUMERIC_STRUCT size"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_BINARY on a SQL_DECIMAL or
+      SQL_NUMERIC column, the old driver returns 68 bytes of raw internal
+      TDWExactNumericType data (the Simba SDK's internal representation). The indicator
+      is set to 68 and the buffer contents are not interpretable by ODBC-compliant
+      applications.
+      NEW driver: Returns a 19-byte SQL_NUMERIC_STRUCT as required by the ODBC
+      specification, with precision, scale (0 — integer part after truncation),
+      sign (1 positive, 0 negative), and val[16] containing the unsigned magnitude
+      in little-endian 128-bit format. The indicator is set to sizeof(SQL_NUMERIC_STRUCT).
+      Impact: Applications requesting SQL_C_BINARY for numeric columns now receive
+      a standards-compliant SQL_NUMERIC_STRUCT. No correct application could have
+      relied on the old 68-byte internal representation.
+      Fix for Old Driver is to be merged with SNOW-3127864
+
+  13:
+    name: "SQL_C_CHAR returns SQL_SUCCESS instead of SQL_ERROR (22003) when whole digits do not fit in buffer"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_CHAR on a DECIMAL/NUMERIC
+      column and the buffer is too small to hold even the whole (non-fractional)
+      digits, the old driver returns SQL_SUCCESS and silently truncates the data.
+      NEW driver: Returns SQL_ERROR with SQLSTATE 22003 (Numeric value out of range),
+      per the ODBC specification which distinguishes between truncation of fractional
+      digits only (01004) and loss of whole digits (22003).
+      Impact: Applications that previously received truncated whole digits silently
+      will now receive an error. This is a spec-compliance improvement — the ODBC
+      specification mandates 22003 when whole digits are lost during numeric-to-char
+      conversion.
+      TODO: To be fixed in old driver
+
+  14:
+    name: "SQL_C_BINARY returns SQL_SUCCESS instead of SQL_ERROR (22003) when buffer is too small for SQL_NUMERIC_STRUCT"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_BINARY on a DECIMAL/NUMERIC
+      column and the buffer is smaller than sizeof(SQL_NUMERIC_STRUCT), the old driver
+      silently writes a partial struct and returns SQL_SUCCESS.
+      NEW driver: Returns SQL_ERROR with SQLSTATE 22003 (Numeric value out of range),
+      per the ODBC specification which states that when byte length of data exceeds
+      BufferLength for SQL_C_BINARY, the result is undefined and SQLSTATE 22003 must
+      be returned.
+      Impact: Applications providing undersized buffers for SQL_C_BINARY will now
+      receive an error instead of corrupted partial data.
+      TODO: To be fixed in old driver
+
+  15:
+    name: "SQL_C_NUMERIC ignores SQL_DESC_PRECISION and SQL_DESC_SCALE set via SQLSetDescField"
+    description: |
+      OLD driver: When SQLSetDescField is used to set SQL_DESC_PRECISION and
+      SQL_DESC_SCALE on the ARD before calling SQLGetData with SQL_C_NUMERIC,
+      the old driver ignores these values and always uses its own defaults
+      (precision=38, scale=0). The resulting SQL_NUMERIC_STRUCT does not reflect
+      the requested precision/scale.
+      NEW driver: Honors SQL_DESC_PRECISION and SQL_DESC_SCALE from the ARD,
+      rescaling the value accordingly. For example, setting scale=2 on a
+      DECIMAL(10,2) column returns val=12345 (unscaled) instead of val=123
+      (truncated to scale=0).
+      Impact: Applications that set descriptor fields for SQL_C_NUMERIC will
+      now see the correct precision and scale in the output struct, matching
+      the ODBC specification behavior.
+      TODO: To be fixed in old driver

--- a/odbc_tests/common/include/TestTable.hpp
+++ b/odbc_tests/common/include/TestTable.hpp
@@ -1,0 +1,28 @@
+#ifndef TEST_TABLE_HPP
+#define TEST_TABLE_HPP
+
+#include <string>
+
+#include "Connection.hpp"
+
+class TestTable {
+ public:
+  TestTable(Connection& conn, const std::string& name, const std::string& columns, const std::string& values)
+      : conn_(conn), name_(name) {
+    conn_.execute("CREATE OR REPLACE TABLE " + name_ + " (" + columns + ")");
+    conn_.execute("INSERT INTO " + name_ + " VALUES " + values);
+  }
+
+  ~TestTable() { conn_.execute("DROP TABLE IF EXISTS " + name_); }
+
+  TestTable(const TestTable&) = delete;
+  TestTable& operator=(const TestTable&) = delete;
+
+  const std::string& name() const { return name_; }
+
+ private:
+  Connection& conn_;
+  std::string name_;
+};
+
+#endif  // TEST_TABLE_HPP

--- a/odbc_tests/common/include/conversion_checks.hpp
+++ b/odbc_tests/common/include/conversion_checks.hpp
@@ -103,4 +103,22 @@ static void check_interval_precision_lost(const StatementHandleWrapper& stmt, in
   CHECK(records[0].sqlState == "22015");
 }
 
+inline std::string check_char_success(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char buffer[8192];
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(indicator >= 0);
+  return std::string(buffer, indicator);
+}
+
+inline std::u16string check_wchar_success(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char16_t buffer[8192];
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(indicator >= 0);
+  return std::u16string(buffer, indicator / sizeof(char16_t));
+}
+
 #endif  // CONVERSION_CHECKS_HPP

--- a/odbc_tests/common/include/get_data.hpp
+++ b/odbc_tests/common/include/get_data.hpp
@@ -56,4 +56,10 @@ inline typename MetaOfSqlCType<SQL_C_TYPE>::type get_data(const StatementHandleW
   return optional_value.value();
 }
 
+template <typename T>
+inline SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
+                              SQLLEN* indicator) {
+  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
+}
+
 #endif  // GET_DATA_HPP

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -1,148 +1,159 @@
-
-#include <picojson.h>
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <numeric>
+#include <optional>
 #include <sstream>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers.hpp>
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
 #include "Schema.hpp"
+#include "TestTable.hpp"
+#include "compatibility.hpp"
+#include "conversion_checks.hpp"
 #include "get_data.hpp"
+#include "get_diag_rec.hpp"
 #include "macros.hpp"
 #include "test_setup.hpp"
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+inline std::string get_data_default_as_string(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char buffer[1000];
+  SQLLEN indicator;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  return std::string(buffer, indicator);
+}
+
+inline SQL_NUMERIC_STRUCT get_binary_as_numeric(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  return *reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+}
+
+inline void check_numeric_val_zero_from(const SQL_NUMERIC_STRUCT& numeric, int start) {
+  for (int i = start; i < 16; ++i) {
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+template <int SQL_C_TYPE>
+void check_integer_columns(const StatementHandleWrapper& stmt, const std::vector<int>& exact_cols,
+                           const std::vector<int>& truncated_cols, typename MetaOfSqlCType<SQL_C_TYPE>::type expected) {
+  for (int col : exact_cols) {
+    INFO("Column " << col << " with " << MetaOfSqlCType<SQL_C_TYPE>().name() << " (exact)");
+    CHECK(check_no_truncation<SQL_C_TYPE>(stmt, col) == expected);
+  }
+  for (int col : truncated_cols) {
+    INFO("Column " << col << " with " << MetaOfSqlCType<SQL_C_TYPE>().name() << " (truncated)");
+    CHECK(check_fractional_truncation<SQL_C_TYPE>(stmt, col) == expected);
+  }
+}
+
+inline void check_null_via_get_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT c_type) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, c_type, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == SQL_NULL_DATA);
+}
+
+// ============================================================================
+// Basic decimal conversion across all C integer types
+// ============================================================================
 
 TEST_CASE("Test decimal conversion", "[datatype][number]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("DROP TABLE IF EXISTS test_number");
-  conn.execute(
-      "CREATE TABLE test_number (num0 NUMBER, num10 NUMBER(10,1), dec20 DECIMAL(20,2), numeric30 "
-      "NUMERIC(30,3), int1 INT, int2 INTEGER)");
-  conn.execute(
-      "INSERT INTO test_number (num0, num10, dec20, numeric30, int1, int2) VALUES (123, 123.4, "
-      "123.45, 123.456, 123, 123)");
+  TestTable table(conn, "test_number",
+                  "num0 NUMBER, num10 NUMBER(10,1), dec20 DECIMAL(20,2), "
+                  "numeric30 NUMERIC(30,3), int1 INT, int2 INTEGER",
+                  "(123, 123.4, 123.45, 123.456, 123, 123)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_number");
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_LONG");
-    CHECK(get_data<SQL_C_LONG>(stmt, i) == 123);
-  }
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
 
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SLONG");
-    CHECK(get_data<SQL_C_SLONG>(stmt, i) == 123);
-  }
+  std::vector<int> exact_cols = {1, 5, 6};
+  std::vector<int> truncated_cols = {2, 3, 4};
 
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_ULONG");
-    CHECK(get_data<SQL_C_ULONG>(stmt, i) == 123);
-  }
+  check_integer_columns<SQL_C_LONG>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_SLONG>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_ULONG>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_SHORT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_SSHORT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_USHORT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_TINYINT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_STINYINT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_UTINYINT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_SBIGINT>(stmt, exact_cols, truncated_cols, 123);
+  check_integer_columns<SQL_C_UBIGINT>(stmt, exact_cols, truncated_cols, 123);
 
-  // Test 16-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SHORT");
-    CHECK(get_data<SQL_C_SHORT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SSHORT");
-    CHECK(get_data<SQL_C_SSHORT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_USHORT");
-    CHECK(get_data<SQL_C_USHORT>(stmt, i) == 123);
-  }
-
-  // Test 8-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_TINYINT");
-    CHECK(get_data<SQL_C_TINYINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_STINYINT");
-    CHECK(get_data<SQL_C_STINYINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_UTINYINT");
-    CHECK(get_data<SQL_C_UTINYINT>(stmt, i) == 123);
-  }
-
-  // Test 64-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SBIGINT");
-    CHECK(get_data<SQL_C_SBIGINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_UBIGINT");
-    CHECK(get_data<SQL_C_UBIGINT>(stmt, i) == 123);
-  }
-
-  // Test floating point types - test all columns
-  std::vector<float> expected_float_values = {123.0f, 123.4f, 123.45f, 123.456f, 123.0f, 123.0f};
-  std::vector<double> expected_double_values = {123.0, 123.4, 123.45, 123.456, 123.0, 123.0};
+  std::vector<float> expected_float = {123.0f, 123.4f, 123.45f, 123.456f, 123.0f, 123.0f};
+  std::vector<double> expected_double = {123.0, 123.4, 123.45, 123.456, 123.0, 123.0};
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_FLOAT");
-    CHECK(get_data<SQL_C_FLOAT>(stmt, i) == expected_float_values[i - 1]);
+    CHECK(check_no_truncation<SQL_C_FLOAT>(stmt, i) == expected_float[i - 1]);
   }
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_DOUBLE");
-    CHECK(get_data<SQL_C_DOUBLE>(stmt, i) == expected_double_values[i - 1]);
+    CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, i) == expected_double[i - 1]);
   }
 
-  // Test character type conversions - each column should return its string representation
-  std::vector<std::string> expected_string_values = {"123", "123.4", "123.45", "123.456", "123", "123"};
+  std::vector<std::string> expected_str = {"123", "123.4", "123.45", "123.456", "123", "123"};
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_CHAR");
-    CHECK(get_data<SQL_C_CHAR>(stmt, i) == expected_string_values[i - 1]);
+    CHECK(check_char_success(stmt, i) == expected_str[i - 1]);
+  }
+
+  for (int i = 1; i <= 6; ++i) {
+    INFO("Testing column " << i << " with SQL_C_DEFAULT");
+    CHECK(get_data_default_as_string(stmt, i) == expected_str[i - 1]);
   }
 }
+
+// ============================================================================
+// Test at type limits
+// ============================================================================
 
 template <int SQL_C_TYPE>
 void test_at_limits(Connection& conn) {
   std::stringstream queryBuilder;
   queryBuilder << "SELECT ";
-  // prefix + to ensure numeric limits are treated as numbers, not characters
   queryBuilder << +std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::max() << " AS max, ";
   queryBuilder << +std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::min() << " AS min";
   auto query = queryBuilder.str();
-  std::cout << "Executing query: " << query << std::endl;
   INFO("Executing query: " << query);
   auto stmt = conn.execute_fetch(query);
-  CHECK(get_data<SQL_C_TYPE>(stmt, 1) == std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::max());
-  CHECK(get_data<SQL_C_TYPE>(stmt, 2) == std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::min());
+  CHECK(check_no_truncation<SQL_C_TYPE>(stmt, 1) ==
+        std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::max());
+  CHECK(check_no_truncation<SQL_C_TYPE>(stmt, 2) ==
+        std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::min());
 }
 
 void test_string_at_limits(Connection& conn) {
-  std::stringstream queryBuilder;
   std::string max = std::string(37, '9');
   std::string min = "-" + std::string(37, '9');
+  std::stringstream queryBuilder;
   queryBuilder << "SELECT " << max << " AS max, " << min << " AS min";
   auto query = queryBuilder.str();
-  std::cout << "Executing query: " << query << std::endl;
   INFO("Executing query: " << query);
   auto stmt = conn.execute_fetch(query);
-  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == max);
-  CHECK(get_data<SQL_C_CHAR>(stmt, 2) == min);
+  CHECK(check_char_success(stmt, 1) == max);
+  CHECK(check_char_success(stmt, 2) == min);
+  CHECK(get_data_default_as_string(stmt, 1) == max);
+  CHECK(get_data_default_as_string(stmt, 2) == min);
 }
 
 TEST_CASE("Test at limits", "[datatype][number]") {
@@ -160,4 +171,1099 @@ TEST_CASE("Test at limits", "[datatype][number]") {
   test_at_limits<SQL_C_SBIGINT>(conn);
   test_at_limits<SQL_C_UBIGINT>(conn);
   test_string_at_limits(conn);
+}
+
+// ============================================================================
+// SQL_DECIMAL default conversion tests (SQL_C_DEFAULT)
+// Per ODBC spec, SQL_DECIMAL's default C type is SQL_C_CHAR.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL default conversion", "[datatype][number][decimal][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("basic values from table") {
+    TestTable table(conn, "test_decimal_default",
+                    "d1 DECIMAL(10,0), d2 DECIMAL(10,1), d3 DECIMAL(10,2), d4 DECIMAL(10,3)",
+                    "(123, 123.4, 123.45, 123.456)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<std::string> expected = {"123", "123.4", "123.45", "123.456"};
+    for (int i = 1; i <= 4; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+    }
+  }
+
+  SECTION("negative values") {
+    auto stmt = conn.execute_fetch(
+        "SELECT -123::DECIMAL(10,0), -123.4::DECIMAL(10,1), "
+        "-123.45::DECIMAL(10,2), -123.456::DECIMAL(10,3)");
+    std::vector<std::string> expected = {"-123", "-123.4", "-123.45", "-123.456"};
+    for (int i = 1; i <= 4; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+    }
+  }
+
+  SECTION("zero with varying scale") {
+    auto stmt = conn.execute_fetch("SELECT 0::DECIMAL(10,0), 0::DECIMAL(10,2), 0::DECIMAL(10,5)");
+    CHECK(get_data_default_as_string(stmt, 1) == "0");
+    CHECK(get_data_default_as_string(stmt, 2) == "0.00");
+    CHECK(get_data_default_as_string(stmt, 3) == "0.00000");
+  }
+
+  SECTION("small values with large scale") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 0.05::DECIMAL(10,2), 0.001::DECIMAL(10,3), "
+        "0.00001::DECIMAL(10,5)");
+    CHECK(get_data_default_as_string(stmt, 1) == "0.05");
+    CHECK(get_data_default_as_string(stmt, 2) == "0.001");
+    CHECK(get_data_default_as_string(stmt, 3) == "0.00001");
+  }
+
+  SECTION("negative small fractional values") {
+    auto stmt = conn.execute_fetch("SELECT -0.05::DECIMAL(10,2), -0.001::DECIMAL(10,3), -0.5::DECIMAL(10,1)");
+    CHECK(check_char_success(stmt, 1) == "-0.05");
+    CHECK(check_char_success(stmt, 2) == "-0.001");
+    CHECK(check_char_success(stmt, 3) == "-0.5");
+    CHECK(get_data_default_as_string(stmt, 1) == "-0.05");
+    CHECK(get_data_default_as_string(stmt, 2) == "-0.001");
+    CHECK(get_data_default_as_string(stmt, 3) == "-0.5");
+  }
+
+  SECTION("various SQL numeric type synonyms") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,2), 42::DECIMAL(10,2), 42::NUMERIC(10,2)");
+    std::string expected = "42.00";
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " with SQL_C_CHAR");
+      CHECK(check_char_success(stmt, i) == expected);
+    }
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " with SQL_C_DEFAULT");
+      CHECK(get_data_default_as_string(stmt, i) == expected);
+    }
+  }
+
+  SECTION("INT column resolves to SQL_C_CHAR") {
+    auto stmt = conn.execute_fetch("SELECT 42::INT, -7::INTEGER, 0::BIGINT");
+    CHECK(get_data_default_as_string(stmt, 1) == "42");
+    CHECK(get_data_default_as_string(stmt, 2) == "-7");
+    CHECK(get_data_default_as_string(stmt, 3) == "0");
+  }
+
+  SECTION("matches explicit SQL_C_CHAR via table") {
+    TestTable table(conn, "test_decimal_default_vs_char", "d1 DECIMAL(10,1), d2 DECIMAL(20,2), d3 DECIMAL(30,3)",
+                    "(123.4, 123.45, 123.456)");
+
+    auto stmt_char = conn.execute_fetch("SELECT * FROM " + table.name());
+    auto stmt_default = conn.execute_fetch("SELECT * FROM " + table.name());
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i);
+      CHECK(check_char_success(stmt_char, i) == get_data_default_as_string(stmt_default, i));
+    }
+  }
+}
+
+TEST_CASE("SQL_DECIMAL default conversion - large precision", "[datatype][number][decimal][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("large values") {
+    TestTable table(conn, "test_decimal_large", "a NUMBER(38,0), b NUMBER(38,37)",
+                    "(10000000000000000000000000000000000000, "
+                    " 1.0000000000000000000000000000000000000)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(get_data_default_as_string(stmt, 1) == "10000000000000000000000000000000000000");
+    CHECK(get_data_default_as_string(stmt, 2) == "1.0000000000000000000000000000000000000");
+  }
+
+  SECTION("max positive and negative values") {
+    TestTable table(conn, "test_decimal_max", "a NUMBER(38,0), b NUMBER(38,37)",
+                    "(99999999999999999999999999999999999999, "
+                    " 9.9999999999999999999999999999999999999), "
+                    "(-99999999999999999999999999999999999999, "
+                    " -9.9999999999999999999999999999999999999)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(get_data_default_as_string(stmt, 1) == "99999999999999999999999999999999999999");
+    CHECK(get_data_default_as_string(stmt, 2) == "9.9999999999999999999999999999999999999");
+
+    SQLRETURN ret = SQLFetch(stmt.getHandle());
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(get_data_default_as_string(stmt, 1) == "-99999999999999999999999999999999999999");
+    CHECK(get_data_default_as_string(stmt, 2) == "-9.9999999999999999999999999999999999999");
+  }
+}
+
+// ============================================================================
+// Explicit conversions - integers truncate, floats preserve
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL explicit conversions", "[datatype][number][decimal]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+  const std::string query = "SELECT 123.789::DECIMAL(10,3)";
+
+  SECTION("integers truncate fractional part") {
+    CHECK(check_fractional_truncation<SQL_C_LONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_SLONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_ULONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_SHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_SSHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_USHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_TINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_UTINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
+  }
+
+  SECTION("floating point preserves fractional part") {
+    float float_val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch(query), 1);
+    CHECK(float_val > 123.78f);
+    CHECK(float_val < 123.80f);
+
+    double double_val = check_no_truncation<SQL_C_DOUBLE>(conn.execute_fetch(query), 1);
+    CHECK(double_val > 123.788);
+    CHECK(double_val < 123.790);
+  }
+}
+
+// ============================================================================
+// NULL handling tests
+// ============================================================================
+
+TEST_CASE("NUMBER NULL handling", "[datatype][number][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_LONG indicator returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0), NULL::DECIMAL(10,2), NULL::NUMERIC(20,5)");
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " should be NULL");
+      check_null_via_get_data(stmt, i, SQL_C_LONG);
+    }
+  }
+
+  SECTION("SQL_C_CHAR returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(20,5)");
+    check_null_via_get_data(stmt, 1, SQL_C_CHAR);
+  }
+
+  SECTION("SQL_C_DEFAULT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");
+    check_null_via_get_data(stmt, 1, SQL_C_DEFAULT);
+  }
+
+  SECTION("SQL_C_WCHAR returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+    check_null_via_get_data(stmt, 1, SQL_C_WCHAR);
+  }
+
+  SECTION("SQL_C_NUMERIC returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,2)");
+    check_null_via_get_data(stmt, 1, SQL_C_NUMERIC);
+  }
+
+  SECTION("SQL_C_BINARY returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+    check_null_via_get_data(stmt, 1, SQL_C_BINARY);
+  }
+}
+
+TEST_CASE("NUMBER NULL mixed with non-NULL in multiple rows", "[datatype][number][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  TestTable table(conn, "test_number_null", "val NUMBER(10,0)", "(42), (NULL), (-7), (NULL), (0)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+
+  std::vector<std::optional<SQLINTEGER>> expected = {42, std::nullopt, -7, std::nullopt, 0};
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+
+  for (size_t row = 0; row < expected.size(); ++row) {
+    if (row > 0) {
+      SQLRETURN ret = SQLFetch(stmt.getHandle());
+      CHECK(ret == SQL_SUCCESS);
+    }
+    INFO("Row " << row);
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    if (expected[row].has_value()) {
+      CHECK(indicator != SQL_NULL_DATA);
+      CHECK(value == expected[row].value());
+    } else {
+      CHECK(indicator == SQL_NULL_DATA);
+    }
+  }
+}
+
+// ============================================================================
+// Truncation and scale tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL truncation and scale", "[datatype][number][truncation]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("zero with high scale to SQL_C_LONG") {
+    auto stmt = conn.execute_fetch("SELECT 0::NUMBER(38,10), 0::NUMBER(38,37), 0::NUMBER(20,15)");
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 1) == 0);
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 2) == 0);
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 3) == 0);
+  }
+
+  SECTION("nonzero with high scale to SQL_C_LONG") {
+    CHECK(check_no_truncation<SQL_C_LONG>(conn.execute_fetch("SELECT 5.0000000000::NUMBER(38,10)"), 1) == 5);
+    CHECK(check_no_truncation<SQL_C_LONG>(conn.execute_fetch("SELECT -3.0000000000::NUMBER(38,10)"), 1) == -3);
+  }
+
+  SECTION("fractional values truncate toward zero") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 0.9::DECIMAL(3,1), -0.9::DECIMAL(3,1), "
+        "0.1::DECIMAL(3,1), -0.1::DECIMAL(3,1), "
+        "0.5::DECIMAL(3,1), -0.5::DECIMAL(3,1)");
+    for (int i = 1; i <= 6; ++i) {
+      INFO("Column " << i);
+      CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, i) == 0);
+    }
+  }
+
+  SECTION("values just below type boundary") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 1.99::DECIMAL(5,2), -1.99::DECIMAL(5,2), "
+        "127.99::DECIMAL(5,2), -128.99::DECIMAL(6,2)");
+    CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 1) == 1);
+    CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 2) == -1);
+    CHECK(check_fractional_truncation<SQL_C_STINYINT>(stmt, 3) == 127);
+    CHECK(check_fractional_truncation<SQL_C_STINYINT>(stmt, 4) == -128);
+  }
+
+  SECTION("exact scale division - no fractional remainder") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 100.00::DECIMAL(10,2), 0.50::DECIMAL(10,2), "
+        "-25.00::DECIMAL(10,2), 1.00::DECIMAL(10,2)");
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 1) == 100);
+    CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 2) == 0);
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 3) == -25);
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 4) == 1);
+  }
+}
+
+// ============================================================================
+// Scale=0 pure integer tests
+// ============================================================================
+
+TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[datatype][number][integer]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  TestTable table(conn, "test_int_types", "a INT, b INTEGER, c BIGINT, d SMALLINT, e TINYINT",
+                  "(100, -200, 9223372036854775807, -32000, 120)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+
+  CHECK(check_no_truncation<SQL_C_LONG>(stmt, 1) == 100);
+  CHECK(check_no_truncation<SQL_C_LONG>(stmt, 2) == -200);
+  CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 3) == 9223372036854775807LL);
+  CHECK(check_no_truncation<SQL_C_SHORT>(stmt, 4) == -32000);
+  CHECK(check_no_truncation<SQL_C_TINYINT>(stmt, 5) == 120);
+
+  CHECK(check_char_success(stmt, 1) == "100");
+  CHECK(check_char_success(stmt, 2) == "-200");
+  CHECK(check_char_success(stmt, 3) == "9223372036854775807");
+  CHECK(check_char_success(stmt, 4) == "-32000");
+  CHECK(check_char_success(stmt, 5) == "120");
+}
+
+// ============================================================================
+// SQL_C_CHAR buffer truncation tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL SQL_C_CHAR buffer handling", "[datatype][number][char][buffer]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("whole digits do not fit returns 22003") {
+    SKIP_OLD_DRIVER("BD#13",
+                    "Old driver returns SQL_SUCCESS instead of SQL_ERROR (22003) when whole digits do not fit in "
+                    "SQL_C_CHAR buffer");
+
+    auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
+
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "22003");
+  }
+
+  SECTION("fractional-only truncation returns 01004") {
+    SKIP_OLD_DRIVER("BD#11",
+                    "SNOW-3120035: Old driver returns SQL_SUCCESS instead of SQL_SUCCESS_WITH_INFO for truncation");
+
+    auto stmt = conn.execute_fetch("SELECT 12.345::DECIMAL(10,3)");
+
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01004");
+  }
+
+  SECTION("exact buffer fits") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
+
+    char exact_buffer[3];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, exact_buffer, sizeof(exact_buffer), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == 2);
+    CHECK(std::string(exact_buffer) == "42");
+  }
+
+  SECTION("negative whole digits do not fit returns 22003") {
+    SKIP_OLD_DRIVER("BD#13",
+                    "Old driver returns SQL_SUCCESS instead of SQL_ERROR (22003) when whole digits do not fit in "
+                    "SQL_C_CHAR buffer");
+
+    auto stmt = conn.execute_fetch("SELECT -123::NUMBER(10,0)");
+
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "22003");
+  }
+
+  SECTION("negative fractional-only truncation returns 01004") {
+    SKIP_OLD_DRIVER("BD#11",
+                    "SNOW-3120035: Old driver returns SQL_SUCCESS instead of SQL_SUCCESS_WITH_INFO for truncation");
+
+    auto stmt = conn.execute_fetch("SELECT -12.345::DECIMAL(10,3)");
+
+    char small_buffer[5];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01004");
+  }
+}
+
+// ============================================================================
+// Multiple rows with varying scales and mixed positive/negative
+// ============================================================================
+
+TEST_CASE("DECIMAL multiple rows", "[datatype][number][multirow]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("various values as SQL_C_CHAR") {
+    TestTable table(conn, "test_number_multi", "val DECIMAL(10,2)",
+                    "(0.00), (1.00), (-1.00), (999.99), (-999.99), (0.01), (-0.01)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<std::string> expected = {"0.00", "1.00", "-1.00", "999.99", "-999.99", "0.01", "-0.01"};
+
+    for (size_t row = 0; row < expected.size(); ++row) {
+      if (row > 0) {
+        SQLRETURN ret = SQLFetch(stmt.getHandle());
+        CHECK(ret == SQL_SUCCESS);
+      }
+      INFO("Row " << row << " expected: " << expected[row]);
+      CHECK(check_char_success(stmt, 1) == expected[row]);
+    }
+  }
+
+  SECTION("various values as SQL_C_DOUBLE") {
+    TestTable table(conn, "test_number_double_multi", "val DECIMAL(10,3)", "(0.000), (1.500), (-2.750), (100.125)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<double> expected = {0.0, 1.5, -2.75, 100.125};
+
+    for (size_t row = 0; row < expected.size(); ++row) {
+      if (row > 0) {
+        SQLRETURN ret = SQLFetch(stmt.getHandle());
+        CHECK(ret == SQL_SUCCESS);
+      }
+      INFO("Row " << row << " expected double: " << expected[row]);
+      CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 1) == expected[row]);
+    }
+  }
+}
+
+// ============================================================================
+// SQL_C_DOUBLE/SQL_C_FLOAT precision checks
+// ============================================================================
+
+TEST_CASE("DECIMAL to floating point precision", "[datatype][number][precision]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_DOUBLE with 15 significant digits") {
+    auto stmt = conn.execute_fetch("SELECT 123456789012345::NUMBER(15,0)");
+    CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 1) == 123456789012345.0);
+  }
+
+  SECTION("SQL_C_FLOAT with 6 significant digits") {
+    auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
+    CHECK(check_no_truncation<SQL_C_FLOAT>(stmt, 1) == 123456.0f);
+  }
+}
+
+// ============================================================================
+// SQL_C_WCHAR (wide character) conversion tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR", "[datatype][number][wchar]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("basic values") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 42::NUMBER(10,0), -7::NUMBER(10,0), 0::NUMBER(10,0), "
+        "123.45::NUMBER(10,2), -0.05::NUMBER(10,2)");
+    CHECK(check_wchar_success(stmt, 1) == u"42");
+    CHECK(check_wchar_success(stmt, 2) == u"-7");
+    CHECK(check_wchar_success(stmt, 3) == u"0");
+    CHECK(check_wchar_success(stmt, 4) == u"123.45");
+    CHECK(check_wchar_success(stmt, 5) == u"-0.05");
+  }
+
+  SECTION("large precision values") {
+    auto stmt = conn.execute_fetch("SELECT 99999999999999999999999999999999999999::NUMBER(38,0)");
+    CHECK(check_wchar_success(stmt, 1) == u"99999999999999999999999999999999999999");
+  }
+
+  SECTION("matches SQL_C_CHAR") {
+    const std::string query = "SELECT 123.456::DECIMAL(10,3)";
+    auto char_str = check_char_success(conn.execute_fetch(query), 1);
+    auto wchar_str = check_wchar_success(conn.execute_fetch(query), 1);
+    std::u16string expected_wchar(char_str.begin(), char_str.end());
+    CHECK(wchar_str == expected_wchar);
+  }
+}
+
+// ============================================================================
+// SQL_C_NUMERIC (SQL_NUMERIC_STRUCT) conversion tests
+// ============================================================================
+
+inline unsigned long long numeric_val_to_ull(const SQL_NUMERIC_STRUCT& n) {
+  unsigned long long result = 0;
+  for (int i = 7; i >= 0; --i) {
+    result = (result << 8) | n.val[i];
+  }
+  return result;
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC", "[datatype][number][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("positive integer") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 42::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 42);
+    check_numeric_val_zero_from(numeric, 1);
+  }
+
+  SECTION("negative value") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -123::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 0);
+    CHECK(numeric.val[0] == 123);
+    check_numeric_val_zero_from(numeric, 1);
+  }
+
+  SECTION("zero") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 0::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 1);
+    check_numeric_val_zero_from(numeric, 0);
+  }
+
+  SECTION("with scale defaults to scale=0 truncation") {
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 123.45::NUMBER(10,2)"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 123);
+  }
+}
+
+// ============================================================================
+// SQL_C_NUMERIC with explicit SQL_DESC_PRECISION / SQL_DESC_SCALE
+// Tests the interaction between source DECIMAL(p,s)
+// and target descriptor precision/scale.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC with SQL_DESC_PRECISION and SQL_DESC_SCALE",
+          "[datatype][number][numeric][descriptor]") {
+  SKIP_OLD_DRIVER("BD#15", "Old driver ignores SQL_DESC_PRECISION and SQL_DESC_SCALE set via SQLSetDescField");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("target scale matches source scale - no truncation") {
+    auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)2, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.precision == 10);
+    CHECK(numeric.scale == 2);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 12345);
+  }
+
+  SECTION("target scale=0 truncates fractional part - 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)0, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01S07");
+    CHECK(numeric.precision == 10);
+    CHECK(numeric.scale == 0);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 123);
+  }
+
+  SECTION("target scale > source scale upscales value") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)3, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.precision == 10);
+    CHECK(numeric.scale == 3);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 42000);
+  }
+
+  SECTION("target scale < source scale with exact division - no truncation") {
+    auto stmt = conn.execute_fetch("SELECT 12.300::DECIMAL(10,3)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)1, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.precision == 10);
+    CHECK(numeric.scale == 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 123);
+  }
+
+  SECTION("target scale < source scale with remainder - 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 1.999::DECIMAL(10,3)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)1, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01S07");
+    CHECK(numeric.precision == 10);
+    CHECK(numeric.scale == 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric_val_to_ull(numeric) == 19);
+  }
+
+  SECTION("custom precision is reflected in output struct") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(38,0)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)5, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)0, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.precision == 5);
+    CHECK(numeric.scale == 0);
+    CHECK(numeric_val_to_ull(numeric) == 42);
+  }
+
+  SECTION("negative value with upscale") {
+    auto stmt = conn.execute_fetch("SELECT -7::NUMBER(10,0)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)2, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.sign == 0);
+    CHECK(numeric.scale == 2);
+    CHECK(numeric_val_to_ull(numeric) == 700);
+  }
+
+  SECTION("zero with non-zero target scale") {
+    auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0)");
+
+    SQLHDESC ard = SQL_NULL_HDESC;
+    SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, NULL);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_PRECISION, (SQLPOINTER)10, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    ret = SQLSetDescField(ard, 1, SQL_DESC_SCALE, (SQLPOINTER)5, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+
+    SQL_NUMERIC_STRUCT numeric = {};
+    SQLLEN indicator = 0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(numeric.scale == 5);
+    CHECK(numeric_val_to_ull(numeric) == 0);
+  }
+}
+
+// ============================================================================
+// SQL_C_BINARY conversion tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY", "[datatype][number][binary]") {
+  SKIP_OLD_DRIVER("BD#12", "SNOW-3127864: Old driver fix to be merged to return the proper size for SQL_NUMERIC");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("integer value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT 42::NUMBER(10,0)"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.val[0] == 42);
+    check_numeric_val_zero_from(num, 1);
+  }
+
+  SECTION("scaled value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT 123.45::NUMBER(10,2)"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.scale == 0);
+    CHECK(num.val[0] == 123);
+    check_numeric_val_zero_from(num, 1);
+  }
+
+  SECTION("negative value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT -7::NUMBER(10,0)"), 1);
+    CHECK(num.sign == 0);
+    CHECK(num.val[0] == 7);
+    check_numeric_val_zero_from(num, 1);
+  }
+}
+
+// ============================================================================
+// SQL_C_BINARY buffer truncation
+// Per ODBC spec: when byte length of data > BufferLength → 22003
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL SQL_C_BINARY buffer too small returns 22003", "[datatype][number][binary][22003]") {
+  SKIP_OLD_DRIVER(
+      "BD#14",
+      "Old driver does not return SQL_ERROR (22003) when SQL_C_BINARY buffer is too small for SQL_NUMERIC_STRUCT");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
+
+  char tiny_buffer[4];
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, tiny_buffer, sizeof(tiny_buffer), &indicator);
+
+  CHECK(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "22003");
+}
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 01S07 — Fractional truncation warning
+// Per ODBC spec, converting a numeric SQL value with fractional digits to an
+// integer C type should return SQL_SUCCESS_WITH_INFO with SQLSTATE 01S07.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_LONG") {
+    auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+    auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 123);
+  }
+
+  SECTION("SQL_C_SHORT") {
+    auto stmt = conn.execute_fetch("SELECT 9.99::DECIMAL(5,2)");
+    auto value = check_fractional_truncation<SQL_C_SHORT>(stmt, 1);
+    CHECK(value == 9);
+  }
+
+  SECTION("SQL_C_STINYINT") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_STINYINT>(stmt, 1);
+    CHECK(value == 1);
+  }
+
+  SECTION("SQL_C_SBIGINT") {
+    auto stmt = conn.execute_fetch("SELECT 999.001::DECIMAL(10,3)");
+    auto value = check_fractional_truncation<SQL_C_SBIGINT>(stmt, 1);
+    CHECK(value == 999);
+  }
+
+  SECTION("exact integer does NOT produce 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 100.00::DECIMAL(10,2)");
+    auto value = check_no_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 100);
+  }
+}
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 22003 — Numeric value out of range (integer overflow)
+// Per ODBC spec, when conversion would result in loss of whole (not fractional)
+// digits, the driver should return SQL_ERROR with SQLSTATE 22003.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL overflow returns 22003", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_LONG - above i32 max") {
+    auto stmt = conn.execute_fetch("SELECT 2147483648::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
+  }
+
+  SECTION("SQL_C_LONG - below i32 min") {
+    auto stmt = conn.execute_fetch("SELECT -2147483649::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
+  }
+
+  SECTION("SQL_C_SHORT - above i16 max") {
+    auto stmt = conn.execute_fetch("SELECT 32768::NUMBER(5,0)");
+    check_numeric_out_of_range<SQL_C_SHORT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_STINYINT - above i8 max") {
+    auto stmt = conn.execute_fetch("SELECT 128::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_STINYINT - below i8 min") {
+    auto stmt = conn.execute_fetch("SELECT -129::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_UTINYINT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_UTINYINT - above u8 max") {
+    auto stmt = conn.execute_fetch("SELECT 256::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_USHORT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_USHORT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_ULONG - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_ULONG>(stmt, 1);
+  }
+}
+
+// ============================================================================
+// ODBC Spec: SQL_C_BIT — spec-compliant behavior
+// Per ODBC spec for SQL_C_BIT:
+//   Exact 0 or 1                    -> SQL_SUCCESS
+//   Value > 0, < 2, != 1 (fraction) -> SQL_SUCCESS_WITH_INFO, 01S07
+//   Value < 0 or >= 2               -> SQL_ERROR, 22003
+// ============================================================================
+
+TEST_CASE("SQL_C_BIT spec compliance", "[datatype][number][bit]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("0 and 1 succeed") {
+    auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0), 1::NUMBER(10,0), 0.00::NUMBER(10,2)");
+    CHECK(check_no_truncation<SQL_C_BIT>(stmt, 1) == 0);
+    CHECK(check_no_truncation<SQL_C_BIT>(stmt, 2) == 1);
+    CHECK(check_no_truncation<SQL_C_BIT>(stmt, 3) == 0);
+  }
+
+  SECTION("negative integer is out of range (22003)") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("value 2 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 2::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("negative fractional value returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -0.5::DECIMAL(3,1)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("fractional 0.5 truncates to 0 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 0.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 0);
+  }
+
+  SECTION("fractional 1.5 truncates to 1 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 1);
+  }
+
+  SECTION("exact 1.0 does NOT produce warning") {
+    auto stmt = conn.execute_fetch("SELECT 1.00::DECIMAL(5,2)");
+    auto value = check_no_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 1);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL SQLGetData NULL without indicator returns 22002", "[datatype][number][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");
+
+  SQLINTEGER value = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), nullptr);
+  CHECK(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "22002");
+}
+
+// ============================================================================
+// TREAT_DECIMAL_AS_INT — FIXED with scale=0 reported as SQL_BIGINT
+// ============================================================================
+
+TEST_CASE("TREAT_DECIMAL_AS_INT SQL_C_DEFAULT resolves to SBIGINT for scale=0",
+          "[datatype][number][treat_decimal_as_int]") {
+  Connection conn;
+  conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("positive integer") {
+    auto stmt = conn.execute_fetch("SELECT 42::DECIMAL(10,0)");
+
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 42);
+  }
+
+  SECTION("negative integer") {
+    auto stmt = conn.execute_fetch("SELECT -123::DECIMAL(10,0)");
+
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == -123);
+  }
+
+  SECTION("zero") {
+    auto stmt = conn.execute_fetch("SELECT 0::DECIMAL(10,0)");
+
+    SQLBIGINT value = -1;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 0);
+  }
+
+  SECTION("max precision 18") {
+    auto stmt = conn.execute_fetch("SELECT 999999999999999999::DECIMAL(18,0)");
+
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 999999999999999999LL);
+  }
+}
+
+TEST_CASE("TREAT_DECIMAL_AS_INT does not affect scale > 0", "[datatype][number][treat_decimal_as_int]") {
+  Connection conn;
+  conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+
+  char buffer[100];
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator > 0);
+  CHECK(std::string(buffer, indicator) == "123.45");
+}
+
+TEST_CASE("TREAT_DECIMAL_AS_INT applies to precision > 18 too", "[datatype][number][treat_decimal_as_int]") {
+  Connection conn;
+  conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(38,0)");
+
+  SQLBIGINT value = 0;
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == sizeof(SQLBIGINT));
+  CHECK(value == 42);
+}
+
+TEST_CASE("TREAT_BIG_NUMBER_AS_STRING overrides TREAT_DECIMAL_AS_INT for precision > 18",
+          "[datatype][number][treat_big_number_as_string]") {
+  Connection conn;
+  conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
+  conn.execute("ALTER SESSION SET ODBC_TREAT_BIG_NUMBER_AS_STRING=true");
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("NUMBER(38,0) resolves to SQL_C_CHAR when both settings are true") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(38,0)");
+
+    char buffer[100];
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator > 0);
+    CHECK(std::string(buffer, indicator) == "42");
+  }
+
+  SECTION("DECIMAL(10,0) still resolves to SBIGINT (precision <= 18)") {
+    auto stmt = conn.execute_fetch("SELECT 42::DECIMAL(10,0)");
+
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 42);
+  }
+}
+
+TEST_CASE("Without TREAT_DECIMAL_AS_INT default is SQL_C_CHAR for scale=0",
+          "[datatype][number][treat_decimal_as_int]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::DECIMAL(10,0)");
+
+  char buffer[100];
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator > 0);
+  CHECK(std::string(buffer, indicator) == "42");
+}
+
+TEST_CASE("TREAT_DECIMAL_AS_INT with table columns", "[datatype][number][treat_decimal_as_int]") {
+  Connection conn;
+  conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
+  auto random_schema = Schema::use_random_schema(conn);
+
+  std::string table_name = "test_decimal_as_int";
+  TestTable table(conn, table_name, "d_int DECIMAL(10,0), d_frac DECIMAL(10,2), d_big NUMBER(38,0)",
+                  "(42, 123.45, 42)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+
+  SECTION("DECIMAL(10,0) column returns SBIGINT via SQL_C_DEFAULT") {
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 42);
+  }
+
+  SECTION("DECIMAL(10,2) column returns CHAR via SQL_C_DEFAULT") {
+    char buffer[100];
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 2, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator > 0);
+    CHECK(std::string(buffer, indicator) == "123.45");
+  }
+
+  SECTION(
+      "NUMBER(38,0) column returns SBIGINT via SQL_C_DEFAULT (BigInt, precision > 18 but no big_number_as_string)") {
+    SQLBIGINT value = 0;
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 3, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator == sizeof(SQLBIGINT));
+    CHECK(value == 42);
+  }
 }

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
@@ -25,13 +25,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Signed Integer Types
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
@@ -33,13 +33,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - Single-component interval types (no truncation)
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
@@ -37,13 +37,6 @@ static long long numeric_val_to_int(const SQL_NUMERIC_STRUCT& num) {
 
 static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>((unsigned char)c); }
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Floating Point Types
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
@@ -23,13 +23,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Date/Time Types
 // ============================================================================

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -399,7 +399,6 @@ pub fn statement_execute_query<'a>(
             .collect()
     });
 
-    // Serialize pointer into integer
     stmt.state = StatementState::Executed;
     Ok(ExecuteResult {
         stream: rowset_stream,

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -64,8 +64,12 @@ impl ClientInfo {
         let crl_config = CrlConfig::from_settings(settings)?;
         let tls_config = TlsConfig::from_settings(settings)?;
 
+        // TODO: ClientInfo should be dynamically created based on the real hardware and
+        // the wrapper client type
         let client_info = ClientInfo {
-            application: "PythonConnector".to_string(),
+            application: settings
+                .get_string("client_app_id")
+                .unwrap_or_else(|| "PythonConnector".to_string()),
             version: "3.15.0".to_string(),
             os: "Darwin".to_string(),
             os_version: "macOS-15.5-arm64-arm-64bit".to_string(),


### PR DESCRIPTION
# Add support for DECIMAL/NUMERIC types

### TL;DR

Implements handling for DECIMAL/NUMERIC types according to ODBC spec, also adds comprehensive tests for numeric data type conversions and improves error handling.

### What changed?

- Added support for SQL_C_DEFAULT for DECIMAL/NUMERIC types, which maps to SQL_C_CHAR per ODBC spec
- Implemented proper SQL_NUMERIC_STRUCT handling for SQL_C_NUMERIC and SQL_C_BINARY types
- Added proper handling for SQL_C_BIT conversions according to ODBC spec
- Improved error handling for numeric conversions:
    - Added SQLSTATE 22002 (indicator variable required) when NULL values are fetched without an indicator
    - Implemented proper range checking for integer conversions
    - Added fractional truncation warnings (01S07) when converting decimal to integer
- Added null terminator to string buffers
- Added comprehensive tests for all numeric conversion scenarios

### How to test?

Run the new and updated tests in `odbc_tests/tests/datatype_tests/number_tests.cpp` which cover:

- SQL_C_DEFAULT conversions for DECIMAL/NUMERIC
- Integer conversions with proper truncation warnings
- Overflow error handling
- NULL value handling
- SQL_C_NUMERIC and SQL_C_BINARY conversions
- SQL_C_BIT conversions
- Buffer handling for string conversions

### Why make this change?

This change improves ODBC specification compliance for numeric data types. The SQL_C_DEFAULT handling is particularly important as applications often rely on the default C type mapping. The proper error handling for NULL values and numeric range checking makes the driver more robust and predictable.