### PR TITLE
SNOW-2467847: Implement JDBC query parameter binding

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -54,3 +54,9 @@ python3 ci/reference_tests/extract_coverage.py \
 - Gradle 6.0+
 - Built Rust components: `sf_core` and `jdbc_bridge`
 - Parameters: `parameters.json` (see main [README.md](../README.md) for setup instructions)
+
+### Lombok
+
+`jdbc` uses Lombok in production and test sources via Gradle annotation processors.
+
+If your IDE shows unresolved Lombok symbols, enable annotation processing for the project and refresh Gradle.

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -35,7 +35,7 @@ configurations {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
-    testImplementation 'org.json:json:20231013'
+    implementation 'org.json:json:20251224'
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
@@ -47,6 +47,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:4.32.1'
 
     referenceTestsOldDriver "net.snowflake:snowflake-jdbc:${oldJdbcVersion}"
+    referenceTestsOldDriver 'org.json:json:20251224'
     // Old JDBC reference run needs SLF4J at runtime, but it is not guaranteed by old artifact metadata.
     referenceTestsOldDriver "org.slf4j:slf4j-api:${slf4jVersion}"
     referenceTestsOldDriver "org.slf4j:slf4j-simple:${slf4jVersion}"

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -15,6 +15,7 @@ plugins {
 // ====================
 def oldJdbcVersion = '4.0.1'
 def slf4jVersion = '2.0.9'
+def lombokVersion = '1.18.42'
 
 group = 'com.snowflake'
 version = '0.1.0'
@@ -35,6 +36,9 @@ configurations {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
     implementation 'org.json:json:20251224'
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
@@ -45,6 +49,8 @@ dependencies {
     implementation 'org.apache.arrow:arrow-memory-netty:17.0.0'
     implementation 'org.apache.arrow:arrow-c-data:17.0.0'
     implementation 'com.google.protobuf:protobuf-java:4.32.1'
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     referenceTestsOldDriver "net.snowflake:snowflake-jdbc:${oldJdbcVersion}"
     referenceTestsOldDriver 'org.json:json:20251224'

--- a/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
@@ -8,4 +8,8 @@ public class SnowflakeSQLException extends SQLException {
   public SnowflakeSQLException(String message) {
     super(message);
   }
+
+  public SnowflakeSQLException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -123,7 +123,7 @@ final class PreparedStatementBindingSerializer {
       this.address = address;
     }
 
-    static NativeBuffer fromBytes(byte[] source) throws SQLException {
+    private static NativeBuffer fromBytes(byte[] source) throws SQLException {
       RootAllocator allocator = null;
       ArrowBuf arrowBuf = null;
       boolean success = false;

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -1,0 +1,155 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.BinaryDataPtr;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.RootAllocator;
+import org.json.JSONStringer;
+
+final class PreparedStatementBindingSerializer {
+  private static final SFLogger logger =
+      SFLoggerFactory.getLogger(PreparedStatementBindingSerializer.class);
+
+  static final class ParameterValue {
+    private final String bindType;
+    private final Object value;
+
+    ParameterValue(String bindType, Object value) {
+      this.bindType = bindType;
+      this.value = value;
+    }
+
+    String bindType() {
+      return bindType;
+    }
+
+    Object value() {
+      return value;
+    }
+  }
+
+  static final class SerializedBindings implements AutoCloseable {
+    private final QueryBindings bindings;
+    private final NativeBuffer buffer;
+
+    SerializedBindings(QueryBindings bindings, NativeBuffer buffer) {
+      this.bindings = bindings;
+      this.buffer = buffer;
+    }
+
+    QueryBindings bindings() {
+      return bindings;
+    }
+
+    @Override
+    public void close() {
+      if (buffer != null) {
+        buffer.close();
+      }
+    }
+  }
+
+  private PreparedStatementBindingSerializer() {}
+
+  static SerializedBindings serialize(ParameterValue[] parameterValues) throws SQLException {
+    if (parameterValues.length == 0) {
+      logger.debug("No parameter placeholders found, skipping bindings serialization.");
+      return new SerializedBindings(null, null);
+    }
+    logger.debug("Serializing prepared bindings: placeholders={}", parameterValues.length);
+
+    JSONStringer jsonStringer = new JSONStringer();
+    jsonStringer.object();
+    for (int i = 0; i < parameterValues.length; i++) {
+      ParameterValue parameterValue = parameterValues[i];
+      int parameterIndex = i + 1;
+      if (parameterValue == null) {
+        logger.warn(
+            "Bindings serialization failed: missing parameter value for index {}", parameterIndex);
+        throw new SQLException("Missing value for parameter index: " + parameterIndex);
+      }
+
+      jsonStringer.key(String.valueOf(parameterIndex)).object();
+      jsonStringer.key("type").value(parameterValue.bindType());
+      if (parameterValue.value() == null) {
+        jsonStringer.key("value").value(null);
+      } else {
+        jsonStringer.key("value").value(String.valueOf(parameterValue.value()));
+      }
+      jsonStringer.endObject();
+    }
+    jsonStringer.endObject();
+
+    byte[] jsonBytes = jsonStringer.toString().getBytes(StandardCharsets.UTF_8);
+    NativeBuffer nativeBuffer = NativeBuffer.fromBytes(jsonBytes);
+    boolean success = false;
+    try {
+      byte[] ptrBytes = nativeBuffer.pointerAsLittleEndianBytes();
+      BinaryDataPtr jsonPtr =
+          BinaryDataPtr.newBuilder()
+              .setValue(ByteString.copyFrom(ptrBytes))
+              .setLength(jsonBytes.length)
+              .build();
+      QueryBindings queryBindings = QueryBindings.newBuilder().setJson(jsonPtr).build();
+      logger.debug(
+          "Prepared bindings serialized: payloadBytes={}, pointerBytes={}",
+          jsonBytes.length,
+          ptrBytes.length);
+      SerializedBindings serializedBindings = new SerializedBindings(queryBindings, nativeBuffer);
+      success = true;
+      return serializedBindings;
+    } finally {
+      if (!success) {
+        nativeBuffer.close();
+      }
+    }
+  }
+
+  private static final class NativeBuffer implements AutoCloseable {
+    private final RootAllocator allocator;
+    private final ArrowBuf arrowBuf;
+    private final long address;
+
+    private NativeBuffer(RootAllocator allocator, ArrowBuf arrowBuf, long address) {
+      this.allocator = allocator;
+      this.arrowBuf = arrowBuf;
+      this.address = address;
+    }
+
+    static NativeBuffer fromBytes(byte[] source) throws SQLException {
+      RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+      ArrowBuf arrowBuf = allocator.buffer(source.length);
+      arrowBuf.setBytes(0, source);
+      long address = arrowBuf.memoryAddress();
+      if (address == 0L) {
+        arrowBuf.close();
+        allocator.close();
+        logger.warn(
+            "Failed to allocate native memory for binding data: payloadBytes={}", source.length);
+        throw new SQLException("Failed to allocate native memory for binding data");
+      }
+      logger.debug("Allocated native binding buffer: payloadBytes={}", source.length);
+      return new NativeBuffer(allocator, arrowBuf, address);
+    }
+
+    byte[] pointerAsLittleEndianBytes() {
+      return ByteBuffer.allocate(Long.BYTES)
+          .order(ByteOrder.LITTLE_ENDIAN)
+          .putLong(address)
+          .array();
+    }
+
+    @Override
+    public void close() {
+      arrowBuf.close();
+      allocator.close();
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -124,19 +124,32 @@ final class PreparedStatementBindingSerializer {
     }
 
     static NativeBuffer fromBytes(byte[] source) throws SQLException {
-      RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-      ArrowBuf arrowBuf = allocator.buffer(source.length);
-      arrowBuf.setBytes(0, source);
-      long address = arrowBuf.memoryAddress();
-      if (address == 0L) {
-        arrowBuf.close();
-        allocator.close();
-        logger.warn(
-            "Failed to allocate native memory for binding data: payloadBytes={}", source.length);
-        throw new SQLException("Failed to allocate native memory for binding data");
+      RootAllocator allocator = null;
+      ArrowBuf arrowBuf = null;
+      boolean success = false;
+      try {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+        arrowBuf = allocator.buffer(source.length);
+        arrowBuf.setBytes(0, source);
+        long address = arrowBuf.memoryAddress();
+        if (address == 0L) {
+          logger.warn(
+              "Failed to allocate native memory for binding data: payloadBytes={}", source.length);
+          throw new SQLException("Failed to allocate native memory for binding data");
+        }
+        logger.debug("Allocated native binding buffer: payloadBytes={}", source.length);
+        success = true;
+        return new NativeBuffer(allocator, arrowBuf, address);
+      } finally {
+        if (!success) {
+          if (arrowBuf != null) {
+            arrowBuf.close();
+          }
+          if (allocator != null) {
+            allocator.close();
+          }
+        }
       }
-      logger.debug("Allocated native binding buffer: payloadBytes={}", source.length);
-      return new NativeBuffer(allocator, arrowBuf, address);
     }
 
     byte[] pointerAsLittleEndianBytes() {

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -25,11 +25,12 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.function.Function;
 import net.snowflake.client.api.statement.SnowflakePreparedStatement;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
-import net.snowflake.client.internal.util.SnowflakeUtil;
+import net.snowflake.client.internal.util.HexUtil;
 
 /**
  * Snowflake JDBC PreparedStatement implementation
@@ -121,31 +122,21 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     checkClosed();
-    if (x == null) {
-      setNull(parameterIndex, Types.DECIMAL);
-      return;
-    }
-    setParameter(parameterIndex, "FIXED", String.valueOf(x));
+    setNullableParameter(
+        parameterIndex, Types.DECIMAL, "FIXED", x, decimal -> String.valueOf(decimal));
   }
 
   @Override
   public void setString(int parameterIndex, String x) throws SQLException {
     checkClosed();
-    if (x == null) {
-      setNull(parameterIndex, Types.VARCHAR);
-      return;
-    }
-    setParameter(parameterIndex, "TEXT", x);
+    setNullableParameter(parameterIndex, Types.VARCHAR, "TEXT", x, stringValue -> stringValue);
   }
 
   @Override
   public void setBytes(int parameterIndex, byte[] x) throws SQLException {
     checkClosed();
-    if (x == null) {
-      setNull(parameterIndex, Types.BINARY);
-      return;
-    }
-    setParameter(parameterIndex, "BINARY", SnowflakeUtil.bytesToHex(x));
+    setNullableParameter(
+        parameterIndex, Types.BINARY, "BINARY", x, bytes -> HexUtil.bytesToHex(bytes));
   }
 
   @Override
@@ -484,6 +475,16 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
         bindType,
         value == null,
         parameterValues.length);
+  }
+
+  private <T> void setNullableParameter(
+      int parameterIndex, int sqlType, String bindType, T value, Function<T, String> serializer)
+      throws SQLException {
+    if (value == null) {
+      setNull(parameterIndex, sqlType);
+      return;
+    }
+    setParameter(parameterIndex, bindType, serializer.apply(value));
   }
 
   private static String sqlTypeToBindType(int sqlType) {

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -21,10 +21,15 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Map;
 import net.snowflake.client.api.statement.SnowflakePreparedStatement;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+import net.snowflake.client.internal.util.SnowflakeUtil;
 
 /**
  * Snowflake JDBC PreparedStatement implementation
@@ -33,112 +38,132 @@ import net.snowflake.client.internal.api.implementation.connection.SnowflakeConn
  */
 public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     implements PreparedStatement, SnowflakePreparedStatement {
+  private static final SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakePreparedStatementImpl.class);
 
   private final String sql;
-  private Object[] parameters;
+  private final PreparedStatementBindingSerializer.ParameterValue[] parameterValues;
 
   public SnowflakePreparedStatementImpl(SnowflakeConnectionImpl connection, String sql) {
     super(connection);
     this.sql = sql;
-    // Count parameter placeholders (simple implementation)
+    // TODO: Align with snowflake-jdbc by deriving bind count from server-side describe metadata
+    // rather than counting '?' directly in raw SQL text.
     int paramCount = sql.length() - sql.replace("?", "").length();
-    this.parameters = new Object[paramCount];
+    this.parameterValues = new PreparedStatementBindingSerializer.ParameterValue[paramCount];
   }
 
   @Override
   public ResultSet executeQuery() throws SQLException {
     checkClosed();
-    return executeQuery(buildSqlWithParameters());
+    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
+        PreparedStatementBindingSerializer.serialize(parameterValues)) {
+      return executeQueryWithBindings(sql, serializedBindings.bindings());
+    }
   }
 
   @Override
   public int executeUpdate() throws SQLException {
     checkClosed();
-    return executeUpdate(buildSqlWithParameters());
+    execute();
+    // TODO return real number of rows affected
+    return 0;
   }
 
   @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, null);
+    setParameter(parameterIndex, "ANY", null);
   }
 
   @Override
   public void setBoolean(int parameterIndex, boolean x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "BOOLEAN", String.valueOf(x));
   }
 
   @Override
   public void setByte(int parameterIndex, byte x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "FIXED", String.valueOf(x));
   }
 
   @Override
   public void setShort(int parameterIndex, short x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "FIXED", String.valueOf(x));
   }
 
   @Override
   public void setInt(int parameterIndex, int x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "FIXED", String.valueOf(x));
   }
 
   @Override
   public void setLong(int parameterIndex, long x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "FIXED", String.valueOf(x));
   }
 
   @Override
   public void setFloat(int parameterIndex, float x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "REAL", String.valueOf(x));
   }
 
   @Override
   public void setDouble(int parameterIndex, double x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    setParameter(parameterIndex, "REAL", String.valueOf(x));
   }
 
   @Override
   public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    if (x == null) {
+      setNull(parameterIndex, Types.DECIMAL);
+      return;
+    }
+    setParameter(parameterIndex, "FIXED", String.valueOf(x));
   }
 
   @Override
   public void setString(int parameterIndex, String x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    if (x == null) {
+      setNull(parameterIndex, Types.VARCHAR);
+      return;
+    }
+    setParameter(parameterIndex, "TEXT", x);
   }
 
   @Override
   public void setBytes(int parameterIndex, byte[] x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    if (x == null) {
+      setNull(parameterIndex, Types.BINARY);
+      return;
+    }
+    setParameter(parameterIndex, "BINARY", SnowflakeUtil.bytesToHex(x));
   }
 
   @Override
   public void setDate(int parameterIndex, Date x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    throw new SQLFeatureNotSupportedException("setDate not supported");
   }
 
   @Override
   public void setTime(int parameterIndex, Time x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    throw new SQLFeatureNotSupportedException("setTime not supported");
   }
 
   @Override
   public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    throw new SQLFeatureNotSupportedException("setTimestamp not supported");
   }
 
   @Override
@@ -159,27 +184,123 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public void clearParameters() throws SQLException {
     checkClosed();
-    for (int i = 0; i < parameters.length; i++) {
-      parameters[i] = null;
-    }
+    logger.trace("Clearing prepared parameters: placeholders={}", parameterValues.length);
+    Arrays.fill(parameterValues, null);
   }
 
   @Override
   public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    if (x == null) {
+      setNull(parameterIndex, targetSqlType);
+      return;
+    }
+    if (targetSqlType == Types.DATE) {
+      if (!(x instanceof Date)) {
+        throw new SQLException(
+            "Invalid parameter type for DATE at index "
+                + parameterIndex
+                + ": "
+                + x.getClass().getCanonicalName());
+      }
+      setDate(parameterIndex, (Date) x);
+      return;
+    }
+    if (targetSqlType == Types.TIME) {
+      if (!(x instanceof Time)) {
+        throw new SQLException(
+            "Invalid parameter type for TIME at index "
+                + parameterIndex
+                + ": "
+                + x.getClass().getCanonicalName());
+      }
+      setTime(parameterIndex, (Time) x);
+      return;
+    }
+    if (targetSqlType == Types.TIMESTAMP) {
+      if (!(x instanceof Timestamp)) {
+        throw new SQLException(
+            "Invalid parameter type for TIMESTAMP at index "
+                + parameterIndex
+                + ": "
+                + x.getClass().getCanonicalName());
+      }
+      setTimestamp(parameterIndex, (Timestamp) x);
+      return;
+    }
+    String bindType = sqlTypeToBindType(targetSqlType);
+    if ("BINARY".equals(bindType) && x instanceof byte[]) {
+      setBytes(parameterIndex, (byte[]) x);
+      return;
+    }
+    setParameter(parameterIndex, bindType, x);
   }
 
   @Override
   public void setObject(int parameterIndex, Object x) throws SQLException {
     checkClosed();
-    setParameter(parameterIndex, x);
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+      return;
+    }
+    if (x instanceof String) {
+      setString(parameterIndex, (String) x);
+      return;
+    }
+    if (x instanceof Boolean) {
+      setBoolean(parameterIndex, (Boolean) x);
+      return;
+    }
+    if (x instanceof Short) {
+      setShort(parameterIndex, (Short) x);
+      return;
+    }
+    if (x instanceof Integer) {
+      setInt(parameterIndex, (Integer) x);
+      return;
+    }
+    if (x instanceof Long) {
+      setLong(parameterIndex, (Long) x);
+      return;
+    }
+    if (x instanceof Float) {
+      setFloat(parameterIndex, (Float) x);
+      return;
+    }
+    if (x instanceof Double) {
+      setDouble(parameterIndex, (Double) x);
+      return;
+    }
+    if (x instanceof BigDecimal) {
+      setBigDecimal(parameterIndex, (BigDecimal) x);
+      return;
+    }
+    if (x instanceof byte[]) {
+      setBytes(parameterIndex, (byte[]) x);
+      return;
+    }
+    logger.warn(
+        "Unsupported prepared parameter value type: index={}, type={}",
+        parameterIndex,
+        x.getClass().getCanonicalName());
+    throw new SQLException(
+        "Unsupported parameter value type at index "
+            + parameterIndex
+            + ": "
+            + x.getClass().getCanonicalName());
   }
 
   @Override
   public boolean execute() throws SQLException {
     checkClosed();
-    return execute(buildSqlWithParameters());
+    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
+        PreparedStatementBindingSerializer.serialize(parameterValues)) {
+      try (ResultSet ignored = executeQueryWithBindings(sql, serializedBindings.bindings())) {
+        // TODO: Align execute() return value and update-count behavior with snowflake-jdbc by using
+        // backend statement-type metadata (true for result sets, false for update counts).
+        return true;
+      }
+    }
   }
 
   @Override
@@ -347,25 +468,48 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     throw new SQLFeatureNotSupportedException("setNClob not supported");
   }
 
-  private void setParameter(int parameterIndex, Object value) throws SQLException {
-    if (parameterIndex < 1 || parameterIndex > parameters.length) {
+  private void setParameter(int parameterIndex, String bindType, Object value) throws SQLException {
+    if (parameterIndex < 1 || parameterIndex > parameterValues.length) {
+      logger.warn(
+          "Invalid prepared parameter index: index={}, placeholders={}",
+          parameterIndex,
+          parameterValues.length);
       throw new SQLException("Invalid parameter index: " + parameterIndex);
     }
-    parameters[parameterIndex - 1] = value;
+    parameterValues[parameterIndex - 1] =
+        new PreparedStatementBindingSerializer.ParameterValue(bindType, value);
+    logger.debug(
+        "Prepared parameter set: index={}, bindType={}, isNull={}, placeholders={}",
+        parameterIndex,
+        bindType,
+        value == null,
+        parameterValues.length);
   }
 
-  private String buildSqlWithParameters() {
-    // Simple parameter substitution (not production ready)
-    String result = sql;
-    for (int i = 0; i < parameters.length; i++) {
-      Object param = parameters[i];
-      String paramStr = param == null ? "NULL" : param.toString();
-      if (param instanceof String) {
-        paramStr = "'" + paramStr.replace("'", "''") + "'";
-      }
-      result = result.replaceFirst("\\?", paramStr);
+  private static String sqlTypeToBindType(int sqlType) {
+    switch (sqlType) {
+      case Types.BOOLEAN:
+      case Types.BIT:
+        return "BOOLEAN";
+      case Types.TINYINT:
+      case Types.SMALLINT:
+      case Types.INTEGER:
+      case Types.BIGINT:
+      case Types.NUMERIC:
+      case Types.DECIMAL:
+        return "FIXED";
+      case Types.FLOAT:
+      case Types.REAL:
+      case Types.DOUBLE:
+        return "REAL";
+      case Types.BINARY:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+      case Types.BLOB:
+        return "BINARY";
+      default:
+        return "TEXT";
     }
-    return result;
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -7,12 +7,16 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.List;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.api.implementation.resultset.SnowflakeResultSetImpl;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteResult;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
@@ -26,6 +30,7 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.State
  * to native Rust implementation via JNI.
  */
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
 
   public final SnowflakeConnectionImpl connection;
   protected boolean closed = false;
@@ -49,6 +54,14 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     checkClosed();
+    return executeQueryWithBindings(sql, null);
+  }
+
+  protected ResultSet executeQueryWithBindings(String sql, QueryBindings bindings)
+      throws SQLException {
+    boolean hasBindings = bindings != null;
+    logger.debug(
+        "Statement executeQueryWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
     StatementSetSqlQueryRequest statementSetSqlQueryRequest =
         StatementSetSqlQueryRequest.newBuilder()
             .setStmtHandle(statementHandle)
@@ -57,18 +70,32 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     try {
       ProtobufApis.databaseDriverV1.statementSetSqlQuery(statementSetSqlQueryRequest);
     } catch (DatabaseDriverService.ServiceException e) {
-      throw new RuntimeException(e);
+      logger.warn("statementSetSqlQuery failed: sql={}, hasBindings={}", sql, hasBindings, e);
+      throw new SnowflakeSQLException("Failed to set SQL query on statement", e);
     }
 
-    StatementExecuteQueryRequest statementExecuteQueryRequest =
-        StatementExecuteQueryRequest.newBuilder().setStmtHandle(statementHandle).build();
+    StatementExecuteQueryRequest.Builder executeQueryRequestBuilder =
+        StatementExecuteQueryRequest.newBuilder().setStmtHandle(statementHandle);
+    if (bindings != null) {
+      executeQueryRequestBuilder.setBindings(bindings);
+    }
+    StatementExecuteQueryRequest executeQueryRequest = executeQueryRequestBuilder.build();
+    logger.debug(
+        "statementExecuteQuery request prepared: hasBindings={}, requestBytes={}",
+        hasBindings,
+        executeQueryRequest.getSerializedSize());
     try {
       StatementExecuteQueryResponse result =
-          ProtobufApis.databaseDriverV1.statementExecuteQuery(statementExecuteQueryRequest);
+          ProtobufApis.databaseDriverV1.statementExecuteQuery(executeQueryRequest);
       ExecuteResult executeResult = result.getResult();
+      logger.debug(
+          "statementExecuteQuery succeeded: hasBindings={}, queryId={}",
+          hasBindings,
+          executeResult.getQueryId());
       return new SnowflakeResultSetImpl(this, executeResult);
     } catch (DatabaseDriverService.ServiceException e) {
-      throw new RuntimeException(e);
+      logger.warn("statementExecuteQuery failed: hasBindings={}", hasBindings, e);
+      throw new SnowflakeSQLException("Failed to execute statement query", e);
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -1,6 +1,11 @@
 package net.snowflake.client.internal.unicore;
 
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+
 public class JNICoreTransport implements CoreTransport {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(JNICoreTransport.class);
+
   static {
     // Load the native library
     try {
@@ -31,10 +36,24 @@ public class JNICoreTransport implements CoreTransport {
   @Override
   public TransportResponse handleMessage(String serviceName, String methodName, byte[] requestBytes)
       throws TransportException {
+    logger.trace(
+        "JNI transport request: service={}, method={}, requestBytes={}",
+        serviceName,
+        methodName,
+        requestBytes == null ? 0 : requestBytes.length);
     TransportResponse response = nativeHandleMessage(serviceName, methodName, requestBytes);
     if (response == null) {
+      logger.warn(
+          "JNI transport returned null response: service={}, method={}", serviceName, methodName);
       throw new TransportException("Empty transport response");
     }
+    byte[] responseBytes = response.getResponseBytes();
+    logger.trace(
+        "JNI transport response: service={}, method={}, code={}, responseBytes={}",
+        serviceName,
+        methodName,
+        response.getCode(),
+        responseBytes == null ? 0 : responseBytes.length);
     return response;
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -40,7 +40,7 @@ public class JNICoreTransport implements CoreTransport {
         "JNI transport request: service={}, method={}, requestBytes={}",
         serviceName,
         methodName,
-        requestBytes == null ? 0 : requestBytes.length);
+        requestBytes == null ? -1 : requestBytes.length);
     TransportResponse response = nativeHandleMessage(serviceName, methodName, requestBytes);
     if (response == null) {
       logger.warn(
@@ -53,7 +53,7 @@ public class JNICoreTransport implements CoreTransport {
         serviceName,
         methodName,
         response.getCode(),
-        responseBytes == null ? 0 : responseBytes.length);
+        responseBytes == null ? -1 : responseBytes.length);
     return response;
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/HexUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/HexUtil.java
@@ -1,0 +1,17 @@
+package net.snowflake.client.internal.util;
+
+public class HexUtil {
+  public static String bytesToHex(byte[] value) {
+    if (value == null) {
+      return null;
+    }
+    char[] hexArray = "0123456789ABCDEF".toCharArray();
+    char[] hexChars = new char[value.length * 2];
+    for (int j = 0; j < value.length; j++) {
+      int v = value[j] & 0xFF;
+      hexChars[j * 2] = hexArray[v >>> 4];
+      hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+    }
+    return new String(hexChars);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
@@ -13,20 +13,4 @@ public class SnowflakeUtil {
   public static final String DATE_STR = "date";
   public static final String BYTE_STR = "byte";
   public static final String BYTES_STR = "byte array";
-
-  private SnowflakeUtil() {}
-
-  public static String bytesToHex(byte[] value) {
-    if (value == null) {
-      return null;
-    }
-    char[] hexArray = "0123456789ABCDEF".toCharArray();
-    char[] hexChars = new char[value.length * 2];
-    for (int j = 0; j < value.length; j++) {
-      int v = value[j] & 0xFF;
-      hexChars[j * 2] = hexArray[v >>> 4];
-      hexChars[j * 2 + 1] = hexArray[v & 0x0F];
-    }
-    return new String(hexChars);
-  }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/util/SnowflakeUtil.java
@@ -15,4 +15,18 @@ public class SnowflakeUtil {
   public static final String BYTES_STR = "byte array";
 
   private SnowflakeUtil() {}
+
+  public static String bytesToHex(byte[] value) {
+    if (value == null) {
+      return null;
+    }
+    char[] hexArray = "0123456789ABCDEF".toCharArray();
+    char[] hexChars = new char[value.length * 2];
+    for (int j = 0; j < value.length; j++) {
+      int v = value[j] & 0xFF;
+      hexChars[j * 2] = hexArray[v >>> 4];
+      hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+    }
+    return new String(hexChars);
+  }
 }

--- a/jdbc/src/test/java/net/snowflake/client/api/resultset/SnowflakeResultSetGettersTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/resultset/SnowflakeResultSetGettersTest.java
@@ -2,11 +2,11 @@ package net.snowflake.client.api.resultset;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -16,8 +16,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetInt() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 42")) {
       assertTrue(rs.next());
       assertEquals(42, rs.getInt(1));
@@ -26,8 +25,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetFloat() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 12.5::FLOAT")) {
       assertTrue(rs.next());
       assertEquals(12.5f, rs.getFloat(1), 0.0001f);
@@ -36,8 +34,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetDouble() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 12345.6789::DOUBLE")) {
       assertTrue(rs.next());
       assertEquals(12345.6789, rs.getDouble(1), 0.0000001);
@@ -46,8 +43,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetString() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 'hello'")) {
       assertTrue(rs.next());
       assertEquals("hello", rs.getString(1));
@@ -56,21 +52,19 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetObject() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 7::NUMBER(10,0)")) {
       assertTrue(rs.next());
       Object value = rs.getObject(1);
       assertNotNull(value);
-      assertTrue(value instanceof Long);
+      assertInstanceOf(Long.class, value);
       assertEquals(7L, value);
     }
   }
 
   @Test
   public void testGetBytes() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT TO_BINARY('0102', 'HEX')")) {
       assertTrue(rs.next());
       assertArrayEquals(new byte[] {0x01, 0x02}, rs.getBytes(1));
@@ -79,8 +73,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testGetBigDecimal() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 123.45::NUMBER(10,2)")) {
       assertTrue(rs.next());
       BigDecimal value = rs.getBigDecimal(1);
@@ -91,8 +84,7 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
 
   @Test
   public void testFloatSpecialValues() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement();
+    try (Statement stmt = getDefaultConnection().createStatement();
         ResultSet rs = stmt.executeQuery("SELECT 'inf'::FLOAT, '-inf'::FLOAT, 'nan'::FLOAT")) {
       assertTrue(rs.next());
       float posInf = rs.getFloat(1);

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
@@ -12,9 +12,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Types;
-import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.ToString;
 import lombok.Value;
@@ -29,7 +27,7 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   @MethodSource("singleSetterCases")
   public void testSingleSetterBindings(SingleSetterCase testCase) throws Exception {
     Connection conn = getDefaultConnection();
-    String tableName = prepareTable(conn, testCase.getSchema());
+    String tableName = createTempTable(conn, "ud_bindings_", testCase.getSchema());
 
     executeInsert(conn, "INSERT INTO " + tableName + " (v) VALUES (?)", testCase.getBinder());
 
@@ -40,10 +38,10 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   public void testAllSupportedSetters() throws Exception {
     Connection conn = getDefaultConnection();
     String tableName =
-        prepareTable(
+        createTempTable(
             conn,
-            "(n INTEGER, s STRING, b BOOLEAN, byte_col INTEGER, short_col INTEGER, i INTEGER, l INTEGER,"
-                + " f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY)");
+            "ud_bindings_",
+            "n INTEGER, s STRING, b BOOLEAN, byte_col INTEGER, short_col INTEGER, i INTEGER, l INTEGER, f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY");
     byte[] bytesValue = new byte[] {0x0A, 0x0B, 0x0C};
     BigDecimal expectedDecimal = new BigDecimal("77.88");
 
@@ -90,10 +88,10 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   public void testSetObject() throws Exception {
     Connection conn = getDefaultConnection();
     String tableName =
-        prepareTable(
+        createTempTable(
             conn,
-            "(n INTEGER, s STRING, b BOOLEAN, i INTEGER, l INTEGER, f FLOAT, d FLOAT,"
-                + " bd NUMBER(18,2), bin BINARY)");
+            "ud_bindings_",
+            "n INTEGER, s STRING, b BOOLEAN, i INTEGER, l INTEGER, f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY");
     byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
     BigDecimal expectedDecimal = new BigDecimal("77.88");
 
@@ -135,7 +133,7 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   @Test
   public void testSetObjectWithTargetSqlTypeAndNull() throws Exception {
     Connection conn = getDefaultConnection();
-    String tableName = prepareTable(conn, "(id INTEGER, txt STRING)");
+    String tableName = createTempTable(conn, "ud_bindings_", "id INTEGER, txt STRING");
 
     executeInsert(
         conn,
@@ -179,7 +177,7 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   @Test
   public void testSetObjectUnsupportedTypeThrowsSQLException() throws Exception {
     Connection conn = getDefaultConnection();
-    String tableName = prepareTable(conn, "(v STRING)");
+    String tableName = createTempTable(conn, "ud_bindings_", "v STRING");
 
     try (PreparedStatement insert =
         conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
@@ -190,7 +188,7 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   @Test
   public void testClearParametersAndPartialRebindFailsDeterministically() throws Exception {
     Connection conn = getDefaultConnection();
-    String tableName = prepareTable(conn, "(id INTEGER, txt STRING)");
+    String tableName = createTempTable(conn, "ud_bindings_", "id INTEGER, txt STRING");
 
     try (PreparedStatement insert =
         conn.prepareStatement("INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)")) {
@@ -206,7 +204,7 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
   @Test
   public void testSetNullWithRepresentativeSqlTypes() throws Exception {
     Connection conn = getDefaultConnection();
-    String tableName = prepareTable(conn, "(b BOOLEAN, i INTEGER, bin BINARY)");
+    String tableName = createTempTable(conn, "ud_bindings_", "b BOOLEAN, i INTEGER, bin BINARY");
 
     executeInsert(
         conn,
@@ -227,69 +225,63 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
         });
   }
 
-  private String prepareTable(Connection conn, String schema) throws Exception {
-    String tableName = buildTempTableName();
-    createTempTable(conn, tableName, schema);
-    return tableName;
-  }
-
   private static Stream<SingleSetterCase> singleSetterCases() {
     byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
     BigDecimal bigDecimalValue = new BigDecimal("12345.67");
     return Stream.of(
         new SingleSetterCase(
             "setNull",
-            "(v INTEGER)",
+            "v INTEGER",
             insert -> insert.setNull(1, Types.INTEGER),
             rs -> assertNull(rs.getObject(1))),
         new SingleSetterCase(
             "setString",
-            "(v STRING)",
+            "v STRING",
             insert -> insert.setString(1, "hello"),
             rs -> assertEquals("hello", rs.getString(1))),
         new SingleSetterCase(
             "setBoolean",
-            "(v BOOLEAN)",
+            "v BOOLEAN",
             insert -> insert.setBoolean(1, true),
             rs -> assertTrue(rs.getBoolean(1))),
         new SingleSetterCase(
             "setByte",
-            "(v INTEGER)",
+            "v INTEGER",
             insert -> insert.setByte(1, (byte) 7),
             rs -> assertEquals((byte) 7, rs.getByte(1))),
         new SingleSetterCase(
             "setShort",
-            "(v INTEGER)",
+            "v INTEGER",
             insert -> insert.setShort(1, (short) 11),
             rs -> assertEquals((short) 11, rs.getShort(1))),
         new SingleSetterCase(
             "setInt",
-            "(v INTEGER)",
+            "v INTEGER",
             insert -> insert.setInt(1, 42),
             rs -> assertEquals(42, rs.getInt(1))),
         new SingleSetterCase(
             "setLong",
-            "(v INTEGER)",
+            "v INTEGER",
             insert -> insert.setLong(1, 123456789L),
             rs -> assertEquals(123456789L, rs.getLong(1))),
         new SingleSetterCase(
             "setFloat",
-            "(v FLOAT)",
+            "v FLOAT",
             insert -> insert.setFloat(1, 1.25f),
             rs -> assertEquals(1.25f, rs.getFloat(1), 0.0001f)),
         new SingleSetterCase(
             "setDouble",
-            "(v FLOAT)",
+            "v FLOAT",
             insert -> insert.setDouble(1, 2.5d),
             rs -> assertEquals(2.5d, rs.getDouble(1), 0.0001d)),
         new SingleSetterCase(
             "setBigDecimal",
-            "(v NUMBER(18,2))",
+            "v NUMBER(18,2)",
             insert -> insert.setBigDecimal(1, bigDecimalValue),
             rs -> assertEquals(0, bigDecimalValue.compareTo(rs.getBigDecimal(1)))),
         new SingleSetterCase(
             "setBytes",
-            "(v BINARY)",
+            "v BINARY",
             insert -> insert.setBytes(1, bytesValue),
             rs -> assertArrayEquals(bytesValue, rs.getBytes(1))));
   }
@@ -339,16 +331,5 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
     String schema;
     SqlInsertBinder binder;
     ResultSetVerifier verifier;
-  }
-
-  private String buildTempTableName() {
-    return "JDBC_PS_BINDING_" + UUID.randomUUID().toString().replace("-", "");
-  }
-
-  private void createTempTable(Connection conn, String tableName, String schema) throws Exception {
-    try (Statement stmt = conn.createStatement()) {
-      stmt.execute("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
-      stmt.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + " " + schema);
-    }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
@@ -2,6 +2,8 @@ package net.snowflake.client.api.statement;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,373 +15,143 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.UUID;
+import java.util.stream.Stream;
+import lombok.ToString;
+import lombok.Value;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationTestBase {
 
-  @Test
-  public void testSetNull() throws Exception {
-    String tableName = buildTempTableName();
+  @ParameterizedTest(name = "{index} => {0}")
+  @MethodSource("singleSetterCases")
+  public void testSingleSetterBindings(SingleSetterCase testCase) throws Exception {
     Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(id INTEGER)");
+    String tableName = prepareTable(conn, testCase.getSchema());
 
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (id) VALUES (?)")) {
-      insert.setNull(1, Types.INTEGER);
-      insert.execute();
-    }
+    executeInsert(conn, "INSERT INTO " + tableName + " (v) VALUES (?)", testCase.getBinder());
 
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), COUNT(id) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(0, rs.getInt(2), "Null column should not contribute to COUNT(column)");
-    }
-  }
-
-  @Test
-  public void testSetString() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(txt STRING)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (txt) VALUES (?)")) {
-      insert.setString(1, "hello");
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(txt) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals("hello", rs.getString(2), "Inserted string value should match");
-    }
-  }
-
-  @Test
-  public void testSetBoolean() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(flag BOOLEAN)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (flag) VALUES (?)")) {
-      insert.setBoolean(1, true);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(flag) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertTrue(rs.getBoolean(2), "Inserted boolean value should match");
-    }
-  }
-
-  @Test
-  public void testSetByte() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v INTEGER)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setByte(1, (byte) 7);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals((byte) 7, rs.getByte(2), "Inserted byte value should match");
-    }
-  }
-
-  @Test
-  public void testSetShort() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v INTEGER)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setShort(1, (short) 11);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals((short) 11, rs.getShort(2), "Inserted short value should match");
-    }
-  }
-
-  @Test
-  public void testSetInt() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v INTEGER)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setInt(1, 42);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(42, rs.getInt(2), "Inserted int value should match");
-    }
-  }
-
-  @Test
-  public void testSetLong() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v INTEGER)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setLong(1, 123456789L);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(123456789L, rs.getLong(2), "Inserted long value should match");
-    }
-  }
-
-  @Test
-  public void testSetFloat() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v FLOAT)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setFloat(1, 1.25f);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(1.25f, rs.getFloat(2), 0.0001f, "Inserted float value should match");
-    }
-  }
-
-  @Test
-  public void testSetDouble() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v FLOAT)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setDouble(1, 2.5d);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(2.5d, rs.getDouble(2), 0.0001d, "Inserted double value should match");
-    }
-  }
-
-  @Test
-  public void testSetBigDecimal() throws Exception {
-    String tableName = buildTempTableName();
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v NUMBER(18,2))");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setBigDecimal(1, new BigDecimal("12345.67"));
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(
-          0,
-          new BigDecimal("12345.67").compareTo(rs.getBigDecimal(2)),
-          "Inserted BigDecimal value should match");
-    }
-  }
-
-  @Test
-  public void testSetBytes() throws Exception {
-    String tableName = buildTempTableName();
-    byte[] value = new byte[] {0x01, 0x02, 0x03};
-    Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v BINARY)");
-
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
-      insert.setBytes(1, value);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertArrayEquals(value, rs.getBytes(2), "Inserted byte[] value should match");
-    }
+    verifySingleValue(conn, "SELECT v FROM " + tableName, testCase.getVerifier());
   }
 
   @Test
   public void testAllSupportedSetters() throws Exception {
-    String tableName = buildTempTableName();
-    byte[] bytesValue = new byte[] {0x0A, 0x0B, 0x0C};
     Connection conn = getDefaultConnection();
-    createTempTable(
+    String tableName =
+        prepareTable(
+            conn,
+            "(n INTEGER, s STRING, b BOOLEAN, byte_col INTEGER, short_col INTEGER, i INTEGER, l INTEGER,"
+                + " f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY)");
+    byte[] bytesValue = new byte[] {0x0A, 0x0B, 0x0C};
+    BigDecimal expectedDecimal = new BigDecimal("77.88");
+
+    executeInsert(
         conn,
-        tableName,
-        "(n INTEGER, s STRING, b BOOLEAN, byte_col INTEGER, short_col INTEGER, i INTEGER, l INTEGER,"
-            + " f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY)");
+        "INSERT INTO "
+            + tableName
+            + " (n, s, b, byte_col, short_col, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        insert -> {
+          insert.setNull(1, Types.INTEGER);
+          insert.setString(2, "all");
+          insert.setBoolean(3, true);
+          insert.setByte(4, (byte) 12);
+          insert.setShort(5, (short) 320);
+          insert.setInt(6, 1234);
+          insert.setLong(7, 987654321L);
+          insert.setFloat(8, 3.25f);
+          insert.setDouble(9, 6.5d);
+          insert.setBigDecimal(10, expectedDecimal);
+          insert.setBytes(11, bytesValue);
+        });
 
-    try (PreparedStatement insert =
-        conn.prepareStatement(
-            "INSERT INTO "
-                + tableName
-                + " (n, s, b, byte_col, short_col, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
-      insert.setNull(1, Types.INTEGER);
-      insert.setString(2, "all");
-      insert.setBoolean(3, true);
-      insert.setByte(4, (byte) 12);
-      insert.setShort(5, (short) 320);
-      insert.setInt(6, 1234);
-      insert.setLong(7, 987654321L);
-      insert.setFloat(8, 3.25f);
-      insert.setDouble(9, 6.5d);
-      insert.setBigDecimal(10, new BigDecimal("77.88"));
-      insert.setBytes(11, bytesValue);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement(
-                "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(byte_col), MIN(short_col),"
-                    + " MIN(i), MIN(l), MIN(f), MIN(d), MIN(bd), MIN(bin) FROM "
-                    + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(0, rs.getInt(2), "setNull column should remain NULL");
-      assertEquals("all", rs.getString(3), "setString value should match");
-      assertTrue(rs.getBoolean(4), "setBoolean value should match");
-      assertEquals((byte) 12, rs.getByte(5), "setByte value should match");
-      assertEquals((short) 320, rs.getShort(6), "setShort value should match");
-      assertEquals(1234, rs.getInt(7), "setInt value should match");
-      assertEquals(987654321L, rs.getLong(8), "setLong value should match");
-      assertEquals(3.25f, rs.getFloat(9), 0.0001f, "setFloat value should match");
-      assertEquals(6.5d, rs.getDouble(10), 0.0001d, "setDouble value should match");
-      assertEquals(
-          0,
-          new BigDecimal("77.88").compareTo(rs.getBigDecimal(11)),
-          "setBigDecimal value should match");
-      assertArrayEquals(bytesValue, rs.getBytes(12), "setBytes value should match");
-    }
+    verifySingleRow(
+        conn,
+        "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(byte_col), MIN(short_col),"
+            + " MIN(i), MIN(l), MIN(f), MIN(d), MIN(bd), MIN(bin) FROM "
+            + tableName,
+        rs -> {
+          assertEquals(0, rs.getInt(2));
+          assertEquals("all", rs.getString(3));
+          assertTrue(rs.getBoolean(4));
+          assertEquals((byte) 12, rs.getByte(5));
+          assertEquals((short) 320, rs.getShort(6));
+          assertEquals(1234, rs.getInt(7));
+          assertEquals(987654321L, rs.getLong(8));
+          assertEquals(3.25f, rs.getFloat(9), 0.0001f);
+          assertEquals(6.5d, rs.getDouble(10), 0.0001d);
+          assertEquals(0, expectedDecimal.compareTo(rs.getBigDecimal(11)));
+          assertArrayEquals(bytesValue, rs.getBytes(12));
+        });
   }
 
   @Test
   public void testSetObject() throws Exception {
-    String tableName = buildTempTableName();
-    byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
     Connection conn = getDefaultConnection();
-    createTempTable(
+    String tableName =
+        prepareTable(
+            conn,
+            "(n INTEGER, s STRING, b BOOLEAN, i INTEGER, l INTEGER, f FLOAT, d FLOAT,"
+                + " bd NUMBER(18,2), bin BINARY)");
+    byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
+    BigDecimal expectedDecimal = new BigDecimal("77.88");
+
+    executeInsert(
         conn,
-        tableName,
-        "(n INTEGER, s STRING, b BOOLEAN, i INTEGER, l INTEGER, f FLOAT, d FLOAT,"
-            + " bd NUMBER(18,2), bin BINARY)");
+        "INSERT INTO "
+            + tableName
+            + " (n, s, b, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        insert -> {
+          insert.setObject(1, null);
+          insert.setObject(2, "obj");
+          insert.setObject(3, true);
+          insert.setObject(4, 123);
+          insert.setObject(5, 987654321L);
+          insert.setObject(6, 1.25f);
+          insert.setObject(7, 2.5d);
+          insert.setObject(8, expectedDecimal);
+          insert.setObject(9, bytesValue);
+        });
 
-    try (PreparedStatement insert =
-        conn.prepareStatement(
-            "INSERT INTO "
-                + tableName
-                + " (n, s, b, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
-      insert.setObject(1, null);
-      insert.setObject(2, "obj");
-      insert.setObject(3, true);
-      insert.setObject(4, 123);
-      insert.setObject(5, 987654321L);
-      insert.setObject(6, 1.25f);
-      insert.setObject(7, 2.5d);
-      insert.setObject(8, new BigDecimal("77.88"));
-      insert.setObject(9, bytesValue);
-      insert.execute();
-    }
-
-    try (PreparedStatement verify =
-            conn.prepareStatement(
-                "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(i), MIN(l), MIN(f), MIN(d),"
-                    + " MIN(bd), MIN(bin) FROM "
-                    + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(0, rs.getInt(2), "setObject(null) should keep INTEGER column NULL");
-      assertEquals("obj", rs.getString(3), "setObject(String) value should match");
-      assertTrue(rs.getBoolean(4), "setObject(Boolean) value should match");
-      assertEquals(123, rs.getInt(5), "setObject(Integer) value should match");
-      assertEquals(987654321L, rs.getLong(6), "setObject(Long) value should match");
-      assertEquals(1.25f, rs.getFloat(7), 0.0001f, "setObject(Float) value should match");
-      assertEquals(2.5d, rs.getDouble(8), 0.0001d, "setObject(Double) value should match");
-      assertEquals(
-          0,
-          new BigDecimal("77.88").compareTo(rs.getBigDecimal(9)),
-          "setObject(BigDecimal) value should match");
-      assertArrayEquals(bytesValue, rs.getBytes(10), "setObject(byte[]) value should match");
-    }
+    verifySingleRow(
+        conn,
+        "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(i), MIN(l), MIN(f), MIN(d),"
+            + " MIN(bd), MIN(bin) FROM "
+            + tableName,
+        rs -> {
+          assertEquals(0, rs.getInt(2));
+          assertEquals("obj", rs.getString(3));
+          assertTrue(rs.getBoolean(4));
+          assertEquals(123, rs.getInt(5));
+          assertEquals(987654321L, rs.getLong(6));
+          assertEquals(1.25f, rs.getFloat(7), 0.0001f);
+          assertEquals(2.5d, rs.getDouble(8), 0.0001d);
+          assertEquals(0, expectedDecimal.compareTo(rs.getBigDecimal(9)));
+          assertArrayEquals(bytesValue, rs.getBytes(10));
+        });
   }
 
   @Test
   public void testSetObjectWithTargetSqlTypeAndNull() throws Exception {
-    String tableName = buildTempTableName();
     Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(id INTEGER, txt STRING)");
+    String tableName = prepareTable(conn, "(id INTEGER, txt STRING)");
 
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)")) {
-      insert.setObject(1, null, Types.INTEGER);
-      insert.setObject(2, "typed", Types.VARCHAR);
-      insert.execute();
-    }
+    executeInsert(
+        conn,
+        "INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)",
+        insert -> {
+          insert.setObject(1, null, Types.INTEGER);
+          insert.setObject(2, "typed", Types.VARCHAR);
+        });
 
-    try (PreparedStatement verify =
-            conn.prepareStatement("SELECT COUNT(*), COUNT(id), MIN(txt) FROM " + tableName);
-        ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(0, rs.getInt(2), "setObject(null, Types.INTEGER) should remain NULL");
-      assertEquals("typed", rs.getString(3), "setObject with sqlType should delegate correctly");
-    }
+    verifySingleRow(
+        conn,
+        "SELECT COUNT(*), COUNT(id), MIN(txt) FROM " + tableName,
+        rs -> {
+          assertEquals(0, rs.getInt(2));
+          assertEquals("typed", rs.getString(3));
+        });
   }
 
   @Test
@@ -388,13 +160,13 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
     try (PreparedStatement stmt =
             conn.prepareStatement("SELECT SYSTEM$TYPEOF(?), SYSTEM$TYPEOF(?)");
         ResultSet rs = executeWithTargetTypes(stmt)) {
-      assertTrue(rs.next(), "TYPEOF query should return one row");
+      assertTrue(rs.next());
       assertTrue(
           rs.getString(1).toUpperCase().contains("VARCHAR"),
-          "setObject(..., Types.VARCHAR) should bind as text type");
+          "Expected VARCHAR binding for setObject(..., Types.VARCHAR)");
       assertTrue(
           rs.getString(2).toUpperCase().contains("NUMBER"),
-          "setObject(..., Types.INTEGER) should bind as numeric type");
+          "Expected NUMBER binding for setObject(..., Types.INTEGER)");
     }
   }
 
@@ -406,9 +178,8 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
 
   @Test
   public void testSetObjectUnsupportedTypeThrowsSQLException() throws Exception {
-    String tableName = buildTempTableName();
     Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(v STRING)");
+    String tableName = prepareTable(conn, "(v STRING)");
 
     try (PreparedStatement insert =
         conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
@@ -418,9 +189,8 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
 
   @Test
   public void testClearParametersAndPartialRebindFailsDeterministically() throws Exception {
-    String tableName = buildTempTableName();
     Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(id INTEGER, txt STRING)");
+    String tableName = prepareTable(conn, "(id INTEGER, txt STRING)");
 
     try (PreparedStatement insert =
         conn.prepareStatement("INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)")) {
@@ -435,28 +205,140 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
 
   @Test
   public void testSetNullWithRepresentativeSqlTypes() throws Exception {
-    String tableName = buildTempTableName();
     Connection conn = getDefaultConnection();
-    createTempTable(conn, tableName, "(b BOOLEAN, i INTEGER, bin BINARY)");
+    String tableName = prepareTable(conn, "(b BOOLEAN, i INTEGER, bin BINARY)");
 
-    try (PreparedStatement insert =
-        conn.prepareStatement("INSERT INTO " + tableName + " (b, i, bin) VALUES (?, ?, ?)")) {
-      insert.setNull(1, Types.BOOLEAN);
-      insert.setNull(2, Types.INTEGER);
-      insert.setNull(3, Types.BINARY);
+    executeInsert(
+        conn,
+        "INSERT INTO " + tableName + " (b, i, bin) VALUES (?, ?, ?)",
+        insert -> {
+          insert.setNull(1, Types.BOOLEAN);
+          insert.setNull(2, Types.INTEGER);
+          insert.setNull(3, Types.BINARY);
+        });
+
+    verifySingleRow(
+        conn,
+        "SELECT COUNT(*), COUNT(b), COUNT(i), COUNT(bin) FROM " + tableName,
+        rs -> {
+          assertEquals(0, rs.getInt(2));
+          assertEquals(0, rs.getInt(3));
+          assertEquals(0, rs.getInt(4));
+        });
+  }
+
+  private String prepareTable(Connection conn, String schema) throws Exception {
+    String tableName = buildTempTableName();
+    createTempTable(conn, tableName, schema);
+    return tableName;
+  }
+
+  private static Stream<SingleSetterCase> singleSetterCases() {
+    byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
+    BigDecimal bigDecimalValue = new BigDecimal("12345.67");
+    return Stream.of(
+        new SingleSetterCase(
+            "setNull",
+            "(v INTEGER)",
+            insert -> insert.setNull(1, Types.INTEGER),
+            rs -> assertNull(rs.getObject(1))),
+        new SingleSetterCase(
+            "setString",
+            "(v STRING)",
+            insert -> insert.setString(1, "hello"),
+            rs -> assertEquals("hello", rs.getString(1))),
+        new SingleSetterCase(
+            "setBoolean",
+            "(v BOOLEAN)",
+            insert -> insert.setBoolean(1, true),
+            rs -> assertTrue(rs.getBoolean(1))),
+        new SingleSetterCase(
+            "setByte",
+            "(v INTEGER)",
+            insert -> insert.setByte(1, (byte) 7),
+            rs -> assertEquals((byte) 7, rs.getByte(1))),
+        new SingleSetterCase(
+            "setShort",
+            "(v INTEGER)",
+            insert -> insert.setShort(1, (short) 11),
+            rs -> assertEquals((short) 11, rs.getShort(1))),
+        new SingleSetterCase(
+            "setInt",
+            "(v INTEGER)",
+            insert -> insert.setInt(1, 42),
+            rs -> assertEquals(42, rs.getInt(1))),
+        new SingleSetterCase(
+            "setLong",
+            "(v INTEGER)",
+            insert -> insert.setLong(1, 123456789L),
+            rs -> assertEquals(123456789L, rs.getLong(1))),
+        new SingleSetterCase(
+            "setFloat",
+            "(v FLOAT)",
+            insert -> insert.setFloat(1, 1.25f),
+            rs -> assertEquals(1.25f, rs.getFloat(1), 0.0001f)),
+        new SingleSetterCase(
+            "setDouble",
+            "(v FLOAT)",
+            insert -> insert.setDouble(1, 2.5d),
+            rs -> assertEquals(2.5d, rs.getDouble(1), 0.0001d)),
+        new SingleSetterCase(
+            "setBigDecimal",
+            "(v NUMBER(18,2))",
+            insert -> insert.setBigDecimal(1, bigDecimalValue),
+            rs -> assertEquals(0, bigDecimalValue.compareTo(rs.getBigDecimal(1)))),
+        new SingleSetterCase(
+            "setBytes",
+            "(v BINARY)",
+            insert -> insert.setBytes(1, bytesValue),
+            rs -> assertArrayEquals(bytesValue, rs.getBytes(1))));
+  }
+
+  private void executeInsert(Connection conn, String sql, SqlInsertBinder binder)
+      throws SQLException {
+    try (PreparedStatement insert = conn.prepareStatement(sql)) {
+      binder.bind(insert);
       insert.execute();
     }
+  }
 
-    try (PreparedStatement verify =
-            conn.prepareStatement(
-                "SELECT COUNT(*), COUNT(b), COUNT(i), COUNT(bin) FROM " + tableName);
+  private void verifySingleRow(Connection conn, String sql, ResultSetVerifier verifier)
+      throws SQLException {
+    try (PreparedStatement verify = conn.prepareStatement(sql);
         ResultSet rs = verify.executeQuery()) {
-      assertTrue(rs.next(), "Verification query should return one row");
-      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
-      assertEquals(0, rs.getInt(2), "BOOLEAN NULL should not contribute to COUNT");
-      assertEquals(0, rs.getInt(3), "INTEGER NULL should not contribute to COUNT");
-      assertEquals(0, rs.getInt(4), "BINARY NULL should not contribute to COUNT");
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      verifier.verify(rs);
     }
+  }
+
+  private void verifySingleValue(Connection conn, String sql, ResultSetVerifier verifier)
+      throws SQLException {
+    try (PreparedStatement verify = conn.prepareStatement(sql);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next());
+      verifier.verify(rs);
+      assertFalse(rs.next());
+    }
+  }
+
+  @FunctionalInterface
+  private interface SqlInsertBinder {
+    void bind(PreparedStatement insert) throws SQLException;
+  }
+
+  @FunctionalInterface
+  private interface ResultSetVerifier {
+    void verify(ResultSet rs) throws SQLException;
+  }
+
+  @Value
+  @ToString(of = "name")
+  private static class SingleSetterCase {
+    String name;
+    String schema;
+    SqlInsertBinder binder;
+    ResultSetVerifier verifier;
   }
 
   private String buildTempTableName() {

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
@@ -1,0 +1,472 @@
+package net.snowflake.client.api.statement;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.UUID;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationTestBase {
+
+  @Test
+  public void testSetNull() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(id INTEGER)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (id) VALUES (?)")) {
+      insert.setNull(1, Types.INTEGER);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), COUNT(id) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(0, rs.getInt(2), "Null column should not contribute to COUNT(column)");
+    }
+  }
+
+  @Test
+  public void testSetString() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(txt STRING)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (txt) VALUES (?)")) {
+      insert.setString(1, "hello");
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(txt) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals("hello", rs.getString(2), "Inserted string value should match");
+    }
+  }
+
+  @Test
+  public void testSetBoolean() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(flag BOOLEAN)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (flag) VALUES (?)")) {
+      insert.setBoolean(1, true);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(flag) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertTrue(rs.getBoolean(2), "Inserted boolean value should match");
+    }
+  }
+
+  @Test
+  public void testSetByte() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v INTEGER)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setByte(1, (byte) 7);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals((byte) 7, rs.getByte(2), "Inserted byte value should match");
+    }
+  }
+
+  @Test
+  public void testSetShort() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v INTEGER)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setShort(1, (short) 11);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals((short) 11, rs.getShort(2), "Inserted short value should match");
+    }
+  }
+
+  @Test
+  public void testSetInt() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v INTEGER)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setInt(1, 42);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(42, rs.getInt(2), "Inserted int value should match");
+    }
+  }
+
+  @Test
+  public void testSetLong() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v INTEGER)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setLong(1, 123456789L);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(123456789L, rs.getLong(2), "Inserted long value should match");
+    }
+  }
+
+  @Test
+  public void testSetFloat() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v FLOAT)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setFloat(1, 1.25f);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(1.25f, rs.getFloat(2), 0.0001f, "Inserted float value should match");
+    }
+  }
+
+  @Test
+  public void testSetDouble() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v FLOAT)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setDouble(1, 2.5d);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(2.5d, rs.getDouble(2), 0.0001d, "Inserted double value should match");
+    }
+  }
+
+  @Test
+  public void testSetBigDecimal() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v NUMBER(18,2))");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setBigDecimal(1, new BigDecimal("12345.67"));
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(
+          0,
+          new BigDecimal("12345.67").compareTo(rs.getBigDecimal(2)),
+          "Inserted BigDecimal value should match");
+    }
+  }
+
+  @Test
+  public void testSetBytes() throws Exception {
+    String tableName = buildTempTableName();
+    byte[] value = new byte[] {0x01, 0x02, 0x03};
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v BINARY)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setBytes(1, value);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), MIN(v) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertArrayEquals(value, rs.getBytes(2), "Inserted byte[] value should match");
+    }
+  }
+
+  @Test
+  public void testAllSupportedSetters() throws Exception {
+    String tableName = buildTempTableName();
+    byte[] bytesValue = new byte[] {0x0A, 0x0B, 0x0C};
+    Connection conn = getDefaultConnection();
+    createTempTable(
+        conn,
+        tableName,
+        "(n INTEGER, s STRING, b BOOLEAN, byte_col INTEGER, short_col INTEGER, i INTEGER, l INTEGER,"
+            + " f FLOAT, d FLOAT, bd NUMBER(18,2), bin BINARY)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement(
+            "INSERT INTO "
+                + tableName
+                + " (n, s, b, byte_col, short_col, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+      insert.setNull(1, Types.INTEGER);
+      insert.setString(2, "all");
+      insert.setBoolean(3, true);
+      insert.setByte(4, (byte) 12);
+      insert.setShort(5, (short) 320);
+      insert.setInt(6, 1234);
+      insert.setLong(7, 987654321L);
+      insert.setFloat(8, 3.25f);
+      insert.setDouble(9, 6.5d);
+      insert.setBigDecimal(10, new BigDecimal("77.88"));
+      insert.setBytes(11, bytesValue);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement(
+                "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(byte_col), MIN(short_col),"
+                    + " MIN(i), MIN(l), MIN(f), MIN(d), MIN(bd), MIN(bin) FROM "
+                    + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(0, rs.getInt(2), "setNull column should remain NULL");
+      assertEquals("all", rs.getString(3), "setString value should match");
+      assertTrue(rs.getBoolean(4), "setBoolean value should match");
+      assertEquals((byte) 12, rs.getByte(5), "setByte value should match");
+      assertEquals((short) 320, rs.getShort(6), "setShort value should match");
+      assertEquals(1234, rs.getInt(7), "setInt value should match");
+      assertEquals(987654321L, rs.getLong(8), "setLong value should match");
+      assertEquals(3.25f, rs.getFloat(9), 0.0001f, "setFloat value should match");
+      assertEquals(6.5d, rs.getDouble(10), 0.0001d, "setDouble value should match");
+      assertEquals(
+          0,
+          new BigDecimal("77.88").compareTo(rs.getBigDecimal(11)),
+          "setBigDecimal value should match");
+      assertArrayEquals(bytesValue, rs.getBytes(12), "setBytes value should match");
+    }
+  }
+
+  @Test
+  public void testSetObject() throws Exception {
+    String tableName = buildTempTableName();
+    byte[] bytesValue = new byte[] {0x01, 0x02, 0x03};
+    Connection conn = getDefaultConnection();
+    createTempTable(
+        conn,
+        tableName,
+        "(n INTEGER, s STRING, b BOOLEAN, i INTEGER, l INTEGER, f FLOAT, d FLOAT,"
+            + " bd NUMBER(18,2), bin BINARY)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement(
+            "INSERT INTO "
+                + tableName
+                + " (n, s, b, i, l, f, d, bd, bin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+      insert.setObject(1, null);
+      insert.setObject(2, "obj");
+      insert.setObject(3, true);
+      insert.setObject(4, 123);
+      insert.setObject(5, 987654321L);
+      insert.setObject(6, 1.25f);
+      insert.setObject(7, 2.5d);
+      insert.setObject(8, new BigDecimal("77.88"));
+      insert.setObject(9, bytesValue);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement(
+                "SELECT COUNT(*), COUNT(n), MIN(s), MIN(b), MIN(i), MIN(l), MIN(f), MIN(d),"
+                    + " MIN(bd), MIN(bin) FROM "
+                    + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(0, rs.getInt(2), "setObject(null) should keep INTEGER column NULL");
+      assertEquals("obj", rs.getString(3), "setObject(String) value should match");
+      assertTrue(rs.getBoolean(4), "setObject(Boolean) value should match");
+      assertEquals(123, rs.getInt(5), "setObject(Integer) value should match");
+      assertEquals(987654321L, rs.getLong(6), "setObject(Long) value should match");
+      assertEquals(1.25f, rs.getFloat(7), 0.0001f, "setObject(Float) value should match");
+      assertEquals(2.5d, rs.getDouble(8), 0.0001d, "setObject(Double) value should match");
+      assertEquals(
+          0,
+          new BigDecimal("77.88").compareTo(rs.getBigDecimal(9)),
+          "setObject(BigDecimal) value should match");
+      assertArrayEquals(bytesValue, rs.getBytes(10), "setObject(byte[]) value should match");
+    }
+  }
+
+  @Test
+  public void testSetObjectWithTargetSqlTypeAndNull() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(id INTEGER, txt STRING)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)")) {
+      insert.setObject(1, null, Types.INTEGER);
+      insert.setObject(2, "typed", Types.VARCHAR);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement("SELECT COUNT(*), COUNT(id), MIN(txt) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(0, rs.getInt(2), "setObject(null, Types.INTEGER) should remain NULL");
+      assertEquals("typed", rs.getString(3), "setObject with sqlType should delegate correctly");
+    }
+  }
+
+  @Test
+  public void testSetObjectWithTargetSqlTypeUsesTargetBindingType() throws Exception {
+    Connection conn = getDefaultConnection();
+    try (PreparedStatement stmt =
+            conn.prepareStatement("SELECT SYSTEM$TYPEOF(?), SYSTEM$TYPEOF(?)");
+        ResultSet rs = executeWithTargetTypes(stmt)) {
+      assertTrue(rs.next(), "TYPEOF query should return one row");
+      assertTrue(
+          rs.getString(1).toUpperCase().contains("VARCHAR"),
+          "setObject(..., Types.VARCHAR) should bind as text type");
+      assertTrue(
+          rs.getString(2).toUpperCase().contains("NUMBER"),
+          "setObject(..., Types.INTEGER) should bind as numeric type");
+    }
+  }
+
+  private ResultSet executeWithTargetTypes(PreparedStatement stmt) throws SQLException {
+    stmt.setObject(1, 123, Types.VARCHAR);
+    stmt.setObject(2, "456", Types.INTEGER);
+    return stmt.executeQuery();
+  }
+
+  @Test
+  public void testSetObjectUnsupportedTypeThrowsSQLException() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(v STRING)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      assertThrows(SQLException.class, () -> insert.setObject(1, new Object()));
+    }
+  }
+
+  @Test
+  public void testClearParametersAndPartialRebindFailsDeterministically() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(id INTEGER, txt STRING)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (id, txt) VALUES (?, ?)")) {
+      insert.setInt(1, 1);
+      insert.setString(2, "before-clear");
+      insert.clearParameters();
+      insert.setInt(1, 2);
+
+      assertThrows(SQLException.class, insert::execute);
+    }
+  }
+
+  @Test
+  public void testSetNullWithRepresentativeSqlTypes() throws Exception {
+    String tableName = buildTempTableName();
+    Connection conn = getDefaultConnection();
+    createTempTable(conn, tableName, "(b BOOLEAN, i INTEGER, bin BINARY)");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (b, i, bin) VALUES (?, ?, ?)")) {
+      insert.setNull(1, Types.BOOLEAN);
+      insert.setNull(2, Types.INTEGER);
+      insert.setNull(3, Types.BINARY);
+      insert.execute();
+    }
+
+    try (PreparedStatement verify =
+            conn.prepareStatement(
+                "SELECT COUNT(*), COUNT(b), COUNT(i), COUNT(bin) FROM " + tableName);
+        ResultSet rs = verify.executeQuery()) {
+      assertTrue(rs.next(), "Verification query should return one row");
+      assertEquals(1, rs.getInt(1), "Exactly one row should be inserted");
+      assertEquals(0, rs.getInt(2), "BOOLEAN NULL should not contribute to COUNT");
+      assertEquals(0, rs.getInt(3), "INTEGER NULL should not contribute to COUNT");
+      assertEquals(0, rs.getInt(4), "BINARY NULL should not contribute to COUNT");
+    }
+  }
+
+  private String buildTempTableName() {
+    return "JDBC_PS_BINDING_" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private void createTempTable(Connection conn, String tableName, String schema) throws Exception {
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
+      stmt.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + " " + schema);
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementUnsupportedFeatureTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementUnsupportedFeatureTest.java
@@ -1,0 +1,192 @@
+package net.snowflake.client.api.statement;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.SQLFeatureNotSupportedException;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@SuppressWarnings("deprecation")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SnowflakePreparedStatementUnsupportedFeatureTest extends SnowflakeIntegrationTestBase {
+
+  private PreparedStatement preparedStatement;
+
+  @BeforeAll
+  public void setUp() throws Exception {
+    preparedStatement = getDefaultConnection().prepareStatement("select ? ? ?");
+  }
+
+  @AfterAll
+  public void tearDown() throws Exception {
+    if (preparedStatement != null) {
+      preparedStatement.close();
+    }
+  }
+
+  @Test
+  public void testSetAsciiStreamWithIntLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setAsciiStream(1, new ByteArrayInputStream(new byte[] {1}), 1));
+  }
+
+  @Test
+  public void testSetUnicodeStreamWithIntLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setUnicodeStream(1, new ByteArrayInputStream(new byte[] {1}), 1));
+  }
+
+  @Test
+  public void testSetBinaryStreamWithIntLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBinaryStream(1, new ByteArrayInputStream(new byte[] {1}), 1));
+  }
+
+  @Test
+  public void testSetCharacterStreamWithIntLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setCharacterStream(1, new StringReader("x"), 1));
+  }
+
+  @Test
+  public void testSetAsciiStreamWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setAsciiStream(1, new ByteArrayInputStream(new byte[] {1}), 1L));
+  }
+
+  @Test
+  public void testSetBinaryStreamWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBinaryStream(1, new ByteArrayInputStream(new byte[] {1}), 1L));
+  }
+
+  @Test
+  public void testSetCharacterStreamWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setCharacterStream(1, new StringReader("x"), 1L));
+  }
+
+  @Test
+  public void testSetAsciiStreamWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setAsciiStream(1, new ByteArrayInputStream(new byte[] {1})));
+  }
+
+  @Test
+  public void testSetBinaryStreamWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBinaryStream(1, new ByteArrayInputStream(new byte[] {1})));
+  }
+
+  @Test
+  public void testSetCharacterStreamWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setCharacterStream(1, new StringReader("x")));
+  }
+
+  @Test
+  public void testSetNCharacterStreamWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setNCharacterStream(1, new StringReader("x"), 1L));
+  }
+
+  @Test
+  public void testSetNCharacterStreamWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setNCharacterStream(1, new StringReader("x")));
+  }
+
+  @Test
+  public void testSetClobReaderWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setClob(1, new StringReader("x"), 1L));
+  }
+
+  @Test
+  public void testSetClobReaderWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setClob(1, new StringReader("x")));
+  }
+
+  @Test
+  public void testSetBlobInputStreamWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBlob(1, new ByteArrayInputStream(new byte[] {1}), 1L));
+  }
+
+  @Test
+  public void testSetBlobInputStreamWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBlob(1, new ByteArrayInputStream(new byte[] {1})));
+  }
+
+  @Test
+  public void testSetNClobObjectThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setNClob(1, (java.sql.NClob) null));
+  }
+
+  @Test
+  public void testSetNClobReaderWithLongLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setNClob(1, new StringReader("x"), 1L));
+  }
+
+  @Test
+  public void testSetNClobReaderWithoutLengthThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setNClob(1, new StringReader("x")));
+  }
+
+  @Test
+  public void testSetRefThrowsFeatureNotSupported() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> preparedStatement.setRef(1, null));
+  }
+
+  @Test
+  public void testSetBlobObjectThrowsFeatureNotSupported() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> preparedStatement.setBlob(1, (java.sql.Blob) null));
+  }
+
+  @Test
+  public void testSetRowIdThrowsFeatureNotSupported() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> preparedStatement.setRowId(1, null));
+  }
+
+  @Test
+  public void testSetUrlThrowsFeatureNotSupported() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> preparedStatement.setURL(1, null));
+  }
+
+  @Test
+  public void testSetSqlXmlThrowsFeatureNotSupported() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> preparedStatement.setSQLXML(1, null));
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
@@ -15,19 +15,16 @@ public class SnowflakeStatementTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testSimpleSelect() throws Exception {
-    try (Connection conn = openConnection()) {
-      // Create and execute statement
-      Statement stmt = conn.createStatement();
-      ResultSet rs = stmt.executeQuery("SELECT 1");
+    Connection conn = getDefaultConnection();
+    // Create and execute statement
+    try (Statement stmt = conn.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery("SELECT 1")) {
 
-      // Verify result
-      assertNotNull(rs, "ResultSet should not be null");
-      assertTrue(rs.next(), "ResultSet should have one row");
-      assertEquals(1, rs.getInt(1), "Result should be 1");
-
-      // Clean up
-      rs.close();
-      stmt.close();
+        // Verify result
+        assertNotNull(rs, "ResultSet should not be null");
+        assertTrue(rs.next(), "ResultSet should have one row");
+        assertEquals(1, rs.getInt(1), "Result should be 1");
+      }
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
@@ -1,0 +1,77 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.BinaryDataPtr;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import org.junit.jupiter.api.Test;
+
+public class PreparedStatementBindingSerializerTest {
+
+  @Test
+  public void testSerializeEmptyParametersReturnsNullBindings() throws Exception {
+    PreparedStatementBindingSerializer.ParameterValue[] params =
+        new PreparedStatementBindingSerializer.ParameterValue[0];
+
+    try (PreparedStatementBindingSerializer.SerializedBindings serialized =
+        PreparedStatementBindingSerializer.serialize(params)) {
+      assertNull(serialized.bindings(), "Expected null bindings for empty parameter list");
+    }
+  }
+
+  @Test
+  public void testSerializeMissingParameterFailsWithIndex() {
+    PreparedStatementBindingSerializer.ParameterValue[] params =
+        new PreparedStatementBindingSerializer.ParameterValue[2];
+    params[0] = new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello");
+
+    SQLException ex =
+        assertThrows(
+            SQLException.class, () -> PreparedStatementBindingSerializer.serialize(params));
+    assertTrue(
+        ex.getMessage().contains("Missing value for parameter index: 2"),
+        "Expected missing-parameter index in error message");
+  }
+
+  @Test
+  public void testSerializeCreatesJsonBindingsWithExpectedPointerMetadata() throws Exception {
+    PreparedStatementBindingSerializer.ParameterValue[] params =
+        new PreparedStatementBindingSerializer.ParameterValue[] {
+          new PreparedStatementBindingSerializer.ParameterValue("FIXED", "42"),
+          new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello")
+        };
+
+    String expectedJson =
+        "{\"1\":{\"type\":\"FIXED\",\"value\":\"42\"},\"2\":{\"type\":\"TEXT\",\"value\":\"hello\"}}";
+    byte[] expectedJsonBytes = expectedJson.getBytes(StandardCharsets.UTF_8);
+
+    try (PreparedStatementBindingSerializer.SerializedBindings serialized =
+        PreparedStatementBindingSerializer.serialize(params)) {
+      QueryBindings bindings = serialized.bindings();
+      assertNotNull(bindings, "Expected non-null bindings");
+      assertTrue(bindings.hasJson(), "Expected JSON query bindings");
+
+      BinaryDataPtr jsonPtr = bindings.getJson();
+      assertEquals(
+          expectedJsonBytes.length,
+          jsonPtr.getLength(),
+          "JSON byte length should match serialized payload length");
+      assertEquals(Long.BYTES, jsonPtr.getValue().size(), "Pointer payload should be 8 bytes");
+
+      long pointerValue =
+          ByteBuffer.wrap(jsonPtr.getValue().toByteArray())
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .getLong();
+      assertNotEquals(0L, pointerValue, "Native pointer value should not be zero");
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/cursor/SnowflakeResultSetCursorTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/cursor/SnowflakeResultSetCursorTest.java
@@ -18,9 +18,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testCursorPosition() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select * from values (1), (2), (3);")) {
         assertTrue(rs.isBeforeFirst());
         assertEquals(0, rs.getRow());
@@ -45,9 +44,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testNextAfterCloseReturnsFalse() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select 1")) {
         assertFalse(rs.isClosed());
         rs.close();
@@ -59,9 +57,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testGettersAfterCloseThrow() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select 1")) {
         assertTrue(rs.next());
         rs.close();
@@ -76,9 +73,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testWasNullUpdatesAfterReads() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select null as n, 1 as v")) {
         assertTrue(rs.next());
         assertNull(rs.getString(1));
@@ -91,9 +87,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testGettersBeforeFirstAndAfterLastThrow() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select 1")) {
         assertThrows(SQLException.class, () -> rs.getInt(1));
         assertTrue(rs.next());
@@ -106,9 +101,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testUnsupportedGettersThrow() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select 1")) {
         assertTrue(rs.next());
         assertThrows(SQLFeatureNotSupportedException.class, () -> rs.getDate(1));
@@ -120,9 +114,8 @@ public class SnowflakeResultSetCursorTest extends SnowflakeIntegrationTestBase {
 
   @Test
   public void testFindColumnCaseInsensitive() throws Exception {
-    try (Connection conn = openConnection();
-        Statement stmt = conn.createStatement()) {
-      ensureDatabaseAndSchema(conn);
+    Connection conn = getDefaultConnection();
+    try (Statement stmt = conn.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("select 1 as FooBar")) {
         assertTrue(rs.next());
         assertEquals(1, rs.findColumn("foobar"));

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -246,7 +246,7 @@ public class IntTests extends SnowflakeIntegrationTestBase {
     // And Query "SELECT * FROM <table>" is executed
     // Then Result should contain integers [0, -2147483648, 2147483647, 9223372036854775807]
     Connection connection = getDefaultConnection();
-    String tableName = createTempTable(connection, "col " + INT_TYPE);
+    String tableName = createTempTable(connection, "ud_int_", "col " + INT_TYPE);
 
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -234,6 +235,35 @@ public class IntTests extends SnowflakeIntegrationTestBase {
       }
       assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + INT_TYPE);
     }
+  }
+
+  @Test
+  public void shouldInsertIntegerUsingParameterBindingForIntAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists
+    // When Integer values [0, -2147483648, 2147483647, 9223372036854775807] are inserted using
+    // binding
+    // And Query "SELECT * FROM <table>" is executed
+    // Then Result should contain integers [0, -2147483648, 2147483647, 9223372036854775807]
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + INT_TYPE);
+
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
+      preparedStatement.setLong(1, 0L);
+      preparedStatement.execute();
+      preparedStatement.setLong(1, Integer.MIN_VALUE);
+      preparedStatement.execute();
+      preparedStatement.setLong(1, Integer.MAX_VALUE);
+      preparedStatement.execute();
+      preparedStatement.setLong(1, Long.MAX_VALUE);
+      preparedStatement.execute();
+    }
+
+    assertSingleColumnRows(
+        connection,
+        tableName,
+        Arrays.asList((long) Integer.MIN_VALUE, 0L, (long) Integer.MAX_VALUE, Long.MAX_VALUE));
   }
 
   private static void assertSingleRow(Connection connection, String sql, List<Long> expected)

--- a/tests/definitions/shared/types/int.feature
+++ b/tests/definitions/shared/types/int.feature
@@ -84,7 +84,7 @@ Feature: INT type support
   #                            Parameter binding                                #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should insert integer using parameter binding for int and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists


### PR DESCRIPTION
## Summary
- Adds query parameter binding support for JDBC prepared statements.
- Introduces prepared statement binding serialization and wires it into statement execution/transport flow.
- Extends and updates unit/integration coverage for binding behavior and related execution paths.
- NO batch support yet, this will be in additional PR since this one got pretty big already

## Testing
- Added/updated tests for:
  - Prepared statement binding behavior.
  - Unsupported feature handling for prepared statements.
  - Statement and result-set related paths impacted by binding support.
  - End-to-end integer type scenarios in shared feature definitions.