### PR TITLE
Add Snowflake REAL type to C type conversions

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1453,6 +1453,121 @@ mod tests {
         }
     }
 
+    mod read_real_explicit {
+        use super::*;
+
+        #[test]
+        fn reads_float64_as_float() {
+            let array = Float64Array::from(vec![3.125]);
+            let field = field_with_real_meta();
+            let mut value: Real = 0.0;
+
+            let binding = Binding {
+                target_type: CDataType::Float,
+                target_value_ptr: &mut value as *mut Real as sql::Pointer,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - 3.125f32).abs() < f32::EPSILON);
+        }
+
+        #[test]
+        fn reads_float64_as_slong() {
+            let array = Float64Array::from(vec![42.7]);
+            let field = field_with_real_meta();
+            let mut value: sql::Integer = 0;
+
+            let binding = Binding {
+                target_type: CDataType::SLong,
+                target_value_ptr: &mut value as *mut sql::Integer as sql::Pointer,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(value, 42);
+        }
+
+        #[test]
+        fn reads_float64_as_sbigint() {
+            let array = Float64Array::from(vec![123456789.9]);
+            let field = field_with_real_meta();
+            let mut value: SBigInt = 0;
+
+            let binding = Binding {
+                target_type: CDataType::SBigInt,
+                target_value_ptr: &mut value as *mut SBigInt as sql::Pointer,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(value, 123456789i64);
+        }
+
+        #[test]
+        fn reads_float64_as_char() {
+            let array = Float64Array::from(vec![3.125]);
+            let field = field_with_real_meta();
+            let mut buffer = vec![0u8; 32];
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Char,
+                target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                buffer_length: buffer.len() as sql::Len,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            let expected = b"3.125";
+            assert_eq!(str_len, expected.len() as sql::Len);
+            assert_eq!(&buffer[..expected.len()], expected);
+            assert_eq!(buffer[expected.len()], 0);
+        }
+
+        #[test]
+        fn reads_float64_as_bit() {
+            let array = Float64Array::from(vec![5.5]);
+            let field = field_with_real_meta();
+            let mut value: u8 = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Bit,
+                target_value_ptr: &mut value as *mut u8 as sql::Pointer,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert_eq!(value, 1);
+        }
+
+        #[test]
+        fn reads_float64_from_different_indices() {
+            let array = Float64Array::from(vec![1.1, 2.2, 3.3]);
+            let field = field_with_real_meta();
+
+            for (idx, expected) in [(0, 1.1), (1, 2.2), (2, 3.3)] {
+                let mut value: Double = 0.0;
+
+                let binding = Binding {
+                    target_type: CDataType::Double,
+                    target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                    ..Default::default()
+                };
+                let result = read_arrow_value_test(&binding, &array, &field, idx);
+
+                assert!(result.is_ok());
+                assert!((value - expected).abs() < f64::EPSILON);
+            }
+        }
+    }
+
     // Tests for null octet_length_ptr
     mod null_indicator_tests {
         use super::*;

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1556,10 +1556,7 @@ mod tests {
             let binding = Binding {
                 target_type: CDataType::Bit,
                 target_value_ptr: &mut value as *mut u8 as sql::Pointer,
-                buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                ..Default::default()
             };
             let result = read_arrow_value_test(&binding, &array, &field, 0);
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -553,7 +553,7 @@ mod tests {
     use super::*;
     use crate::cdata_types::{Double, Real, SBigInt, UBigInt};
     use arrow::array::{
-        Decimal128Array, Int8Array, Int16Array, Int32Array, Int64Array, StringArray,
+        Decimal128Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, StringArray,
     };
     use arrow::datatypes::{DataType, Field};
     use std::collections::HashMap;
@@ -595,6 +595,12 @@ mod tests {
         metadata.insert("scale".to_string(), scale.to_string());
         metadata.insert("precision".to_string(), precision.to_string());
         Field::new("test", DataType::Decimal128(precision, scale), false).with_metadata(metadata)
+    }
+
+    fn field_with_real_meta() -> Field {
+        let mut metadata = HashMap::new();
+        metadata.insert("logicalType".to_string(), "REAL".to_string());
+        Field::new("test", DataType::Float64, false).with_metadata(metadata)
     }
 
     // Tests for CDataType::Char
@@ -1380,6 +1386,70 @@ mod tests {
             let expected = b"1.2345678901234567890123456789012345678";
             assert_eq!(str_len, expected.len() as sql::Len);
             assert_eq!(&buffer[..expected.len()], expected);
+        }
+    }
+
+    mod read_real_to_default {
+        use super::*;
+
+        #[test]
+        fn default_reads_float64_as_double() {
+            let array = Float64Array::from(vec![3.125]);
+            let field = field_with_real_meta();
+            let mut value: Double = 0.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - 3.125).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn default_reads_negative_float64() {
+            let array = Float64Array::from(vec![-99.5]);
+            let field = field_with_real_meta();
+            let mut value: Double = 0.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - (-99.5)).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn default_reads_zero_float64() {
+            let array = Float64Array::from(vec![0.0]);
+            let field = field_with_real_meta();
+            let mut value: Double = 1.0;
+            let mut str_len: sql::Len = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Default,
+                target_value_ptr: &mut value as *mut Double as sql::Pointer,
+                buffer_length: 0,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_ok());
+            assert!((value - 0.0).abs() < f64::EPSILON);
         }
     }
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1532,7 +1532,7 @@ mod tests {
 
         #[test]
         fn reads_float64_as_bit() {
-            let array = Float64Array::from(vec![5.5]);
+            let array = Float64Array::from(vec![1.0]);
             let field = field_with_real_meta();
             let mut value: u8 = 0;
 
@@ -1545,6 +1545,25 @@ mod tests {
 
             assert!(result.is_ok());
             assert_eq!(value, 1);
+        }
+
+        #[test]
+        fn reads_float64_as_bit_out_of_range() {
+            let array = Float64Array::from(vec![5.5]);
+            let field = field_with_real_meta();
+            let mut value: u8 = 0;
+
+            let binding = Binding {
+                target_type: CDataType::Bit,
+                target_value_ptr: &mut value as *mut u8 as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: std::ptr::null_mut(),
+                precision: None,
+                scale: None,
+            };
+            let result = read_arrow_value_test(&binding, &array, &field, 0);
+
+            assert!(result.is_err());
         }
 
         #[test]

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -15,13 +15,16 @@ mod number;
 mod number_tests;
 mod real;
 #[cfg(test)]
+mod real_tests;
+#[cfg(test)]
 mod test_utils;
 mod timestamp;
 mod varchar;
 
 use arrow::array::Array;
 use arrow::datatypes::{
-    DataType, Date32Type, Decimal128Type, Field, Int8Type, Int16Type, Int32Type, Int64Type,
+    DataType, Date32Type, Decimal128Type, Field, Float64Type, Int8Type, Int16Type, Int32Type,
+    Int64Type,
 };
 use snafu::ResultExt;
 pub use traits::{Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType};
@@ -172,11 +175,11 @@ impl SnowflakeFieldType {
                     sql_type,
                 }))
             }
-            "REAL" => Ok(Self::Real(real::SnowflakeReal)),
             "DATE" => Ok(Self::Date(date::SnowflakeDate)),
             "TIMESTAMP_NTZ" => Ok(Self::TimestampNtz(timestamp::SnowflakeTimestampNtz)),
             "BOOLEAN" => Ok(Self::Boolean(boolean::SnowflakeBoolean)),
             "BINARY" => Ok(Self::Binary(binary::SnowflakeBinary)),
+            "REAL" => Ok(Self::Real(real::SnowflakeReal)),
             lt => IncompatibleFieldMetadataSnafu {
                 logical_type: lt.to_string(),
                 data_type: field.data_type().clone(),
@@ -292,12 +295,7 @@ pub fn make_converter<'a>(
             )
         }
         SnowflakeFieldType::Real(snowflake_type) => {
-            make_primitive_data_converter!(
-                arrow::datatypes::Float64Type,
-                snowflake_type,
-                arrow_array,
-                nullable
-            )
+            make_primitive_data_converter!(Float64Type, snowflake_type, arrow_array, nullable)
         }
     }
 }

--- a/odbc/src/conversion/real.rs
+++ b/odbc/src/conversion/real.rs
@@ -2,11 +2,15 @@ use arrow::array::{Array, Float64Array};
 use odbc_sys as sql;
 
 use crate::cdata_types::CDataType;
-use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
+use crate::conversion::error::{
+    NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
+};
 use crate::conversion::traits::Binding;
-use crate::conversion::warning::Warnings;
+use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
 
+/// Handles Snowflake's "REAL" logical type (FLOAT, DOUBLE, REAL).
+/// The old driver maps "real" → SQL_DOUBLE; the default C type is SQL_C_DOUBLE.
 pub(crate) struct SnowflakeReal;
 
 impl SnowflakeType for SnowflakeReal {
@@ -28,6 +32,39 @@ impl ReadArrowType<Float64Array> for SnowflakeReal {
     }
 }
 
+fn check_float_range(value: f64, min: f64, max: f64) -> Result<(), WriteOdbcError> {
+    if value.is_nan() {
+        return NumericValueOutOfRangeSnafu {
+            reason: "NaN cannot be converted to an integer type".to_string(),
+        }
+        .fail();
+    }
+    let truncated = value.trunc();
+    if truncated < min || truncated > max {
+        NumericValueOutOfRangeSnafu {
+            reason: format!("Value {value} is out of range ({min} to {max})"),
+        }
+        .fail()
+    } else {
+        Ok(())
+    }
+}
+
+fn whole_digits_len(num_str: &str) -> usize {
+    match num_str.find('.') {
+        Some(pos) => pos,
+        None => num_str.len(),
+    }
+}
+
+fn fractional_warning(value: f64) -> Warnings {
+    if value.fract() != 0.0 {
+        vec![Warning::NumericValueTruncated]
+    } else {
+        vec![]
+    }
+}
+
 impl WriteODBCType for SnowflakeReal {
     fn sql_type(&self) -> sql::SqlDataType {
         sql::SqlDataType::DOUBLE
@@ -45,21 +82,222 @@ impl WriteODBCType for SnowflakeReal {
         &self,
         snowflake_value: Self::Representation<'_>,
         binding: &Binding,
-        _get_data_offset: &mut Option<usize>,
+        get_data_offset: &mut Option<usize>,
     ) -> Result<Warnings, WriteOdbcError> {
-        match binding.target_type {
-            CDataType::Default | CDataType::Double => {
+        let target_type = match binding.target_type {
+            CDataType::Default => CDataType::Double,
+            other => other,
+        };
+        match target_type {
+            CDataType::Double => {
                 binding.write_fixed(snowflake_value);
                 Ok(vec![])
             }
             CDataType::Float => {
+                if snowflake_value.abs() > f32::MAX as f64 {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!("Value {snowflake_value} is out of range for SQL_C_FLOAT"),
+                    }
+                    .fail();
+                }
                 binding.write_fixed(snowflake_value as f32);
                 Ok(vec![])
             }
-            _ => UnsupportedOdbcTypeSnafu {
-                target_type: binding.target_type,
+            CDataType::Short | CDataType::SShort => {
+                check_float_range(snowflake_value, i16::MIN as f64, i16::MAX as f64)?;
+                binding.write_fixed(snowflake_value as i16);
+                Ok(fractional_warning(snowflake_value))
             }
-            .fail(),
+            CDataType::UShort => {
+                check_float_range(snowflake_value, 0.0, u16::MAX as f64)?;
+                binding.write_fixed(snowflake_value as u16);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::TinyInt | CDataType::STinyInt => {
+                check_float_range(snowflake_value, i8::MIN as f64, i8::MAX as f64)?;
+                binding.write_fixed(snowflake_value as i8);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::UTinyInt => {
+                check_float_range(snowflake_value, 0.0, u8::MAX as f64)?;
+                binding.write_fixed(snowflake_value as u8);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::Long | CDataType::SLong => {
+                check_float_range(snowflake_value, i32::MIN as f64, i32::MAX as f64)?;
+                binding.write_fixed(snowflake_value as i32);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::ULong => {
+                check_float_range(snowflake_value, 0.0, u32::MAX as f64)?;
+                binding.write_fixed(snowflake_value as u32);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::SBigInt => {
+                check_float_range(snowflake_value, i64::MIN as f64, i64::MAX as f64)?;
+                binding.write_fixed(snowflake_value as i64);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::UBigInt => {
+                check_float_range(snowflake_value, 0.0, u64::MAX as f64)?;
+                binding.write_fixed(snowflake_value as u64);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::Bit => {
+                if !snowflake_value.is_finite()
+                    || snowflake_value < 0.0
+                    || snowflake_value.trunc() >= 2.0
+                {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!(
+                            "Value out of range for SQL_C_BIT (must be 0 or 1, got {snowflake_value})"
+                        ),
+                    }
+                    .fail();
+                }
+                binding.write_fixed(snowflake_value.trunc() as u8);
+                Ok(fractional_warning(snowflake_value))
+            }
+            CDataType::Numeric => {
+                if snowflake_value.is_nan() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "NaN cannot be converted to SQL_C_NUMERIC".to_string(),
+                    }
+                    .fail();
+                }
+                let target_scale = binding.scale.unwrap_or(0);
+                let abs_value = snowflake_value.abs();
+
+                let scale_factor = 10f64.powi(target_scale as i32);
+                let scaled = abs_value * scale_factor;
+                let int_scaled = scaled.trunc();
+                let was_truncated = scaled != int_scaled;
+
+                if int_scaled > u128::MAX as f64 {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!(
+                            "Value {snowflake_value} is out of range for SQL_C_NUMERIC"
+                        ),
+                    }
+                    .fail();
+                }
+
+                let magnitude = int_scaled as u128;
+                let numeric = sql::Numeric {
+                    precision: binding.precision.unwrap_or(38) as u8,
+                    scale: target_scale as i8,
+                    sign: if magnitude > 0 && snowflake_value.is_sign_negative() {
+                        0
+                    } else {
+                        1
+                    },
+                    val: magnitude.to_le_bytes(),
+                };
+
+                binding.write_fixed(numeric);
+                if was_truncated {
+                    Ok(vec![Warning::NumericValueTruncated])
+                } else {
+                    Ok(vec![])
+                }
+            }
+            CDataType::Char => {
+                let num_str = snowflake_value.to_string();
+                let warnings = binding.write_char_string(&num_str, get_data_offset);
+                if warnings
+                    .iter()
+                    .any(|w| matches!(w, Warning::StringDataTruncated))
+                {
+                    let whole_len = whole_digits_len(&num_str);
+                    if whole_len >= binding.buffer_length as usize {
+                        *get_data_offset = None;
+                        return NumericValueOutOfRangeSnafu {
+                            reason: format!(
+                                "Whole digits of '{num_str}' do not fit in buffer of {} bytes",
+                                binding.buffer_length
+                            ),
+                        }
+                        .fail();
+                    }
+                }
+                Ok(warnings)
+            }
+            CDataType::WChar => {
+                let num_str = snowflake_value.to_string();
+                let warnings = binding.write_wchar_string(&num_str, get_data_offset);
+                if warnings
+                    .iter()
+                    .any(|w| matches!(w, Warning::StringDataTruncated))
+                {
+                    let whole_len = whole_digits_len(&num_str);
+                    let wchar_capacity = (binding.buffer_length / 2) as usize;
+                    if whole_len >= wchar_capacity {
+                        *get_data_offset = None;
+                        return NumericValueOutOfRangeSnafu {
+                            reason: format!(
+                                "Whole digits of '{num_str}' do not fit in wchar buffer of {wchar_capacity} chars",
+                            ),
+                        }
+                        .fail();
+                    }
+                }
+                Ok(warnings)
+            }
+            CDataType::Binary => {
+                if snowflake_value.is_nan() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "NaN cannot be converted to SQL_C_BINARY".to_string(),
+                    }
+                    .fail();
+                }
+                let truncated = snowflake_value.trunc();
+                let abs_val = truncated.abs();
+                if abs_val > u128::MAX as f64 {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!("Value {snowflake_value} is out of range for SQL_C_BINARY"),
+                    }
+                    .fail();
+                }
+                let magnitude = abs_val as u128;
+                let numeric = sql::Numeric {
+                    precision: 38,
+                    scale: 0,
+                    sign: if magnitude > 0 && snowflake_value.is_sign_negative() {
+                        0
+                    } else {
+                        1
+                    },
+                    val: magnitude.to_le_bytes(),
+                };
+                let numeric_size = std::mem::size_of::<sql::Numeric>();
+                if (binding.buffer_length as usize) < numeric_size {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: format!(
+                            "Buffer size {} is too small for SQL_C_BINARY (need {numeric_size} bytes)",
+                            binding.buffer_length
+                        ),
+                    }
+                    .fail();
+                }
+                let numeric_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &numeric as *const sql::Numeric as *const u8,
+                        numeric_size,
+                    )
+                };
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        numeric_bytes.as_ptr(),
+                        binding.target_value_ptr as *mut u8,
+                        numeric_size,
+                    );
+                }
+                let _ = binding.write_length_or_null(
+                    crate::conversion::traits::LengthOrNull::Length(numeric_size as sql::Len),
+                );
+                Ok(fractional_warning(snowflake_value))
+            }
+            _ => UnsupportedOdbcTypeSnafu { target_type }.fail(),
         }
     }
 }

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -137,7 +137,8 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::SBigInt, &mut value, &mut str_len);
 
-        sr.write_odbc_type(123456789.9, &binding, &mut None).unwrap();
+        sr.write_odbc_type(123456789.9, &binding, &mut None)
+            .unwrap();
 
         assert_eq!(value, 123456789i64);
     }

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -192,6 +192,56 @@ mod tests {
         assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
 
+    #[test]
+    fn real_explicit_float_overflow_positive() {
+        let sr = make_real();
+        let mut value: f32 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(1e300, &binding, &mut None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn real_explicit_float_overflow_negative() {
+        let sr = make_real();
+        let mut value: f32 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(-1e300, &binding, &mut None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn real_explicit_float_max_succeeds() {
+        let sr = make_real();
+        let mut value: f32 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
+
+        let warnings = sr
+            .write_odbc_type(f32::MAX as f64, &binding, &mut None)
+            .unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(value, f32::MAX);
+    }
+
+    #[test]
+    fn real_explicit_float_just_above_max_fails() {
+        let sr = make_real();
+        let mut value: f32 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
+
+        // f32::MAX as f64 is 3.4028234663852886e+38; a value just above it
+        // is outside the f32 range per the ODBC spec even though IEEE 754
+        // rounding would round it back to FLT_MAX.
+        let just_above = (f32::MAX as f64) * (1.0 + f64::EPSILON);
+        assert!(sr.write_odbc_type(just_above, &binding, &mut None).is_err());
+    }
+
     // ======================================================================
     // Exact integer values — no truncation warning
     // ======================================================================
@@ -388,6 +438,170 @@ mod tests {
             (expected.len() * std::mem::size_of::<u16>()) as sql::Len
         );
         assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    // ======================================================================
+    // SQL_C_NUMERIC
+    // ======================================================================
+
+    fn binding_for_numeric(
+        value: &mut sql::Numeric,
+        str_len: &mut sql::Len,
+        precision: Option<i16>,
+        scale: Option<i16>,
+    ) -> Binding {
+        Binding {
+            target_type: CDataType::Numeric,
+            target_value_ptr: value as *mut sql::Numeric as sql::Pointer,
+            buffer_length: 0,
+            str_len_or_ind_ptr: str_len as *mut sql::Len,
+            precision,
+            scale,
+        }
+    }
+
+    #[test]
+    fn real_numeric_positive_integer() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(value.sign, 1);
+        assert_eq!(value.val[0], 42);
+        for i in 1..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    #[test]
+    fn real_numeric_negative_integer() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(-7.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(value.sign, 0);
+        assert_eq!(value.val[0], 7);
+        for i in 1..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    #[test]
+    fn real_numeric_zero() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(value.sign, 1);
+        for i in 0..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    #[test]
+    fn real_numeric_fractional_truncates_with_scale_zero() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(123.456, &binding, &mut None).unwrap();
+
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert_eq!(value.sign, 1);
+        assert_eq!(value.val[0], 123);
+        for i in 1..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    #[test]
+    fn real_numeric_with_scale() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, Some(10), Some(2));
+
+        let warnings = sr.write_odbc_type(12.5, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(value.sign, 1);
+        assert_eq!(value.scale, 2);
+        let stored = u128::from_le_bytes(value.val);
+        assert_eq!(stored, 1250);
+    }
+
+    #[test]
+    fn real_numeric_large_value() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(1000000.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(value.sign, 1);
+        let stored = u128::from_le_bytes(value.val);
+        assert_eq!(stored, 1000000);
+    }
+
+    #[test]
+    fn real_numeric_overflow_returns_error() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let result = sr.write_odbc_type(1e300, &binding, &mut None);
+        assert!(result.is_err());
     }
 
     // ======================================================================

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::conversion::WriteODBCType;
     use crate::conversion::real::SnowflakeReal;
     use crate::conversion::traits::Binding;
+    use crate::conversion::warning::Warning;
     use odbc_sys as sql;
 
     fn binding_for_value<T>(
@@ -36,9 +37,28 @@ mod tests {
         }
     }
 
+    fn binding_for_wchar_buffer(
+        target_type: CDataType,
+        buffer: &mut [u16],
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: (buffer.len() * 2) as sql::Len,
+            str_len_or_ind_ptr: str_len as *mut sql::Len,
+            precision: None,
+            scale: None,
+        }
+    }
+
     fn make_real() -> SnowflakeReal {
         SnowflakeReal
     }
+
+    // ======================================================================
+    // Default (SQL_C_DOUBLE) tests
+    // ======================================================================
 
     #[test]
     fn real_default_writes_positive_f64() {
@@ -103,7 +123,7 @@ mod tests {
     }
 
     // ======================================================================
-    // Explicit C types
+    // Explicit C types — basic
     // ======================================================================
 
     #[test]
@@ -125,9 +145,10 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
 
-        sr.write_odbc_type(42.7, &binding, &mut None).unwrap();
+        let warnings = sr.write_odbc_type(42.7, &binding, &mut None).unwrap();
 
         assert_eq!(value, 42);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
 
     #[test]
@@ -137,10 +158,12 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::SBigInt, &mut value, &mut str_len);
 
-        sr.write_odbc_type(123456789.9, &binding, &mut None)
+        let warnings = sr
+            .write_odbc_type(123456789.9, &binding, &mut None)
             .unwrap();
 
         assert_eq!(value, 123456789i64);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
 
     #[test]
@@ -150,9 +173,10 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::SShort, &mut value, &mut str_len);
 
-        sr.write_odbc_type(100.9, &binding, &mut None).unwrap();
+        let warnings = sr.write_odbc_type(100.9, &binding, &mut None).unwrap();
 
         assert_eq!(value, 100);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
 
     #[test]
@@ -162,34 +186,143 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::STinyInt, &mut value, &mut str_len);
 
-        sr.write_odbc_type(42.9, &binding, &mut None).unwrap();
+        let warnings = sr.write_odbc_type(42.9, &binding, &mut None).unwrap();
 
         assert_eq!(value, 42);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+    }
+
+    // ======================================================================
+    // Exact integer values — no truncation warning
+    // ======================================================================
+
+    #[test]
+    fn real_exact_integer_no_warning() {
+        let sr = make_real();
+        let mut value: i32 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+
+        let warnings = sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 42);
+        assert!(warnings.is_empty());
+    }
+
+    // ======================================================================
+    // SQL_C_BIT — full spec compliance
+    // ======================================================================
+
+    #[test]
+    fn real_explicit_bit_zero_succeeds() {
+        let sr = make_real();
+        let mut value: u8 = 99;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let warnings = sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 0);
+        assert!(warnings.is_empty());
     }
 
     #[test]
-    fn real_explicit_bit_writes_one_for_nonzero() {
+    fn real_explicit_bit_one_succeeds() {
         let sr = make_real();
         let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        sr.write_odbc_type(5.5, &binding, &mut None).unwrap();
+        let warnings = sr.write_odbc_type(1.0, &binding, &mut None).unwrap();
 
         assert_eq!(value, 1);
+        assert!(warnings.is_empty());
     }
 
     #[test]
-    fn real_explicit_bit_writes_zero_for_zero() {
+    fn real_explicit_bit_fractional_truncates() {
         let sr = make_real();
-        let mut value: u8 = 1;
+        let mut value: u8 = 99;
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+        let warnings = sr.write_odbc_type(0.5, &binding, &mut None).unwrap();
 
         assert_eq!(value, 0);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
+
+    #[test]
+    fn real_explicit_bit_above_range_errors() {
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(5.5, &binding, &mut None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn real_explicit_bit_negative_errors() {
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(-1.5, &binding, &mut None);
+        assert!(result.is_err());
+    }
+
+    // ======================================================================
+    // Overflow errors (22003)
+    // ======================================================================
+
+    #[test]
+    fn real_overflow_stinyint() {
+        let sr = make_real();
+        let mut value: i8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::STinyInt, &mut value, &mut str_len);
+
+        assert!(sr.write_odbc_type(128.0, &binding, &mut None).is_err());
+        assert!(sr.write_odbc_type(-129.0, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn real_overflow_utinyint_negative() {
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::UTinyInt, &mut value, &mut str_len);
+
+        assert!(sr.write_odbc_type(-1.0, &binding, &mut None).is_err());
+        assert!(sr.write_odbc_type(256.0, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn real_overflow_sshort() {
+        let sr = make_real();
+        let mut value: i16 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::SShort, &mut value, &mut str_len);
+
+        assert!(sr.write_odbc_type(32768.0, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn real_overflow_ulong_negative() {
+        let sr = make_real();
+        let mut value: u32 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::ULong, &mut value, &mut str_len);
+
+        assert!(sr.write_odbc_type(-1.0, &binding, &mut None).is_err());
+    }
+
+    // ======================================================================
+    // SQL_C_CHAR
+    // ======================================================================
 
     #[test]
     fn real_explicit_char_writes_string() {
@@ -235,6 +368,31 @@ mod tests {
         assert_eq!(&buffer[..expected.len()], expected);
         assert_eq!(buffer[expected.len()], 0);
     }
+
+    // ======================================================================
+    // SQL_C_WCHAR
+    // ======================================================================
+
+    #[test]
+    fn real_explicit_wchar_writes_string() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(3.125, &binding, &mut None).unwrap();
+
+        let expected: Vec<u16> = "3.125".encode_utf16().collect();
+        assert_eq!(
+            str_len,
+            (expected.len() * std::mem::size_of::<u16>()) as sql::Len
+        );
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    // ======================================================================
+    // Unsupported type
+    // ======================================================================
 
     #[test]
     fn real_unsupported_type_returns_error() {

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -21,6 +21,21 @@ mod tests {
         }
     }
 
+    fn binding_for_char_buffer(
+        target_type: CDataType,
+        buffer: &mut [u8],
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: buffer.len() as sql::Len,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
     fn make_real() -> SnowflakeReal {
         SnowflakeReal
     }
@@ -85,6 +100,139 @@ mod tests {
         sr.write_odbc_type(input, &binding, &mut None).unwrap();
 
         assert!((value - input).abs() < f64::EPSILON);
+    }
+
+    // ======================================================================
+    // Explicit C types
+    // ======================================================================
+
+    #[test]
+    fn real_explicit_float_writes_f32() {
+        let sr = make_real();
+        let mut value: f32 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
+
+        sr.write_odbc_type(3.125, &binding, &mut None).unwrap();
+
+        assert!((value - 3.125f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn real_explicit_slong_writes_i32() {
+        let sr = make_real();
+        let mut value: i32 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+
+        sr.write_odbc_type(42.7, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn real_explicit_sbigint_writes_i64() {
+        let sr = make_real();
+        let mut value: i64 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::SBigInt, &mut value, &mut str_len);
+
+        sr.write_odbc_type(123456789.9, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 123456789i64);
+    }
+
+    #[test]
+    fn real_explicit_sshort_writes_i16() {
+        let sr = make_real();
+        let mut value: i16 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::SShort, &mut value, &mut str_len);
+
+        sr.write_odbc_type(100.9, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 100);
+    }
+
+    #[test]
+    fn real_explicit_stinyint_writes_i8() {
+        let sr = make_real();
+        let mut value: i8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::STinyInt, &mut value, &mut str_len);
+
+        sr.write_odbc_type(42.9, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn real_explicit_bit_writes_one_for_nonzero() {
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        sr.write_odbc_type(5.5, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 1);
+    }
+
+    #[test]
+    fn real_explicit_bit_writes_zero_for_zero() {
+        let sr = make_real();
+        let mut value: u8 = 1;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 0);
+    }
+
+    #[test]
+    fn real_explicit_char_writes_string() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(3.125, &binding, &mut None).unwrap();
+
+        let expected = b"3.125";
+        assert_eq!(str_len, expected.len() as sql::Len);
+        assert_eq!(&buffer[..expected.len()], expected);
+        assert_eq!(buffer[expected.len()], 0);
+    }
+
+    #[test]
+    fn real_explicit_char_writes_negative_value() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(-99.5, &binding, &mut None).unwrap();
+
+        let expected = b"-99.5";
+        assert_eq!(str_len, expected.len() as sql::Len);
+        assert_eq!(&buffer[..expected.len()], expected);
+        assert_eq!(buffer[expected.len()], 0);
+    }
+
+    #[test]
+    fn real_explicit_char_writes_integer_value() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
+
+        let expected = b"42";
+        assert_eq!(str_len, expected.len() as sql::Len);
+        assert_eq!(&buffer[..expected.len()], expected);
+        assert_eq!(buffer[expected.len()], 0);
     }
 
     #[test]

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -1,0 +1,101 @@
+#[cfg(test)]
+mod tests {
+    use crate::cdata_types::CDataType;
+    use crate::conversion::WriteODBCType;
+    use crate::conversion::real::SnowflakeReal;
+    use crate::conversion::traits::Binding;
+    use odbc_sys as sql;
+
+    fn binding_for_value<T>(
+        target_type: CDataType,
+        value: &mut T,
+        str_len: &mut sql::Len,
+    ) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: value as *mut T as sql::Pointer,
+            buffer_length: 0,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
+    fn make_real() -> SnowflakeReal {
+        SnowflakeReal
+    }
+
+    #[test]
+    fn real_default_writes_positive_f64() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(3.125, &binding, &mut None).unwrap();
+
+        assert!((value - 3.125).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_negative_f64() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(-99.5, &binding, &mut None).unwrap();
+
+        assert!((value - (-99.5)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_zero() {
+        let sr = make_real();
+        let mut value: f64 = 1.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert!((value - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_very_small_value() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        let input = 1.23e-10;
+        sr.write_odbc_type(input, &binding, &mut None).unwrap();
+
+        assert!((value - input).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_default_writes_very_large_value() {
+        let sr = make_real();
+        let mut value: f64 = 0.0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+
+        let input = 1.23e+100;
+        sr.write_odbc_type(input, &binding, &mut None).unwrap();
+
+        assert!((value - input).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn real_unsupported_type_returns_error() {
+        let sr = make_real();
+        let mut value: i32 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Binary, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(1.0, &binding, &mut None);
+
+        assert!(result.is_err());
+    }
+}

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -942,6 +942,53 @@ mod tests {
         assert_eq!(u128::from_le_bytes(numeric.val), 1000000);
     }
 
+    #[test]
+    fn real_binary_large_positive_beyond_i64() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let large = 1e19_f64;
+        let warnings = sr.write_odbc_type(large, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 1);
+        assert_eq!(u128::from_le_bytes(numeric.val), large as u128);
+    }
+
+    #[test]
+    fn real_binary_large_negative_beyond_i64() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let large_neg = -1e19_f64;
+        let warnings = sr.write_odbc_type(large_neg, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 0);
+        assert_eq!(u128::from_le_bytes(numeric.val), large_neg.abs() as u128);
+    }
+
+    #[test]
+    fn real_binary_overflow_returns_error() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let result = sr.write_odbc_type(f64::MAX, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
     // ======================================================================
     // Multiple row indices
     // ======================================================================

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -46,9 +46,37 @@ mod tests {
             target_type,
             target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
             buffer_length: (buffer.len() * 2) as sql::Len,
-            str_len_or_ind_ptr: str_len as *mut sql::Len,
-            precision: None,
-            scale: None,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
+    fn binding_for_numeric(
+        value: &mut sql::Numeric,
+        str_len: &mut sql::Len,
+        precision: Option<i16>,
+        scale: Option<i16>,
+    ) -> Binding {
+        Binding {
+            target_type: CDataType::Numeric,
+            target_value_ptr: value as *mut sql::Numeric as sql::Pointer,
+            buffer_length: 0,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            precision,
+            scale,
+        }
+    }
+
+    fn binding_for_binary(buffer: &mut [u8], str_len: &mut sql::Len) -> Binding {
+        Binding {
+            target_type: CDataType::Binary,
+            target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+            buffer_length: buffer.len() as sql::Len,
+            octet_length_ptr: str_len as *mut sql::Len,
+            indicator_ptr: str_len as *mut sql::Len,
+            ..Default::default()
         }
     }
 
@@ -123,7 +151,154 @@ mod tests {
     }
 
     // ======================================================================
-    // Explicit C types — basic
+    // Integer conversions — macro-based comprehensive tests
+    // Pattern from number_tests.rs: value, expected, truncation warning
+    // ======================================================================
+
+    macro_rules! real_integer_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $input:expr => $expected:expr, truncated=$trunc:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sr = make_real();
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    let warnings = sr.write_odbc_type($input, &binding, &mut None).unwrap();
+                    assert_eq!(value, $expected as $rust_type,
+                        "value mismatch: expected {}, got {}", $expected, value);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
+                }
+            )*
+        };
+    }
+
+    real_integer_tests! {
+        // SQL_C_SLONG / SQL_C_LONG — basic
+        slong_positive:             CDataType::SLong,    i32, 42.0    => 42,    truncated=false;
+        slong_negative:             CDataType::SLong,    i32, -42.0   => -42,   truncated=false;
+        slong_zero:                 CDataType::SLong,    i32, 0.0     => 0,     truncated=false;
+        slong_one:                  CDataType::SLong,    i32, 1.0     => 1,     truncated=false;
+        slong_neg_one:              CDataType::SLong,    i32, -1.0    => -1,    truncated=false;
+        slong_truncates_frac:       CDataType::SLong,    i32, 42.7    => 42,    truncated=true;
+        slong_truncates_neg_frac:   CDataType::SLong,    i32, -42.9   => -42,   truncated=true;
+        long_positive:              CDataType::Long,     i32, 42.0    => 42,    truncated=false;
+
+        // SQL_C_SLONG boundaries
+        slong_i32_max:              CDataType::SLong,    i32, 2_147_483_647.0   => 2_147_483_647i32,  truncated=false;
+        slong_i32_min:              CDataType::SLong,    i32, -2_147_483_648.0  => -2_147_483_648i32, truncated=false;
+
+        // SQL_C_ULONG
+        ulong_positive:             CDataType::ULong,    u32, 42.0    => 42u32,  truncated=false;
+        ulong_zero:                 CDataType::ULong,    u32, 0.0     => 0u32,   truncated=false;
+        ulong_truncates_frac:       CDataType::ULong,    u32, 42.9    => 42u32,  truncated=true;
+
+        // SQL_C_SSHORT / SQL_C_SHORT
+        sshort_positive:            CDataType::SShort,   i16, 100.0   => 100i16,  truncated=false;
+        sshort_negative:            CDataType::SShort,   i16, -100.0  => -100i16, truncated=false;
+        sshort_zero:                CDataType::SShort,   i16, 0.0     => 0i16,    truncated=false;
+        sshort_truncates_frac:      CDataType::SShort,   i16, 100.9   => 100i16,  truncated=true;
+        short_positive:             CDataType::Short,    i16, 300.0   => 300i16,  truncated=false;
+
+        // SQL_C_SSHORT boundaries
+        sshort_i16_max:             CDataType::SShort,   i16, 32767.0    => 32767i16,  truncated=false;
+        sshort_i16_min:             CDataType::SShort,   i16, -32768.0   => -32768i16, truncated=false;
+
+        // SQL_C_USHORT
+        ushort_positive:            CDataType::UShort,   u16, 300.0   => 300u16,   truncated=false;
+        ushort_zero:                CDataType::UShort,   u16, 0.0     => 0u16,     truncated=false;
+        ushort_truncates_frac:      CDataType::UShort,   u16, 300.9   => 300u16,   truncated=true;
+        ushort_u16_max:             CDataType::UShort,   u16, 65535.0 => 65535u16, truncated=false;
+
+        // SQL_C_STINYINT / SQL_C_TINYINT
+        stinyint_positive:          CDataType::STinyInt, i8, 42.0     => 42i8,    truncated=false;
+        stinyint_negative:          CDataType::STinyInt, i8, -42.0    => -42i8,   truncated=false;
+        stinyint_zero:              CDataType::STinyInt, i8, 0.0      => 0i8,     truncated=false;
+        stinyint_truncates_frac:    CDataType::STinyInt, i8, 42.9     => 42i8,    truncated=true;
+        tinyint_positive:           CDataType::TinyInt,  i8, 42.0     => 42i8,    truncated=false;
+
+        // SQL_C_STINYINT boundaries
+        stinyint_i8_max:            CDataType::STinyInt, i8, 127.0    => 127i8,   truncated=false;
+        stinyint_i8_min:            CDataType::STinyInt, i8, -128.0   => -128i8,  truncated=false;
+
+        // SQL_C_UTINYINT
+        utinyint_positive:          CDataType::UTinyInt, u8, 42.0     => 42u8,    truncated=false;
+        utinyint_zero:              CDataType::UTinyInt, u8, 0.0      => 0u8,     truncated=false;
+        utinyint_truncates_frac:    CDataType::UTinyInt, u8, 42.9     => 42u8,    truncated=true;
+        utinyint_u8_max:            CDataType::UTinyInt, u8, 255.0    => 255u8,   truncated=false;
+
+        // SQL_C_SBIGINT
+        sbigint_positive:           CDataType::SBigInt,  i64, 123456789.0     => 123456789i64,   truncated=false;
+        sbigint_negative:           CDataType::SBigInt,  i64, -123456789.0    => -123456789i64,  truncated=false;
+        sbigint_zero:               CDataType::SBigInt,  i64, 0.0            => 0i64,           truncated=false;
+        sbigint_truncates_frac:     CDataType::SBigInt,  i64, 123456789.9    => 123456789i64,   truncated=true;
+
+        // SQL_C_UBIGINT
+        ubigint_positive:           CDataType::UBigInt,  u64, 123456789.0     => 123456789u64,   truncated=false;
+        ubigint_zero:               CDataType::UBigInt,  u64, 0.0            => 0u64,           truncated=false;
+        ubigint_truncates_frac:     CDataType::UBigInt,  u64, 123456789.9    => 123456789u64,   truncated=true;
+    }
+
+    // ======================================================================
+    // Integer conversions — overflow error cases (SQLSTATE 22003)
+    // ======================================================================
+
+    macro_rules! real_overflow_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $input:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sr = make_real();
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    assert!(sr.write_odbc_type($input, &binding, &mut None).is_err());
+                }
+            )*
+        };
+    }
+
+    real_overflow_tests! {
+        // i32 overflow
+        slong_overflow_above:           CDataType::SLong,    i32, 2_147_483_648.0;
+        slong_overflow_below:           CDataType::SLong,    i32, -2_147_483_649.0;
+
+        // u32 overflow
+        ulong_overflow_above:           CDataType::ULong,    u32, 4_294_967_296.0;
+        ulong_overflow_negative:        CDataType::ULong,    u32, -1.0;
+
+        // i16 overflow
+        sshort_overflow_above:          CDataType::SShort,   i16, 32768.0;
+        sshort_overflow_below:          CDataType::SShort,   i16, -32769.0;
+
+        // u16 overflow
+        ushort_overflow_above:          CDataType::UShort,   u16, 65536.0;
+        ushort_overflow_negative:       CDataType::UShort,   u16, -1.0;
+
+        // i8 overflow
+        stinyint_overflow_above:        CDataType::STinyInt, i8,  128.0;
+        stinyint_overflow_below:        CDataType::STinyInt, i8,  -129.0;
+
+        // u8 overflow
+        utinyint_overflow_above:        CDataType::UTinyInt, u8,  256.0;
+        utinyint_overflow_negative:     CDataType::UTinyInt, u8,  -1.0;
+
+        // i64 overflow
+        sbigint_overflow_above:         CDataType::SBigInt,  i64, 1e19;
+        sbigint_overflow_below:         CDataType::SBigInt,  i64, -1e19;
+
+        // u64 overflow
+        ubigint_overflow_above:         CDataType::UBigInt,  u64, 1e20;
+        ubigint_overflow_negative:      CDataType::UBigInt,  u64, -1.0;
+
+        // Fractional value above boundary still overflows
+        stinyint_frac_overflow:         CDataType::STinyInt, i8,  128.1;
+    }
+
+    // ======================================================================
+    // SQL_C_FLOAT — explicit tests
     // ======================================================================
 
     #[test]
@@ -139,57 +314,27 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_slong_writes_i32() {
+    fn real_explicit_float_negative() {
         let sr = make_real();
-        let mut value: i32 = 0;
+        let mut value: f32 = 0.0;
         let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
 
-        let warnings = sr.write_odbc_type(42.7, &binding, &mut None).unwrap();
+        sr.write_odbc_type(-99.5, &binding, &mut None).unwrap();
 
-        assert_eq!(value, 42);
-        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert!((value - (-99.5f32)).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn real_explicit_sbigint_writes_i64() {
+    fn real_explicit_float_zero() {
         let sr = make_real();
-        let mut value: i64 = 0;
+        let mut value: f32 = 1.0;
         let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SBigInt, &mut value, &mut str_len);
+        let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
 
-        let warnings = sr
-            .write_odbc_type(123456789.9, &binding, &mut None)
-            .unwrap();
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
 
-        assert_eq!(value, 123456789i64);
-        assert!(warnings.contains(&Warning::NumericValueTruncated));
-    }
-
-    #[test]
-    fn real_explicit_sshort_writes_i16() {
-        let sr = make_real();
-        let mut value: i16 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SShort, &mut value, &mut str_len);
-
-        let warnings = sr.write_odbc_type(100.9, &binding, &mut None).unwrap();
-
-        assert_eq!(value, 100);
-        assert!(warnings.contains(&Warning::NumericValueTruncated));
-    }
-
-    #[test]
-    fn real_explicit_stinyint_writes_i8() {
-        let sr = make_real();
-        let mut value: i8 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::STinyInt, &mut value, &mut str_len);
-
-        let warnings = sr.write_odbc_type(42.9, &binding, &mut None).unwrap();
-
-        assert_eq!(value, 42);
-        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert_eq!(value, 0.0f32);
     }
 
     #[test]
@@ -199,8 +344,7 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
 
-        let result = sr.write_odbc_type(1e300, &binding, &mut None);
-        assert!(result.is_err());
+        assert!(sr.write_odbc_type(1e300, &binding, &mut None).is_err());
     }
 
     #[test]
@@ -210,8 +354,7 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
 
-        let result = sr.write_odbc_type(-1e300, &binding, &mut None);
-        assert!(result.is_err());
+        assert!(sr.write_odbc_type(-1e300, &binding, &mut None).is_err());
     }
 
     #[test]
@@ -235,28 +378,8 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Float, &mut value, &mut str_len);
 
-        // f32::MAX as f64 is 3.4028234663852886e+38; a value just above it
-        // is outside the f32 range per the ODBC spec even though IEEE 754
-        // rounding would round it back to FLT_MAX.
         let just_above = (f32::MAX as f64) * (1.0 + f64::EPSILON);
         assert!(sr.write_odbc_type(just_above, &binding, &mut None).is_err());
-    }
-
-    // ======================================================================
-    // Exact integer values — no truncation warning
-    // ======================================================================
-
-    #[test]
-    fn real_exact_integer_no_warning() {
-        let sr = make_real();
-        let mut value: i32 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
-
-        let warnings = sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
-
-        assert_eq!(value, 42);
-        assert!(warnings.is_empty());
     }
 
     // ======================================================================
@@ -264,7 +387,7 @@ mod tests {
     // ======================================================================
 
     #[test]
-    fn real_explicit_bit_zero_succeeds() {
+    fn real_bit_zero_succeeds() {
         let sr = make_real();
         let mut value: u8 = 99;
         let mut str_len: sql::Len = 0;
@@ -277,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_bit_one_succeeds() {
+    fn real_bit_one_succeeds() {
         let sr = make_real();
         let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
@@ -290,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_bit_fractional_truncates() {
+    fn real_bit_fractional_truncates_to_zero() {
         let sr = make_real();
         let mut value: u8 = 99;
         let mut str_len: sql::Len = 0;
@@ -303,79 +426,54 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_bit_above_range_errors() {
+    fn real_bit_fractional_truncates_to_one() {
         let sr = make_real();
         let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        let result = sr.write_odbc_type(5.5, &binding, &mut None);
-        assert!(result.is_err());
+        let warnings = sr.write_odbc_type(1.5, &binding, &mut None).unwrap();
+
+        assert_eq!(value, 1);
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
     }
 
     #[test]
-    fn real_explicit_bit_negative_errors() {
+    fn real_bit_above_range_errors() {
         let sr = make_real();
         let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
         let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        let result = sr.write_odbc_type(-1.5, &binding, &mut None);
-        assert!(result.is_err());
-    }
-
-    // ======================================================================
-    // Overflow errors (22003)
-    // ======================================================================
-
-    #[test]
-    fn real_overflow_stinyint() {
-        let sr = make_real();
-        let mut value: i8 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::STinyInt, &mut value, &mut str_len);
-
-        assert!(sr.write_odbc_type(128.0, &binding, &mut None).is_err());
-        assert!(sr.write_odbc_type(-129.0, &binding, &mut None).is_err());
+        assert!(sr.write_odbc_type(5.5, &binding, &mut None).is_err());
     }
 
     #[test]
-    fn real_overflow_utinyint_negative() {
+    fn real_bit_negative_errors() {
         let sr = make_real();
         let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::UTinyInt, &mut value, &mut str_len);
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        assert!(sr.write_odbc_type(-1.0, &binding, &mut None).is_err());
-        assert!(sr.write_odbc_type(256.0, &binding, &mut None).is_err());
+        assert!(sr.write_odbc_type(-1.5, &binding, &mut None).is_err());
     }
 
     #[test]
-    fn real_overflow_sshort() {
+    fn real_bit_large_positive_errors() {
         let sr = make_real();
-        let mut value: i16 = 0;
+        let mut value: u8 = 0;
         let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SShort, &mut value, &mut str_len);
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
 
-        assert!(sr.write_odbc_type(32768.0, &binding, &mut None).is_err());
-    }
-
-    #[test]
-    fn real_overflow_ulong_negative() {
-        let sr = make_real();
-        let mut value: u32 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::ULong, &mut value, &mut str_len);
-
-        assert!(sr.write_odbc_type(-1.0, &binding, &mut None).is_err());
+        assert!(sr.write_odbc_type(100.0, &binding, &mut None).is_err());
     }
 
     // ======================================================================
-    // SQL_C_CHAR
+    // SQL_C_CHAR — string conversion
     // ======================================================================
 
     #[test]
-    fn real_explicit_char_writes_string() {
+    fn real_char_positive() {
         let sr = make_real();
         let mut buffer = vec![0u8; 32];
         let mut str_len: sql::Len = 0;
@@ -390,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_char_writes_negative_value() {
+    fn real_char_negative() {
         let sr = make_real();
         let mut buffer = vec![0u8; 32];
         let mut str_len: sql::Len = 0;
@@ -405,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn real_explicit_char_writes_integer_value() {
+    fn real_char_integer_value() {
         let sr = make_real();
         let mut buffer = vec![0u8; 32];
         let mut str_len: sql::Len = 0;
@@ -419,12 +517,52 @@ mod tests {
         assert_eq!(buffer[expected.len()], 0);
     }
 
+    #[test]
+    fn real_char_zero() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        let expected = b"0";
+        assert_eq!(str_len, expected.len() as sql::Len);
+        assert_eq!(&buffer[..expected.len()], expected);
+    }
+
+    #[test]
+    fn real_char_fractional_only_truncation_returns_01004() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 4]; // "7.98765" → whole digits "7" (1 char), fits in 4-byte buffer
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(7.98765, &binding, &mut None).unwrap();
+
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    #[test]
+    fn real_char_whole_digits_lost_returns_22003() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 4]; // "123456.789" → whole digits "123456" (6 chars), doesn't fit in 4-byte buffer
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+
+        assert!(sr.write_odbc_type(123456.789, &binding, &mut None).is_err());
+    }
+
     // ======================================================================
-    // SQL_C_WCHAR
+    // SQL_C_WCHAR — wide string conversion
     // ======================================================================
 
     #[test]
-    fn real_explicit_wchar_writes_string() {
+    fn real_wchar_positive() {
         let sr = make_real();
         let mut buffer = vec![0u16; 32];
         let mut str_len: sql::Len = 0;
@@ -440,25 +578,86 @@ mod tests {
         assert_eq!(&buffer[..expected.len()], &expected[..]);
     }
 
+    #[test]
+    fn real_wchar_negative() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(-99.5, &binding, &mut None).unwrap();
+
+        let expected: Vec<u16> = "-99.5".encode_utf16().collect();
+        assert_eq!(
+            str_len,
+            (expected.len() * std::mem::size_of::<u16>()) as sql::Len
+        );
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    #[test]
+    fn real_wchar_zero() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        let expected: Vec<u16> = "0".encode_utf16().collect();
+        assert_eq!(
+            str_len,
+            (expected.len() * std::mem::size_of::<u16>()) as sql::Len
+        );
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    #[test]
+    fn real_wchar_integer() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
+
+        let expected: Vec<u16> = "42".encode_utf16().collect();
+        assert_eq!(
+            str_len,
+            (expected.len() * std::mem::size_of::<u16>()) as sql::Len
+        );
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    #[test]
+    fn real_wchar_fractional_only_truncation_returns_01004() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 4]; // "7.98765" → whole digits "7" (1 char), fits in 4-wchar buffer
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(7.98765, &binding, &mut None).unwrap();
+
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    #[test]
+    fn real_wchar_whole_digits_lost_returns_22003() {
+        let sr = make_real();
+        let mut buffer = vec![0u16; 4]; // "123456.789" → whole digits "123456" (6 chars), doesn't fit in 4-wchar buffer
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(CDataType::WChar, &mut buffer, &mut str_len);
+
+        assert!(sr.write_odbc_type(123456.789, &binding, &mut None).is_err());
+    }
+
     // ======================================================================
     // SQL_C_NUMERIC
     // ======================================================================
-
-    fn binding_for_numeric(
-        value: &mut sql::Numeric,
-        str_len: &mut sql::Len,
-        precision: Option<i16>,
-        scale: Option<i16>,
-    ) -> Binding {
-        Binding {
-            target_type: CDataType::Numeric,
-            target_value_ptr: value as *mut sql::Numeric as sql::Pointer,
-            buffer_length: 0,
-            str_len_or_ind_ptr: str_len as *mut sql::Len,
-            precision,
-            scale,
-        }
-    }
 
     #[test]
     fn real_numeric_positive_integer() {
@@ -476,10 +675,7 @@ mod tests {
 
         assert!(warnings.is_empty());
         assert_eq!(value.sign, 1);
-        assert_eq!(value.val[0], 42);
-        for i in 1..16 {
-            assert_eq!(value.val[i], 0);
-        }
+        assert_eq!(u128::from_le_bytes(value.val), 42);
     }
 
     #[test]
@@ -498,10 +694,7 @@ mod tests {
 
         assert!(warnings.is_empty());
         assert_eq!(value.sign, 0);
-        assert_eq!(value.val[0], 7);
-        for i in 1..16 {
-            assert_eq!(value.val[i], 0);
-        }
+        assert_eq!(u128::from_le_bytes(value.val), 7);
     }
 
     #[test]
@@ -520,9 +713,7 @@ mod tests {
 
         assert!(warnings.is_empty());
         assert_eq!(value.sign, 1);
-        for i in 0..16 {
-            assert_eq!(value.val[i], 0);
-        }
+        assert_eq!(u128::from_le_bytes(value.val), 0);
     }
 
     #[test]
@@ -541,14 +732,11 @@ mod tests {
 
         assert!(warnings.contains(&Warning::NumericValueTruncated));
         assert_eq!(value.sign, 1);
-        assert_eq!(value.val[0], 123);
-        for i in 1..16 {
-            assert_eq!(value.val[i], 0);
-        }
+        assert_eq!(u128::from_le_bytes(value.val), 123);
     }
 
     #[test]
-    fn real_numeric_with_scale() {
+    fn real_numeric_with_explicit_scale() {
         let sr = make_real();
         let mut value = sql::Numeric {
             precision: 0,
@@ -564,8 +752,7 @@ mod tests {
         assert!(warnings.is_empty());
         assert_eq!(value.sign, 1);
         assert_eq!(value.scale, 2);
-        let stored = u128::from_le_bytes(value.val);
-        assert_eq!(stored, 1250);
+        assert_eq!(u128::from_le_bytes(value.val), 1250);
     }
 
     #[test]
@@ -584,8 +771,7 @@ mod tests {
 
         assert!(warnings.is_empty());
         assert_eq!(value.sign, 1);
-        let stored = u128::from_le_bytes(value.val);
-        assert_eq!(stored, 1000000);
+        assert_eq!(u128::from_le_bytes(value.val), 1000000);
     }
 
     #[test]
@@ -600,8 +786,178 @@ mod tests {
         let mut str_len: sql::Len = 0;
         let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
 
-        let result = sr.write_odbc_type(1e300, &binding, &mut None);
-        assert!(result.is_err());
+        assert!(sr.write_odbc_type(1e300, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn real_numeric_negative_fractional() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(-99.9, &binding, &mut None).unwrap();
+
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert_eq!(value.sign, 0);
+        assert_eq!(u128::from_le_bytes(value.val), 99);
+    }
+
+    #[test]
+    fn real_numeric_val_255_single_byte() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        sr.write_odbc_type(255.0, &binding, &mut None).unwrap();
+
+        assert_eq!(value.val[0], 255);
+        for i in 1..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    #[test]
+    fn real_numeric_val_256_spans_two_bytes() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        sr.write_odbc_type(256.0, &binding, &mut None).unwrap();
+
+        assert_eq!(value.val[0], 0);
+        assert_eq!(value.val[1], 1);
+        for i in 2..16 {
+            assert_eq!(value.val[i], 0);
+        }
+    }
+
+    // ======================================================================
+    // SQL_C_BINARY — new conversion (per ODBC matrix)
+    // Writes SQL_NUMERIC_STRUCT into the binary buffer, same pattern as NUMBER.
+    // ======================================================================
+
+    #[test]
+    fn real_binary_positive_integer() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(42.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, std::mem::size_of::<sql::Numeric>() as sql::Len);
+
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 1);
+        assert_eq!(u128::from_le_bytes(numeric.val), 42);
+    }
+
+    #[test]
+    fn real_binary_negative_integer() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(-7.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 0);
+        assert_eq!(u128::from_le_bytes(numeric.val), 7);
+    }
+
+    #[test]
+    fn real_binary_zero() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(0.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 1);
+        assert_eq!(u128::from_le_bytes(numeric.val), 0);
+    }
+
+    #[test]
+    fn real_binary_fractional_truncates() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(42.9, &binding, &mut None).unwrap();
+
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 1);
+        assert_eq!(u128::from_le_bytes(numeric.val), 42);
+    }
+
+    #[test]
+    fn real_binary_buffer_too_small_returns_error() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; 4]; // too small for SQL_NUMERIC_STRUCT
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        assert!(sr.write_odbc_type(42.0, &binding, &mut None).is_err());
+    }
+
+    #[test]
+    fn real_binary_exact_size_succeeds() {
+        let sr = make_real();
+        let numeric_size = std::mem::size_of::<sql::Numeric>();
+        let mut buffer = vec![0u8; numeric_size];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(1000000.0, &binding, &mut None).unwrap();
+
+        assert!(warnings.is_empty());
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(numeric.sign, 1);
+        assert_eq!(u128::from_le_bytes(numeric.val), 1000000);
+    }
+
+    // ======================================================================
+    // Multiple row indices
+    // ======================================================================
+
+    #[test]
+    fn real_reads_from_different_indices() {
+        use crate::conversion::ReadArrowType;
+        use arrow::array::Float64Array;
+
+        let sr = make_real();
+        let array = Float64Array::from(vec![1.1, 2.2, 3.3]);
+
+        for (idx, expected) in [(0, 1.1), (1, 2.2), (2, 3.3)] {
+            let value: f64 = sr.read_arrow_type(&array, idx).unwrap();
+            assert!((value - expected).abs() < f64::EPSILON);
+        }
     }
 
     // ======================================================================
@@ -613,10 +969,8 @@ mod tests {
         let sr = make_real();
         let mut value: i32 = 0;
         let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::Binary, &mut value, &mut str_len);
+        let binding = binding_for_value(CDataType::TypeDate, &mut value, &mut str_len);
 
-        let result = sr.write_odbc_type(1.0, &binding, &mut None);
-
-        assert!(result.is_err());
+        assert!(sr.write_odbc_type(1.0, &binding, &mut None).is_err());
     }
 }

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -1008,6 +1008,225 @@ mod tests {
     }
 
     // ======================================================================
+    // BIT — negative fractional values must error (22003)
+    // ======================================================================
+
+    #[test]
+    fn real_bit_negative_fraction_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(-0.5, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn real_bit_negative_tiny_fraction_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(-0.001, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn real_bit_nan_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(f64::NAN, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn real_bit_infinity_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+
+        let result = sr.write_odbc_type(f64::INFINITY, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    // ======================================================================
+    // NaN — must error for all integer types (22003)
+    // ======================================================================
+
+    macro_rules! nan_integer_error_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    use crate::conversion::error::WriteOdbcError;
+                    let sr = make_real();
+                    let mut value: $rust_type = 0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    let result = sr.write_odbc_type(f64::NAN, &binding, &mut None);
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        WriteOdbcError::NumericValueOutOfRange { .. }
+                    ));
+                }
+            )*
+        };
+    }
+
+    nan_integer_error_tests! {
+        nan_to_short_errors:    CDataType::Short,    i16;
+        nan_to_ushort_errors:   CDataType::UShort,   u16;
+        nan_to_tinyint_errors:  CDataType::TinyInt,  i8;
+        nan_to_utinyint_errors: CDataType::UTinyInt,  u8;
+        nan_to_long_errors:     CDataType::Long,     i32;
+        nan_to_ulong_errors:    CDataType::ULong,    u32;
+        nan_to_sbigint_errors:  CDataType::SBigInt,  i64;
+        nan_to_ubigint_errors:  CDataType::UBigInt,  u64;
+    }
+
+    // ======================================================================
+    // NaN — must error for Numeric and Binary (22003)
+    // ======================================================================
+
+    #[test]
+    fn nan_to_numeric_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0u8; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let result = sr.write_odbc_type(f64::NAN, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn nan_to_binary_errors() {
+        use crate::conversion::error::WriteOdbcError;
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let result = sr.write_odbc_type(f64::NAN, &binding, &mut None);
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteOdbcError::NumericValueOutOfRange { .. }
+        ));
+    }
+
+    // ======================================================================
+    // Negative zero — Numeric and Binary must produce sign=1 (positive)
+    // when magnitude is zero
+    // ======================================================================
+
+    #[test]
+    fn numeric_negative_fraction_no_negative_zero() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0u8; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(-0.5, &binding, &mut None).unwrap();
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert_eq!(
+            value.sign, 1,
+            "sign must be positive when magnitude is zero"
+        );
+        assert_eq!(u128::from_le_bytes(value.val), 0);
+    }
+
+    #[test]
+    fn numeric_negative_tiny_fraction_no_negative_zero() {
+        let sr = make_real();
+        let mut value = sql::Numeric {
+            precision: 0,
+            scale: 0,
+            sign: 0,
+            val: [0u8; 16],
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_numeric(&mut value, &mut str_len, None, None);
+
+        let warnings = sr.write_odbc_type(-0.001, &binding, &mut None).unwrap();
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        assert_eq!(
+            value.sign, 1,
+            "sign must be positive when magnitude is zero"
+        );
+        assert_eq!(u128::from_le_bytes(value.val), 0);
+    }
+
+    #[test]
+    fn binary_negative_fraction_no_negative_zero() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(-0.5, &binding, &mut None).unwrap();
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(
+            numeric.sign, 1,
+            "sign must be positive when magnitude is zero"
+        );
+        assert_eq!(u128::from_le_bytes(numeric.val), 0);
+    }
+
+    #[test]
+    fn binary_negative_tiny_fraction_no_negative_zero() {
+        let sr = make_real();
+        let mut buffer = vec![0u8; std::mem::size_of::<sql::Numeric>()];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_binary(&mut buffer, &mut str_len);
+
+        let warnings = sr.write_odbc_type(-0.001, &binding, &mut None).unwrap();
+        assert!(warnings.contains(&Warning::NumericValueTruncated));
+        let numeric: &sql::Numeric = unsafe { &*(buffer.as_ptr() as *const sql::Numeric) };
+        assert_eq!(
+            numeric.sign, 1,
+            "sign must be positive when magnitude is zero"
+        );
+        assert_eq!(u128::from_le_bytes(numeric.val), 0);
+    }
+
+    // ======================================================================
     // Unsupported type
     // ======================================================================
 

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -160,3 +160,19 @@ behavior_differences:
       Impact: Applications that previously received 0 for NaN inputs to integer types
       will now receive an error. This is a spec-compliance improvement.
       TODO: To be fixed in old driver
+
+  19:
+    name: "SQL_C_NUMERIC produces negative zero for FLOAT values like -0.5 that truncate to zero magnitude"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_NUMERIC on a FLOAT/DOUBLE
+      column containing a negative fractional value whose integer part is zero
+      (e.g. -0.5, -0.001), the old driver returns sign=0 (negative) with val=0.
+      This produces a "negative zero" in the SQL_NUMERIC_STRUCT, which is not a
+      meaningful numeric representation.
+      NEW driver: Returns sign=1 (positive) when the magnitude is zero, regardless
+      of the original float's sign. The sign is derived from the computed magnitude
+      rather than the source value, preventing negative zero.
+      Impact: Applications converting negative fractional FLOAT values to
+      SQL_C_NUMERIC will now receive a well-formed positive zero instead of a
+      semantically invalid negative zero.
+      TODO: To be fixed in old driver

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -126,6 +126,7 @@ behavior_differences:
       receive a standards-compliant SQL_NUMERIC_STRUCT instead of raw double bytes.
       Related: BD#12 (same issue for DECIMAL/NUMERIC columns).
       TODO: To be fixed in old driver
+
   17:
     name: "SQL_C_CHAR with small buffer on FLOAT columns returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO"
     description: |

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -141,3 +141,22 @@ behavior_differences:
       DECIMAL/NUMERIC columns where the old driver returns SQL_SUCCESS (too lenient)
       rather than SQL_ERROR (too strict as seen here for FLOAT).
       TODO: To be fixed in old driver
+
+  18:
+    name: "NaN FLOAT value silently converts to 0 for integer and BIT targets instead of returning 22003"
+    description: |
+      OLD driver: When SQLGetData is called on a FLOAT/DOUBLE column containing NaN
+      with an integer target type (SQL_C_SLONG, SQL_C_ULONG, SQL_C_SHORT, SQL_C_USHORT,
+      SQL_C_STINYINT, SQL_C_UTINYINT, SQL_C_SBIGINT, SQL_C_UBIGINT) or SQL_C_BIT,
+      the old driver returns SQL_SUCCESS_WITH_INFO and silently writes 0 to the output
+      buffer. This happens because NaN comparisons always return false, so range checks
+      pass, and the cast produces 0.
+      NEW driver: Returns SQL_ERROR with SQLSTATE 22003 (Numeric value out of range).
+      NaN is not a representable numeric value and cannot be meaningfully converted to
+      any integer or BIT type.
+      Note: Both drivers correctly reject NaN for SQL_C_NUMERIC (returning 22003) and
+      both correctly produce the string "NaN" for SQL_C_CHAR. The discrepancy is limited
+      to integer and BIT targets.
+      Impact: Applications that previously received 0 for NaN inputs to integer types
+      will now receive an error. This is a spec-compliance improvement.
+      TODO: To be fixed in old driver

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -109,3 +109,34 @@ behavior_differences:
       now see the correct precision and scale in the output struct, matching
       the ODBC specification behavior.
       TODO: To be fixed in old driver
+
+  16:
+    name: "SQL_C_BINARY on FLOAT/DOUBLE/REAL columns returns raw f64 bytes instead of SQL_NUMERIC_STRUCT"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_BINARY on a SQL_DOUBLE
+      (FLOAT/DOUBLE/REAL) column, the old driver returns the raw 8-byte IEEE 754
+      double representation. The indicator is set to 8 and the buffer contents
+      are not interpretable as an SQL_NUMERIC_STRUCT.
+      NEW driver: Returns a 19-byte SQL_NUMERIC_STRUCT as required by the ODBC
+      specification, with precision=38, scale=0 (integer part after truncation),
+      sign (1 positive, 0 negative), and val[16] containing the unsigned magnitude
+      in little-endian 128-bit format. The indicator is set to sizeof(SQL_NUMERIC_STRUCT).
+      Fractional values produce SQL_SUCCESS_WITH_INFO with SQLSTATE 01S07.
+      Impact: Applications requesting SQL_C_BINARY for floating-point columns now
+      receive a standards-compliant SQL_NUMERIC_STRUCT instead of raw double bytes.
+      Related: BD#12 (same issue for DECIMAL/NUMERIC columns).
+      TODO: To be fixed in old driver
+  17:
+    name: "SQL_C_CHAR with small buffer on FLOAT columns returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO"
+    description: |
+      OLD driver: When SQLGetData is called with SQL_C_CHAR on a FLOAT/DOUBLE/REAL
+      column and the buffer is too small to hold the full string representation,
+      the old driver returns SQL_ERROR.
+      NEW driver: Returns SQL_SUCCESS_WITH_INFO with SQLSTATE 01004 (String data,
+      right truncation), per the ODBC specification for string data truncation.
+      Impact: Applications providing small buffers for SQL_C_CHAR on FLOAT columns
+      will now receive a truncated result with a warning instead of an error.
+      Note: This is distinct from BD#11, which covers the same scenario for
+      DECIMAL/NUMERIC columns where the old driver returns SQL_SUCCESS (too lenient)
+      rather than SQL_ERROR (too strict as seen here for FLOAT).
+      TODO: To be fixed in old driver

--- a/odbc_tests/common/include/conversion_checks.hpp
+++ b/odbc_tests/common/include/conversion_checks.hpp
@@ -103,6 +103,14 @@ static void check_interval_precision_lost(const StatementHandleWrapper& stmt, in
   CHECK(records[0].sqlState == "22015");
 }
 
+inline void check_null_via_get_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT c_type) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, c_type, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == SQL_NULL_DATA);
+}
+
 inline std::string check_char_success(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
   char buffer[8192];
   SQLLEN indicator = -999;

--- a/odbc_tests/tests/datatype_tests/CMakeLists.txt
+++ b/odbc_tests/tests/datatype_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 4.0)
 
 add_odbc_test(string_tests string_tests.cpp)
-add_odbc_test(number_tests number_tests.cpp)
+add_odbc_test(number_tests number_tests.cpp real_tests.cpp)

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -60,14 +60,6 @@ void check_integer_columns(const StatementHandleWrapper& stmt, const std::vector
   }
 }
 
-inline void check_null_via_get_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT c_type) {
-  char buffer[100] = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, c_type, buffer, sizeof(buffer), &indicator);
-  CHECK(ret == SQL_SUCCESS);
-  CHECK(indicator == SQL_NULL_DATA);
-}
-
 // ============================================================================
 // Basic decimal conversion across all C integer types
 // ============================================================================

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -674,6 +674,7 @@ TEST_CASE("REAL SQL_C_CHAR buffer handling", "[datatype][real][char][buffer]") {
     SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
 
     CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01004");
   }
 }
 
@@ -709,5 +710,224 @@ TEST_CASE("REAL table column conversions", "[datatype][real]") {
     CHECK(std::stod(s1) == 1.5);
     CHECK(std::stod(s2) == -2.75);
     CHECK(std::stod(s3) == 100.0);
+  }
+}
+
+// ============================================================================
+// SQL_C_NUMERIC conversion from REAL
+// The old driver (via Simba SDK) supports SQL_C_NUMERIC for SQL_DOUBLE.
+// ============================================================================
+
+TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("positive integer value") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 42);
+    for (int i = 1; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("negative integer value") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -7.0::FLOAT"), 1);
+    CHECK(numeric.sign == 0);
+    CHECK(numeric.val[0] == 7);
+    for (int i = 1; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("zero") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 0.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    for (int i = 0; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("fractional value truncates with 01S07") {
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 123.456::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    unsigned long long stored = 0;
+    for (int i = 7; i >= 0; --i) {
+      stored = (stored << 8) | numeric.val[i];
+    }
+    CHECK(stored == 123);
+  }
+
+  SECTION("large integer value") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    unsigned long long stored = 0;
+    for (int i = 7; i >= 0; --i) {
+      stored = (stored << 8) | numeric.val[i];
+    }
+    CHECK(stored == 1000000);
+  }
+
+  SECTION("negative fractional value truncates with 01S07") {
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -99.9::FLOAT"), 1);
+    CHECK(numeric.sign == 0);
+    unsigned long long stored = 0;
+    for (int i = 7; i >= 0; --i) {
+      stored = (stored << 8) | numeric.val[i];
+    }
+    CHECK(stored == 99);
+  }
+
+  SECTION("value 1 has correct val bytes") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 1.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 1);
+    for (int i = 1; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("value 255 uses single byte") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 255.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 255);
+    for (int i = 1; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("value 256 spans two bytes") {
+    auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 0);
+    CHECK(numeric.val[1] == 1);
+    for (int i = 2; i < 16; ++i)
+      CHECK(numeric.val[i] == 0);
+  }
+
+  SECTION("NULL returns SQL_NULL_DATA") {
+    check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_NUMERIC);
+  }
+}
+
+// ============================================================================
+// Edge cases: negative zero, boundary values
+// ============================================================================
+
+TEST_CASE("REAL negative zero", "[datatype][real][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -0.0::FLOAT");
+  double val = check_no_truncation<SQL_C_DOUBLE>(stmt, 1);
+  CHECK(val == 0.0);
+}
+
+TEST_CASE("REAL integer boundary values for overflow", "[datatype][real][edge][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("exactly at i8 max succeeds") {
+    CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 127.0::FLOAT"), 1) == 127);
+  }
+
+  SECTION("exactly at i8 min succeeds") {
+    CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT -128.0::FLOAT"), 1) == -128);
+  }
+
+  SECTION("exactly at i16 max succeeds") {
+    CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT 32767.0::FLOAT"), 1) == 32767);
+  }
+
+  SECTION("exactly at i16 min succeeds") {
+    CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT -32768.0::FLOAT"), 1) == -32768);
+  }
+
+  SECTION("exactly at u8 max succeeds") {
+    CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 255.0::FLOAT"), 1) == 255);
+  }
+
+  SECTION("exactly at u16 max succeeds") {
+    CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch("SELECT 65535.0::FLOAT"), 1) == 65535);
+  }
+
+  SECTION("one past i8 max overflows") {
+    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.0::FLOAT"), 1);
+  }
+
+  SECTION("one past i8 min overflows") {
+    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT -129.0::FLOAT"), 1);
+  }
+
+  SECTION("one past u8 max overflows") {
+    check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
+  }
+
+  SECTION("one past u16 max overflows") {
+    check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 65536.0::FLOAT"), 1);
+  }
+
+  SECTION("fractional value well within i8 range truncates with 01S07") {
+    CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 126.9::FLOAT"), 1) == 126);
+  }
+
+  SECTION("fractional value above i8 max overflows") {
+    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.1::FLOAT"), 1);
+  }
+}
+
+TEST_CASE("REAL SQL_C_FLOAT precision loss", "[datatype][real][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("value representable in f32 matches") {
+    float val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 0.5::FLOAT"), 1);
+    CHECK(val == 0.5f);
+  }
+
+  SECTION("large value representable in f32") {
+    float val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
+    CHECK(val == 1000000.0f);
+  }
+}
+
+TEST_CASE("REAL SQL_C_FLOAT overflow returns 22003", "[datatype][real][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("positive overflow") {
+    check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e300::FLOAT"), 1);
+  }
+
+  SECTION("negative overflow") {
+    check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT -1e300::FLOAT"), 1);
+  }
+
+  SECTION("large value within f32 range succeeds") {
+    auto val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e38::FLOAT"), 1);
+    CHECK(val == 1e38f);
+  }
+}
+
+TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[datatype][real][char][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("integer value has no decimal point") {
+    std::string s = check_char_success(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
+    CHECK(std::stod(s) == 42.0);
+  }
+
+  SECTION("negative value") {
+    std::string s = check_char_success(conn.execute_fetch("SELECT -0.001::FLOAT"), 1);
+    CHECK(std::stod(s) == -0.001);
+  }
+
+  SECTION("very small positive value") {
+    std::string s = check_char_success(conn.execute_fetch("SELECT 1e-300::FLOAT"), 1);
+    double parsed = std::stod(s);
+    CHECK(parsed > 0.0);
+    CHECK(parsed < 1e-299);
+  }
+
+  SECTION("very large value") {
+    std::string s = check_char_success(conn.execute_fetch("SELECT 1e300::FLOAT"), 1);
+    double parsed = std::stod(s);
+    CHECK(parsed > 9e299);
   }
 }

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -664,10 +664,12 @@ TEST_CASE("REAL SQL_C_CHAR buffer handling", "[datatype][real][char][buffer]") {
     CHECK(std::stod(std::string(buffer, indicator)) == 42.5);
   }
 
-  SECTION("small buffer truncates") {
-    SKIP_OLD_DRIVER("BD#11", "Old driver returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO for small buffer");
+  SECTION("fractional-only truncation returns 01004") {
+    SKIP_OLD_DRIVER(
+        "BD#17",
+        "Old driver returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO for small SQL_C_CHAR buffer on FLOAT columns");
 
-    auto stmt = conn.execute_fetch("SELECT 123456.789::FLOAT");
+    auto stmt = conn.execute_fetch("SELECT 3.14159::FLOAT");
 
     char small_buffer[4];
     SQLLEN indicator = 0;
@@ -675,6 +677,58 @@ TEST_CASE("REAL SQL_C_CHAR buffer handling", "[datatype][real][char][buffer]") {
 
     CHECK(ret == SQL_SUCCESS_WITH_INFO);
     CHECK(get_sqlstate(stmt) == "01004");
+  }
+
+  SECTION("whole digits lost returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 123456.789::FLOAT");
+
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "22003");
+  }
+}
+
+// ============================================================================
+// SQL_C_WCHAR buffer truncation for REAL
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_WCHAR buffer handling", "[datatype][real][wchar][buffer]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("large buffer succeeds") {
+    auto stmt = conn.execute_fetch("SELECT 42.5::FLOAT");
+    auto result = check_wchar_success(stmt, 1);
+    CHECK(!result.empty());
+  }
+
+  SECTION("fractional-only truncation returns 01004") {
+    SKIP_OLD_DRIVER(
+        "BD#17",
+        "Old driver returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO for small SQL_C_WCHAR buffer on FLOAT columns");
+
+    auto stmt = conn.execute_fetch("SELECT 3.14159::FLOAT");
+
+    char16_t small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_WCHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+    CHECK(get_sqlstate(stmt) == "01004");
+  }
+
+  SECTION("whole digits lost returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 123456.789::FLOAT");
+
+    char16_t small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_WCHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "22003");
   }
 }
 
@@ -902,6 +956,128 @@ TEST_CASE("REAL SQL_C_FLOAT overflow returns 22003", "[datatype][real][22003]") 
     auto val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e38::FLOAT"), 1);
     CHECK(val == 1e38f);
   }
+}
+
+// ============================================================================
+// SQL_C_BINARY conversion from REAL
+// Per ODBC spec, SQL_C_BINARY for SQL_REAL/SQL_FLOAT/SQL_DOUBLE writes the
+// value as SQL_NUMERIC_STRUCT into the buffer.
+// ============================================================================
+
+inline SQL_NUMERIC_STRUCT get_real_binary_as_numeric(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  return *reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+}
+
+inline SQL_NUMERIC_STRUCT get_real_binary_as_numeric_with_truncation(const StatementHandleWrapper& stmt,
+                                                                     SQLUSMALLINT col) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  auto records = get_diag_rec(stmt);
+  CHECK(records.size() == 1);
+  CHECK(records[0].sqlState == "01S07");
+  return *reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+}
+
+inline void check_real_numeric_val_zero_from(const SQL_NUMERIC_STRUCT& numeric, int start) {
+  for (int i = start; i < 16; ++i) {
+    INFO("val[" << i << "] should be 0");
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+inline unsigned long long real_numeric_val_to_ull(const SQL_NUMERIC_STRUCT& n) {
+  unsigned long long result = 0;
+  for (int i = 7; i >= 0; --i) {
+    result = (result << 8) | n.val[i];
+  }
+  return result;
+}
+
+TEST_CASE("REAL to SQL_C_BINARY", "[datatype][real][binary]") {
+  SKIP_OLD_DRIVER("BD#16",
+                  "Old driver returns raw f64 bytes instead of SQL_NUMERIC_STRUCT for SQL_C_BINARY on FLOAT columns");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("positive integer value") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.val[0] == 42);
+    check_real_numeric_val_zero_from(num, 1);
+  }
+
+  SECTION("negative integer value") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT -7.0::FLOAT"), 1);
+    CHECK(num.sign == 0);
+    CHECK(num.val[0] == 7);
+    check_real_numeric_val_zero_from(num, 1);
+  }
+
+  SECTION("zero") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 0.0::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    check_real_numeric_val_zero_from(num, 0);
+  }
+
+  SECTION("fractional value truncates with 01S07") {
+    auto num = get_real_binary_as_numeric_with_truncation(conn.execute_fetch("SELECT 123.456::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.scale == 0);
+    CHECK(real_numeric_val_to_ull(num) == 123);
+  }
+
+  SECTION("large integer value") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    CHECK(real_numeric_val_to_ull(num) == 1000000);
+  }
+
+  SECTION("negative fractional truncates with 01S07") {
+    auto num = get_real_binary_as_numeric_with_truncation(conn.execute_fetch("SELECT -99.9::FLOAT"), 1);
+    CHECK(num.sign == 0);
+    CHECK(real_numeric_val_to_ull(num) == 99);
+  }
+
+  SECTION("value 255 uses single byte") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 255.0::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.val[0] == 255);
+    check_real_numeric_val_zero_from(num, 1);
+  }
+
+  SECTION("value 256 spans two bytes") {
+    auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.val[0] == 0);
+    CHECK(num.val[1] == 1);
+    check_real_numeric_val_zero_from(num, 2);
+  }
+
+  SECTION("NULL returns SQL_NULL_DATA") {
+    check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_BINARY);
+  }
+}
+
+TEST_CASE("REAL SQL_C_BINARY buffer too small returns 22003", "[datatype][real][binary][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42.0::FLOAT");
+
+  char tiny_buffer[4];
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, tiny_buffer, sizeof(tiny_buffer), &indicator);
+
+  CHECK(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "22003");
 }
 
 TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[datatype][real][char][edge]") {

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1174,3 +1174,115 @@ TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[datatype][real][char]
     CHECK(parsed > 9e299);
   }
 }
+
+// ============================================================================
+// Negative fractional values to unsigned integer types
+// Values like -0.1 truncate to -0.0 (IEEE 754).
+// ============================================================================
+
+TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][unsigned][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_UTINYINT with -0.1") {
+    auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
+    typename MetaOfSqlCType<SQL_C_UTINYINT>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << (int)value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+
+  SECTION("SQL_C_USHORT with -0.1") {
+    auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
+    typename MetaOfSqlCType<SQL_C_USHORT>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_USHORT, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+
+  SECTION("SQL_C_ULONG with -0.1") {
+    auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
+    typename MetaOfSqlCType<SQL_C_ULONG>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_ULONG, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+
+  SECTION("SQL_C_UBIGINT with -0.1") {
+    auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
+    typename MetaOfSqlCType<SQL_C_UBIGINT>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UBIGINT, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+
+  SECTION("SQL_C_UTINYINT with -0.9") {
+    auto stmt = conn.execute_fetch("SELECT -0.9::FLOAT");
+    typename MetaOfSqlCType<SQL_C_UTINYINT>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << (int)value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+
+  SECTION("SQL_C_USHORT with -0.9") {
+    auto stmt = conn.execute_fetch("SELECT -0.9::FLOAT");
+    typename MetaOfSqlCType<SQL_C_USHORT>::type value{};
+    SQLLEN indicator = -999;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_USHORT, &value, sizeof(value), &indicator);
+    INFO("ret=" << ret << " value=" << value << " indicator=" << indicator);
+    if (ret == SQL_SUCCESS_WITH_INFO) {
+      CHECK(value == 0);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "01S07");
+    } else {
+      REQUIRE(ret == SQL_ERROR);
+      auto records = get_diag_rec(stmt);
+      CHECK(records[0].sqlState == "22003");
+    }
+  }
+}

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1111,6 +1111,7 @@ TEST_CASE("REAL SQL_C_BIT rejects negative fractions", "[datatype][real][bit][ed
 // ============================================================================
 
 TEST_CASE("REAL SQL_C_NUMERIC no negative zero", "[datatype][real][numeric][edge]") {
+  SKIP_OLD_DRIVER("BD#19", "Old driver produces negative zero in SQL_NUMERIC_STRUCT for negative fractional values");
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1,0 +1,247 @@
+
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include "Connection.hpp"
+#include "HandleWrapper.hpp"
+#include "Schema.hpp"
+#include "get_data.hpp"
+#include "macros.hpp"
+#include "test_setup.hpp"
+
+/// Helper: fetch a column with SQL_C_DEFAULT into an SQLDOUBLE.
+/// Per ODBC spec, SQL_C_DEFAULT for SQL_DOUBLE resolves to SQL_C_DOUBLE.
+inline SQLDOUBLE get_data_default_as_double(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  SQLDOUBLE value = 0.0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
+  CHECK_ODBC(ret, stmt);
+  return value;
+}
+
+// ============================================================================
+// SQL_C_DEFAULT for FLOAT/DOUBLE columns
+// Per ODBC spec, the "real" logical type maps to SQL_DOUBLE.
+// SQL_C_DEFAULT for SQL_DOUBLE is SQL_C_DOUBLE.
+// ============================================================================
+
+TEST_CASE("REAL default conversion - basic values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_default");
+  conn.execute(
+      "CREATE TABLE test_real_default ("
+      "  f1 FLOAT, "
+      "  f2 DOUBLE, "
+      "  f3 FLOAT)");
+  conn.execute("INSERT INTO test_real_default VALUES (1.5, -2.75, 0.0)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_default");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 1.5);
+  CHECK(get_data_default_as_double(stmt, 2) == -2.75);
+  CHECK(get_data_default_as_double(stmt, 3) == 0.0);
+}
+
+TEST_CASE("REAL default conversion - integer values stored as float", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::FLOAT, -100::FLOAT, 0::FLOAT, 1::FLOAT");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 42.0);
+  CHECK(get_data_default_as_double(stmt, 2) == -100.0);
+  CHECK(get_data_default_as_double(stmt, 3) == 0.0);
+  CHECK(get_data_default_as_double(stmt, 4) == 1.0);
+}
+
+TEST_CASE("REAL default conversion - extreme values near DBL_MAX", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_extreme");
+  conn.execute("CREATE TABLE test_real_extreme (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_extreme VALUES "
+      "(1.7976931348623157e308), "
+      "(1.7e308), "
+      "(1.7976931348623151e308), "
+      "(-1.7976931348623151e308), "
+      "(-1.7e308), "
+      "(-1.7976931348623157e308)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_extreme");
+
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7976931348623157e308);
+
+  SQLRETURN ret;
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == 1.7976931348623151e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623151e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7e308);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623157e308);
+}
+
+TEST_CASE("REAL default conversion - very small values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch(
+      "SELECT 2.2250738585072014e-308::DOUBLE, "
+      "       1e-307::DOUBLE, "
+      "       -2.2250738585072014e-308::DOUBLE");
+
+  double v1 = get_data_default_as_double(stmt, 1);
+  double v2 = get_data_default_as_double(stmt, 2);
+  double v3 = get_data_default_as_double(stmt, 3);
+
+  CHECK(v1 > 0.0);
+  CHECK(v1 < 1e-300);
+  CHECK(v2 == 1e-307);
+  CHECK(v3 < 0.0);
+  CHECK(v3 > -1e-300);
+}
+
+TEST_CASE("REAL default conversion - FLOAT, DOUBLE, REAL synonyms produce same result", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_synonyms");
+  conn.execute(
+      "CREATE TABLE test_real_synonyms ("
+      "  f FLOAT, "
+      "  d DOUBLE, "
+      "  r REAL)");
+  conn.execute("INSERT INTO test_real_synonyms VALUES (123.456, 123.456, 123.456)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_synonyms");
+
+  double f = get_data_default_as_double(stmt, 1);
+  double d = get_data_default_as_double(stmt, 2);
+  double r = get_data_default_as_double(stmt, 3);
+
+  CHECK(f == d);
+  CHECK(d == r);
+}
+
+// ============================================================================
+// SQL_C_DEFAULT must produce the same result as explicit SQL_C_DOUBLE
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_default_vs_explicit");
+  conn.execute("CREATE TABLE test_real_default_vs_explicit (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_default_vs_explicit VALUES "
+      "(1.5), (-2.75), (0.0), (999999.999), (1.7976931348623157e308)");
+
+  // Fetch with SQL_C_DOUBLE explicitly
+  auto stmt_explicit = conn.execute_fetch("SELECT * FROM test_real_default_vs_explicit");
+  std::vector<double> explicit_results;
+  explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+  for (int i = 1; i < 5; ++i) {
+    SQLRETURN ret = SQLFetch(stmt_explicit.getHandle());
+    CHECK_ODBC(ret, stmt_explicit);
+    explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+  }
+
+  // Fetch with SQL_C_DEFAULT
+  auto stmt_default = conn.execute_fetch("SELECT * FROM test_real_default_vs_explicit");
+  std::vector<double> default_results;
+  default_results.push_back(get_data_default_as_double(stmt_default, 1));
+  for (int i = 1; i < 5; ++i) {
+    SQLRETURN ret = SQLFetch(stmt_default.getHandle());
+    CHECK_ODBC(ret, stmt_default);
+    default_results.push_back(get_data_default_as_double(stmt_default, 1));
+  }
+
+  // They must match exactly
+  for (size_t i = 0; i < explicit_results.size(); ++i) {
+    INFO("Row " << i << ": SQL_C_DOUBLE=" << explicit_results[i] << " vs SQL_C_DEFAULT=" << default_results[i]);
+    CHECK(explicit_results[i] == default_results[i]);
+  }
+}
+
+// ============================================================================
+// Multiple rows
+// ============================================================================
+
+TEST_CASE("REAL default conversion - multiple rows", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  conn.execute("DROP TABLE IF EXISTS test_real_multi");
+  conn.execute("CREATE TABLE test_real_multi (val DOUBLE)");
+  conn.execute(
+      "INSERT INTO test_real_multi VALUES "
+      "(1.5), (-2.75), (0.0), (1e100), (-1e100)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM test_real_multi");
+
+  std::vector<double> expected = {1.5, -2.75, 0.0, 1e100, -1e100};
+
+  CHECK(get_data_default_as_double(stmt, 1) == expected[0]);
+  for (size_t i = 1; i < expected.size(); ++i) {
+    SQLRETURN ret = SQLFetch(stmt.getHandle());
+    CHECK_ODBC(ret, stmt);
+    INFO("Row " << i);
+    CHECK(get_data_default_as_double(stmt, 1) == expected[i]);
+  }
+}
+
+// ============================================================================
+// Fractional values and zero
+// ============================================================================
+
+TEST_CASE("REAL default conversion - fractional values", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0.1::FLOAT, 0.5::FLOAT, 0.333333333::FLOAT");
+
+  double v1 = get_data_default_as_double(stmt, 1);
+  double v2 = get_data_default_as_double(stmt, 2);
+  double v3 = get_data_default_as_double(stmt, 3);
+
+  CHECK(std::abs(v1 - 0.1) < 1e-15);
+  CHECK(v2 == 0.5);
+  CHECK(std::abs(v3 - 0.333333333) < 1e-8);
+}
+
+TEST_CASE("REAL zero is exactly zero", "[datatype][real][default]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT");
+
+  double val = get_data_default_as_double(stmt, 1);
+  CHECK(val == 0.0);
+}

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1080,6 +1080,73 @@ TEST_CASE("REAL SQL_C_BINARY buffer too small returns 22003", "[datatype][real][
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
+// ============================================================================
+// BIT — negative fractional values must return 22003
+// Per ODBC spec, any value < 0 is out of range for SQL_C_BIT.
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_BIT rejects negative fractions", "[datatype][real][bit][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("-0.5 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("-0.001 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -0.001::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("-0.9999 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -0.9999::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+}
+
+// ============================================================================
+// Numeric / Binary — negative fractional values that truncate to zero
+// must NOT produce negative-zero (sign must be 1/positive when val=0).
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_NUMERIC no negative zero", "[datatype][real][numeric][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("-0.5 produces positive zero") {
+    auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(stmt, 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 0);
+  }
+
+  SECTION("-0.001 produces positive zero") {
+    auto stmt = conn.execute_fetch("SELECT -0.001::FLOAT");
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(stmt, 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 0);
+  }
+}
+
+TEST_CASE("REAL SQL_C_BINARY no negative zero", "[datatype][real][binary][edge]") {
+  SKIP_OLD_DRIVER("BD#12", "SNOW-3127864: Old driver fix to be merged to return the proper size for SQL_NUMERIC");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
+
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(get_sqlstate(stmt) == "01S07");
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  auto* numeric = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+  CHECK(numeric->sign == 1);
+  CHECK(numeric->val[0] == 0);
+}
+
 TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[datatype][real][char][edge]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
@@ -205,7 +206,7 @@ TEST_CASE("REAL explicit SQL_C_DOUBLE", "[datatype][real]") {
   auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT");
 
   double val = check_no_truncation<SQL_C_DOUBLE>(stmt, 1);
-  CHECK(std::abs(val - 123.456) < 1e-9);
+  CHECK_THAT(val, Catch::Matchers::WithinRel(123.456));
 }
 
 TEST_CASE("REAL explicit SQL_C_FLOAT", "[datatype][real]") {
@@ -215,7 +216,7 @@ TEST_CASE("REAL explicit SQL_C_FLOAT", "[datatype][real]") {
   auto stmt = conn.execute_fetch("SELECT 123.5::FLOAT");
 
   float val = check_no_truncation<SQL_C_FLOAT>(stmt, 1);
-  CHECK(std::abs(val - 123.5f) < 0.01f);
+  CHECK_THAT(val, Catch::Matchers::WithinRel(123.5f));
 }
 
 TEST_CASE("REAL explicit SQL_C_CHAR", "[datatype][real]") {
@@ -228,9 +229,9 @@ TEST_CASE("REAL explicit SQL_C_CHAR", "[datatype][real]") {
   std::string s2 = check_char_success(stmt, 2);
   std::string s3 = check_char_success(stmt, 3);
 
-  CHECK(std::stod(s1) == 123.456);
-  CHECK(std::stod(s2) == -99.5);
-  CHECK(std::stod(s3) == 0.0);
+  CHECK_THAT(std::stod(s1), Catch::Matchers::WithinRel(123.456));
+  CHECK_THAT(std::stod(s2), Catch::Matchers::WithinRel(-99.5));
+  CHECK_THAT(std::stod(s3), Catch::Matchers::WithinAbs(0.0, 1e-15));
 }
 
 TEST_CASE("REAL explicit integer conversions truncate fractional part", "[datatype][real]") {
@@ -326,7 +327,7 @@ TEST_CASE("REAL precision - Snowflake FLOAT has ~15 significant digits", "[datat
 
   auto stmt = conn.execute_fetch("SELECT 1.23456789012345::FLOAT");
   double val = check_no_truncation<SQL_C_DOUBLE>(stmt, 1);
-  CHECK(std::abs(val - 1.23456789012345) < 1e-13);
+  CHECK_THAT(val, Catch::Matchers::WithinRel(1.23456789012345));
 }
 
 TEST_CASE("REAL default conversion - fractional values", "[datatype][real][default]") {
@@ -339,9 +340,9 @@ TEST_CASE("REAL default conversion - fractional values", "[datatype][real][defau
   double v2 = get_data_default_as_double(stmt, 2);
   double v3 = get_data_default_as_double(stmt, 3);
 
-  CHECK(std::abs(v1 - 0.1) < 1e-15);
+  CHECK_THAT(v1, Catch::Matchers::WithinRel(0.1));
   CHECK(v2 == 0.5);
-  CHECK(std::abs(v3 - 0.333333333) < 1e-8);
+  CHECK_THAT(v3, Catch::Matchers::WithinRel(0.333333333));
 }
 
 TEST_CASE("REAL zero is exactly zero", "[datatype][real][default]") {
@@ -364,37 +365,43 @@ TEST_CASE("REAL fractional truncation returns 01S07", "[datatype][real][01S07]")
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("SQL_C_LONG") {
+  // SQL_C_LONG
+  {
     auto stmt = conn.execute_fetch("SELECT 123.45::FLOAT");
     auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
     CHECK(value == 123);
   }
 
-  SECTION("SQL_C_SHORT") {
+  // SQL_C_SHORT
+  {
     auto stmt = conn.execute_fetch("SELECT 9.99::FLOAT");
     auto value = check_fractional_truncation<SQL_C_SHORT>(stmt, 1);
     CHECK(value == 9);
   }
 
-  SECTION("SQL_C_STINYINT") {
+  // SQL_C_STINYINT
+  {
     auto stmt = conn.execute_fetch("SELECT 1.5::FLOAT");
     auto value = check_fractional_truncation<SQL_C_STINYINT>(stmt, 1);
     CHECK(value == 1);
   }
 
-  SECTION("SQL_C_SBIGINT") {
+  // SQL_C_SBIGINT
+  {
     auto stmt = conn.execute_fetch("SELECT 999.001::FLOAT");
     auto value = check_fractional_truncation<SQL_C_SBIGINT>(stmt, 1);
     CHECK(value == 999);
   }
 
-  SECTION("exact integer does NOT produce 01S07") {
+  // exact integer does NOT produce 01S07
+  {
     auto stmt = conn.execute_fetch("SELECT 100.0::FLOAT");
     auto value = check_no_truncation<SQL_C_LONG>(stmt, 1);
     CHECK(value == 100);
   }
 
-  SECTION("negative fractional truncates toward zero") {
+  // negative fractional truncates toward zero
+  {
     auto stmt = conn.execute_fetch("SELECT -42.9::FLOAT");
     auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
     CHECK(value == -42);
@@ -411,45 +418,29 @@ TEST_CASE("REAL overflow returns 22003", "[datatype][real][22003]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("SQL_C_STINYINT - above i8 max") {
-    auto stmt = conn.execute_fetch("SELECT 128.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
-  }
+  // SQL_C_STINYINT - above i8 max
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.0::FLOAT"), 1);
 
-  SECTION("SQL_C_STINYINT - below i8 min") {
-    auto stmt = conn.execute_fetch("SELECT -129.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
-  }
+  // SQL_C_STINYINT - below i8 min
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT -129.0::FLOAT"), 1);
 
-  SECTION("SQL_C_UTINYINT - negative") {
-    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
-  }
+  // SQL_C_UTINYINT - negative
+  check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT -1.0::FLOAT"), 1);
 
-  SECTION("SQL_C_UTINYINT - above u8 max") {
-    auto stmt = conn.execute_fetch("SELECT 256.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
-  }
+  // SQL_C_UTINYINT - above u8 max
+  check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
 
-  SECTION("SQL_C_SHORT - above i16 max") {
-    auto stmt = conn.execute_fetch("SELECT 32768.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_SHORT>(stmt, 1);
-  }
+  // SQL_C_SHORT - above i16 max
+  check_numeric_out_of_range<SQL_C_SHORT>(conn.execute_fetch("SELECT 32768.0::FLOAT"), 1);
 
-  SECTION("SQL_C_USHORT - negative") {
-    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_USHORT>(stmt, 1);
-  }
+  // SQL_C_USHORT - negative
+  check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT -1.0::FLOAT"), 1);
 
-  SECTION("SQL_C_LONG - above i32 max") {
-    auto stmt = conn.execute_fetch("SELECT 2147483648.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
-  }
+  // SQL_C_LONG - above i32 max
+  check_numeric_out_of_range<SQL_C_LONG>(conn.execute_fetch("SELECT 2147483648.0::FLOAT"), 1);
 
-  SECTION("SQL_C_ULONG - negative") {
-    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_ULONG>(stmt, 1);
-  }
+  // SQL_C_ULONG - negative
+  check_numeric_out_of_range<SQL_C_ULONG>(conn.execute_fetch("SELECT -1.0::FLOAT"), 1);
 }
 
 // ============================================================================
@@ -464,38 +455,33 @@ TEST_CASE("REAL SQL_C_BIT spec compliance", "[datatype][real][bit]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("0.0 and 1.0 succeed") {
+  // 0.0 and 1.0 succeed
+  {
     auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 1.0::FLOAT");
     CHECK(check_no_truncation<SQL_C_BIT>(stmt, 1) == 0);
     CHECK(check_no_truncation<SQL_C_BIT>(stmt, 2) == 1);
   }
 
-  SECTION("value 2 returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT 2.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // value 2 returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 2.0::FLOAT"), 1);
 
-  SECTION("negative value returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // negative value returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -1.0::FLOAT"), 1);
 
-  SECTION("fractional 0.5 truncates to 0 with 01S07") {
-    auto stmt = conn.execute_fetch("SELECT 0.5::FLOAT");
-    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+  // fractional 0.5 truncates to 0 with 01S07
+  {
+    auto value = check_fractional_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 0.5::FLOAT"), 1);
     CHECK(value == 0);
   }
 
-  SECTION("fractional 1.5 truncates to 1 with 01S07") {
-    auto stmt = conn.execute_fetch("SELECT 1.5::FLOAT");
-    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+  // fractional 1.5 truncates to 1 with 01S07
+  {
+    auto value = check_fractional_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 1.5::FLOAT"), 1);
     CHECK(value == 1);
   }
 
-  SECTION("large positive value returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT 100.0::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // large positive value returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 100.0::FLOAT"), 1);
 }
 
 // ============================================================================
@@ -506,40 +492,26 @@ TEST_CASE("REAL NULL handling", "[datatype][real][null]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("SQL_C_DOUBLE returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_DOUBLE);
-  }
+  // SQL_C_DOUBLE returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_DOUBLE);
 
-  SECTION("SQL_C_FLOAT returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::DOUBLE");
-    check_null_via_get_data(stmt, 1, SQL_C_FLOAT);
-  }
+  // SQL_C_FLOAT returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::DOUBLE"), 1, SQL_C_FLOAT);
 
-  SECTION("SQL_C_LONG returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_LONG);
-  }
+  // SQL_C_LONG returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_LONG);
 
-  SECTION("SQL_C_CHAR returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_CHAR);
-  }
+  // SQL_C_CHAR returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_CHAR);
 
-  SECTION("SQL_C_DEFAULT returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_DEFAULT);
-  }
+  // SQL_C_DEFAULT returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_DEFAULT);
 
-  SECTION("SQL_C_BIT returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_BIT);
-  }
+  // SQL_C_BIT returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_BIT);
 
-  SECTION("SQL_C_SBIGINT returns SQL_NULL_DATA") {
-    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
-    check_null_via_get_data(stmt, 1, SQL_C_SBIGINT);
-  }
+  // SQL_C_SBIGINT returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_SBIGINT);
 }
 
 TEST_CASE("REAL NULL mixed with non-NULL in multiple rows", "[datatype][real][null]") {
@@ -591,7 +563,8 @@ TEST_CASE("REAL to SQL_C_WCHAR", "[datatype][real][wchar]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("basic values") {
+  // basic values
+  {
     auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT, -99.5::FLOAT, 0.0::FLOAT");
     auto s1 = check_wchar_success(stmt, 1);
     auto s2 = check_wchar_success(stmt, 2);
@@ -602,7 +575,8 @@ TEST_CASE("REAL to SQL_C_WCHAR", "[datatype][real][wchar]") {
     CHECK(!s3.empty());
   }
 
-  SECTION("matches SQL_C_CHAR") {
+  // matches SQL_C_CHAR
+  {
     const std::string query = "SELECT 3.125::FLOAT";
     auto char_str = check_char_success(conn.execute_fetch(query), 1);
     auto wchar_str = check_wchar_success(conn.execute_fetch(query), 1);
@@ -623,21 +597,24 @@ TEST_CASE("REAL explicit unsigned integer conversions", "[datatype][real]") {
   const std::string q_frac = "SELECT 42.9::FLOAT";
   const std::string q_zero = "SELECT 0.0::FLOAT";
 
-  SECTION("positive value to unsigned types") {
+  // positive value to unsigned types
+  {
     CHECK(check_no_truncation<SQL_C_ULONG>(conn.execute_fetch(q_exact), 1) == 42u);
     CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch(q_exact), 1) == 42u);
     CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_exact), 1) == 42u);
     CHECK(check_no_truncation<SQL_C_UBIGINT>(conn.execute_fetch(q_exact), 1) == 42u);
   }
 
-  SECTION("fractional value to unsigned types truncates with 01S07") {
+  // fractional value to unsigned types truncates with 01S07
+  {
     CHECK(check_fractional_truncation<SQL_C_ULONG>(conn.execute_fetch(q_frac), 1) == 42u);
     CHECK(check_fractional_truncation<SQL_C_USHORT>(conn.execute_fetch(q_frac), 1) == 42u);
     CHECK(check_fractional_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_frac), 1) == 42u);
     CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(q_frac), 1) == 42u);
   }
 
-  SECTION("zero to unsigned types") {
+  // zero to unsigned types
+  {
     CHECK(check_no_truncation<SQL_C_ULONG>(conn.execute_fetch(q_zero), 1) == 0u);
     CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch(q_zero), 1) == 0u);
     CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_zero), 1) == 0u);
@@ -661,7 +638,7 @@ TEST_CASE("REAL SQL_C_CHAR buffer handling", "[datatype][real][char][buffer]") {
     SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
     CHECK(ret == SQL_SUCCESS);
     CHECK(indicator > 0);
-    CHECK(std::stod(std::string(buffer, indicator)) == 42.5);
+    CHECK_THAT(std::stod(std::string(buffer, indicator)), Catch::Matchers::WithinRel(42.5));
   }
 
   SECTION("fractional-only truncation returns 01004") {
@@ -742,28 +719,31 @@ TEST_CASE("REAL table column conversions", "[datatype][real]") {
 
   TestTable table(conn, "test_real_conversions", "f FLOAT, d DOUBLE, r REAL", "(1.5, -2.75, 100.0)");
 
-  SECTION("SQL_C_DOUBLE from all column types") {
+  // SQL_C_DOUBLE from all column types
+  {
     auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
     CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 1) == 1.5);
     CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 2) == -2.75);
     CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 3) == 100.0);
   }
 
-  SECTION("SQL_C_LONG truncates fractional with 01S07") {
+  // SQL_C_LONG truncates fractional with 01S07
+  {
     auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
     CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 1) == 1);
     CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 2) == -2);
     CHECK(check_no_truncation<SQL_C_LONG>(stmt, 3) == 100);
   }
 
-  SECTION("SQL_C_CHAR returns string representation") {
+  // SQL_C_CHAR returns string representation
+  {
     auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
     std::string s1 = check_char_success(stmt, 1);
     std::string s2 = check_char_success(stmt, 2);
     std::string s3 = check_char_success(stmt, 3);
-    CHECK(std::stod(s1) == 1.5);
-    CHECK(std::stod(s2) == -2.75);
-    CHECK(std::stod(s3) == 100.0);
+    CHECK_THAT(std::stod(s1), Catch::Matchers::WithinRel(1.5));
+    CHECK_THAT(std::stod(s2), Catch::Matchers::WithinRel(-2.75));
+    CHECK_THAT(std::stod(s3), Catch::Matchers::WithinRel(100.0));
   }
 }
 
@@ -776,7 +756,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("positive integer value") {
+  // positive integer value
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 42);
@@ -784,7 +765,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("negative integer value") {
+  // negative integer value
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -7.0::FLOAT"), 1);
     CHECK(numeric.sign == 0);
     CHECK(numeric.val[0] == 7);
@@ -792,14 +774,16 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("zero") {
+  // zero
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 0.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     for (int i = 0; i < 16; ++i)
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("fractional value truncates with 01S07") {
+  // fractional value truncates with 01S07
+  {
     auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 123.456::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     unsigned long long stored = 0;
@@ -809,7 +793,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
     CHECK(stored == 123);
   }
 
-  SECTION("large integer value") {
+  // large integer value
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     unsigned long long stored = 0;
@@ -819,7 +804,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
     CHECK(stored == 1000000);
   }
 
-  SECTION("negative fractional value truncates with 01S07") {
+  // negative fractional value truncates with 01S07
+  {
     auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -99.9::FLOAT"), 1);
     CHECK(numeric.sign == 0);
     unsigned long long stored = 0;
@@ -829,7 +815,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
     CHECK(stored == 99);
   }
 
-  SECTION("value 1 has correct val bytes") {
+  // value 1 has correct val bytes
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 1.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 1);
@@ -837,7 +824,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("value 255 uses single byte") {
+  // value 255 uses single byte
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 255.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 255);
@@ -845,7 +833,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("value 256 spans two bytes") {
+  // value 256 spans two bytes
+  {
     auto numeric = check_no_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 0);
@@ -854,9 +843,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[datatype][real][numeric]") {
       CHECK(numeric.val[i] == 0);
   }
 
-  SECTION("NULL returns SQL_NULL_DATA") {
-    check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_NUMERIC);
-  }
+  // NULL returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_NUMERIC);
 }
 
 // ============================================================================
@@ -876,86 +864,66 @@ TEST_CASE("REAL integer boundary values for overflow", "[datatype][real][edge][2
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("exactly at i8 max succeeds") {
-    CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 127.0::FLOAT"), 1) == 127);
-  }
+  // exactly at i8 max succeeds
+  CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 127.0::FLOAT"), 1) == 127);
 
-  SECTION("exactly at i8 min succeeds") {
-    CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT -128.0::FLOAT"), 1) == -128);
-  }
+  // exactly at i8 min succeeds
+  CHECK(check_no_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT -128.0::FLOAT"), 1) == -128);
 
-  SECTION("exactly at i16 max succeeds") {
-    CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT 32767.0::FLOAT"), 1) == 32767);
-  }
+  // exactly at i16 max succeeds
+  CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT 32767.0::FLOAT"), 1) == 32767);
 
-  SECTION("exactly at i16 min succeeds") {
-    CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT -32768.0::FLOAT"), 1) == -32768);
-  }
+  // exactly at i16 min succeeds
+  CHECK(check_no_truncation<SQL_C_SHORT>(conn.execute_fetch("SELECT -32768.0::FLOAT"), 1) == -32768);
 
-  SECTION("exactly at u8 max succeeds") {
-    CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 255.0::FLOAT"), 1) == 255);
-  }
+  // exactly at u8 max succeeds
+  CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 255.0::FLOAT"), 1) == 255);
 
-  SECTION("exactly at u16 max succeeds") {
-    CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch("SELECT 65535.0::FLOAT"), 1) == 65535);
-  }
+  // exactly at u16 max succeeds
+  CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch("SELECT 65535.0::FLOAT"), 1) == 65535);
 
-  SECTION("one past i8 max overflows") {
-    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.0::FLOAT"), 1);
-  }
+  // one past i8 max overflows
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.0::FLOAT"), 1);
 
-  SECTION("one past i8 min overflows") {
-    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT -129.0::FLOAT"), 1);
-  }
+  // one past i8 min overflows
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT -129.0::FLOAT"), 1);
 
-  SECTION("one past u8 max overflows") {
-    check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
-  }
+  // one past u8 max overflows
+  check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
 
-  SECTION("one past u16 max overflows") {
-    check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 65536.0::FLOAT"), 1);
-  }
+  // one past u16 max overflows
+  check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 65536.0::FLOAT"), 1);
 
-  SECTION("fractional value well within i8 range truncates with 01S07") {
-    CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 126.9::FLOAT"), 1) == 126);
-  }
+  // fractional value well within i8 range truncates with 01S07
+  CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch("SELECT 126.9::FLOAT"), 1) == 126);
 
-  SECTION("fractional value above i8 max overflows") {
-    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.1::FLOAT"), 1);
-  }
+  // fractional value above i8 max overflows
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.1::FLOAT"), 1);
 }
 
 TEST_CASE("REAL SQL_C_FLOAT precision loss", "[datatype][real][edge]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("value representable in f32 matches") {
-    float val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 0.5::FLOAT"), 1);
-    CHECK(val == 0.5f);
-  }
+  // value representable in f32 matches
+  CHECK(check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 0.5::FLOAT"), 1) == 0.5f);
 
-  SECTION("large value representable in f32") {
-    float val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
-    CHECK(val == 1000000.0f);
-  }
+  // large value representable in f32
+  CHECK(check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1) == 1000000.0f);
 }
 
 TEST_CASE("REAL SQL_C_FLOAT overflow returns 22003", "[datatype][real][22003]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("positive overflow") {
-    check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e300::FLOAT"), 1);
-  }
+  // positive overflow
+  check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e300::FLOAT"), 1);
 
-  SECTION("negative overflow") {
-    check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT -1e300::FLOAT"), 1);
-  }
+  // negative overflow
+  check_numeric_out_of_range<SQL_C_FLOAT>(conn.execute_fetch("SELECT -1e300::FLOAT"), 1);
 
-  SECTION("large value within f32 range succeeds") {
-    auto val = check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e38::FLOAT"), 1);
-    CHECK(val == 1e38f);
-  }
+  // large value within f32 range succeeds
+  CHECK(check_no_truncation<SQL_C_FLOAT>(conn.execute_fetch("SELECT 1e38::FLOAT"), 1) == 1e38f);
 }
 
 // ============================================================================
@@ -1007,53 +975,61 @@ TEST_CASE("REAL to SQL_C_BINARY", "[datatype][real][binary]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("positive integer value") {
+  // positive integer value
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
     CHECK(num.sign == 1);
     CHECK(num.val[0] == 42);
     check_real_numeric_val_zero_from(num, 1);
   }
 
-  SECTION("negative integer value") {
+  // negative integer value
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT -7.0::FLOAT"), 1);
     CHECK(num.sign == 0);
     CHECK(num.val[0] == 7);
     check_real_numeric_val_zero_from(num, 1);
   }
 
-  SECTION("zero") {
+  // zero
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 0.0::FLOAT"), 1);
     CHECK(num.sign == 1);
     check_real_numeric_val_zero_from(num, 0);
   }
 
-  SECTION("fractional value truncates with 01S07") {
+  // fractional value truncates with 01S07
+  {
     auto num = get_real_binary_as_numeric_with_truncation(conn.execute_fetch("SELECT 123.456::FLOAT"), 1);
     CHECK(num.sign == 1);
     CHECK(num.scale == 0);
     CHECK(real_numeric_val_to_ull(num) == 123);
   }
 
-  SECTION("large integer value") {
+  // large integer value
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 1000000.0::FLOAT"), 1);
     CHECK(num.sign == 1);
     CHECK(real_numeric_val_to_ull(num) == 1000000);
   }
 
-  SECTION("negative fractional truncates with 01S07") {
+  // negative fractional truncates with 01S07
+  {
     auto num = get_real_binary_as_numeric_with_truncation(conn.execute_fetch("SELECT -99.9::FLOAT"), 1);
     CHECK(num.sign == 0);
     CHECK(real_numeric_val_to_ull(num) == 99);
   }
 
-  SECTION("value 255 uses single byte") {
+  // value 255 uses single byte
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 255.0::FLOAT"), 1);
     CHECK(num.sign == 1);
     CHECK(num.val[0] == 255);
     check_real_numeric_val_zero_from(num, 1);
   }
 
-  SECTION("value 256 spans two bytes") {
+  // value 256 spans two bytes
+  {
     auto num = get_real_binary_as_numeric(conn.execute_fetch("SELECT 256.0::FLOAT"), 1);
     CHECK(num.sign == 1);
     CHECK(num.val[0] == 0);
@@ -1061,9 +1037,8 @@ TEST_CASE("REAL to SQL_C_BINARY", "[datatype][real][binary]") {
     check_real_numeric_val_zero_from(num, 2);
   }
 
-  SECTION("NULL returns SQL_NULL_DATA") {
-    check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_BINARY);
-  }
+  // NULL returns SQL_NULL_DATA
+  check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_BINARY);
 }
 
 TEST_CASE("REAL SQL_C_BINARY buffer too small returns 22003", "[datatype][real][binary][22003]") {
@@ -1089,20 +1064,14 @@ TEST_CASE("REAL SQL_C_BIT rejects negative fractions", "[datatype][real][bit][ed
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("-0.5 returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // -0.5 returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -0.5::FLOAT"), 1);
 
-  SECTION("-0.001 returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT -0.001::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // -0.001 returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -0.001::FLOAT"), 1);
 
-  SECTION("-0.9999 returns 22003") {
-    auto stmt = conn.execute_fetch("SELECT -0.9999::FLOAT");
-    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
-  }
+  // -0.9999 returns 22003
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -0.9999::FLOAT"), 1);
 }
 
 // ============================================================================
@@ -1115,16 +1084,16 @@ TEST_CASE("REAL SQL_C_NUMERIC no negative zero", "[datatype][real][numeric][edge
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("-0.5 produces positive zero") {
-    auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
-    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(stmt, 1);
+  // -0.5 produces positive zero
+  {
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -0.5::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 0);
   }
 
-  SECTION("-0.001 produces positive zero") {
-    auto stmt = conn.execute_fetch("SELECT -0.001::FLOAT");
-    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(stmt, 1);
+  // -0.001 produces positive zero
+  {
+    auto numeric = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -0.001::FLOAT"), 1);
     CHECK(numeric.sign == 1);
     CHECK(numeric.val[0] == 0);
   }
@@ -1152,24 +1121,28 @@ TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[datatype][real][char]
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("integer value has no decimal point") {
+  // integer value has no decimal point
+  {
     std::string s = check_char_success(conn.execute_fetch("SELECT 42.0::FLOAT"), 1);
-    CHECK(std::stod(s) == 42.0);
+    CHECK_THAT(std::stod(s), Catch::Matchers::WithinAbs(42.0, 1e-15));
   }
 
-  SECTION("negative value") {
+  // negative value
+  {
     std::string s = check_char_success(conn.execute_fetch("SELECT -0.001::FLOAT"), 1);
-    CHECK(std::stod(s) == -0.001);
+    CHECK_THAT(std::stod(s), Catch::Matchers::WithinRel(-0.001));
   }
 
-  SECTION("very small positive value") {
+  // very small positive value
+  {
     std::string s = check_char_success(conn.execute_fetch("SELECT 1e-300::FLOAT"), 1);
     double parsed = std::stod(s);
     CHECK(parsed > 0.0);
     CHECK(parsed < 1e-299);
   }
 
-  SECTION("very large value") {
+  // very large value
+  {
     std::string s = check_char_success(conn.execute_fetch("SELECT 1e300::FLOAT"), 1);
     double parsed = std::stod(s);
     CHECK(parsed > 9e299);
@@ -1185,7 +1158,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("SQL_C_UTINYINT with -0.1") {
+  // SQL_C_UTINYINT with -0.1
+  {
     auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
     typename MetaOfSqlCType<SQL_C_UTINYINT>::type value{};
     SQLLEN indicator = -999;
@@ -1202,7 +1176,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 
-  SECTION("SQL_C_USHORT with -0.1") {
+  // SQL_C_USHORT with -0.1
+  {
     auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
     typename MetaOfSqlCType<SQL_C_USHORT>::type value{};
     SQLLEN indicator = -999;
@@ -1219,7 +1194,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 
-  SECTION("SQL_C_ULONG with -0.1") {
+  // SQL_C_ULONG with -0.1
+  {
     auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
     typename MetaOfSqlCType<SQL_C_ULONG>::type value{};
     SQLLEN indicator = -999;
@@ -1236,7 +1212,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 
-  SECTION("SQL_C_UBIGINT with -0.1") {
+  // SQL_C_UBIGINT with -0.1
+  {
     auto stmt = conn.execute_fetch("SELECT -0.1::FLOAT");
     typename MetaOfSqlCType<SQL_C_UBIGINT>::type value{};
     SQLLEN indicator = -999;
@@ -1253,7 +1230,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 
-  SECTION("SQL_C_UTINYINT with -0.9") {
+  // SQL_C_UTINYINT with -0.9
+  {
     auto stmt = conn.execute_fetch("SELECT -0.9::FLOAT");
     typename MetaOfSqlCType<SQL_C_UTINYINT>::type value{};
     SQLLEN indicator = -999;
@@ -1270,7 +1248,8 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 
-  SECTION("SQL_C_USHORT with -0.9") {
+  // SQL_C_USHORT with -0.9
+  {
     auto stmt = conn.execute_fetch("SELECT -0.9::FLOAT");
     typename MetaOfSqlCType<SQL_C_USHORT>::type value{};
     SQLLEN indicator = -999;
@@ -1300,25 +1279,29 @@ TEST_CASE("REAL NaN to integer types returns error", "[datatype][real][nan][edge
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  SECTION("SQL_C_SLONG") { check_numeric_out_of_range<SQL_C_SLONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_SLONG
+  check_numeric_out_of_range<SQL_C_SLONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_ULONG") { check_numeric_out_of_range<SQL_C_ULONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_ULONG
+  check_numeric_out_of_range<SQL_C_ULONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_SHORT") { check_numeric_out_of_range<SQL_C_SHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_SHORT
+  check_numeric_out_of_range<SQL_C_SHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_USHORT") { check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_USHORT
+  check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_STINYINT") {
-    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
-  }
+  // SQL_C_STINYINT
+  check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_UTINYINT") {
-    check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
-  }
+  // SQL_C_UTINYINT
+  check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_SBIGINT") { check_numeric_out_of_range<SQL_C_SBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_SBIGINT
+  check_numeric_out_of_range<SQL_C_SBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 
-  SECTION("SQL_C_UBIGINT") { check_numeric_out_of_range<SQL_C_UBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+  // SQL_C_UBIGINT
+  check_numeric_out_of_range<SQL_C_UBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 }
 
 TEST_CASE("REAL NaN to BIT returns error", "[datatype][real][nan][edge]") {

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -191,6 +191,103 @@ TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[datatype][real][
 }
 
 // ============================================================================
+// Explicit C type conversions from FLOAT columns
+// ============================================================================
+
+TEST_CASE("REAL explicit SQL_C_DOUBLE", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT");
+
+  double val = get_data<SQL_C_DOUBLE>(stmt, 1);
+  CHECK(std::abs(val - 123.456) < 1e-9);
+}
+
+TEST_CASE("REAL explicit SQL_C_FLOAT", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.5::FLOAT");
+
+  float val = get_data<SQL_C_FLOAT>(stmt, 1);
+  CHECK(std::abs(val - 123.5f) < 0.01f);
+}
+
+TEST_CASE("REAL explicit SQL_C_CHAR", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT, -99.5::FLOAT, 0::FLOAT");
+
+  std::string s1 = get_data<SQL_C_CHAR>(stmt, 1);
+  std::string s2 = get_data<SQL_C_CHAR>(stmt, 2);
+  std::string s3 = get_data<SQL_C_CHAR>(stmt, 3);
+
+  // Verify the string representations contain the expected value.
+  // Exact format may vary but must parse back to the same double.
+  CHECK(std::stod(s1) == 123.456);
+  CHECK(std::stod(s2) == -99.5);
+  CHECK(std::stod(s3) == 0.0);
+}
+
+TEST_CASE("REAL explicit integer conversions truncate fractional part", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.789::FLOAT");
+
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_SLONG>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_ULONG>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_SHORT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_SSHORT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_USHORT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_TINYINT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_STINYINT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_UTINYINT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_UBIGINT>(stmt, 1) == 123);
+}
+
+TEST_CASE("REAL explicit integer conversions - negative value", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -42.9::FLOAT");
+
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_SLONG>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_SHORT>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_SSHORT>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_TINYINT>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_STINYINT>(stmt, 1) == -42);
+  CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == -42);
+}
+
+TEST_CASE("REAL explicit SQL_C_BIT", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 5.5::FLOAT, 0::FLOAT, -1.5::FLOAT");
+
+  CHECK(get_data<SQL_C_BIT>(stmt, 1) == 1);
+  CHECK(get_data<SQL_C_BIT>(stmt, 2) == 0);
+  CHECK(get_data<SQL_C_BIT>(stmt, 3) == 1);
+}
+
+TEST_CASE("REAL explicit SQL_C_SBIGINT with large values", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 9007199254740992::FLOAT");
+
+  // 2^53 = 9007199254740992: largest integer exactly representable as f64
+  SQLBIGINT val = get_data<SQL_C_SBIGINT>(stmt, 1);
+  CHECK(val == 9007199254740992LL);
+}
+
+// ============================================================================
 // Multiple rows
 // ============================================================================
 
@@ -218,8 +315,19 @@ TEST_CASE("REAL default conversion - multiple rows", "[datatype][real][default]"
 }
 
 // ============================================================================
-// Fractional values and zero
+// Precision boundary
 // ============================================================================
+
+TEST_CASE("REAL precision - Snowflake FLOAT has ~15 significant digits", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // 15 significant digits should round-trip exactly
+  auto stmt = conn.execute_fetch("SELECT 1.23456789012345::FLOAT");
+  double val = get_data<SQL_C_DOUBLE>(stmt, 1);
+  // Check at least 14 digits match (allow for last-digit rounding)
+  CHECK(std::abs(val - 1.23456789012345) < 1e-13);
+}
 
 TEST_CASE("REAL default conversion - fractional values", "[datatype][real][default]") {
   Connection conn;

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -6,16 +6,19 @@
 #include <cfloat>
 #include <cmath>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers.hpp>
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
 #include "Schema.hpp"
-#include "get_data.hpp"
+#include "TestTable.hpp"
+#include "compatibility.hpp"
+#include "conversion_checks.hpp"
+#include "get_diag_rec.hpp"
 #include "macros.hpp"
 #include "test_setup.hpp"
 
@@ -23,9 +26,10 @@
 /// Per ODBC spec, SQL_C_DEFAULT for SQL_DOUBLE resolves to SQL_C_DOUBLE.
 inline SQLDOUBLE get_data_default_as_double(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
   SQLDOUBLE value = 0.0;
-  SQLLEN indicator = 0;
+  SQLLEN indicator = -999;
   SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_DEFAULT, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(indicator == sizeof(SQLDOUBLE));
   return value;
 }
 
@@ -87,23 +91,23 @@ TEST_CASE("REAL default conversion - extreme values near DBL_MAX", "[datatype][r
 
   SQLRETURN ret;
   ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
   CHECK(get_data_default_as_double(stmt, 1) == 1.7e308);
 
   ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
   CHECK(get_data_default_as_double(stmt, 1) == 1.7976931348623151e308);
 
   ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
   CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623151e308);
 
   ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
   CHECK(get_data_default_as_double(stmt, 1) == -1.7e308);
 
   ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
+  CHECK(ret == SQL_SUCCESS);
   CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623157e308);
 }
 
@@ -166,11 +170,11 @@ TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[datatype][real][
   // Fetch with SQL_C_DOUBLE explicitly
   auto stmt_explicit = conn.execute_fetch("SELECT * FROM test_real_default_vs_explicit");
   std::vector<double> explicit_results;
-  explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+  explicit_results.push_back(check_no_truncation<SQL_C_DOUBLE>(stmt_explicit, 1));
   for (int i = 1; i < 5; ++i) {
     SQLRETURN ret = SQLFetch(stmt_explicit.getHandle());
-    CHECK_ODBC(ret, stmt_explicit);
-    explicit_results.push_back(get_data<SQL_C_DOUBLE>(stmt_explicit, 1));
+    CHECK(ret == SQL_SUCCESS);
+    explicit_results.push_back(check_no_truncation<SQL_C_DOUBLE>(stmt_explicit, 1));
   }
 
   // Fetch with SQL_C_DEFAULT
@@ -179,7 +183,7 @@ TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[datatype][real][
   default_results.push_back(get_data_default_as_double(stmt_default, 1));
   for (int i = 1; i < 5; ++i) {
     SQLRETURN ret = SQLFetch(stmt_default.getHandle());
-    CHECK_ODBC(ret, stmt_default);
+    CHECK(ret == SQL_SUCCESS);
     default_results.push_back(get_data_default_as_double(stmt_default, 1));
   }
 
@@ -200,7 +204,7 @@ TEST_CASE("REAL explicit SQL_C_DOUBLE", "[datatype][real]") {
 
   auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT");
 
-  double val = get_data<SQL_C_DOUBLE>(stmt, 1);
+  double val = check_no_truncation<SQL_C_DOUBLE>(stmt, 1);
   CHECK(std::abs(val - 123.456) < 1e-9);
 }
 
@@ -210,7 +214,7 @@ TEST_CASE("REAL explicit SQL_C_FLOAT", "[datatype][real]") {
 
   auto stmt = conn.execute_fetch("SELECT 123.5::FLOAT");
 
-  float val = get_data<SQL_C_FLOAT>(stmt, 1);
+  float val = check_no_truncation<SQL_C_FLOAT>(stmt, 1);
   CHECK(std::abs(val - 123.5f) < 0.01f);
 }
 
@@ -220,12 +224,10 @@ TEST_CASE("REAL explicit SQL_C_CHAR", "[datatype][real]") {
 
   auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT, -99.5::FLOAT, 0::FLOAT");
 
-  std::string s1 = get_data<SQL_C_CHAR>(stmt, 1);
-  std::string s2 = get_data<SQL_C_CHAR>(stmt, 2);
-  std::string s3 = get_data<SQL_C_CHAR>(stmt, 3);
+  std::string s1 = check_char_success(stmt, 1);
+  std::string s2 = check_char_success(stmt, 2);
+  std::string s3 = check_char_success(stmt, 3);
 
-  // Verify the string representations contain the expected value.
-  // Exact format may vary but must parse back to the same double.
   CHECK(std::stod(s1) == 123.456);
   CHECK(std::stod(s2) == -99.5);
   CHECK(std::stod(s3) == 0.0);
@@ -235,45 +237,46 @@ TEST_CASE("REAL explicit integer conversions truncate fractional part", "[dataty
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 123.789::FLOAT");
+  const std::string query = "SELECT 123.789::FLOAT";
 
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_SLONG>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_ULONG>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_SHORT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_SSHORT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_USHORT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_TINYINT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_STINYINT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_UTINYINT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == 123);
-  CHECK(get_data<SQL_C_UBIGINT>(stmt, 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_LONG>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_SLONG>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_ULONG>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_SHORT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_SSHORT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_USHORT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_TINYINT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_UTINYINT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == 123);
+  CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
 }
 
 TEST_CASE("REAL explicit integer conversions - negative value", "[datatype][real]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT -42.9::FLOAT");
+  const std::string query = "SELECT -42.9::FLOAT";
 
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_SLONG>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_SHORT>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_SSHORT>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_TINYINT>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_STINYINT>(stmt, 1) == -42);
-  CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_LONG>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_SLONG>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_SHORT>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_SSHORT>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_TINYINT>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_STINYINT>(conn.execute_fetch(query), 1) == -42);
+  CHECK(check_fractional_truncation<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == -42);
 }
 
-TEST_CASE("REAL explicit SQL_C_BIT", "[datatype][real]") {
+TEST_CASE("REAL explicit SQL_C_BIT - basic", "[datatype][real]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 5.5::FLOAT, 0::FLOAT, -1.5::FLOAT");
-
-  CHECK(get_data<SQL_C_BIT>(stmt, 1) == 1);
-  CHECK(get_data<SQL_C_BIT>(stmt, 2) == 0);
-  CHECK(get_data<SQL_C_BIT>(stmt, 3) == 1);
+  CHECK(check_no_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 0.0::FLOAT"), 1) == 0);
+  CHECK(check_no_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 1.0::FLOAT"), 1) == 1);
+  CHECK(check_fractional_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 0.5::FLOAT"), 1) == 0);
+  CHECK(check_fractional_truncation<SQL_C_BIT>(conn.execute_fetch("SELECT 1.5::FLOAT"), 1) == 1);
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 5.5::FLOAT"), 1);
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -1.5::FLOAT"), 1);
 }
 
 TEST_CASE("REAL explicit SQL_C_SBIGINT with large values", "[datatype][real]") {
@@ -283,8 +286,7 @@ TEST_CASE("REAL explicit SQL_C_SBIGINT with large values", "[datatype][real]") {
   auto stmt = conn.execute_fetch("SELECT 9007199254740992::FLOAT");
 
   // 2^53 = 9007199254740992: largest integer exactly representable as f64
-  SQLBIGINT val = get_data<SQL_C_SBIGINT>(stmt, 1);
-  CHECK(val == 9007199254740992LL);
+  CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 1) == 9007199254740992LL);
 }
 
 // ============================================================================
@@ -308,7 +310,7 @@ TEST_CASE("REAL default conversion - multiple rows", "[datatype][real][default]"
   CHECK(get_data_default_as_double(stmt, 1) == expected[0]);
   for (size_t i = 1; i < expected.size(); ++i) {
     SQLRETURN ret = SQLFetch(stmt.getHandle());
-    CHECK_ODBC(ret, stmt);
+    CHECK(ret == SQL_SUCCESS);
     INFO("Row " << i);
     CHECK(get_data_default_as_double(stmt, 1) == expected[i]);
   }
@@ -322,10 +324,8 @@ TEST_CASE("REAL precision - Snowflake FLOAT has ~15 significant digits", "[datat
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  // 15 significant digits should round-trip exactly
   auto stmt = conn.execute_fetch("SELECT 1.23456789012345::FLOAT");
-  double val = get_data<SQL_C_DOUBLE>(stmt, 1);
-  // Check at least 14 digits match (allow for last-digit rounding)
+  double val = check_no_truncation<SQL_C_DOUBLE>(stmt, 1);
   CHECK(std::abs(val - 1.23456789012345) < 1e-13);
 }
 
@@ -352,4 +352,362 @@ TEST_CASE("REAL zero is exactly zero", "[datatype][real][default]") {
 
   double val = get_data_default_as_double(stmt, 1);
   CHECK(val == 0.0);
+}
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 01S07 — Fractional truncation warning
+// Converting a FLOAT value with fractional digits to an integer C type
+// should return SQL_SUCCESS_WITH_INFO with SQLSTATE 01S07.
+// ============================================================================
+
+TEST_CASE("REAL fractional truncation returns 01S07", "[datatype][real][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_LONG") {
+    auto stmt = conn.execute_fetch("SELECT 123.45::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 123);
+  }
+
+  SECTION("SQL_C_SHORT") {
+    auto stmt = conn.execute_fetch("SELECT 9.99::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_SHORT>(stmt, 1);
+    CHECK(value == 9);
+  }
+
+  SECTION("SQL_C_STINYINT") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_STINYINT>(stmt, 1);
+    CHECK(value == 1);
+  }
+
+  SECTION("SQL_C_SBIGINT") {
+    auto stmt = conn.execute_fetch("SELECT 999.001::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_SBIGINT>(stmt, 1);
+    CHECK(value == 999);
+  }
+
+  SECTION("exact integer does NOT produce 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 100.0::FLOAT");
+    auto value = check_no_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 100);
+  }
+
+  SECTION("negative fractional truncates toward zero") {
+    auto stmt = conn.execute_fetch("SELECT -42.9::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == -42);
+  }
+}
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 22003 — Numeric value out of range (integer overflow)
+// When a FLOAT value exceeds the target integer C type range, the driver
+// should return SQL_ERROR with SQLSTATE 22003.
+// ============================================================================
+
+TEST_CASE("REAL overflow returns 22003", "[datatype][real][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_STINYINT - above i8 max") {
+    auto stmt = conn.execute_fetch("SELECT 128.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_STINYINT - below i8 min") {
+    auto stmt = conn.execute_fetch("SELECT -129.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_UTINYINT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_UTINYINT - above u8 max") {
+    auto stmt = conn.execute_fetch("SELECT 256.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_SHORT - above i16 max") {
+    auto stmt = conn.execute_fetch("SELECT 32768.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_SHORT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_USHORT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_USHORT>(stmt, 1);
+  }
+
+  SECTION("SQL_C_LONG - above i32 max") {
+    auto stmt = conn.execute_fetch("SELECT 2147483648.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
+  }
+
+  SECTION("SQL_C_ULONG - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_ULONG>(stmt, 1);
+  }
+}
+
+// ============================================================================
+// ODBC Spec: SQL_C_BIT — full spec-compliant behavior for FLOAT source
+// Per ODBC spec for SQL_C_BIT:
+//   Exact 0 or 1                    -> SQL_SUCCESS
+//   Value > 0, < 2, != 1 (fraction) -> SQL_SUCCESS_WITH_INFO, 01S07
+//   Value < 0 or >= 2               -> SQL_ERROR, 22003
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_BIT spec compliance", "[datatype][real][bit]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("0.0 and 1.0 succeed") {
+    auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 1.0::FLOAT");
+    CHECK(check_no_truncation<SQL_C_BIT>(stmt, 1) == 0);
+    CHECK(check_no_truncation<SQL_C_BIT>(stmt, 2) == 1);
+  }
+
+  SECTION("value 2 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 2.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("negative value returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -1.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+
+  SECTION("fractional 0.5 truncates to 0 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 0.5::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 0);
+  }
+
+  SECTION("fractional 1.5 truncates to 1 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::FLOAT");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 1);
+  }
+
+  SECTION("large positive value returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 100.0::FLOAT");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
+}
+
+// ============================================================================
+// NULL handling for REAL/FLOAT columns
+// ============================================================================
+
+TEST_CASE("REAL NULL handling", "[datatype][real][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_DOUBLE returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_DOUBLE);
+  }
+
+  SECTION("SQL_C_FLOAT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::DOUBLE");
+    check_null_via_get_data(stmt, 1, SQL_C_FLOAT);
+  }
+
+  SECTION("SQL_C_LONG returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_LONG);
+  }
+
+  SECTION("SQL_C_CHAR returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_CHAR);
+  }
+
+  SECTION("SQL_C_DEFAULT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_DEFAULT);
+  }
+
+  SECTION("SQL_C_BIT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_BIT);
+  }
+
+  SECTION("SQL_C_SBIGINT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+    check_null_via_get_data(stmt, 1, SQL_C_SBIGINT);
+  }
+}
+
+TEST_CASE("REAL NULL mixed with non-NULL in multiple rows", "[datatype][real][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  TestTable table(conn, "test_real_null", "val FLOAT", "(1.5), (NULL), (-2.75), (NULL), (0.0)");
+
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+
+  std::vector<std::optional<double>> expected = {1.5, std::nullopt, -2.75, std::nullopt, 0.0};
+  SQLDOUBLE value = 0;
+  SQLLEN indicator = 0;
+
+  for (size_t row = 0; row < expected.size(); ++row) {
+    if (row > 0) {
+      SQLRETURN ret = SQLFetch(stmt.getHandle());
+      CHECK(ret == SQL_SUCCESS);
+    }
+    INFO("Row " << row);
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DOUBLE, &value, sizeof(value), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    if (expected[row].has_value()) {
+      CHECK(indicator != SQL_NULL_DATA);
+      CHECK(value == expected[row].value());
+    } else {
+      CHECK(indicator == SQL_NULL_DATA);
+    }
+  }
+}
+
+TEST_CASE("REAL SQLGetData NULL without indicator returns 22002", "[datatype][real][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
+
+  SQLDOUBLE value = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DOUBLE, &value, sizeof(value), nullptr);
+  CHECK(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "22002");
+}
+
+// ============================================================================
+// SQL_C_WCHAR (wide character) conversion for REAL
+// ============================================================================
+
+TEST_CASE("REAL to SQL_C_WCHAR", "[datatype][real][wchar]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("basic values") {
+    auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT, -99.5::FLOAT, 0.0::FLOAT");
+    auto s1 = check_wchar_success(stmt, 1);
+    auto s2 = check_wchar_success(stmt, 2);
+    auto s3 = check_wchar_success(stmt, 3);
+
+    CHECK(!s1.empty());
+    CHECK(!s2.empty());
+    CHECK(!s3.empty());
+  }
+
+  SECTION("matches SQL_C_CHAR") {
+    const std::string query = "SELECT 3.125::FLOAT";
+    auto char_str = check_char_success(conn.execute_fetch(query), 1);
+    auto wchar_str = check_wchar_success(conn.execute_fetch(query), 1);
+    std::u16string expected_wchar(char_str.begin(), char_str.end());
+    CHECK(wchar_str == expected_wchar);
+  }
+}
+
+// ============================================================================
+// Unsigned integer conversions from FLOAT
+// ============================================================================
+
+TEST_CASE("REAL explicit unsigned integer conversions", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  const std::string q_exact = "SELECT 42.0::FLOAT";
+  const std::string q_frac = "SELECT 42.9::FLOAT";
+  const std::string q_zero = "SELECT 0.0::FLOAT";
+
+  SECTION("positive value to unsigned types") {
+    CHECK(check_no_truncation<SQL_C_ULONG>(conn.execute_fetch(q_exact), 1) == 42u);
+    CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch(q_exact), 1) == 42u);
+    CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_exact), 1) == 42u);
+    CHECK(check_no_truncation<SQL_C_UBIGINT>(conn.execute_fetch(q_exact), 1) == 42u);
+  }
+
+  SECTION("fractional value to unsigned types truncates with 01S07") {
+    CHECK(check_fractional_truncation<SQL_C_ULONG>(conn.execute_fetch(q_frac), 1) == 42u);
+    CHECK(check_fractional_truncation<SQL_C_USHORT>(conn.execute_fetch(q_frac), 1) == 42u);
+    CHECK(check_fractional_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_frac), 1) == 42u);
+    CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(q_frac), 1) == 42u);
+  }
+
+  SECTION("zero to unsigned types") {
+    CHECK(check_no_truncation<SQL_C_ULONG>(conn.execute_fetch(q_zero), 1) == 0u);
+    CHECK(check_no_truncation<SQL_C_USHORT>(conn.execute_fetch(q_zero), 1) == 0u);
+    CHECK(check_no_truncation<SQL_C_UTINYINT>(conn.execute_fetch(q_zero), 1) == 0u);
+    CHECK(check_no_truncation<SQL_C_UBIGINT>(conn.execute_fetch(q_zero), 1) == 0u);
+  }
+}
+
+// ============================================================================
+// SQL_C_CHAR buffer truncation for REAL
+// ============================================================================
+
+TEST_CASE("REAL SQL_C_CHAR buffer handling", "[datatype][real][char][buffer]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("large buffer succeeds") {
+    auto stmt = conn.execute_fetch("SELECT 42.5::FLOAT");
+
+    char buffer[100];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
+    CHECK(ret == SQL_SUCCESS);
+    CHECK(indicator > 0);
+    CHECK(std::stod(std::string(buffer, indicator)) == 42.5);
+  }
+
+  SECTION("small buffer truncates") {
+    SKIP_OLD_DRIVER("BD#11", "Old driver returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO for small buffer");
+
+    auto stmt = conn.execute_fetch("SELECT 123456.789::FLOAT");
+
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  }
+}
+
+// ============================================================================
+// Table-based tests with FLOAT column types
+// ============================================================================
+
+TEST_CASE("REAL table column conversions", "[datatype][real]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  TestTable table(conn, "test_real_conversions", "f FLOAT, d DOUBLE, r REAL", "(1.5, -2.75, 100.0)");
+
+  SECTION("SQL_C_DOUBLE from all column types") {
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 1) == 1.5);
+    CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 2) == -2.75);
+    CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 3) == 100.0);
+  }
+
+  SECTION("SQL_C_LONG truncates fractional with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 1) == 1);
+    CHECK(check_fractional_truncation<SQL_C_LONG>(stmt, 2) == -2);
+    CHECK(check_no_truncation<SQL_C_LONG>(stmt, 3) == 100);
+  }
+
+  SECTION("SQL_C_CHAR returns string representation") {
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::string s1 = check_char_success(stmt, 1);
+    std::string s2 = check_char_success(stmt, 2);
+    std::string s3 = check_char_success(stmt, 3);
+    CHECK(std::stod(s1) == 1.5);
+    CHECK(std::stod(s2) == -2.75);
+    CHECK(std::stod(s3) == 100.0);
+  }
 }

--- a/odbc_tests/tests/datatype_tests/real_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/real_tests.cpp
@@ -1286,3 +1286,64 @@ TEST_CASE("REAL negative fraction to unsigned integer types", "[datatype][real][
     }
   }
 }
+
+// ============================================================================
+// NaN handling for integer, bit, numeric, and binary targets
+// NaN must not silently convert to 0. Per ODBC spec, NaN should produce
+// SQL_ERROR with SQLSTATE 22003 for integer/bit/numeric/binary targets.
+// For CHAR/WCHAR targets, NaN should produce the string "NaN".
+// ============================================================================
+
+TEST_CASE("REAL NaN to integer types returns error", "[datatype][real][nan][edge]") {
+  SKIP_OLD_DRIVER("BD#18", "Old driver silently converts NaN to 0 for integer targets");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  SECTION("SQL_C_SLONG") { check_numeric_out_of_range<SQL_C_SLONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+
+  SECTION("SQL_C_ULONG") { check_numeric_out_of_range<SQL_C_ULONG>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+
+  SECTION("SQL_C_SHORT") { check_numeric_out_of_range<SQL_C_SHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+
+  SECTION("SQL_C_USHORT") { check_numeric_out_of_range<SQL_C_USHORT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+
+  SECTION("SQL_C_STINYINT") {
+    check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
+  }
+
+  SECTION("SQL_C_UTINYINT") {
+    check_numeric_out_of_range<SQL_C_UTINYINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
+  }
+
+  SECTION("SQL_C_SBIGINT") { check_numeric_out_of_range<SQL_C_SBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+
+  SECTION("SQL_C_UBIGINT") { check_numeric_out_of_range<SQL_C_UBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1); }
+}
+
+TEST_CASE("REAL NaN to BIT returns error", "[datatype][real][nan][edge]") {
+  SKIP_OLD_DRIVER("BD#18", "Old driver silently converts NaN to 0 for BIT target");
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
+}
+
+TEST_CASE("REAL NaN to NUMERIC returns error", "[datatype][real][nan][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  check_numeric_out_of_range<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
+}
+
+TEST_CASE("REAL NaN to CHAR produces NaN string", "[datatype][real][nan][edge]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 'NaN'::FLOAT");
+  char buf[64] = {};
+  SQLLEN indicator = -999;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, buf, sizeof(buf), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  std::string result(buf);
+  CHECK(result == "NaN");
+}


### PR DESCRIPTION
### TL;DR

Added support for Snowflake's REAL logical type (FLOAT, DOUBLE, REAL) in the ODBC driver with proper type conversions and comprehensive test coverage.

### Changes

- **Added REAL type conversion support**: Implemented `SnowflakeReal` converter in `odbc/src/conversion/real.rs` that handles conversions from Float64Array to various ODBC C data types including SQL_C_DOUBLE (default), SQL_C_FLOAT, integer types, SQL_C_BIT, SQL_C_CHAR, SQL_C_WCHAR, SQL_C_NUMERIC, and SQL_C_BINARY

- **Integrated REAL type into conversion framework**: Added `Real(real::SnowflakeReal)` variant to `SnowflakeFieldType` enum and registered "REAL" logical type mapping in the conversion system

- **Added comprehensive test coverage**: Created extensive unit tests in `real_tests.rs` covering all conversion scenarios, edge cases, overflow conditions, and SQLSTATE compliance (01S07 for fractional truncation, 22003 for numeric overflow)

- **Added integration tests**: Implemented full ODBC integration tests in `real_tests.cpp` testing default conversions, explicit type conversions, NULL handling, buffer management, and multi-row scenarios

- **Updated behavior differences documentation**: Added entries BD#16 and BD#17 documenting differences from the old driver regarding SQL_C_BINARY conversion (now returns SQL_NUMERIC_STRUCT instead of raw bytes) and SQL_C_CHAR buffer truncation handling (now returns SQL_SUCCESS_WITH_INFO instead of SQL_ERROR)

- **Enhanced test infrastructure**: Added `Float64Array` import and `field_with_real_meta()` helper function to support REAL type testing in the data conversion test suite

The implementation follows ODBC specification requirements for type conversions, proper error handling with appropriate SQLSTATEs, and maintains compatibility with existing Snowflake FLOAT/DOUBLE/REAL column types.