### PR TITLE
Extend conversion support for Fixed types  in number conversion

### DIFF
--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -1,4 +1,5 @@
 use arrow::array::{Array, ArrowPrimitiveType, PrimitiveArray};
+use odbc_sys as sql;
 
 use crate::cdata_types::CDataType;
 use crate::conversion::error::{
@@ -55,6 +56,29 @@ where
     }
 }
 
+impl SnowflakeNumber {
+    fn format_decimal(value: i128, scale: u32) -> String {
+        if scale > 0 {
+            let mut s = value.to_string();
+            let is_negative = s.starts_with('-');
+            if is_negative {
+                s.remove(0);
+            }
+            while s.len() <= scale as usize {
+                s.insert(0, '0');
+            }
+            let decimal_pos = s.len() - scale as usize;
+            s.insert(decimal_pos, '.');
+            if is_negative {
+                s.insert(0, '-');
+            }
+            s
+        } else {
+            value.to_string()
+        }
+    }
+}
+
 impl WriteODBCType for SnowflakeNumber {
     fn write_odbc_type(
         &self,
@@ -77,27 +101,27 @@ impl WriteODBCType for SnowflakeNumber {
                 Ok(vec![])
             }
             CDataType::Short | CDataType::SShort | CDataType::UShort => {
-                let short_value = (snowflake_value as i64) / 10i64.pow(self.scale);
+                let short_value = snowflake_value / 10i128.pow(self.scale);
                 binding.write_fixed(short_value as u16);
                 Ok(vec![])
             }
             CDataType::TinyInt | CDataType::STinyInt | CDataType::UTinyInt => {
-                let tinyint_value = (snowflake_value as i64) / 10i64.pow(self.scale);
+                let tinyint_value = snowflake_value / 10i128.pow(self.scale);
                 binding.write_fixed(tinyint_value as u8);
                 Ok(vec![])
             }
             CDataType::Long | CDataType::SLong | CDataType::ULong => {
-                let long_value = (snowflake_value as i32) / 10i32.pow(self.scale);
-                binding.write_fixed(long_value);
+                let long_value = snowflake_value / 10i128.pow(self.scale);
+                binding.write_fixed(long_value as i32);
                 Ok(vec![])
             }
             CDataType::SBigInt | CDataType::UBigInt => {
-                let int_value = (snowflake_value as i64) / 10i64.pow(self.scale);
-                binding.write_fixed(int_value);
+                let int_value = snowflake_value / 10i128.pow(self.scale);
+                binding.write_fixed(int_value as i64);
                 Ok(vec![])
             }
             CDataType::Bit => {
-                let int_value = (snowflake_value as i64) / 10i64.pow(self.scale);
+                let int_value = snowflake_value / 10i128.pow(self.scale);
                 if !(0..=1).contains(&int_value) {
                     return NumericValueOutOfRangeSnafu {
                         reason: format!(
@@ -111,29 +135,61 @@ impl WriteODBCType for SnowflakeNumber {
                 Ok(vec![])
             }
             CDataType::Char => {
-                let num_str = if self.scale > 0 {
-                    let mut s = snowflake_value.to_string();
-                    let is_negative = s.starts_with('-');
-                    if is_negative {
-                        s.remove(0);
-                    }
-
-                    while s.len() <= self.scale as usize {
-                        s.insert(0, '0');
-                    }
-
-                    let decimal_pos = s.len() - self.scale as usize;
-                    s.insert(decimal_pos, '.');
-
-                    if is_negative {
-                        s.insert(0, '-');
-                    }
-                    s
-                } else {
-                    snowflake_value.to_string()
-                };
+                let num_str = Self::format_decimal(snowflake_value, self.scale);
                 let warnings = binding.write_char_string(&num_str);
                 Ok(warnings)
+            }
+            CDataType::WChar => {
+                let num_str = Self::format_decimal(snowflake_value, self.scale);
+                let warnings = binding.write_wchar_string(&num_str);
+                Ok(warnings)
+            }
+            CDataType::Numeric => {
+                let int_value = snowflake_value / 10i128.pow(self.scale);
+                let abs_value = int_value.unsigned_abs();
+                let sign: u8 = if int_value >= 0 { 1 } else { 0 };
+                let numeric = sql::Numeric {
+                    precision: self.precision as u8,
+                    scale: 0,
+                    sign,
+                    val: abs_value.to_le_bytes(),
+                };
+                binding.write_fixed(numeric);
+                Ok(vec![])
+            }
+            CDataType::Binary => {
+                let int_value = snowflake_value / 10i128.pow(self.scale);
+                let abs_value = int_value.unsigned_abs();
+                let sign: u8 = if int_value >= 0 { 1 } else { 0 };
+                let numeric = sql::Numeric {
+                    precision: self.precision as u8,
+                    scale: 0,
+                    sign,
+                    val: abs_value.to_le_bytes(),
+                };
+                let numeric_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &numeric as *const sql::Numeric as *const u8,
+                        std::mem::size_of::<sql::Numeric>(),
+                    )
+                };
+                let copy_len = std::cmp::min(numeric_bytes.len(), binding.buffer_length as usize);
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        numeric_bytes.as_ptr(),
+                        binding.target_value_ptr as *mut u8,
+                        copy_len,
+                    );
+                }
+                if !binding.str_len_or_ind_ptr.is_null() {
+                    unsafe {
+                        std::ptr::write(
+                            binding.str_len_or_ind_ptr,
+                            std::mem::size_of::<sql::Numeric>() as sql::Len,
+                        )
+                    };
+                }
+                Ok(vec![])
             }
             _ => UnsupportedOdbcTypeSnafu { target_type }.fail(),
         }

--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -6,7 +6,7 @@ use crate::conversion::error::{
     NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
 use crate::conversion::traits::Binding;
-use crate::conversion::warning::Warnings;
+use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
 
 /// Represents the SQL numeric data types as defined by the ODBC specification.
@@ -28,7 +28,6 @@ impl NumericSqlType {
 
 pub(crate) struct SnowflakeNumber {
     pub(crate) scale: u32,
-    #[allow(dead_code)]
     pub(crate) precision: u32,
     pub(crate) sql_type: NumericSqlType,
 }
@@ -77,6 +76,25 @@ impl SnowflakeNumber {
             value.to_string()
         }
     }
+
+    fn check_integer_range(value: i128, min: i128, max: i128) -> Result<(), WriteOdbcError> {
+        if value < min || value > max {
+            NumericValueOutOfRangeSnafu {
+                reason: format!("Value {value} is out of range ({min} to {max})"),
+            }
+            .fail()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn fractional_warning(has_fractional: bool) -> Warnings {
+        if has_fractional {
+            vec![Warning::NumericValueTruncated]
+        } else {
+            vec![]
+        }
+    }
 }
 
 impl WriteODBCType for SnowflakeNumber {
@@ -89,50 +107,90 @@ impl WriteODBCType for SnowflakeNumber {
             CDataType::Default => self.sql_type.default_c_type(),
             other => other,
         };
+
+        let scale_factor = 10i128.pow(self.scale);
+        let int_value = snowflake_value / scale_factor;
+        let has_fractional = self.scale > 0 && snowflake_value % scale_factor != 0;
+
         match target_type {
             CDataType::Double => {
                 let double_value: f64 = snowflake_value as f64 / 10f64.powi(self.scale as i32);
+                if double_value.is_infinite() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "Value out of range for SQL_C_DOUBLE".to_string(),
+                    }
+                    .fail();
+                }
                 binding.write_fixed(double_value);
                 Ok(vec![])
             }
             CDataType::Float => {
                 let float_value: f32 = snowflake_value as f32 / 10f32.powi(self.scale as i32);
+                if float_value.is_infinite() {
+                    return NumericValueOutOfRangeSnafu {
+                        reason: "Value out of range for SQL_C_FLOAT".to_string(),
+                    }
+                    .fail();
+                }
                 binding.write_fixed(float_value);
                 Ok(vec![])
             }
-            CDataType::Short | CDataType::SShort | CDataType::UShort => {
-                let short_value = snowflake_value / 10i128.pow(self.scale);
-                binding.write_fixed(short_value as u16);
-                Ok(vec![])
+            CDataType::Short | CDataType::SShort => {
+                Self::check_integer_range(int_value, i16::MIN as i128, i16::MAX as i128)?;
+                binding.write_fixed(int_value as i16);
+                Ok(Self::fractional_warning(has_fractional))
             }
-            CDataType::TinyInt | CDataType::STinyInt | CDataType::UTinyInt => {
-                let tinyint_value = snowflake_value / 10i128.pow(self.scale);
-                binding.write_fixed(tinyint_value as u8);
-                Ok(vec![])
+            CDataType::UShort => {
+                Self::check_integer_range(int_value, 0, u16::MAX as i128)?;
+                binding.write_fixed(int_value as u16);
+                Ok(Self::fractional_warning(has_fractional))
             }
-            CDataType::Long | CDataType::SLong | CDataType::ULong => {
-                let long_value = snowflake_value / 10i128.pow(self.scale);
-                binding.write_fixed(long_value as i32);
-                Ok(vec![])
+            CDataType::TinyInt | CDataType::STinyInt => {
+                Self::check_integer_range(int_value, i8::MIN as i128, i8::MAX as i128)?;
+                binding.write_fixed(int_value as i8);
+                Ok(Self::fractional_warning(has_fractional))
             }
-            CDataType::SBigInt | CDataType::UBigInt => {
-                let int_value = snowflake_value / 10i128.pow(self.scale);
+            CDataType::UTinyInt => {
+                Self::check_integer_range(int_value, 0, u8::MAX as i128)?;
+                binding.write_fixed(int_value as u8);
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::Long | CDataType::SLong => {
+                Self::check_integer_range(int_value, i32::MIN as i128, i32::MAX as i128)?;
+                binding.write_fixed(int_value as i32);
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::ULong => {
+                Self::check_integer_range(int_value, 0, u32::MAX as i128)?;
+                binding.write_fixed(int_value as u32);
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::SBigInt => {
+                Self::check_integer_range(int_value, i64::MIN as i128, i64::MAX as i128)?;
                 binding.write_fixed(int_value as i64);
-                Ok(vec![])
+                Ok(Self::fractional_warning(has_fractional))
+            }
+            CDataType::UBigInt => {
+                Self::check_integer_range(int_value, 0, u64::MAX as i128)?;
+                binding.write_fixed(int_value as u64);
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::Bit => {
-                let int_value = snowflake_value / 10i128.pow(self.scale);
-                if !(0..=1).contains(&int_value) {
+                // ODBC spec checks the original decimal value, not the truncated integer:
+                //   "Data is 0 or 1" → ok, no warning
+                //   "Data > 0, < 2, != 1" → truncated, 01S07
+                //   "Data < 0 or >= 2" → 22003
+                if snowflake_value < 0 || int_value >= 2 {
                     return NumericValueOutOfRangeSnafu {
                         reason: format!(
-                            "Value {} out of range for SQL_C_BIT (must be 0 or 1)",
+                            "Value out of range for SQL_C_BIT (must be 0 or 1, got {})",
                             int_value
                         ),
                     }
                     .fail();
                 }
                 binding.write_fixed(int_value as u8);
-                Ok(vec![])
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::Char => {
                 let num_str = Self::format_decimal(snowflake_value, self.scale);
@@ -145,7 +203,6 @@ impl WriteODBCType for SnowflakeNumber {
                 Ok(warnings)
             }
             CDataType::Numeric => {
-                let int_value = snowflake_value / 10i128.pow(self.scale);
                 let abs_value = int_value.unsigned_abs();
                 let sign: u8 = if int_value >= 0 { 1 } else { 0 };
                 let numeric = sql::Numeric {
@@ -155,10 +212,9 @@ impl WriteODBCType for SnowflakeNumber {
                     val: abs_value.to_le_bytes(),
                 };
                 binding.write_fixed(numeric);
-                Ok(vec![])
+                Ok(Self::fractional_warning(has_fractional))
             }
             CDataType::Binary => {
-                let int_value = snowflake_value / 10i128.pow(self.scale);
                 let abs_value = int_value.unsigned_abs();
                 let sign: u8 = if int_value >= 0 { 1 } else { 0 };
                 let numeric = sql::Numeric {

--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -46,11 +46,13 @@ mod tests {
     }
 
     // ========================================================================
-    // Integer conversions (SQL_C_LONG, SQL_C_SHORT, SQL_C_TINYINT, SQL_C_SBIGINT, etc.)
+    // Integer conversions — success cases
+    // (SQL_C_LONG, SQL_C_SHORT, SQL_C_TINYINT, SQL_C_SBIGINT, etc.)
+    // Per ODBC spec: exact conversion → no warning; fractional truncation → 01S07
     // ========================================================================
 
     macro_rules! integer_conversion_tests {
-        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => $expected:expr, truncated=$trunc:expr;)*) => {
             $(
                 #[test]
                 fn $name() {
@@ -58,72 +60,132 @@ mod tests {
                     let mut value: $rust_type = 0 as $rust_type;
                     let mut str_len: sql::Len = 0;
                     let binding = binding_for_value($c_type, &mut value, &mut str_len);
-                    sn.write_odbc_type($input, &binding).unwrap();
+                    let warnings = sn.write_odbc_type($input, &binding).unwrap();
                     assert_eq!(value, $expected as $rust_type);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
                 }
             )*
         };
     }
 
     integer_conversion_tests! {
-        // Basic values
-        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                              => 42;
-        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                       => 123456789;
-        short_integer:                          CDataType::Short,    u16, 0,  5,  300i128                              => 300;
-        tinyint_integer:                        CDataType::TinyInt,  u8,  0,  3,  123i128                              => 123;
+        // Basic values — no truncation
+        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                              => 42,    truncated=false;
+        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                       => 123456789, truncated=false;
+        short_integer:                          CDataType::Short,    i16, 0,  5,  300i128                              => 300,   truncated=false;
+        tinyint_integer:                        CDataType::TinyInt,  i8,  0,  3,  123i128                              => 123,   truncated=false;
 
         // Zero across all types
-        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                                => 0;
-        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                                => 0;
-        short_zero:                             CDataType::Short,    u16, 0,  5,  0i128                                => 0;
-        tinyint_zero:                           CDataType::TinyInt,  u8,  0,  3,  0i128                                => 0;
+        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                                => 0,     truncated=false;
+        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                                => 0,     truncated=false;
+        short_zero:                             CDataType::Short,    i16, 0,  5,  0i128                                => 0,     truncated=false;
+        tinyint_zero:                           CDataType::TinyInt,  i8,  0,  3,  0i128                                => 0,     truncated=false;
 
         // One and negative one
-        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                                => 1;
-        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                               => -1;
+        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                                => 1,     truncated=false;
+        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                               => -1,    truncated=false;
 
         // Negative values
-        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                              => -42;
-        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                       => -123456789;
+        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                              => -42,   truncated=false;
+        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                       => -123456789, truncated=false;
 
-        // i32 boundary values
-        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128                    => 2_147_483_647;
-        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128                   => -2_147_483_648;
+        // Boundary values — no truncation
+        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128                    => 2_147_483_647, truncated=false;
+        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128                   => -2_147_483_648, truncated=false;
+        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128        => 9_223_372_036_854_775_807i64, truncated=false;
+        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128       => -9_223_372_036_854_775_808i64, truncated=false;
+        short_i16_max:                          CDataType::Short,    i16, 0,  5,  32767i128                            => 32767,  truncated=false;
+        short_i16_min:                          CDataType::Short,    i16, 0,  5,  -32768i128                           => -32768, truncated=false;
+        ushort_u16_max:                         CDataType::UShort,   u16, 0,  5,  65535i128                            => 65535,  truncated=false;
+        tinyint_i8_max:                         CDataType::TinyInt,  i8,  0,  3,  127i128                              => 127,   truncated=false;
+        tinyint_i8_min:                         CDataType::TinyInt,  i8,  0,  3,  -128i128                             => -128,  truncated=false;
+        utinyint_u8_max:                        CDataType::UTinyInt, u8,  0,  3,  255i128                              => 255,   truncated=false;
 
-        // i64 boundary values
-        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128        => 9_223_372_036_854_775_807i64;
-        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128       => -9_223_372_036_854_775_808i64;
-
-        // u16 / u8 boundary values
-        short_u16_max:                          CDataType::Short,    u16, 0,  5,  65535i128                            => 65535;
-        tinyint_u8_max:                         CDataType::TinyInt,  u8,  0,  3,  255i128                              => 255;
-
-        // Fractional truncation toward zero
-        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                              => 9;
-        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                             => -9;
-        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                               => 0;
-        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                              => 0;
-        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                            => 12;
-        short_truncates_frac:                   CDataType::Short,    u16, 1,  5,  255i128                              => 25;
-        tinyint_truncates_frac:                 CDataType::TinyInt,  u8,  1,  3,  99i128                               => 9;
+        // Fractional truncation — should produce 01S07 warning
+        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                              => 9,     truncated=true;
+        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                             => -9,    truncated=true;
+        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                               => 0,     truncated=true;
+        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                              => 0,     truncated=true;
+        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                            => 12,    truncated=true;
+        short_truncates_frac:                   CDataType::Short,    i16, 1,  5,  255i128                              => 25,    truncated=true;
+        tinyint_truncates_frac:                 CDataType::TinyInt,  i8,  1,  3,  99i128                               => 9,     truncated=true;
 
         // High scale
-        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                                => 0;
-        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                                => 0;
-        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128                   => 5;
-        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128                  => -3;
-        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                                => 0;
-        ulong_zero_scale_10:                    CDataType::ULong,    i32, 10, 38, 0i128                                => 0;
-        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                                => 0;
-        short_zero_scale_10:                    CDataType::Short,    u16, 10, 38, 0i128                                => 0;
-        tinyint_zero_scale_10:                  CDataType::TinyInt,  u8,  10, 38, 0i128                                => 0;
+        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                                => 0,     truncated=false;
+        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                                => 0,     truncated=false;
+        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128                   => 5,     truncated=false;
+        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128                  => -3,    truncated=false;
+        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                                => 0,     truncated=false;
+        ulong_zero_scale_10:                    CDataType::ULong,    u32, 10, 38, 0i128                                => 0,     truncated=false;
+        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                                => 0,     truncated=false;
+        short_zero_scale_10:                    CDataType::Short,    i16, 10, 38, 0i128                                => 0,     truncated=false;
+        tinyint_zero_scale_10:                  CDataType::TinyInt,  i8,  10, 38, 0i128                                => 0,     truncated=false;
 
-        // Type aliases (SShort, UShort, STinyInt, UTinyInt, UBigInt)
-        sshort_integer:                         CDataType::SShort,   u16, 0,  5,  300i128                              => 300;
-        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                              => 300;
-        stinyint_integer:                       CDataType::STinyInt, u8,  0,  3,  100i128                              => 100;
-        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                              => 200;
-        ubigint_integer:                        CDataType::UBigInt,  i64, 0,  10, 999i128                              => 999;
+        // Type aliases
+        sshort_integer:                         CDataType::SShort,   i16, 0,  5,  300i128                              => 300,   truncated=false;
+        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                              => 300,   truncated=false;
+        stinyint_integer:                       CDataType::STinyInt, i8,  0,  3,  100i128                              => 100,   truncated=false;
+        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                              => 200,   truncated=false;
+        ubigint_integer:                        CDataType::UBigInt,  u64, 0,  10, 999i128                              => 999,   truncated=false;
+        ubigint_u64_max:                        CDataType::UBigInt,  u64, 0,  20, 18_446_744_073_709_551_615i128       => 18_446_744_073_709_551_615u64, truncated=false;
+    }
+
+    // ========================================================================
+    // Integer conversions — overflow error cases (SQLSTATE 22003)
+    // ========================================================================
+
+    macro_rules! integer_overflow_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    assert!(sn.write_odbc_type($input, &binding).is_err());
+                }
+            )*
+        };
+    }
+
+    integer_overflow_tests! {
+        // i32 overflow
+        slong_overflow_above:               CDataType::SLong,    i32, 0, 10, 2_147_483_648i128;
+        slong_overflow_below:               CDataType::SLong,    i32, 0, 10, -2_147_483_649i128;
+
+        // u32 overflow (ULong)
+        ulong_overflow_above:               CDataType::ULong,    u32, 0, 10, 4_294_967_296i128;
+        ulong_overflow_negative:            CDataType::ULong,    u32, 0, 10, -1i128;
+
+        // i16 overflow
+        short_overflow_above:               CDataType::Short,    i16, 0, 5,  32768i128;
+        short_overflow_below:               CDataType::Short,    i16, 0, 5,  -32769i128;
+
+        // u16 overflow (UShort)
+        ushort_overflow_above:              CDataType::UShort,   u16, 0, 5,  65536i128;
+        ushort_overflow_negative:           CDataType::UShort,   u16, 0, 5,  -1i128;
+
+        // i8 overflow
+        tinyint_overflow_above:             CDataType::TinyInt,  i8,  0, 3,  128i128;
+        tinyint_overflow_below:             CDataType::TinyInt,  i8,  0, 3,  -129i128;
+
+        // u8 overflow (UTinyInt)
+        utinyint_overflow_above:            CDataType::UTinyInt, u8,  0, 3,  256i128;
+        utinyint_overflow_negative:         CDataType::UTinyInt, u8,  0, 3,  -1i128;
+
+        // i64 overflow
+        sbigint_overflow_above:             CDataType::SBigInt,  i64, 0, 20, 9_223_372_036_854_775_808i128;
+        sbigint_overflow_below:             CDataType::SBigInt,  i64, 0, 20, -9_223_372_036_854_775_809i128;
+
+        // u64 overflow (UBigInt)
+        ubigint_overflow_above:             CDataType::UBigInt,  u64, 0, 20, 18_446_744_073_709_551_616i128;
+        ubigint_overflow_negative:          CDataType::UBigInt,  u64, 0, 20, -1i128;
+
+        // Overflow after scale division (value fits in i128 but not in target after division)
+        slong_overflow_after_scale:         CDataType::SLong,    i32, 1, 10, 21_474_836_480i128;
     }
 
     // ========================================================================
@@ -271,10 +333,11 @@ mod tests {
 
     // ========================================================================
     // SQL_C_NUMERIC struct conversions
+    // Per ODBC spec: fractional truncation → 01S07
     // ========================================================================
 
     macro_rules! numeric_struct_tests {
-        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, val=$val:expr;)*) => {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, val=$val:expr, truncated=$trunc:expr;)*) => {
             $(
                 #[test]
                 fn $name() {
@@ -287,40 +350,43 @@ mod tests {
                     };
                     let mut str_len: sql::Len = 0;
                     let binding = binding_for_value(CDataType::Numeric, &mut value, &mut str_len);
-                    sn.write_odbc_type($input, &binding).unwrap();
+                    let warnings = sn.write_odbc_type($input, &binding).unwrap();
                     assert_eq!(value.precision, $precision as u8);
                     assert_eq!(value.scale, 0);
                     assert_eq!(value.sign, $sign);
                     assert_eq!(u128::from_le_bytes(value.val), $val as u128);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
                 }
             )*
         };
     }
 
     numeric_struct_tests! {
-        numeric_positive_with_scale:    2,  10, 12345i128                   => sign=1, val=123;
-        numeric_negative:               0,  10, -42i128                     => sign=0, val=42;
-        numeric_zero:                   0,  10, 0i128                       => sign=1, val=0;
-        numeric_one:                    0,  10, 1i128                       => sign=1, val=1;
-        numeric_negative_one:           0,  10, -1i128                      => sign=0, val=1;
+        numeric_positive_with_scale:    2,  10, 12345i128                   => sign=1, val=123,        truncated=true;
+        numeric_negative:               0,  10, -42i128                     => sign=0, val=42,         truncated=false;
+        numeric_zero:                   0,  10, 0i128                       => sign=1, val=0,          truncated=false;
+        numeric_one:                    0,  10, 1i128                       => sign=1, val=1,          truncated=false;
+        numeric_negative_one:           0,  10, -1i128                      => sign=0, val=1,          truncated=false;
 
         // LE byte boundary values
-        numeric_255:                    0,  10, 255i128                     => sign=1, val=255;
-        numeric_256:                    0,  10, 256i128                     => sign=1, val=256;
-        numeric_65535:                  0,  10, 65535i128                   => sign=1, val=65535;
-        numeric_65536:                  0,  10, 65536i128                   => sign=1, val=65536;
-        numeric_1_000_000:              0,  10, 1_000_000i128              => sign=1, val=1_000_000;
+        numeric_255:                    0,  10, 255i128                     => sign=1, val=255,        truncated=false;
+        numeric_256:                    0,  10, 256i128                     => sign=1, val=256,        truncated=false;
+        numeric_65535:                  0,  10, 65535i128                   => sign=1, val=65535,      truncated=false;
+        numeric_65536:                  0,  10, 65536i128                   => sign=1, val=65536,      truncated=false;
+        numeric_1_000_000:              0,  10, 1_000_000i128              => sign=1, val=1_000_000,  truncated=false;
 
         // Scale truncation
-        numeric_scale_truncates_frac:   2,  10, 999i128                    => sign=1, val=9;
-        numeric_scale_neg_truncates:    2,  10, -999i128                   => sign=0, val=9;
-        numeric_zero_with_scale:        5,  10, 0i128                      => sign=1, val=0;
+        numeric_scale_truncates_frac:   2,  10, 999i128                    => sign=1, val=9,          truncated=true;
+        numeric_scale_neg_truncates:    2,  10, -999i128                   => sign=0, val=9,          truncated=true;
+        numeric_zero_with_scale:        5,  10, 0i128                      => sign=1, val=0,          truncated=false;
 
         // High scale
-        numeric_high_scale_zero:        10, 38, 0i128                      => sign=1, val=0;
-        numeric_high_scale_positive:    10, 38, 50_000_000_000i128         => sign=1, val=5;
-        numeric_high_scale_negative:    10, 38, -30_000_000_000i128        => sign=0, val=3;
-        numeric_scale_37_zero:          37, 38, 0i128                      => sign=1, val=0;
+        numeric_high_scale_zero:        10, 38, 0i128                      => sign=1, val=0,          truncated=false;
+        numeric_high_scale_positive:    10, 38, 50_000_000_000i128         => sign=1, val=5,          truncated=false;
+        numeric_high_scale_negative:    10, 38, -30_000_000_000i128        => sign=0, val=3,          truncated=false;
+        numeric_scale_37_zero:          37, 38, 0i128                      => sign=1, val=0,          truncated=false;
     }
 
     // ========================================================================
@@ -359,11 +425,14 @@ mod tests {
     }
 
     // ========================================================================
-    // SQL_C_BIT conversions
+    // SQL_C_BIT conversions (per ODBC spec)
+    //   Exact 0 or 1       → ok, no warning
+    //   0 < value < 2, ≠ 1 → truncate, 01S07
+    //   value < 0 or ≥ 2   → 22003 error
     // ========================================================================
 
     macro_rules! bit_ok_tests {
-        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr, truncated=$trunc:expr;)*) => {
             $(
                 #[test]
                 fn $name() {
@@ -371,20 +440,28 @@ mod tests {
                     let mut value: u8 = 0xFF;
                     let mut str_len: sql::Len = 0;
                     let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
-                    sn.write_odbc_type($input, &binding).unwrap();
+                    let warnings = sn.write_odbc_type($input, &binding).unwrap();
                     assert_eq!(value, $expected);
+                    assert_eq!(!warnings.is_empty(), $trunc,
+                        "truncation warning mismatch: expected truncated={}, got warnings={:?}",
+                        $trunc, warnings);
                 }
             )*
         };
     }
 
     bit_ok_tests! {
-        bit_zero:                       0,  10, 0i128   => 0;
-        bit_one:                        0,  10, 1i128   => 1;
-        bit_frac_truncates_to_zero:     1,  10, 9i128   => 0;
-        bit_frac_truncates_to_one:      1,  10, 15i128  => 1;
-        bit_zero_with_high_scale:       10, 38, 0i128   => 0;
-        bit_one_with_scale:             2,  10, 100i128 => 1;
+        // Exact values — no warning
+        bit_exact_zero:                     0,  10, 0i128   => 0, truncated=false;
+        bit_exact_one:                      0,  10, 1i128   => 1, truncated=false;
+        bit_exact_one_via_scale:            2,  10, 100i128 => 1, truncated=false;
+        bit_exact_zero_high_scale:          10, 38, 0i128   => 0, truncated=false;
+
+        // Fractional truncation → 01S07
+        bit_frac_truncates_to_zero:         1,  10, 9i128   => 0, truncated=true;
+        bit_frac_truncates_to_one:          1,  10, 15i128  => 1, truncated=true;
+        bit_frac_099_truncates_to_zero:     2,  10, 99i128  => 0, truncated=true;
+        bit_frac_150_truncates_to_one:      2,  10, 150i128 => 1, truncated=true;
     }
 
     macro_rules! bit_error_tests {
@@ -403,10 +480,14 @@ mod tests {
     }
 
     bit_error_tests! {
-        bit_rejects_two:                0,  10, 2i128;
-        bit_rejects_negative_one:       0,  10, -1i128;
-        bit_rejects_large_positive:     0,  10, 100i128;
-        bit_rejects_large_negative:     0,  10, -100i128;
-        bit_rejects_frac_truncates_2:   1,  10, 25i128;
+        // value >= 2
+        bit_rejects_two:                    0,  10, 2i128;
+        bit_rejects_large_positive:         0,  10, 100i128;
+        bit_rejects_frac_truncates_to_2:    1,  10, 25i128;
+
+        // value < 0 (checked on original snowflake_value, not truncated)
+        bit_rejects_negative_one:           0,  10, -1i128;
+        bit_rejects_large_negative:         0,  10, -100i128;
+        bit_rejects_neg_frac:               1,  10, -5i128;
     }
 }

--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -45,95 +45,368 @@ mod tests {
         assert_eq!(NumericSqlType::Decimal.default_c_type(), CDataType::Char);
     }
 
-    #[test]
-    fn decimal_default_writes_integer_as_char() {
-        let sn = make_decimal(0, 10);
-        let mut buffer = vec![0u8; 32];
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+    // ========================================================================
+    // Integer conversions (SQL_C_LONG, SQL_C_SHORT, SQL_C_TINYINT, SQL_C_SBIGINT, etc.)
+    // ========================================================================
 
-        sn.write_odbc_type(42, &binding).unwrap();
-
-        assert_eq!(str_len, 2);
-        assert_eq!(&buffer[..2], b"42");
-        assert_eq!(buffer[2], 0);
+    macro_rules! integer_conversion_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0 as $rust_type;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    assert_eq!(value, $expected as $rust_type);
+                }
+            )*
+        };
     }
 
-    #[test]
-    fn decimal_default_writes_scaled_value_as_char() {
-        let sn = make_decimal(2, 10);
-        let mut buffer = vec![0u8; 32];
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+    integer_conversion_tests! {
+        // Basic values
+        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                              => 42;
+        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                       => 123456789;
+        short_integer:                          CDataType::Short,    u16, 0,  5,  300i128                              => 300;
+        tinyint_integer:                        CDataType::TinyInt,  u8,  0,  3,  123i128                              => 123;
 
-        sn.write_odbc_type(12345, &binding).unwrap();
+        // Zero across all types
+        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                                => 0;
+        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                                => 0;
+        short_zero:                             CDataType::Short,    u16, 0,  5,  0i128                                => 0;
+        tinyint_zero:                           CDataType::TinyInt,  u8,  0,  3,  0i128                                => 0;
 
-        assert_eq!(str_len, 6);
-        assert_eq!(&buffer[..6], b"123.45");
-        assert_eq!(buffer[6], 0);
+        // One and negative one
+        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                                => 1;
+        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                               => -1;
+
+        // Negative values
+        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                              => -42;
+        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                       => -123456789;
+
+        // i32 boundary values
+        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128                    => 2_147_483_647;
+        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128                   => -2_147_483_648;
+
+        // i64 boundary values
+        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128        => 9_223_372_036_854_775_807i64;
+        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128       => -9_223_372_036_854_775_808i64;
+
+        // u16 / u8 boundary values
+        short_u16_max:                          CDataType::Short,    u16, 0,  5,  65535i128                            => 65535;
+        tinyint_u8_max:                         CDataType::TinyInt,  u8,  0,  3,  255i128                              => 255;
+
+        // Fractional truncation toward zero
+        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                              => 9;
+        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                             => -9;
+        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                               => 0;
+        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                              => 0;
+        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                            => 12;
+        short_truncates_frac:                   CDataType::Short,    u16, 1,  5,  255i128                              => 25;
+        tinyint_truncates_frac:                 CDataType::TinyInt,  u8,  1,  3,  99i128                               => 9;
+
+        // High scale
+        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                                => 0;
+        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                                => 0;
+        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128                   => 5;
+        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128                  => -3;
+        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                                => 0;
+        ulong_zero_scale_10:                    CDataType::ULong,    i32, 10, 38, 0i128                                => 0;
+        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                                => 0;
+        short_zero_scale_10:                    CDataType::Short,    u16, 10, 38, 0i128                                => 0;
+        tinyint_zero_scale_10:                  CDataType::TinyInt,  u8,  10, 38, 0i128                                => 0;
+
+        // Type aliases (SShort, UShort, STinyInt, UTinyInt, UBigInt)
+        sshort_integer:                         CDataType::SShort,   u16, 0,  5,  300i128                              => 300;
+        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                              => 300;
+        stinyint_integer:                       CDataType::STinyInt, u8,  0,  3,  100i128                              => 100;
+        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                              => 200;
+        ubigint_integer:                        CDataType::UBigInt,  i64, 0,  10, 999i128                              => 999;
     }
 
-    #[test]
-    fn decimal_default_writes_negative_scaled_value_as_char() {
-        let sn = make_decimal(3, 10);
-        let mut buffer = vec![0u8; 32];
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+    // ========================================================================
+    // Char / Default string conversions
+    // ========================================================================
 
-        sn.write_odbc_type(-50, &binding).unwrap();
-
-        assert_eq!(str_len, 6);
-        assert_eq!(&buffer[..6], b"-0.050");
-        assert_eq!(buffer[6], 0);
+    macro_rules! char_conversion_tests {
+        ($($name:ident: $c_type:expr, $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u8; 128];
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_char_buffer($c_type, &mut buffer, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    let expected: &str = $expected;
+                    assert_eq!(str_len, expected.len() as sql::Len);
+                    assert_eq!(&buffer[..expected.len()], expected.as_bytes());
+                    assert_eq!(buffer[expected.len()], 0);
+                }
+            )*
+        };
     }
 
-    #[test]
-    fn decimal_default_writes_zero_as_char() {
-        let sn = make_decimal(0, 10);
-        let mut buffer = vec![0u8; 32];
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_char_buffer(CDataType::Default, &mut buffer, &mut str_len);
+    char_conversion_tests! {
+        // Default type (maps to Char)
+        default_integer_as_char:                CDataType::Default, 0,  10, 42i128                  => "42";
+        default_scaled_as_char:                 CDataType::Default, 2,  10, 12345i128               => "123.45";
+        default_negative_scaled_as_char:        CDataType::Default, 3,  10, -50i128                 => "-0.050";
+        default_zero_as_char:                   CDataType::Default, 0,  10, 0i128                   => "0";
 
-        sn.write_odbc_type(0, &binding).unwrap();
+        // Explicit Char type
+        char_integer:                           CDataType::Char,    0,  10, 42i128                  => "42";
+        char_negative_integer:                  CDataType::Char,    0,  10, -42i128                 => "-42";
+        char_one:                               CDataType::Char,    0,  10, 1i128                   => "1";
+        char_negative_one:                      CDataType::Char,    0,  10, -1i128                  => "-1";
+        char_single_digit:                      CDataType::Char,    0,  1,  5i128                   => "5";
 
-        assert_eq!(str_len, 1);
-        assert_eq!(&buffer[..1], b"0");
-        assert_eq!(buffer[1], 0);
+        // Leading zeros in fractional part
+        char_leading_zeros_3:                   CDataType::Char,    3,  10, 1i128                   => "0.001";
+        char_leading_zeros_3_neg:               CDataType::Char,    3,  10, -1i128                  => "-0.001";
+        char_leading_zeros_5:                   CDataType::Char,    5,  10, 1i128                   => "0.00001";
+        char_leading_zeros_5_neg:               CDataType::Char,    5,  10, -1i128                  => "-0.00001";
+
+        // Zero with various scales
+        char_zero_scale_1:                      CDataType::Char,    1,  10, 0i128                   => "0.0";
+        char_zero_scale_3:                      CDataType::Char,    3,  10, 0i128                   => "0.000";
+        char_zero_scale_5:                      CDataType::Char,    5,  10, 0i128                   => "0.00000";
+
+        // Scale boundary: value digits == scale (entire value is fractional)
+        char_scale_equals_digits:               CDataType::Char,    2,  10, 99i128                  => "0.99";
+        char_scale_equals_digits_neg:           CDataType::Char,    2,  10, -99i128                 => "-0.99";
+        char_scale_exactly_at_boundary:         CDataType::Char,    2,  10, 100i128                 => "1.00";
+        char_trailing_zeros_preserved:          CDataType::Char,    3,  10, 1000i128                => "1.000";
+
+        // Large numbers
+        char_large_integer:                     CDataType::Char,    0,  38, 99999999999999i128       => "99999999999999";
+        char_large_negative:                    CDataType::Char,    0,  38, -99999999999999i128      => "-99999999999999";
+        char_large_with_scale:                  CDataType::Char,    2,  38, 9999999999999900i128     => "99999999999999.00";
     }
 
-    #[test]
-    fn decimal_explicit_slong_writes_i32() {
-        let sn = make_decimal(0, 10);
-        let mut value: i32 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+    // ========================================================================
+    // WChar conversions
+    // ========================================================================
 
-        sn.write_odbc_type(42, &binding).unwrap();
-
-        assert_eq!(value, 42);
+    macro_rules! wchar_conversion_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u16; 128];
+                    let mut str_len: sql::Len = 0;
+                    let binding = Binding {
+                        target_type: CDataType::WChar,
+                        target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
+                        buffer_length: (buffer.len() * 2) as sql::Len,
+                        str_len_or_ind_ptr: &mut str_len as *mut sql::Len,
+                    };
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    let expected_str: &str = $expected;
+                    let expected: Vec<u16> = expected_str.encode_utf16().collect();
+                    assert_eq!(str_len, (expected.len() * 2) as sql::Len);
+                    assert_eq!(&buffer[..expected.len()], &expected[..]);
+                    assert_eq!(buffer[expected.len()], 0);
+                }
+            )*
+        };
     }
 
-    #[test]
-    fn decimal_explicit_sbigint_writes_i64() {
-        let sn = make_decimal(0, 10);
-        let mut value: i64 = 0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::SBigInt, &mut value, &mut str_len);
-
-        sn.write_odbc_type(123456789, &binding).unwrap();
-
-        assert_eq!(value, 123456789i64);
+    wchar_conversion_tests! {
+        wchar_integer:              0, 10, 42i128       => "42";
+        wchar_scaled:               2, 10, 12345i128    => "123.45";
+        wchar_zero:                 0, 10, 0i128        => "0";
+        wchar_negative:             0, 10, -42i128      => "-42";
+        wchar_negative_scaled:      2, 10, -12345i128   => "-123.45";
+        wchar_leading_zeros:        3, 10, 1i128        => "0.001";
+        wchar_zero_with_scale:      2, 10, 0i128        => "0.00";
+        wchar_large:                0, 38, 999999i128   => "999999";
     }
 
-    #[test]
-    fn decimal_explicit_double_writes_f64() {
-        let sn = make_decimal(0, 10);
-        let mut value: f64 = 0.0;
-        let mut str_len: sql::Len = 0;
-        let binding = binding_for_value(CDataType::Double, &mut value, &mut str_len);
+    // ========================================================================
+    // Float / Double conversions (approximate comparison)
+    // ========================================================================
 
-        sn.write_odbc_type(42, &binding).unwrap();
+    macro_rules! float_conversion_tests {
+        ($($name:ident: $c_type:expr, $rust_type:ty, $scale:expr, $precision:expr, $input:expr => approx $expected:expr, tol $tol:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: $rust_type = 0.0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value($c_type, &mut value, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    assert!(
+                        (value - ($expected) as $rust_type).abs() < ($tol) as $rust_type,
+                        "expected approximately {}, got {}", $expected, value
+                    );
+                }
+            )*
+        };
+    }
 
-        assert!((value - 42.0).abs() < f64::EPSILON);
+    float_conversion_tests! {
+        // f64
+        double_integer:             CDataType::Double, f64, 0, 10, 42i128               => approx 42.0,       tol f64::EPSILON;
+        double_zero:                CDataType::Double, f64, 0, 10, 0i128                => approx 0.0,        tol f64::EPSILON;
+        double_negative:            CDataType::Double, f64, 0, 10, -42i128              => approx -42.0,      tol f64::EPSILON;
+        double_one:                 CDataType::Double, f64, 0, 10, 1i128                => approx 1.0,        tol f64::EPSILON;
+        double_neg_one:             CDataType::Double, f64, 0, 10, -1i128               => approx -1.0,       tol f64::EPSILON;
+        double_scaled:              CDataType::Double, f64, 2, 10, 12345i128            => approx 123.45,     tol 0.001;
+        double_negative_scaled:     CDataType::Double, f64, 3, 10, -50i128              => approx -0.05,      tol 0.001;
+        double_large:               CDataType::Double, f64, 0, 15, 1_000_000_000i128    => approx 1e9,        tol 1.0;
+        double_small_fraction:      CDataType::Double, f64, 5, 10, 1i128                => approx 0.00001,    tol 1e-8;
+
+        // f32
+        float_scaled:               CDataType::Float,  f32, 3, 10, 123789i128           => approx 123.789,    tol 0.01;
+        float_zero:                 CDataType::Float,  f32, 0, 10, 0i128                => approx 0.0,        tol f32::EPSILON;
+        float_negative:             CDataType::Float,  f32, 0, 10, -100i128             => approx -100.0,     tol 0.01;
+        float_small_fraction:       CDataType::Float,  f32, 2, 10, 1i128                => approx 0.01,       tol 0.001;
+        float_one:                  CDataType::Float,  f32, 0, 10, 1i128                => approx 1.0,        tol f32::EPSILON;
+    }
+
+    // ========================================================================
+    // SQL_C_NUMERIC struct conversions
+    // ========================================================================
+
+    macro_rules! numeric_struct_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, val=$val:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value = sql::Numeric {
+                        precision: 0,
+                        scale: 0,
+                        sign: 0,
+                        val: [0u8; 16],
+                    };
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Numeric, &mut value, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    assert_eq!(value.precision, $precision as u8);
+                    assert_eq!(value.scale, 0);
+                    assert_eq!(value.sign, $sign);
+                    assert_eq!(u128::from_le_bytes(value.val), $val as u128);
+                }
+            )*
+        };
+    }
+
+    numeric_struct_tests! {
+        numeric_positive_with_scale:    2,  10, 12345i128                   => sign=1, val=123;
+        numeric_negative:               0,  10, -42i128                     => sign=0, val=42;
+        numeric_zero:                   0,  10, 0i128                       => sign=1, val=0;
+        numeric_one:                    0,  10, 1i128                       => sign=1, val=1;
+        numeric_negative_one:           0,  10, -1i128                      => sign=0, val=1;
+
+        // LE byte boundary values
+        numeric_255:                    0,  10, 255i128                     => sign=1, val=255;
+        numeric_256:                    0,  10, 256i128                     => sign=1, val=256;
+        numeric_65535:                  0,  10, 65535i128                   => sign=1, val=65535;
+        numeric_65536:                  0,  10, 65536i128                   => sign=1, val=65536;
+        numeric_1_000_000:              0,  10, 1_000_000i128              => sign=1, val=1_000_000;
+
+        // Scale truncation
+        numeric_scale_truncates_frac:   2,  10, 999i128                    => sign=1, val=9;
+        numeric_scale_neg_truncates:    2,  10, -999i128                   => sign=0, val=9;
+        numeric_zero_with_scale:        5,  10, 0i128                      => sign=1, val=0;
+
+        // High scale
+        numeric_high_scale_zero:        10, 38, 0i128                      => sign=1, val=0;
+        numeric_high_scale_positive:    10, 38, 50_000_000_000i128         => sign=1, val=5;
+        numeric_high_scale_negative:    10, 38, -30_000_000_000i128        => sign=0, val=3;
+        numeric_scale_37_zero:          37, 38, 0i128                      => sign=1, val=0;
+    }
+
+    // ========================================================================
+    // SQL_C_BINARY conversions (raw SQL_NUMERIC_STRUCT bytes)
+    // ========================================================================
+
+    macro_rules! binary_struct_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => sign=$sign:expr, first_val_byte=$byte:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut buffer = vec![0u8; 64];
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_char_buffer(CDataType::Binary, &mut buffer, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    let numeric_size = std::mem::size_of::<sql::Numeric>() as sql::Len;
+                    assert_eq!(str_len, numeric_size);
+                    assert_eq!(buffer[2], $sign);   // sign at offset 2 (after precision + scale)
+                    assert_eq!(buffer[3], $byte);   // val[0] at offset 3
+                }
+            )*
+        };
+    }
+
+    binary_struct_tests! {
+        binary_integer:             0,  10, 42i128      => sign=1, first_val_byte=42;
+        binary_with_scale:          2,  10, 12345i128   => sign=1, first_val_byte=123;
+        binary_zero:                0,  10, 0i128       => sign=1, first_val_byte=0;
+        binary_one:                 0,  10, 1i128       => sign=1, first_val_byte=1;
+        binary_negative:            0,  10, -42i128     => sign=0, first_val_byte=42;
+        binary_255:                 0,  10, 255i128     => sign=1, first_val_byte=255;
+        binary_256_le_low_byte:     0,  10, 256i128     => sign=1, first_val_byte=0;
+        binary_high_scale_zero:     10, 38, 0i128       => sign=1, first_val_byte=0;
+        binary_high_scale_positive: 10, 38, 50_000_000_000i128 => sign=1, first_val_byte=5;
+    }
+
+    // ========================================================================
+    // SQL_C_BIT conversions
+    // ========================================================================
+
+    macro_rules! bit_ok_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr => $expected:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: u8 = 0xFF;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+                    sn.write_odbc_type($input, &binding).unwrap();
+                    assert_eq!(value, $expected);
+                }
+            )*
+        };
+    }
+
+    bit_ok_tests! {
+        bit_zero:                       0,  10, 0i128   => 0;
+        bit_one:                        0,  10, 1i128   => 1;
+        bit_frac_truncates_to_zero:     1,  10, 9i128   => 0;
+        bit_frac_truncates_to_one:      1,  10, 15i128  => 1;
+        bit_zero_with_high_scale:       10, 38, 0i128   => 0;
+        bit_one_with_scale:             2,  10, 100i128 => 1;
+    }
+
+    macro_rules! bit_error_tests {
+        ($($name:ident: $scale:expr, $precision:expr, $input:expr;)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let sn = make_decimal($scale, $precision);
+                    let mut value: u8 = 0;
+                    let mut str_len: sql::Len = 0;
+                    let binding = binding_for_value(CDataType::Bit, &mut value, &mut str_len);
+                    assert!(sn.write_odbc_type($input, &binding).is_err());
+                }
+            )*
+        };
+    }
+
+    bit_error_tests! {
+        bit_rejects_two:                0,  10, 2i128;
+        bit_rejects_negative_one:       0,  10, -1i128;
+        bit_rejects_large_positive:     0,  10, 100i128;
+        bit_rejects_large_negative:     0,  10, -100i128;
+        bit_rejects_frac_truncates_2:   1,  10, 25i128;
     }
 }

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -541,6 +541,29 @@ TEST_CASE("SQL_DECIMAL to SQL_C_BIT - negative value is out of range", "[datatyp
 }
 
 // ============================================================================
+// High scale zero conversion (regression: 10^scale overflow in i32 arithmetic)
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL zero with high scale to SQL_C_LONG", "[datatype][number][truncation]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0::NUMBER(38,10), 0::NUMBER(38,37), 0::NUMBER(20,15)");
+
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 0);
+  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
+  CHECK(get_data<SQL_C_LONG>(stmt, 3) == 0);
+}
+
+TEST_CASE("SQL_DECIMAL nonzero with high scale to SQL_C_LONG", "[datatype][number][truncation]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT 5.0000000000::NUMBER(38,10)"), 1) == 5);
+  CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT -3.0000000000::NUMBER(38,10)"), 1) == -3);
+}
+
+// ============================================================================
 // Integer truncation toward zero tests
 // ============================================================================
 
@@ -755,4 +778,232 @@ TEST_CASE("SQL_C_DEFAULT for INT column resolves to SQL_C_CHAR", "[datatype][num
   CHECK(get_data_default_as_string(stmt, 1) == "42");
   CHECK(get_data_default_as_string(stmt, 2) == "-7");
   CHECK(get_data_default_as_string(stmt, 3) == "0");
+}
+
+// ============================================================================
+// SQL_C_WCHAR (wide character) conversion tests
+// ============================================================================
+
+inline std::u16string get_wchar_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char16_t buffer[1000];
+  SQLLEN indicator;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  return std::u16string(buffer, indicator / sizeof(char16_t));
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - basic values", "[datatype][number][wchar]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch(
+      "SELECT 42::NUMBER(10,0), -7::NUMBER(10,0), 0::NUMBER(10,0), "
+      "123.45::NUMBER(10,2), -0.05::NUMBER(10,2)");
+
+  CHECK(get_wchar_data(stmt, 1) == u"42");
+  CHECK(get_wchar_data(stmt, 2) == u"-7");
+  CHECK(get_wchar_data(stmt, 3) == u"0");
+  CHECK(get_wchar_data(stmt, 4) == u"123.45");
+  CHECK(get_wchar_data(stmt, 5) == u"-0.05");
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - large precision values", "[datatype][number][wchar]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 99999999999999999999999999999999999999::NUMBER(38,0)");
+  CHECK(get_wchar_data(stmt, 1) == u"99999999999999999999999999999999999999");
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - NULL returns SQL_NULL_DATA", "[datatype][number][wchar][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+
+  char16_t buffer[100];
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR matches SQL_C_CHAR", "[datatype][number][wchar]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  const std::string query = "SELECT 123.456::DECIMAL(10,3)";
+  auto char_str = get_data<SQL_C_CHAR>(conn.execute_fetch(query), 1);
+  auto wchar_str = get_wchar_data(conn.execute_fetch(query), 1);
+
+  std::u16string expected_wchar(char_str.begin(), char_str.end());
+  CHECK(wchar_str == expected_wchar);
+}
+
+// ============================================================================
+// SQL_C_NUMERIC (SQL_NUMERIC_STRUCT) conversion tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - positive integer", "[datatype][number][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
+
+  SQL_NUMERIC_STRUCT numeric = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator != SQL_NULL_DATA);
+  CHECK(numeric.sign == 1);
+  // val is little-endian 128-bit unsigned: 42 = 0x2A
+  CHECK(numeric.val[0] == 42);
+  for (int i = 1; i < 16; ++i) {
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - negative value", "[datatype][number][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -123::NUMBER(10,0)");
+
+  SQL_NUMERIC_STRUCT numeric = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator != SQL_NULL_DATA);
+  CHECK(numeric.sign == 0);
+  CHECK(numeric.val[0] == 123);
+  for (int i = 1; i < 16; ++i) {
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - zero", "[datatype][number][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0)");
+
+  SQL_NUMERIC_STRUCT numeric = {};
+  numeric.sign = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(numeric.sign == 1);
+  for (int i = 0; i < 16; ++i) {
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - with scale", "[datatype][number][numeric]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.45::NUMBER(10,2)");
+
+  SQL_NUMERIC_STRUCT numeric = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(numeric.sign == 1);
+
+  unsigned long long stored = 0;
+  for (int i = 7; i >= 0; --i) {
+    stored = (stored << 8) | numeric.val[i];
+  }
+  CHECK(stored == 123);
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - NULL returns SQL_NULL_DATA", "[datatype][number][numeric][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,2)");
+
+  SQL_NUMERIC_STRUCT numeric = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
+}
+
+// ============================================================================
+// SQL_C_BINARY conversion tests
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - integer value", "[datatype][number][binary]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
+
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  // Interpret as SQL_NUMERIC_STRUCT
+  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+  CHECK(num->sign == 1);
+  CHECK(num->val[0] == 42);
+  for (int i = 1; i < 16; ++i) {
+    CHECK(num->val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - scaled value", "[datatype][number][binary]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.45::NUMBER(10,2)");
+
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+  CHECK(num->sign == 1);
+  CHECK(num->scale == 0);
+  // 123.45 with scale=2 => integer part 123
+  CHECK(num->val[0] == 123);
+  for (int i = 1; i < 16; ++i) {
+    CHECK(num->val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - negative value", "[datatype][number][binary]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -7::NUMBER(10,0)");
+
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+  CHECK(num->sign == 0);
+  CHECK(num->val[0] == 7);
+  for (int i = 1; i < 16; ++i) {
+    CHECK(num->val[i] == 0);
+  }
+}
+
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - NULL returns SQL_NULL_DATA", "[datatype][number][binary][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
 }

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -1007,3 +1007,311 @@ TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - NULL returns SQL_NULL_DATA", "[datatype
   CHECK_ODBC(ret, stmt);
   CHECK(indicator == SQL_NULL_DATA);
 }
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 01S07 — Fractional truncation warning
+// Per ODBC spec, converting a numeric SQL value with fractional digits to an
+// integer C type should return SQL_SUCCESS_WITH_INFO with SQLSTATE 01S07.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_LONG", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 123);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_SHORT", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 9.99::DECIMAL(5,2)");
+
+  SQLSMALLINT value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SHORT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 9);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_TINYINT", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+
+  SQLSCHAR value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 1);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_SBIGINT", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 999.001::DECIMAL(10,3)");
+
+  SQLBIGINT value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SBIGINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 999);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_DECIMAL exact integer does NOT produce 01S07", "[datatype][number][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 100.00::DECIMAL(10,2)");
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(value == 100);
+}
+
+// ============================================================================
+// ODBC Spec: SQLSTATE 22003 — Numeric value out of range (integer overflow)
+// Per ODBC spec, when conversion would result in loss of whole (not fractional)
+// digits, the driver should return SQL_ERROR with SQLSTATE 22003.
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_LONG - above i32 max", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 2147483648::NUMBER(10,0)");
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_LONG - below i32 min", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -2147483649::NUMBER(10,0)");
+
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_SHORT - above i16 max", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 32768::NUMBER(5,0)");
+
+  SQLSMALLINT value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SHORT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_STINYINT - above i8 max", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 128::NUMBER(3,0)");
+
+  SQLSCHAR value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_STINYINT - below i8 min", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -129::NUMBER(3,0)");
+
+  SQLSCHAR value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_UTINYINT - negative", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+
+  SQLCHAR value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_UTINYINT - above u8 max", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 256::NUMBER(3,0)");
+
+  SQLCHAR value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_USHORT - negative", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+
+  SQLUSMALLINT value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_USHORT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_DECIMAL overflow SQL_C_ULONG - negative", "[datatype][number][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+
+  SQLUINTEGER value = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_ULONG, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+// ============================================================================
+// ODBC Spec: SQL_C_BIT — spec-compliant behavior
+// Per ODBC spec for SQL_C_BIT:
+//   Exact 0 or 1                    → SQL_SUCCESS
+//   Value > 0, < 2, ≠ 1 (fraction) → SQL_SUCCESS_WITH_INFO, 01S07
+//   Value < 0 or ≥ 2               → SQL_ERROR, 22003
+// ============================================================================
+
+TEST_CASE("SQL_C_BIT - value 2 returns 22003", "[datatype][number][bit][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 2::NUMBER(1,0)");
+
+  unsigned char value = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_C_BIT - negative fractional value returns 22003", "[datatype][number][bit][22003]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // -0.5 is less than 0 per spec → should be 22003
+  auto stmt = conn.execute_fetch("SELECT -0.5::DECIMAL(3,1)");
+
+  unsigned char value = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_ERROR);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "22003");
+}
+
+TEST_CASE("SQL_C_BIT - fractional 0.5 truncates to 0 with 01S07", "[datatype][number][bit][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 0.5::DECIMAL(3,1)");
+
+  unsigned char value = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 0);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_C_BIT - fractional 1.5 truncates to 1 with 01S07", "[datatype][number][bit][01S07]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+
+  unsigned char value = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS_WITH_INFO);
+  CHECK(value == 1);
+  auto diags = get_diag_rec(stmt);
+  REQUIRE(!diags.empty());
+  CHECK(diags[0].sqlState == "01S07");
+}
+
+TEST_CASE("SQL_C_BIT - exact 1.0 does NOT produce warning", "[datatype][number][bit]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT 1.00::DECIMAL(5,2)");
+
+  unsigned char value = 0xFF;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(value == 1);
+}

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -541,7 +541,7 @@ TEST_CASE("SQL_DECIMAL to SQL_C_BIT - negative value is out of range", "[datatyp
 }
 
 // ============================================================================
-// High scale zero conversion (regression: 10^scale overflow in i32 arithmetic)
+// High scale zero conversion
 // ============================================================================
 
 TEST_CASE("SQL_DECIMAL zero with high scale to SQL_C_LONG", "[datatype][number][truncation]") {


### PR DESCRIPTION
### TL;DR

Enhanced ODBC numeric type conversion support with additional target types and improved handling of large numbers.

### What changed?

- Added support for converting `SnowflakeNumber` to additional ODBC target types:
  - `SQL_C_WCHAR` for wide character string representation
  - `SQL_C_NUMERIC` for structured numeric representation
  - `SQL_C_BINARY` for raw binary representation
- Improved handling of decimal formatting with a dedicated `format_decimal` method
- Fixed potential overflow issues by using `i128` for calculations instead of smaller integer types
- Ensured proper handling of high-scale zero values
- Added comprehensive test coverage for all conversion types

### How to test?

The changes are covered by extensive unit tests in `number_tests.rs` and integration tests in `number_tests.cpp`, which verify:
- Conversion to various integer types (LONG, SHORT, TINYINT, BIGINT)
- String formatting with proper decimal point placement
- Wide character (WCHAR) string conversion
- Numeric struct conversion with proper sign handling
- Binary representation of numeric values
- Edge cases like high-scale values and boundary conditions

### Why make this change?

This change improves ODBC driver compatibility with applications that use different C data types for retrieving numeric values. The enhanced support for additional target types allows applications to work with numeric data in their preferred format, whether as strings, binary data, or structured numeric types. The use of `i128` for calculations prevents potential overflow issues when dealing with large numbers or high scale values.