### PR TITLE
Add SQL state 22002 for indicator variable required but not supplied

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -318,6 +318,9 @@ impl OdbcError {
                     WriteOdbcError::NumericValueOutOfRange { .. } => {
                         SqlState::NumericValueOutOfRange
                     }
+                    WriteOdbcError::IndicatorVariableRequired { .. } => {
+                        SqlState::IndicatorVariableRequired
+                    }
                     _ => SqlState::GeneralError,
                 },
                 ConversionError::ReadArrowValue { .. } => SqlState::GeneralError,

--- a/odbc/src/api/sql_state.rs
+++ b/odbc/src/api/sql_state.rs
@@ -95,6 +95,8 @@ pub enum SqlState {
     FeatureNotSupported,
 
     // Cast error class (22)
+    /// 22002 - Indicator variable required but not supplied
+    IndicatorVariableRequired,
     /// 22003 - Numeric value out of range
     NumericValueOutOfRange,
     /// 22018 - Invalid character value for cast
@@ -338,6 +340,7 @@ impl SqlState {
             SqlState::CommunicationLinkFailure => "08S01",
             SqlState::TriggeredActionException => "09000",
             SqlState::FeatureNotSupported => "0A000",
+            SqlState::IndicatorVariableRequired => "22002",
             SqlState::NumericValueOutOfRange => "22003",
             SqlState::InvalidCharacterValueForCast => "22018",
             SqlState::InvalidTransactionState => "25000",
@@ -509,6 +512,7 @@ impl FromStr for SqlState {
             "08S01" => SqlState::CommunicationLinkFailure,
             "09000" => SqlState::TriggeredActionException,
             "0A000" => SqlState::FeatureNotSupported,
+            "22002" => SqlState::IndicatorVariableRequired,
             "22003" => SqlState::NumericValueOutOfRange,
             "22018" => SqlState::InvalidCharacterValueForCast,
             "25000" => SqlState::InvalidTransactionState,

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -43,6 +43,12 @@ pub enum WriteOdbcError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Indicator variable required but not supplied"))]
+    IndicatorVariableRequired {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     /// The target ODBC type is not supported for the given Snowflake/Arrow source type.
     #[snafu(display("Target ODBC type '{target_type:?}' is not supported for this conversion"))]
     UnsupportedOdbcType {

--- a/odbc/src/conversion/nullable.rs
+++ b/odbc/src/conversion/nullable.rs
@@ -2,10 +2,11 @@ use crate::{
     cdata_types::SQL_NULL_DATA,
     conversion::{
         Binding, ReadArrowType, SnowflakeType, WriteODBCType,
-        error::{ReadArrowError, WriteOdbcError},
+        error::{IndicatorVariableRequiredSnafu, ReadArrowError, WriteOdbcError},
         warning::Warnings,
     },
 };
+use snafu::ensure;
 
 pub(crate) struct Nullable<T> {
     pub value: T,
@@ -39,6 +40,10 @@ impl<T: WriteODBCType> WriteODBCType for Nullable<T> {
         match snowflake_value {
             Some(value) => self.value.write_odbc_type(value, binding),
             None => {
+                ensure!(
+                    !binding.str_len_or_ind_ptr.is_null(),
+                    IndicatorVariableRequiredSnafu
+                );
                 unsafe {
                     std::ptr::write(binding.str_len_or_ind_ptr, SQL_NULL_DATA);
                 }

--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -490,4 +490,74 @@ mod tests {
         bit_rejects_large_negative:      0, 10, -100i128;
         bit_rejects_neg_frac:            1, 10, -5i128;
     }
+
+    // ========================================================================
+    // Nullable NULL handling (SQLSTATE 22002)
+    // When the value is SQL NULL and no indicator pointer is provided,
+    // the driver must return an IndicatorVariableRequired error.
+    // ========================================================================
+
+    mod nullable_null_tests {
+        use super::*;
+        use crate::cdata_types::SQL_NULL_DATA;
+        use crate::conversion::WriteODBCType;
+        use crate::conversion::error::WriteOdbcError;
+        use crate::conversion::nullable::Nullable;
+
+        #[test]
+        fn null_with_indicator_writes_sql_null_data() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 42;
+            let mut str_len: sql::Len = 0;
+            let binding = binding_for_value(CDataType::SLong, &mut value, &mut str_len);
+
+            let warnings = nullable.write_odbc_type(None::<i128>, &binding).unwrap();
+
+            assert!(warnings.is_empty());
+            assert_eq!(str_len, SQL_NULL_DATA);
+        }
+
+        #[test]
+        fn null_without_indicator_returns_error() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 42;
+            let binding = Binding {
+                target_type: CDataType::SLong,
+                target_value_ptr: &mut value as *mut i32 as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: std::ptr::null_mut(),
+            };
+
+            let result = nullable.write_odbc_type(None::<i128>, &binding);
+
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                WriteOdbcError::IndicatorVariableRequired { .. }
+            ));
+        }
+
+        #[test]
+        fn non_null_with_null_indicator_still_writes_value() {
+            let nullable = Nullable {
+                value: make_decimal(0, 10),
+            };
+            let mut value: i32 = 0;
+            let binding = Binding {
+                target_type: CDataType::SLong,
+                target_value_ptr: &mut value as *mut i32 as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: std::ptr::null_mut(),
+            };
+
+            let warnings = nullable.write_odbc_type(Some(42i128), &binding).unwrap();
+
+            assert!(warnings.is_empty());
+            assert_eq!(value, 42);
+        }
+    }
 }

--- a/odbc_tests/tests/datatype_tests/number_tests.cpp
+++ b/odbc_tests/tests/datatype_tests/number_tests.cpp
@@ -822,3 +822,15 @@ TEST_CASE("SQL_C_BIT spec compliance", "[datatype][number][bit]") {
     CHECK(value == 1);
   }
 }
+
+TEST_CASE("SQL_DECIMAL SQLGetData NULL without indicator returns 22002", "[datatype][number][null]") {
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");
+
+  SQLINTEGER value = 0;
+  SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), nullptr);
+  CHECK(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "22002");
+}


### PR DESCRIPTION
### TL;DR

Added support for SQL state 22002 (indicator variable required but not supplied) when NULL values are fetched without an indicator pointer.

### What changed?

- Added a new `SqlState` enum variant `IndicatorVariableRequired` with code "22002"
- Added a new `WriteOdbcError` variant `IndicatorVariableRequired` 
- Updated the `Nullable<T>::write_odbc_type` implementation to check if the indicator pointer is null when writing a NULL value, and return an appropriate error if it is
- Added a test case that verifies the correct SQL state is returned when attempting to fetch a NULL value without an indicator pointer

### How to test?

Run the new test case in `odbc_tests/tests/datatype_tests/number_tests.cpp` which verifies that:
1. When fetching a NULL decimal value without an indicator pointer
2. The operation returns SQL_ERROR
3. The SQL state is correctly set to "22002"

### Why make this change?

This change improves ODBC specification compliance by properly handling the case where an application attempts to fetch a NULL value without providing an indicator variable. According to the ODBC specification, this scenario should return SQL state 22002, and this change ensures our driver correctly implements this behavior.