### PR TITLE
python: pin mypy-protobuf toolchain and require it for .pyi generation

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Generate proto
         run: |
           ./scripts/generate_proto.sh

--- a/proto_generator/src/generators/python_generator.rs
+++ b/proto_generator/src/generators/python_generator.rs
@@ -27,40 +27,37 @@ impl PythonGenerator {
         let protoc = &context.protoc_path;
 
         // Run protoc with Python output
-        std::process::Command::new(protoc)
+        let python_output = std::process::Command::new(protoc)
             .arg(format!("--python_out={out_dir}"))
             .arg(proto_file)
             .arg(format!("-I={include_dir}"))
-            .status()
-            .whatever_context("Failed to run protoc")?;
+            .output()
+            .whatever_context("Failed to run protoc --python_out")?;
 
-        // Generate .pyi type stubs.
-        // Prefer mypy-protobuf (--mypy_out) for higher-quality stubs that
-        // correctly handle proto3 optional fields, HasField overloads, etc.
-        // Fall back to protoc's built-in --pyi_out if mypy-protobuf is not
-        // installed.
-        let mypy_status = std::process::Command::new(protoc)
+        if !python_output.status.success() {
+            snafu::whatever!(
+                "protoc --python_out failed: {}",
+                String::from_utf8_lossy(&python_output.stderr)
+            );
+        }
+
+        // Generate .pyi type stubs via mypy-protobuf (--mypy_out).
+        // This is required to keep generated typing deterministic between
+        // local and CI environments.
+        let mypy_output = std::process::Command::new(protoc)
             .arg(format!("--mypy_out={out_dir}"))
             .arg(proto_file)
             .arg(format!("-I={include_dir}"))
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+            .output()
+            .whatever_context("Failed to run protoc --mypy_out")?;
 
-        match mypy_status {
-            Ok(status) if status.success() => {
-                info!("Generated .pyi stubs using mypy-protobuf");
-            }
-            _ => {
-                info!("mypy-protobuf not available, falling back to protoc --pyi_out");
-                std::process::Command::new(protoc)
-                    .arg(format!("--pyi_out={out_dir}"))
-                    .arg(proto_file)
-                    .arg(format!("-I={include_dir}"))
-                    .status()
-                    .whatever_context("Failed to run protoc --pyi_out")?;
-            }
+        if !mypy_output.status.success() {
+            snafu::whatever!(
+                "protoc --mypy_out failed: {}",
+                String::from_utf8_lossy(&mypy_output.stderr)
+            );
         }
+        info!("Generated .pyi stubs using mypy-protobuf");
 
         let mut result = GenerationResult::new();
 

--- a/scripts/generate_proto.sh
+++ b/scripts/generate_proto.sh
@@ -1,9 +1,38 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+MYPY_PROTOBUF_VERSION="~=5.0"
+PROTOBUF_VERSION="~=6.33"
+TYPES_PROTOBUF_VERSION="~=6.32"
+
+if [[ -n "${PYTHON:-}" ]]; then
+  PYTHON_BIN="${PYTHON}"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "Error: no python interpreter found" >&2
+  exit 1
+fi
 
 echo "--- Installing mypy-protobuf for Python .pyi stub generation ---"
-pip install "mypy-protobuf==5.0.0" 2>/dev/null || pip3 install "mypy-protobuf==5.0.0" 2>/dev/null || pipx install "mypy-protobuf==5.0.0" 2>/dev/null || echo "Warning: could not install mypy-protobuf, will fall back to protoc --pyi_out"
+"${PYTHON_BIN}" -m pip install \
+  "mypy-protobuf${MYPY_PROTOBUF_VERSION}" \
+  "protobuf${PROTOBUF_VERSION}" \
+  "types-protobuf${TYPES_PROTOBUF_VERSION}"
+
+# Ensure the pip user bin dir is visible so protoc can find protoc-gen-mypy.
+USER_BASE="$("${PYTHON_BIN}" -m site --user-base 2>/dev/null || true)"
+if [[ -n "${USER_BASE}" && -d "${USER_BASE}/bin" ]]; then
+  export PATH="${USER_BASE}/bin:${PATH}"
+fi
+
+if ! command -v protoc-gen-mypy >/dev/null 2>&1; then
+  echo "Error: protoc-gen-mypy not found on PATH" >&2
+  exit 1
+fi
 
 echo "--- Generating proto (Rust is generated on the fly via build.rs) ---"
 cargo run --bin proto_generator -- --generator python --input protobuf/database_driver_v1.proto --output python/src/snowflake/connector/_internal/protobuf_gen/


### PR DESCRIPTION
The `.pyi` stubs committed to the repo were diverging between local and CI because `generate_proto.sh` installed `mypy-protobuf` without pinning its transitive deps (`protobuf`, `types-protobuf`), and because `PythonGenerator` silently fell back to `protoc --pyi_out` when `protoc-gen-mypy` was not on `PATH`. These two silent fallbacks produced structurally different stub files depending on environment.

`generate_proto.sh` now pins all three packages to a compatible-release range (`~=5.0`, `~=6.33`, `~=6.32`) via `python -m pip`, appends the pip user `bin` dir to `PATH` so `protoc-gen-mypy` is discoverable, and fails hard if no Python interpreter or `protoc-gen-mypy` is found. The CI `proto` job gains an explicit `python-version: '3.13'` step to match the interpreter used in other jobs. In `PythonGenerator`, the `--pyi_out` fallback is removed and both `protoc` invocations are switched from `.status()` to `.output()` so failures surface their stderr rather than being swallowed.