### PR TITLE
Split str_len_or_ind into octet_length and inidicator

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -224,14 +224,39 @@ fn write_row_status(row_status_ptr: *mut u16, row_idx: usize, status: RowStatus)
     }
 }
 
-/// Compute the data stride (in bytes) between successive rows for a column
-/// when using column-wise binding.
-fn column_wise_data_stride(binding: &Binding) -> usize {
-    if binding.buffer_length > 0 {
-        binding.buffer_length as usize
+fn value_stride(binding: &Binding, bind_type: usize) -> usize {
+    if bind_type == 0 {
+        binding
+            .target_type
+            .fixed_size()
+            .unwrap_or(binding.buffer_length as usize)
     } else {
-        binding.target_type.fixed_size().unwrap_or(8)
+        bind_type
     }
+}
+
+fn indicator_or_length_stride(bind_type: usize) -> usize {
+    if bind_type == 0 {
+        std::mem::size_of::<sql::Len>()
+    } else {
+        bind_type
+    }
+}
+
+fn advance_by_element_stride<T>(
+    ptr: *mut T,
+    row_idx: usize,
+    element_stride: usize,
+    bind_offset: isize,
+) -> *mut T {
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    let stride = row_idx
+        .checked_mul(element_stride)
+        .expect("row index and element stride multiplication overflowed");
+    let byte_ptr = ptr as *mut u8;
+    unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T }
 }
 
 /// Create an adjusted `Binding` whose pointers target `row_idx` within the
@@ -243,67 +268,27 @@ fn adjust_binding_for_row(
     bind_type: usize,
     bind_offset: isize,
 ) -> Binding {
-    if row_idx == 0 && bind_offset == 0 {
-        return Binding {
-            target_type: binding.target_type,
-            target_value_ptr: binding.target_value_ptr,
-            buffer_length: binding.buffer_length,
-            str_len_or_ind_ptr: binding.str_len_or_ind_ptr,
-            precision: binding.precision,
-            scale: binding.scale,
-        };
-    }
-
-    let (data_ptr, ind_ptr) = if bind_type == 0 {
-        let stride = column_wise_data_stride(binding);
-        let row_offset = row_idx
-            .checked_mul(stride)
-            .expect("row index and stride multiplication overflowed");
-        let data_ptr = unsafe {
-            (binding.target_value_ptr as *mut u8)
-                .offset(bind_offset)
-                .add(row_offset) as sql::Pointer
-        };
-        let ind_ptr = if !binding.str_len_or_ind_ptr.is_null() {
-            let ind_stride = std::mem::size_of::<sql::Len>();
-            let ind_offset = row_idx
-                .checked_mul(ind_stride)
-                .expect("row index and indicator stride multiplication overflowed");
-            unsafe {
-                (binding.str_len_or_ind_ptr as *mut u8)
-                    .offset(bind_offset)
-                    .add(ind_offset) as *mut sql::Len
-            }
-        } else {
-            std::ptr::null_mut()
-        };
-        (data_ptr, ind_ptr)
-    } else {
-        let row_byte_offset = row_idx
-            .checked_mul(bind_type)
-            .expect("row index and bind type multiplication overflowed");
-        let data_ptr = unsafe {
-            (binding.target_value_ptr as *mut u8)
-                .offset(bind_offset)
-                .add(row_byte_offset) as sql::Pointer
-        };
-        let ind_ptr = if !binding.str_len_or_ind_ptr.is_null() {
-            unsafe {
-                (binding.str_len_or_ind_ptr as *mut u8)
-                    .offset(bind_offset)
-                    .add(row_byte_offset) as *mut sql::Len
-            }
-        } else {
-            std::ptr::null_mut()
-        };
-        (data_ptr, ind_ptr)
-    };
-
     Binding {
         target_type: binding.target_type,
-        target_value_ptr: data_ptr,
+        target_value_ptr: advance_by_element_stride(
+            binding.target_value_ptr,
+            row_idx,
+            value_stride(binding, bind_type),
+            bind_offset,
+        ),
         buffer_length: binding.buffer_length,
-        str_len_or_ind_ptr: ind_ptr,
+        octet_length_ptr: advance_by_element_stride(
+            binding.octet_length_ptr,
+            row_idx,
+            indicator_or_length_stride(bind_type),
+            bind_offset,
+        ),
+        indicator_ptr: advance_by_element_stride(
+            binding.indicator_ptr,
+            row_idx,
+            indicator_or_length_stride(bind_type),
+            bind_offset,
+        ),
         precision: binding.precision,
         scale: binding.scale,
     }
@@ -448,9 +433,9 @@ pub fn get_data(
                 target_type,
                 target_value_ptr,
                 buffer_length,
-                str_len_or_ind_ptr,
-                precision: None,
-                scale: None,
+                octet_length_ptr: str_len_or_ind_ptr,
+                indicator_ptr: str_len_or_ind_ptr,
+                ..Default::default()
             };
             let conversion_warnings =
                 read_arrow_value(&binding, array_ref, field, *batch_idx, &mut offset)
@@ -545,9 +530,8 @@ mod tests {
                 target_type: CDataType::Char,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: buffer.len() as sql::Len,
-                str_len_or_ind_ptr: &mut str_len,
-                precision: None,
-                scale: None,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -567,9 +551,8 @@ mod tests {
                 target_type: CDataType::Char,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: buffer.len() as sql::Len,
-                str_len_or_ind_ptr: &mut str_len,
-                precision: None,
-                scale: None,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -589,14 +572,13 @@ mod tests {
                 target_type: CDataType::Char,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: buffer.len() as sql::Len,
-                str_len_or_ind_ptr: &mut str_len,
-                precision: None,
-                scale: None,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
             assert!(result.is_ok());
-            assert_eq!(str_len, sql::NO_TOTAL); // SQL_NO_TOTAL when truncated
+            assert_eq!(str_len, 11); // total character count of "hello world"
             assert_eq!(&buffer[..4], b"hell"); // Truncated with null terminator at position 4
             assert_eq!(buffer[4], 0); // Null terminator
         }
@@ -616,9 +598,8 @@ mod tests {
                 target_type: CDataType::UBigInt,
                 target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -636,9 +617,8 @@ mod tests {
                 target_type: CDataType::UBigInt,
                 target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -658,9 +638,8 @@ mod tests {
                 target_type: CDataType::UBigInt,
                 target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -683,9 +662,8 @@ mod tests {
                 target_type: CDataType::SBigInt,
                 target_value_ptr: &mut value as *mut SBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -703,9 +681,8 @@ mod tests {
                 target_type: CDataType::SBigInt,
                 target_value_ptr: &mut value as *mut SBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -728,9 +705,8 @@ mod tests {
                 target_type: CDataType::Long,
                 target_value_ptr: &mut value as *mut sql::Integer as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -748,9 +724,8 @@ mod tests {
                 target_type: CDataType::SLong,
                 target_value_ptr: &mut value as *mut sql::Integer as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -773,9 +748,8 @@ mod tests {
                 target_type: CDataType::ULong,
                 target_value_ptr: &mut value as *mut sql::UInteger as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -798,9 +772,8 @@ mod tests {
                 target_type: CDataType::Short,
                 target_value_ptr: &mut value as *mut sql::SmallInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -818,9 +791,8 @@ mod tests {
                 target_type: CDataType::SShort,
                 target_value_ptr: &mut value as *mut sql::SmallInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -843,9 +815,8 @@ mod tests {
                 target_type: CDataType::UShort,
                 target_value_ptr: &mut value as *mut sql::USmallInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -868,9 +839,8 @@ mod tests {
                 target_type: CDataType::TinyInt,
                 target_value_ptr: &mut value as *mut sql::SChar as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -888,9 +858,8 @@ mod tests {
                 target_type: CDataType::STinyInt,
                 target_value_ptr: &mut value as *mut sql::SChar as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -913,9 +882,8 @@ mod tests {
                 target_type: CDataType::UTinyInt,
                 target_value_ptr: &mut value as *mut sql::Char as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -938,9 +906,8 @@ mod tests {
                 target_type: CDataType::Float,
                 target_value_ptr: &mut value as *mut Real as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -963,9 +930,8 @@ mod tests {
                 target_type: CDataType::Double,
                 target_value_ptr: &mut value as *mut Double as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -985,9 +951,8 @@ mod tests {
                 target_type: CDataType::Double,
                 target_value_ptr: &mut value as *mut Double as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -1010,9 +975,8 @@ mod tests {
                 target_type: CDataType::Binary, // Unsupported
                 target_value_ptr: &mut value as *mut i64 as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(),
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -1033,9 +997,8 @@ mod tests {
                 target_type: CDataType::WChar,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: (buffer.len() * 2) as sql::Len, // buffer_length is in bytes for WChar
-                str_len_or_ind_ptr: &mut str_len,
-                precision: None,
-                scale: None,
+                octet_length_ptr: &mut str_len,
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -1071,9 +1034,8 @@ mod tests {
                     target_type: CDataType::UBigInt,
                     target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                     buffer_length: 0,
-                    str_len_or_ind_ptr: std::ptr::null_mut(),
-                    precision: None,
-                    scale: None,
+                    octet_length_ptr: std::ptr::null_mut(),
+                    ..Default::default()
                 };
                 let result = read_arrow_value(&binding, &array, &field, idx, &mut None);
 
@@ -1095,9 +1057,8 @@ mod tests {
                     target_type: CDataType::Char,
                     target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                     buffer_length: buffer.len() as sql::Len,
-                    str_len_or_ind_ptr: &mut str_len,
-                    precision: None,
-                    scale: None,
+                    octet_length_ptr: &mut str_len,
+                    ..Default::default()
                 };
                 let result = read_arrow_value(&binding, &array, &field, idx, &mut None);
 
@@ -1108,7 +1069,7 @@ mod tests {
         }
     }
 
-    // Tests for null str_len_or_ind_ptr
+    // Tests for null octet_length_ptr
     mod null_indicator_tests {
         use super::*;
 
@@ -1122,9 +1083,8 @@ mod tests {
                 target_type: CDataType::UBigInt,
                 target_value_ptr: &mut value as *mut UBigInt as sql::Pointer,
                 buffer_length: 0,
-                str_len_or_ind_ptr: std::ptr::null_mut(), // null indicator
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(), // null indicator
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -1142,9 +1102,8 @@ mod tests {
                 target_type: CDataType::Char,
                 target_value_ptr: buffer.as_mut_ptr() as sql::Pointer,
                 buffer_length: buffer.len() as sql::Len,
-                str_len_or_ind_ptr: std::ptr::null_mut(), // null indicator
-                precision: None,
-                scale: None,
+                octet_length_ptr: std::ptr::null_mut(), // null indicator
+                ..Default::default()
             };
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
 
@@ -1171,9 +1130,10 @@ mod tests {
                 target_type: CDataType::Numeric,
                 target_value_ptr: &mut numeric as *mut sql::Numeric as sql::Pointer,
                 buffer_length: std::mem::size_of::<sql::Numeric>() as sql::Len,
-                str_len_or_ind_ptr: &mut indicator,
+                octet_length_ptr: &mut indicator,
                 precision: Some(10),
                 scale: Some(2),
+                ..Default::default()
             };
 
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
@@ -1201,9 +1161,10 @@ mod tests {
                 target_type: CDataType::Numeric,
                 target_value_ptr: &mut numeric as *mut sql::Numeric as sql::Pointer,
                 buffer_length: std::mem::size_of::<sql::Numeric>() as sql::Len,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
+                octet_length_ptr: std::ptr::null_mut(),
                 precision: Some(5),
                 scale: Some(0),
+                ..Default::default()
             };
 
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
@@ -1234,9 +1195,10 @@ mod tests {
                 target_type: CDataType::Numeric,
                 target_value_ptr: &mut numeric as *mut sql::Numeric as sql::Pointer,
                 buffer_length: std::mem::size_of::<sql::Numeric>() as sql::Len,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
+                octet_length_ptr: std::ptr::null_mut(),
                 precision: Some(10),
                 scale: Some(4),
+                ..Default::default()
             };
 
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);
@@ -1264,9 +1226,10 @@ mod tests {
                 target_type: CDataType::Numeric,
                 target_value_ptr: &mut numeric as *mut sql::Numeric as sql::Pointer,
                 buffer_length: std::mem::size_of::<sql::Numeric>() as sql::Len,
-                str_len_or_ind_ptr: std::ptr::null_mut(),
+                octet_length_ptr: std::ptr::null_mut(),
                 precision: None, // not set
                 scale: Some(0),
+                ..Default::default()
             };
 
             let result = read_arrow_value(&binding, &array, &field, 0, &mut None);

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1,6 +1,6 @@
 use crate::api::error::{
-    ConversionSnafu, DataNotFetchedSnafu, ExecutionDoneSnafu, FetchDataSnafu,
-    InvalidBufferLengthSnafu, InvalidCursorPositionSnafu, InvalidCursorStateSnafu,
+    ConversionSnafu, DataNotFetchedSnafu, ExecutionDoneSnafu, ExtendedFetchUsedSnafu,
+    FetchDataSnafu, InvalidBufferLengthSnafu, InvalidCursorPositionSnafu, InvalidCursorStateSnafu,
     InvalidDescriptorIndexSnafu, NoMoreDataSnafu, NullPointerSnafu, StatementErrorStateSnafu,
     StatementNotExecutedSnafu, UnsupportedFeatureSnafu,
 };
@@ -106,6 +106,16 @@ fn advance_cursor(state: &mut crate::api::State<StatementState>) -> OdbcResult<(
 pub fn fetch(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcResult<()> {
     tracing::debug!("fetch called");
     let stmt = stmt_from_handle(statement_handle);
+
+    if stmt.extended_fetch_used {
+        return ExtendedFetchUsedSnafu.fail();
+    }
+
+    fetch_inner(stmt, warnings)
+}
+
+/// Core fetch logic shared by `fetch` and `extended_fetch`.
+fn fetch_inner(stmt: &mut Statement, warnings: &mut Warnings) -> OdbcResult<()> {
     stmt.get_data_state = None;
 
     let array_size = stmt.ard.array_size.max(1);
@@ -216,6 +226,46 @@ pub fn fetch_scroll(
         return UnsupportedFeatureSnafu.fail();
     }
     fetch(statement_handle, warnings)
+}
+
+/// `SQLExtendedFetch` — deprecated ODBC 2.x function. Only `SQL_FETCH_NEXT` is
+/// supported. Sets `extended_fetch_used` so that subsequent `SQLFetch` calls
+/// return HY010 until the cursor is closed with `SQLFreeStmt(SQL_CLOSE)`.
+pub fn extended_fetch(
+    statement_handle: sql::Handle,
+    fetch_orientation: sql::SmallInt,
+    row_count_ptr: *mut sql::ULen,
+    row_status_ptr: *mut sql::USmallInt,
+    warnings: &mut Warnings,
+) -> OdbcResult<()> {
+    tracing::debug!("extended_fetch called");
+    if fetch_orientation != SQL_FETCH_NEXT {
+        tracing::warn!(
+            "extended_fetch: unsupported orientation {}",
+            fetch_orientation
+        );
+        return UnsupportedFeatureSnafu.fail();
+    }
+
+    let stmt = stmt_from_handle(statement_handle);
+    stmt.extended_fetch_used = true;
+
+    let saved_row_status = stmt.ird.array_status_ptr;
+    let saved_rows_fetched = stmt.ird.rows_processed_ptr;
+
+    if !row_status_ptr.is_null() {
+        stmt.ird.array_status_ptr = row_status_ptr;
+    }
+    if !row_count_ptr.is_null() {
+        stmt.ird.rows_processed_ptr = row_count_ptr;
+    }
+
+    let result = fetch_inner(stmt, warnings);
+
+    stmt.ird.array_status_ptr = saved_row_status;
+    stmt.ird.rows_processed_ptr = saved_rows_fetched;
+
+    result
 }
 
 fn write_row_status(row_status_ptr: *mut u16, row_idx: usize, status: RowStatus) {

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -129,11 +129,20 @@ fn get_ard_field(
                 }
                 Ok(())
             }
-            DescField::IndicatorPtr | DescField::OctetLengthPtr => {
+            DescField::IndicatorPtr => {
                 unsafe {
                     std::ptr::write_unaligned(
                         value_ptr as *mut *mut sql::Len,
-                        binding.str_len_or_ind_ptr,
+                        binding.indicator_ptr,
+                    );
+                }
+                Ok(())
+            }
+            DescField::OctetLengthPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::Len,
+                        binding.octet_length_ptr,
                     );
                 }
                 Ok(())
@@ -344,7 +353,7 @@ fn set_ard_field(
                 let ptr = value_ptr as *mut sql::Len;
                 tracing::debug!("set_desc_field: setting indicator_ptr on record {column_number}");
                 let binding = desc.bindings.entry(column_number).or_default();
-                binding.str_len_or_ind_ptr = ptr;
+                binding.indicator_ptr = ptr;
                 Ok(())
             }
             DescField::OctetLengthPtr => {
@@ -353,7 +362,7 @@ fn set_ard_field(
                     "set_desc_field: setting octet_length_ptr on record {column_number}"
                 );
                 let binding = desc.bindings.entry(column_number).or_default();
-                binding.str_len_or_ind_ptr = ptr;
+                binding.octet_length_ptr = ptr;
                 Ok(())
             }
             _ => {

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -225,11 +225,13 @@ pub fn from_warning(warning: &Warning) -> DiagnosticRecord {
         Warning::StringDataTruncated => "String data truncated",
         Warning::NumericValueTruncated => "Numeric value truncated",
         Warning::RowError => "Error in row",
+        Warning::OptionValueChanged => "Option value changed",
     };
     let sql_state = match warning {
         Warning::StringDataTruncated => SqlState::StringDataRightTruncated,
         Warning::NumericValueTruncated => SqlState::FractionalTruncation,
         Warning::RowError => SqlState::ErrorInRow,
+        Warning::OptionValueChanged => SqlState::OptionValueChanged,
     };
     DiagnosticRecord {
         native_error: 0,

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -180,6 +180,12 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("SQLFetch cannot be mixed with SQLExtendedFetch without closing cursor"))]
+    ExtendedFetchUsed {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to parse port '{port}'"))]
     InvalidPort {
         port: String,
@@ -372,6 +378,7 @@ impl OdbcError {
             OdbcError::NoMoreData { .. } => SqlState::NoDataFound,
             OdbcError::InvalidCursorPosition { .. } => SqlState::InvalidCursorPosition,
             OdbcError::UnsupportedFeature { .. } => SqlState::OptionalFeatureNotImplemented,
+            OdbcError::ExtendedFetchUsed { .. } => SqlState::FunctionSequenceError,
             OdbcError::InvalidPort { .. } => SqlState::InvalidConnectionStringAttribute,
             OdbcError::SetSqlQuery { .. } => SqlState::SyntaxErrorOrAccessRuleViolation,
             OdbcError::PrepareStatement { .. } => SqlState::SyntaxErrorOrAccessRuleViolation,

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -405,11 +405,17 @@ impl OdbcError {
             OdbcError::TextConversionFromUtf16 { .. } => SqlState::StringDataRightTruncated,
             OdbcError::ArrowBinding { .. } => SqlState::GeneralError,
             OdbcError::CoreError {
-                source: CoreProtobufError::Application { error, .. },
+                source: CoreProtobufError::Application { error, message, .. },
                 ..
             } => match error.as_ref() {
                 ErrorType::AuthError(_) => SqlState::InvalidAuthorizationSpecification,
-                ErrorType::GenericError(_) => SqlState::GeneralError,
+                ErrorType::GenericError(_) => {
+                    if message.contains("SQL compilation error") {
+                        SqlState::SyntaxErrorOrAccessRuleViolation
+                    } else {
+                        SqlState::GeneralError
+                    }
+                }
                 ErrorType::InvalidParameterValue(ProtoInvalidParameterValue {
                     parameter, ..
                 }) => {
@@ -426,7 +432,13 @@ impl OdbcError {
                         SqlState::InvalidConnectionStringAttribute
                     }
                 }
-                ErrorType::InternalError(_) => SqlState::GeneralError,
+                ErrorType::InternalError(_) => {
+                    if message.contains("SQL compilation error") {
+                        SqlState::SyntaxErrorOrAccessRuleViolation
+                    } else {
+                        SqlState::GeneralError
+                    }
+                }
                 ErrorType::LoginError(_) => SqlState::InvalidAuthorizationSpecification,
             },
             OdbcError::CoreError { source, .. } => match source {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -57,6 +57,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement<'
                 get_data_state: None,
                 cursor_type: crate::api::CursorType::ForwardOnly,
                 max_length: 0,
+                extended_fetch_used: false,
             });
             Ok(Box::into_raw(stmt))
         }

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -55,6 +55,8 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement<'
                 ird: IrdDescriptor::new(),
                 diagnostic_info: DiagnosticInfo::default(),
                 get_data_state: None,
+                cursor_type: crate::api::CursorType::ForwardOnly,
+                max_length: 0,
             });
             Ok(Box::into_raw(stmt))
         }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -269,6 +269,7 @@ pub fn free_stmt(statement_handle: sql::Handle, option: sql::FreeStmtOption) -> 
             tracing::info!("free_stmt: Closing cursor");
             stmt.state = StatementState::Created.into();
             stmt.get_data_state = None;
+            stmt.extended_fetch_used = false;
         }
         sql::FreeStmtOption::Unbind => {
             tracing::info!("free_stmt: Unbinding all columns");

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -312,7 +312,8 @@ pub fn bind_col(
                 target_type,
                 target_value_ptr,
                 buffer_length,
-                str_len_or_ind_ptr,
+                octet_length_ptr: str_len_or_ind_ptr,
+                indicator_ptr: str_len_or_ind_ptr,
                 precision: None,
                 scale: None,
             },
@@ -327,8 +328,10 @@ pub fn set_stmt_attr(
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
     _string_length: sql::Integer,
+    warnings: &mut crate::conversion::warning::Warnings,
 ) -> OdbcResult<()> {
-    use crate::api::StmtAttr;
+    use crate::api::{CursorType, StmtAttr};
+    use crate::conversion::warning::Warning;
 
     tracing::debug!(
         "set_stmt_attr: statement_handle={:?}, attribute={}, value_ptr={:?}",
@@ -341,6 +344,24 @@ pub fn set_stmt_attr(
     let stmt = stmt_from_handle(statement_handle);
 
     match attr {
+        StmtAttr::CursorType => {
+            let raw = value_ptr as sql::ULen;
+            let requested = CursorType::try_from(raw)?;
+            tracing::debug!("set_stmt_attr: CursorType requested = {requested:?}");
+            if requested != CursorType::ForwardOnly {
+                stmt.cursor_type = CursorType::ForwardOnly;
+                warnings.push(Warning::OptionValueChanged);
+            } else {
+                stmt.cursor_type = CursorType::ForwardOnly;
+            }
+            Ok(())
+        }
+        StmtAttr::MaxLength => {
+            let length = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: MaxLength = {}", length);
+            stmt.max_length = length;
+            Ok(())
+        }
         StmtAttr::UseBookmarks => {
             tracing::debug!("set_stmt_attr: UseBookmarks (ignored, bookmarks not supported)");
             Ok(())
@@ -408,6 +429,30 @@ pub fn get_stmt_attr(
     let stmt = stmt_from_handle(statement_handle);
 
     match attr {
+        StmtAttr::CursorType => {
+            unsafe {
+                std::ptr::write_unaligned(
+                    value_ptr as *mut sql::ULen,
+                    stmt.cursor_type as sql::ULen,
+                );
+                if !string_length_ptr.is_null() {
+                    std::ptr::write_unaligned(
+                        string_length_ptr,
+                        std::mem::size_of::<sql::ULen>() as sql::Integer,
+                    );
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::MaxLength => {
+            unsafe {
+                *(value_ptr as *mut sql::ULen) = stmt.max_length;
+                if !string_length_ptr.is_null() {
+                    *string_length_ptr = std::mem::size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
         StmtAttr::AppRowDesc => {
             let ard_ptr = &mut stmt.ard as *mut crate::api::ArdDescriptor as sql::Handle;
             unsafe {

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -593,6 +593,9 @@ pub struct Statement<'a> {
     pub cursor_type: CursorType,
     /// `SQL_ATTR_MAX_LENGTH` — default 0 (no limit). Stored but not enforced.
     pub max_length: sql::ULen,
+    /// Set to `true` after `SQLExtendedFetch` is called. While set, `SQLFetch`
+    /// must return HY010 (function sequence error). Cleared by `SQLFreeStmt(SQL_CLOSE)`.
+    pub extended_fetch_used: bool,
 }
 
 // Helper functions for handle conversion

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -127,13 +127,51 @@ impl Bitmask for GetDataExtensions {
     }
 }
 
+/// ODBC cursor type values (matching `SQL_CURSOR_*` constants from `sql.h`).
+#[repr(u64)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CursorType {
+    /// `SQL_CURSOR_FORWARD_ONLY` (0) — sequential access only.
+    ForwardOnly = 0,
+    /// `SQL_CURSOR_KEYSET_DRIVEN` (1) — keyset-driven cursor.
+    KeysetDriven = 1,
+    /// `SQL_CURSOR_DYNAMIC` (2) — dynamic cursor.
+    Dynamic = 2,
+    /// `SQL_CURSOR_STATIC` (3) — static cursor.
+    Static = 3,
+}
+
+impl TryFrom<sql::ULen> for CursorType {
+    type Error = OdbcError;
+
+    fn try_from(value: sql::ULen) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(CursorType::ForwardOnly),
+            1 => Ok(CursorType::KeysetDriven),
+            2 => Ok(CursorType::Dynamic),
+            3 => Ok(CursorType::Static),
+            _ => {
+                tracing::warn!("Unsupported cursor type: {}", value);
+                Err(OdbcError::UnknownAttribute {
+                    attribute: value as i32,
+                    location: snafu::location!(),
+                })
+            }
+        }
+    }
+}
+
 /// ODBC statement attribute identifiers (matching `SQL_ATTR_*` constants from `sql.h`).
 #[repr(i32)]
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StmtAttr {
+    /// `SQL_ATTR_MAX_LENGTH` (3) — maximum amount of data returned from character/binary columns.
+    MaxLength = 3,
     /// `SQL_ATTR_ROW_BIND_TYPE` (5) — row-wise vs column-wise binding.
     RowBindType = 5,
+    /// `SQL_ATTR_CURSOR_TYPE` (6) — type of cursor.
+    CursorType = 6,
     /// `SQL_ATTR_USE_BOOKMARKS` (12) — whether bookmarks are used.
     UseBookmarks = 12,
     /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
@@ -159,7 +197,9 @@ impl TryFrom<i32> for StmtAttr {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
+            3 => Ok(StmtAttr::MaxLength),
             5 => Ok(StmtAttr::RowBindType),
+            6 => Ok(StmtAttr::CursorType),
             12 => Ok(StmtAttr::UseBookmarks),
             23 => Ok(StmtAttr::RowBindOffsetPtr),
             25 => Ok(StmtAttr::RowStatusPtr),
@@ -549,6 +589,10 @@ pub struct Statement<'a> {
     pub ird: IrdDescriptor,
     pub diagnostic_info: DiagnosticInfo,
     pub get_data_state: Option<GetDataState>,
+    /// `SQL_ATTR_CURSOR_TYPE` — default `ForwardOnly`.
+    pub cursor_type: CursorType,
+    /// `SQL_ATTR_MAX_LENGTH` — default 0 (no limit). Stored but not enforced.
+    pub max_length: sql::ULen,
 }
 
 // Helper functions for handle conversion

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -8,12 +8,26 @@ use tracing;
 
 /// Get the number of result columns
 pub fn num_result_cols(
-    _statement_handle: sql::Handle,
+    statement_handle: sql::Handle,
     column_count_ptr: *mut sql::SmallInt,
 ) -> OdbcResult<()> {
     tracing::debug!("num_result_cols called");
+    let stmt = stmt_from_handle(statement_handle);
+
+    let schema = match stmt.state.as_ref() {
+        StatementState::Executed { reader, .. } => reader.schema(),
+        StatementState::Fetching { record_batch, .. } => record_batch.schema(),
+        _ => return StatementNotExecutedSnafu.fail(),
+    };
+
+    let num_cols = schema.fields().len() as sql::SmallInt;
+
+    if column_count_ptr.is_null() {
+        tracing::warn!("num_result_cols: null column_count_ptr");
+        return crate::api::error::NullPointerSnafu.fail();
+    }
     unsafe {
-        std::ptr::write(column_count_ptr, 1);
+        std::ptr::write(column_count_ptr, num_cols);
     }
     Ok(())
 }

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -269,6 +269,34 @@ pub unsafe extern "C" fn SQLFetchScroll(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLExtendedFetch(
+    statement_handle: sql::Handle,
+    fetch_orientation: sql::SmallInt,
+    _fetch_offset: sql::Len,
+    row_count_ptr: *mut sql::ULen,
+    row_status_ptr: *mut sql::USmallInt,
+) -> sql::RetCode {
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let mut warnings = vec![];
+    let result = api::data::extended_fetch(
+        statement_handle,
+        fetch_orientation,
+        row_count_ptr,
+        row_status_ptr,
+        &mut warnings,
+    );
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code_with_warnings(&warnings)
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLGetData(
     statement_handle: sql::Handle,
     col_or_param_num: sql::USmallInt,

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -48,7 +48,10 @@ pub unsafe extern "C" fn SQLExecDirect(
     statement_text: *const sql::Char,
     text_length: sql::Integer,
 ) -> sql::RetCode {
-    api::statement::exec_direct_n(statement_handle, statement_text, text_length).to_sql_code()
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::statement::exec_direct_n(statement_handle, statement_text, text_length);
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
 }
 
 /// # Safety
@@ -59,7 +62,10 @@ pub unsafe extern "C" fn SQLExecDirectW(
     statement_text: *const sql::WChar,
     text_length: sql::Integer,
 ) -> sql::RetCode {
-    api::statement::exec_direct_w(statement_handle, statement_text, text_length).to_sql_code()
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::statement::exec_direct_w(statement_handle, statement_text, text_length);
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
 }
 
 /// # Safety
@@ -468,8 +474,22 @@ pub unsafe extern "C" fn SQLSetStmtAttr(
     value_ptr: sql::Pointer,
     string_length: sql::Integer,
 ) -> sql::RetCode {
-    api::statement::set_stmt_attr(statement_handle, attribute, value_ptr, string_length)
-        .to_sql_code()
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let mut warnings = vec![];
+    let result = api::statement::set_stmt_attr(
+        statement_handle,
+        attribute,
+        value_ptr,
+        string_length,
+        &mut warnings,
+    );
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code_with_warnings(&warnings)
 }
 
 /// # Safety

--- a/odbc/src/cdata_types.rs
+++ b/odbc/src/cdata_types.rs
@@ -30,6 +30,7 @@ use odbc_sys as sql;
 pub const C_TYPES_EXTENDED: i16 = 0x04000;
 
 pub const SQL_NULL_DATA: sql::Len = -1;
+pub const SQL_NO_TOTAL: sql::Len = -4;
 
 #[repr(i16)]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -17,7 +17,7 @@ use arrow::datatypes::{
     DataType, Date32Type, Decimal128Type, Field, Int8Type, Int16Type, Int32Type, Int64Type,
 };
 use snafu::ResultExt;
-pub use traits::{Binding, ReadArrowType, SnowflakeType, WriteODBCType};
+pub use traits::{Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType};
 
 pub use error::{
     ArrowArrayDowncastSnafu, ConversionError, FieldMetadataParsingSnafu, MissingFieldMetadataSnafu,

--- a/odbc/src/conversion/nullable.rs
+++ b/odbc/src/conversion/nullable.rs
@@ -1,12 +1,10 @@
-use crate::{
-    cdata_types::SQL_NULL_DATA,
-    conversion::{
-        Binding, ReadArrowType, SnowflakeType, WriteODBCType,
-        error::{IndicatorRequiredSnafu, ReadArrowError, WriteOdbcError},
-        warning::Warnings,
-    },
-};
 use odbc_sys as sql;
+
+use crate::conversion::{
+    Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType,
+    error::{ReadArrowError, WriteOdbcError},
+    warning::Warnings,
+};
 
 pub(crate) struct Nullable<T> {
     pub value: T,
@@ -45,12 +43,7 @@ impl<T: WriteODBCType> WriteODBCType for Nullable<T> {
         match snowflake_value {
             Some(value) => self.value.write_odbc_type(value, binding, get_data_offset),
             None => {
-                if binding.str_len_or_ind_ptr.is_null() {
-                    return IndicatorRequiredSnafu.fail();
-                }
-                unsafe {
-                    std::ptr::write(binding.str_len_or_ind_ptr, SQL_NULL_DATA);
-                }
+                binding.write_length_or_null(LengthOrNull::Null)?;
                 Ok(vec![])
             }
         }

--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -1,6 +1,5 @@
 use arrow::array::{Array, ArrowPrimitiveType, PrimitiveArray};
 use odbc_sys as sql;
-use odbc_sys::Len;
 
 use crate::cdata_types::CDataType;
 use crate::conversion::error::{
@@ -49,7 +48,7 @@ impl WriteODBCType for SnowflakeNumber {
         &self,
         snowflake_value: Self::Representation<'_>,
         binding: &Binding,
-        _get_data_offset: &mut Option<usize>,
+        get_data_offset: &mut Option<usize>,
     ) -> Result<Warnings, WriteOdbcError> {
         match binding.target_type {
             CDataType::Double => {
@@ -210,18 +209,7 @@ impl WriteODBCType for SnowflakeNumber {
                 } else {
                     snowflake_value.to_string()
                 };
-                let bytes = num_str.as_bytes();
-                if !binding.str_len_or_ind_ptr.is_null() {
-                    unsafe { std::ptr::write(binding.str_len_or_ind_ptr, bytes.len() as Len) };
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        bytes.as_ptr(),
-                        binding.target_value_ptr as *mut u8,
-                        std::cmp::min(binding.buffer_length as usize, bytes.len()),
-                    );
-                }
-                Ok(vec![])
+                Ok(binding.write_char_string(&num_str, get_data_offset))
             }
             _ => UnsupportedOdbcTypeSnafu {
                 target_type: binding.target_type,

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -1,15 +1,27 @@
 use odbc_sys as sql;
 
 use crate::cdata_types::CDataType;
-use crate::conversion::error::{ReadArrowError, WriteOdbcError};
+use crate::conversion::error::{IndicatorRequiredSnafu, ReadArrowError, WriteOdbcError};
 use crate::conversion::warning::{Warning, Warnings};
+
+pub enum LengthOrNull {
+    Null,
+    Length(sql::Len),
+}
 
 #[derive(Debug, Default)]
 pub struct Binding {
     pub target_type: CDataType,
     pub target_value_ptr: sql::Pointer,
     pub buffer_length: sql::Len,
-    pub str_len_or_ind_ptr: *mut sql::Len,
+    /// Octet-length pointer — receives the byte length of the data after fetch.
+    /// Set by `SQLBindCol` (combined StrLen/Ind role) or `SQL_DESC_OCTET_LENGTH_PTR`.
+    pub octet_length_ptr: *mut sql::Len,
+    /// Indicator (StrLen_or_Ind) pointer.
+    /// When `SQLBindCol` is used with a combined StrLen/Ind buffer, this is the same
+    /// pointer as `octet_length_ptr`. When separate descriptor fields are used, this
+    /// may be distinct from `octet_length_ptr` or null if no indicator is bound.
+    pub indicator_ptr: *mut sql::Len,
     /// Numeric precision, set via SQLSetDescField(SQL_DESC_PRECISION) on the ARD.
     /// Used for SQL_C_NUMERIC conversions.
     pub precision: Option<i16>,
@@ -19,22 +31,50 @@ pub struct Binding {
 }
 
 impl Binding {
+    pub fn write_length_or_null(&self, length_or_null: LengthOrNull) -> Result<(), WriteOdbcError> {
+        match length_or_null {
+            LengthOrNull::Null => {
+                if self.indicator_ptr.is_null() {
+                    return IndicatorRequiredSnafu.fail();
+                }
+                unsafe {
+                    std::ptr::write(self.indicator_ptr, crate::cdata_types::SQL_NULL_DATA);
+                }
+                Ok(())
+            }
+            LengthOrNull::Length(length) => {
+                if !self.octet_length_ptr.is_null() {
+                    if !self.indicator_ptr.is_null() {
+                        unsafe { std::ptr::write(self.indicator_ptr, 0) };
+                    }
+                    unsafe { std::ptr::write(self.octet_length_ptr, length) };
+                } else if !self.indicator_ptr.is_null() {
+                    unsafe { std::ptr::write(self.indicator_ptr, length as sql::Len) };
+                }
+                Ok(())
+            }
+        }
+    }
+
     pub fn write_fixed<T>(&self, value: T) {
         unsafe {
             if !self.target_value_ptr.is_null() {
                 std::ptr::write(self.target_value_ptr as *mut T, value);
             }
-            if !self.str_len_or_ind_ptr.is_null() {
-                std::ptr::write(
-                    self.str_len_or_ind_ptr,
-                    std::mem::size_of::<T>() as sql::Len,
-                );
-            }
         }
+        let _ =
+            self.write_length_or_null(LengthOrNull::Length(std::mem::size_of::<T>() as sql::Len));
     }
 
     pub fn write_char_string(&self, src: &str, get_data_offset: &mut Option<usize>) -> Warnings {
+        if self.target_value_ptr.is_null() || self.buffer_length <= 0 {
+            let total_chars = src.chars().count() as sql::Len;
+            let _ = self.write_length_or_null(LengthOrNull::Length(total_chars));
+            return vec![Warning::StringDataTruncated];
+        }
+
         let offset = get_data_offset.unwrap_or(0);
+        let total_chars = src.chars().count();
         let max_len = self.buffer_length as usize;
         let mut dst_idx = 0;
         let value_ptr = self.target_value_ptr as *mut u8;
@@ -42,10 +82,9 @@ impl Binding {
             if dst_idx == max_len - 1 {
                 unsafe {
                     std::ptr::write(value_ptr.add(max_len - 1), 0);
-                    if !self.str_len_or_ind_ptr.is_null() {
-                        std::ptr::write(self.str_len_or_ind_ptr, sql::NO_TOTAL);
-                    }
                 }
+                let remaining = (total_chars - offset) as sql::Len;
+                let _ = self.write_length_or_null(LengthOrNull::Length(remaining));
                 *get_data_offset = Some(offset + dst_idx);
                 return vec![Warning::StringDataTruncated];
             }
@@ -57,10 +96,8 @@ impl Binding {
         }
         unsafe {
             std::ptr::write(value_ptr.add(dst_idx), 0);
-            if !self.str_len_or_ind_ptr.is_null() {
-                std::ptr::write(self.str_len_or_ind_ptr, dst_idx as sql::Len);
-            }
         }
+        let _ = self.write_length_or_null(LengthOrNull::Length(dst_idx as sql::Len));
         *get_data_offset = None;
         vec![]
     }
@@ -79,11 +116,7 @@ impl Binding {
             );
         }
 
-        if !self.str_len_or_ind_ptr.is_null() {
-            unsafe {
-                std::ptr::write(self.str_len_or_ind_ptr, remaining.len() as sql::Len);
-            }
-        }
+        let _ = self.write_length_or_null(LengthOrNull::Length(remaining.len() as sql::Len));
 
         if remaining.len() > buffer_length {
             *get_data_offset = Some(offset + copy_len);
@@ -95,7 +128,14 @@ impl Binding {
     }
 
     pub fn write_wchar_string(&self, src: &str, get_data_offset: &mut Option<usize>) -> Warnings {
+        if self.target_value_ptr.is_null() || self.buffer_length < 2 {
+            let total_bytes = (src.encode_utf16().count() * 2) as sql::Len;
+            let _ = self.write_length_or_null(LengthOrNull::Length(total_bytes));
+            return vec![Warning::StringDataTruncated];
+        }
+
         let offset = get_data_offset.unwrap_or(0);
+        let total_units = src.encode_utf16().count();
         let max_len = (self.buffer_length / 2) as usize;
         let value_ptr = self.target_value_ptr as *mut u16;
         let mut dst_idx = 0;
@@ -103,10 +143,9 @@ impl Binding {
             if dst_idx == max_len - 1 {
                 unsafe {
                     std::ptr::write(value_ptr.add(max_len - 1), 0);
-                    if !self.str_len_or_ind_ptr.is_null() {
-                        std::ptr::write(self.str_len_or_ind_ptr, sql::NO_TOTAL);
-                    }
                 }
+                let remaining_bytes = ((total_units - offset) * 2) as sql::Len;
+                let _ = self.write_length_or_null(LengthOrNull::Length(remaining_bytes));
                 *get_data_offset = Some(offset + dst_idx);
                 return vec![Warning::StringDataTruncated];
             }
@@ -117,15 +156,11 @@ impl Binding {
         }
         unsafe {
             std::ptr::write(value_ptr.add(dst_idx), 0);
-            if !self.str_len_or_ind_ptr.is_null() {
-                // COMPATIBILITY: ODBC 3.80 specification says that the string length should be the number of characters, not the number of bytes.
-                // However, older versions of Snowflake ODBC driver returns the number of bytes.
-                // So we need to convert the number of characters to the number of bytes.
-                let num_characters = dst_idx as sql::Len;
-                let num_bytes = num_characters * 2;
-                std::ptr::write(self.str_len_or_ind_ptr, num_bytes);
-            }
         }
+        // COMPATIBILITY: ODBC 3.80 specification says that the string length should be the number of characters, not the number of bytes.
+        // However, older versions of Snowflake ODBC driver returns the number of bytes.
+        let num_bytes = (dst_idx as sql::Len) * 2;
+        let _ = self.write_length_or_null(LengthOrNull::Length(num_bytes));
         *get_data_offset = None;
         vec![]
     }

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -1,6 +1,6 @@
 use odbc_sys as sql;
 
-use crate::cdata_types::CDataType;
+use crate::cdata_types::{CDataType, SQL_NO_TOTAL};
 use crate::conversion::error::{IndicatorRequiredSnafu, ReadArrowError, WriteOdbcError};
 use crate::conversion::warning::{Warning, Warnings};
 
@@ -135,7 +135,6 @@ impl Binding {
         }
 
         let offset = get_data_offset.unwrap_or(0);
-        let total_units = src.encode_utf16().count();
         let max_len = (self.buffer_length / 2) as usize;
         let value_ptr = self.target_value_ptr as *mut u16;
         let mut dst_idx = 0;
@@ -144,8 +143,7 @@ impl Binding {
                 unsafe {
                     std::ptr::write(value_ptr.add(max_len - 1), 0);
                 }
-                let remaining_bytes = ((total_units - offset) * 2) as sql::Len;
-                let _ = self.write_length_or_null(LengthOrNull::Length(remaining_bytes));
+                let _ = self.write_length_or_null(LengthOrNull::Length(SQL_NO_TOTAL));
                 *get_data_offset = Some(offset + dst_idx);
                 return vec![Warning::StringDataTruncated];
             }

--- a/odbc/src/conversion/warning.rs
+++ b/odbc/src/conversion/warning.rs
@@ -5,4 +5,5 @@ pub enum Warning {
     StringDataTruncated,
     NumericValueTruncated,
     RowError,
+    OptionValueChanged,
 }

--- a/odbc_tests/tests/e2e/query/basic_execute_query.cpp
+++ b/odbc_tests/tests/e2e/query/basic_execute_query.cpp
@@ -23,7 +23,6 @@ TEST_CASE("should execute simple SELECT returning single value", "[query]") {
 }
 
 TEST_CASE("should execute SELECT returning multiple columns", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -66,7 +65,6 @@ TEST_CASE("should execute SELECT returning multiple rows", "[query]") {
 }
 
 TEST_CASE("should execute SELECT returning empty result set", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -154,7 +152,6 @@ TEST_CASE("should execute INSERT and retrieve inserted data", "[query]") {
 // =============================================================================
 
 TEST_CASE("should return error for invalid SQL syntax", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -48,7 +48,6 @@ TEST_CASE("SQLFetch returns data about number of rows affected.") {
 }
 
 TEST_CASE("SQLSetStmtAttr sets supported cursor types.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -524,7 +523,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_BIND_TYPE set on ARD for row-wise binding.
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_COUNT set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -568,7 +566,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_COUNT set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_DATA_PTR set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -603,7 +600,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_DATA_PTR set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_INDICATOR_PTR set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -638,7 +634,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_INDICATOR_PTR set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_OCTET_LENGTH set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -676,7 +671,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_OCTET_LENGTH set on ARD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_OCTET_LENGTH_PTR set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -750,7 +744,6 @@ TEST_CASE("SQLFetch respects SQL_DESC_ROWS_PROCESSED_PTR set on IRD.") {
 }
 
 TEST_CASE("SQLFetch respects SQL_DESC_TYPE set on ARD.") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -907,7 +900,6 @@ TEST_CASE("SQLFetch respects both ARD and IRD descriptor fields.") {
 // Note: This is old driver behavior - not the specification.
 // Specifically, the specification says that the data should be truncated to the SQL_ATTR_MAX_LENGTH characters
 TEST_CASE("SQLFetch ignores SQL_ATTR_MAX_LENGTH on statement handle.", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -1091,7 +1083,6 @@ TEST_CASE("SQLFetch moves cursor forward when no columns are bound.", "[query]")
 }
 
 TEST_CASE("SQLFetch supports separate length and indicator buffers via descriptor.", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -1149,7 +1140,6 @@ TEST_CASE("SQLFetch supports separate length and indicator buffers via descripto
 }
 
 TEST_CASE("SQLFetch cannot be called after SQLExtendedFetch without SQLFreeStmt.", "[query]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();


### PR DESCRIPTION
Split str_len_or_ind_ptr into two independent pointers: octet_lenght_ptr, indicator_ptr:  
\- SQLBindCol sets both to the same value  
\- You can manipulate them independently by modyfing ARD descriptor of the statement - by setting SQL_DESC_OCTET_LENGTH_PTR or SQL_DESC_INDICATOR_PTR