### PR TITLE
SNOW-3111596: Add connection URL parsing

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -7,6 +7,8 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.logging.Logger;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.api.implementation.connection.ConnectionString;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 
 /**
@@ -21,6 +23,7 @@ public class SnowflakeDriver implements Driver {
   private static final String DRIVER_VERSION = "4.0.0";
   private static final int MAJOR_VERSION = 4;
   private static final int MINOR_VERSION = 0;
+  public static final Properties EMPTY_PROPERTIES = new Properties();
 
   public static void empty() {}
 
@@ -38,19 +41,19 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public Connection connect(String url, Properties info) throws SQLException {
-    if (!acceptsURL(url)) {
+    if (ConnectionString.hasSupportedPrefix(url)) {
       return null;
     }
-
+    ConnectionString parsed = ConnectionString.parse(url, info);
+    if (!parsed.isValid()) {
+      throw new SnowflakeSQLException("Connection string is invalid. Unable to parse.");
+    }
     return new SnowflakeConnectionImpl(url, info);
   }
 
   @Override
   public boolean acceptsURL(String url) throws SQLException {
-    if (url == null) {
-      return false;
-    }
-    return url.startsWith("jdbc:snowflake:");
+    return ConnectionString.parse(url, EMPTY_PROPERTIES).isValid();
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -23,7 +23,6 @@ public class SnowflakeDriver implements Driver {
   private static final String DRIVER_VERSION = "4.0.0";
   private static final int MAJOR_VERSION = 4;
   private static final int MINOR_VERSION = 0;
-  public static final Properties EMPTY_PROPERTIES = new Properties();
 
   public static void empty() {}
 
@@ -41,7 +40,7 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public Connection connect(String url, Properties info) throws SQLException {
-    if (ConnectionString.hasSupportedPrefix(url)) {
+    if (ConnectionString.hasUnsupportedPrefix(url)) {
       return null;
     }
     ConnectionString parsed = ConnectionString.parse(url, info);
@@ -53,7 +52,7 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public boolean acceptsURL(String url) throws SQLException {
-    return ConnectionString.parse(url, EMPTY_PROPERTIES).isValid();
+    return ConnectionString.parse(url).isValid();
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -12,7 +12,6 @@ import net.snowflake.client.internal.api.implementation.connection.ConnectionStr
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
-import org.slf4j.LoggerFactory;
 
 /**
  * Snowflake JDBC Driver implementation
@@ -26,7 +25,6 @@ public class SnowflakeDriver implements Driver {
   private static final String DRIVER_VERSION = "4.0.0";
   private static final int MAJOR_VERSION = 4;
   private static final int MINOR_VERSION = 0;
-  private static final org.slf4j.Logger log = LoggerFactory.getLogger(SnowflakeDriver.class);
 
   public static void empty() {}
 
@@ -57,7 +55,10 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public boolean acceptsURL(String url) throws SQLException {
-    return ConnectionString.parse(url).isValid();
+    if (url == null) {
+      throw new SQLException("URL must not be null");
+    }
+    return url.startsWith("jdbc:snowflake:");
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -10,6 +10,9 @@ import java.util.logging.Logger;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.connection.ConnectionString;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+import org.slf4j.LoggerFactory;
 
 /**
  * Snowflake JDBC Driver implementation
@@ -18,11 +21,12 @@ import net.snowflake.client.internal.api.implementation.connection.SnowflakeConn
  * native Rust implementation via JNI.
  */
 public class SnowflakeDriver implements Driver {
-
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeDriver.class);
   private static final String DRIVER_NAME = "Snowflake JDBC Driver";
   private static final String DRIVER_VERSION = "4.0.0";
   private static final int MAJOR_VERSION = 4;
   private static final int MINOR_VERSION = 0;
+  private static final org.slf4j.Logger log = LoggerFactory.getLogger(SnowflakeDriver.class);
 
   public static void empty() {}
 
@@ -41,6 +45,7 @@ public class SnowflakeDriver implements Driver {
   @Override
   public Connection connect(String url, Properties info) throws SQLException {
     if (ConnectionString.hasUnsupportedPrefix(url)) {
+      logger.debug("Connect strings must start with jdbc:snowflake://");
       return null;
     }
     ConnectionString parsed = ConnectionString.parse(url, info);

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
@@ -38,6 +38,9 @@ final class ConnectionOptionsResolver {
 
     for (Map.Entry<String, Object> entry : parsed.getParameters().entrySet()) {
       String normalizedKey = entry.getKey().toLowerCase(Locale.ROOT);
+      if (normalizedKey.trim().isEmpty()) {
+        continue;
+      }
       Object value = entry.getValue();
       if (value == null) {
         continue;
@@ -47,7 +50,7 @@ final class ConnectionOptionsResolver {
   }
 
   private static void setIfAbsent(Properties resolved, String key, String value) {
-    if (value != null && !value.isEmpty() && resolved.getProperty(key) == null) {
+    if (value != null && !value.isEmpty() && !resolved.containsKey(key)) {
       resolved.setProperty(key, value);
     }
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
@@ -42,9 +42,6 @@ final class ConnectionOptionsResolver {
         continue;
       }
       Object value = entry.getValue();
-      if (value == null) {
-        continue;
-      }
       setIfAbsent(resolved, normalizedKey, value.toString());
     }
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
@@ -1,0 +1,64 @@
+package net.snowflake.client.internal.api.implementation.connection;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+final class ConnectionOptionsResolver {
+  private ConnectionOptionsResolver() {}
+
+  static Properties resolve(String url, Properties properties) {
+    Properties resolved = new Properties();
+    if (properties != null) {
+      resolved.putAll(properties);
+    }
+
+    String effectiveUrl = firstNonBlank(url, resolved.getProperty("url"));
+    if (effectiveUrl != null) {
+      populateFromConnectionString(effectiveUrl, resolved);
+    }
+    return resolved;
+  }
+
+  private static void populateFromConnectionString(String jdbcUrl, Properties resolved) {
+    ConnectionString parsed = ConnectionString.parse(jdbcUrl, resolved);
+    if (!parsed.isValid()) {
+      return;
+    }
+
+    setIfAbsent(resolved, "host", parsed.getHost());
+    setIfAbsent(resolved, "protocol", parsed.getScheme());
+    if (parsed.getPort() > 0) {
+      setIfAbsent(resolved, "port", Integer.toString(parsed.getPort()));
+    }
+
+    if (parsed.getAccount() != null) {
+      setIfAbsent(resolved, "account", parsed.getAccount());
+    }
+
+    for (Map.Entry<String, Object> entry : parsed.getParameters().entrySet()) {
+      String normalizedKey = entry.getKey().toLowerCase(Locale.ROOT);
+      Object value = entry.getValue();
+      if (value == null) {
+        continue;
+      }
+      setIfAbsent(resolved, normalizedKey, value.toString());
+    }
+  }
+
+  private static void setIfAbsent(Properties resolved, String key, String value) {
+    if (value != null && !value.isEmpty() && resolved.getProperty(key) == null) {
+      resolved.setProperty(key, value);
+    }
+  }
+
+  private static String firstNonBlank(String first, String second) {
+    if (first != null && !first.trim().isEmpty()) {
+      return first;
+    }
+    if (second != null && !second.trim().isEmpty()) {
+      return second;
+    }
+    return null;
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
@@ -1,6 +1,6 @@
 package net.snowflake.client.internal.api.implementation.connection;
 
-import static net.snowflake.client.internal.util.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.util.StringUtil.isNullOrEmpty;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -62,6 +62,7 @@ public class ConnectionString {
           .deriveAccountFromHostIfMissing()
           .ensureAccountPresent()
           .normalizeHostForUnderscoreAccount()
+          .applyDefaultPortForEffectiveScheme()
           .build();
     } catch (URISyntaxException uriEx) {
       logger.warn(
@@ -155,9 +156,6 @@ public class ConnectionString {
         logger.debug("Connect strings must have a valid host: found null or empty host");
         throw new IllegalArgumentException("Missing host");
       }
-      if (port == -1) {
-        port = 443;
-      }
       String path = uri.getPath();
       if (!isNullOrEmpty(path) && !"/".equals(path)) {
         logger.debug("Connect strings must have no path: expecting empty or null or '/'");
@@ -241,6 +239,14 @@ public class ConnectionString {
       if (account.contains("_") && !allowUnderscoresInHost && host.startsWith(account)) {
         host = host.replaceFirst(account, account.replace("_", "-"));
       }
+      return this;
+    }
+
+    ConnectionStringBuilder applyDefaultPortForEffectiveScheme() {
+      if (port != -1) {
+        return this;
+      }
+      port = "http".equals(scheme) ? 80 : 443;
       return this;
     }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
@@ -1,0 +1,252 @@
+package net.snowflake.client.internal.api.implementation.connection;
+
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+public class ConnectionString implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private static final String PREFIX = "jdbc:snowflake://";
+  private static final String ALLOW_UNDERSCORES_IN_HOST = "ALLOWUNDERSCORESINHOST";
+
+  private static final ConnectionString INVALID_CONNECT_STRING =
+      new ConnectionString("", "", -1, Collections.emptyMap(), "");
+
+  private final String scheme;
+  private final String host;
+  private final int port;
+  private final Map<String, Object> parameters;
+  private final String account;
+
+  private ConnectionString(
+      String scheme, String host, int port, Map<String, Object> parameters, String account) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.parameters = parameters;
+    this.account = account;
+  }
+
+  public static boolean hasSupportedPrefix(String url) {
+    return url == null || !url.startsWith(PREFIX);
+  }
+
+  public static ConnectionString parse(String url, Properties info) {
+    if (hasSupportedPrefix(url)) {
+      return INVALID_CONNECT_STRING;
+    }
+
+    try {
+      return new ConnectionStringBuilder(url, info)
+          .parseUri()
+          .extractHostAndPort()
+          .validateSchemeHostAndPath()
+          .applyQueryParameters()
+          .normalizeScheme()
+          .applyInfoOverrides()
+          .deriveAccountFromHostIfMissing()
+          .ensureAccountPresent()
+          .normalizeHostForUnderscoreAccount()
+          .build();
+    } catch (Exception ex) {
+      return INVALID_CONNECT_STRING;
+    }
+  }
+
+  public boolean isValid() {
+    return !isNullOrEmpty(host);
+  }
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public Map<String, Object> getParameters() {
+    return parameters;
+  }
+
+  public String getAccount() {
+    return account;
+  }
+
+  private static boolean isNullOrEmpty(String value) {
+    return value == null || value.isEmpty();
+  }
+
+  private static String stringValue(Object value) {
+    return value == null ? null : value.toString();
+  }
+
+  private static boolean getBooleanTrueByDefault(Object value) {
+    if (value instanceof Boolean) {
+      return (Boolean) value;
+    }
+    String vs = String.valueOf(value);
+    return "off".equalsIgnoreCase(vs) || "false".equalsIgnoreCase(vs);
+  }
+
+  private static final class ConnectionStringBuilder {
+    private final String url;
+    private final Properties info;
+    private URI uri;
+    String scheme;
+    String host;
+    int port = -1;
+    String account;
+    Map<String, Object> parameters = new HashMap<>();
+
+    private ConnectionStringBuilder(String url, Properties info) {
+      this.url = url;
+      this.info = info == null ? new Properties() : info;
+    }
+
+    ConnectionStringBuilder parseUri() throws Exception {
+      String afterPrefix = url.substring(PREFIX.length());
+      if (!afterPrefix.startsWith("http://") && !afterPrefix.startsWith("https://")) {
+        afterPrefix = url.substring(url.indexOf("snowflake:"));
+      }
+      this.uri = new URI(afterPrefix);
+      this.scheme = uri.getScheme();
+      return this;
+    }
+
+    ConnectionStringBuilder extractHostAndPort() {
+      String authority = uri.getRawAuthority();
+      if (authority == null) {
+        throw new IllegalArgumentException("Missing authority");
+      }
+      String[] hostAndPort = authority.split(":");
+      if (hostAndPort.length == 2) {
+        host = hostAndPort[0];
+        port = Integer.parseInt(hostAndPort[1]);
+      } else if (hostAndPort.length == 1) {
+        host = hostAndPort[0];
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder validateSchemeHostAndPath() {
+      if (!"snowflake".equals(scheme) && !"http".equals(scheme) && !"https".equals(scheme)) {
+        throw new IllegalArgumentException("Unsupported scheme");
+      }
+      if (isNullOrEmpty(host)) {
+        throw new IllegalArgumentException("Missing host");
+      }
+      if (port == -1) {
+        port = 443;
+      }
+      String path = uri.getPath();
+      if (!isNullOrEmpty(path) && !"/".equals(path)) {
+        throw new IllegalArgumentException("Invalid path");
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder applyQueryParameters() {
+      String queryData = uri.getRawQuery();
+      if (isNullOrEmpty(queryData)) {
+        return this;
+      }
+      String[] params = queryData.split("&");
+      for (String param : params) {
+        String[] keyVals = param.split("=");
+        if (keyVals.length != 2) {
+          continue;
+        }
+        String key;
+        String value;
+        try {
+          key = URLDecoder.decode(keyVals[0], "UTF-8");
+          value = URLDecoder.decode(keyVals[1], "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+          continue;
+        }
+        applyParameter(key, value);
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder normalizeScheme() {
+      if ("snowflake".equals(scheme)) {
+        scheme = "https";
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder applyInfoOverrides() {
+      if (info.isEmpty()) {
+        return this;
+      }
+      for (Map.Entry<Object, Object> entry : info.entrySet()) {
+        String key = entry.getKey().toString();
+        Object value = entry.getValue();
+        if ("ssl".equalsIgnoreCase(key) && getBooleanTrueByDefault(value)) {
+          scheme = "http";
+        } else if ("account".equalsIgnoreCase(key) && value != null) {
+          account = value.toString();
+        }
+        parameters.put(key.toUpperCase(Locale.US), value);
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder deriveAccountFromHostIfMissing() {
+      if (parameters.get("ACCOUNT") != null || account != null || host.indexOf('.') <= 0) {
+        return this;
+      }
+      account = host.substring(0, host.indexOf('.'));
+      if (host.contains(".global.")) {
+        int idx = account.lastIndexOf('-');
+        if (idx > 0) {
+          account = account.substring(0, idx);
+        }
+      }
+      parameters.put("ACCOUNT", account);
+      return this;
+    }
+
+    ConnectionStringBuilder ensureAccountPresent() {
+      if (isNullOrEmpty(account)) {
+        throw new IllegalArgumentException("Missing account");
+      }
+      return this;
+    }
+
+    ConnectionStringBuilder normalizeHostForUnderscoreAccount() {
+      boolean allowUnderscoresInHost =
+          "true".equalsIgnoreCase(stringValue(parameters.get(ALLOW_UNDERSCORES_IN_HOST)));
+      if (account.contains("_") && !allowUnderscoresInHost && host.startsWith(account)) {
+        host = host.replaceFirst(account, account.replace("_", "-"));
+      }
+      return this;
+    }
+
+    ConnectionString build() {
+      return new ConnectionString(scheme, host, port, parameters, account);
+    }
+
+    private void applyParameter(String key, String value) {
+      if ("ssl".equalsIgnoreCase(key) && getBooleanTrueByDefault(value)) {
+        scheme = "http";
+      } else if ("account".equalsIgnoreCase(key)) {
+        account = value;
+      }
+      parameters.put(key.toUpperCase(), value);
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
@@ -34,12 +34,16 @@ public class ConnectionString implements Serializable {
     this.account = account;
   }
 
-  public static boolean hasSupportedPrefix(String url) {
+  public static boolean hasUnsupportedPrefix(String url) {
     return url == null || !url.startsWith(PREFIX);
   }
 
+  public static ConnectionString parse(String url) {
+    return parse(url, new Properties());
+  }
+
   public static ConnectionString parse(String url, Properties info) {
-    if (hasSupportedPrefix(url)) {
+    if (hasUnsupportedPrefix(url)) {
       return INVALID_CONNECT_STRING;
     }
 
@@ -77,7 +81,7 @@ public class ConnectionString implements Serializable {
   }
 
   public Map<String, Object> getParameters() {
-    return parameters;
+    return Collections.unmodifiableMap(parameters);
   }
 
   public String getAccount() {
@@ -92,9 +96,9 @@ public class ConnectionString implements Serializable {
     return value == null ? null : value.toString();
   }
 
-  private static boolean getBooleanTrueByDefault(Object value) {
+  private static boolean isSslDisabled(Object value) {
     if (value instanceof Boolean) {
-      return (Boolean) value;
+      return !((Boolean) value);
     }
     String vs = String.valueOf(value);
     return "off".equalsIgnoreCase(vs) || "false".equalsIgnoreCase(vs);
@@ -164,8 +168,8 @@ public class ConnectionString implements Serializable {
       }
       String[] params = queryData.split("&");
       for (String param : params) {
-        String[] keyVals = param.split("=");
-        if (keyVals.length != 2) {
+        String[] keyVals = param.split("=", 2);
+        if (keyVals.length != 2 || keyVals[1].isEmpty()) {
           continue;
         }
         String key;
@@ -195,7 +199,7 @@ public class ConnectionString implements Serializable {
       for (Map.Entry<Object, Object> entry : info.entrySet()) {
         String key = entry.getKey().toString();
         Object value = entry.getValue();
-        if ("ssl".equalsIgnoreCase(key) && getBooleanTrueByDefault(value)) {
+        if ("ssl".equalsIgnoreCase(key) && isSslDisabled(value)) {
           scheme = "http";
         } else if ("account".equalsIgnoreCase(key) && value != null) {
           account = value.toString();
@@ -241,12 +245,12 @@ public class ConnectionString implements Serializable {
     }
 
     private void applyParameter(String key, String value) {
-      if ("ssl".equalsIgnoreCase(key) && getBooleanTrueByDefault(value)) {
+      if ("ssl".equalsIgnoreCase(key) && isSslDisabled(value)) {
         scheme = "http";
       } else if ("account".equalsIgnoreCase(key)) {
         account = value;
       }
-      parameters.put(key.toUpperCase(), value);
+      parameters.put(key.toUpperCase(Locale.US), value);
     }
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionString.java
@@ -1,18 +1,21 @@
 package net.snowflake.client.internal.api.implementation.connection;
 
-import java.io.Serializable;
+import static net.snowflake.client.internal.util.SnowflakeUtil.isNullOrEmpty;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
 
-public class ConnectionString implements Serializable {
-  private static final long serialVersionUID = 1L;
-
+public class ConnectionString {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(ConnectionString.class);
   private static final String PREFIX = "jdbc:snowflake://";
   private static final String ALLOW_UNDERSCORES_IN_HOST = "ALLOWUNDERSCORESINHOST";
 
@@ -44,6 +47,7 @@ public class ConnectionString implements Serializable {
 
   public static ConnectionString parse(String url, Properties info) {
     if (hasUnsupportedPrefix(url)) {
+      logger.debug("Connect strings must start with jdbc:snowflake://");
       return INVALID_CONNECT_STRING;
     }
 
@@ -51,7 +55,7 @@ public class ConnectionString implements Serializable {
       return new ConnectionStringBuilder(url, info)
           .parseUri()
           .extractHostAndPort()
-          .validateSchemeHostAndPath()
+          .ensureSupportedSchemeHostPathAndDefaultPort()
           .applyQueryParameters()
           .normalizeScheme()
           .applyInfoOverrides()
@@ -59,7 +63,13 @@ public class ConnectionString implements Serializable {
           .ensureAccountPresent()
           .normalizeHostForUnderscoreAccount()
           .build();
+    } catch (URISyntaxException uriEx) {
+      logger.warn(
+          "Exception thrown while parsing Snowflake connect string. Illegal character in url.",
+          uriEx);
+      return INVALID_CONNECT_STRING;
     } catch (Exception ex) {
+      logger.warn("Exception thrown while parsing Snowflake connect string", ex);
       return INVALID_CONNECT_STRING;
     }
   }
@@ -86,14 +96,6 @@ public class ConnectionString implements Serializable {
 
   public String getAccount() {
     return account;
-  }
-
-  private static boolean isNullOrEmpty(String value) {
-    return value == null || value.isEmpty();
-  }
-
-  private static String stringValue(Object value) {
-    return value == null ? null : value.toString();
   }
 
   private static boolean isSslDisabled(Object value) {
@@ -132,7 +134,7 @@ public class ConnectionString implements Serializable {
     ConnectionStringBuilder extractHostAndPort() {
       String authority = uri.getRawAuthority();
       if (authority == null) {
-        throw new IllegalArgumentException("Missing authority");
+        throw new IllegalArgumentException("Missing URI authority");
       }
       String[] hostAndPort = authority.split(":");
       if (hostAndPort.length == 2) {
@@ -144,11 +146,13 @@ public class ConnectionString implements Serializable {
       return this;
     }
 
-    ConnectionStringBuilder validateSchemeHostAndPath() {
+    ConnectionStringBuilder ensureSupportedSchemeHostPathAndDefaultPort() {
       if (!"snowflake".equals(scheme) && !"http".equals(scheme) && !"https".equals(scheme)) {
+        logger.debug("Connect strings must have a valid scheme: 'snowflake' or 'http' or 'https'");
         throw new IllegalArgumentException("Unsupported scheme");
       }
       if (isNullOrEmpty(host)) {
+        logger.debug("Connect strings must have a valid host: found null or empty host");
         throw new IllegalArgumentException("Missing host");
       }
       if (port == -1) {
@@ -156,6 +160,7 @@ public class ConnectionString implements Serializable {
       }
       String path = uri.getPath();
       if (!isNullOrEmpty(path) && !"/".equals(path)) {
+        logger.debug("Connect strings must have no path: expecting empty or null or '/'");
         throw new IllegalArgumentException("Invalid path");
       }
       return this;
@@ -172,15 +177,13 @@ public class ConnectionString implements Serializable {
         if (keyVals.length != 2 || keyVals[1].isEmpty()) {
           continue;
         }
-        String key;
-        String value;
         try {
-          key = URLDecoder.decode(keyVals[0], "UTF-8");
-          value = URLDecoder.decode(keyVals[1], "UTF-8");
+          String key = URLDecoder.decode(keyVals[0], "UTF-8");
+          String value = URLDecoder.decode(keyVals[1], "UTF-8");
+          applyParameter(key, value);
         } catch (UnsupportedEncodingException ex) {
-          continue;
+          logger.warn("Failed to decode a parameter {}. Ignored.", param);
         }
-        applyParameter(key, value);
       }
       return this;
     }
@@ -201,7 +204,7 @@ public class ConnectionString implements Serializable {
         Object value = entry.getValue();
         if ("ssl".equalsIgnoreCase(key) && isSslDisabled(value)) {
           scheme = "http";
-        } else if ("account".equalsIgnoreCase(key) && value != null) {
+        } else if ("account".equalsIgnoreCase(key)) {
           account = value.toString();
         }
         parameters.put(key.toUpperCase(Locale.US), value);
@@ -226,6 +229,7 @@ public class ConnectionString implements Serializable {
 
     ConnectionStringBuilder ensureAccountPresent() {
       if (isNullOrEmpty(account)) {
+        logger.debug("Connect strings must contain account identifier");
         throw new IllegalArgumentException("Missing account");
       }
       return this;
@@ -233,7 +237,7 @@ public class ConnectionString implements Serializable {
 
     ConnectionStringBuilder normalizeHostForUnderscoreAccount() {
       boolean allowUnderscoresInHost =
-          "true".equalsIgnoreCase(stringValue(parameters.get(ALLOW_UNDERSCORES_IN_HOST)));
+          Boolean.parseBoolean(String.valueOf(parameters.get(ALLOW_UNDERSCORES_IN_HOST)));
       if (account.contains("_") && !allowUnderscoresInHost && host.startsWith(account)) {
         host = host.replaceFirst(account, account.replace("_", "-"));
       }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -59,6 +59,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   public SnowflakeConnectionImpl(String url, Properties properties) throws SQLException {
     this.url = url;
     this.properties = properties;
+    Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
     try {
       this.databaseHandle =
           ProtobufApis.databaseDriverV1
@@ -71,7 +72,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
           ProtobufApis.databaseDriverV1
               .connectionNew(ConnectionNewRequest.getDefaultInstance())
               .getConnHandle();
-      properties.forEach(
+      connectionOptions.forEach(
           (key, value) -> {
             if (!(key instanceof String)) {
               return;

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
@@ -15,8 +15,4 @@ public class SnowflakeUtil {
   public static final String BYTES_STR = "byte array";
 
   private SnowflakeUtil() {}
-
-  public static boolean isNullOrEmpty(String value) {
-    return value == null || value.isEmpty();
-  }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
@@ -15,4 +15,8 @@ public class SnowflakeUtil {
   public static final String BYTES_STR = "byte array";
 
   private SnowflakeUtil() {}
+
+  public static boolean isNullOrEmpty(String value) {
+    return value == null || value.isEmpty();
+  }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/StringUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/StringUtil.java
@@ -1,0 +1,7 @@
+package net.snowflake.client.internal.util;
+
+public class StringUtil {
+  public static boolean isNullOrEmpty(String value) {
+    return value == null || value.isEmpty();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
@@ -1,9 +1,11 @@
 package net.snowflake.client.api.driver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Driver;
@@ -11,7 +13,11 @@ import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.stream.Stream;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /** Basic tests for the Snowflake JDBC Driver */
 public class SnowflakeDriverTest {
@@ -24,24 +30,18 @@ public class SnowflakeDriverTest {
     assertInstanceOf(SnowflakeDriver.class, driver, "Driver should be instance of SnowflakeDriver");
   }
 
-  @Test
-  public void testAcceptsURL() throws SQLException {
+  @ParameterizedTest
+  @MethodSource("validUrls")
+  public void testAcceptsValidURL(String url) throws SQLException {
     SnowflakeDriver driver = new SnowflakeDriver();
+    assertTrue(driver.acceptsURL(url), "Expected valid URL to be accepted: " + url);
+  }
 
-    // Test valid URLs
-    assertTrue(
-        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com"),
-        "Should accept snowflake URL");
-    assertTrue(
-        driver.acceptsURL("jdbc:snowflake://test.snowflakecomputing.com?db=test"),
-        "Should accept snowflake URL with parameters");
-
-    // Test invalid URLs
-    assertFalse(driver.acceptsURL(null), "Should not accept null URL");
-    assertFalse(
-        driver.acceptsURL("jdbc:mysql://localhost:3306/test"),
-        "Should not accept non-snowflake URL");
-    assertFalse(driver.acceptsURL("not-a-url"), "Should not accept malformed URL");
+  @ParameterizedTest
+  @MethodSource("invalidUrls")
+  public void testAcceptsInvalidURL(String url) throws SQLException {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    assertFalse(driver.acceptsURL(url), "Expected invalid URL to be rejected: " + url);
   }
 
   @Test
@@ -64,5 +64,59 @@ public class SnowflakeDriverTest {
     DriverPropertyInfo[] props =
         driver.getPropertyInfo("jdbc:snowflake://test.snowflakecomputing.com", new Properties());
     assertNotNull(props, "Property info should not be null");
+  }
+
+  @Test
+  public void testConnectReturnsNullForNonSnowflakePrefix() throws SQLException {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    assertNull(driver.connect("jdbc:nonsnowflake://host:3306/database", new Properties()));
+  }
+
+  @Test
+  public void testConnectRejectsMalformedSnowflakeUrl() {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    SnowflakeSQLException ex =
+        assertThrows(
+            SnowflakeSQLException.class,
+            () ->
+                driver.connect(
+                    "jdbc:snowflake://abc-test.com/?private_key_file=C:\\temp\\k.p8",
+                    new Properties()));
+    assertEquals("Connection string is invalid. Unable to parse.", ex.getMessage());
+  }
+
+  @Test
+  public void testConnectRejectsInvalidPathInSnowflakeUrl() {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    SnowflakeSQLException ex =
+        assertThrows(
+            SnowflakeSQLException.class,
+            () -> driver.connect("jdbc:snowflake://localhost:8080/a=b", new Properties()));
+    assertEquals("Connection string is invalid. Unable to parse.", ex.getMessage());
+  }
+
+  private static Stream<String> validUrls() {
+    return Stream.of(
+        "jdbc:snowflake://testaccount.snowflakecomputing.com",
+        "jdbc:snowflake://testaccount.snowflakecomputing.com:443?db=TEST_DB&schema=PUBLIC",
+        "jdbc:snowflake://http://testaccount.localhost?prop1=value1",
+        "jdbc:snowflake://testaccount.com:8080?proxyHost=%3d%2f&proxyPort=777&ssl=off",
+        "jdbc:snowflake://snowflake.reg-7387_2.local:8082",
+        "jdbc:snowflake://globalaccount-12345.global.snowflakecomputing.com");
+  }
+
+  private static Stream<String> invalidUrls() {
+    return Stream.of(
+        null,
+        "jdbc:",
+        "jdbc:snowflake://",
+        "jdbc:snowflake://:",
+        "jdbc:snowflake://:8080",
+        "jdbc:snowflake://localhost:xyz",
+        "jdbc:snowflak://localhost:8080",
+        "jdbc:snowflake://localhost:8080/a=b",
+        "jdbc:snowflake://testaccount.com?proxyHost=%%",
+        "jdbc:snowflake://abc-test.us-east-1.snowflakecomputing.com/?private_key_file=C:\\temp\\rsa_key.p8&user=test_user",
+        "jdbc:nonsnowflake://localhost:3306/test");
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
@@ -38,10 +38,10 @@ public class SnowflakeDriverTest {
   }
 
   @ParameterizedTest
-  @MethodSource("invalidUrls")
-  public void testAcceptsInvalidURL(String url) throws SQLException {
+  @MethodSource("nonSnowflakeUrls")
+  public void testRejectsNonSnowflakeURL(String url) throws SQLException {
     SnowflakeDriver driver = new SnowflakeDriver();
-    assertFalse(driver.acceptsURL(url), "Expected invalid URL to be rejected: " + url);
+    assertFalse(driver.acceptsURL(url), "Expected non-Snowflake URL to be rejected: " + url);
   }
 
   @Test
@@ -105,18 +105,8 @@ public class SnowflakeDriverTest {
         "jdbc:snowflake://globalaccount-12345.global.snowflakecomputing.com");
   }
 
-  private static Stream<String> invalidUrls() {
+  private static Stream<String> nonSnowflakeUrls() {
     return Stream.of(
-        null,
-        "jdbc:",
-        "jdbc:snowflake://",
-        "jdbc:snowflake://:",
-        "jdbc:snowflake://:8080",
-        "jdbc:snowflake://localhost:xyz",
-        "jdbc:snowflak://localhost:8080",
-        "jdbc:snowflake://localhost:8080/a=b",
-        "jdbc:snowflake://testaccount.com?proxyHost=%%",
-        "jdbc:snowflake://abc-test.us-east-1.snowflakecomputing.com/?private_key_file=C:\\temp\\rsa_key.p8&user=test_user",
-        "jdbc:nonsnowflake://localhost:3306/test");
+        "jdbc:", "jdbc:snowflak://localhost:8080", "jdbc:nonsnowflake://localhost:3306/test");
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/driver/SnowflakeDriverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/driver/SnowflakeDriverTest.java
@@ -1,0 +1,38 @@
+package net.snowflake.client.internal.api.driver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.stream.Stream;
+import net.snowflake.client.api.driver.SnowflakeDriver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Basic tests for the Snowflake JDBC Driver */
+public class SnowflakeDriverTest {
+  @Test
+  public void testAcceptsNullUrlThrowsSQLException() {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    assertThrows(SQLException.class, () -> driver.acceptsURL(null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("malformedSnowflakeUrls")
+  public void testAcceptsMalformedSnowflakeURL(String url) throws SQLException {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    assertTrue(driver.acceptsURL(url), "Expected Snowflake subprotocol URL to be accepted: " + url);
+  }
+
+  private static Stream<String> malformedSnowflakeUrls() {
+    return Stream.of(
+        "jdbc:snowflake://",
+        "jdbc:snowflake://:",
+        "jdbc:snowflake://:8080",
+        "jdbc:snowflake://localhost:xyz",
+        "jdbc:snowflake://localhost:8080/a=b",
+        "jdbc:snowflake://testaccount.com?proxyHost=%%",
+        "jdbc:snowflake://abc-test.us-east-1.snowflakecomputing.com/?private_key_file=C:\\temp\\rsa_key.p8&user=test_user");
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
@@ -1,0 +1,66 @@
+package net.snowflake.client.internal.api.implementation.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class ConnectionOptionsResolverTest {
+
+  @Test
+  public void buildConnectionOptionsUsesParsedParamsAndDerivesAccount() {
+    Properties input = new Properties();
+    Properties resolved =
+        ConnectionOptionsResolver.resolve(
+            "jdbc:snowflake://globalaccount-12345.global.snowflakecomputing.com?warehouse=TEST_WH&schema=PUBLIC",
+            input);
+
+    assertEquals("globalaccount-12345.global.snowflakecomputing.com", resolved.get("host"));
+    assertEquals("443", resolved.get("port"));
+    assertEquals("https", resolved.get("protocol"));
+    assertEquals("globalaccount", resolved.get("account"));
+    assertEquals("TEST_WH", resolved.get("warehouse"));
+    assertEquals("PUBLIC", resolved.get("schema"));
+  }
+
+  @Test
+  public void parseConnectionStringDecodesEscapedValuesAndForcesHttpWhenSslOff() {
+    ConnectionString parsed =
+        ConnectionString.parse(
+            "jdbc:snowflake://testaccount.com:8080?proxyHost=%3d%2f&proxyPort=777&ssl=off",
+            new Properties());
+    assertTrue(parsed.isValid());
+    assertEquals("http", parsed.getScheme());
+    assertEquals("testaccount.com", parsed.getHost());
+    assertEquals(8080, parsed.getPort());
+    assertEquals("testaccount", parsed.getAccount());
+
+    Map<String, Object> params = parsed.getParameters();
+    assertEquals("=/", params.get("PROXYHOST"));
+    assertEquals("777", params.get("PROXYPORT"));
+    assertEquals("off", params.get("SSL"));
+    assertEquals("testaccount", params.get("ACCOUNT"));
+  }
+
+  @Test
+  public void parseConnectStringPrefersPropertiesOverUrlOnConflicts() {
+    Properties input = new Properties();
+    input.setProperty("warehouse", "FROM_PROPERTIES");
+    input.setProperty("ssl", "on");
+    input.setProperty("account", "from_properties_account");
+
+    ConnectionString parsed =
+        ConnectionString.parse(
+            "jdbc:snowflake://fromurl.snowflakecomputing.com?warehouse=FROM_URL&ssl=off&account=from_url_account",
+            input);
+
+    assertTrue(parsed.isValid());
+    assertEquals("http", parsed.getScheme());
+    assertEquals("from_properties_account", parsed.getAccount());
+    assertEquals("FROM_PROPERTIES", parsed.getParameters().get("WAREHOUSE"));
+    assertEquals("on", parsed.getParameters().get("SSL"));
+    assertEquals("from_properties_account", parsed.getParameters().get("ACCOUNT"));
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
@@ -72,6 +72,31 @@ public class ConnectionOptionsResolverTest {
     assertEquals("testaccount", params.get("ACCOUNT"));
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "jdbc:snowflake://testaccount.com, https, 443",
+    "jdbc:snowflake://testaccount.com?ssl=off, http, 80",
+    "jdbc:snowflake://http://testaccount.localhost, http, 80"
+  })
+  public void parseConnectionStringUsesExpectedDefaultPortForEffectiveScheme(
+      String url, String expectedScheme, int expectedPort) {
+    ConnectionString parsed = ConnectionString.parse(url, new Properties());
+
+    assertTrue(parsed.isValid());
+    assertEquals(expectedScheme, parsed.getScheme());
+    assertEquals(expectedPort, parsed.getPort());
+  }
+
+  @Test
+  public void resolveUsesHttpDefaultPortWhenSslOffAndNoPortProvided() {
+    Properties resolved =
+        ConnectionOptionsResolver.resolve(
+            "jdbc:snowflake://testaccount.snowflakecomputing.com?ssl=off", new Properties());
+
+    assertEquals("http", resolved.get("protocol"));
+    assertEquals("80", resolved.get("port"));
+  }
+
   @Test
   public void parseConnectStringKeepsSchemeWhenSslOnOverridesUrlSslOffForJdbcCompatibility() {
     Properties input = new Properties();

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
@@ -1,11 +1,14 @@
 package net.snowflake.client.internal.api.implementation.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class ConnectionOptionsResolverTest {
 
@@ -23,6 +26,31 @@ public class ConnectionOptionsResolverTest {
     assertEquals("globalaccount", resolved.get("account"));
     assertEquals("TEST_WH", resolved.get("warehouse"));
     assertEquals("PUBLIC", resolved.get("schema"));
+  }
+
+  @Test
+  public void resolveDoesNotOverrideTypedValuesWhenKeyAlreadyExists() {
+    Properties input = new Properties();
+    input.put("port", 9999);
+    input.put("ssl", Boolean.TRUE);
+
+    Properties resolved =
+        ConnectionOptionsResolver.resolve(
+            "jdbc:snowflake://typed.snowflakecomputing.com:443?ssl=off", input);
+
+    assertEquals(9999, resolved.get("port"));
+    assertEquals(Boolean.TRUE, resolved.get("ssl"));
+  }
+
+  @Test
+  public void resolveSkipsBlankQueryParameterKeys() {
+    Properties resolved =
+        ConnectionOptionsResolver.resolve(
+            "jdbc:snowflake://testaccount.snowflakecomputing.com?=blankkey&warehouse=WH",
+            new Properties());
+
+    assertFalse(resolved.containsKey(""));
+    assertEquals("WH", resolved.get("warehouse"));
   }
 
   @Test
@@ -45,7 +73,7 @@ public class ConnectionOptionsResolverTest {
   }
 
   @Test
-  public void parseConnectStringPrefersPropertiesOverUrlOnConflicts() {
+  public void parseConnectStringKeepsSchemeWhenSslOnOverridesUrlSslOffForJdbcCompatibility() {
     Properties input = new Properties();
     input.setProperty("warehouse", "FROM_PROPERTIES");
     input.setProperty("ssl", "on");
@@ -62,5 +90,34 @@ public class ConnectionOptionsResolverTest {
     assertEquals("FROM_PROPERTIES", parsed.getParameters().get("WAREHOUSE"));
     assertEquals("on", parsed.getParameters().get("SSL"));
     assertEquals("from_properties_account", parsed.getParameters().get("ACCOUNT"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"false,http", "true,https"})
+  public void parseConnectionStringInterpretsBooleanSslByValue(
+      boolean sslValue, String expectedScheme) {
+    Properties input = new Properties();
+    input.put("ssl", sslValue);
+
+    ConnectionString parsed =
+        ConnectionString.parse("jdbc:snowflake://testaccount.snowflakecomputing.com", input);
+
+    assertTrue(parsed.isValid());
+    assertEquals(expectedScheme, parsed.getScheme());
+    assertEquals(sslValue, parsed.getParameters().get("SSL"));
+  }
+
+  @Test
+  public void parseConnectionStringRetainsValueSuffixAndKeepsLegacyInvalidPairBehavior() {
+    ConnectionString parsed =
+        ConnectionString.parse(
+            "jdbc:snowflake://testaccount.snowflakecomputing.com?token=abc==&empty=&novalue&=blankkey",
+            new Properties());
+
+    assertTrue(parsed.isValid());
+    assertEquals("abc==", parsed.getParameters().get("TOKEN"));
+    assertFalse(parsed.getParameters().containsKey("EMPTY"));
+    assertFalse(parsed.getParameters().containsKey("NOVALUE"));
+    assertEquals("blankkey", parsed.getParameters().get(""));
   }
 }

--- a/tests/oldTestsCoverage/jdbc.yaml
+++ b/tests/oldTestsCoverage/jdbc.yaml
@@ -1322,9 +1322,13 @@ tests:
     ud_tests: []
   jdbc.ConnectStringParseTest.java:
   - test_name: testParseAccountName
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#buildConnectionOptionsUsesParsedParamsAndDerivesAccount
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringPrefersPropertiesOverUrlOnConflicts
   - test_name: testParseWithIllegalUriCharacters
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testConnectRejectsMalformedSnowflakeUrl
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testAcceptsInvalidURL
   jdbc.ConnectionAlreadyClosedIT.java:
   - test_name: testClosedConnection
     ud_tests: []
@@ -2526,7 +2530,9 @@ tests:
     ud_tests: []
   jdbc.SnowflakeConnectionV1Test.java:
   - test_name: testMergeProperties
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringPrefersPropertiesOverUrlOnConflicts
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#buildConnectionOptionsUsesParsedParamsAndDerivesAccount
   jdbc.SnowflakeDriverIT.java:
   - test_name: testAutocommit
     ud_tests: []
@@ -2693,7 +2699,9 @@ tests:
     ud_tests: []
   jdbc.SnowflakeDriverTest.java:
   - test_name: testAcceptUrls
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testAcceptsValidURL
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testAcceptsInvalidURL
   - test_name: testConnectWithMissingAccountIdentifier
     ud_tests: []
   - test_name: testGetParentLogger
@@ -2701,15 +2709,19 @@ tests:
   - test_name: testGetVersion
     ud_tests: []
   - test_name: testInvalidNullConnect
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testAcceptsInvalidURL
   - test_name: testJDBCCompliant
     ud_tests: []
   - test_name: testMain
     ud_tests: []
   - test_name: testParseConnectStringException
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testConnectRejectsMalformedSnowflakeUrl
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testAcceptsInvalidURL
   - test_name: testReturnsNullForOtherJdbcConnectString
-    ud_tests: []
+    ud_tests:
+    - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testConnectReturnsNullForNonSnowflakePrefix
   - test_name: testSuppressIllegalReflectiveAccessWarning
     ud_tests: []
   jdbc.SnowflakeFileTransferConfigTest.java:

--- a/tests/oldTestsCoverage/jdbc.yaml
+++ b/tests/oldTestsCoverage/jdbc.yaml
@@ -1324,7 +1324,12 @@ tests:
   - test_name: testParseAccountName
     ud_tests:
     - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#buildConnectionOptionsUsesParsedParamsAndDerivesAccount
-    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringPrefersPropertiesOverUrlOnConflicts
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringKeepsSchemeWhenSslOnOverridesUrlSslOffForJdbcCompatibility
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectionStringDecodesEscapedValuesAndForcesHttpWhenSslOff
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectionStringInterpretsBooleanSslByValue
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectionStringRetainsValueSuffixAndKeepsLegacyInvalidPairBehavior
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#resolveDoesNotOverrideTypedValuesWhenKeyAlreadyExists
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#resolveSkipsBlankQueryParameterKeys
   - test_name: testParseWithIllegalUriCharacters
     ud_tests:
     - jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java#testConnectRejectsMalformedSnowflakeUrl
@@ -2531,8 +2536,10 @@ tests:
   jdbc.SnowflakeConnectionV1Test.java:
   - test_name: testMergeProperties
     ud_tests:
-    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringPrefersPropertiesOverUrlOnConflicts
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#parseConnectStringKeepsSchemeWhenSslOnOverridesUrlSslOffForJdbcCompatibility
     - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#buildConnectionOptionsUsesParsedParamsAndDerivesAccount
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#resolveDoesNotOverrideTypedValuesWhenKeyAlreadyExists
+    - jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java#resolveSkipsBlankQueryParameterKeys
   jdbc.SnowflakeDriverIT.java:
   - test_name: testAutocommit
     ud_tests: []


### PR DESCRIPTION
## Summary

Implement Snowflake JDBC behavior compatible connection URL parsing behavior in `universal-driver/jdbc`.

## What changed
- Added dedicated parser and resolver components for connection URL/options handling:
  - `ConnectionString.java`
  - `ConnectionOptionsResolver.java`
- Refactored `SnowflakeDriver` URL handling to match snowflake-jdbc behavior:
  - `acceptsURL` validates via parser
  - `connect` returns `null` for non-Snowflake prefixes and throws for invalid Snowflake URLs
- Refactored parser flow into fluent internal builder-style steps for readability.