### PR TITLE
NO-SNOW Add configuration option to load a test private key from path instead of content

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 spotless {
     java {
         removeUnusedImports()
-        googleJavaFormat('1.15.0')
+        googleJavaFormat('1.7')
         target 'src/main/java/**/*.java', 'src/test/java/**/*.java'
         targetExclude 'src/**/protobuf_gen/**/*.java'
     }

--- a/odbc/README.md
+++ b/odbc/README.md
@@ -10,6 +10,7 @@ Before running tests, ensure you have:
 - Set up credentials (see main [README.md](../README.md) for setup instructions)
 - CMake 3.10 or later
 - C++17 compatible compiler
+- coreutils (for `nproc`), unixodbc (for `odbc_config`) from `brew`
 
 ### Local Testing (macOS/Linux)
 

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -83,6 +83,14 @@ inline void add_param_optional(std::stringstream& ss, const picojson::object& pa
   }
 }
 
+inline std::string get_private_key_file_path(const picojson::object& params) {
+  auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
+  if (it != params.end() && it->second.is<std::string>()) {
+    return it->second.get<std::string>();
+  }
+  return "";
+}
+
 inline std::string read_private_key(const picojson::object& params) {
   auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS");
   if (it == params.end()) {

--- a/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
@@ -22,6 +22,13 @@
 using pg_utils::TempTestDir;
 
 std::string get_private_key_path_for_auth(picojson::object& params, const TempTestDir& tmp) {
+  // First check if a private key file path is provided
+  auto private_key_file_path = get_private_key_file_path(params);
+  if (!private_key_file_path.empty()) {
+    return private_key_file_path;
+  }
+
+  // Otherwise, create a temporary file from contents
   auto private_key = read_private_key(params);
   auto path = tmp.path() / "rsa_key_auth.p8";
   std::ofstream file(path, std::ios::out | std::ios::trunc);

--- a/python/tests/config.py
+++ b/python/tests/config.py
@@ -35,6 +35,7 @@ def get_test_parameters() -> dict[str, Any]:
         "SNOWFLAKE_TEST_HOST",
         "SNOWFLAKE_TEST_PORT",
         "SNOWFLAKE_TEST_PROTOCOL",
+        "SNOWFLAKE_TEST_PRIVATE_KEY_FILE",
         "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS",
         "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD",
     ]

--- a/python/tests/private_key_helper.py
+++ b/python/tests/private_key_helper.py
@@ -59,6 +59,12 @@ def get_private_key_from_parameters() -> str:
         RuntimeError: If SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS not found
     """
     test_params = get_test_parameters()
+
+    # First check if a private key file path is provided
+    private_key_file = test_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_FILE")
+    if private_key_file:
+        return private_key_file
+
     private_key_contents = test_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")
 
     if not private_key_contents:

--- a/sf_core/tests/common/config.rs
+++ b/sf_core/tests/common/config.rs
@@ -32,6 +32,8 @@ pub struct Parameters {
     pub port: Option<i64>,
     #[serde(rename = "SNOWFLAKE_TEST_PROTOCOL")]
     pub protocol: Option<String>,
+    #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_FILE")]
+    pub private_key_path: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")]
     pub private_key_contents: Option<Vec<String>>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD")]

--- a/sf_core/tests/common/config.rs
+++ b/sf_core/tests/common/config.rs
@@ -33,7 +33,7 @@ pub struct Parameters {
     #[serde(rename = "SNOWFLAKE_TEST_PROTOCOL")]
     pub protocol: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_FILE")]
-    pub private_key_path: Option<String>,
+    pub private_key_file: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")]
     pub private_key_contents: Option<Vec<String>>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD")]

--- a/sf_core/tests/common/private_key_helper.rs
+++ b/sf_core/tests/common/private_key_helper.rs
@@ -37,7 +37,7 @@ impl PrivateKeyFile {
 }
 
 pub fn get_private_key_from_parameters(parameters: &Parameters) -> Result<PrivateKeyFile, String> {
-    if let Some(path) = parameters.private_key_path.as_ref() {
+    if let Some(path) = parameters.private_key_file.as_ref() {
         return Path::new(path)
             .exists()
             .then_some(Ok(PrivateKeyFile::Existing(PathBuf::from(path))))

--- a/sf_core/tests/common/private_key_helper.rs
+++ b/sf_core/tests/common/private_key_helper.rs
@@ -11,7 +11,7 @@ pub enum PrivateKeyFile {
         PathBuf,
         TempDir, // Keep the TempDir alive to ensure the file is not deleted
     ),
-    // A private key file that already exists on the filesystem, which we should not delete.
+    /// A private key file that already exists on the filesystem, which we should not delete.
     Existing(PathBuf),
 }
 

--- a/sf_core/tests/common/private_key_helper.rs
+++ b/sf_core/tests/common/private_key_helper.rs
@@ -5,38 +5,48 @@ use tempfile::TempDir;
 use super::config::Parameters;
 use super::file_utils::repo_root;
 
-/// A temporary private key file, automatically cleaned up when dropped.
-pub struct TempPrivateKeyFile {
-    _temp_dir: TempDir,
-    file_path: PathBuf,
+pub enum PrivateKeyFile {
+    /// A temporary private key file, automatically cleaned up when dropped.
+    Temp(
+        PathBuf,
+        TempDir, // Keep the TempDir alive to ensure the file is not deleted
+    ),
+    // A private key file that already exists on the filesystem, which we should not delete.
+    Existing(PathBuf),
 }
 
-impl TempPrivateKeyFile {
-    fn new(private_key_contents: &[String]) -> Result<Self, String> {
+impl PrivateKeyFile {
+    fn temp(private_key_contents: &[String]) -> Result<Self, String> {
         let temp_dir = TempDir::new().map_err(|e| format!("Failed to create temp dir: {e}"))?;
         let file_path = temp_dir.path().join("private_key.p8");
         let private_key_str = private_key_contents.join("\n") + "\n";
         fs::write(&file_path, private_key_str)
             .map_err(|e| format!("Failed to write private key file: {e}"))?;
 
-        Ok(Self {
-            _temp_dir: temp_dir,
-            file_path,
-        })
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.file_path
+        Ok(PrivateKeyFile::Temp(file_path, temp_dir))
     }
 }
 
-pub fn get_private_key_from_parameters(
-    parameters: &Parameters,
-) -> Result<TempPrivateKeyFile, String> {
+impl PrivateKeyFile {
+    pub fn path(&self) -> &Path {
+        match self {
+            PrivateKeyFile::Temp(path, _) => path,
+            PrivateKeyFile::Existing(path) => path,
+        }
+    }
+}
+
+pub fn get_private_key_from_parameters(parameters: &Parameters) -> Result<PrivateKeyFile, String> {
+    if let Some(path) = parameters.private_key_path.as_ref() {
+        return Path::new(path)
+            .exists()
+            .then_some(Ok(PrivateKeyFile::Existing(PathBuf::from(path))))
+            .ok_or_else(|| format!("Private key file not found at path: {path}"))?;
+    }
     let private_key_contents = parameters.private_key_contents.as_ref().ok_or_else(|| {
         "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS not found in parameters.json".to_string()
     })?;
-    TempPrivateKeyFile::new(private_key_contents)
+    PrivateKeyFile::temp(private_key_contents)
 }
 
 fn get_test_private_key_contents() -> Vec<String> {
@@ -55,7 +65,7 @@ fn get_test_private_key_contents() -> Vec<String> {
     key_content.lines().map(|s| s.to_string()).collect()
 }
 
-pub fn get_test_private_key_file() -> Result<TempPrivateKeyFile, String> {
+pub fn get_test_private_key_file() -> Result<PrivateKeyFile, String> {
     let key_contents = get_test_private_key_contents();
-    TempPrivateKeyFile::new(&key_contents)
+    PrivateKeyFile::temp(&key_contents)
 }

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -9,14 +9,14 @@ use std::mem::size_of;
 use std::sync::Arc;
 
 use super::config::{Parameters, get_parameters, setup_logging};
-use super::private_key_helper::{self, TempPrivateKeyFile};
+use super::private_key_helper::{self, PrivateKeyFile};
 
 /// Creates a connected Snowflake client with database and connection initialized
 pub struct SnowflakeTestClient {
     pub conn_handle: ConnectionHandle,
     pub db_handle: DatabaseHandle,
     pub parameters: Parameters,
-    temp_key_file: Option<TempPrivateKeyFile>,
+    private_key_file: Option<PrivateKeyFile>,
 }
 
 impl SnowflakeTestClient {
@@ -40,7 +40,7 @@ impl SnowflakeTestClient {
             conn_handle,
             db_handle,
             parameters,
-            temp_key_file: None,
+            private_key_file: None,
         };
 
         client.set_options_from_parameters();
@@ -53,7 +53,7 @@ impl SnowflakeTestClient {
         let mut client = Self::with_default_params();
 
         let temp_key_file = client.setup_jwt_auth();
-        client.temp_key_file = Some(temp_key_file);
+        client.private_key_file = Some(temp_key_file);
         client
     }
 
@@ -69,7 +69,7 @@ impl SnowflakeTestClient {
         })
         .unwrap();
 
-        client.temp_key_file = Some(temp_key_file);
+        client.private_key_file = Some(temp_key_file);
         client
     }
 
@@ -107,7 +107,7 @@ impl SnowflakeTestClient {
             conn_handle,
             db_handle,
             parameters: test_parameters,
-            temp_key_file: None,
+            private_key_file: None,
         };
 
         client.set_options_from_parameters();
@@ -128,7 +128,7 @@ impl SnowflakeTestClient {
         })
         .unwrap();
 
-        client.temp_key_file = Some(temp_key_file);
+        client.private_key_file = Some(temp_key_file);
         client
     }
 
@@ -279,8 +279,8 @@ impl SnowflakeTestClient {
     }
 
     /// Stores a temporary private key file to keep it alive for the duration of the test.
-    pub fn set_temp_key_file(&mut self, temp_key_file: TempPrivateKeyFile) {
-        self.temp_key_file = Some(temp_key_file);
+    pub fn set_temp_key_file(&mut self, temp_key_file: PrivateKeyFile) {
+        self.private_key_file = Some(temp_key_file);
     }
 
     pub fn verify_simple_query(&self, connection_result: Result<(), String>) {
@@ -318,7 +318,7 @@ impl SnowflakeTestClient {
     }
 
     /// Sets up JWT authentication configuration and returns a private key file
-    fn setup_jwt_auth(&mut self) -> TempPrivateKeyFile {
+    fn setup_jwt_auth(&mut self) -> PrivateKeyFile {
         self.set_connection_option("authenticator", "SNOWFLAKE_JWT");
         let temp_key_file = private_key_helper::get_private_key_from_parameters(&self.parameters)
             .expect("Failed to create private key file");

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -44,7 +44,16 @@ pub fn create_connection(
 
     // Use JWT key-pair authentication
     set_connection_option(&conn_handle, "authenticator", "SNOWFLAKE_JWT")?;
-    let private_key_file = write_private_key_to_file(&params.private_key_contents)?;
+
+    // First check if a private key file path is provided, otherwise create from contents
+    let private_key_file = if let Some(ref key_file_path) = params.private_key_file {
+        key_file_path.clone()
+    } else if let Some(ref key_contents) = params.private_key_contents {
+        write_private_key_to_file(key_contents)?
+    } else {
+        return Err("Neither SNOWFLAKE_TEST_PRIVATE_KEY_FILE nor SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS provided".to_string());
+    };
+
     set_connection_option(&conn_handle, "private_key_file", &private_key_file)?;
     if let Some(password) = &params.private_key_password {
         set_connection_option(&conn_handle, "private_key_password", password)?;

--- a/tests/performance/drivers/core/app/src/types.rs
+++ b/tests/performance/drivers/core/app/src/types.rs
@@ -10,8 +10,10 @@ pub struct TestConnectionParams {
     pub host: String,
     #[serde(rename = "SNOWFLAKE_TEST_USER")]
     pub user: String,
+    #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_FILE")]
+    pub private_key_file: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")]
-    pub private_key_contents: Vec<String>,
+    pub private_key_contents: Option<Vec<String>>,
     #[serde(rename = "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD")]
     pub private_key_password: Option<String>,
     #[serde(rename = "SNOWFLAKE_TEST_DATABASE")]

--- a/tests/performance/drivers/odbc/app/config.cpp
+++ b/tests/performance/drivers/odbc/app/config.cpp
@@ -78,7 +78,18 @@ std::map<std::string, std::string> parse_parameters_json() {
     }
   }
 
-  // Parse private key contents (array of strings)
+  // Parse private key file path or contents
+  // First check for SNOWFLAKE_TEST_PRIVATE_KEY_FILE
+  size_t key_file_start = json_str.find("\"SNOWFLAKE_TEST_PRIVATE_KEY_FILE\"");
+  if (key_file_start != std::string::npos) {
+    std::regex pattern("\"SNOWFLAKE_TEST_PRIVATE_KEY_FILE\"\\s*:\\s*\"([^\"]*)\"");
+    std::smatch match;
+    if (std::regex_search(json_str, match, pattern)) {
+      params["private_key_file"] = match[1].str();
+    }
+  }
+
+  // Parse private key contents (array of strings) if no file path is provided
   // Find the start of SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS array
   size_t key_start = json_str.find("\"SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS\"");
   if (key_start != std::string::npos) {

--- a/tests/performance/drivers/odbc/app/connection.cpp
+++ b/tests/performance/drivers/odbc/app/connection.cpp
@@ -180,14 +180,12 @@ std::string get_connection_string() {
   std::string account = params["account"];
   std::string host = params["host"];
   std::string user = params["user"];
-  std::string private_key = params["private_key"];
 
-  if (account.empty() || user.empty() || private_key.empty()) {
+  if (account.empty() || user.empty()) {
     std::cerr << "ERROR: Missing required connection parameters in PARAMETERS_JSON\n";
-    std::cerr << "Required: account, user, private_key\n";
+    std::cerr << "Required: account, user\n";
     std::cerr << "Found: account=" << (account.empty() ? "MISSING" : "OK")
-              << ", user=" << (user.empty() ? "MISSING" : "OK")
-              << ", private_key=" << (private_key.empty() ? "MISSING" : "OK") << "\n";
+              << ", user=" << (user.empty() ? "MISSING" : "OK") << "\n";
     exit(1);
   }
 
@@ -196,8 +194,18 @@ std::string get_connection_string() {
   ss << "UID=" << user << ";";
 
   // Use key-pair authentication
-  // ODBC driver requires private key to be in a file
-  std::string key_file_path = write_private_key_to_file(private_key);
+  // First check if a private key file path is provided, otherwise create from contents
+  std::string key_file_path;
+  if (!params["private_key_file"].empty()) {
+    key_file_path = params["private_key_file"];
+  } else if (!params["private_key"].empty()) {
+    // ODBC driver requires private key to be in a file
+    key_file_path = write_private_key_to_file(params["private_key"]);
+  } else {
+    std::cerr << "ERROR: Neither SNOWFLAKE_TEST_PRIVATE_KEY_FILE nor SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS provided\n";
+    exit(1);
+  }
+
   ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
   ss << "PRIV_KEY_FILE=" << key_file_path << ";";
 

--- a/tests/performance/drivers/python/app/config.py
+++ b/tests/performance/drivers/python/app/config.py
@@ -42,20 +42,23 @@ class TestConfig:
         """Parse connection parameters from JSON."""
         params = json.loads(self.params_json)
         conn_params = params.get("testconnection", {})
-        
-        # Parse private key contents (array of strings) and write to temporary file
-        private_key_contents = conn_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS", [])
-        private_key_file = None
-        
-        if private_key_contents:
-            # Write private key to a temporary file for authentication (OS-agnostic)
-            temp_dir = Path(tempfile.gettempdir())
-            key_file_path = temp_dir / "perf_test_private_key.p8"
-            with open(key_file_path, 'w') as f:
-                f.write("\n".join(private_key_contents))
-                f.write("\n")
-            private_key_file = str(key_file_path)
-        
+
+        # First check if private key file path is provided
+        private_key_file = conn_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_FILE")
+
+        # If no file path, parse private key contents (array of strings) and write to temporary file
+        if not private_key_file:
+            private_key_contents = conn_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS", [])
+
+            if private_key_contents:
+                # Write private key to a temporary file for authentication (OS-agnostic)
+                temp_dir = Path(tempfile.gettempdir())
+                key_file_path = temp_dir / "perf_test_private_key.p8"
+                with open(key_file_path, 'w') as f:
+                    f.write("\n".join(private_key_contents))
+                    f.write("\n")
+                private_key_file = str(key_file_path)
+
         connection_params = {
             "account": conn_params.get("SNOWFLAKE_TEST_ACCOUNT") or conn_params.get("account"),
             "host": conn_params.get("SNOWFLAKE_TEST_HOST") or conn_params.get("host"),
@@ -65,15 +68,15 @@ class TestConfig:
             "warehouse": conn_params.get("SNOWFLAKE_TEST_WAREHOUSE") or conn_params.get("warehouse"),
             "role": conn_params.get("SNOWFLAKE_TEST_ROLE") or conn_params.get("role"),
         }
-        
+
         # Add JWT authentication parameters if private key is provided
         if private_key_file:
             connection_params["authenticator"] = "SNOWFLAKE_JWT"
             connection_params["private_key_file"] = private_key_file
-        
+
         # Process TLS/certificate verification parameters (for WireMock testing)
         _process_tls_parameters(conn_params, connection_params, self.driver_type)
-        
+
         return connection_params
     
     def get_driver_label(self):

--- a/tests/performance/drivers/python/app/config.py
+++ b/tests/performance/drivers/python/app/config.py
@@ -46,10 +46,14 @@ class TestConfig:
         # First check if private key file path is provided
         private_key_file = conn_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_FILE")
 
+        # If a file path is provided, ensure it exists to avoid confusing auth errors later
+        if private_key_file and not Path(private_key_file).is_file():
+            print(f"ERROR: Private key file '{private_key_file}' does not exist")
+            sys.exit(1)
+
         # If no file path, parse private key contents (array of strings) and write to temporary file
         if not private_key_file:
             private_key_contents = conn_params.get("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS", [])
-
             if private_key_contents:
                 # Write private key to a temporary file for authentication (OS-agnostic)
                 temp_dir = Path(tempfile.gettempdir())


### PR DESCRIPTION
This PR makes loading private key from the parameters.json easier - instead of having private key content embedded into JSON, just use `SNOWFLAKE_TEST_PRIVATE_KEY_FILE` to provide a private key path.