### PR TITLE
Add SQL_C_DEFAULT conversion for Snowflake REAL (FLOAT/DOUBLE) type

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -517,7 +517,7 @@ mod tests {
     use super::*;
     use crate::cdata_types::{Double, Real, SBigInt, UBigInt};
     use arrow::array::{
-        Decimal128Array, Int8Array, Int16Array, Int32Array, Int64Array, StringArray,
+        Decimal128Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, StringArray,
     };
     use arrow::datatypes::{DataType, Field};
     use std::collections::HashMap;
@@ -559,6 +559,12 @@ mod tests {
         metadata.insert("scale".to_string(), scale.to_string());
         metadata.insert("precision".to_string(), precision.to_string());
         Field::new("test", DataType::Decimal128(precision, scale), false).with_metadata(metadata)
+    }
+
+    fn field_with_real_meta() -> Field {
+        let mut metadata = HashMap::new();
+        metadata.insert("logicalType".to_string(), "REAL".to_string());
+        Field::new("test", DataType::Float64, false).with_metadata(metadata)
     }
 
     // Tests for CDataType::Char
@@ -1380,6 +1386,73 @@ mod tests {
             let expected = b"1.2345678901234567890123456789012345678";
             assert_eq!(str_len, expected.len() as sql::Len);
             assert_eq!(&buffer[..expected.len()], expected);
+        }
+    }
+
+    mod read_real_to_default {
+        use super::*;
+
+        #[test]
+        fn default_reads_float64_as_double() {
+            let array = Float64Array::from(vec![3.125]);
+            let field = field_with_real_meta();
+            let mut value: Double = 0.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: &mut str_len,
+                precision: None,
+                scale: None,
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - 3.125).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn default_reads_negative_float64() {
+            let array = Float64Array::from(vec![-99.5]);
+            let field = field_with_real_meta();
+            let mut value: Double = 0.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: &mut str_len,
+                precision: None,
+                scale: None,
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - (-99.5)).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn default_reads_zero_float64() {
+            let array = Float64Array::from(vec![0.0]);
+            let field = field_with_real_meta();
+            let mut value: Double = 1.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: &mut str_len,
+                precision: None,
+                scale: None,
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - 0.0).abs() < f64::EPSILON);
         }
     }
 

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -11,12 +11,16 @@ mod nullable;
 mod number;
 #[cfg(test)]
 mod number_tests;
+mod real;
+#[cfg(test)]
+mod real_tests;
 mod timestamp;
 mod varchar;
 
 use arrow::array::Array;
 use arrow::datatypes::{
-    DataType, Date32Type, Decimal128Type, Field, Int8Type, Int16Type, Int32Type, Int64Type,
+    DataType, Date32Type, Decimal128Type, Field, Float64Type, Int8Type, Int16Type, Int32Type,
+    Int64Type,
 };
 use snafu::ResultExt;
 pub use traits::{Binding, ReadArrowType, SnowflakeType, WriteODBCType};
@@ -135,6 +139,7 @@ enum SnowflakeFieldType {
     TimestampNtz(timestamp::SnowflakeTimestampNtz),
     Boolean(boolean::SnowflakeBoolean),
     Binary(binary::SnowflakeBinary),
+    Real(real::SnowflakeReal),
 }
 
 impl SnowflakeFieldType {
@@ -170,6 +175,7 @@ impl SnowflakeFieldType {
             "TIMESTAMP_NTZ" => Ok(Self::TimestampNtz(timestamp::SnowflakeTimestampNtz)),
             "BOOLEAN" => Ok(Self::Boolean(boolean::SnowflakeBoolean)),
             "BINARY" => Ok(Self::Binary(binary::SnowflakeBinary)),
+            "REAL" => Ok(Self::Real(real::SnowflakeReal)),
             lt => IncompatibleFieldMetadataSnafu {
                 logical_type: lt.to_string(),
                 data_type: field.data_type().clone(),
@@ -186,6 +192,7 @@ impl SnowflakeFieldType {
             Self::TimestampNtz(t) => t.sql_type(),
             Self::Boolean(t) => t.sql_type(),
             Self::Binary(t) => t.sql_type(),
+            Self::Real(t) => t.sql_type(),
         }
     }
 }
@@ -258,6 +265,9 @@ pub fn make_converter<'a>(
                 arrow_array,
                 nullable
             )
+        }
+        SnowflakeFieldType::Real(snowflake_type) => {
+            make_primitive_data_converter!(Float64Type, snowflake_type, arrow_array, nullable)
         }
     }
 }

--- a/odbc/src/conversion/real.rs
+++ b/odbc/src/conversion/real.rs
@@ -1,0 +1,51 @@
+use arrow::array::Float64Array;
+use odbc_sys as sql;
+
+use crate::cdata_types::CDataType;
+use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
+use crate::conversion::traits::Binding;
+use crate::conversion::warning::Warnings;
+use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
+
+/// Handles Snowflake's "REAL" logical type (FLOAT, DOUBLE, REAL).
+/// The old driver maps "real" → SQL_DOUBLE; the default C type is SQL_C_DOUBLE.
+pub(crate) struct SnowflakeReal;
+
+impl SnowflakeType for SnowflakeReal {
+    type Representation<'a> = f64;
+}
+
+impl ReadArrowType<Float64Array> for SnowflakeReal {
+    fn read_arrow_type<'a>(
+        &self,
+        array: &'a Float64Array,
+        row_idx: usize,
+    ) -> Result<Self::Representation<'a>, ReadArrowError> {
+        Ok(array.value(row_idx))
+    }
+}
+
+impl WriteODBCType for SnowflakeReal {
+    fn sql_type(&self) -> sql::SqlDataType {
+        sql::SqlDataType::DOUBLE
+    }
+
+    fn write_odbc_type(
+        &self,
+        snowflake_value: Self::Representation<'_>,
+        binding: &Binding,
+        _get_data_offset: &mut Option<usize>,
+    ) -> Result<Warnings, WriteOdbcError> {
+        let target_type = match binding.target_type {
+            CDataType::Default => CDataType::Double,
+            other => other,
+        };
+        match target_type {
+            CDataType::Double => {
+                binding.write_fixed(snowflake_value);
+                Ok(vec![])
+            }
+            _ => UnsupportedOdbcTypeSnafu { target_type }.fail(),
+        }
+    }
+}

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -1,0 +1,101 @@
+#[cfg(test)]
+mod tests {
+    use crate::cdata_types::CDataType;
+    use crate::conversion::WriteODBCType;
+    use crate::conversion::real::SnowflakeReal;
+    use crate::conversion::traits::Binding;
+    use odbc_sys as sql;
+
+    fn binding_for_value<T>(
+        target_type: CDataType,
+        value: &mut T,
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: value as *mut T as sql::Pointer,
+            buffer_length: 0,
+            str_len_or_ind_ptr: str_len as *mut sql::Len,
+            precision: None,
+            scale: None,
+        }
+    }
+
+    fn make_real() -> SnowflakeReal {
+        SnowflakeReal
+    }
+
+    #[test]
+    fn real_default_writes_positive_f64() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(3.125, &binding, &mut None).unwrap();
+
+        assert!((value - 3.125).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_negative_f64() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(-99.5, &binding, &mut None).unwrap();
+
+        assert!((value - (-99.5)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_zero() {
+        let sr = make_real();
+        let mut value: f64 = 1.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert!((value - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_very_small_value() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        let input = 1.23e-10;
+        sr.write_odbc_type(input, &binding, &mut None).unwrap();
+
+        assert!((value - input).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_very_large_value() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        let input = 1.23e+100;
+        sr.write_odbc_type(input, &binding, &mut None).unwrap();
+
+        assert!((value - input).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_unsupported_type_returns_error() {
+        let sr = make_real();
+        let mut value: i32 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Binary, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(1.0, &binding, &mut None);
+
+        assert!(result.is_err());
+    }
+}

--- a/odbc_tests/tests/datatype_tests/CMakeLists.txt
+++ b/odbc_tests/tests/datatype_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 4.0)
 
 add_odbc_test(string_tests string_tests.cpp)
-add_odbc_test(number_tests number_tests.cpp)
+add_odbc_test(number_tests number_tests.cpp real_tests.cpp)

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1,0 +1,247 @@
+
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include "Connection.hpp"
+#include "HandleWrapper.hpp"
+#include "Schema.hpp"
+#include "get_data.hpp"
+#include "macros.hpp"
+#include "test_setup.hpp"
+
+/// Helper: fetch a column with SQL_C_DEFAULT into an SQLDOUBLE.
+/// Per ODBC spec, SQL_C_DEFAULT for SQL_DOUBLE resolves to SQL_C_DOUBLE.
+inline SQLDOUBLE get_data_default_as_double(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  SQLDOUBLE value = 0.0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+  CHECK_ODBC(ret, stmt);
+  return value;
+}
+
+// ============================================================================
+// SQL_C_DEFAULT for FLOAT/DOUBLE columns
+// Per ODBC spec, the "real" logical type maps to SQL_DOUBLE.
+// SQL_C_DEFAULT for SQL_DOUBLE is SQL_C_DOUBLE.
+// ============================================================================
+
+TEST_CASE("REAL default conversion - basic values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_default");
+  conn.execute(
+      "CREATE TABLE test_real_default ("
+      "  f1 FLOAT, "
+      "  f2 DOUBLE, "
+      "  f3 FLOAT)");
+  conn.execute("INSERT INTO test_real_default VALUES (1.5, -2.75, 0.0)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_default");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 1.5);
+  CHECK(get_data_default_as_double(stmt, 2) == -2.75);
+  CHECK(get_data_default_as_double(stmt, 3) == 0.0);
+}
+
+TEST_CASE("REAL default conversion - integer values stored as float", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::FLOAT, -100::FLOAT, 0::FLOAT, 1::FLOAT");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 42.0);
+  CHECK(get_data_default_as_double(stmt, 2) == -100.0);
+  CHECK(get_data_default_as_double(stmt, 3) == 0.0);
+  CHECK(get_data_default_as_double(stmt, 4) == 1.0);
+}
+
+TEST_CASE("REAL default conversion - extreme values near DBL_MAX", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_extreme");
+  conn.execute("CREATE TABLE test_real_extreme (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_extreme VALUES "
+      "(1.7976931348623157e308), "
+      "(1.7e308), "
+      "(1.7976931348623151e308), "
+      "(-1.7976931348623151e308), "
+      "(-1.7e308), "
+      "(-1.7976931348623157e308)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_extreme");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7976931348623157e308);
+
+  SQLRETURN ret;
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7976931348623151e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623151e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623157e308);
+}
+
+TEST_CASE("REAL default conversion - very small values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch(
+      "SELECT 2.2250738585072014e-308::DOUBLE, "
+      "       1e-307::DOUBLE, "
+      "       -2.2250738585072014e-308::DOUBLE");
+
+  double v1 = get_data_default_as_double(stmt, 1);
+  double v2 = get_data_default_as_double(stmt, 2);
+  double v3 = get_data_default_as_double(stmt, 3);
+
+  CHECK(v1 > 0.0);
+  CHECK(v1 < 1e-300);
+  CHECK(v2 == 1e-307);
+  CHECK(v3 < 0.0);
+  CHECK(v3 > -1e-300);
+}
+
+TEST_CASE("REAL default conversion - FLOAT, DOUBLE, REAL synonyms produce same result", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_synonyms");
+  conn.execute(
+      "CREATE TABLE test_real_synonyms ("
+      "  f FLOAT, "
+      "  d DOUBLE, "
+      "  r REAL)");
+  conn.execute("INSERT INTO test_real_synonyms VALUES (123.456, 123.456, 123.456)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_synonyms");
+
+  double f = get_data_default_as_double(stmt, 1);
+  double d = get_data_default_as_double(stmt, 2);
+  double r = get_data_default_as_double(stmt, 3);
+
+  CHECK(f == d);
+  CHECK(d == r);
+}
+
+// ============================================================================
+// SQL_C_DEFAULT must produce the same result as explicit SQL_C_DOUBLE
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_default_vs_explicit");
+  conn.execute("CREATE TABLE test_real_default_vs_explicit (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_default_vs_explicit VALUES "
+      "(1.5), (-2.75), (0.0), (999999.999), (1.7976931348623157e308)");
+
+  // Fetch with SQL_C_DOUBLE explicitly
+  auto stmt_explicit = conn.execute_fetch("SELECT * FROM test_real_default_vs_explicit");
+  std::vector<double> explicit_results;
+  explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+  for (int i = 1; i < 5; ++i) {
+    SQLRETURN ret = SQLFetch(stmt_explicit.getHandle());
+    CHECK_ODBC(ret, stmt_explicit);
+    explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+  }
+
+  // Fetch with SQL_C_DEFAULT
+  auto stmt_default = conn.execute_fetch("SELECT * FROM test_real_default_vs_explicit");
+  std::vector<double> default_results;
+  default_results.push_back(get_data_default_as_double(stmt_default, 1));
+  for (int i = 1; i < 5; ++i) {
+    SQLRETURN ret = SQLFetch(stmt_default.getHandle());
+    CHECK_ODBC(ret, stmt_default);
+    default_results.push_back(get_data_default_as_double(stmt_default, 1));
+  }
+
+  // They must match exactly
+  for (size_t i = 0; i < explicit_results.size(); ++i) {
+    INFO("Row " << i << ": SQL_C_DOUBLE=" << explicit_results[i] << " vs SQL_C_DEFAULT=" << default_results[i]);
+    CHECK(explicit_results[i] == default_results[i]);
+  }
+}
+
+// ============================================================================
+// Multiple rows
+// ============================================================================
+
+TEST_CASE("REAL default conversion - multiple rows", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_multi");
+  conn.execute("CREATE TABLE test_real_multi (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_multi VALUES "
+      "(1.5), (-2.75), (0.0), (1e100), (-1e100)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_multi");
+
+  std::vector<double> expected = {1.5, -2.75, 0.0, 1e100, -1e100};
+
+  CHECK(get_data_default_as_double(stmt, 1) == expected[0]);
+  for (size_t i = 1; i < expected.size(); ++i) {
+    SQLRETURN ret = SQLFetch(stmt.getHandle());
+    CHECK_ODBC(ret, stmt);
+    INFO("Row " << i);
+    CHECK(get_data_default_as_double(stmt, 1) == expected[i]);
+  }
+}
+
+// ============================================================================
+// Fractional values and zero
+// ============================================================================
+
+TEST_CASE("REAL default conversion - fractional values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0.1::FLOAT, 0.5::FLOAT, 0.333333333::FLOAT");
+
+  double v1 = get_data_default_as_double(stmt, 1);
+  double v2 = get_data_default_as_double(stmt, 2);
+  double v3 = get_data_default_as_double(stmt, 3);
+
+  CHECK(std::abs(v1 - 0.1) < 1e-15);
+  CHECK(v2 == 0.5);
+  CHECK(std::abs(v3 - 0.333333333) < 1e-8);
+}
+
+TEST_CASE("REAL zero is exactly zero", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT");
+
+  double val = get_data_default_as_double(stmt, 1);
+  CHECK(val == 0.0);
+}


### PR DESCRIPTION
Implements the default C type mapping for the "REAL" logical type.
Per ODBC spec, SQL_DOUBLE maps to SQL_C_DOUBLE as the default C type.
This matches the old driver's behavior where "real" -> SQL_DOUBLE.

- Add SnowflakeReal converter with Default->Double mapping
- Wire "REAL" logical type into make_converter (Float64 Arrow type)
- Add unit tests (real_tests.rs) and integration tests (data.rs)
- Add e2e compatibility tests (real_tests.cpp) covering:
  basic values, extremes near DBL_MAX, very small values,
  FLOAT/DOUBLE/REAL synonyms, default-vs-explicit match, multi-row

Co-authored-by: Cursor <cursoragent@cursor.com>