### PR TITLE
Format number tests for better readability

### DIFF
--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -72,64 +72,64 @@ mod tests {
 
     integer_conversion_tests! {
         // Basic values — no truncation
-        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                              => 42,    truncated=false;
-        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                       => 123456789, truncated=false;
-        short_integer:                          CDataType::Short,    i16, 0,  5,  300i128                              => 300,   truncated=false;
-        tinyint_integer:                        CDataType::TinyInt,  i8,  0,  3,  123i128                              => 123,   truncated=false;
+        slong_integer:                          CDataType::SLong,    i32, 0,  10, 42i128                         => 42,                            truncated=false;
+        sbigint_integer:                        CDataType::SBigInt,  i64, 0,  10, 123456789i128                  => 123456789,                     truncated=false;
+        short_integer:                          CDataType::Short,    i16, 0,  5,  300i128                        => 300,                           truncated=false;
+        tinyint_integer:                        CDataType::TinyInt,  i8,  0,  3,  123i128                        => 123,                           truncated=false;
 
         // Zero across all types
-        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                                => 0,     truncated=false;
-        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                                => 0,     truncated=false;
-        short_zero:                             CDataType::Short,    i16, 0,  5,  0i128                                => 0,     truncated=false;
-        tinyint_zero:                           CDataType::TinyInt,  i8,  0,  3,  0i128                                => 0,     truncated=false;
+        slong_zero:                             CDataType::SLong,    i32, 0,  10, 0i128                          => 0,                             truncated=false;
+        sbigint_zero:                           CDataType::SBigInt,  i64, 0,  10, 0i128                          => 0,                             truncated=false;
+        short_zero:                             CDataType::Short,    i16, 0,  5,  0i128                          => 0,                             truncated=false;
+        tinyint_zero:                           CDataType::TinyInt,  i8,  0,  3,  0i128                          => 0,                             truncated=false;
 
         // One and negative one
-        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                                => 1,     truncated=false;
-        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                               => -1,    truncated=false;
+        slong_one:                              CDataType::SLong,    i32, 0,  10, 1i128                          => 1,                             truncated=false;
+        slong_neg_one:                          CDataType::SLong,    i32, 0,  10, -1i128                         => -1,                            truncated=false;
 
         // Negative values
-        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                              => -42,   truncated=false;
-        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                       => -123456789, truncated=false;
+        slong_negative:                         CDataType::SLong,    i32, 0,  10, -42i128                        => -42,                           truncated=false;
+        sbigint_negative:                       CDataType::SBigInt,  i64, 0,  10, -123456789i128                 => -123456789,                    truncated=false;
 
         // Boundary values — no truncation
-        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128                    => 2_147_483_647, truncated=false;
-        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128                   => -2_147_483_648, truncated=false;
-        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128        => 9_223_372_036_854_775_807i64, truncated=false;
-        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128       => -9_223_372_036_854_775_808i64, truncated=false;
-        short_i16_max:                          CDataType::Short,    i16, 0,  5,  32767i128                            => 32767,  truncated=false;
-        short_i16_min:                          CDataType::Short,    i16, 0,  5,  -32768i128                           => -32768, truncated=false;
-        ushort_u16_max:                         CDataType::UShort,   u16, 0,  5,  65535i128                            => 65535,  truncated=false;
-        tinyint_i8_max:                         CDataType::TinyInt,  i8,  0,  3,  127i128                              => 127,   truncated=false;
-        tinyint_i8_min:                         CDataType::TinyInt,  i8,  0,  3,  -128i128                             => -128,  truncated=false;
-        utinyint_u8_max:                        CDataType::UTinyInt, u8,  0,  3,  255i128                              => 255,   truncated=false;
+        slong_i32_max:                          CDataType::SLong,    i32, 0,  10, 2_147_483_647i128              => 2_147_483_647,                 truncated=false;
+        slong_i32_min:                          CDataType::SLong,    i32, 0,  10, -2_147_483_648i128             => -2_147_483_648,                truncated=false;
+        sbigint_i64_max:                        CDataType::SBigInt,  i64, 0,  19, 9_223_372_036_854_775_807i128  => 9_223_372_036_854_775_807i64,  truncated=false;
+        sbigint_i64_min:                        CDataType::SBigInt,  i64, 0,  19, -9_223_372_036_854_775_808i128 => -9_223_372_036_854_775_808i64, truncated=false;
+        short_i16_max:                          CDataType::Short,    i16, 0,  5,  32767i128                      => 32767,                         truncated=false;
+        short_i16_min:                          CDataType::Short,    i16, 0,  5,  -32768i128                     => -32768,                        truncated=false;
+        ushort_u16_max:                         CDataType::UShort,   u16, 0,  5,  65535i128                      => 65535,                         truncated=false;
+        tinyint_i8_max:                         CDataType::TinyInt,  i8,  0,  3,  127i128                        => 127,                           truncated=false;
+        tinyint_i8_min:                         CDataType::TinyInt,  i8,  0,  3,  -128i128                       => -128,                          truncated=false;
+        utinyint_u8_max:                        CDataType::UTinyInt, u8,  0,  3,  255i128                        => 255,                           truncated=false;
 
         // Fractional truncation — should produce 01S07 warning
-        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                              => 9,     truncated=true;
-        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                             => -9,    truncated=true;
-        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                               => 0,     truncated=true;
-        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                              => 0,     truncated=true;
-        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                            => 12,    truncated=true;
-        short_truncates_frac:                   CDataType::Short,    i16, 1,  5,  255i128                              => 25,    truncated=true;
-        tinyint_truncates_frac:                 CDataType::TinyInt,  i8,  1,  3,  99i128                               => 9,     truncated=true;
+        slong_truncates_positive_frac:          CDataType::SLong,    i32, 2,  10, 999i128                        => 9,                             truncated=true;
+        slong_truncates_negative_frac:          CDataType::SLong,    i32, 2,  10, -999i128                       => -9,                            truncated=true;
+        slong_frac_below_one_to_zero:           CDataType::SLong,    i32, 1,  10, 9i128                          => 0,                             truncated=true;
+        slong_neg_frac_below_one_to_zero:       CDataType::SLong,    i32, 1,  10, -9i128                         => 0,                             truncated=true;
+        sbigint_truncates_frac:                 CDataType::SBigInt,  i64, 3,  10, 12345i128                      => 12,                            truncated=true;
+        short_truncates_frac:                   CDataType::Short,    i16, 1,  5,  255i128                        => 25,                            truncated=true;
+        tinyint_truncates_frac:                 CDataType::TinyInt,  i8,  1,  3,  99i128                         => 9,                             truncated=true;
 
         // High scale
-        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                                => 0,     truncated=false;
-        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                                => 0,     truncated=false;
-        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128                   => 5,     truncated=false;
-        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128                  => -3,    truncated=false;
-        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                                => 0,     truncated=false;
-        ulong_zero_scale_10:                    CDataType::ULong,    u32, 10, 38, 0i128                                => 0,     truncated=false;
-        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                                => 0,     truncated=false;
-        short_zero_scale_10:                    CDataType::Short,    i16, 10, 38, 0i128                                => 0,     truncated=false;
-        tinyint_zero_scale_10:                  CDataType::TinyInt,  i8,  10, 38, 0i128                                => 0,     truncated=false;
+        slong_zero_scale_10:                    CDataType::SLong,    i32, 10, 38, 0i128                          => 0,                             truncated=false;
+        slong_zero_scale_37:                    CDataType::SLong,    i32, 37, 38, 0i128                          => 0,                             truncated=false;
+        slong_positive_scale_10:                CDataType::SLong,    i32, 10, 38, 50_000_000_000i128             => 5,                             truncated=false;
+        slong_negative_scale_10:                CDataType::SLong,    i32, 10, 38, -30_000_000_000i128            => -3,                            truncated=false;
+        long_zero_scale_15:                     CDataType::Long,     i32, 15, 20, 0i128                          => 0,                             truncated=false;
+        ulong_zero_scale_10:                    CDataType::ULong,    u32, 10, 38, 0i128                          => 0,                             truncated=false;
+        sbigint_zero_scale_20:                  CDataType::SBigInt,  i64, 20, 38, 0i128                          => 0,                             truncated=false;
+        short_zero_scale_10:                    CDataType::Short,    i16, 10, 38, 0i128                          => 0,                             truncated=false;
+        tinyint_zero_scale_10:                  CDataType::TinyInt,  i8,  10, 38, 0i128                          => 0,                             truncated=false;
 
         // Type aliases
-        sshort_integer:                         CDataType::SShort,   i16, 0,  5,  300i128                              => 300,   truncated=false;
-        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                              => 300,   truncated=false;
-        stinyint_integer:                       CDataType::STinyInt, i8,  0,  3,  100i128                              => 100,   truncated=false;
-        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                              => 200,   truncated=false;
-        ubigint_integer:                        CDataType::UBigInt,  u64, 0,  10, 999i128                              => 999,   truncated=false;
-        ubigint_u64_max:                        CDataType::UBigInt,  u64, 0,  20, 18_446_744_073_709_551_615i128       => 18_446_744_073_709_551_615u64, truncated=false;
+        sshort_integer:                         CDataType::SShort,   i16, 0,  5,  300i128                        => 300,                           truncated=false;
+        ushort_integer:                         CDataType::UShort,   u16, 0,  5,  300i128                        => 300,                           truncated=false;
+        stinyint_integer:                       CDataType::STinyInt, i8,  0,  3,  100i128                        => 100,                           truncated=false;
+        utinyint_integer:                       CDataType::UTinyInt, u8,  0,  3,  200i128                        => 200,                           truncated=false;
+        ubigint_integer:                        CDataType::UBigInt,  u64, 0,  10, 999i128                        => 999,                           truncated=false;
+        ubigint_u64_max:                        CDataType::UBigInt,  u64, 0,  20, 18_446_744_073_709_551_615i128 => 18_446_744_073_709_551_615u64, truncated=false;
     }
 
     // ========================================================================
@@ -213,39 +213,39 @@ mod tests {
 
     char_conversion_tests! {
         // Default type (maps to Char)
-        default_integer_as_char:                CDataType::Default, 0,  10, 42i128                  => "42";
-        default_scaled_as_char:                 CDataType::Default, 2,  10, 12345i128               => "123.45";
-        default_negative_scaled_as_char:        CDataType::Default, 3,  10, -50i128                 => "-0.050";
-        default_zero_as_char:                   CDataType::Default, 0,  10, 0i128                   => "0";
+        default_integer_as_char:                CDataType::Default, 0, 10, 42i128               => "42";
+        default_scaled_as_char:                 CDataType::Default, 2, 10, 12345i128            => "123.45";
+        default_negative_scaled_as_char:        CDataType::Default, 3, 10, -50i128              => "-0.050";
+        default_zero_as_char:                   CDataType::Default, 0, 10, 0i128                => "0";
 
         // Explicit Char type
-        char_integer:                           CDataType::Char,    0,  10, 42i128                  => "42";
-        char_negative_integer:                  CDataType::Char,    0,  10, -42i128                 => "-42";
-        char_one:                               CDataType::Char,    0,  10, 1i128                   => "1";
-        char_negative_one:                      CDataType::Char,    0,  10, -1i128                  => "-1";
-        char_single_digit:                      CDataType::Char,    0,  1,  5i128                   => "5";
+        char_integer:                           CDataType::Char,    0, 10, 42i128               => "42";
+        char_negative_integer:                  CDataType::Char,    0, 10, -42i128              => "-42";
+        char_one:                               CDataType::Char,    0, 10, 1i128                => "1";
+        char_negative_one:                      CDataType::Char,    0, 10, -1i128               => "-1";
+        char_single_digit:                      CDataType::Char,    0, 1,  5i128                => "5";
 
         // Leading zeros in fractional part
-        char_leading_zeros_3:                   CDataType::Char,    3,  10, 1i128                   => "0.001";
-        char_leading_zeros_3_neg:               CDataType::Char,    3,  10, -1i128                  => "-0.001";
-        char_leading_zeros_5:                   CDataType::Char,    5,  10, 1i128                   => "0.00001";
-        char_leading_zeros_5_neg:               CDataType::Char,    5,  10, -1i128                  => "-0.00001";
+        char_leading_zeros_3:                   CDataType::Char,    3, 10, 1i128                => "0.001";
+        char_leading_zeros_3_neg:               CDataType::Char,    3, 10, -1i128               => "-0.001";
+        char_leading_zeros_5:                   CDataType::Char,    5, 10, 1i128                => "0.00001";
+        char_leading_zeros_5_neg:               CDataType::Char,    5, 10, -1i128               => "-0.00001";
 
         // Zero with various scales
-        char_zero_scale_1:                      CDataType::Char,    1,  10, 0i128                   => "0.0";
-        char_zero_scale_3:                      CDataType::Char,    3,  10, 0i128                   => "0.000";
-        char_zero_scale_5:                      CDataType::Char,    5,  10, 0i128                   => "0.00000";
+        char_zero_scale_1:                      CDataType::Char,    1, 10, 0i128                => "0.0";
+        char_zero_scale_3:                      CDataType::Char,    3, 10, 0i128                => "0.000";
+        char_zero_scale_5:                      CDataType::Char,    5, 10, 0i128                => "0.00000";
 
         // Scale boundary: value digits == scale (entire value is fractional)
-        char_scale_equals_digits:               CDataType::Char,    2,  10, 99i128                  => "0.99";
-        char_scale_equals_digits_neg:           CDataType::Char,    2,  10, -99i128                 => "-0.99";
-        char_scale_exactly_at_boundary:         CDataType::Char,    2,  10, 100i128                 => "1.00";
-        char_trailing_zeros_preserved:          CDataType::Char,    3,  10, 1000i128                => "1.000";
+        char_scale_equals_digits:               CDataType::Char,    2, 10, 99i128               => "0.99";
+        char_scale_equals_digits_neg:           CDataType::Char,    2, 10, -99i128              => "-0.99";
+        char_scale_exactly_at_boundary:         CDataType::Char,    2, 10, 100i128              => "1.00";
+        char_trailing_zeros_preserved:          CDataType::Char,    3, 10, 1000i128             => "1.000";
 
         // Large numbers
-        char_large_integer:                     CDataType::Char,    0,  38, 99999999999999i128       => "99999999999999";
-        char_large_negative:                    CDataType::Char,    0,  38, -99999999999999i128      => "-99999999999999";
-        char_large_with_scale:                  CDataType::Char,    2,  38, 9999999999999900i128     => "99999999999999.00";
+        char_large_integer:                     CDataType::Char,    0, 38, 99999999999999i128   => "99999999999999";
+        char_large_negative:                    CDataType::Char,    0, 38, -99999999999999i128  => "-99999999999999";
+        char_large_with_scale:                  CDataType::Char,    2, 38, 9999999999999900i128 => "99999999999999.00";
     }
 
     // ========================================================================
@@ -278,14 +278,14 @@ mod tests {
     }
 
     wchar_conversion_tests! {
-        wchar_integer:              0, 10, 42i128       => "42";
-        wchar_scaled:               2, 10, 12345i128    => "123.45";
-        wchar_zero:                 0, 10, 0i128        => "0";
-        wchar_negative:             0, 10, -42i128      => "-42";
-        wchar_negative_scaled:      2, 10, -12345i128   => "-123.45";
-        wchar_leading_zeros:        3, 10, 1i128        => "0.001";
-        wchar_zero_with_scale:      2, 10, 0i128        => "0.00";
-        wchar_large:                0, 38, 999999i128   => "999999";
+        wchar_integer:              0, 10, 42i128     => "42";
+        wchar_scaled:               2, 10, 12345i128  => "123.45";
+        wchar_zero:                 0, 10, 0i128      => "0";
+        wchar_negative:             0, 10, -42i128    => "-42";
+        wchar_negative_scaled:      2, 10, -12345i128 => "-123.45";
+        wchar_leading_zeros:        3, 10, 1i128      => "0.001";
+        wchar_zero_with_scale:      2, 10, 0i128      => "0.00";
+        wchar_large:                0, 38, 999999i128 => "999999";
     }
 
     // ========================================================================
@@ -313,22 +313,22 @@ mod tests {
 
     float_conversion_tests! {
         // f64
-        double_integer:             CDataType::Double, f64, 0, 10, 42i128               => approx 42.0,       tol f64::EPSILON;
-        double_zero:                CDataType::Double, f64, 0, 10, 0i128                => approx 0.0,        tol f64::EPSILON;
-        double_negative:            CDataType::Double, f64, 0, 10, -42i128              => approx -42.0,      tol f64::EPSILON;
-        double_one:                 CDataType::Double, f64, 0, 10, 1i128                => approx 1.0,        tol f64::EPSILON;
-        double_neg_one:             CDataType::Double, f64, 0, 10, -1i128               => approx -1.0,       tol f64::EPSILON;
-        double_scaled:              CDataType::Double, f64, 2, 10, 12345i128            => approx 123.45,     tol 0.001;
-        double_negative_scaled:     CDataType::Double, f64, 3, 10, -50i128              => approx -0.05,      tol 0.001;
-        double_large:               CDataType::Double, f64, 0, 15, 1_000_000_000i128    => approx 1e9,        tol 1.0;
-        double_small_fraction:      CDataType::Double, f64, 5, 10, 1i128                => approx 0.00001,    tol 1e-8;
+        double_integer:             CDataType::Double, f64, 0, 10, 42i128            => approx 42.0,    tol f64::EPSILON;
+        double_zero:                CDataType::Double, f64, 0, 10, 0i128             => approx 0.0,     tol f64::EPSILON;
+        double_negative:            CDataType::Double, f64, 0, 10, -42i128           => approx -42.0,   tol f64::EPSILON;
+        double_one:                 CDataType::Double, f64, 0, 10, 1i128             => approx 1.0,     tol f64::EPSILON;
+        double_neg_one:             CDataType::Double, f64, 0, 10, -1i128            => approx -1.0,    tol f64::EPSILON;
+        double_scaled:              CDataType::Double, f64, 2, 10, 12345i128         => approx 123.45,  tol 0.001;
+        double_negative_scaled:     CDataType::Double, f64, 3, 10, -50i128           => approx -0.05,   tol 0.001;
+        double_large:               CDataType::Double, f64, 0, 15, 1_000_000_000i128 => approx 1e9,     tol 1.0;
+        double_small_fraction:      CDataType::Double, f64, 5, 10, 1i128             => approx 0.00001, tol 1e-8;
 
         // f32
-        float_scaled:               CDataType::Float,  f32, 3, 10, 123789i128           => approx 123.789,    tol 0.01;
-        float_zero:                 CDataType::Float,  f32, 0, 10, 0i128                => approx 0.0,        tol f32::EPSILON;
-        float_negative:             CDataType::Float,  f32, 0, 10, -100i128             => approx -100.0,     tol 0.01;
-        float_small_fraction:       CDataType::Float,  f32, 2, 10, 1i128                => approx 0.01,       tol 0.001;
-        float_one:                  CDataType::Float,  f32, 0, 10, 1i128                => approx 1.0,        tol f32::EPSILON;
+        float_scaled:               CDataType::Float,  f32, 3, 10, 123789i128        => approx 123.789, tol 0.01;
+        float_zero:                 CDataType::Float,  f32, 0, 10, 0i128             => approx 0.0,     tol f32::EPSILON;
+        float_negative:             CDataType::Float,  f32, 0, 10, -100i128          => approx -100.0,  tol 0.01;
+        float_small_fraction:       CDataType::Float,  f32, 2, 10, 1i128             => approx 0.01,    tol 0.001;
+        float_one:                  CDataType::Float,  f32, 0, 10, 1i128             => approx 1.0,     tol f32::EPSILON;
     }
 
     // ========================================================================
@@ -364,29 +364,29 @@ mod tests {
     }
 
     numeric_struct_tests! {
-        numeric_positive_with_scale:    2,  10, 12345i128                   => sign=1, val=123,        truncated=true;
-        numeric_negative:               0,  10, -42i128                     => sign=0, val=42,         truncated=false;
-        numeric_zero:                   0,  10, 0i128                       => sign=1, val=0,          truncated=false;
-        numeric_one:                    0,  10, 1i128                       => sign=1, val=1,          truncated=false;
-        numeric_negative_one:           0,  10, -1i128                      => sign=0, val=1,          truncated=false;
+        numeric_positive_with_scale:    2,  10, 12345i128           => sign=1, val=123,        truncated=true;
+        numeric_negative:               0,  10, -42i128             => sign=0, val=42,         truncated=false;
+        numeric_zero:                   0,  10, 0i128               => sign=1, val=0,          truncated=false;
+        numeric_one:                    0,  10, 1i128               => sign=1, val=1,          truncated=false;
+        numeric_negative_one:           0,  10, -1i128              => sign=0, val=1,          truncated=false;
 
         // LE byte boundary values
-        numeric_255:                    0,  10, 255i128                     => sign=1, val=255,        truncated=false;
-        numeric_256:                    0,  10, 256i128                     => sign=1, val=256,        truncated=false;
-        numeric_65535:                  0,  10, 65535i128                   => sign=1, val=65535,      truncated=false;
-        numeric_65536:                  0,  10, 65536i128                   => sign=1, val=65536,      truncated=false;
-        numeric_1_000_000:              0,  10, 1_000_000i128              => sign=1, val=1_000_000,  truncated=false;
+        numeric_255:                    0,  10, 255i128             => sign=1, val=255,        truncated=false;
+        numeric_256:                    0,  10, 256i128             => sign=1, val=256,        truncated=false;
+        numeric_65535:                  0,  10, 65535i128           => sign=1, val=65535,      truncated=false;
+        numeric_65536:                  0,  10, 65536i128           => sign=1, val=65536,      truncated=false;
+        numeric_1_000_000:              0,  10, 1_000_000i128       => sign=1, val=1_000_000,  truncated=false;
 
         // Scale truncation
-        numeric_scale_truncates_frac:   2,  10, 999i128                    => sign=1, val=9,          truncated=true;
-        numeric_scale_neg_truncates:    2,  10, -999i128                   => sign=0, val=9,          truncated=true;
-        numeric_zero_with_scale:        5,  10, 0i128                      => sign=1, val=0,          truncated=false;
+        numeric_scale_truncates_frac:   2,  10, 999i128             => sign=1, val=9,          truncated=true;
+        numeric_scale_neg_truncates:    2,  10, -999i128            => sign=0, val=9,          truncated=true;
+        numeric_zero_with_scale:        5,  10, 0i128               => sign=1, val=0,          truncated=false;
 
         // High scale
-        numeric_high_scale_zero:        10, 38, 0i128                      => sign=1, val=0,          truncated=false;
-        numeric_high_scale_positive:    10, 38, 50_000_000_000i128         => sign=1, val=5,          truncated=false;
-        numeric_high_scale_negative:    10, 38, -30_000_000_000i128        => sign=0, val=3,          truncated=false;
-        numeric_scale_37_zero:          37, 38, 0i128                      => sign=1, val=0,          truncated=false;
+        numeric_high_scale_zero:        10, 38, 0i128               => sign=1, val=0,          truncated=false;
+        numeric_high_scale_positive:    10, 38, 50_000_000_000i128  => sign=1, val=5,          truncated=false;
+        numeric_high_scale_negative:    10, 38, -30_000_000_000i128 => sign=0, val=3,          truncated=false;
+        numeric_scale_37_zero:          37, 38, 0i128               => sign=1, val=0,          truncated=false;
     }
 
     // ========================================================================
@@ -413,14 +413,14 @@ mod tests {
     }
 
     binary_struct_tests! {
-        binary_integer:             0,  10, 42i128      => sign=1, first_val_byte=42;
-        binary_with_scale:          2,  10, 12345i128   => sign=1, first_val_byte=123;
-        binary_zero:                0,  10, 0i128       => sign=1, first_val_byte=0;
-        binary_one:                 0,  10, 1i128       => sign=1, first_val_byte=1;
-        binary_negative:            0,  10, -42i128     => sign=0, first_val_byte=42;
-        binary_255:                 0,  10, 255i128     => sign=1, first_val_byte=255;
-        binary_256_le_low_byte:     0,  10, 256i128     => sign=1, first_val_byte=0;
-        binary_high_scale_zero:     10, 38, 0i128       => sign=1, first_val_byte=0;
+        binary_integer:             0,  10, 42i128             => sign=1, first_val_byte=42;
+        binary_with_scale:          2,  10, 12345i128          => sign=1, first_val_byte=123;
+        binary_zero:                0,  10, 0i128              => sign=1, first_val_byte=0;
+        binary_one:                 0,  10, 1i128              => sign=1, first_val_byte=1;
+        binary_negative:            0,  10, -42i128            => sign=0, first_val_byte=42;
+        binary_255:                 0,  10, 255i128            => sign=1, first_val_byte=255;
+        binary_256_le_low_byte:     0,  10, 256i128            => sign=1, first_val_byte=0;
+        binary_high_scale_zero:     10, 38, 0i128              => sign=1, first_val_byte=0;
         binary_high_scale_positive: 10, 38, 50_000_000_000i128 => sign=1, first_val_byte=5;
     }
 
@@ -481,13 +481,13 @@ mod tests {
 
     bit_error_tests! {
         // value >= 2
-        bit_rejects_two:                    0,  10, 2i128;
-        bit_rejects_large_positive:         0,  10, 100i128;
-        bit_rejects_frac_truncates_to_2:    1,  10, 25i128;
+        bit_rejects_two:                 0, 10, 2i128;
+        bit_rejects_large_positive:      0, 10, 100i128;
+        bit_rejects_frac_truncates_to_2: 1, 10, 25i128;
 
         // value < 0 (checked on original snowflake_value, not truncated)
-        bit_rejects_negative_one:           0,  10, -1i128;
-        bit_rejects_large_negative:         0,  10, -100i128;
-        bit_rejects_neg_frac:               1,  10, -5i128;
+        bit_rejects_negative_one:        0, 10, -1i128;
+        bit_rejects_large_negative:      0, 10, -100i128;
+        bit_rejects_neg_frac:            1, 10, -5i128;
     }
 }

--- a/odbc_tests/common/include/TestTable.hpp
+++ b/odbc_tests/common/include/TestTable.hpp
@@ -1,0 +1,29 @@
+#ifndef TEST_TABLE_HPP
+#define TEST_TABLE_HPP
+
+#include <string>
+
+#include "Connection.hpp"
+
+class TestTable {
+ public:
+  TestTable(Connection& conn, const std::string& name, const std::string& columns, const std::string& values)
+      : conn_(conn), name_(name) {
+    conn_.execute("DROP TABLE IF EXISTS " + name_);
+    conn_.execute("CREATE TABLE " + name_ + " (" + columns + ")");
+    conn_.execute("INSERT INTO " + name_ + " VALUES " + values);
+  }
+
+  ~TestTable() { conn_.execute("DROP TABLE IF EXISTS " + name_); }
+
+  TestTable(const TestTable&) = delete;
+  TestTable& operator=(const TestTable&) = delete;
+
+  const std::string& name() const { return name_; }
+
+ private:
+  Connection& conn_;
+  std::string name_;
+};
+
+#endif  // TEST_TABLE_HPP

--- a/odbc_tests/common/include/get_data.hpp
+++ b/odbc_tests/common/include/get_data.hpp
@@ -56,4 +56,10 @@ inline typename MetaOfSqlCType<SQL_C_TYPE>::type get_data(const StatementHandleW
   return optional_value.value();
 }
 
+template <typename T>
+inline SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
+                              SQLLEN* indicator) {
+  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
+}
+
 #endif  // GET_DATA_HPP

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -486,6 +486,7 @@ TEST_CASE("SQL_DECIMAL SQL_C_CHAR buffer handling", "[datatype][number][char][bu
     SQLLEN indicator = 0;
     SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
 
+    // TODO: Old driver fix for the bug is awaiting release
     OLD_DRIVER_ONLY("BD#13") { CHECK(ret == SQL_SUCCESS); }
 
     NEW_DRIVER_ONLY("BD#13") {

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -1,33 +1,29 @@
-
-#include <picojson.h>
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <numeric>
+#include <optional>
 #include <sstream>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers.hpp>
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
 #include "Schema.hpp"
+#include "TestTable.hpp"
 #include "compatibility.hpp"
+#include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-/// Helper to call SQLGetData with SQL_C_DEFAULT and return the result as a string.
-/// Per ODBC spec, SQL_C_DEFAULT for SQL_DECIMAL resolves to SQL_C_CHAR.
+// ============================================================================
+// Helpers
+// ============================================================================
+
 inline std::string get_data_default_as_string(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
   char buffer[1000];
   SQLLEN indicator;
@@ -36,114 +32,101 @@ inline std::string get_data_default_as_string(const StatementHandleWrapper& stmt
   return std::string(buffer, indicator);
 }
 
+inline SQL_NUMERIC_STRUCT get_binary_as_numeric(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
+  return *reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
+}
+
+inline void check_numeric_val_zero_from(const SQL_NUMERIC_STRUCT& numeric, int start) {
+  for (int i = start; i < 16; ++i) {
+    CHECK(numeric.val[i] == 0);
+  }
+}
+
+template <int SQL_C_TYPE>
+void check_all_columns_equal(const StatementHandleWrapper& stmt, int num_cols,
+                             typename MetaOfSqlCType<SQL_C_TYPE>::type expected) {
+  for (int i = 1; i <= num_cols; ++i) {
+    INFO("Testing column " << i << " with " << MetaOfSqlCType<SQL_C_TYPE>().name());
+    CHECK(get_data<SQL_C_TYPE>(stmt, i) == expected);
+  }
+}
+
+inline void check_null_via_get_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT c_type) {
+  char buffer[100] = {};
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, c_type, buffer, sizeof(buffer), &indicator);
+  CHECK_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
+}
+
+// ============================================================================
+// Basic decimal conversion across all C integer types
+// ============================================================================
+
 TEST_CASE("Test decimal conversion", "[datatype][number]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("DROP TABLE IF EXISTS test_number");
-  conn.execute(
-      "CREATE TABLE test_number (num0 NUMBER, num10 NUMBER(10,1), dec20 DECIMAL(20,2), numeric30 "
-      "NUMERIC(30,3), int1 INT, int2 INTEGER)");
-  conn.execute(
-      "INSERT INTO test_number (num0, num10, dec20, numeric30, int1, int2) VALUES (123, 123.4, "
-      "123.45, 123.456, 123, 123)");
+  TestTable table(conn, "test_number",
+                  "num0 NUMBER, num10 NUMBER(10,1), dec20 DECIMAL(20,2), "
+                  "numeric30 NUMERIC(30,3), int1 INT, int2 INTEGER",
+                  "(123, 123.4, 123.45, 123.456, 123, 123)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_number");
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_LONG");
-    CHECK(get_data<SQL_C_LONG>(stmt, i) == 123);
-  }
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
 
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SLONG");
-    CHECK(get_data<SQL_C_SLONG>(stmt, i) == 123);
-  }
+  check_all_columns_equal<SQL_C_LONG>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_SLONG>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_ULONG>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_SHORT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_SSHORT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_USHORT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_TINYINT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_STINYINT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_UTINYINT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_SBIGINT>(stmt, 6, 123);
+  check_all_columns_equal<SQL_C_UBIGINT>(stmt, 6, 123);
 
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_ULONG");
-    CHECK(get_data<SQL_C_ULONG>(stmt, i) == 123);
-  }
-
-  // Test 16-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SHORT");
-    CHECK(get_data<SQL_C_SHORT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SSHORT");
-    CHECK(get_data<SQL_C_SSHORT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_USHORT");
-    CHECK(get_data<SQL_C_USHORT>(stmt, i) == 123);
-  }
-
-  // Test 8-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_TINYINT");
-    CHECK(get_data<SQL_C_TINYINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_STINYINT");
-    CHECK(get_data<SQL_C_STINYINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_UTINYINT");
-    CHECK(get_data<SQL_C_UTINYINT>(stmt, i) == 123);
-  }
-
-  // Test 64-bit integer types - all should return 123 for the integer columns
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_SBIGINT");
-    CHECK(get_data<SQL_C_SBIGINT>(stmt, i) == 123);
-  }
-
-  for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_UBIGINT");
-    CHECK(get_data<SQL_C_UBIGINT>(stmt, i) == 123);
-  }
-
-  // Test floating point types - test all columns
-  std::vector<float> expected_float_values = {123.0f, 123.4f, 123.45f, 123.456f, 123.0f, 123.0f};
-  std::vector<double> expected_double_values = {123.0, 123.4, 123.45, 123.456, 123.0, 123.0};
+  std::vector<float> expected_float = {123.0f, 123.4f, 123.45f, 123.456f, 123.0f, 123.0f};
+  std::vector<double> expected_double = {123.0, 123.4, 123.45, 123.456, 123.0, 123.0};
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_FLOAT");
-    CHECK(get_data<SQL_C_FLOAT>(stmt, i) == expected_float_values[i - 1]);
+    CHECK(get_data<SQL_C_FLOAT>(stmt, i) == expected_float[i - 1]);
   }
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_DOUBLE");
-    CHECK(get_data<SQL_C_DOUBLE>(stmt, i) == expected_double_values[i - 1]);
+    CHECK(get_data<SQL_C_DOUBLE>(stmt, i) == expected_double[i - 1]);
   }
 
-  // Test character type conversions - each column should return its string representation
-  std::vector<std::string> expected_string_values = {"123", "123.4", "123.45", "123.456", "123", "123"};
+  std::vector<std::string> expected_str = {"123", "123.4", "123.45", "123.456", "123", "123"};
 
   for (int i = 1; i <= 6; ++i) {
     INFO("Testing column " << i << " with SQL_C_CHAR");
-    CHECK(get_data<SQL_C_CHAR>(stmt, i) == expected_string_values[i - 1]);
+    CHECK(get_data<SQL_C_CHAR>(stmt, i) == expected_str[i - 1]);
   }
 
-  // SQL_C_DEFAULT must produce the same results as SQL_C_CHAR for DECIMAL columns
   for (int i = 1; i <= 6; ++i) {
-    INFO("Testing column " << i << " with SQL_C_DEFAULT (must match SQL_C_CHAR)");
-    CHECK(get_data_default_as_string(stmt, i) == expected_string_values[i - 1]);
+    INFO("Testing column " << i << " with SQL_C_DEFAULT");
+    CHECK(get_data_default_as_string(stmt, i) == expected_str[i - 1]);
   }
 }
+
+// ============================================================================
+// Test at type limits
+// ============================================================================
 
 template <int SQL_C_TYPE>
 void test_at_limits(Connection& conn) {
   std::stringstream queryBuilder;
   queryBuilder << "SELECT ";
-  // prefix + to ensure numeric limits are treated as numbers, not characters
   queryBuilder << +std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::max() << " AS max, ";
   queryBuilder << +std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::min() << " AS min";
   auto query = queryBuilder.str();
-  std::cout << "Executing query: " << query << std::endl;
   INFO("Executing query: " << query);
   auto stmt = conn.execute_fetch(query);
   CHECK(get_data<SQL_C_TYPE>(stmt, 1) == std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::max());
@@ -151,17 +134,15 @@ void test_at_limits(Connection& conn) {
 }
 
 void test_string_at_limits(Connection& conn) {
-  std::stringstream queryBuilder;
   std::string max = std::string(37, '9');
   std::string min = "-" + std::string(37, '9');
+  std::stringstream queryBuilder;
   queryBuilder << "SELECT " << max << " AS max, " << min << " AS min";
   auto query = queryBuilder.str();
-  std::cout << "Executing query: " << query << std::endl;
   INFO("Executing query: " << query);
   auto stmt = conn.execute_fetch(query);
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == max);
   CHECK(get_data<SQL_C_CHAR>(stmt, 2) == min);
-  // SQL_C_DEFAULT must produce the same results as SQL_C_CHAR
   CHECK(get_data_default_as_string(stmt, 1) == max);
   CHECK(get_data_default_as_string(stmt, 2) == min);
 }
@@ -186,252 +167,200 @@ TEST_CASE("Test at limits", "[datatype][number]") {
 // ============================================================================
 // SQL_DECIMAL default conversion tests (SQL_C_DEFAULT)
 // Per ODBC spec, SQL_DECIMAL's default C type is SQL_C_CHAR.
-// These tests verify compatibility between old and new driver implementations.
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL default conversion - basic values", "[datatype][number][decimal][default]") {
+TEST_CASE("SQL_DECIMAL default conversion", "[datatype][number][decimal][default]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  // Use DECIMAL types with explicit scale to ensure the SQL type is SQL_DECIMAL.
-  conn.execute("DROP TABLE IF EXISTS test_decimal_default");
-  conn.execute(
-      "CREATE TABLE test_decimal_default ("
-      "  d1 DECIMAL(10,0), "
-      "  d2 DECIMAL(10,1), "
-      "  d3 DECIMAL(10,2), "
-      "  d4 DECIMAL(10,3))");
-  conn.execute("INSERT INTO test_decimal_default VALUES (123, 123.4, 123.45, 123.456)");
+  SECTION("basic values from table") {
+    TestTable table(conn, "test_decimal_default",
+                    "d1 DECIMAL(10,0), d2 DECIMAL(10,1), d3 DECIMAL(10,2), d4 DECIMAL(10,3)",
+                    "(123, 123.4, 123.45, 123.456)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_decimal_default");
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<std::string> expected = {"123", "123.4", "123.45", "123.456"};
+    for (int i = 1; i <= 4; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+    }
+  }
 
-  // SQL_C_DEFAULT should resolve to SQL_C_CHAR for SQL_DECIMAL columns
-  std::vector<std::string> expected = {"123", "123.4", "123.45", "123.456"};
+  SECTION("negative values") {
+    auto stmt = conn.execute_fetch(
+        "SELECT -123::DECIMAL(10,0), -123.4::DECIMAL(10,1), "
+        "-123.45::DECIMAL(10,2), -123.456::DECIMAL(10,3)");
+    std::vector<std::string> expected = {"-123", "-123.4", "-123.45", "-123.456"};
+    for (int i = 1; i <= 4; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+    }
+  }
 
-  for (int i = 1; i <= 4; ++i) {
-    INFO("Testing column " << i << " with SQL_C_DEFAULT (expects SQL_C_CHAR behavior)");
-    CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+  SECTION("zero with varying scale") {
+    auto stmt = conn.execute_fetch("SELECT 0::DECIMAL(10,0), 0::DECIMAL(10,2), 0::DECIMAL(10,5)");
+    CHECK(get_data_default_as_string(stmt, 1) == "0");
+    CHECK(get_data_default_as_string(stmt, 2) == "0.00");
+    CHECK(get_data_default_as_string(stmt, 3) == "0.00000");
+  }
+
+  SECTION("small values with large scale") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 0.05::DECIMAL(10,2), 0.001::DECIMAL(10,3), "
+        "0.00001::DECIMAL(10,5)");
+    CHECK(get_data_default_as_string(stmt, 1) == "0.05");
+    CHECK(get_data_default_as_string(stmt, 2) == "0.001");
+    CHECK(get_data_default_as_string(stmt, 3) == "0.00001");
+  }
+
+  SECTION("negative small fractional values") {
+    auto stmt = conn.execute_fetch("SELECT -0.05::DECIMAL(10,2), -0.001::DECIMAL(10,3), -0.5::DECIMAL(10,1)");
+    CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-0.05");
+    CHECK(get_data<SQL_C_CHAR>(stmt, 2) == "-0.001");
+    CHECK(get_data<SQL_C_CHAR>(stmt, 3) == "-0.5");
+    CHECK(get_data_default_as_string(stmt, 1) == "-0.05");
+    CHECK(get_data_default_as_string(stmt, 2) == "-0.001");
+    CHECK(get_data_default_as_string(stmt, 3) == "-0.5");
+  }
+
+  SECTION("various SQL numeric type synonyms") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,2), 42::DECIMAL(10,2), 42::NUMERIC(10,2)");
+    std::string expected = "42.00";
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " with SQL_C_CHAR");
+      CHECK(get_data<SQL_C_CHAR>(stmt, i) == expected);
+    }
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " with SQL_C_DEFAULT");
+      CHECK(get_data_default_as_string(stmt, i) == expected);
+    }
+  }
+
+  SECTION("INT column resolves to SQL_C_CHAR") {
+    auto stmt = conn.execute_fetch("SELECT 42::INT, -7::INTEGER, 0::BIGINT");
+    CHECK(get_data_default_as_string(stmt, 1) == "42");
+    CHECK(get_data_default_as_string(stmt, 2) == "-7");
+    CHECK(get_data_default_as_string(stmt, 3) == "0");
+  }
+
+  SECTION("matches explicit SQL_C_CHAR via table") {
+    TestTable table(conn, "test_decimal_default_vs_char", "d1 DECIMAL(10,1), d2 DECIMAL(20,2), d3 DECIMAL(30,3)",
+                    "(123.4, 123.45, 123.456)");
+
+    auto stmt_char = conn.execute_fetch("SELECT * FROM " + table.name());
+    auto stmt_default = conn.execute_fetch("SELECT * FROM " + table.name());
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data<SQL_C_CHAR>(stmt_char, i) == get_data_default_as_string(stmt_default, i));
+    }
   }
 }
 
-TEST_CASE("SQL_DECIMAL default conversion - negative values", "[datatype][number][decimal][default]") {
+TEST_CASE("SQL_DECIMAL default conversion - large precision", "[datatype][number][decimal][default]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch(
-      "SELECT -123::DECIMAL(10,0), -123.4::DECIMAL(10,1), "
-      "-123.45::DECIMAL(10,2), -123.456::DECIMAL(10,3)");
+  SECTION("large values") {
+    TestTable table(conn, "test_decimal_large", "a NUMBER(38,0), b NUMBER(38,37)",
+                    "(10000000000000000000000000000000000000, "
+                    " 1.0000000000000000000000000000000000000)");
 
-  std::vector<std::string> expected = {"-123", "-123.4", "-123.45", "-123.456"};
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(get_data_default_as_string(stmt, 1) == "10000000000000000000000000000000000000");
+    CHECK(get_data_default_as_string(stmt, 2) == "1.0000000000000000000000000000000000000");
+  }
 
-  for (int i = 1; i <= 4; ++i) {
-    INFO("Testing column " << i << " with SQL_C_DEFAULT (negative values)");
-    CHECK(get_data_default_as_string(stmt, i) == expected[i - 1]);
+  SECTION("max positive and negative values") {
+    TestTable table(conn, "test_decimal_max", "a NUMBER(38,0), b NUMBER(38,37)",
+                    "(99999999999999999999999999999999999999, "
+                    " 9.9999999999999999999999999999999999999), "
+                    "(-99999999999999999999999999999999999999, "
+                    " -9.9999999999999999999999999999999999999)");
+
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    CHECK(get_data_default_as_string(stmt, 1) == "99999999999999999999999999999999999999");
+    CHECK(get_data_default_as_string(stmt, 2) == "9.9999999999999999999999999999999999999");
+
+    SQLRETURN ret = SQLFetch(stmt.getHandle());
+    CHECK_ODBC(ret, stmt);
+    CHECK(get_data_default_as_string(stmt, 1) == "-99999999999999999999999999999999999999");
+    CHECK(get_data_default_as_string(stmt, 2) == "-9.9999999999999999999999999999999999999");
   }
 }
 
-TEST_CASE("SQL_DECIMAL default conversion - zero", "[datatype][number][decimal][default]") {
+// ============================================================================
+// Explicit conversions - integers truncate, floats preserve
+// ============================================================================
+
+TEST_CASE("SQL_DECIMAL explicit conversions", "[datatype][number][decimal]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 0::DECIMAL(10,0), 0::DECIMAL(10,2), 0::DECIMAL(10,5)");
-
-  CHECK(get_data_default_as_string(stmt, 1) == "0");
-  CHECK(get_data_default_as_string(stmt, 2) == "0.00");
-  CHECK(get_data_default_as_string(stmt, 3) == "0.00000");
-}
-
-TEST_CASE("SQL_DECIMAL default conversion - small values with large scale", "[datatype][number][decimal][default]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch(
-      "SELECT 0.05::DECIMAL(10,2), 0.001::DECIMAL(10,3), "
-      "0.00001::DECIMAL(10,5)");
-
-  CHECK(get_data_default_as_string(stmt, 1) == "0.05");
-  CHECK(get_data_default_as_string(stmt, 2) == "0.001");
-  CHECK(get_data_default_as_string(stmt, 3) == "0.00001");
-}
-
-TEST_CASE("SQL_DECIMAL default conversion - large precision values", "[datatype][number][decimal][default]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  // Test with large precision numbers (up to 38 digits, Snowflake's max)
-  conn.execute("DROP TABLE IF EXISTS test_decimal_large");
-  conn.execute(
-      "CREATE TABLE test_decimal_large ("
-      "  a NUMBER(38,0), "
-      "  b NUMBER(38,37))");
-  conn.execute(
-      "INSERT INTO test_decimal_large VALUES "
-      "(10000000000000000000000000000000000000, "
-      " 1.0000000000000000000000000000000000000)");
-
-  auto stmt = conn.execute_fetch("SELECT * FROM test_decimal_large");
-
-  CHECK(get_data_default_as_string(stmt, 1) == "10000000000000000000000000000000000000");
-  CHECK(get_data_default_as_string(stmt, 2) == "1.0000000000000000000000000000000000000");
-}
-
-TEST_CASE("SQL_DECIMAL default conversion - max precision values", "[datatype][number][decimal][default]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  conn.execute("DROP TABLE IF EXISTS test_decimal_max");
-  conn.execute(
-      "CREATE TABLE test_decimal_max ("
-      "  a NUMBER(38,0), "
-      "  b NUMBER(38,37))");
-  conn.execute(
-      "INSERT INTO test_decimal_max VALUES "
-      "(99999999999999999999999999999999999999, "
-      " 9.9999999999999999999999999999999999999), "
-      "(-99999999999999999999999999999999999999, "
-      " -9.9999999999999999999999999999999999999)");
-
-  auto stmt = conn.execute_fetch("SELECT * FROM test_decimal_max");
-
-  // First row
-  CHECK(get_data_default_as_string(stmt, 1) == "99999999999999999999999999999999999999");
-  CHECK(get_data_default_as_string(stmt, 2) == "9.9999999999999999999999999999999999999");
-
-  // Second row
-  SQLRETURN ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
-  CHECK(get_data_default_as_string(stmt, 1) == "-99999999999999999999999999999999999999");
-  CHECK(get_data_default_as_string(stmt, 2) == "-9.9999999999999999999999999999999999999");
-}
-
-TEST_CASE("SQL_DECIMAL default conversion matches explicit SQL_C_CHAR", "[datatype][number][decimal][default]") {
-  // This is the key compatibility test: SQL_C_DEFAULT should produce
-  // identical results to SQL_C_CHAR for SQL_DECIMAL columns.
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  conn.execute("DROP TABLE IF EXISTS test_decimal_default_vs_char");
-  conn.execute(
-      "CREATE TABLE test_decimal_default_vs_char ("
-      "  d1 DECIMAL(10,1), "
-      "  d2 DECIMAL(20,2), "
-      "  d3 DECIMAL(30,3))");
-  conn.execute("INSERT INTO test_decimal_default_vs_char VALUES (123.4, 123.45, 123.456)");
-
-  // Get data with SQL_C_CHAR explicitly
-  auto stmt_char = conn.execute_fetch("SELECT * FROM test_decimal_default_vs_char");
-  std::vector<std::string> char_results;
-  for (int i = 1; i <= 3; ++i) {
-    char_results.push_back(get_data<SQL_C_CHAR>(stmt_char, i));
-  }
-
-  // Get data with SQL_C_DEFAULT
-  auto stmt_default = conn.execute_fetch("SELECT * FROM test_decimal_default_vs_char");
-  std::vector<std::string> default_results;
-  for (int i = 1; i <= 3; ++i) {
-    default_results.push_back(get_data_default_as_string(stmt_default, i));
-  }
-
-  // They must match
-  for (int i = 0; i < 3; ++i) {
-    INFO("Comparing column " << (i + 1) << ": SQL_C_CHAR='" << char_results[i] << "' vs SQL_C_DEFAULT='"
-                             << default_results[i] << "'");
-    CHECK(char_results[i] == default_results[i]);
-  }
-}
-
-TEST_CASE("SQL_DECIMAL SQL_C_CHAR and SQL_C_DEFAULT - various SQL numeric type synonyms",
-          "[datatype][number][decimal][default]") {
-  // NUMBER, DECIMAL, NUMERIC are all "fixed" type in Snowflake.
-  // They all should produce consistent results when fetched as SQL_C_CHAR or SQL_C_DEFAULT.
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,2), 42::DECIMAL(10,2), 42::NUMERIC(10,2)");
-
-  std::string expected = "42.00";
-  for (int i = 1; i <= 3; ++i) {
-    INFO("Testing SQL numeric synonym column " << i << " with SQL_C_CHAR");
-    CHECK(get_data<SQL_C_CHAR>(stmt, i) == expected);
-  }
-  for (int i = 1; i <= 3; ++i) {
-    INFO("Testing SQL numeric synonym column " << i << " with SQL_C_DEFAULT");
-    CHECK(get_data_default_as_string(stmt, i) == expected);
-  }
-}
-
-TEST_CASE("SQL_DECIMAL explicit conversions - integers truncate fractional part", "[datatype][number][decimal]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
   const std::string query = "SELECT 123.789::DECIMAL(10,3)";
 
-  // Each type needs its own query execution because SQLGetData consumes the column.
-  CHECK(get_data<SQL_C_LONG>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_SLONG>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_ULONG>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_SHORT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_SSHORT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_USHORT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_TINYINT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_STINYINT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_UTINYINT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == 123);
-  CHECK(get_data<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
-}
+  SECTION("integers truncate fractional part") {
+    CHECK(get_data<SQL_C_LONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_SLONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_ULONG>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_SHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_SSHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_USHORT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_TINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_STINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_UTINYINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == 123);
+    CHECK(get_data<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
+  }
 
-TEST_CASE("SQL_DECIMAL explicit conversions - floating point preserves fractional part",
-          "[datatype][number][decimal]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("floating point preserves fractional part") {
+    float float_val = get_data<SQL_C_FLOAT>(conn.execute_fetch(query), 1);
+    CHECK(float_val > 123.78f);
+    CHECK(float_val < 123.80f);
 
-  const std::string query = "SELECT 123.789::DECIMAL(10,3)";
-
-  // Each type needs its own query execution because SQLGetData consumes the column.
-  float float_val = get_data<SQL_C_FLOAT>(conn.execute_fetch(query), 1);
-  CHECK(float_val > 123.78f);
-  CHECK(float_val < 123.80f);
-
-  double double_val = get_data<SQL_C_DOUBLE>(conn.execute_fetch(query), 1);
-  CHECK(double_val > 123.788);
-  CHECK(double_val < 123.790);
-}
-
-TEST_CASE("SQL_DECIMAL SQL_C_CHAR and SQL_C_DEFAULT - negative small fractional values",
-          "[datatype][number][decimal][default]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -0.05::DECIMAL(10,2), -0.001::DECIMAL(10,3), -0.5::DECIMAL(10,1)");
-
-  // SQL_C_CHAR
-  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-0.05");
-  CHECK(get_data<SQL_C_CHAR>(stmt, 2) == "-0.001");
-  CHECK(get_data<SQL_C_CHAR>(stmt, 3) == "-0.5");
-
-  // SQL_C_DEFAULT must produce the same results
-  CHECK(get_data_default_as_string(stmt, 1) == "-0.05");
-  CHECK(get_data_default_as_string(stmt, 2) == "-0.001");
-  CHECK(get_data_default_as_string(stmt, 3) == "-0.5");
+    double double_val = get_data<SQL_C_DOUBLE>(conn.execute_fetch(query), 1);
+    CHECK(double_val > 123.788);
+    CHECK(double_val < 123.790);
+  }
 }
 
 // ============================================================================
 // NULL handling tests
 // ============================================================================
 
-TEST_CASE("NUMBER NULL values - indicator returns SQL_NULL_DATA", "[datatype][number][null]") {
+TEST_CASE("NUMBER NULL handling", "[datatype][number][null]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0), NULL::DECIMAL(10,2), NULL::NUMERIC(20,5)");
+  SECTION("SQL_C_LONG indicator returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0), NULL::DECIMAL(10,2), NULL::NUMERIC(20,5)");
+    for (int i = 1; i <= 3; ++i) {
+      INFO("Column " << i << " should be NULL");
+      check_null_via_get_data(stmt, i, SQL_C_LONG);
+    }
+  }
 
-  for (int i = 1; i <= 3; ++i) {
-    SQLINTEGER value = 0;
-    SQLLEN indicator = 0;
-    SQLRETURN ret = SQLGetData(stmt.getHandle(), i, SQL_C_LONG, &value, sizeof(value), &indicator);
-    CHECK_ODBC(ret, stmt);
-    INFO("Column " << i << " should be NULL");
-    CHECK(indicator == SQL_NULL_DATA);
+  SECTION("SQL_C_CHAR returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(20,5)");
+    check_null_via_get_data(stmt, 1, SQL_C_CHAR);
+  }
+
+  SECTION("SQL_C_DEFAULT returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");
+    check_null_via_get_data(stmt, 1, SQL_C_DEFAULT);
+  }
+
+  SECTION("SQL_C_WCHAR returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+    check_null_via_get_data(stmt, 1, SQL_C_WCHAR);
+  }
+
+  SECTION("SQL_C_NUMERIC returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,2)");
+    check_null_via_get_data(stmt, 1, SQL_C_NUMERIC);
+  }
+
+  SECTION("SQL_C_BINARY returns SQL_NULL_DATA") {
+    auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
+    check_null_via_get_data(stmt, 1, SQL_C_BINARY);
   }
 }
 
@@ -439,165 +368,81 @@ TEST_CASE("NUMBER NULL mixed with non-NULL in multiple rows", "[datatype][number
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("DROP TABLE IF EXISTS test_number_null");
-  conn.execute("CREATE TABLE test_number_null (val NUMBER(10,0))");
-  conn.execute("INSERT INTO test_number_null VALUES (42), (NULL), (-7), (NULL), (0)");
+  TestTable table(conn, "test_number_null", "val NUMBER(10,0)", "(42), (NULL), (-7), (NULL), (0)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_number_null");
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
 
-  // Row 1: 42
+  std::vector<std::optional<SQLINTEGER>> expected = {42, std::nullopt, -7, std::nullopt, 0};
   SQLINTEGER value = 0;
   SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator != SQL_NULL_DATA);
-  CHECK(value == 42);
 
-  // Row 2: NULL
-  ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
-  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-
-  // Row 3: -7
-  ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
-  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator != SQL_NULL_DATA);
-  CHECK(value == -7);
-
-  // Row 4: NULL
-  ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
-  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-
-  // Row 5: 0
-  ret = SQLFetch(stmt.getHandle());
-  CHECK_ODBC(ret, stmt);
-  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator != SQL_NULL_DATA);
-  CHECK(value == 0);
-}
-
-TEST_CASE("NUMBER NULL with SQL_C_CHAR returns SQL_NULL_DATA", "[datatype][number][null]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(20,5)");
-
-  char buffer[100];
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-}
-
-TEST_CASE("NUMBER NULL with SQL_C_DEFAULT returns SQL_NULL_DATA", "[datatype][number][null]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");
-
-  char buffer[100];
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DEFAULT, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
+  for (size_t row = 0; row < expected.size(); ++row) {
+    if (row > 0) {
+      SQLRETURN ret = SQLFetch(stmt.getHandle());
+      CHECK_ODBC(ret, stmt);
+    }
+    INFO("Row " << row);
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+    CHECK_ODBC(ret, stmt);
+    if (expected[row].has_value()) {
+      CHECK(indicator != SQL_NULL_DATA);
+      CHECK(value == expected[row].value());
+    } else {
+      CHECK(indicator == SQL_NULL_DATA);
+    }
+  }
 }
 
 // ============================================================================
-// SQL_C_BIT conversion tests
+// Truncation and scale tests
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BIT - 0 and 1", "[datatype][number][bit]") {
+TEST_CASE("SQL_DECIMAL truncation and scale", "[datatype][number][truncation]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0), 1::NUMBER(10,0), 0.00::NUMBER(10,2)");
+  SECTION("zero with high scale to SQL_C_LONG") {
+    auto stmt = conn.execute_fetch("SELECT 0::NUMBER(38,10), 0::NUMBER(38,37), 0::NUMBER(20,15)");
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 0);
+    CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
+    CHECK(get_data<SQL_C_LONG>(stmt, 3) == 0);
+  }
 
-  CHECK(get_data<SQL_C_BIT>(stmt, 1) == 0);
-  CHECK(get_data<SQL_C_BIT>(stmt, 2) == 1);
-  CHECK(get_data<SQL_C_BIT>(stmt, 3) == 0);
-}
+  SECTION("nonzero with high scale to SQL_C_LONG") {
+    CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT 5.0000000000::NUMBER(38,10)"), 1) == 5);
+    CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT -3.0000000000::NUMBER(38,10)"), 1) == -3);
+  }
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BIT - negative value is out of range", "[datatype][number][bit]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("fractional values truncate toward zero") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 0.9::DECIMAL(3,1), -0.9::DECIMAL(3,1), "
+        "0.1::DECIMAL(3,1), -0.1::DECIMAL(3,1), "
+        "0.5::DECIMAL(3,1), -0.5::DECIMAL(3,1)");
+    for (int i = 1; i <= 6; ++i) {
+      INFO("Column " << i);
+      CHECK(get_data<SQL_C_LONG>(stmt, i) == 0);
+    }
+  }
 
-  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(10,0)");
+  SECTION("values just below type boundary") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 1.99::DECIMAL(5,2), -1.99::DECIMAL(5,2), "
+        "127.99::DECIMAL(5,2), -128.99::DECIMAL(6,2)");
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 1);
+    CHECK(get_data<SQL_C_LONG>(stmt, 2) == -1);
+    CHECK(get_data<SQL_C_STINYINT>(stmt, 3) == 127);
+    CHECK(get_data<SQL_C_STINYINT>(stmt, 4) == -128);
+  }
 
-  unsigned char bit_val = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &bit_val, sizeof(bit_val), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-// ============================================================================
-// High scale zero conversion
-// ============================================================================
-
-TEST_CASE("SQL_DECIMAL zero with high scale to SQL_C_LONG", "[datatype][number][truncation]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 0::NUMBER(38,10), 0::NUMBER(38,37), 0::NUMBER(20,15)");
-
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 3) == 0);
-}
-
-TEST_CASE("SQL_DECIMAL nonzero with high scale to SQL_C_LONG", "[datatype][number][truncation]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT 5.0000000000::NUMBER(38,10)"), 1) == 5);
-  CHECK(get_data<SQL_C_LONG>(conn.execute_fetch("SELECT -3.0000000000::NUMBER(38,10)"), 1) == -3);
-}
-
-// ============================================================================
-// Integer truncation toward zero tests
-// ============================================================================
-
-TEST_CASE("SQL_DECIMAL fractional truncation toward zero", "[datatype][number][truncation]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  // Values less than 1 in magnitude should all truncate to 0
-  auto stmt = conn.execute_fetch(
-      "SELECT 0.9::DECIMAL(3,1), -0.9::DECIMAL(3,1), "
-      "0.1::DECIMAL(3,1), -0.1::DECIMAL(3,1), "
-      "0.5::DECIMAL(3,1), -0.5::DECIMAL(3,1)");
-
-  // All should truncate to 0 (truncation toward zero, not rounding)
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 3) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 4) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 5) == 0);
-  CHECK(get_data<SQL_C_LONG>(stmt, 6) == 0);
-}
-
-TEST_CASE("SQL_DECIMAL fractional truncation - values just below boundary", "[datatype][number][truncation]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch(
-      "SELECT 1.99::DECIMAL(5,2), -1.99::DECIMAL(5,2), "
-      "127.99::DECIMAL(5,2), -128.99::DECIMAL(6,2)");
-
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 1);
-  CHECK(get_data<SQL_C_LONG>(stmt, 2) == -1);
-  CHECK(get_data<SQL_C_STINYINT>(stmt, 3) == 127);
-  CHECK(get_data<SQL_C_STINYINT>(stmt, 4) == -128);
+  SECTION("exact scale division - no fractional remainder") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 100.00::DECIMAL(10,2), 0.50::DECIMAL(10,2), "
+        "-25.00::DECIMAL(10,2), 1.00::DECIMAL(10,2)");
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 100);
+    CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
+    CHECK(get_data<SQL_C_LONG>(stmt, 3) == -25);
+    CHECK(get_data<SQL_C_LONG>(stmt, 4) == 1);
+  }
 }
 
 // ============================================================================
@@ -608,11 +453,10 @@ TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[datatype][number][integer]
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("DROP TABLE IF EXISTS test_int_types");
-  conn.execute("CREATE TABLE test_int_types (a INT, b INTEGER, c BIGINT, d SMALLINT, e TINYINT)");
-  conn.execute("INSERT INTO test_int_types VALUES (100, -200, 9223372036854775807, -32000, 120)");
+  TestTable table(conn, "test_int_types", "a INT, b INTEGER, c BIGINT, d SMALLINT, e TINYINT",
+                  "(100, -200, 9223372036854775807, -32000, 120)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_int_types");
+  auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
 
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 100);
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == -200);
@@ -620,7 +464,6 @@ TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[datatype][number][integer]
   CHECK(get_data<SQL_C_SHORT>(stmt, 4) == -32000);
   CHECK(get_data<SQL_C_TINYINT>(stmt, 5) == 120);
 
-  // Also verify SQL_C_CHAR representations for scale=0
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "100");
   CHECK(get_data<SQL_C_CHAR>(stmt, 2) == "-200");
   CHECK(get_data<SQL_C_CHAR>(stmt, 3) == "9223372036854775807");
@@ -632,380 +475,201 @@ TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[datatype][number][integer]
 // SQL_C_CHAR buffer truncation tests
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL SQL_C_CHAR with small buffer", "[datatype][number][char][buffer]") {
+TEST_CASE("SQL_DECIMAL SQL_C_CHAR buffer handling", "[datatype][number][char][buffer]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
+  SECTION("small buffer truncates") {
+    auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
 
-  char small_buffer[4];
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
+    char small_buffer[4];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, small_buffer, sizeof(small_buffer), &indicator);
 
-  OLD_DRIVER_ONLY("BD#13") { CHECK(ret == SQL_SUCCESS); }
+    OLD_DRIVER_ONLY("BD#13") { CHECK(ret == SQL_SUCCESS); }
 
-  NEW_DRIVER_ONLY("BD#13") {
-    CHECK(ret == SQL_SUCCESS_WITH_INFO);
-    CHECK(indicator == SQL_NO_TOTAL);
-    CHECK(std::string(small_buffer) == "123");
+    NEW_DRIVER_ONLY("BD#13") {
+      CHECK(ret == SQL_SUCCESS_WITH_INFO);
+      CHECK(indicator == SQL_NO_TOTAL);
+      CHECK(std::string(small_buffer) == "123");
+    }
   }
-}
 
-TEST_CASE("SQL_DECIMAL SQL_C_CHAR with exact buffer", "[datatype][number][char][buffer]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("exact buffer fits") {
+    auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
 
-  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
-
-  // Buffer of size 3: "42" + null terminator
-  char exact_buffer[3];
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, exact_buffer, sizeof(exact_buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == 2);
-  CHECK(std::string(exact_buffer) == "42");
+    char exact_buffer[3];
+    SQLLEN indicator = 0;
+    SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_CHAR, exact_buffer, sizeof(exact_buffer), &indicator);
+    CHECK_ODBC(ret, stmt);
+    CHECK(indicator == 2);
+    CHECK(std::string(exact_buffer) == "42");
+  }
 }
 
 // ============================================================================
 // Multiple rows with varying scales and mixed positive/negative
 // ============================================================================
 
-TEST_CASE("DECIMAL multiple rows with various values", "[datatype][number][multirow]") {
+TEST_CASE("DECIMAL multiple rows", "[datatype][number][multirow]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("DROP TABLE IF EXISTS test_number_multi");
-  conn.execute("CREATE TABLE test_number_multi (val DECIMAL(10,2))");
-  conn.execute(
-      "INSERT INTO test_number_multi VALUES "
-      "(0.00), (1.00), (-1.00), (999.99), (-999.99), (0.01), (-0.01)");
+  SECTION("various values as SQL_C_CHAR") {
+    TestTable table(conn, "test_number_multi", "val DECIMAL(10,2)",
+                    "(0.00), (1.00), (-1.00), (999.99), (-999.99), (0.01), (-0.01)");
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_number_multi");
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<std::string> expected = {"0.00", "1.00", "-1.00", "999.99", "-999.99", "0.01", "-0.01"};
 
-  std::vector<std::string> expected = {"0.00", "1.00", "-1.00", "999.99", "-999.99", "0.01", "-0.01"};
-
-  for (size_t row = 0; row < expected.size(); ++row) {
-    if (row > 0) {
-      SQLRETURN ret = SQLFetch(stmt.getHandle());
-      CHECK_ODBC(ret, stmt);
+    for (size_t row = 0; row < expected.size(); ++row) {
+      if (row > 0) {
+        SQLRETURN ret = SQLFetch(stmt.getHandle());
+        CHECK_ODBC(ret, stmt);
+      }
+      INFO("Row " << row << " expected: " << expected[row]);
+      CHECK(get_data<SQL_C_CHAR>(stmt, 1) == expected[row]);
     }
-    INFO("Row " << row << " expected: " << expected[row]);
-    CHECK(get_data<SQL_C_CHAR>(stmt, 1) == expected[row]);
   }
-}
 
-TEST_CASE("DECIMAL multiple rows fetched as SQL_C_DOUBLE", "[datatype][number][multirow]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("various values as SQL_C_DOUBLE") {
+    TestTable table(conn, "test_number_double_multi", "val DECIMAL(10,3)", "(0.000), (1.500), (-2.750), (100.125)");
 
-  conn.execute("DROP TABLE IF EXISTS test_number_double_multi");
-  conn.execute("CREATE TABLE test_number_double_multi (val DECIMAL(10,3))");
-  conn.execute(
-      "INSERT INTO test_number_double_multi VALUES "
-      "(0.000), (1.500), (-2.750), (100.125)");
+    auto stmt = conn.execute_fetch("SELECT * FROM " + table.name());
+    std::vector<double> expected = {0.0, 1.5, -2.75, 100.125};
 
-  auto stmt = conn.execute_fetch("SELECT * FROM test_number_double_multi");
-
-  // These values are exactly representable in f64 (powers of 2 denominators)
-  std::vector<double> expected = {0.0, 1.5, -2.75, 100.125};
-
-  for (size_t row = 0; row < expected.size(); ++row) {
-    if (row > 0) {
-      SQLRETURN ret = SQLFetch(stmt.getHandle());
-      CHECK_ODBC(ret, stmt);
+    for (size_t row = 0; row < expected.size(); ++row) {
+      if (row > 0) {
+        SQLRETURN ret = SQLFetch(stmt.getHandle());
+        CHECK_ODBC(ret, stmt);
+      }
+      INFO("Row " << row << " expected double: " << expected[row]);
+      CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == expected[row]);
     }
-    INFO("Row " << row << " expected double: " << expected[row]);
-    CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == expected[row]);
   }
 }
 
 // ============================================================================
-// Exact scale conversion tests (scale divides evenly)
+// SQL_C_DOUBLE/SQL_C_FLOAT precision checks
 // ============================================================================
 
-TEST_CASE("DECIMAL exact scale division - no fractional remainder", "[datatype][number][scale]") {
+TEST_CASE("DECIMAL to floating point precision", "[datatype][number][precision]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  // 100.00 with scale=2 stored as 10000 in i128, divides by 100 evenly
-  auto stmt = conn.execute_fetch(
-      "SELECT 100.00::DECIMAL(10,2), 0.50::DECIMAL(10,2), "
-      "-25.00::DECIMAL(10,2), 1.00::DECIMAL(10,2)");
+  SECTION("SQL_C_DOUBLE with 15 significant digits") {
+    auto stmt = conn.execute_fetch("SELECT 123456789012345::NUMBER(15,0)");
+    CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == 123456789012345.0);
+  }
 
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 100);
-  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);  // 0.50 truncates to 0
-  CHECK(get_data<SQL_C_LONG>(stmt, 3) == -25);
-  CHECK(get_data<SQL_C_LONG>(stmt, 4) == 1);
-}
-
-// ============================================================================
-// Numeric type to SQL_C_DOUBLE/SQL_C_FLOAT precision checks
-// ============================================================================
-
-TEST_CASE("DECIMAL to SQL_C_DOUBLE - precision for large values", "[datatype][number][precision]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  // Value with 15 significant digits (within f64 precision)
-  auto stmt = conn.execute_fetch("SELECT 123456789012345::NUMBER(15,0)");
-
-  double val = get_data<SQL_C_DOUBLE>(stmt, 1);
-  // f64 has ~15-16 significant digits, this should be exact
-  CHECK(val == 123456789012345.0);
-}
-
-TEST_CASE("DECIMAL to SQL_C_FLOAT - limited precision", "[datatype][number][precision]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
-
-  float val = get_data<SQL_C_FLOAT>(stmt, 1);
-  CHECK(val == 123456.0f);
-}
-
-// ============================================================================
-// SQL_C_DEFAULT for various column definitions
-// ============================================================================
-
-TEST_CASE("SQL_C_DEFAULT for INT column resolves to SQL_C_CHAR", "[datatype][number][default]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  // INT is NUMBER(38,0) under the hood - SQL type is SQL_DECIMAL
-  auto stmt = conn.execute_fetch("SELECT 42::INT, -7::INTEGER, 0::BIGINT");
-
-  CHECK(get_data_default_as_string(stmt, 1) == "42");
-  CHECK(get_data_default_as_string(stmt, 2) == "-7");
-  CHECK(get_data_default_as_string(stmt, 3) == "0");
+  SECTION("SQL_C_FLOAT with 6 significant digits") {
+    auto stmt = conn.execute_fetch("SELECT 123456::NUMBER(10,0)");
+    CHECK(get_data<SQL_C_FLOAT>(stmt, 1) == 123456.0f);
+  }
 }
 
 // ============================================================================
 // SQL_C_WCHAR (wide character) conversion tests
 // ============================================================================
 
-inline std::u16string get_wchar_data(const StatementHandleWrapper& stmt, SQLUSMALLINT col) {
-  char16_t buffer[1000];
-  SQLLEN indicator;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  return std::u16string(buffer, indicator / sizeof(char16_t));
-}
-
-TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - basic values", "[datatype][number][wchar]") {
+TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR", "[datatype][number][wchar]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch(
-      "SELECT 42::NUMBER(10,0), -7::NUMBER(10,0), 0::NUMBER(10,0), "
-      "123.45::NUMBER(10,2), -0.05::NUMBER(10,2)");
+  SECTION("basic values") {
+    auto stmt = conn.execute_fetch(
+        "SELECT 42::NUMBER(10,0), -7::NUMBER(10,0), 0::NUMBER(10,0), "
+        "123.45::NUMBER(10,2), -0.05::NUMBER(10,2)");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 1) == u"42");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 2) == u"-7");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 3) == u"0");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 4) == u"123.45");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 5) == u"-0.05");
+  }
 
-  CHECK(get_wchar_data(stmt, 1) == u"42");
-  CHECK(get_wchar_data(stmt, 2) == u"-7");
-  CHECK(get_wchar_data(stmt, 3) == u"0");
-  CHECK(get_wchar_data(stmt, 4) == u"123.45");
-  CHECK(get_wchar_data(stmt, 5) == u"-0.05");
-}
+  SECTION("large precision values") {
+    auto stmt = conn.execute_fetch("SELECT 99999999999999999999999999999999999999::NUMBER(38,0)");
+    CHECK(get_data<SQL_C_WCHAR>(stmt, 1) == u"99999999999999999999999999999999999999");
+  }
 
-TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - large precision values", "[datatype][number][wchar]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 99999999999999999999999999999999999999::NUMBER(38,0)");
-  CHECK(get_wchar_data(stmt, 1) == u"99999999999999999999999999999999999999");
-}
-
-TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR - NULL returns SQL_NULL_DATA", "[datatype][number][wchar][null]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
-
-  char16_t buffer[100];
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-}
-
-TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR matches SQL_C_CHAR", "[datatype][number][wchar]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  const std::string query = "SELECT 123.456::DECIMAL(10,3)";
-  auto char_str = get_data<SQL_C_CHAR>(conn.execute_fetch(query), 1);
-  auto wchar_str = get_wchar_data(conn.execute_fetch(query), 1);
-
-  std::u16string expected_wchar(char_str.begin(), char_str.end());
-  CHECK(wchar_str == expected_wchar);
+  SECTION("matches SQL_C_CHAR") {
+    const std::string query = "SELECT 123.456::DECIMAL(10,3)";
+    auto char_str = get_data<SQL_C_CHAR>(conn.execute_fetch(query), 1);
+    auto wchar_str = get_data<SQL_C_WCHAR>(conn.execute_fetch(query), 1);
+    std::u16string expected_wchar(char_str.begin(), char_str.end());
+    CHECK(wchar_str == expected_wchar);
+  }
 }
 
 // ============================================================================
 // SQL_C_NUMERIC (SQL_NUMERIC_STRUCT) conversion tests
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - positive integer", "[datatype][number][numeric]") {
+TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC", "[datatype][number][numeric]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
-
-  SQL_NUMERIC_STRUCT numeric = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator != SQL_NULL_DATA);
-  CHECK(numeric.sign == 1);
-  // val is little-endian 128-bit unsigned: 42 = 0x2A
-  CHECK(numeric.val[0] == 42);
-  for (int i = 1; i < 16; ++i) {
-    CHECK(numeric.val[i] == 0);
+  SECTION("positive integer") {
+    auto numeric = get_data<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 42::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 1);
+    CHECK(numeric.val[0] == 42);
+    check_numeric_val_zero_from(numeric, 1);
   }
-}
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - negative value", "[datatype][number][numeric]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -123::NUMBER(10,0)");
-
-  SQL_NUMERIC_STRUCT numeric = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator != SQL_NULL_DATA);
-  CHECK(numeric.sign == 0);
-  CHECK(numeric.val[0] == 123);
-  for (int i = 1; i < 16; ++i) {
-    CHECK(numeric.val[i] == 0);
+  SECTION("negative value") {
+    auto numeric = get_data<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -123::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 0);
+    CHECK(numeric.val[0] == 123);
+    check_numeric_val_zero_from(numeric, 1);
   }
-}
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - zero", "[datatype][number][numeric]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0)");
-
-  SQL_NUMERIC_STRUCT numeric = {};
-  numeric.sign = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(numeric.sign == 1);
-  for (int i = 0; i < 16; ++i) {
-    CHECK(numeric.val[i] == 0);
+  SECTION("zero") {
+    auto numeric = get_data<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 0::NUMBER(10,0)"), 1);
+    CHECK(numeric.sign == 1);
+    check_numeric_val_zero_from(numeric, 0);
   }
-}
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - with scale", "[datatype][number][numeric]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("with scale") {
+    auto numeric = get_data<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 123.45::NUMBER(10,2)"), 1);
+    CHECK(numeric.sign == 1);
 
-  auto stmt = conn.execute_fetch("SELECT 123.45::NUMBER(10,2)");
-
-  SQL_NUMERIC_STRUCT numeric = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(numeric.sign == 1);
-
-  unsigned long long stored = 0;
-  for (int i = 7; i >= 0; --i) {
-    stored = (stored << 8) | numeric.val[i];
+    unsigned long long stored = 0;
+    for (int i = 7; i >= 0; --i) {
+      stored = (stored << 8) | numeric.val[i];
+    }
+    CHECK(stored == 123);
   }
-  CHECK(stored == 123);
-}
-
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC - NULL returns SQL_NULL_DATA", "[datatype][number][numeric][null]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,2)");
-
-  SQL_NUMERIC_STRUCT numeric = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
 }
 
 // ============================================================================
 // SQL_C_BINARY conversion tests
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - integer value", "[datatype][number][binary]") {
+TEST_CASE("SQL_DECIMAL to SQL_C_BINARY", "[datatype][number][binary]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
-
-  char buffer[100] = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-
-  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
-  // Interpret as SQL_NUMERIC_STRUCT
-  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
-  CHECK(num->sign == 1);
-  CHECK(num->val[0] == 42);
-  for (int i = 1; i < 16; ++i) {
-    CHECK(num->val[i] == 0);
+  SECTION("integer value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT 42::NUMBER(10,0)"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.val[0] == 42);
+    check_numeric_val_zero_from(num, 1);
   }
-}
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - scaled value", "[datatype][number][binary]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 123.45::NUMBER(10,2)");
-
-  char buffer[100] = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
-  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
-  CHECK(num->sign == 1);
-  CHECK(num->scale == 0);
-  // 123.45 with scale=2 => integer part 123
-  CHECK(num->val[0] == 123);
-  for (int i = 1; i < 16; ++i) {
-    CHECK(num->val[i] == 0);
+  SECTION("scaled value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT 123.45::NUMBER(10,2)"), 1);
+    CHECK(num.sign == 1);
+    CHECK(num.scale == 0);
+    CHECK(num.val[0] == 123);
+    check_numeric_val_zero_from(num, 1);
   }
-}
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - negative value", "[datatype][number][binary]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -7::NUMBER(10,0)");
-
-  char buffer[100] = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == sizeof(SQL_NUMERIC_STRUCT));
-  auto* num = reinterpret_cast<SQL_NUMERIC_STRUCT*>(buffer);
-  CHECK(num->sign == 0);
-  CHECK(num->val[0] == 7);
-  for (int i = 1; i < 16; ++i) {
-    CHECK(num->val[i] == 0);
+  SECTION("negative value") {
+    auto num = get_binary_as_numeric(conn.execute_fetch("SELECT -7::NUMBER(10,0)"), 1);
+    CHECK(num.sign == 0);
+    CHECK(num.val[0] == 7);
+    check_numeric_val_zero_from(num, 1);
   }
-}
-
-TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - NULL returns SQL_NULL_DATA", "[datatype][number][binary][null]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
-
-  char buffer[100] = {};
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BINARY, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
 }
 
 // ============================================================================
@@ -1014,81 +678,39 @@ TEST_CASE("SQL_DECIMAL to SQL_C_BINARY - NULL returns SQL_NULL_DATA", "[datatype
 // integer C type should return SQL_SUCCESS_WITH_INFO with SQLSTATE 01S07.
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_LONG", "[datatype][number][01S07]") {
+TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07", "[datatype][number][01S07]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+  SECTION("SQL_C_LONG") {
+    auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
+    auto value = check_fractional_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 123);
+  }
 
-  SQLINTEGER value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 123);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
+  SECTION("SQL_C_SHORT") {
+    auto stmt = conn.execute_fetch("SELECT 9.99::DECIMAL(5,2)");
+    auto value = check_fractional_truncation<SQL_C_SHORT>(stmt, 1);
+    CHECK(value == 9);
+  }
 
-TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_SHORT", "[datatype][number][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("SQL_C_STINYINT") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_STINYINT>(stmt, 1);
+    CHECK(value == 1);
+  }
 
-  auto stmt = conn.execute_fetch("SELECT 9.99::DECIMAL(5,2)");
+  SECTION("SQL_C_SBIGINT") {
+    auto stmt = conn.execute_fetch("SELECT 999.001::DECIMAL(10,3)");
+    auto value = check_fractional_truncation<SQL_C_SBIGINT>(stmt, 1);
+    CHECK(value == 999);
+  }
 
-  SQLSMALLINT value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SHORT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 9);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
-
-TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_TINYINT", "[datatype][number][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
-
-  SQLSCHAR value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 1);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
-
-TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07 for SQL_C_SBIGINT", "[datatype][number][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 999.001::DECIMAL(10,3)");
-
-  SQLBIGINT value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SBIGINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 999);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
-
-TEST_CASE("SQL_DECIMAL exact integer does NOT produce 01S07", "[datatype][number][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 100.00::DECIMAL(10,2)");
-
-  SQLINTEGER value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS);
-  CHECK(value == 100);
+  SECTION("exact integer does NOT produce 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 100.00::DECIMAL(10,2)");
+    auto value = check_no_truncation<SQL_C_LONG>(stmt, 1);
+    CHECK(value == 100);
+  }
 }
 
 // ============================================================================
@@ -1097,221 +719,105 @@ TEST_CASE("SQL_DECIMAL exact integer does NOT produce 01S07", "[datatype][number
 // digits, the driver should return SQL_ERROR with SQLSTATE 22003.
 // ============================================================================
 
-TEST_CASE("SQL_DECIMAL overflow SQL_C_LONG - above i32 max", "[datatype][number][22003]") {
+TEST_CASE("SQL_DECIMAL overflow returns 22003", "[datatype][number][22003]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 2147483648::NUMBER(10,0)");
+  SECTION("SQL_C_LONG - above i32 max") {
+    auto stmt = conn.execute_fetch("SELECT 2147483648::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
+  }
 
-  SQLINTEGER value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
+  SECTION("SQL_C_LONG - below i32 min") {
+    auto stmt = conn.execute_fetch("SELECT -2147483649::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_LONG>(stmt, 1);
+  }
 
-TEST_CASE("SQL_DECIMAL overflow SQL_C_LONG - below i32 min", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("SQL_C_SHORT - above i16 max") {
+    auto stmt = conn.execute_fetch("SELECT 32768::NUMBER(5,0)");
+    check_numeric_out_of_range<SQL_C_SHORT>(stmt, 1);
+  }
 
-  auto stmt = conn.execute_fetch("SELECT -2147483649::NUMBER(10,0)");
+  SECTION("SQL_C_STINYINT - above i8 max") {
+    auto stmt = conn.execute_fetch("SELECT 128::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
 
-  SQLINTEGER value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
+  SECTION("SQL_C_STINYINT - below i8 min") {
+    auto stmt = conn.execute_fetch("SELECT -129::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 1);
+  }
 
-TEST_CASE("SQL_DECIMAL overflow SQL_C_SHORT - above i16 max", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("SQL_C_UTINYINT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
 
-  auto stmt = conn.execute_fetch("SELECT 32768::NUMBER(5,0)");
+  SECTION("SQL_C_UTINYINT - above u8 max") {
+    auto stmt = conn.execute_fetch("SELECT 256::NUMBER(3,0)");
+    check_numeric_out_of_range<SQL_C_UTINYINT>(stmt, 1);
+  }
 
-  SQLSMALLINT value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_SHORT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
+  SECTION("SQL_C_USHORT - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_USHORT>(stmt, 1);
+  }
 
-TEST_CASE("SQL_DECIMAL overflow SQL_C_STINYINT - above i8 max", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 128::NUMBER(3,0)");
-
-  SQLSCHAR value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-TEST_CASE("SQL_DECIMAL overflow SQL_C_STINYINT - below i8 min", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -129::NUMBER(3,0)");
-
-  SQLSCHAR value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_STINYINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-TEST_CASE("SQL_DECIMAL overflow SQL_C_UTINYINT - negative", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
-
-  SQLCHAR value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-TEST_CASE("SQL_DECIMAL overflow SQL_C_UTINYINT - above u8 max", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 256::NUMBER(3,0)");
-
-  SQLCHAR value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_UTINYINT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-TEST_CASE("SQL_DECIMAL overflow SQL_C_USHORT - negative", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
-
-  SQLUSMALLINT value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_USHORT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
-
-TEST_CASE("SQL_DECIMAL overflow SQL_C_ULONG - negative", "[datatype][number][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
-
-  SQLUINTEGER value = 0;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_ULONG, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
+  SECTION("SQL_C_ULONG - negative") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_ULONG>(stmt, 1);
+  }
 }
 
 // ============================================================================
 // ODBC Spec: SQL_C_BIT — spec-compliant behavior
 // Per ODBC spec for SQL_C_BIT:
-//   Exact 0 or 1                    → SQL_SUCCESS
-//   Value > 0, < 2, ≠ 1 (fraction) → SQL_SUCCESS_WITH_INFO, 01S07
-//   Value < 0 or ≥ 2               → SQL_ERROR, 22003
+//   Exact 0 or 1                    -> SQL_SUCCESS
+//   Value > 0, < 2, != 1 (fraction) -> SQL_SUCCESS_WITH_INFO, 01S07
+//   Value < 0 or >= 2               -> SQL_ERROR, 22003
 // ============================================================================
 
-TEST_CASE("SQL_C_BIT - value 2 returns 22003", "[datatype][number][bit][22003]") {
+TEST_CASE("SQL_C_BIT spec compliance", "[datatype][number][bit]") {
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
-  auto stmt = conn.execute_fetch("SELECT 2::NUMBER(1,0)");
+  SECTION("0 and 1 succeed") {
+    auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0), 1::NUMBER(10,0), 0.00::NUMBER(10,2)");
+    CHECK(get_data<SQL_C_BIT>(stmt, 1) == 0);
+    CHECK(get_data<SQL_C_BIT>(stmt, 2) == 1);
+    CHECK(get_data<SQL_C_BIT>(stmt, 3) == 0);
+  }
 
-  unsigned char value = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
+  SECTION("negative integer is out of range (22003)") {
+    auto stmt = conn.execute_fetch("SELECT -1::NUMBER(10,0)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
 
-TEST_CASE("SQL_C_BIT - negative fractional value returns 22003", "[datatype][number][bit][22003]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("value 2 returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT 2::NUMBER(1,0)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
 
-  // -0.5 is less than 0 per spec → should be 22003
-  auto stmt = conn.execute_fetch("SELECT -0.5::DECIMAL(3,1)");
+  SECTION("negative fractional value returns 22003") {
+    auto stmt = conn.execute_fetch("SELECT -0.5::DECIMAL(3,1)");
+    check_numeric_out_of_range<SQL_C_BIT>(stmt, 1);
+  }
 
-  unsigned char value = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_ERROR);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "22003");
-}
+  SECTION("fractional 0.5 truncates to 0 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 0.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 0);
+  }
 
-TEST_CASE("SQL_C_BIT - fractional 0.5 truncates to 0 with 01S07", "[datatype][number][bit][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  SECTION("fractional 1.5 truncates to 1 with 01S07") {
+    auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
+    auto value = check_fractional_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 1);
+  }
 
-  auto stmt = conn.execute_fetch("SELECT 0.5::DECIMAL(3,1)");
-
-  unsigned char value = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 0);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
-
-TEST_CASE("SQL_C_BIT - fractional 1.5 truncates to 1 with 01S07", "[datatype][number][bit][01S07]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 1.5::DECIMAL(3,1)");
-
-  unsigned char value = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS_WITH_INFO);
-  CHECK(value == 1);
-  auto diags = get_diag_rec(stmt);
-  REQUIRE(!diags.empty());
-  CHECK(diags[0].sqlState == "01S07");
-}
-
-TEST_CASE("SQL_C_BIT - exact 1.0 does NOT produce warning", "[datatype][number][bit]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
-  auto stmt = conn.execute_fetch("SELECT 1.00::DECIMAL(5,2)");
-
-  unsigned char value = 0xFF;
-  SQLLEN indicator = 0;
-  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_BIT, &value, sizeof(value), &indicator);
-  CHECK(ret == SQL_SUCCESS);
-  CHECK(value == 1);
+  SECTION("exact 1.0 does NOT produce warning") {
+    auto stmt = conn.execute_fetch("SELECT 1.00::DECIMAL(5,2)");
+    auto value = check_no_truncation<SQL_C_BIT>(stmt, 1);
+    CHECK(value == 1);
+  }
 }

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
@@ -25,13 +25,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Signed Integer Types
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
@@ -33,13 +33,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - Single-component interval types (no truncation)
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
@@ -37,13 +37,6 @@ static long long numeric_val_to_int(const SQL_NUMERIC_STRUCT& num) {
 
 static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>((unsigned char)c); }
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Floating Point Types
 // ============================================================================

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
@@ -23,13 +23,6 @@
 #include "macros.hpp"
 #include "test_setup.hpp"
 
-// Helper to get raw data with error checking for expected failures
-template <typename T>
-static SQLRETURN get_data_raw(const StatementHandleWrapper& stmt, SQLUSMALLINT col, SQLSMALLINT target_type, T* value,
-                              SQLLEN* indicator) {
-  return SQLGetData(stmt.getHandle(), col, target_type, value, sizeof(*value), indicator);
-}
-
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Date/Time Types
 // ============================================================================


### PR DESCRIPTION
# Improve code formatting and test organization in number_tests

This PR improves the readability and maintainability of the number conversion tests:

1. Reformats the test macros in `number_tests.rs` to align values and expected results for better readability
2. Extracts common test helpers to a new `TestTable` class to simplify test setup and teardown
3. Moves the `get_data_raw` helper function to the common include directory for reuse across test files
4. Restructures the C++ number tests to use SECTION-based organization for better grouping and clarity
5. Adds a TODO comment for an old driver bug fix that's awaiting release

The changes maintain all existing test coverage while making the code more maintainable and easier to read.