### PR TITLE
SQLBindCol, SQLFetch: Multirow fetch implementation

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1,7 +1,8 @@
 use crate::api::error::{
     ConversionSnafu, DataNotFetchedSnafu, ExecutionDoneSnafu, FetchDataSnafu,
-    InvalidBufferLengthSnafu, InvalidCursorStateSnafu, InvalidDescriptorIndexSnafu,
-    NoMoreDataSnafu, NullPointerSnafu, StatementErrorStateSnafu, StatementNotExecutedSnafu,
+    InvalidBufferLengthSnafu, InvalidCursorPositionSnafu, InvalidCursorStateSnafu,
+    InvalidDescriptorIndexSnafu, NoMoreDataSnafu, NullPointerSnafu, StatementErrorStateSnafu,
+    StatementNotExecutedSnafu, UnsupportedFeatureSnafu,
 };
 use crate::api::{
     GetDataState, OdbcResult, Statement, StatementState, WithState, stmt_from_handle,
@@ -27,126 +28,329 @@ fn read_arrow_value(
     Ok(warnings)
 }
 
-/// Fetch the next row of data
-pub fn fetch(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcResult<()> {
-    tracing::debug!("fetch called");
-    let stmt = stmt_from_handle(statement_handle);
-    stmt.get_data_state = None;
-    stmt.state.transition_or_err(|state| match state {
-        StatementState::NoResultSet => {
-            tracing::error!("fetch: no result set associated with the statement");
-            InvalidCursorStateSnafu
-                .fail()
-                .with_state(StatementState::NoResultSet)
-        }
+const SQL_FETCH_NEXT: sql::SmallInt = 1;
+
+#[repr(u16)]
+#[derive(Debug, Clone, Copy)]
+enum RowStatus {
+    Success = 0,
+    NoRow = 3,
+    Error = 5,
+    SuccessWithInfo = 6,
+}
+
+/// Advance the cursor by one row. Handles state transitions from
+/// `Executed` → `Fetching` and from one batch to the next.
+fn advance_cursor(state: &mut crate::api::State<StatementState>) -> OdbcResult<()> {
+    state.transition_or_err(|s| match s {
+        StatementState::NoResultSet => InvalidCursorStateSnafu
+            .fail()
+            .with_state(StatementState::NoResultSet),
         StatementState::Executed { mut reader, .. } => match reader.next() {
-            Some(record_batch_result) => {
-                let record_batch = record_batch_result
+            Some(rb) => {
+                let record_batch = rb
                     .context(FetchDataSnafu)
                     .with_state(StatementState::Error)?;
-                tracing::debug!(
-                    "fetch: fetched record_batch with {} rows",
-                    record_batch.num_rows()
-                );
-                let next_state = StatementState::Fetching {
-                    reader,
-                    record_batch,
-                    batch_idx: 0,
-                };
-                Ok((next_state, ()))
+                Ok((
+                    StatementState::Fetching {
+                        reader,
+                        record_batch,
+                        batch_idx: 0,
+                    },
+                    (),
+                ))
             }
-            None => {
-                tracing::debug!("fetch: no more data available");
-                NoMoreDataSnafu.fail().with_state(StatementState::Done)
-            }
+            None => NoMoreDataSnafu.fail().with_state(StatementState::Done),
         },
         StatementState::Fetching {
             mut reader,
             record_batch,
             batch_idx,
         } => {
-            let new_batch_idx = batch_idx + 1;
-            if new_batch_idx < record_batch.num_rows() {
+            let new_idx = batch_idx + 1;
+            if new_idx < record_batch.num_rows() {
                 Ok((
                     StatementState::Fetching {
                         reader,
                         record_batch,
-                        batch_idx: new_batch_idx,
+                        batch_idx: new_idx,
                     },
                     (),
                 ))
             } else {
                 match reader.next() {
-                    Some(new_record_batch_result) => {
-                        let new_record_batch = new_record_batch_result
+                    Some(rb) => {
+                        let new_batch = rb
                             .context(FetchDataSnafu)
                             .with_state(StatementState::Error)?;
-                        let next_state = StatementState::Fetching {
-                            reader,
-                            record_batch: new_record_batch,
-                            batch_idx: 0,
-                        };
-                        Ok((next_state, ()))
+                        Ok((
+                            StatementState::Fetching {
+                                reader,
+                                record_batch: new_batch,
+                                batch_idx: 0,
+                            },
+                            (),
+                        ))
                     }
-                    None => {
-                        tracing::debug!("fetch: no more data available");
-                        NoMoreDataSnafu.fail().with_state(StatementState::Done)
-                    }
+                    None => NoMoreDataSnafu.fail().with_state(StatementState::Done),
                 }
             }
         }
-        state @ StatementState::Error => {
-            tracing::error!("fetch: statement error");
-            StatementErrorStateSnafu.fail().with_state(state)
+        state @ StatementState::Error => StatementErrorStateSnafu.fail().with_state(state),
+        state @ StatementState::Done => ExecutionDoneSnafu.fail().with_state(state),
+        state @ StatementState::Created => StatementNotExecutedSnafu.fail().with_state(state),
+    })
+}
+
+/// Fetch the next rowset of data (block cursor aware).
+pub fn fetch(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcResult<()> {
+    tracing::debug!("fetch called");
+    let stmt = stmt_from_handle(statement_handle);
+    stmt.get_data_state = None;
+
+    let array_size = stmt.ard.array_size.max(1);
+    let bind_type = stmt.ard.bind_type;
+    let bind_offset_ptr = stmt.ard.bind_offset_ptr;
+    let row_status_ptr = stmt.ird.array_status_ptr;
+    let rows_fetched_ptr = stmt.ird.rows_processed_ptr;
+
+    if array_size == 1 && bind_offset_ptr.is_null() {
+        advance_cursor(&mut stmt.state)?;
+        if !rows_fetched_ptr.is_null() {
+            unsafe { *rows_fetched_ptr = 1 };
         }
-        state @ StatementState::Done => {
-            tracing::debug!("fetch: statement execution is done");
-            ExecutionDoneSnafu.fail().with_state(state)
+        match execute_bindings_for_row(stmt, 0, 0, 0) {
+            Ok(row_warnings) => {
+                let status = if row_warnings.is_empty() {
+                    RowStatus::Success
+                } else {
+                    RowStatus::SuccessWithInfo
+                };
+                write_row_status(row_status_ptr, 0, status);
+                warnings.extend(row_warnings);
+            }
+            Err(e) => {
+                write_row_status(row_status_ptr, 0, RowStatus::Error);
+                return Err(e);
+            }
         }
-        state @ StatementState::Created => {
-            tracing::error!("fetch: statement not executed");
-            StatementNotExecutedSnafu.fail().with_state(state)
+        return Ok(());
+    }
+
+    let bind_offset = if !bind_offset_ptr.is_null() {
+        unsafe { *bind_offset_ptr }
+    } else {
+        0
+    };
+
+    let mut rows_fetched: usize = 0;
+    let mut has_error = false;
+
+    for row_idx in 0..array_size {
+        match advance_cursor(&mut stmt.state) {
+            Ok(()) => {
+                rows_fetched += 1;
+                match execute_bindings_for_row(stmt, row_idx, bind_type, bind_offset) {
+                    Ok(w) => {
+                        let status = if w.is_empty() {
+                            RowStatus::Success
+                        } else {
+                            RowStatus::SuccessWithInfo
+                        };
+                        write_row_status(row_status_ptr, row_idx, status);
+                        warnings.extend(w);
+                    }
+                    Err(_) => {
+                        write_row_status(row_status_ptr, row_idx, RowStatus::Error);
+                        has_error = true;
+                    }
+                }
+            }
+            Err(crate::api::OdbcError::NoMoreData { .. })
+            | Err(crate::api::OdbcError::ExecutionDone { .. }) => {
+                for remaining in row_idx..array_size {
+                    write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
+                }
+                break;
+            }
+            Err(e) => {
+                if rows_fetched == 0 {
+                    return Err(e);
+                }
+                write_row_status(row_status_ptr, row_idx, RowStatus::Error);
+                has_error = true;
+                for remaining in (row_idx + 1)..array_size {
+                    write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
+                }
+                break;
+            }
         }
-    })?;
-    warnings.extend(execute_bindings(stmt)?);
+    }
+
+    if !rows_fetched_ptr.is_null() {
+        unsafe { *rows_fetched_ptr = rows_fetched as sql::ULen };
+    }
+
+    if rows_fetched == 0 {
+        return NoMoreDataSnafu.fail();
+    }
+
+    if has_error {
+        warnings.push(crate::conversion::warning::Warning::RowError);
+    }
+
     Ok(())
 }
 
-fn execute_bindings(stmt: &mut Statement) -> OdbcResult<Warnings> {
+/// `SQLFetchScroll` — currently only `SQL_FETCH_NEXT` is supported.
+pub fn fetch_scroll(
+    statement_handle: sql::Handle,
+    fetch_orientation: sql::SmallInt,
+    warnings: &mut Warnings,
+) -> OdbcResult<()> {
+    if fetch_orientation != SQL_FETCH_NEXT {
+        tracing::warn!(
+            "fetch_scroll: unsupported orientation {}",
+            fetch_orientation
+        );
+        return UnsupportedFeatureSnafu.fail();
+    }
+    fetch(statement_handle, warnings)
+}
+
+fn write_row_status(row_status_ptr: *mut u16, row_idx: usize, status: RowStatus) {
+    if !row_status_ptr.is_null() {
+        unsafe { *row_status_ptr.add(row_idx) = status as u16 };
+    }
+}
+
+/// Compute the data stride (in bytes) between successive rows for a column
+/// when using column-wise binding.
+fn column_wise_data_stride(binding: &Binding) -> usize {
+    if binding.buffer_length > 0 {
+        binding.buffer_length as usize
+    } else {
+        binding.target_type.fixed_size().unwrap_or(8)
+    }
+}
+
+/// Create an adjusted `Binding` whose pointers target `row_idx` within the
+/// bound arrays, taking into account column-wise vs row-wise binding and an
+/// optional bind offset.
+fn adjust_binding_for_row(
+    binding: &Binding,
+    row_idx: usize,
+    bind_type: usize,
+    bind_offset: isize,
+) -> Binding {
+    if row_idx == 0 && bind_offset == 0 {
+        return Binding {
+            target_type: binding.target_type,
+            target_value_ptr: binding.target_value_ptr,
+            buffer_length: binding.buffer_length,
+            str_len_or_ind_ptr: binding.str_len_or_ind_ptr,
+            precision: binding.precision,
+            scale: binding.scale,
+        };
+    }
+
+    let (data_ptr, ind_ptr) = if bind_type == 0 {
+        let stride = column_wise_data_stride(binding);
+        let row_offset = row_idx
+            .checked_mul(stride)
+            .expect("row index and stride multiplication overflowed");
+        let data_ptr = unsafe {
+            (binding.target_value_ptr as *mut u8)
+                .offset(bind_offset)
+                .add(row_offset) as sql::Pointer
+        };
+        let ind_ptr = if !binding.str_len_or_ind_ptr.is_null() {
+            let ind_stride = std::mem::size_of::<sql::Len>();
+            let ind_offset = row_idx
+                .checked_mul(ind_stride)
+                .expect("row index and indicator stride multiplication overflowed");
+            unsafe {
+                (binding.str_len_or_ind_ptr as *mut u8)
+                    .offset(bind_offset)
+                    .add(ind_offset) as *mut sql::Len
+            }
+        } else {
+            std::ptr::null_mut()
+        };
+        (data_ptr, ind_ptr)
+    } else {
+        let row_byte_offset = row_idx
+            .checked_mul(bind_type)
+            .expect("row index and bind type multiplication overflowed");
+        let data_ptr = unsafe {
+            (binding.target_value_ptr as *mut u8)
+                .offset(bind_offset)
+                .add(row_byte_offset) as sql::Pointer
+        };
+        let ind_ptr = if !binding.str_len_or_ind_ptr.is_null() {
+            unsafe {
+                (binding.str_len_or_ind_ptr as *mut u8)
+                    .offset(bind_offset)
+                    .add(row_byte_offset) as *mut sql::Len
+            }
+        } else {
+            std::ptr::null_mut()
+        };
+        (data_ptr, ind_ptr)
+    };
+
+    Binding {
+        target_type: binding.target_type,
+        target_value_ptr: data_ptr,
+        buffer_length: binding.buffer_length,
+        str_len_or_ind_ptr: ind_ptr,
+        precision: binding.precision,
+        scale: binding.scale,
+    }
+}
+
+/// Execute column bindings for a single row within a block-cursor fetch.
+fn execute_bindings_for_row(
+    stmt: &mut Statement,
+    row_idx: usize,
+    bind_type: usize,
+    bind_offset: isize,
+) -> OdbcResult<Warnings> {
     let mut warnings = vec![];
     if let StatementState::Fetching {
-        reader: _,
         record_batch,
         batch_idx,
-    } = &stmt.state.as_ref()
+        ..
+    } = stmt.state.as_ref()
     {
-        for (column_number, binding) in &stmt.ard.bindings {
-            let schema = record_batch.schema();
-            let arrow_column_number = *column_number as usize - 1;
-            if arrow_column_number >= schema.fields().len() {
+        let batch_idx = *batch_idx;
+        let schema = record_batch.schema();
+        let bindings: Vec<(u16, Binding)> = stmt
+            .ard
+            .bindings
+            .iter()
+            .map(|(&col, b)| {
+                (
+                    col,
+                    adjust_binding_for_row(b, row_idx, bind_type, bind_offset),
+                )
+            })
+            .collect();
+
+        for (column_number, adjusted) in &bindings {
+            let arrow_col = *column_number as usize - 1;
+            if arrow_col >= schema.fields().len() {
                 tracing::error!(
-                    "execute_bindings: column_number {} is out of range",
-                    *column_number
+                    "execute_bindings_for_row: column_number {} is out of range",
+                    column_number
                 );
                 continue;
             }
-            let array_ref = record_batch.column(arrow_column_number);
-            let field = schema.field(arrow_column_number);
-            tracing::debug!(
-                "execute_bindings: column_number={}, binding={:?}",
-                column_number,
-                binding
-            );
-            let conversion_warnings =
-                read_arrow_value(binding, array_ref, field, *batch_idx, &mut None)
-                    .context(ConversionSnafu)?;
-            tracing::debug!(
-                "execute_bindings: column_number={}, binding={:?}, conversion_warnings={:?}",
-                column_number,
-                binding,
-                conversion_warnings
-            );
-            warnings.extend(conversion_warnings);
+            let array_ref = record_batch.column(arrow_col);
+            let field = schema.field(arrow_col);
+            let w = read_arrow_value(adjusted, array_ref, field, batch_idx, &mut None)
+                .context(ConversionSnafu)?;
+            warnings.extend(w);
         }
     }
     Ok(warnings)
@@ -176,6 +380,11 @@ pub fn get_data(
     }
 
     let stmt = stmt_from_handle(statement_handle);
+
+    if stmt.ard.array_size > 1 {
+        tracing::warn!("get_data: cannot use SQLGetData with row_array_size > 1");
+        return InvalidCursorPositionSnafu.fail();
+    }
 
     // Column 0 is reserved for bookmarks; reject it when bookmarks are off
     if col_or_param_num == 0 {

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -1,4 +1,4 @@
-use crate::api::{DescField, OdbcResult, desc_from_handle};
+use crate::api::{DescField, DescriptorRef, OdbcResult, desc_ref_from_handle};
 use crate::cdata_types::CDataType;
 use odbc_sys as sql;
 use tracing;
@@ -30,10 +30,21 @@ pub fn get_desc_field(
     }
 
     let field = DescField::try_from(field_identifier)?;
-    let desc = desc_from_handle(desc_handle)?;
+    let desc_ref = desc_ref_from_handle(desc_handle)?;
 
+    match desc_ref {
+        DescriptorRef::Ard(desc) => get_ard_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Ird(desc) => get_ird_field(desc, rec_number, field, value_ptr),
+    }
+}
+
+fn get_ard_field(
+    desc: &crate::api::ArdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
     if rec_number == 0 {
-        // Header fields (record 0)
         match field {
             DescField::Count => {
                 let count = desc.desc_count();
@@ -45,16 +56,42 @@ pub fn get_desc_field(
                 }
                 Ok(())
             }
+            DescField::ArraySize => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::ULen,
+                        desc.array_size as sql::ULen,
+                    );
+                }
+                Ok(())
+            }
+            DescField::BindType => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::ULen,
+                        desc.bind_type as sql::ULen,
+                    );
+                }
+                Ok(())
+            }
+            DescField::BindOffsetPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::Len,
+                        desc.bind_offset_ptr,
+                    );
+                }
+                Ok(())
+            }
             _ => {
-                tracing::warn!("get_desc_field: unsupported header field {:?}", field);
+                tracing::warn!("get_desc_field: unsupported ARD header field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
-                    attribute: field_identifier as i32,
+                    attribute: field as i32,
                 }
                 .fail()
             }
         }
     } else {
-        // Record-level fields
         let column_number = rec_number as u16;
         let binding = match desc.bindings.get(&column_number) {
             Some(b) => b,
@@ -102,13 +139,53 @@ pub fn get_desc_field(
                 Ok(())
             }
             _ => {
-                tracing::warn!("get_desc_field: unsupported record field {:?}", field);
+                tracing::warn!("get_desc_field: unsupported ARD record field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
-                    attribute: field_identifier as i32,
+                    attribute: field as i32,
                 }
                 .fail()
             }
         }
+    }
+}
+
+fn get_ird_field(
+    desc: &crate::api::IrdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::ArrayStatusPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+                }
+                Ok(())
+            }
+            DescField::RowsProcessedPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::ULen,
+                        desc.rows_processed_ptr,
+                    );
+                }
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("get_desc_field: unsupported IRD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        tracing::warn!(
+            "get_desc_field: IRD record fields not supported (rec={})",
+            rec_number
+        );
+        crate::api::error::NoMoreDataSnafu.fail()
     }
 }
 
@@ -133,8 +210,20 @@ pub fn set_desc_field(
     }
 
     let field = DescField::try_from(field_identifier)?;
-    let desc = desc_from_handle(desc_handle)?;
+    let desc_ref = desc_ref_from_handle(desc_handle)?;
 
+    match desc_ref {
+        DescriptorRef::Ard(desc) => set_ard_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Ird(desc) => set_ird_field(desc, rec_number, field, value_ptr),
+    }
+}
+
+fn set_ard_field(
+    desc: &mut crate::api::ArdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
     if rec_number == 0 {
         match field {
             DescField::Count => {
@@ -146,16 +235,40 @@ pub fn set_desc_field(
                 desc.set_desc_count(count);
                 Ok(())
             }
+            DescField::ArraySize => {
+                let size = value_ptr as usize;
+                tracing::debug!("set_desc_field: ARD ArraySize = {}", size);
+                if size == 0 {
+                    tracing::error!(
+                        "set_desc_field: invalid ARD ArraySize {}, must be >= 1",
+                        size
+                    );
+                    return crate::api::error::InvalidDescriptorIndexSnafu { number: 0i16 }.fail();
+                }
+                desc.array_size = size;
+                Ok(())
+            }
+            DescField::BindType => {
+                let bind_type = value_ptr as usize;
+                tracing::debug!("set_desc_field: ARD BindType = {}", bind_type);
+                desc.bind_type = bind_type;
+                Ok(())
+            }
+            DescField::BindOffsetPtr => {
+                let ptr = value_ptr as *mut sql::Len;
+                tracing::debug!("set_desc_field: ARD BindOffsetPtr = {:?}", ptr);
+                desc.bind_offset_ptr = ptr;
+                Ok(())
+            }
             _ => {
-                tracing::warn!("set_desc_field: unsupported header field {:?}", field);
+                tracing::warn!("set_desc_field: unsupported ARD header field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
-                    attribute: field_identifier as i32,
+                    attribute: field as i32,
                 }
                 .fail()
             }
         }
     } else {
-        // Record-level set fields (for SQL_C_NUMERIC support etc.)
         let column_number = rec_number as u16;
 
         match field {
@@ -218,13 +331,78 @@ pub fn set_desc_field(
                 binding.target_value_ptr = value_ptr;
                 Ok(())
             }
+            DescField::OctetLength => {
+                let length = value_ptr as sql::Len;
+                tracing::debug!(
+                    "set_desc_field: setting buffer_length={length} on record {column_number}"
+                );
+                let binding = desc.bindings.entry(column_number).or_default();
+                binding.buffer_length = length;
+                Ok(())
+            }
+            DescField::IndicatorPtr => {
+                let ptr = value_ptr as *mut sql::Len;
+                tracing::debug!("set_desc_field: setting indicator_ptr on record {column_number}");
+                let binding = desc.bindings.entry(column_number).or_default();
+                binding.str_len_or_ind_ptr = ptr;
+                Ok(())
+            }
+            DescField::OctetLengthPtr => {
+                let ptr = value_ptr as *mut sql::Len;
+                tracing::debug!(
+                    "set_desc_field: setting octet_length_ptr on record {column_number}"
+                );
+                let binding = desc.bindings.entry(column_number).or_default();
+                binding.str_len_or_ind_ptr = ptr;
+                Ok(())
+            }
             _ => {
-                tracing::warn!("set_desc_field: unsupported record field {:?}", field);
+                tracing::warn!("set_desc_field: unsupported ARD record field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
-                    attribute: field_identifier as i32,
+                    attribute: field as i32,
                 }
                 .fail()
             }
         }
+    }
+}
+
+fn set_ird_field(
+    desc: &mut crate::api::IrdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::ArrayStatusPtr => {
+                let ptr = value_ptr as *mut u16;
+                tracing::debug!("set_desc_field: IRD ArrayStatusPtr = {:?}", ptr);
+                desc.array_status_ptr = ptr;
+                Ok(())
+            }
+            DescField::RowsProcessedPtr => {
+                let ptr = value_ptr as *mut sql::ULen;
+                tracing::debug!("set_desc_field: IRD RowsProcessedPtr = {:?}", ptr);
+                desc.rows_processed_ptr = ptr;
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("set_desc_field: unsupported IRD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        tracing::warn!(
+            "set_desc_field: IRD record fields are read-only (rec={})",
+            rec_number
+        );
+        crate::api::error::UnknownAttributeSnafu {
+            attribute: field as i32,
+        }
+        .fail()
     }
 }

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -224,10 +224,12 @@ pub fn from_warning(warning: &Warning) -> DiagnosticRecord {
     let message_text = match warning {
         Warning::StringDataTruncated => "String data truncated",
         Warning::NumericValueTruncated => "Numeric value truncated",
+        Warning::RowError => "Error in row",
     };
     let sql_state = match warning {
         Warning::StringDataTruncated => SqlState::StringDataRightTruncated,
         Warning::NumericValueTruncated => SqlState::FractionalTruncation,
+        Warning::RowError => SqlState::ErrorInRow,
     };
     DiagnosticRecord {
         native_error: 0,

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -37,6 +37,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("Invalid descriptor kind: {kind}"))]
+    InvalidDescriptorKind {
+        kind: u16,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid use of null pointer"))]
     NullPointer {
         #[snafu(implicit)]
@@ -157,6 +164,18 @@ pub enum OdbcError {
 
     #[snafu(display("No more data available"))]
     NoMoreData {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid cursor position"))]
+    InvalidCursorPosition {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Optional feature not implemented"))]
+    UnsupportedFeature {
         #[snafu(implicit)]
         location: Location,
     },
@@ -329,6 +348,7 @@ impl OdbcError {
             OdbcError::Disconnected { .. } => SqlState::ConnectionDoesNotExist,
             OdbcError::InvalidHandle { .. } => SqlState::InvalidConnectionName,
             OdbcError::NullPointer { .. } => SqlState::InvalidUseOfNullPointer,
+            OdbcError::InvalidDescriptorKind { .. } => SqlState::GeneralError,
             OdbcError::InvalidBufferLength { .. } => SqlState::InvalidStringOrBufferLength,
             OdbcError::InvalidApplicationBufferType { .. } => {
                 SqlState::InvalidApplicationBufferType
@@ -350,6 +370,8 @@ impl OdbcError {
             OdbcError::DataNotFetched { .. } => SqlState::FunctionSequenceError,
             OdbcError::ExecutionDone { .. } => SqlState::FunctionSequenceError,
             OdbcError::NoMoreData { .. } => SqlState::NoDataFound,
+            OdbcError::InvalidCursorPosition { .. } => SqlState::InvalidCursorPosition,
+            OdbcError::UnsupportedFeature { .. } => SqlState::OptionalFeatureNotImplemented,
             OdbcError::InvalidPort { .. } => SqlState::InvalidConnectionStringAttribute,
             OdbcError::SetSqlQuery { .. } => SqlState::SyntaxErrorOrAccessRuleViolation,
             OdbcError::PrepareStatement { .. } => SqlState::SyntaxErrorOrAccessRuleViolation,

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -1,6 +1,6 @@
 use crate::api::{
-    ArdDescriptor, Connection, ConnectionState, Environment, OdbcResult, Statement, StatementState,
-    conn_from_handle,
+    ArdDescriptor, Connection, ConnectionState, Environment, IrdDescriptor, OdbcResult, Statement,
+    StatementState, conn_from_handle,
     diagnostic::DiagnosticInfo,
     error::{DisconnectedSnafu, InvalidHandleSnafu, Required},
 };
@@ -52,6 +52,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement<'
                 state: StatementState::Created.into(),
                 parameter_bindings: std::collections::HashMap::new(),
                 ard: ArdDescriptor::new(),
+                ird: IrdDescriptor::new(),
                 diagnostic_info: DiagnosticInfo::default(),
                 get_data_state: None,
             });

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -325,23 +325,68 @@ pub fn bind_col(
 pub fn set_stmt_attr(
     statement_handle: sql::Handle,
     attribute: sql::Integer,
-    _value_ptr: sql::Pointer,
+    value_ptr: sql::Pointer,
     _string_length: sql::Integer,
 ) -> OdbcResult<()> {
     use crate::api::StmtAttr;
 
     tracing::debug!(
-        "set_stmt_attr: statement_handle={:?}, attribute={}",
+        "set_stmt_attr: statement_handle={:?}, attribute={}, value_ptr={:?}",
         statement_handle,
-        attribute
+        attribute,
+        value_ptr
     );
 
     let attr = StmtAttr::try_from(attribute)?;
-    let _stmt = stmt_from_handle(statement_handle);
+    let stmt = stmt_from_handle(statement_handle);
 
     match attr {
         StmtAttr::UseBookmarks => {
             tracing::debug!("set_stmt_attr: UseBookmarks (ignored, bookmarks not supported)");
+            Ok(())
+        }
+        StmtAttr::RowArraySize => {
+            let size = value_ptr as usize;
+            tracing::debug!("set_stmt_attr: RowArraySize = {}", size);
+            let effective_size = if size == 0 {
+                tracing::warn!("set_stmt_attr: RowArraySize value 0 is invalid; coercing to 1");
+                1
+            } else {
+                size
+            };
+            stmt.ard.array_size = effective_size;
+            Ok(())
+        }
+        StmtAttr::RowStatusPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: RowStatusPtr = {:?}", ptr);
+            stmt.ird.array_status_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::RowsFetchedPtr => {
+            let ptr = value_ptr as *mut sql::ULen;
+            tracing::debug!("set_stmt_attr: RowsFetchedPtr = {:?}", ptr);
+            stmt.ird.rows_processed_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::RowBindType => {
+            let raw_bind_type = value_ptr as isize;
+            tracing::debug!("set_stmt_attr: RowBindType (raw) = {}", raw_bind_type);
+            if raw_bind_type < 0 {
+                tracing::warn!(
+                    "set_stmt_attr: RowBindType is negative ({}); ignoring invalid value",
+                    raw_bind_type
+                );
+                return Ok(());
+            }
+            let bind_type = raw_bind_type as usize;
+            stmt.ard.bind_type = bind_type;
+            Ok(())
+        }
+        StmtAttr::RowBindOffsetPtr => {
+            let ptr = value_ptr as *mut sql::Len;
+            tracing::debug!("set_stmt_attr: RowBindOffsetPtr = {:?}", ptr);
+            stmt.ard.bind_offset_ptr = ptr;
             Ok(())
         }
         _ => {
@@ -357,7 +402,7 @@ pub fn get_stmt_attr(
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
     _buffer_length: sql::Integer,
-    _string_length_ptr: *mut sql::Integer,
+    string_length_ptr: *mut sql::Integer,
 ) -> OdbcResult<()> {
     use crate::api::StmtAttr;
 
@@ -375,6 +420,49 @@ pub fn get_stmt_attr(
             let ard_ptr = &mut stmt.ard as *mut crate::api::ArdDescriptor as sql::Handle;
             unsafe {
                 *(value_ptr as *mut sql::Handle) = ard_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::ImpRowDesc => {
+            let ird_ptr = &mut stmt.ird as *mut crate::api::IrdDescriptor as sql::Handle;
+            unsafe {
+                *(value_ptr as *mut sql::Handle) = ird_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::RowArraySize => {
+            unsafe {
+                *(value_ptr as *mut sql::ULen) = stmt.ard.array_size as sql::ULen;
+                if !string_length_ptr.is_null() {
+                    *string_length_ptr = std::mem::size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::RowStatusPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut u16) = stmt.ird.array_status_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::RowsFetchedPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut sql::ULen) = stmt.ird.rows_processed_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::RowBindType => {
+            unsafe {
+                *(value_ptr as *mut sql::ULen) = stmt.ard.bind_type as sql::ULen;
+                if !string_length_ptr.is_null() {
+                    *string_length_ptr = std::mem::size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::RowBindOffsetPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut sql::Len) = stmt.ard.bind_offset_ptr;
             }
             Ok(())
         }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -370,17 +370,9 @@ pub fn set_stmt_attr(
             Ok(())
         }
         StmtAttr::RowBindType => {
-            let raw_bind_type = value_ptr as isize;
+            let raw_bind_type = value_ptr as sql::ULen;
             tracing::debug!("set_stmt_attr: RowBindType (raw) = {}", raw_bind_type);
-            if raw_bind_type < 0 {
-                tracing::warn!(
-                    "set_stmt_attr: RowBindType is negative ({}); ignoring invalid value",
-                    raw_bind_type
-                );
-                return Ok(());
-            }
-            let bind_type = raw_bind_type as usize;
-            stmt.ard.bind_type = bind_type;
+            stmt.ard.bind_type = raw_bind_type;
             Ok(())
         }
         StmtAttr::RowBindOffsetPtr => {
@@ -453,7 +445,7 @@ pub fn get_stmt_attr(
         }
         StmtAttr::RowBindType => {
             unsafe {
-                *(value_ptr as *mut sql::ULen) = stmt.ard.bind_type as sql::ULen;
+                *(value_ptr as *mut sql::ULen) = stmt.ard.bind_type;
                 if !string_length_ptr.is_null() {
                     *string_length_ptr = std::mem::size_of::<sql::ULen>() as sql::Integer;
                 }

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -1,4 +1,5 @@
 use crate::api::bitmask::Bitmask;
+use crate::api::error::InvalidDescriptorKindSnafu;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::cdata_types::CDataType;
 use crate::conversion::Binding;
@@ -131,15 +132,25 @@ impl Bitmask for GetDataExtensions {
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StmtAttr {
-    /// `SQL_ATTR_USE_BOOKMARKS` (12) - whether bookmarks are used.
+    /// `SQL_ATTR_ROW_BIND_TYPE` (5) — row-wise vs column-wise binding.
+    RowBindType = 5,
+    /// `SQL_ATTR_USE_BOOKMARKS` (12) — whether bookmarks are used.
     UseBookmarks = 12,
-    /// `SQL_ATTR_APP_ROW_DESC` - handle to the Application Row Descriptor.
+    /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
+    RowBindOffsetPtr = 23,
+    /// `SQL_ATTR_ROW_STATUS_PTR` (25) — pointer to per-row status array.
+    RowStatusPtr = 25,
+    /// `SQL_ATTR_ROWS_FETCHED_PTR` (26) — pointer to count of rows fetched.
+    RowsFetchedPtr = 26,
+    /// `SQL_ATTR_ROW_ARRAY_SIZE` (27) — number of rows per fetch.
+    RowArraySize = 27,
+    /// `SQL_ATTR_APP_ROW_DESC` — handle to the Application Row Descriptor.
     AppRowDesc = 10010,
-    /// `SQL_ATTR_APP_PARAM_DESC` - handle to the Application Parameter Descriptor.
+    /// `SQL_ATTR_APP_PARAM_DESC` — handle to the Application Parameter Descriptor.
     AppParamDesc = 10011,
-    /// `SQL_ATTR_IMP_ROW_DESC` - handle to the Implementation Row Descriptor.
+    /// `SQL_ATTR_IMP_ROW_DESC` — handle to the Implementation Row Descriptor.
     ImpRowDesc = 10012,
-    /// `SQL_ATTR_IMP_PARAM_DESC` - handle to the Implementation Parameter Descriptor.
+    /// `SQL_ATTR_IMP_PARAM_DESC` — handle to the Implementation Parameter Descriptor.
     ImpParamDesc = 10013,
 }
 
@@ -148,7 +159,12 @@ impl TryFrom<i32> for StmtAttr {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
+            5 => Ok(StmtAttr::RowBindType),
             12 => Ok(StmtAttr::UseBookmarks),
+            23 => Ok(StmtAttr::RowBindOffsetPtr),
+            25 => Ok(StmtAttr::RowStatusPtr),
+            26 => Ok(StmtAttr::RowsFetchedPtr),
+            27 => Ok(StmtAttr::RowArraySize),
             10010 => Ok(StmtAttr::AppRowDesc),
             10011 => Ok(StmtAttr::AppParamDesc),
             10012 => Ok(StmtAttr::ImpRowDesc),
@@ -164,27 +180,37 @@ impl TryFrom<i32> for StmtAttr {
     }
 }
 
-/// ODBC descriptor field identifiers (matching `SQL_DESC_*` constants from `sql.h`).
+/// ODBC descriptor field identifiers (matching `SQL_DESC_*` constants from `sql.h` / `sqlext.h`).
 #[repr(i16)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum DescField {
-    /// `SQL_DESC_CONCISE_TYPE` - concise data type of the column.
+    /// `SQL_DESC_CONCISE_TYPE` (2) — concise data type of the column.
     ConciseType = 2,
-    /// `SQL_DESC_COUNT` - number of bound columns (header field, record 0).
+    /// `SQL_DESC_ARRAY_SIZE` (20) — header: number of rows in the rowset.
+    ArraySize = 20,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` (21) — header: pointer to row status array.
+    ArrayStatusPtr = 21,
+    /// `SQL_DESC_BIND_OFFSET_PTR` (24) — header: binding offset pointer.
+    BindOffsetPtr = 24,
+    /// `SQL_DESC_BIND_TYPE` (25) — header: row-wise vs column-wise binding.
+    BindType = 25,
+    /// `SQL_DESC_ROWS_PROCESSED_PTR` (34) — header: pointer to rows-processed count.
+    RowsProcessedPtr = 34,
+    /// `SQL_DESC_COUNT` (1001) — number of bound columns (header field, record 0).
     Count = 1001,
-    /// `SQL_DESC_TYPE` - verbose data type of the column.
+    /// `SQL_DESC_TYPE` (1002) — verbose data type of the column.
     Type = 1002,
-    /// `SQL_DESC_OCTET_LENGTH_PTR` - pointer to the octet-length buffer.
+    /// `SQL_DESC_OCTET_LENGTH_PTR` (1004) — pointer to the octet-length buffer.
     OctetLengthPtr = 1004,
-    /// `SQL_DESC_PRECISION` - numeric precision.
+    /// `SQL_DESC_PRECISION` (1005) — numeric precision.
     Precision = 1005,
-    /// `SQL_DESC_SCALE` - numeric scale.
+    /// `SQL_DESC_SCALE` (1006) — numeric scale.
     Scale = 1006,
-    /// `SQL_DESC_INDICATOR_PTR` - pointer to the indicator buffer.
+    /// `SQL_DESC_INDICATOR_PTR` (1009) — pointer to the indicator buffer.
     IndicatorPtr = 1009,
-    /// `SQL_DESC_DATA_PTR` - pointer to the data buffer.
+    /// `SQL_DESC_DATA_PTR` (1010) — pointer to the data buffer.
     DataPtr = 1010,
-    /// `SQL_DESC_OCTET_LENGTH` - length in bytes of the data buffer.
+    /// `SQL_DESC_OCTET_LENGTH` (1013) — length in bytes of the data buffer.
     OctetLength = 1013,
 }
 
@@ -194,6 +220,11 @@ impl TryFrom<i16> for DescField {
     fn try_from(value: i16) -> Result<Self, Self::Error> {
         match value {
             2 => Ok(DescField::ConciseType),
+            20 => Ok(DescField::ArraySize),
+            21 => Ok(DescField::ArrayStatusPtr),
+            24 => Ok(DescField::BindOffsetPtr),
+            25 => Ok(DescField::BindType),
+            34 => Ok(DescField::RowsProcessedPtr),
             1001 => Ok(DescField::Count),
             1002 => Ok(DescField::Type),
             1004 => Ok(DescField::OctetLengthPtr),
@@ -213,19 +244,60 @@ impl TryFrom<i16> for DescField {
     }
 }
 
+/// Discriminant tag placed at offset 0 in both `ArdDescriptor` and `IrdDescriptor`
+/// so that `desc_ref_from_handle` can determine the descriptor type from a raw handle.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DescriptorKind {
+    Ard = 1,
+    Ird = 2,
+}
+
+impl TryFrom<u8> for DescriptorKind {
+    type Error = OdbcError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(DescriptorKind::Ard),
+            2 => Ok(DescriptorKind::Ird),
+            _ => {
+                tracing::error!("Invalid descriptor kind: {}", value);
+                InvalidDescriptorKindSnafu { kind: value }.fail()
+            }
+        }
+    }
+}
 /// Application Row Descriptor (ARD).
 ///
-/// Stores column binding information. This struct is embedded in `Statement`
-/// and a pointer to it is returned as the descriptor handle via `SQLGetStmtAttr`.
-#[derive(Default)]
+/// Stores column binding information and block-cursor header fields.
+/// A pointer to this struct is returned as the descriptor handle via
+/// `SQLGetStmtAttr(SQL_ATTR_APP_ROW_DESC)`.
+#[repr(C)]
 pub struct ArdDescriptor {
+    kind: DescriptorKind,
     pub bindings: HashMap<u16, Binding>,
+    /// `SQL_DESC_ARRAY_SIZE` / `SQL_ATTR_ROW_ARRAY_SIZE` — default 1.
+    pub array_size: usize,
+    /// `SQL_DESC_BIND_TYPE` / `SQL_ATTR_ROW_BIND_TYPE` — 0 = column-wise (default).
+    pub bind_type: usize,
+    /// `SQL_DESC_BIND_OFFSET_PTR` / `SQL_ATTR_ROW_BIND_OFFSET_PTR` — default null.
+    pub bind_offset_ptr: *mut sql::Len,
+}
+
+impl Default for ArdDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArdDescriptor {
     pub fn new() -> Self {
         Self {
+            kind: DescriptorKind::Ard,
             bindings: HashMap::new(),
+            array_size: 1,
+            bind_type: 0,
+            bind_offset_ptr: std::ptr::null_mut(),
         }
     }
 
@@ -247,17 +319,73 @@ impl ArdDescriptor {
     }
 }
 
-/// Convert a descriptor handle (returned by SQLGetStmtAttr) back to a `&mut ArdDescriptor`.
-pub fn desc_from_handle<'a>(handle: sql::Handle) -> OdbcResult<&'a mut ArdDescriptor> {
-    let desc_ptr = handle as *mut ArdDescriptor;
-    if desc_ptr.is_null() {
+/// Implementation Row Descriptor (IRD).
+///
+/// Stores per-fetch status information written by the driver.
+/// A pointer to this struct is returned as the descriptor handle via
+/// `SQLGetStmtAttr(SQL_ATTR_IMP_ROW_DESC)`.
+#[repr(C)]
+pub struct IrdDescriptor {
+    kind: DescriptorKind,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` / `SQL_ATTR_ROW_STATUS_PTR` — default null.
+    pub array_status_ptr: *mut u16,
+    /// `SQL_DESC_ROWS_PROCESSED_PTR` / `SQL_ATTR_ROWS_FETCHED_PTR` — default null.
+    pub rows_processed_ptr: *mut sql::ULen,
+}
+
+impl Default for IrdDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IrdDescriptor {
+    pub fn new() -> Self {
+        Self {
+            kind: DescriptorKind::Ird,
+            array_status_ptr: std::ptr::null_mut(),
+            rows_processed_ptr: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// A resolved descriptor reference returned by `desc_ref_from_handle`.
+pub enum DescriptorRef<'a> {
+    Ard(&'a mut ArdDescriptor),
+    Ird(&'a mut IrdDescriptor),
+}
+
+/// Convert a descriptor handle (returned by `SQLGetStmtAttr`) back to a
+/// typed `DescriptorRef` by reading the `DescriptorKind` tag at offset 0.
+pub fn desc_ref_from_handle<'a>(handle: sql::Handle) -> OdbcResult<DescriptorRef<'a>> {
+    if handle.is_null() {
         return Err(OdbcError::InvalidHandle {
             location: snafu::location!(),
         });
     }
-    // SAFETY: We have checked that `desc_ptr` is not null. The caller is responsible
-    // for ensuring that `handle` actually points to a valid `ArdDescriptor`.
-    unsafe { Ok(&mut *desc_ptr) }
+    // Read the raw discriminant byte at offset 0 and validate before
+    // interpreting it as a DescriptorKind enum to avoid UB on corrupt handles.
+    let raw_kind = unsafe { *(handle as *const u8) };
+    let kind = DescriptorKind::try_from(raw_kind)?;
+    match raw_kind {
+        1 => {
+            let desc = unsafe { &mut *(handle as *mut ArdDescriptor) };
+            Ok(DescriptorRef::Ard(desc))
+        }
+        2 => {
+            let desc = unsafe { &mut *(handle as *mut IrdDescriptor) };
+            Ok(DescriptorRef::Ird(desc))
+        }
+        _ => {
+            tracing::error!(
+                "desc_ref_from_handle: invalid descriptor kind tag {}",
+                raw_kind
+            );
+            Err(OdbcError::InvalidHandle {
+                location: snafu::location!(),
+            })
+        }
+    }
 }
 
 /// Result type for ODBC operations
@@ -427,6 +555,7 @@ pub struct Statement<'a> {
     pub state: State<StatementState>,
     pub parameter_bindings: HashMap<u16, ParameterBinding>,
     pub ard: ArdDescriptor,
+    pub ird: IrdDescriptor,
     pub diagnostic_info: DiagnosticInfo,
     pub get_data_state: Option<GetDataState>,
 }

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -279,7 +279,7 @@ pub struct ArdDescriptor {
     /// `SQL_DESC_ARRAY_SIZE` / `SQL_ATTR_ROW_ARRAY_SIZE` — default 1.
     pub array_size: usize,
     /// `SQL_DESC_BIND_TYPE` / `SQL_ATTR_ROW_BIND_TYPE` — 0 = column-wise (default).
-    pub bind_type: usize,
+    pub bind_type: sql::ULen,
     /// `SQL_DESC_BIND_OFFSET_PTR` / `SQL_ATTR_ROW_BIND_OFFSET_PTR` — default null.
     pub bind_offset_ptr: *mut sql::Len,
 }
@@ -367,23 +367,14 @@ pub fn desc_ref_from_handle<'a>(handle: sql::Handle) -> OdbcResult<DescriptorRef
     // interpreting it as a DescriptorKind enum to avoid UB on corrupt handles.
     let raw_kind = unsafe { *(handle as *const u8) };
     let kind = DescriptorKind::try_from(raw_kind)?;
-    match raw_kind {
-        1 => {
+    match kind {
+        DescriptorKind::Ard => {
             let desc = unsafe { &mut *(handle as *mut ArdDescriptor) };
             Ok(DescriptorRef::Ard(desc))
         }
-        2 => {
+        DescriptorKind::Ird => {
             let desc = unsafe { &mut *(handle as *mut IrdDescriptor) };
             Ok(DescriptorRef::Ird(desc))
-        }
-        _ => {
-            tracing::error!(
-                "desc_ref_from_handle: invalid descriptor kind tag {}",
-                raw_kind
-            );
-            Err(OdbcError::InvalidHandle {
-                location: snafu::location!(),
-            })
         }
     }
 }

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -228,8 +228,29 @@ pub unsafe extern "C" fn SQLDisconnect(connection_handle: sql::Handle) -> sql::R
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFetch(statement_handle: sql::Handle) -> sql::RetCode {
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
     let mut warnings = vec![];
     let result = api::data::fetch(statement_handle, &mut warnings);
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code_with_warnings(&warnings)
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLFetchScroll(
+    statement_handle: sql::Handle,
+    fetch_orientation: sql::SmallInt,
+    _fetch_offset: sql::Len,
+) -> sql::RetCode {
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let mut warnings = vec![];
+    let result = api::data::fetch_scroll(statement_handle, fetch_orientation, &mut warnings);
     api::diagnostic::set_diag_info_from_warnings(
         sql::HandleType::Stmt,
         statement_handle,

--- a/odbc/src/cdata_types.rs
+++ b/odbc/src/cdata_types.rs
@@ -108,6 +108,42 @@ pub enum CDataType {
     SsTimestampOffset = C_TYPES_EXTENDED + 1,
 }
 
+impl CDataType {
+    /// Returns the byte size of fixed-length C data types, or `None` for
+    /// variable-length types (CHAR, WCHAR, BINARY).
+    pub fn fixed_size(&self) -> Option<usize> {
+        match self {
+            CDataType::Bit | CDataType::TinyInt | CDataType::STinyInt | CDataType::UTinyInt => {
+                Some(1)
+            }
+            CDataType::Short | CDataType::SShort | CDataType::UShort => Some(2),
+            CDataType::Long | CDataType::SLong | CDataType::ULong | CDataType::Float => Some(4),
+            CDataType::Double | CDataType::SBigInt | CDataType::UBigInt => Some(8),
+            CDataType::Numeric => Some(std::mem::size_of::<sql::Numeric>()),
+            CDataType::TypeDate | CDataType::Date => Some(std::mem::size_of::<sql::Date>()),
+            CDataType::TypeTimestamp | CDataType::TimeStamp => {
+                Some(std::mem::size_of::<sql::Timestamp>())
+            }
+            CDataType::TypeTime | CDataType::Time => Some(std::mem::size_of::<sql::Time>()),
+            CDataType::Guid => Some(16),
+            CDataType::IntervalYear
+            | CDataType::IntervalMonth
+            | CDataType::IntervalDay
+            | CDataType::IntervalHour
+            | CDataType::IntervalMinute
+            | CDataType::IntervalSecond
+            | CDataType::IntervalYearToMonth
+            | CDataType::IntervalDayToHour
+            | CDataType::IntervalDayToMinute
+            | CDataType::IntervalDayToSecond
+            | CDataType::IntervalHourToMinute
+            | CDataType::IntervalHourToSecond
+            | CDataType::IntervalMinuteToSecond => Some(std::mem::size_of::<sql::IntervalStruct>()),
+            _ => None,
+        }
+    }
+}
+
 impl TryFrom<i16> for CDataType {
     type Error = i16;
 

--- a/odbc/src/conversion/warning.rs
+++ b/odbc/src/conversion/warning.rs
@@ -4,4 +4,5 @@ pub type Warnings = Vec<Warning>;
 pub enum Warning {
     StringDataTruncated,
     NumericValueTruncated,
+    RowError,
 }

--- a/odbc_tests/tests/e2e/query/sql_bind_col.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_col.cpp
@@ -1203,7 +1203,6 @@ TEST_CASE("SQLBindCol sets ARD descriptor fields for multiple columns.", "[query
 // =============================================================================
 
 TEST_CASE("SQLBindCol supports column-wise binding with arrays.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "In column-wise binding, the application binds separate data and
   //       length/indicator arrays to each column."
   // Doc: "To use column-wise binding, the application first sets the
@@ -1249,7 +1248,6 @@ TEST_CASE("SQLBindCol supports column-wise binding with arrays.", "[query][bind_
 // =============================================================================
 
 TEST_CASE("SQLBindCol supports row-wise binding.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "In row-wise binding, the application defines a structure that contains
   //       data and length/indicator buffers for each column to be bound."
   // Doc: "Sets the SQL_ATTR_ROW_BIND_TYPE statement attribute to the size of the
@@ -1307,7 +1305,6 @@ TEST_CASE("SQLBindCol supports row-wise binding.", "[query][bind_col]") {
 // =============================================================================
 
 TEST_CASE("SQLBindCol supports binding offsets via SQL_ATTR_ROW_BIND_OFFSET_PTR.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "Using a binding offset has basically the same effect as rebinding a
   //       column by calling SQLBindCol. The difference is that a new call to
   //       SQLBindCol specifies new addresses for the data buffer and
@@ -1358,7 +1355,6 @@ TEST_CASE("SQLBindCol supports binding offsets via SQL_ATTR_ROW_BIND_OFFSET_PTR.
 }
 
 TEST_CASE("SQLBindCol binding offset of 0 uses originally bound addresses.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "In particular, if the offset is set to 0 or if the statement attribute
   //       is set to a null pointer, the driver uses the originally bound
   //       addresses."
@@ -1395,7 +1391,6 @@ TEST_CASE("SQLBindCol binding offset of 0 uses originally bound addresses.", "[q
 // =============================================================================
 
 TEST_CASE("SQLBindCol binds arrays when SQL_ATTR_ROW_ARRAY_SIZE > 1.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "If the rowset size (the value of the SQL_ATTR_ROW_ARRAY_SIZE statement
   //       attribute) is greater than 1, the application binds arrays of buffers
   //       instead of single buffers."
@@ -2117,7 +2112,6 @@ TEST_CASE("SQLBindCol supports SQL_C_NUMERIC binding.", "[query][bind_col]") {
 // =============================================================================
 
 TEST_CASE("SQLBindCol works with SQLFetchScroll.", "[query][bind_col]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "SQLBindCol is used to associate, or bind, columns in the result set
   //       to data buffers and length/indicator buffers in the application.
   //       When the application calls SQLFetch, SQLFetchScroll, or SQLSetPos to

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -29,7 +29,6 @@ TEST_CASE("SQLFetch fetches a row from SELECT query", "[query]") {
 }
 
 TEST_CASE("SQLFetch returns data about number of rows affected.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -102,7 +101,6 @@ TEST_CASE("SQLSetStmtAttr sets supported cursor types.") {
 }
 
 TEST_CASE("SQLFetch can be mixed with SQLFetchScroll.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -133,7 +131,6 @@ TEST_CASE("SQLFetch can be mixed with SQLFetchScroll.") {
 }
 
 TEST_CASE("SQLFetch returns multiple rows when SQL_ATTR_ROW_ARRAY_SIZE is set.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -178,7 +175,6 @@ TEST_CASE("SQLFetch returns multiple rows when SQL_ATTR_ROW_ARRAY_SIZE is set.")
 }
 
 TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_SUCCESS for successfully fetched rows.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -221,7 +217,6 @@ TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_SUCCESS for successfully fetc
 }
 
 TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_SUCCESS_WITH_INFO when data is truncated.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -262,7 +257,6 @@ TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_SUCCESS_WITH_INFO when data i
 }
 
 TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_ERROR when conversion error occurs.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -298,7 +292,6 @@ TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_ERROR when conversion error o
 }
 
 TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_NOROW when rowset overlaps end of result set.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -352,7 +345,6 @@ TEST_CASE("SQL_ATTR_ROW_STATUS_PTR returns SQL_ROW_NOROW when rowset overlaps en
 // =============================================================================
 
 TEST_CASE("SQLFetch respects SQL_DESC_ARRAY_SIZE set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -392,7 +384,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_ARRAY_SIZE set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_ARRAY_STATUS_PTR set on IRD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -433,7 +424,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_ARRAY_STATUS_PTR set on IRD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_BIND_OFFSET_PTR set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -481,7 +471,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_BIND_OFFSET_PTR set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_BIND_TYPE set on ARD for row-wise binding.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -724,7 +713,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_OCTET_LENGTH_PTR set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_ROWS_PROCESSED_PTR set on IRD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -793,7 +781,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_TYPE set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects multiple ARD descriptor fields set together.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -860,7 +847,6 @@ TEST_CASE("SQLFetch respects multiple ARD descriptor fields set together.") {
 }
 
 TEST_CASE("SQLFetch respects both ARD and IRD descriptor fields.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -1199,7 +1185,6 @@ TEST_CASE("SQLFetch cannot be called after SQLExtendedFetch without SQLFreeStmt.
 }
 
 TEST_CASE("SQLGetDiagField returns correct row and column number on fetch error.", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -1256,7 +1241,6 @@ TEST_CASE("SQLGetDiagField returns correct row and column number on fetch error.
 }
 
 TEST_CASE("SQLFetch returns SQL_SUCCESS_WITH_INFO when error occurs on subset of rows in block cursor.", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/query/sql_get_data.cpp
+++ b/odbc_tests/tests/e2e/query/sql_get_data.cpp
@@ -107,7 +107,6 @@ TEST_CASE("SQLGetData can only be called after rows have been fetched.", "[query
 }
 
 TEST_CASE("SQLGetData can retrieve data after SQLFetchScroll.", "[query][get_data]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "SQLGetData can be called only after one or more rows have been fetched from
   //       the result set by SQLFetch, SQLFetchScroll, or SQLExtendedFetch."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function#comments
@@ -1210,7 +1209,6 @@ TEST_CASE("SQLGetData returns SQL_SUCCESS on the last part of truncated data.", 
 // =============================================================================
 
 TEST_CASE("SQLGetData cannot be called when SQL_ATTR_ROW_ARRAY_SIZE is set and SQL_GD_BLOCK is not supported.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "If no extensions are supported, SQLGetData cannot be called if the
   //       rowset size is greater than 1."
   // Doc: "SQL_GD_BLOCK. If this option is returned by SQLGetInfo for the
@@ -1559,7 +1557,6 @@ TEST_CASE("SQLGetData on a bound column when SQL_GD_BOUND is supported.", "[quer
 // =============================================================================
 
 TEST_CASE("SQLGetData can be mixed with SQLFetch and SQLFetchScroll calls.", "[query][get_data]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Doc: "SQLGetData can be called only after one or more rows have been fetched
   //       from the result set by SQLFetch, SQLFetchScroll, or SQLExtendedFetch."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function#comments


### PR DESCRIPTION
This PR enables next batch of tests for SQLFetch and SQLBindCol:  
\- It implements multirow fetch (fetching multiple rows with SQL_ATTR_ROW_ARRAY_SIZE)  
   - Reading those rows using SQLBindCol  
   - Using multiple bind types: row or column wise bindings  
\- It implements or improves setter and getter functions required by testing scenarios: SQLSetStmtAttr, SQLGetDescField etc.