### PR TITLE
[4/7] config: introduce ConfigResolver to formalize layered config merge strategy

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -10,8 +10,7 @@ use super::global_state::CONN_HANDLE_MANAGER;
 use super::validation::{ValidationIssue, resolve_and_apply_options};
 use crate::config::param_registry::param_names;
 use crate::config::ParamStore;
-use crate::config::config_manager;
-use crate::config::path_resolver::ConfigPaths;
+use crate::config::resolver;
 use crate::config::rest_parameters::{ClientInfo, LoginParameters};
 use crate::config::retry::RetryPolicy;
 use crate::rest::snowflake::{self, RestError, SessionTokens, SnowflakeResponseError};
@@ -19,62 +18,19 @@ use crate::sensitive::SensitiveString;
 use crate::tls::client::create_tls_client_with_config;
 use reqwest;
 
-/// Load configuration from TOML files for a named connection.
-///
-/// Takes a mutable reference to the connection to avoid double-locking.
-/// Only sets config values for keys not already present (explicit settings win).
-pub fn connection_load_from_config(
-    conn: &mut Connection,
-    connection_name: &str,
-) -> Result<(), ApiError> {
-    let config_settings =
-        config_manager::load_connection_config(connection_name).context(ConfigurationSnafu)?;
-
-    for (key, value) in config_settings {
-        conn.settings.insert_if_absent(key, value);
-    }
-    Ok(())
-}
-
-/// Load configuration from TOML files using explicit config paths.
-pub fn connection_load_from_config_with_paths(
-    conn: &mut Connection,
-    connection_name: &str,
-    paths: &ConfigPaths,
-) -> Result<(), ApiError> {
-    let config_settings = config_manager::load_connection_config_with_paths(connection_name, paths)
-        .context(ConfigurationSnafu)?;
-
-    for (key, value) in config_settings {
-        conn.settings.insert_if_absent(key, value);
-    }
-    Ok(())
-}
-
 pub fn connection_init(conn_handle: Handle, _db_handle: Handle) -> Result<(), ApiError> {
     match CONN_HANDLE_MANAGER.get_obj(conn_handle) {
         Some(conn_ptr) => {
-            let mut conn = conn_ptr
+            let conn = conn_ptr
                 .lock()
                 .map_err(|_| ConnectionLockingSnafu {}.build())?;
 
-            // Check if connection_name is set and load from config if present
-            let connection_name = conn.settings.get(param_names::CONNECTION_NAME).and_then(|s| {
-                if let Setting::String(name) = s {
-                    Some(name.clone())
-                } else {
-                    None
-                }
-            });
-
-            if let Some(name) = connection_name {
-                connection_load_from_config(&mut conn, &name)?;
-            }
+            let resolved = conn.resolved_settings().context(ConfigurationSnafu)?;
 
             let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
 
             let login_parameters =
-                LoginParameters::from_settings(&conn.settings).context(ConfigurationSnafu)?;
+                LoginParameters::from_settings(&resolved).context(ConfigurationSnafu)?;
             let init_params = conn.init_session_parameters.clone();
             drop(conn);
 
@@ -228,6 +184,12 @@ impl Connection {
     /// handle manager.
     pub fn set_option(&mut self, key: String, value: Setting) {
         self.settings.insert(key, value);
+    }
+
+    fn resolved_settings(
+        &self,
+    ) -> Result<crate::config::ParamStore, crate::config::ConfigError> {
+        resolver::resolve(&self.settings)
     }
 
     fn initialize(

--- a/sf_core/src/config/mod.rs
+++ b/sf_core/src/config/mod.rs
@@ -5,6 +5,7 @@ pub use param_registry::ParamKey;
 pub use param_registry::param_names;
 pub use param_store::ParamStore;
 pub mod path_resolver;
+pub mod resolver;
 pub mod rest_parameters;
 pub mod retry;
 pub mod settings;

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
-
 use super::param_registry::ParamKey;
 use super::settings::{Setting, Settings};
+use crate::sensitive::SensitiveString;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct ParamStore {
@@ -19,21 +19,90 @@ impl ParamStore {
         self.inner.get(key.as_str())
     }
 
+    /// Extract a string value for `key`, returning `None` if absent or not a string.
+    pub fn get_string(&self, key: ParamKey) -> Option<String> {
+        match self.get(key)? {
+            Setting::String(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    /// Extract an integer value for `key`, returning `None` if absent or not an integer.
+    pub fn get_int(&self, key: ParamKey) -> Option<i64> {
+        match self.get(key)? {
+            Setting::Int(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    /// Extract a string value for `key` and wrap it in [`SensitiveString`],
+    /// returning `None` if absent or not a string. Use for credential fields
+    /// that must never appear in debug output.
+    pub fn get_sensitive_string(&self, key: ParamKey) -> Option<SensitiveString> {
+        match self.get(key)? {
+            Setting::String(s) => Some(SensitiveString::from(s.clone())),
+            _ => None,
+        }
+    }
+
+    /// Extract a boolean value for `key`.
+    ///
+    /// Checks `Setting::Bool` first, then falls back to `Setting::String` with
+    /// `"true"` / `"false"` parsing for backward compatibility with TOML-loaded
+    /// values. Unrecognised strings return `None`.
+    pub fn get_bool(&self, key: ParamKey) -> Option<bool> {
+        match self.get(key)? {
+            Setting::Bool(b) => Some(*b),
+            Setting::String(s) => match s.to_lowercase().as_str() {
+                "true" => Some(true),
+                "false" => Some(false),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Create a `ParamStore` pre-populated with all registry defaults.
+    ///
+    /// Use this in tests that call `ConnectionConfig::build()` directly,
+    /// bypassing `resolver::resolve`. This ensures every param that has a
+    /// registry default behaves as if `resolve` had been called, so the
+    /// production code path, which assumes defaults are present, does not
+    /// need defensive `.unwrap_or(literal)` fallbacks.
+    ///
+    /// **Do not** use this for `Connection.settings` on a live connection:
+    /// pre-populating defaults there would override TOML file settings in
+    /// `resolver::resolve_with_paths` because explicit settings are applied
+    /// last (Layer 1) and would overwrite file settings (Layer 3/2).
+    #[cfg(test)]
+    pub(crate) fn with_registry_defaults() -> Self {
+        let mut store = Self::new();
+        for param in super::param_registry::registry().all_params() {
+            if let Some(f) = param.default {
+                store.insert(param.canonical_name.to_owned(), f());
+            }
+        }
+        store
+    }
+
+    /// Insert or overwrite a setting by its canonical string key.
     pub fn insert(&mut self, key: String, value: Setting) {
         self.inner.insert(key, value);
     }
 
-    pub(crate) fn insert_if_absent(&mut self, key: String, value: Setting) {
-        self.inner.entry(key).or_insert(value);
-    }
-
     /// Copy all entries from `other` into `self`, overwriting any existing
-    /// values for the same key. Used by `resolver::merge_with_paths` to
+    /// values for the same key. Used by `resolver::resolve_with_paths` to
     /// apply each successive config layer onto the merged result.
     pub(crate) fn extend_from(&mut self, other: &ParamStore) {
         for (k, v) in &other.inner {
             self.inner.insert(k.clone(), v.clone());
         }
+    }
+
+    /// Iterate over all canonical key names. Used by `validate_settings` to
+    /// check for unknown parameters.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &String> {
+        self.inner.keys()
     }
 }
 

--- a/sf_core/src/config/resolver.rs
+++ b/sf_core/src/config/resolver.rs
@@ -1,0 +1,280 @@
+use crate::config::config_manager;
+use crate::config::param_names;
+use crate::config::param_registry;
+use crate::config::path_resolver::ConfigPaths;
+use crate::config::ParamStore;
+use crate::config::settings::Setting;
+use crate::config::ConfigError;
+
+/// Resolve final settings by merging explicit settings with file-based
+/// config and registry defaults.
+///
+/// Precedence (highest to lowest):
+/// 1. Explicit programmatic settings (from `SetOptions` / `SetOption*` RPCs)
+/// 2. TOML file: `connections.toml` `[connection_name]` section
+/// 3. TOML file: `config.toml` `[connections.connection_name]` section
+/// 4. Registry defaults (`ParamDef::default`)
+///
+/// `explicit` contains values set via the programmatic API (already
+/// alias-resolved and type-checked by `connection_set_options`).
+///
+/// If `connection_name` is present in `explicit`, file-based config is
+/// loaded and merged underneath.
+pub fn resolve(
+    explicit: &ParamStore,
+) -> Result<ParamStore, ConfigError> {
+    let paths = crate::config::path_resolver::get_config_paths()?;
+    resolve_with_paths(explicit, &paths)
+}
+
+/// Same as [`resolve`] but accepts explicit config file paths (for testing).
+pub fn resolve_with_paths(
+    explicit: &ParamStore,
+    paths: &ConfigPaths,
+) -> Result<ParamStore, ConfigError> {
+    let mut merged = ParamStore::new();
+
+    // Layer 4: Registry defaults (lowest priority)
+    for param in param_registry::registry().all_params() {
+        if let Some(default_fn) = param.default {
+            merged.insert(param.canonical_name.to_owned(), default_fn());
+        }
+    }
+
+    // Layer 3+2: TOML files (if connection_name is set)
+    if let Some(Setting::String(name)) = explicit.get(param_names::CONNECTION_NAME) {
+        let file_settings =
+            config_manager::load_connection_config_with_paths(name, paths)?;
+        for (k, v) in file_settings {
+            merged.insert(k, v);
+        }
+    }
+
+    // Layer 1: Explicit programmatic settings (highest priority)
+    merged.extend_from(explicit);
+
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::param_names;
+    use crate::config::path_resolver::ConfigPaths;
+    use crate::config::settings::Setting;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_paths(dir: &TempDir) -> ConfigPaths {
+        ConfigPaths {
+            config_file: Some(dir.path().join("config.toml")),
+            connections_file: Some(dir.path().join("connections.toml")),
+        }
+    }
+
+    fn write_config(dir: &TempDir, filename: &str, content: &str) {
+        let path = dir.path().join(filename);
+        fs::write(&path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    #[test]
+    fn explicit_settings_override_file_settings() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+user = "file_user"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_account".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "explicit_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        if let Some(Setting::String(user)) = resolved.get(param_names::USER) {
+            assert_eq!(user, "file_user");
+        } else {
+            panic!("Expected user setting from file");
+        }
+    }
+
+    #[test]
+    fn file_settings_override_registry_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+protocol = "http"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(protocol)) = resolved.get(param_names::PROTOCOL) {
+            assert_eq!(protocol, "http");
+        } else {
+            panic!("Expected protocol setting");
+        }
+    }
+
+    #[test]
+    fn connections_toml_overrides_config_toml() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "config.toml",
+            r#"
+[connections.testconn]
+account = "config_account"
+user = "config_user"
+"#,
+        );
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "connections_account"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "connections_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        if let Some(Setting::String(user)) = resolved.get(param_names::USER) {
+            assert_eq!(user, "config_user");
+        } else {
+            panic!("Expected user setting");
+        }
+    }
+
+    #[test]
+    fn no_connection_name_uses_only_explicit_and_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_account".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "explicit_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        // Registry default for protocol should be present
+        if let Some(Setting::String(protocol)) = resolved.get(param_names::PROTOCOL) {
+            assert_eq!(protocol, "https");
+        } else {
+            panic!("Expected default protocol setting");
+        }
+    }
+
+    fn get_str(map: &ParamStore, key: crate::config::param_registry::ParamKey) -> Option<String> {
+        match map.get(key) {
+            Some(Setting::String(v)) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn integration_full_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "config.toml",
+            r#"
+[connections.myconn]
+account = "config_acct"
+user = "config_user"
+warehouse = "config_wh"
+"#,
+        );
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[myconn]
+account = "conn_acct"
+database = "conn_db"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("myconn".to_owned()),
+        );
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_acct".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        assert_eq!(get_str(&resolved, param_names::ACCOUNT), Some("explicit_acct".to_owned()));
+        assert_eq!(get_str(&resolved, param_names::DATABASE), Some("conn_db".to_owned()));
+        assert_eq!(get_str(&resolved, param_names::USER), Some("config_user".to_owned()));
+        assert_eq!(get_str(&resolved, param_names::WAREHOUSE), Some("config_wh".to_owned()));
+        assert_eq!(get_str(&resolved, param_names::PROTOCOL), Some("https".to_owned()));
+    }
+}

--- a/sf_core/tests/integration/config/config_manager.rs
+++ b/sf_core/tests/integration/config/config_manager.rs
@@ -1,11 +1,11 @@
 use sf_core::apis::database_driver_v1::Setting;
-use sf_core::apis::database_driver_v1::connection::{
-    Connection, connection_load_from_config_with_paths,
-};
 use sf_core::config::config_manager::{
     load_all_config_sections_with_paths, load_config_section_with_paths,
 };
+use sf_core::config::param_names;
+use sf_core::config::param_store::ParamStore;
 use sf_core::config::path_resolver::ConfigPaths;
+use sf_core::config::resolver;
 use std::fs;
 use tempfile::TempDir;
 
@@ -26,9 +26,16 @@ fn write_config(dir: &TempDir, filename: &str, content: &str) {
     }
 }
 
+fn make_explicit(pairs: &[(&str, &str)]) -> ParamStore {
+    let mut store = ParamStore::new();
+    for (k, v) in pairs {
+        store.insert(k.to_string(), Setting::String(v.to_string()));
+    }
+    store
+}
+
 #[test]
-fn connection_load_from_config_basic() {
-    // Given A connections.toml file with test_connection defined
+fn resolve_basic_connection() {
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -42,17 +49,25 @@ warehouse = "mywarehouse"
 "#,
     );
 
-    // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let resolved = resolver::resolve_with_paths(&explicit, &paths).unwrap();
 
-    // Then The connection settings should be loaded
-    assert!(result.is_ok());
+    assert_eq!(
+        resolved.get(param_names::ACCOUNT),
+        Some(&Setting::String("myaccount".into()))
+    );
+    assert_eq!(
+        resolved.get(param_names::USER),
+        Some(&Setting::String("myuser".into()))
+    );
+    assert_eq!(
+        resolved.get(param_names::WAREHOUSE),
+        Some(&Setting::String("mywarehouse".into()))
+    );
 }
 
 #[test]
 fn explicit_setting_overrides_config() {
-    // Given A connections.toml with connection having account setting
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -65,38 +80,36 @@ user = "config_user"
 "#,
     );
 
-    // And An explicit account setting on the connection
-    let mut conn = Connection::new();
-    conn.set_option(
-        "account".to_string(),
-        Setting::String("explicit_account".to_string()),
-    );
+    let explicit = make_explicit(&[
+        ("connection_name", "testconn"),
+        ("account", "explicit_account"),
+    ]);
 
-    // When sf_core loads the connection config
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then The explicit setting should take precedence
     assert!(result.is_ok());
+    let resolved = result.unwrap();
+    if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+        assert_eq!(account, "explicit_account");
+    } else {
+        panic!("Expected account setting");
+    }
 }
 
 #[test]
 fn connection_not_found_in_config() {
-    // Given No configuration files exist
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
 
-    // When sf_core loads connection named nonexistent
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "nonexistent", &paths);
+    let explicit = make_explicit(&[("connection_name", "nonexistent")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then ConnectionNotFound error should be returned
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("not found"));
 }
 
 #[test]
 fn config_precedence() {
-    // Given A config.toml with connection account set to config_account
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -109,8 +122,6 @@ user = "config_user"
 database = "config_db"
 "#,
     );
-
-    // And A connections.toml with same connection account set to connections_account
     write_config(
         &temp_dir,
         "connections.toml",
@@ -121,12 +132,16 @@ warehouse = "connections_wh"
 "#,
     );
 
-    // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then connections.toml values should override config.toml
     assert!(result.is_ok());
+    let resolved = result.unwrap();
+    if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+        assert_eq!(account, "connections_account");
+    } else {
+        panic!("Expected account setting");
+    }
 }
 
 #[cfg(unix)]
@@ -134,7 +149,6 @@ warehouse = "connections_wh"
 fn insecure_permissions_rejected() {
     use std::os::unix::fs::PermissionsExt;
 
-    // Given A connections.toml file with insecure permissions
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
 
@@ -144,22 +158,17 @@ fn insecure_permissions_rejected() {
 account = "myaccount"
 "#;
     fs::write(&connections_file, content).unwrap();
-
-    // Set insecure permissions (writable by others)
     fs::set_permissions(&connections_file, fs::Permissions::from_mode(0o666)).unwrap();
 
-    // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then An insecure permissions error should be returned
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Insecure"));
 }
 
 #[test]
 fn multiple_data_types() {
-    // Given A connections.toml with string, integer, float, and boolean values
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -174,35 +183,29 @@ validate_certs = true
 "#,
     );
 
-    // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then Each value should be parsed to the correct Setting type
     assert!(result.is_ok());
 }
 
 #[test]
 fn empty_config_files() {
-    // Given Empty config.toml and connections.toml files
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(&temp_dir, "connections.toml", "");
     write_config(&temp_dir, "config.toml", "");
 
-    // When sf_core loads connection named testconn
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
-    // Then ConnectionNotFound error should be returned
     assert!(result.is_err());
 }
 
-// Tests for non-connection sections
+// Tests for non-connection sections (config_manager returns HashMap, unchanged)
 
 #[test]
 fn load_log_section() {
-    // Given A config.toml with a log section
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -218,11 +221,9 @@ account = "myaccount"
 "#,
     );
 
-    // When sf_core loads the log section
     let result = load_config_section_with_paths("log", &paths);
     assert!(result.is_ok());
 
-    // Then The log settings should be returned
     let log_section = result.unwrap();
     assert!(log_section.is_some());
 
@@ -233,7 +234,6 @@ account = "myaccount"
 
 #[test]
 fn load_multiple_sections() {
-    // Given A config.toml with log, proxy, and retry sections
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -255,13 +255,11 @@ account = "myaccount"
 "#,
     );
 
-    // When sf_core loads all config sections
     let result = load_all_config_sections_with_paths(&paths);
     assert!(result.is_ok());
 
-    // Then All sections should be returned including connections
     let sections = result.unwrap();
-    assert_eq!(sections.len(), 4); // log, proxy, retry, connections.testconn
+    assert_eq!(sections.len(), 4);
     assert!(sections.contains_key("log"));
     assert!(sections.contains_key("proxy"));
     assert!(sections.contains_key("retry"));
@@ -271,7 +269,6 @@ account = "myaccount"
 
 #[test]
 fn connections_toml_does_not_override_log_section() {
-    // Given A config.toml with log section and a connections.toml with log section
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -299,11 +296,9 @@ file = "connections_log.txt"
 "#,
     );
 
-    // When sf_core loads the log config section
     let result = load_config_section_with_paths("log", &paths);
     assert!(result.is_ok());
 
-    // Then The config.toml log values should be used
     let log_section = result.unwrap();
     assert!(log_section.is_some());
 
@@ -323,7 +318,6 @@ file = "connections_log.txt"
 
 #[test]
 fn load_nonexistent_section() {
-    // Given A config.toml with a log section
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -335,18 +329,15 @@ level = "info"
 "#,
     );
 
-    // When sf_core loads a nonexistent section
     let result = load_config_section_with_paths("nonexistent_section", &paths);
     assert!(result.is_ok());
 
-    // Then None should be returned
     let section = result.unwrap();
     assert!(section.is_none());
 }
 
 #[test]
 fn cannot_load_connections_via_load_config_section() {
-    // Given A config.toml with connections section
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -358,17 +349,14 @@ account = "myaccount"
 "#,
     );
 
-    // When sf_core loads section connections
     let result = load_config_section_with_paths("connections", &paths);
 
-    // Then None should be returned
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
 }
 
 #[test]
 fn load_nested_config_section() {
-    // Given A config.toml with nested sections like database.connection
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -389,18 +377,15 @@ max_size = 10485760
 "#,
     );
 
-    // When sf_core loads a nested section by dotted path
     let result = load_config_section_with_paths("database.connection", &paths);
     assert!(result.is_ok());
     let section = result.unwrap();
     assert!(section.is_some());
 
-    // Then The nested section settings should be returned
     let settings = section.unwrap();
     assert!(matches!(settings.get("timeout"), Some(Setting::Int(30))));
     assert!(matches!(settings.get("max_retries"), Some(Setting::Int(5))));
 
-    // Also verify other nested sections
     let result = load_config_section_with_paths("database.pool", &paths);
     assert!(result.is_ok());
     let section = result.unwrap();
@@ -424,7 +409,6 @@ max_size = 10485760
 
 #[test]
 fn nested_connections_blocked() {
-    // Given A config.toml with connections.dev and connections.prod
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -439,10 +423,7 @@ account = "prod_account"
 "#,
     );
 
-    // When sf_core loads section connections.dev
     let result = load_config_section_with_paths("connections.dev", &paths);
-
-    // Then None should be returned
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
 
@@ -453,7 +434,6 @@ account = "prod_account"
 
 #[test]
 fn nonexistent_nested_section() {
-    // Given A config.toml with database.connection section
     let temp_dir = TempDir::new().unwrap();
     let paths = make_paths(&temp_dir);
     write_config(
@@ -465,10 +445,7 @@ timeout = 30
 "#,
     );
 
-    // When sf_core loads section database.pool
     let result = load_config_section_with_paths("database.pool", &paths);
-
-    // Then None should be returned
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
 

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -7,7 +7,6 @@ use sf_core::crl::config::CrlConfig;
 use sf_core::rest::snowflake::SessionTokens;
 use sf_core::sensitive::SensitiveString;
 use sf_core::tls::config::TlsConfig;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};


### PR DESCRIPTION
Config resolution in `connection_init` was ad-hoc: a manual check for `connection_name`, a call to `connection_load_from_config`, and `entry().or_insert()` merges scattered across `connection.rs` and `config_manager.rs` with no documented precedence order. This made it hard to reason about which source wins when the same key appears in multiple places.

This change introduces `sf_core/src/config/resolver.rs` with a `ConfigResolver` struct that codifies a four-layer merge strategy (highest to lowest priority): explicit programmatic settings set via the API, `connections.toml` `[connection_name]` section, `config.toml` `[connections.connection_name]` section, and registry defaults from `ParamDef::default`. The resolver is stateless and exposes a `resolve_with_paths` variant that accepts explicit file paths, making it straightforward to test with temporary TOML fixtures. `connection_init` is simplified to a single `ConfigResolver::resolve()` call, and the now-unused `connection_load_from_config` helpers are removed.

An env-var layer is intentionally not included; the precedence slot between layers 1 and 2 is reserved for a future task.