### PR TITLE
[5/7] config: add typed ConnectionConfig builder and ConnectionValidateOptions RPC

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverService.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverService.java
@@ -139,6 +139,11 @@ public interface DatabaseDriverService {
     DatabaseDriverV1.ConnectionGetParameterResponse connectionGetParameter(DatabaseDriverV1.ConnectionGetParameterRequest request) throws ServiceException, TransportException;
 
     /**
+     * Method: connectionValidateOptions
+     */
+    DatabaseDriverV1.ConnectionValidateOptionsResponse connectionValidateOptions(DatabaseDriverV1.ConnectionValidateOptionsRequest request) throws ServiceException, TransportException;
+
+    /**
      * Method: statementNew
      */
     DatabaseDriverV1.StatementNewResponse statementNew(DatabaseDriverV1.StatementNewRequest request) throws ServiceException, TransportException;

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverServiceClient.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverServiceClient.java
@@ -903,6 +903,40 @@ public class DatabaseDriverServiceClient implements DatabaseDriverService {
     }
     
     /**
+     * Method: connectionValidateOptions
+     */
+    public DatabaseDriverV1.ConnectionValidateOptionsResponse connectionValidateOptions(DatabaseDriverV1.ConnectionValidateOptionsRequest request) throws ServiceException, TransportException {
+        TransportResponse response = transport.handleMessage(
+            "DatabaseDriver",
+            "connection_validate_options",
+            request.toByteArray()
+        );
+        
+        int code = response.getCode();
+        byte[] responseBytes = response.getResponseBytes();
+        
+        if (code == CoreTransport.CODE_SUCCESS) {
+            try {
+                return DatabaseDriverV1.ConnectionValidateOptionsResponse.parseFrom(responseBytes);
+            } catch (InvalidProtocolBufferException e) {
+                throw new TransportException("Invalid protocol buffer exception: " + e.getMessage());
+            }
+        } else if (code == CoreTransport.CODE_APPLICATION_ERROR) {
+            try {
+                DatabaseDriverV1.DriverException error = DatabaseDriverV1.DriverException.parseFrom(responseBytes);
+                throw new ServiceException(error);
+            } catch (InvalidProtocolBufferException e) {
+                throw new TransportException("Invalid protocol buffer exception: " + e.getMessage());
+            }
+        } else if (code == CoreTransport.CODE_TRANSPORT_ERROR) {
+            String errorMessage = new String(responseBytes);
+            throw new TransportException(errorMessage);
+        } else {
+            throw new TransportException("Unknown error code: " + code);
+        }
+    }
+    
+    /**
      * Method: statementNew
      */
     public DatabaseDriverV1.StatementNewResponse statementNew(DatabaseDriverV1.StatementNewRequest request) throws ServiceException, TransportException {

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverV1.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDriverV1.java
@@ -44694,6 +44694,1316 @@ java.lang.String defaultValue) {
 
   }
 
+  public interface ConnectionValidateOptionsRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:database_driver_v1.ConnectionValidateOptionsRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     * @return Whether the connHandle field is set.
+     */
+    boolean hasConnHandle();
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     * @return The connHandle.
+     */
+    net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle getConnHandle();
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     */
+    net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder getConnHandleOrBuilder();
+  }
+  /**
+   * Protobuf type {@code database_driver_v1.ConnectionValidateOptionsRequest}
+   */
+  public static final class ConnectionValidateOptionsRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:database_driver_v1.ConnectionValidateOptionsRequest)
+      ConnectionValidateOptionsRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 32,
+        /* patch= */ 1,
+        /* suffix= */ "",
+        ConnectionValidateOptionsRequest.class.getName());
+    }
+    // Use ConnectionValidateOptionsRequest.newBuilder() to construct.
+    private ConnectionValidateOptionsRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ConnectionValidateOptionsRequest() {
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.class, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int CONN_HANDLE_FIELD_NUMBER = 1;
+    private net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle connHandle_;
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     * @return Whether the connHandle field is set.
+     */
+    @java.lang.Override
+    public boolean hasConnHandle() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     * @return The connHandle.
+     */
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle getConnHandle() {
+      return connHandle_ == null ? net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.getDefaultInstance() : connHandle_;
+    }
+    /**
+     * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+     */
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder getConnHandleOrBuilder() {
+      return connHandle_ == null ? net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.getDefaultInstance() : connHandle_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getConnHandle());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getConnHandle());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest)) {
+        return super.equals(obj);
+      }
+      net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest other = (net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest) obj;
+
+      if (hasConnHandle() != other.hasConnHandle()) return false;
+      if (hasConnHandle()) {
+        if (!getConnHandle()
+            .equals(other.getConnHandle())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasConnHandle()) {
+        hash = (37 * hash) + CONN_HANDLE_FIELD_NUMBER;
+        hash = (53 * hash) + getConnHandle().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code database_driver_v1.ConnectionValidateOptionsRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:database_driver_v1.ConnectionValidateOptionsRequest)
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.class, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.Builder.class);
+      }
+
+      // Construct using net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage
+                .alwaysUseFieldBuilders) {
+          internalGetConnHandleFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        connHandle_ = null;
+        if (connHandleBuilder_ != null) {
+          connHandleBuilder_.dispose();
+          connHandleBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest getDefaultInstanceForType() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest build() {
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest buildPartial() {
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest result = new net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.connHandle_ = connHandleBuilder_ == null
+              ? connHandle_
+              : connHandleBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest) {
+          return mergeFrom((net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest other) {
+        if (other == net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest.getDefaultInstance()) return this;
+        if (other.hasConnHandle()) {
+          mergeConnHandle(other.getConnHandle());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                input.readMessage(
+                    internalGetConnHandleFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle connHandle_;
+      private com.google.protobuf.SingleFieldBuilder<
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder> connHandleBuilder_;
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       * @return Whether the connHandle field is set.
+       */
+      public boolean hasConnHandle() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       * @return The connHandle.
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle getConnHandle() {
+        if (connHandleBuilder_ == null) {
+          return connHandle_ == null ? net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.getDefaultInstance() : connHandle_;
+        } else {
+          return connHandleBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public Builder setConnHandle(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle value) {
+        if (connHandleBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          connHandle_ = value;
+        } else {
+          connHandleBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public Builder setConnHandle(
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.Builder builderForValue) {
+        if (connHandleBuilder_ == null) {
+          connHandle_ = builderForValue.build();
+        } else {
+          connHandleBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public Builder mergeConnHandle(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle value) {
+        if (connHandleBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+            connHandle_ != null &&
+            connHandle_ != net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.getDefaultInstance()) {
+            getConnHandleBuilder().mergeFrom(value);
+          } else {
+            connHandle_ = value;
+          }
+        } else {
+          connHandleBuilder_.mergeFrom(value);
+        }
+        if (connHandle_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public Builder clearConnHandle() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        connHandle_ = null;
+        if (connHandleBuilder_ != null) {
+          connHandleBuilder_.dispose();
+          connHandleBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.Builder getConnHandleBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return internalGetConnHandleFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder getConnHandleOrBuilder() {
+        if (connHandleBuilder_ != null) {
+          return connHandleBuilder_.getMessageOrBuilder();
+        } else {
+          return connHandle_ == null ?
+              net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.getDefaultInstance() : connHandle_;
+        }
+      }
+      /**
+       * <code>.database_driver_v1.ConnectionHandle conn_handle = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder> 
+          internalGetConnHandleFieldBuilder() {
+        if (connHandleBuilder_ == null) {
+          connHandleBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandleOrBuilder>(
+                  getConnHandle(),
+                  getParentForChildren(),
+                  isClean());
+          connHandle_ = null;
+        }
+        return connHandleBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:database_driver_v1.ConnectionValidateOptionsRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:database_driver_v1.ConnectionValidateOptionsRequest)
+    private static final net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest();
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ConnectionValidateOptionsRequest>
+        PARSER = new com.google.protobuf.AbstractParser<ConnectionValidateOptionsRequest>() {
+      @java.lang.Override
+      public ConnectionValidateOptionsRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<ConnectionValidateOptionsRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ConnectionValidateOptionsRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ConnectionValidateOptionsResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:database_driver_v1.ConnectionValidateOptionsResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> 
+        getIssuesList();
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue getIssues(int index);
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    int getIssuesCount();
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    java.util.List<? extends net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder> 
+        getIssuesOrBuilderList();
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder getIssuesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code database_driver_v1.ConnectionValidateOptionsResponse}
+   */
+  public static final class ConnectionValidateOptionsResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:database_driver_v1.ConnectionValidateOptionsResponse)
+      ConnectionValidateOptionsResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 32,
+        /* patch= */ 1,
+        /* suffix= */ "",
+        ConnectionValidateOptionsResponse.class.getName());
+    }
+    // Use ConnectionValidateOptionsResponse.newBuilder() to construct.
+    private ConnectionValidateOptionsResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ConnectionValidateOptionsResponse() {
+      issues_ = java.util.Collections.emptyList();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.class, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.Builder.class);
+    }
+
+    public static final int ISSUES_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> issues_;
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    @java.lang.Override
+    public java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> getIssuesList() {
+      return issues_;
+    }
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder> 
+        getIssuesOrBuilderList() {
+      return issues_;
+    }
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    @java.lang.Override
+    public int getIssuesCount() {
+      return issues_.size();
+    }
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue getIssues(int index) {
+      return issues_.get(index);
+    }
+    /**
+     * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+     */
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder getIssuesOrBuilder(
+        int index) {
+      return issues_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < issues_.size(); i++) {
+        output.writeMessage(1, issues_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < issues_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, issues_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse)) {
+        return super.equals(obj);
+      }
+      net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse other = (net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse) obj;
+
+      if (!getIssuesList()
+          .equals(other.getIssuesList())) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getIssuesCount() > 0) {
+        hash = (37 * hash) + ISSUES_FIELD_NUMBER;
+        hash = (53 * hash) + getIssuesList().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code database_driver_v1.ConnectionValidateOptionsResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:database_driver_v1.ConnectionValidateOptionsResponse)
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.class, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.Builder.class);
+      }
+
+      // Construct using net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        if (issuesBuilder_ == null) {
+          issues_ = java.util.Collections.emptyList();
+        } else {
+          issues_ = null;
+          issuesBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse getDefaultInstanceForType() {
+        return net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse build() {
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse buildPartial() {
+        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse result = new net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse(this);
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse result) {
+        if (issuesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0)) {
+            issues_ = java.util.Collections.unmodifiableList(issues_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.issues_ = issues_;
+        } else {
+          result.issues_ = issuesBuilder_.build();
+        }
+      }
+
+      private void buildPartial0(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse result) {
+        int from_bitField0_ = bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse) {
+          return mergeFrom((net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse other) {
+        if (other == net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse.getDefaultInstance()) return this;
+        if (issuesBuilder_ == null) {
+          if (!other.issues_.isEmpty()) {
+            if (issues_.isEmpty()) {
+              issues_ = other.issues_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureIssuesIsMutable();
+              issues_.addAll(other.issues_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.issues_.isEmpty()) {
+            if (issuesBuilder_.isEmpty()) {
+              issuesBuilder_.dispose();
+              issuesBuilder_ = null;
+              issues_ = other.issues_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              issuesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   internalGetIssuesFieldBuilder() : null;
+            } else {
+              issuesBuilder_.addAllMessages(other.issues_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue m =
+                    input.readMessage(
+                        net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.parser(),
+                        extensionRegistry);
+                if (issuesBuilder_ == null) {
+                  ensureIssuesIsMutable();
+                  issues_.add(m);
+                } else {
+                  issuesBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> issues_ =
+        java.util.Collections.emptyList();
+      private void ensureIssuesIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          issues_ = new java.util.ArrayList<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue>(issues_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder> issuesBuilder_;
+
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> getIssuesList() {
+        if (issuesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(issues_);
+        } else {
+          return issuesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public int getIssuesCount() {
+        if (issuesBuilder_ == null) {
+          return issues_.size();
+        } else {
+          return issuesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue getIssues(int index) {
+        if (issuesBuilder_ == null) {
+          return issues_.get(index);
+        } else {
+          return issuesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder setIssues(
+          int index, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue value) {
+        if (issuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIssuesIsMutable();
+          issues_.set(index, value);
+          onChanged();
+        } else {
+          issuesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder setIssues(
+          int index, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder builderForValue) {
+        if (issuesBuilder_ == null) {
+          ensureIssuesIsMutable();
+          issues_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          issuesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder addIssues(net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue value) {
+        if (issuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIssuesIsMutable();
+          issues_.add(value);
+          onChanged();
+        } else {
+          issuesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder addIssues(
+          int index, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue value) {
+        if (issuesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIssuesIsMutable();
+          issues_.add(index, value);
+          onChanged();
+        } else {
+          issuesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder addIssues(
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder builderForValue) {
+        if (issuesBuilder_ == null) {
+          ensureIssuesIsMutable();
+          issues_.add(builderForValue.build());
+          onChanged();
+        } else {
+          issuesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder addIssues(
+          int index, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder builderForValue) {
+        if (issuesBuilder_ == null) {
+          ensureIssuesIsMutable();
+          issues_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          issuesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder addAllIssues(
+          java.lang.Iterable<? extends net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue> values) {
+        if (issuesBuilder_ == null) {
+          ensureIssuesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, issues_);
+          onChanged();
+        } else {
+          issuesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder clearIssues() {
+        if (issuesBuilder_ == null) {
+          issues_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          issuesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public Builder removeIssues(int index) {
+        if (issuesBuilder_ == null) {
+          ensureIssuesIsMutable();
+          issues_.remove(index);
+          onChanged();
+        } else {
+          issuesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder getIssuesBuilder(
+          int index) {
+        return internalGetIssuesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder getIssuesOrBuilder(
+          int index) {
+        if (issuesBuilder_ == null) {
+          return issues_.get(index);  } else {
+          return issuesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public java.util.List<? extends net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder> 
+           getIssuesOrBuilderList() {
+        if (issuesBuilder_ != null) {
+          return issuesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(issues_);
+        }
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder addIssuesBuilder() {
+        return internalGetIssuesFieldBuilder().addBuilder(
+            net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder addIssuesBuilder(
+          int index) {
+        return internalGetIssuesFieldBuilder().addBuilder(
+            index, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .database_driver_v1.ValidationIssue issues = 1;</code>
+       */
+      public java.util.List<net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder> 
+           getIssuesBuilderList() {
+        return internalGetIssuesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder> 
+          internalGetIssuesFieldBuilder() {
+        if (issuesBuilder_ == null) {
+          issuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue.Builder, net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssueOrBuilder>(
+                  issues_,
+                  ((bitField0_ & 0x00000001) != 0),
+                  getParentForChildren(),
+                  isClean());
+          issues_ = null;
+        }
+        return issuesBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:database_driver_v1.ConnectionValidateOptionsResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:database_driver_v1.ConnectionValidateOptionsResponse)
+    private static final net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse();
+    }
+
+    public static net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ConnectionValidateOptionsResponse>
+        PARSER = new com.google.protobuf.AbstractParser<ConnectionValidateOptionsResponse>() {
+      @java.lang.Override
+      public ConnectionValidateOptionsResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<ConnectionValidateOptionsResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ConnectionValidateOptionsResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionValidateOptionsResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface StatementNewRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:database_driver_v1.StatementNewRequest)
       com.google.protobuf.MessageOrBuilder {
@@ -71684,6 +72994,16 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_database_driver_v1_ConnectionGetParameterResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_database_driver_v1_ConnectionValidateOptionsRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_database_driver_v1_ConnectionValidateOptionsResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_database_driver_v1_StatementNewRequest_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -72076,285 +73396,293 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
       "ionGetParameterRequest\0229\n\013conn_handle\030\001 " +
       "\001(\0132$.database_driver_v1.ConnectionHandl" +
       "e\022\013\n\003key\030\002 \001(\t\">\n\036ConnectionGetParameter" +
-      "Response\022\022\n\005value\030\001 \001(\tH\000\210\001\001B\010\n\006_value\"P" +
-      "\n\023StatementNewRequest\0229\n\013conn_handle\030\001 \001" +
-      "(\0132$.database_driver_v1.ConnectionHandle" +
-      "\"P\n\024StatementNewResponse\0228\n\013stmt_handle\030" +
-      "\001 \001(\0132#.database_driver_v1.StatementHand" +
-      "le\"S\n\027StatementReleaseRequest\0228\n\013stmt_ha" +
-      "ndle\030\001 \001(\0132#.database_driver_v1.Statemen" +
-      "tHandle\"\032\n\030StatementReleaseResponse\"f\n\033S" +
-      "tatementSetSqlQueryRequest\0228\n\013stmt_handl" +
-      "e\030\001 \001(\0132#.database_driver_v1.StatementHa" +
-      "ndle\022\r\n\005query\030\002 \001(\t\"\036\n\034StatementSetSqlQu" +
-      "eryResponse\"j\n StatementSetSubstraitPlan" +
-      "Request\0228\n\013stmt_handle\030\001 \001(\0132#.database_" +
-      "driver_v1.StatementHandle\022\014\n\004plan\030\002 \001(\014\"" +
-      "#\n!StatementSetSubstraitPlanResponse\"}\n\r" +
-      "PrepareResult\0227\n\006stream\030\001 \001(\0132\'.database" +
-      "_driver_v1.ArrowArrayStreamPtr\0223\n\007column" +
-      "s\030\004 \003(\0132\".database_driver_v1.ColumnMetad" +
-      "ata\"S\n\027StatementPrepareRequest\0228\n\013stmt_h" +
-      "andle\030\001 \001(\0132#.database_driver_v1.Stateme" +
-      "ntHandle\"M\n\030StatementPrepareResponse\0221\n\006" +
-      "result\030\001 \001(\0132!.database_driver_v1.Prepar" +
-      "eResult\"w\n\037StatementSetOptionStringReque" +
-      "st\0228\n\013stmt_handle\030\001 \001(\0132#.database_drive" +
-      "r_v1.StatementHandle\022\013\n\003key\030\002 \001(\t\022\r\n\005val" +
-      "ue\030\003 \001(\t\"\"\n StatementSetOptionStringResp" +
-      "onse\"v\n\036StatementSetOptionBytesRequest\0228" +
-      "\n\013stmt_handle\030\001 \001(\0132#.database_driver_v1" +
-      ".StatementHandle\022\013\n\003key\030\002 \001(\t\022\r\n\005value\030\003" +
-      " \001(\014\"!\n\037StatementSetOptionBytesResponse\"" +
-      "t\n\034StatementSetOptionIntRequest\0228\n\013stmt_" +
-      "handle\030\001 \001(\0132#.database_driver_v1.Statem" +
-      "entHandle\022\013\n\003key\030\002 \001(\t\022\r\n\005value\030\003 \001(\003\"\037\n" +
-      "\035StatementSetOptionIntResponse\"w\n\037Statem" +
-      "entSetOptionDoubleRequest\0228\n\013stmt_handle" +
+      "Response\022\022\n\005value\030\001 \001(\tH\000\210\001\001B\010\n\006_value\"]" +
+      "\n ConnectionValidateOptionsRequest\0229\n\013co" +
+      "nn_handle\030\001 \001(\0132$.database_driver_v1.Con" +
+      "nectionHandle\"X\n!ConnectionValidateOptio" +
+      "nsResponse\0223\n\006issues\030\001 \003(\0132#.database_dr" +
+      "iver_v1.ValidationIssue\"P\n\023StatementNewR" +
+      "equest\0229\n\013conn_handle\030\001 \001(\0132$.database_d" +
+      "river_v1.ConnectionHandle\"P\n\024StatementNe" +
+      "wResponse\0228\n\013stmt_handle\030\001 \001(\0132#.databas" +
+      "e_driver_v1.StatementHandle\"S\n\027Statement" +
+      "ReleaseRequest\0228\n\013stmt_handle\030\001 \001(\0132#.da" +
+      "tabase_driver_v1.StatementHandle\"\032\n\030Stat" +
+      "ementReleaseResponse\"f\n\033StatementSetSqlQ" +
+      "ueryRequest\0228\n\013stmt_handle\030\001 \001(\0132#.datab" +
+      "ase_driver_v1.StatementHandle\022\r\n\005query\030\002" +
+      " \001(\t\"\036\n\034StatementSetSqlQueryResponse\"j\n " +
+      "StatementSetSubstraitPlanRequest\0228\n\013stmt" +
+      "_handle\030\001 \001(\0132#.database_driver_v1.State" +
+      "mentHandle\022\014\n\004plan\030\002 \001(\014\"#\n!StatementSet" +
+      "SubstraitPlanResponse\"}\n\rPrepareResult\0227" +
+      "\n\006stream\030\001 \001(\0132\'.database_driver_v1.Arro" +
+      "wArrayStreamPtr\0223\n\007columns\030\004 \003(\0132\".datab" +
+      "ase_driver_v1.ColumnMetadata\"S\n\027Statemen" +
+      "tPrepareRequest\0228\n\013stmt_handle\030\001 \001(\0132#.d" +
+      "atabase_driver_v1.StatementHandle\"M\n\030Sta" +
+      "tementPrepareResponse\0221\n\006result\030\001 \001(\0132!." +
+      "database_driver_v1.PrepareResult\"w\n\037Stat" +
+      "ementSetOptionStringRequest\0228\n\013stmt_hand" +
+      "le\030\001 \001(\0132#.database_driver_v1.StatementH" +
+      "andle\022\013\n\003key\030\002 \001(\t\022\r\n\005value\030\003 \001(\t\"\"\n Sta" +
+      "tementSetOptionStringResponse\"v\n\036Stateme" +
+      "ntSetOptionBytesRequest\0228\n\013stmt_handle\030\001" +
+      " \001(\0132#.database_driver_v1.StatementHandl" +
+      "e\022\013\n\003key\030\002 \001(\t\022\r\n\005value\030\003 \001(\014\"!\n\037Stateme" +
+      "ntSetOptionBytesResponse\"t\n\034StatementSet" +
+      "OptionIntRequest\0228\n\013stmt_handle\030\001 \001(\0132#." +
+      "database_driver_v1.StatementHandle\022\013\n\003ke" +
+      "y\030\002 \001(\t\022\r\n\005value\030\003 \001(\003\"\037\n\035StatementSetOp" +
+      "tionIntResponse\"w\n\037StatementSetOptionDou" +
+      "bleRequest\0228\n\013stmt_handle\030\001 \001(\0132#.databa" +
+      "se_driver_v1.StatementHandle\022\013\n\003key\030\002 \001(" +
+      "\t\022\r\n\005value\030\003 \001(\001\"\"\n StatementSetOptionDo" +
+      "ubleResponse\"u\n\035StatementSetOptionBoolRe" +
+      "quest\0228\n\013stmt_handle\030\001 \001(\0132#.database_dr" +
+      "iver_v1.StatementHandle\022\013\n\003key\030\002 \001(\t\022\r\n\005" +
+      "value\030\003 \001(\010\" \n\036StatementSetOptionBoolRes" +
+      "ponse\"^\n\"StatementGetParameterSchemaRequ" +
+      "est\0228\n\013stmt_handle\030\001 \001(\0132#.database_driv" +
+      "er_v1.StatementHandle\"Y\n#StatementGetPar" +
+      "ameterSchemaResponse\0222\n\006schema\030\001 \001(\0132\".d" +
+      "atabase_driver_v1.ArrowSchemaPtr\"\237\001\n\034Sta" +
+      "tementExecuteQueryRequest\0228\n\013stmt_handle" +
       "\030\001 \001(\0132#.database_driver_v1.StatementHan" +
-      "dle\022\013\n\003key\030\002 \001(\t\022\r\n\005value\030\003 \001(\001\"\"\n State" +
-      "mentSetOptionDoubleResponse\"u\n\035Statement" +
-      "SetOptionBoolRequest\0228\n\013stmt_handle\030\001 \001(" +
-      "\0132#.database_driver_v1.StatementHandle\022\013" +
-      "\n\003key\030\002 \001(\t\022\r\n\005value\030\003 \001(\010\" \n\036StatementS" +
-      "etOptionBoolResponse\"^\n\"StatementGetPara" +
-      "meterSchemaRequest\0228\n\013stmt_handle\030\001 \001(\0132" +
-      "#.database_driver_v1.StatementHandle\"Y\n#" +
-      "StatementGetParameterSchemaResponse\0222\n\006s" +
-      "chema\030\001 \001(\0132\".database_driver_v1.ArrowSc" +
-      "hemaPtr\"\237\001\n\034StatementExecuteQueryRequest" +
-      "\0228\n\013stmt_handle\030\001 \001(\0132#.database_driver_" +
-      "v1.StatementHandle\0228\n\010bindings\030\002 \001(\0132!.d" +
-      "atabase_driver_v1.QueryBindingsH\000\210\001\001B\013\n\t" +
-      "_bindings\"R\n\035StatementExecuteQueryRespon" +
-      "se\0221\n\006result\030\001 \001(\0132!.database_driver_v1." +
-      "ExecuteResult\"]\n!StatementExecutePartiti" +
-      "onsRequest\0228\n\013stmt_handle\030\001 \001(\0132#.databa" +
-      "se_driver_v1.StatementHandle\"[\n\"Statemen" +
-      "tExecutePartitionsResponse\0225\n\006result\030\001 \001" +
-      "(\0132%.database_driver_v1.PartitionedResul" +
-      "t\"w\n\035StatementReadPartitionRequest\0228\n\013st" +
-      "mt_handle\030\001 \001(\0132#.database_driver_v1.Sta" +
-      "tementHandle\022\034\n\024partition_descriptor\030\002 \001" +
-      "(\014\":\n\036StatementReadPartitionResponse\022\030\n\020" +
-      "partition_stream\030\001 \001(\003\"\241\001\n\017ValidationIss" +
-      "ue\0228\n\010severity\030\001 \001(\0162&.database_driver_v" +
-      "1.ValidationSeverity\022\021\n\tparameter\030\002 \001(\t\022" +
-      "\017\n\007message\030\003 \001(\t\0220\n\004code\030\004 \001(\0162\".databas" +
-      "e_driver_v1.ValidationCode\"\212\001\n\rConfigSet" +
-      "ting\022\026\n\014string_value\030\001 \001(\tH\000\022\023\n\tint_valu" +
-      "e\030\002 \001(\003H\000\022\026\n\014double_value\030\003 \001(\001H\000\022\025\n\013byt" +
-      "es_value\030\004 \001(\014H\000\022\024\n\nbool_value\030\005 \001(\010H\000B\007" +
-      "\n\005value\"\246\001\n\rConfigSection\022A\n\010settings\030\001 " +
-      "\003(\0132/.database_driver_v1.ConfigSection.S" +
-      "ettingsEntry\032R\n\rSettingsEntry\022\013\n\003key\030\001 \001" +
-      "(\t\0220\n\005value\030\002 \001(\0132!.database_driver_v1.C" +
-      "onfigSetting:\0028\001\"\372\001\n\033ConnectionSetOption" +
-      "sRequest\0229\n\013conn_handle\030\001 \001(\0132$.database" +
-      "_driver_v1.ConnectionHandle\022M\n\007options\030\002" +
-      " \003(\0132<.database_driver_v1.ConnectionSetO" +
-      "ptionsRequest.OptionsEntry\032Q\n\014OptionsEnt" +
-      "ry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001(\0132!.databas" +
-      "e_driver_v1.ConfigSetting:\0028\001\"U\n\034Connect" +
-      "ionSetOptionsResponse\0225\n\010warnings\030\001 \003(\0132" +
-      "#.database_driver_v1.ValidationIssue\"\362\001\n" +
-      "\031DatabaseSetOptionsRequest\0225\n\tdb_handle\030" +
-      "\001 \001(\0132\".database_driver_v1.DatabaseHandl" +
-      "e\022K\n\007options\030\002 \003(\0132:.database_driver_v1." +
-      "DatabaseSetOptionsRequest.OptionsEntry\032Q" +
+      "dle\0228\n\010bindings\030\002 \001(\0132!.database_driver_" +
+      "v1.QueryBindingsH\000\210\001\001B\013\n\t_bindings\"R\n\035St" +
+      "atementExecuteQueryResponse\0221\n\006result\030\001 " +
+      "\001(\0132!.database_driver_v1.ExecuteResult\"]" +
+      "\n!StatementExecutePartitionsRequest\0228\n\013s" +
+      "tmt_handle\030\001 \001(\0132#.database_driver_v1.St" +
+      "atementHandle\"[\n\"StatementExecutePartiti" +
+      "onsResponse\0225\n\006result\030\001 \001(\0132%.database_d" +
+      "river_v1.PartitionedResult\"w\n\035StatementR" +
+      "eadPartitionRequest\0228\n\013stmt_handle\030\001 \001(\013" +
+      "2#.database_driver_v1.StatementHandle\022\034\n" +
+      "\024partition_descriptor\030\002 \001(\014\":\n\036Statement" +
+      "ReadPartitionResponse\022\030\n\020partition_strea" +
+      "m\030\001 \001(\003\"\241\001\n\017ValidationIssue\0228\n\010severity\030" +
+      "\001 \001(\0162&.database_driver_v1.ValidationSev" +
+      "erity\022\021\n\tparameter\030\002 \001(\t\022\017\n\007message\030\003 \001(" +
+      "\t\0220\n\004code\030\004 \001(\0162\".database_driver_v1.Val" +
+      "idationCode\"\212\001\n\rConfigSetting\022\026\n\014string_" +
+      "value\030\001 \001(\tH\000\022\023\n\tint_value\030\002 \001(\003H\000\022\026\n\014do" +
+      "uble_value\030\003 \001(\001H\000\022\025\n\013bytes_value\030\004 \001(\014H" +
+      "\000\022\024\n\nbool_value\030\005 \001(\010H\000B\007\n\005value\"\246\001\n\rCon" +
+      "figSection\022A\n\010settings\030\001 \003(\0132/.database_" +
+      "driver_v1.ConfigSection.SettingsEntry\032R\n" +
+      "\rSettingsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001" +
+      "(\0132!.database_driver_v1.ConfigSetting:\0028" +
+      "\001\"\372\001\n\033ConnectionSetOptionsRequest\0229\n\013con" +
+      "n_handle\030\001 \001(\0132$.database_driver_v1.Conn" +
+      "ectionHandle\022M\n\007options\030\002 \003(\0132<.database" +
+      "_driver_v1.ConnectionSetOptionsRequest.O" +
+      "ptionsEntry\032Q\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t" +
+      "\0220\n\005value\030\002 \001(\0132!.database_driver_v1.Con" +
+      "figSetting:\0028\001\"U\n\034ConnectionSetOptionsRe" +
+      "sponse\0225\n\010warnings\030\001 \003(\0132#.database_driv" +
+      "er_v1.ValidationIssue\"\362\001\n\031DatabaseSetOpt" +
+      "ionsRequest\0225\n\tdb_handle\030\001 \001(\0132\".databas" +
+      "e_driver_v1.DatabaseHandle\022K\n\007options\030\002 " +
+      "\003(\0132:.database_driver_v1.DatabaseSetOpti" +
+      "onsRequest.OptionsEntry\032Q\n\014OptionsEntry\022" +
+      "\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001(\0132!.database_d" +
+      "river_v1.ConfigSetting:\0028\001\"S\n\032DatabaseSe" +
+      "tOptionsResponse\0225\n\010warnings\030\001 \003(\0132#.dat" +
+      "abase_driver_v1.ValidationIssue\"\367\001\n\032Stat" +
+      "ementSetOptionsRequest\0228\n\013stmt_handle\030\001 " +
+      "\001(\0132#.database_driver_v1.StatementHandle" +
+      "\022L\n\007options\030\002 \003(\0132;.database_driver_v1.S" +
+      "tatementSetOptionsRequest.OptionsEntry\032Q" +
       "\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001" +
       "(\0132!.database_driver_v1.ConfigSetting:\0028" +
-      "\001\"S\n\032DatabaseSetOptionsResponse\0225\n\010warni" +
-      "ngs\030\001 \003(\0132#.database_driver_v1.Validatio" +
-      "nIssue\"\367\001\n\032StatementSetOptionsRequest\0228\n" +
-      "\013stmt_handle\030\001 \001(\0132#.database_driver_v1." +
-      "StatementHandle\022L\n\007options\030\002 \003(\0132;.datab" +
-      "ase_driver_v1.StatementSetOptionsRequest" +
-      ".OptionsEntry\032Q\n\014OptionsEntry\022\013\n\003key\030\001 \001" +
-      "(\t\0220\n\005value\030\002 \001(\0132!.database_driver_v1.C" +
-      "onfigSetting:\0028\001\"T\n\033StatementSetOptionsR" +
-      "esponse\0225\n\010warnings\030\001 \003(\0132#.database_dri" +
-      "ver_v1.ValidationIssue\"|\n\034ConfigLoadAllS" +
-      "ectionsRequest\022\030\n\013config_file\030\001 \001(\tH\000\210\001\001" +
-      "\022\035\n\020connections_file\030\002 \001(\tH\001\210\001\001B\016\n\014_conf" +
-      "ig_fileB\023\n\021_connections_file\"4\n\035ConfigLo" +
-      "adAllSectionsResponse\022\023\n\013config_json\030\001 \001" +
-      "(\t\"\027\n\025ConfigGetPathsRequest\"G\n\026ConfigGet" +
-      "PathsResponse\022\023\n\013config_file\030\001 \001(\t\022\030\n\020co" +
-      "nnections_file\030\002 \001(\t*\264\004\n\nStatusCode\022\033\n\027S" +
-      "TATUS_CODE_UNSPECIFIED\020\000\022\022\n\016STATUS_CODE_" +
-      "OK\020\001\022$\n STATUS_CODE_AUTHENTICATION_ERROR" +
-      "\020\002\022\037\n\033STATUS_CODE_NOT_IMPLEMENTED\020\003\022\031\n\025S" +
-      "TATUS_CODE_NOT_FOUND\020\004\022\036\n\032STATUS_CODE_AL" +
-      "READY_EXISTS\020\005\022 \n\034STATUS_CODE_INVALID_AR" +
-      "GUMENT\020\006\022\035\n\031STATUS_CODE_INVALID_STATE\020\007\022" +
-      "\034\n\030STATUS_CODE_INVALID_DATA\020\010\022\022\n\016STATUS_" +
-      "CODE_IO\020\t\022\031\n\025STATUS_CODE_CANCELLED\020\n\022\037\n\033" +
-      "STATUS_CODE_UNAUTHENTICATED\020\013\022\034\n\030STATUS_" +
-      "CODE_UNAUTHORIZED\020\014\022\035\n\031STATUS_CODE_GENER" +
-      "IC_ERROR\020\r\022\036\n\032STATUS_CODE_INTERNAL_ERROR" +
-      "\020\016\022!\n\035STATUS_CODE_MISSING_PARAMETER\020\017\022\'\n" +
-      "#STATUS_CODE_INVALID_PARAMETER_VALUE\020\020\022\033" +
-      "\n\027STATUS_CODE_LOGIN_ERROR\020\021*\230\003\n\010InfoCode" +
-      "\022\031\n\025INFO_CODE_UNSPECIFIED\020\000\022\031\n\025INFO_CODE" +
-      "_VENDOR_NAME\020\001\022\034\n\030INFO_CODE_VENDOR_VERSI" +
-      "ON\020\002\022\"\n\036INFO_CODE_VENDOR_ARROW_VERSION\020\003" +
-      "\022\030\n\024INFO_CODE_VENDOR_SQL\020e\022\036\n\032INFO_CODE_" +
-      "VENDOR_SUBSTRAIT\020f\022*\n&INFO_CODE_VENDOR_S" +
-      "UBSTRAIT_MIN_VERSION\020g\022*\n&INFO_CODE_VEND" +
-      "OR_SUBSTRAIT_MAX_VERSION\020h\022\032\n\025INFO_CODE_" +
-      "DRIVER_NAME\020\311\001\022\035\n\030INFO_CODE_DRIVER_VERSI" +
-      "ON\020\312\001\022#\n\036INFO_CODE_DRIVER_ARROW_VERSION\020" +
-      "\313\001\022\"\n\035INFO_CODE_DRIVER_ADBC_VERSION\020\314\001*T" +
-      "\n\022ValidationSeverity\022\035\n\031VALIDATION_SEVER" +
-      "ITY_ERROR\020\000\022\037\n\033VALIDATION_SEVERITY_WARNI" +
-      "NG\020\001*\231\002\n\016ValidationCode\022\037\n\033VALIDATION_CO" +
-      "DE_UNSPECIFIED\020\000\022$\n VALIDATION_CODE_MISS" +
-      "ING_REQUIRED\020\001\022 \n\034VALIDATION_CODE_INVALI" +
-      "D_TYPE\020\002\022!\n\035VALIDATION_CODE_INVALID_VALU" +
-      "E\020\003\022%\n!VALIDATION_CODE_UNKNOWN_PARAMETER" +
-      "\020\004\022(\n$VALIDATION_CODE_DEPRECATED_PARAMET" +
-      "ER\020\005\022*\n&VALIDATION_CODE_CONFLICTING_PARA" +
-      "METERS\020\0062\377)\n\016DatabaseDriver\022^\n\013DatabaseN" +
-      "ew\022&.database_driver_v1.DatabaseNewReque" +
-      "st\032\'.database_driver_v1.DatabaseNewRespo" +
-      "nse\022\202\001\n\027DatabaseSetOptionString\0222.databa" +
-      "se_driver_v1.DatabaseSetOptionStringRequ" +
-      "est\0323.database_driver_v1.DatabaseSetOpti" +
-      "onStringResponse\022\177\n\026DatabaseSetOptionByt" +
-      "es\0221.database_driver_v1.DatabaseSetOptio" +
-      "nBytesRequest\0322.database_driver_v1.Datab" +
-      "aseSetOptionBytesResponse\022y\n\024DatabaseSet" +
-      "OptionInt\022/.database_driver_v1.DatabaseS" +
-      "etOptionIntRequest\0320.database_driver_v1." +
-      "DatabaseSetOptionIntResponse\022\202\001\n\027Databas" +
-      "eSetOptionDouble\0222.database_driver_v1.Da" +
-      "tabaseSetOptionDoubleRequest\0323.database_" +
-      "driver_v1.DatabaseSetOptionDoubleRespons" +
-      "e\022|\n\025DatabaseSetOptionBool\0220.database_dr" +
-      "iver_v1.DatabaseSetOptionBoolRequest\0321.d" +
-      "atabase_driver_v1.DatabaseSetOptionBoolR" +
-      "esponse\022s\n\022DatabaseSetOptions\022-.database" +
-      "_driver_v1.DatabaseSetOptionsRequest\032..d" +
-      "atabase_driver_v1.DatabaseSetOptionsResp" +
-      "onse\022a\n\014DatabaseInit\022\'.database_driver_v" +
-      "1.DatabaseInitRequest\032(.database_driver_" +
-      "v1.DatabaseInitResponse\022j\n\017DatabaseRelea" +
-      "se\022*.database_driver_v1.DatabaseReleaseR" +
-      "equest\032+.database_driver_v1.DatabaseRele" +
-      "aseResponse\022d\n\rConnectionNew\022(.database_" +
-      "driver_v1.ConnectionNewRequest\032).databas" +
-      "e_driver_v1.ConnectionNewResponse\022\210\001\n\031Co" +
-      "nnectionSetOptionString\0224.database_drive" +
-      "r_v1.ConnectionSetOptionStringRequest\0325." +
-      "database_driver_v1.ConnectionSetOptionSt" +
-      "ringResponse\022\205\001\n\030ConnectionSetOptionByte" +
-      "s\0223.database_driver_v1.ConnectionSetOpti" +
-      "onBytesRequest\0324.database_driver_v1.Conn" +
-      "ectionSetOptionBytesResponse\022\177\n\026Connecti" +
-      "onSetOptionInt\0221.database_driver_v1.Conn" +
-      "ectionSetOptionIntRequest\0322.database_dri" +
-      "ver_v1.ConnectionSetOptionIntResponse\022\210\001" +
-      "\n\031ConnectionSetOptionDouble\0224.database_d" +
-      "river_v1.ConnectionSetOptionDoubleReques" +
-      "t\0325.database_driver_v1.ConnectionSetOpti" +
-      "onDoubleResponse\022\202\001\n\027ConnectionSetOption" +
-      "Bool\0222.database_driver_v1.ConnectionSetO" +
-      "ptionBoolRequest\0323.database_driver_v1.Co" +
-      "nnectionSetOptionBoolResponse\022y\n\024Connect" +
-      "ionSetOptions\022/.database_driver_v1.Conne" +
-      "ctionSetOptionsRequest\0320.database_driver" +
-      "_v1.ConnectionSetOptionsResponse\022g\n\016Conn" +
-      "ectionInit\022).database_driver_v1.Connecti" +
-      "onInitRequest\032*.database_driver_v1.Conne" +
-      "ctionInitResponse\022p\n\021ConnectionRelease\022," +
-      ".database_driver_v1.ConnectionReleaseReq" +
-      "uest\032-.database_driver_v1.ConnectionRele" +
-      "aseResponse\022p\n\021ConnectionGetInfo\022,.datab" +
-      "ase_driver_v1.ConnectionGetInfoRequest\032-" +
-      ".database_driver_v1.ConnectionGetInfoRes" +
-      "ponse\022y\n\024ConnectionGetObjects\022/.database" +
-      "_driver_v1.ConnectionGetObjectsRequest\0320" +
-      ".database_driver_v1.ConnectionGetObjects" +
-      "Response\022\205\001\n\030ConnectionGetTableSchema\0223." +
-      "database_driver_v1.ConnectionGetTableSch" +
-      "emaRequest\0324.database_driver_v1.Connecti" +
-      "onGetTableSchemaResponse\022\202\001\n\027ConnectionG" +
-      "etTableTypes\0222.database_driver_v1.Connec" +
-      "tionGetTableTypesRequest\0323.database_driv" +
-      "er_v1.ConnectionGetTableTypesResponse\022m\n" +
-      "\020ConnectionCommit\022+.database_driver_v1.C" +
-      "onnectionCommitRequest\032,.database_driver" +
-      "_v1.ConnectionCommitResponse\022s\n\022Connecti" +
-      "onRollback\022-.database_driver_v1.Connecti" +
-      "onRollbackRequest\032..database_driver_v1.C" +
-      "onnectionRollbackResponse\022\227\001\n\036Connection" +
-      "SetSessionParameters\0229.database_driver_v" +
-      "1.ConnectionSetSessionParametersRequest\032" +
-      ":.database_driver_v1.ConnectionSetSessio" +
-      "nParametersResponse\022\177\n\026ConnectionGetPara" +
-      "meter\0221.database_driver_v1.ConnectionGet" +
-      "ParameterRequest\0322.database_driver_v1.Co" +
-      "nnectionGetParameterResponse\022a\n\014Statemen" +
-      "tNew\022\'.database_driver_v1.StatementNewRe" +
-      "quest\032(.database_driver_v1.StatementNewR" +
-      "esponse\022m\n\020StatementRelease\022+.database_d" +
-      "river_v1.StatementReleaseRequest\032,.datab" +
-      "ase_driver_v1.StatementReleaseResponse\022y" +
-      "\n\024StatementSetSqlQuery\022/.database_driver" +
-      "_v1.StatementSetSqlQueryRequest\0320.databa" +
-      "se_driver_v1.StatementSetSqlQueryRespons" +
-      "e\022\210\001\n\031StatementSetSubstraitPlan\0224.databa" +
-      "se_driver_v1.StatementSetSubstraitPlanRe" +
-      "quest\0325.database_driver_v1.StatementSetS" +
-      "ubstraitPlanResponse\022m\n\020StatementPrepare" +
-      "\022+.database_driver_v1.StatementPrepareRe" +
-      "quest\032,.database_driver_v1.StatementPrep" +
-      "areResponse\022\205\001\n\030StatementSetOptionString" +
-      "\0223.database_driver_v1.StatementSetOption" +
-      "StringRequest\0324.database_driver_v1.State" +
-      "mentSetOptionStringResponse\022\202\001\n\027Statemen" +
-      "tSetOptionBytes\0222.database_driver_v1.Sta" +
-      "tementSetOptionBytesRequest\0323.database_d" +
-      "river_v1.StatementSetOptionBytesResponse" +
-      "\022|\n\025StatementSetOptionInt\0220.database_dri" +
-      "ver_v1.StatementSetOptionIntRequest\0321.da" +
-      "tabase_driver_v1.StatementSetOptionIntRe" +
-      "sponse\022\205\001\n\030StatementSetOptionDouble\0223.da" +
-      "tabase_driver_v1.StatementSetOptionDoubl",
-      "eRequest\0324.database_driver_v1.StatementS" +
-      "etOptionDoubleResponse\022\177\n\026StatementSetOp" +
-      "tionBool\0221.database_driver_v1.StatementS" +
-      "etOptionBoolRequest\0322.database_driver_v1" +
-      ".StatementSetOptionBoolResponse\022v\n\023State" +
-      "mentSetOptions\022..database_driver_v1.Stat" +
-      "ementSetOptionsRequest\032/.database_driver" +
-      "_v1.StatementSetOptionsResponse\022\216\001\n\033Stat" +
-      "ementGetParameterSchema\0226.database_drive" +
-      "r_v1.StatementGetParameterSchemaRequest\032" +
-      "7.database_driver_v1.StatementGetParamet" +
-      "erSchemaResponse\022|\n\025StatementExecuteQuer" +
-      "y\0220.database_driver_v1.StatementExecuteQ" +
-      "ueryRequest\0321.database_driver_v1.Stateme" +
-      "ntExecuteQueryResponse\022\213\001\n\032StatementExec" +
-      "utePartitions\0225.database_driver_v1.State" +
-      "mentExecutePartitionsRequest\0326.database_" +
-      "driver_v1.StatementExecutePartitionsResp" +
-      "onse\022\177\n\026StatementReadPartition\0221.databas" +
-      "e_driver_v1.StatementReadPartitionReques" +
-      "t\0322.database_driver_v1.StatementReadPart" +
-      "itionResponse\022|\n\025ConfigLoadAllSections\0220" +
-      ".database_driver_v1.ConfigLoadAllSection" +
-      "sRequest\0321.database_driver_v1.ConfigLoad" +
-      "AllSectionsResponse\022g\n\016ConfigGetPaths\022)." +
-      "database_driver_v1.ConfigGetPathsRequest" +
-      "\032*.database_driver_v1.ConfigGetPathsResp" +
-      "onse\032\024\302\251\311\001\017DriverException:;\n\rservice_er" +
-      "ror\022\037.google.protobuf.ServiceOptions\030\230\225\031" +
-      " \001(\t\210\001\001:9\n\014method_error\022\036.google.protobu" +
-      "f.MethodOptions\030\230\225\031 \001(\t\210\001\001B4\n2net.snowfl" +
-      "ake.client.internal.unicore.protobuf_gen" +
-      "b\006proto3"
+      "\001\"T\n\033StatementSetOptionsResponse\0225\n\010warn" +
+      "ings\030\001 \003(\0132#.database_driver_v1.Validati" +
+      "onIssue\"|\n\034ConfigLoadAllSectionsRequest\022" +
+      "\030\n\013config_file\030\001 \001(\tH\000\210\001\001\022\035\n\020connections" +
+      "_file\030\002 \001(\tH\001\210\001\001B\016\n\014_config_fileB\023\n\021_con" +
+      "nections_file\"4\n\035ConfigLoadAllSectionsRe" +
+      "sponse\022\023\n\013config_json\030\001 \001(\t\"\027\n\025ConfigGet" +
+      "PathsRequest\"G\n\026ConfigGetPathsResponse\022\023" +
+      "\n\013config_file\030\001 \001(\t\022\030\n\020connections_file\030" +
+      "\002 \001(\t*\264\004\n\nStatusCode\022\033\n\027STATUS_CODE_UNSP" +
+      "ECIFIED\020\000\022\022\n\016STATUS_CODE_OK\020\001\022$\n STATUS_" +
+      "CODE_AUTHENTICATION_ERROR\020\002\022\037\n\033STATUS_CO" +
+      "DE_NOT_IMPLEMENTED\020\003\022\031\n\025STATUS_CODE_NOT_" +
+      "FOUND\020\004\022\036\n\032STATUS_CODE_ALREADY_EXISTS\020\005\022" +
+      " \n\034STATUS_CODE_INVALID_ARGUMENT\020\006\022\035\n\031STA" +
+      "TUS_CODE_INVALID_STATE\020\007\022\034\n\030STATUS_CODE_" +
+      "INVALID_DATA\020\010\022\022\n\016STATUS_CODE_IO\020\t\022\031\n\025ST" +
+      "ATUS_CODE_CANCELLED\020\n\022\037\n\033STATUS_CODE_UNA" +
+      "UTHENTICATED\020\013\022\034\n\030STATUS_CODE_UNAUTHORIZ" +
+      "ED\020\014\022\035\n\031STATUS_CODE_GENERIC_ERROR\020\r\022\036\n\032S" +
+      "TATUS_CODE_INTERNAL_ERROR\020\016\022!\n\035STATUS_CO" +
+      "DE_MISSING_PARAMETER\020\017\022\'\n#STATUS_CODE_IN" +
+      "VALID_PARAMETER_VALUE\020\020\022\033\n\027STATUS_CODE_L" +
+      "OGIN_ERROR\020\021*\230\003\n\010InfoCode\022\031\n\025INFO_CODE_U" +
+      "NSPECIFIED\020\000\022\031\n\025INFO_CODE_VENDOR_NAME\020\001\022" +
+      "\034\n\030INFO_CODE_VENDOR_VERSION\020\002\022\"\n\036INFO_CO" +
+      "DE_VENDOR_ARROW_VERSION\020\003\022\030\n\024INFO_CODE_V" +
+      "ENDOR_SQL\020e\022\036\n\032INFO_CODE_VENDOR_SUBSTRAI" +
+      "T\020f\022*\n&INFO_CODE_VENDOR_SUBSTRAIT_MIN_VE" +
+      "RSION\020g\022*\n&INFO_CODE_VENDOR_SUBSTRAIT_MA" +
+      "X_VERSION\020h\022\032\n\025INFO_CODE_DRIVER_NAME\020\311\001\022" +
+      "\035\n\030INFO_CODE_DRIVER_VERSION\020\312\001\022#\n\036INFO_C" +
+      "ODE_DRIVER_ARROW_VERSION\020\313\001\022\"\n\035INFO_CODE" +
+      "_DRIVER_ADBC_VERSION\020\314\001*T\n\022ValidationSev" +
+      "erity\022\035\n\031VALIDATION_SEVERITY_ERROR\020\000\022\037\n\033" +
+      "VALIDATION_SEVERITY_WARNING\020\001*\231\002\n\016Valida" +
+      "tionCode\022\037\n\033VALIDATION_CODE_UNSPECIFIED\020" +
+      "\000\022$\n VALIDATION_CODE_MISSING_REQUIRED\020\001\022" +
+      " \n\034VALIDATION_CODE_INVALID_TYPE\020\002\022!\n\035VAL" +
+      "IDATION_CODE_INVALID_VALUE\020\003\022%\n!VALIDATI" +
+      "ON_CODE_UNKNOWN_PARAMETER\020\004\022(\n$VALIDATIO" +
+      "N_CODE_DEPRECATED_PARAMETER\020\005\022*\n&VALIDAT" +
+      "ION_CODE_CONFLICTING_PARAMETERS\020\0062\212+\n\016Da" +
+      "tabaseDriver\022^\n\013DatabaseNew\022&.database_d" +
+      "river_v1.DatabaseNewRequest\032\'.database_d" +
+      "river_v1.DatabaseNewResponse\022\202\001\n\027Databas" +
+      "eSetOptionString\0222.database_driver_v1.Da" +
+      "tabaseSetOptionStringRequest\0323.database_" +
+      "driver_v1.DatabaseSetOptionStringRespons" +
+      "e\022\177\n\026DatabaseSetOptionBytes\0221.database_d" +
+      "river_v1.DatabaseSetOptionBytesRequest\0322" +
+      ".database_driver_v1.DatabaseSetOptionByt" +
+      "esResponse\022y\n\024DatabaseSetOptionInt\022/.dat" +
+      "abase_driver_v1.DatabaseSetOptionIntRequ" +
+      "est\0320.database_driver_v1.DatabaseSetOpti" +
+      "onIntResponse\022\202\001\n\027DatabaseSetOptionDoubl" +
+      "e\0222.database_driver_v1.DatabaseSetOption" +
+      "DoubleRequest\0323.database_driver_v1.Datab" +
+      "aseSetOptionDoubleResponse\022|\n\025DatabaseSe" +
+      "tOptionBool\0220.database_driver_v1.Databas" +
+      "eSetOptionBoolRequest\0321.database_driver_" +
+      "v1.DatabaseSetOptionBoolResponse\022s\n\022Data" +
+      "baseSetOptions\022-.database_driver_v1.Data" +
+      "baseSetOptionsRequest\032..database_driver_" +
+      "v1.DatabaseSetOptionsResponse\022a\n\014Databas" +
+      "eInit\022\'.database_driver_v1.DatabaseInitR" +
+      "equest\032(.database_driver_v1.DatabaseInit" +
+      "Response\022j\n\017DatabaseRelease\022*.database_d" +
+      "river_v1.DatabaseReleaseRequest\032+.databa" +
+      "se_driver_v1.DatabaseReleaseResponse\022d\n\r" +
+      "ConnectionNew\022(.database_driver_v1.Conne" +
+      "ctionNewRequest\032).database_driver_v1.Con" +
+      "nectionNewResponse\022\210\001\n\031ConnectionSetOpti" +
+      "onString\0224.database_driver_v1.Connection" +
+      "SetOptionStringRequest\0325.database_driver" +
+      "_v1.ConnectionSetOptionStringResponse\022\205\001" +
+      "\n\030ConnectionSetOptionBytes\0223.database_dr" +
+      "iver_v1.ConnectionSetOptionBytesRequest\032" +
+      "4.database_driver_v1.ConnectionSetOption" +
+      "BytesResponse\022\177\n\026ConnectionSetOptionInt\022" +
+      "1.database_driver_v1.ConnectionSetOption" +
+      "IntRequest\0322.database_driver_v1.Connecti" +
+      "onSetOptionIntResponse\022\210\001\n\031ConnectionSet" +
+      "OptionDouble\0224.database_driver_v1.Connec" +
+      "tionSetOptionDoubleRequest\0325.database_dr" +
+      "iver_v1.ConnectionSetOptionDoubleRespons" +
+      "e\022\202\001\n\027ConnectionSetOptionBool\0222.database" +
+      "_driver_v1.ConnectionSetOptionBoolReques" +
+      "t\0323.database_driver_v1.ConnectionSetOpti" +
+      "onBoolResponse\022y\n\024ConnectionSetOptions\022/" +
+      ".database_driver_v1.ConnectionSetOptions" +
+      "Request\0320.database_driver_v1.ConnectionS" +
+      "etOptionsResponse\022g\n\016ConnectionInit\022).da" +
+      "tabase_driver_v1.ConnectionInitRequest\032*" +
+      ".database_driver_v1.ConnectionInitRespon" +
+      "se\022p\n\021ConnectionRelease\022,.database_drive" +
+      "r_v1.ConnectionReleaseRequest\032-.database" +
+      "_driver_v1.ConnectionReleaseResponse\022p\n\021" +
+      "ConnectionGetInfo\022,.database_driver_v1.C" +
+      "onnectionGetInfoRequest\032-.database_drive" +
+      "r_v1.ConnectionGetInfoResponse\022y\n\024Connec" +
+      "tionGetObjects\022/.database_driver_v1.Conn" +
+      "ectionGetObjectsRequest\0320.database_drive" +
+      "r_v1.ConnectionGetObjectsResponse\022\205\001\n\030Co" +
+      "nnectionGetTableSchema\0223.database_driver" +
+      "_v1.ConnectionGetTableSchemaRequest\0324.da" +
+      "tabase_driver_v1.ConnectionGetTableSchem" +
+      "aResponse\022\202\001\n\027ConnectionGetTableTypes\0222." +
+      "database_driver_v1.ConnectionGetTableTyp" +
+      "esRequest\0323.database_driver_v1.Connectio" +
+      "nGetTableTypesResponse\022m\n\020ConnectionComm" +
+      "it\022+.database_driver_v1.ConnectionCommit" +
+      "Request\032,.database_driver_v1.ConnectionC" +
+      "ommitResponse\022s\n\022ConnectionRollback\022-.da" +
+      "tabase_driver_v1.ConnectionRollbackReque" +
+      "st\032..database_driver_v1.ConnectionRollba" +
+      "ckResponse\022\227\001\n\036ConnectionSetSessionParam" +
+      "eters\0229.database_driver_v1.ConnectionSet" +
+      "SessionParametersRequest\032:.database_driv" +
+      "er_v1.ConnectionSetSessionParametersResp" +
+      "onse\022\177\n\026ConnectionGetParameter\0221.databas" +
+      "e_driver_v1.ConnectionGetParameterReques" +
+      "t\0322.database_driver_v1.ConnectionGetPara" +
+      "meterResponse\022\210\001\n\031ConnectionValidateOpti" +
+      "ons\0224.database_driver_v1.ConnectionValid" +
+      "ateOptionsRequest\0325.database_driver_v1.C" +
+      "onnectionValidateOptionsResponse\022a\n\014Stat" +
+      "ementNew\022\'.database_driver_v1.StatementN" +
+      "ewRequest\032(.database_driver_v1.Statement" +
+      "NewResponse\022m\n\020StatementRelease\022+.databa" +
+      "se_driver_v1.StatementReleaseRequest\032,.d" +
+      "atabase_driver_v1.StatementReleaseRespon" +
+      "se\022y\n\024StatementSetSqlQuery\022/.database_dr" +
+      "iver_v1.StatementSetSqlQueryRequest\0320.da" +
+      "tabase_driver_v1.StatementSetSqlQueryRes" +
+      "ponse\022\210\001\n\031StatementSetSubstraitPlan\0224.da" +
+      "tabase_driver_v1.StatementSetSubstraitPl" +
+      "anRequest\0325.database_driver_v1.Statement" +
+      "SetSubstraitPlanResponse\022m\n\020StatementPre" +
+      "pare\022+.database_driver_v1.StatementPrepa" +
+      "reRequest\032,.database_driver_v1.Statement" +
+      "PrepareResponse\022\205\001\n\030StatementSetOptionSt" +
+      "ring\0223.database_driver_v1.StatementSetOp" +
+      "tionStringRequest\0324.database_driver_v1.S" +
+      "tatementSetOptionStringResponse\022\202\001\n\027Stat",
+      "ementSetOptionBytes\0222.database_driver_v1" +
+      ".StatementSetOptionBytesRequest\0323.databa" +
+      "se_driver_v1.StatementSetOptionBytesResp" +
+      "onse\022|\n\025StatementSetOptionInt\0220.database" +
+      "_driver_v1.StatementSetOptionIntRequest\032" +
+      "1.database_driver_v1.StatementSetOptionI" +
+      "ntResponse\022\205\001\n\030StatementSetOptionDouble\022" +
+      "3.database_driver_v1.StatementSetOptionD" +
+      "oubleRequest\0324.database_driver_v1.Statem" +
+      "entSetOptionDoubleResponse\022\177\n\026StatementS" +
+      "etOptionBool\0221.database_driver_v1.Statem" +
+      "entSetOptionBoolRequest\0322.database_drive" +
+      "r_v1.StatementSetOptionBoolResponse\022v\n\023S" +
+      "tatementSetOptions\022..database_driver_v1." +
+      "StatementSetOptionsRequest\032/.database_dr" +
+      "iver_v1.StatementSetOptionsResponse\022\216\001\n\033" +
+      "StatementGetParameterSchema\0226.database_d" +
+      "river_v1.StatementGetParameterSchemaRequ" +
+      "est\0327.database_driver_v1.StatementGetPar" +
+      "ameterSchemaResponse\022|\n\025StatementExecute" +
+      "Query\0220.database_driver_v1.StatementExec" +
+      "uteQueryRequest\0321.database_driver_v1.Sta" +
+      "tementExecuteQueryResponse\022\213\001\n\032Statement" +
+      "ExecutePartitions\0225.database_driver_v1.S" +
+      "tatementExecutePartitionsRequest\0326.datab" +
+      "ase_driver_v1.StatementExecutePartitions" +
+      "Response\022\177\n\026StatementReadPartition\0221.dat" +
+      "abase_driver_v1.StatementReadPartitionRe" +
+      "quest\0322.database_driver_v1.StatementRead" +
+      "PartitionResponse\022|\n\025ConfigLoadAllSectio" +
+      "ns\0220.database_driver_v1.ConfigLoadAllSec" +
+      "tionsRequest\0321.database_driver_v1.Config" +
+      "LoadAllSectionsResponse\022g\n\016ConfigGetPath" +
+      "s\022).database_driver_v1.ConfigGetPathsReq" +
+      "uest\032*.database_driver_v1.ConfigGetPaths" +
+      "Response\032\024\302\251\311\001\017DriverException:;\n\rservic" +
+      "e_error\022\037.google.protobuf.ServiceOptions" +
+      "\030\230\225\031 \001(\t\210\001\001:9\n\014method_error\022\036.google.pro" +
+      "tobuf.MethodOptions\030\230\225\031 \001(\t\210\001\001B4\n2net.sn" +
+      "owflake.client.internal.unicore.protobuf" +
+      "_genb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -72775,194 +74103,206 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConnectionGetParameterResponse_descriptor,
         new java.lang.String[] { "Value", });
-    internal_static_database_driver_v1_StatementNewRequest_descriptor =
+    internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor =
       getDescriptor().getMessageTypes().get(68);
+    internal_static_database_driver_v1_ConnectionValidateOptionsRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_database_driver_v1_ConnectionValidateOptionsRequest_descriptor,
+        new java.lang.String[] { "ConnHandle", });
+    internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor =
+      getDescriptor().getMessageTypes().get(69);
+    internal_static_database_driver_v1_ConnectionValidateOptionsResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_database_driver_v1_ConnectionValidateOptionsResponse_descriptor,
+        new java.lang.String[] { "Issues", });
+    internal_static_database_driver_v1_StatementNewRequest_descriptor =
+      getDescriptor().getMessageTypes().get(70);
     internal_static_database_driver_v1_StatementNewRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementNewRequest_descriptor,
         new java.lang.String[] { "ConnHandle", });
     internal_static_database_driver_v1_StatementNewResponse_descriptor =
-      getDescriptor().getMessageTypes().get(69);
+      getDescriptor().getMessageTypes().get(71);
     internal_static_database_driver_v1_StatementNewResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementNewResponse_descriptor,
         new java.lang.String[] { "StmtHandle", });
     internal_static_database_driver_v1_StatementReleaseRequest_descriptor =
-      getDescriptor().getMessageTypes().get(70);
+      getDescriptor().getMessageTypes().get(72);
     internal_static_database_driver_v1_StatementReleaseRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementReleaseRequest_descriptor,
         new java.lang.String[] { "StmtHandle", });
     internal_static_database_driver_v1_StatementReleaseResponse_descriptor =
-      getDescriptor().getMessageTypes().get(71);
+      getDescriptor().getMessageTypes().get(73);
     internal_static_database_driver_v1_StatementReleaseResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementReleaseResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetSqlQueryRequest_descriptor =
-      getDescriptor().getMessageTypes().get(72);
+      getDescriptor().getMessageTypes().get(74);
     internal_static_database_driver_v1_StatementSetSqlQueryRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetSqlQueryRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Query", });
     internal_static_database_driver_v1_StatementSetSqlQueryResponse_descriptor =
-      getDescriptor().getMessageTypes().get(73);
+      getDescriptor().getMessageTypes().get(75);
     internal_static_database_driver_v1_StatementSetSqlQueryResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetSqlQueryResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetSubstraitPlanRequest_descriptor =
-      getDescriptor().getMessageTypes().get(74);
+      getDescriptor().getMessageTypes().get(76);
     internal_static_database_driver_v1_StatementSetSubstraitPlanRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetSubstraitPlanRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Plan", });
     internal_static_database_driver_v1_StatementSetSubstraitPlanResponse_descriptor =
-      getDescriptor().getMessageTypes().get(75);
+      getDescriptor().getMessageTypes().get(77);
     internal_static_database_driver_v1_StatementSetSubstraitPlanResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetSubstraitPlanResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_PrepareResult_descriptor =
-      getDescriptor().getMessageTypes().get(76);
+      getDescriptor().getMessageTypes().get(78);
     internal_static_database_driver_v1_PrepareResult_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_PrepareResult_descriptor,
         new java.lang.String[] { "Stream", "Columns", });
     internal_static_database_driver_v1_StatementPrepareRequest_descriptor =
-      getDescriptor().getMessageTypes().get(77);
+      getDescriptor().getMessageTypes().get(79);
     internal_static_database_driver_v1_StatementPrepareRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementPrepareRequest_descriptor,
         new java.lang.String[] { "StmtHandle", });
     internal_static_database_driver_v1_StatementPrepareResponse_descriptor =
-      getDescriptor().getMessageTypes().get(78);
+      getDescriptor().getMessageTypes().get(80);
     internal_static_database_driver_v1_StatementPrepareResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementPrepareResponse_descriptor,
         new java.lang.String[] { "Result", });
     internal_static_database_driver_v1_StatementSetOptionStringRequest_descriptor =
-      getDescriptor().getMessageTypes().get(79);
+      getDescriptor().getMessageTypes().get(81);
     internal_static_database_driver_v1_StatementSetOptionStringRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionStringRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionStringResponse_descriptor =
-      getDescriptor().getMessageTypes().get(80);
+      getDescriptor().getMessageTypes().get(82);
     internal_static_database_driver_v1_StatementSetOptionStringResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionStringResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetOptionBytesRequest_descriptor =
-      getDescriptor().getMessageTypes().get(81);
+      getDescriptor().getMessageTypes().get(83);
     internal_static_database_driver_v1_StatementSetOptionBytesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionBytesRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionBytesResponse_descriptor =
-      getDescriptor().getMessageTypes().get(82);
+      getDescriptor().getMessageTypes().get(84);
     internal_static_database_driver_v1_StatementSetOptionBytesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionBytesResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetOptionIntRequest_descriptor =
-      getDescriptor().getMessageTypes().get(83);
+      getDescriptor().getMessageTypes().get(85);
     internal_static_database_driver_v1_StatementSetOptionIntRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionIntRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionIntResponse_descriptor =
-      getDescriptor().getMessageTypes().get(84);
+      getDescriptor().getMessageTypes().get(86);
     internal_static_database_driver_v1_StatementSetOptionIntResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionIntResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetOptionDoubleRequest_descriptor =
-      getDescriptor().getMessageTypes().get(85);
+      getDescriptor().getMessageTypes().get(87);
     internal_static_database_driver_v1_StatementSetOptionDoubleRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionDoubleRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionDoubleResponse_descriptor =
-      getDescriptor().getMessageTypes().get(86);
+      getDescriptor().getMessageTypes().get(88);
     internal_static_database_driver_v1_StatementSetOptionDoubleResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionDoubleResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementSetOptionBoolRequest_descriptor =
-      getDescriptor().getMessageTypes().get(87);
+      getDescriptor().getMessageTypes().get(89);
     internal_static_database_driver_v1_StatementSetOptionBoolRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionBoolRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionBoolResponse_descriptor =
-      getDescriptor().getMessageTypes().get(88);
+      getDescriptor().getMessageTypes().get(90);
     internal_static_database_driver_v1_StatementSetOptionBoolResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionBoolResponse_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_StatementGetParameterSchemaRequest_descriptor =
-      getDescriptor().getMessageTypes().get(89);
+      getDescriptor().getMessageTypes().get(91);
     internal_static_database_driver_v1_StatementGetParameterSchemaRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementGetParameterSchemaRequest_descriptor,
         new java.lang.String[] { "StmtHandle", });
     internal_static_database_driver_v1_StatementGetParameterSchemaResponse_descriptor =
-      getDescriptor().getMessageTypes().get(90);
+      getDescriptor().getMessageTypes().get(92);
     internal_static_database_driver_v1_StatementGetParameterSchemaResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementGetParameterSchemaResponse_descriptor,
         new java.lang.String[] { "Schema", });
     internal_static_database_driver_v1_StatementExecuteQueryRequest_descriptor =
-      getDescriptor().getMessageTypes().get(91);
+      getDescriptor().getMessageTypes().get(93);
     internal_static_database_driver_v1_StatementExecuteQueryRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementExecuteQueryRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "Bindings", });
     internal_static_database_driver_v1_StatementExecuteQueryResponse_descriptor =
-      getDescriptor().getMessageTypes().get(92);
+      getDescriptor().getMessageTypes().get(94);
     internal_static_database_driver_v1_StatementExecuteQueryResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementExecuteQueryResponse_descriptor,
         new java.lang.String[] { "Result", });
     internal_static_database_driver_v1_StatementExecutePartitionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(93);
+      getDescriptor().getMessageTypes().get(95);
     internal_static_database_driver_v1_StatementExecutePartitionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementExecutePartitionsRequest_descriptor,
         new java.lang.String[] { "StmtHandle", });
     internal_static_database_driver_v1_StatementExecutePartitionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(94);
+      getDescriptor().getMessageTypes().get(96);
     internal_static_database_driver_v1_StatementExecutePartitionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementExecutePartitionsResponse_descriptor,
         new java.lang.String[] { "Result", });
     internal_static_database_driver_v1_StatementReadPartitionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(95);
+      getDescriptor().getMessageTypes().get(97);
     internal_static_database_driver_v1_StatementReadPartitionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementReadPartitionRequest_descriptor,
         new java.lang.String[] { "StmtHandle", "PartitionDescriptor", });
     internal_static_database_driver_v1_StatementReadPartitionResponse_descriptor =
-      getDescriptor().getMessageTypes().get(96);
+      getDescriptor().getMessageTypes().get(98);
     internal_static_database_driver_v1_StatementReadPartitionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementReadPartitionResponse_descriptor,
         new java.lang.String[] { "PartitionStream", });
     internal_static_database_driver_v1_ValidationIssue_descriptor =
-      getDescriptor().getMessageTypes().get(97);
+      getDescriptor().getMessageTypes().get(99);
     internal_static_database_driver_v1_ValidationIssue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ValidationIssue_descriptor,
         new java.lang.String[] { "Severity", "Parameter", "Message", "Code", });
     internal_static_database_driver_v1_ConfigSetting_descriptor =
-      getDescriptor().getMessageTypes().get(98);
+      getDescriptor().getMessageTypes().get(100);
     internal_static_database_driver_v1_ConfigSetting_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigSetting_descriptor,
         new java.lang.String[] { "StringValue", "IntValue", "DoubleValue", "BytesValue", "BoolValue", "Value", });
     internal_static_database_driver_v1_ConfigSection_descriptor =
-      getDescriptor().getMessageTypes().get(99);
+      getDescriptor().getMessageTypes().get(101);
     internal_static_database_driver_v1_ConfigSection_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigSection_descriptor,
@@ -72974,7 +74314,7 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
         internal_static_database_driver_v1_ConfigSection_SettingsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_database_driver_v1_ConnectionSetOptionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(100);
+      getDescriptor().getMessageTypes().get(102);
     internal_static_database_driver_v1_ConnectionSetOptionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConnectionSetOptionsRequest_descriptor,
@@ -72986,13 +74326,13 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
         internal_static_database_driver_v1_ConnectionSetOptionsRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_database_driver_v1_ConnectionSetOptionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(101);
+      getDescriptor().getMessageTypes().get(103);
     internal_static_database_driver_v1_ConnectionSetOptionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConnectionSetOptionsResponse_descriptor,
         new java.lang.String[] { "Warnings", });
     internal_static_database_driver_v1_DatabaseSetOptionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(102);
+      getDescriptor().getMessageTypes().get(104);
     internal_static_database_driver_v1_DatabaseSetOptionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_DatabaseSetOptionsRequest_descriptor,
@@ -73004,13 +74344,13 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
         internal_static_database_driver_v1_DatabaseSetOptionsRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_database_driver_v1_DatabaseSetOptionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(103);
+      getDescriptor().getMessageTypes().get(105);
     internal_static_database_driver_v1_DatabaseSetOptionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_DatabaseSetOptionsResponse_descriptor,
         new java.lang.String[] { "Warnings", });
     internal_static_database_driver_v1_StatementSetOptionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(104);
+      getDescriptor().getMessageTypes().get(106);
     internal_static_database_driver_v1_StatementSetOptionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionsRequest_descriptor,
@@ -73022,31 +74362,31 @@ net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSettin
         internal_static_database_driver_v1_StatementSetOptionsRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_database_driver_v1_StatementSetOptionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(105);
+      getDescriptor().getMessageTypes().get(107);
     internal_static_database_driver_v1_StatementSetOptionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_StatementSetOptionsResponse_descriptor,
         new java.lang.String[] { "Warnings", });
     internal_static_database_driver_v1_ConfigLoadAllSectionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(106);
+      getDescriptor().getMessageTypes().get(108);
     internal_static_database_driver_v1_ConfigLoadAllSectionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigLoadAllSectionsRequest_descriptor,
         new java.lang.String[] { "ConfigFile", "ConnectionsFile", });
     internal_static_database_driver_v1_ConfigLoadAllSectionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(107);
+      getDescriptor().getMessageTypes().get(109);
     internal_static_database_driver_v1_ConfigLoadAllSectionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigLoadAllSectionsResponse_descriptor,
         new java.lang.String[] { "ConfigJson", });
     internal_static_database_driver_v1_ConfigGetPathsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(108);
+      getDescriptor().getMessageTypes().get(110);
     internal_static_database_driver_v1_ConfigGetPathsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigGetPathsRequest_descriptor,
         new java.lang.String[] { });
     internal_static_database_driver_v1_ConfigGetPathsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(109);
+      getDescriptor().getMessageTypes().get(111);
     internal_static_database_driver_v1_ConfigGetPathsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_database_driver_v1_ConfigGetPathsResponse_descriptor,

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -420,6 +420,14 @@ message ConnectionGetParameterResponse {
   optional string value = 1;
 }
 
+message ConnectionValidateOptionsRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionValidateOptionsResponse {
+  repeated ValidationIssue issues = 1;
+}
+
 // Statement service requests and responses
 
 message StatementNewRequest {
@@ -668,6 +676,8 @@ service DatabaseDriver {
   // gets cached session parameter. Cache is updated with subset of connection parameters
   // (chosen by server, included in HTTP response) after each query
   rpc ConnectionGetParameter(ConnectionGetParameterRequest) returns (ConnectionGetParameterResponse);
+  // pre-flight validation of connection options - reports all issues at once
+  rpc ConnectionValidateOptions(ConnectionValidateOptionsRequest) returns (ConnectionValidateOptionsResponse);
 
   // Statement operations
   rpc StatementNew(StatementNewRequest) returns (StatementNewResponse);

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -8,10 +8,11 @@ use super::Setting;
 use super::error::*;
 use super::global_state::CONN_HANDLE_MANAGER;
 use super::validation::{ValidationIssue, resolve_and_apply_options};
-use crate::config::param_registry::param_names;
 use crate::config::ParamStore;
+use crate::config::connection_config::{AuthConfig, ConnectionConfig};
+use crate::config::param_names;
 use crate::config::resolver;
-use crate::config::rest_parameters::{ClientInfo, LoginParameters};
+use crate::config::rest_parameters::{ClientInfo, LoginMethod, LoginParameters};
 use crate::config::retry::RetryPolicy;
 use crate::rest::snowflake::{self, RestError, SessionTokens, SnowflakeResponseError};
 use crate::sensitive::SensitiveString;
@@ -29,14 +30,17 @@ pub fn connection_init(conn_handle: Handle, _db_handle: Handle) -> Result<(), Ap
 
             let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
 
-            let login_parameters =
-                LoginParameters::from_settings(&resolved).context(ConfigurationSnafu)?;
+            let config = ConnectionConfig::build(&resolved).context(ConfigurationSnafu)?;
+            let host = setting_string(&resolved, param_names::HOST);
+            let port = setting_int(&resolved, param_names::PORT);
             let init_params = conn.init_session_parameters.clone();
             drop(conn);
 
-            let http_client =
-                create_tls_client_with_config(login_parameters.client_info.tls_config.clone())
-                    .context(TlsClientCreationSnafu)?;
+            let http_client = create_tls_client_with_config(config.tls.clone())
+                .context(TlsClientCreationSnafu)?;
+
+            // Transitional: map ConnectionConfig → LoginParameters for existing login API
+            let login_parameters = login_parameters_from_config(&config);
 
             let login_result = rt
                 .block_on(async {
@@ -62,6 +66,8 @@ pub fn connection_init(conn_handle: Handle, _db_handle: Handle) -> Result<(), Ap
                 .initialize(
                     login_result.tokens,
                     http_client,
+                    host,
+                    port,
                     login_parameters.server_url.clone(),
                     login_parameters.client_info.clone(),
                     merged_params,
@@ -72,6 +78,52 @@ pub fn connection_init(conn_handle: Handle, _db_handle: Handle) -> Result<(), Ap
             argument: "Connection handle not found".to_string(),
         }
         .fail(),
+    }
+}
+
+/// Transitional bridge: map `ConnectionConfig` fields into the existing
+/// `LoginParameters` struct so the REST login layer can remain unchanged.
+fn login_parameters_from_config(config: &ConnectionConfig) -> LoginParameters {
+    let login_method = match &config.auth {
+        AuthConfig::Password { user, password } => LoginMethod::Password {
+            username: user.clone(),
+            password: password.clone(),
+        },
+        AuthConfig::Jwt {
+            user,
+            private_key_pem,
+            passphrase,
+        } => LoginMethod::PrivateKey {
+            username: user.clone(),
+            private_key: private_key_pem.clone(),
+            passphrase: passphrase.clone(),
+        },
+        AuthConfig::Pat { user, token } => LoginMethod::Pat {
+            username: user.clone(),
+            token: token.clone(),
+        },
+    };
+
+    let client_info = ClientInfo {
+        application: "PythonConnector".to_string(),
+        version: "3.15.0".to_string(),
+        os: "Darwin".to_string(),
+        os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
+        ocsp_mode: Some("FAIL_OPEN".to_string()),
+        crl_config: config.tls.crl_config.clone(),
+        tls_config: config.tls.clone(),
+    };
+
+    LoginParameters {
+        account_name: config.server.account.clone(),
+        login_method,
+        server_url: config.server.server_url.clone(),
+        database: config.session.database.clone(),
+        schema: config.session.schema.clone(),
+        warehouse: config.session.warehouse.clone(),
+        role: config.session.role.clone(),
+        client_info,
+        session_parameters: None,
     }
 }
 
@@ -128,6 +180,24 @@ pub fn connection_set_session_parameters(
     }
 }
 
+pub fn connection_validate_options(
+    conn_handle: Handle,
+) -> Result<Vec<ValidationIssue>, ApiError> {
+    match CONN_HANDLE_MANAGER.get_obj(conn_handle) {
+        Some(conn_ptr) => {
+            let conn = conn_ptr
+                .lock()
+                .map_err(|_| ConnectionLockingSnafu {}.build())?;
+            let resolved = conn.resolved_settings().context(ConfigurationSnafu)?;
+            Ok(crate::config::connection_config::validate_settings(&resolved))
+        }
+        None => InvalidArgumentSnafu {
+            argument: "Connection handle not found".to_string(),
+        }
+        .fail(),
+    }
+}
+
 pub fn connection_new() -> Handle {
     CONN_HANDLE_MANAGER.add_handle(Mutex::new(Connection::new()))
 }
@@ -148,6 +218,10 @@ pub struct Connection {
     pub tokens: Arc<AsyncRwLock<Option<SessionTokens>>>,
     pub http_client: Option<reqwest::Client>,
     pub retry_policy: RetryPolicy,
+    /// Effective host used by the successful initialization snapshot.
+    pub host: Option<String>,
+    /// Effective port used by the successful initialization snapshot.
+    pub port: Option<i64>,
     /// Server URL for refresh requests
     pub server_url: Option<String>,
     /// Client info for refresh requests
@@ -171,6 +245,8 @@ impl Connection {
             tokens: Arc::new(AsyncRwLock::new(None)),
             http_client: None,
             retry_policy: RetryPolicy::default(),
+            host: None,
+            port: None,
             server_url: None,
             client_info: None,
             session_parameters: Arc::new(RwLock::new(HashMap::new())),
@@ -196,6 +272,8 @@ impl Connection {
         &mut self,
         tokens: SessionTokens,
         http_client: reqwest::Client,
+        host: Option<String>,
+        port: Option<i64>,
         server_url: String,
         client_info: ClientInfo,
         session_params: HashMap<String, String>,
@@ -203,6 +281,8 @@ impl Connection {
         // Use blocking_write since we're in a sync context during connection_init
         *self.tokens.blocking_write() = Some(tokens);
         self.http_client = Some(http_client);
+        self.host = host;
+        self.port = port;
         self.server_url = Some(server_url);
         self.client_info = Some(client_info);
 
@@ -473,20 +553,24 @@ pub fn connection_get_info(conn_handle: Handle) -> Result<ConnectionInfo, ApiErr
                 .map_err(|_| ConnectionLockingSnafu {}.build())?;
 
             // Extract host and port from settings
-            let host = conn.settings.get(param_names::HOST).and_then(|s| {
-                if let Setting::String(v) = s {
-                    Some(v.clone())
-                } else {
-                    None
-                }
+            let host = conn.host.clone().or_else(|| {
+                conn.settings.get(param_names::HOST).and_then(|s| {
+                    if let Setting::String(v) = s {
+                        Some(v.clone())
+                    } else {
+                        None
+                    }
+                })
             });
 
-            let port = conn.settings.get(param_names::PORT).and_then(|s| {
-                if let Setting::Int(v) = s {
-                    Some(*v)
-                } else {
-                    None
-                }
+            let port = conn.port.or_else(|| {
+                conn.settings.get(param_names::PORT).and_then(|s| {
+                    if let Setting::Int(v) = s {
+                        Some(*v)
+                    } else {
+                        None
+                    }
+                })
             });
 
             // Get server_url
@@ -513,5 +597,93 @@ pub fn connection_get_info(conn_handle: Handle) -> Result<ConnectionInfo, ApiErr
             argument: "Connection handle not found".to_string(),
         }
         .fail(),
+    }
+}
+
+fn setting_string(settings: &ParamStore, key: crate::config::ParamKey) -> Option<String> {
+    settings.get_string(key)
+}
+
+fn setting_int(settings: &ParamStore, key: crate::config::ParamKey) -> Option<i64> {
+    settings.get_int(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crl::config::CrlConfig;
+    use crate::tls::config::TlsConfig;
+
+    fn test_client_info() -> ClientInfo {
+        ClientInfo {
+            application: "PythonConnector".to_string(),
+            version: "3.15.0".to_string(),
+            os: "Darwin".to_string(),
+            os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
+            ocsp_mode: Some("FAIL_OPEN".to_string()),
+            crl_config: CrlConfig::default(),
+            tls_config: TlsConfig::default(),
+        }
+    }
+
+    fn test_tokens() -> SessionTokens {
+        SessionTokens {
+            session_token: SensitiveString::from("session-token"),
+            master_token: SensitiveString::from("master-token"),
+            session_id: 42,
+            session_expires_at: None,
+            master_expires_at: None,
+        }
+    }
+
+    #[test]
+    fn connection_get_info_uses_explicit_settings_before_initialize() {
+        let handle = connection_new();
+        connection_set_option(
+            handle,
+            param_names::HOST.as_str().to_string(),
+            Setting::String("explicit-host".to_string()),
+        )
+        .expect("set host");
+        connection_set_option(handle, param_names::PORT.as_str().to_string(), Setting::Int(443))
+            .expect("set port");
+
+        let info = connection_get_info(handle).expect("connection_get_info should succeed");
+
+        assert_eq!(info.host.as_deref(), Some("explicit-host"));
+        assert_eq!(info.port, Some(443));
+        assert!(info.server_url.is_none());
+
+        connection_release(handle).expect("connection_release should succeed");
+    }
+
+    #[test]
+    fn connection_get_info_uses_init_snapshot_after_initialize() {
+        let handle = connection_new();
+        let conn_ptr = CONN_HANDLE_MANAGER
+            .get_obj(handle)
+            .expect("connection handle should exist");
+
+        conn_ptr
+            .lock()
+            .expect("connection lock")
+            .initialize(
+                test_tokens(),
+                reqwest::Client::new(),
+                Some("config-host".to_string()),
+                Some(8443),
+                "https://config-host:8443".to_string(),
+                test_client_info(),
+                HashMap::new(),
+            );
+
+        let info = connection_get_info(handle).expect("connection_get_info should succeed");
+
+        assert_eq!(info.host.as_deref(), Some("config-host"));
+        assert_eq!(info.port, Some(8443));
+        assert_eq!(info.server_url.as_deref(), Some("https://config-host:8443"));
+        assert_eq!(info.session_id, Some(42));
+
+        connection_release(handle).expect("connection_release should succeed");
     }
 }

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -21,6 +21,7 @@ pub use connection::connection_release;
 pub use connection::connection_set_option;
 pub use connection::connection_set_options;
 pub use connection::connection_set_session_parameters;
+pub use connection::connection_validate_options;
 pub use connection::with_valid_session;
 pub use database::database_init;
 pub use database::database_new;

--- a/sf_core/src/apis/database_driver_v1/validation.rs
+++ b/sf_core/src/apis/database_driver_v1/validation.rs
@@ -1,45 +1,11 @@
 use std::collections::HashMap;
-use std::fmt;
 
 use super::error::{ApiError, InvalidArgumentSnafu};
 use crate::config::ParamStore;
 use crate::config::param_registry::{self, ValueType};
 use crate::config::settings::Setting;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationSeverity {
-    Error,
-    Warning,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationCode {
-    Unspecified,
-    MissingRequired,
-    InvalidType,
-    InvalidValue,
-    UnknownParameter,
-    DeprecatedParameter,
-    ConflictingParameters,
-}
-
-#[derive(Debug, Clone)]
-pub struct ValidationIssue {
-    pub severity: ValidationSeverity,
-    pub parameter: String,
-    pub message: String,
-    pub code: ValidationCode,
-}
-
-impl fmt::Display for ValidationIssue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{:?}] {}: {}",
-            self.severity, self.parameter, self.message
-        )
-    }
-}
+pub use crate::config::connection_config::{ValidationCode, ValidationIssue, ValidationSeverity};
 
 fn setting_matches_value_type(setting: &Setting, expected: ValueType) -> bool {
     matches!(

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -1,0 +1,943 @@
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+
+use base64::{Engine as _, engine::general_purpose};
+use chrono::Duration;
+use openssl::pkey::PKey;
+use snafu::OptionExt;
+
+use crate::config::param_names::*;
+use crate::config::param_registry::ParamKey;
+use crate::config::settings::Setting;
+use crate::config::ParamStore;
+use crate::sensitive::SensitiveString;
+use crate::config::{
+    ConfigError, ConflictingParametersSnafu, InvalidParameterValueSnafu, MissingParameterSnafu,
+    ValidationFailedSnafu,
+};
+use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
+use crate::tls::config::TlsConfig;
+
+// ---------------------------------------------------------------------------
+// Typed config structs
+// ---------------------------------------------------------------------------
+
+/// Fully validated, typed connection configuration.
+#[derive(Debug)]
+pub struct ConnectionConfig {
+    pub server: ServerConfig,
+    pub auth: AuthConfig,
+    pub session: SessionContext,
+    pub tls: TlsConfig,
+}
+
+#[derive(Debug)]
+pub struct ServerConfig {
+    pub account: String,
+    pub server_url: String,
+}
+
+#[derive(Debug)]
+pub enum AuthConfig {
+    Password {
+        user: String,
+        password: SensitiveString,
+    },
+    Jwt {
+        user: String,
+        private_key_pem: SensitiveString,
+        passphrase: Option<SensitiveString>,
+    },
+    Pat {
+        user: String,
+        token: SensitiveString,
+    },
+}
+
+#[derive(Debug)]
+pub struct SessionContext {
+    pub database: Option<String>,
+    pub schema: Option<String>,
+    pub warehouse: Option<String>,
+    pub role: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Validation types — canonical definitions, re-exported by apis::validation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationCode {
+    Unspecified,
+    MissingRequired,
+    InvalidType,
+    InvalidValue,
+    UnknownParameter,
+    DeprecatedParameter,
+    ConflictingParameters,
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    pub severity: ValidationSeverity,
+    pub parameter: String,
+    pub message: String,
+    pub code: ValidationCode,
+}
+
+impl fmt::Display for ValidationIssue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{:?}] {}: {}",
+            self.severity, self.parameter, self.message
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setting helpers – extract typed values from ParamStore
+// ---------------------------------------------------------------------------
+
+fn get_string(settings: &ParamStore, key: ParamKey) -> Option<String> {
+    settings.get_string(key)
+}
+
+fn get_sensitive_string(settings: &ParamStore, key: ParamKey) -> Option<SensitiveString> {
+    settings.get_sensitive_string(key)
+}
+
+fn get_int(settings: &ParamStore, key: ParamKey) -> Option<i64> {
+    settings.get_int(key)
+}
+
+/// Read a boolean parameter.  Checks `Setting::Bool` first, then falls back
+/// to `Setting::String` with `"true"` / `"false"` parsing for backward
+/// compatibility with TOML-loaded values.  Unrecognized strings (typos like
+/// `"ture"`) return `None` so the caller falls through to its default rather
+/// than silently degrading to `false`.
+fn get_bool(settings: &ParamStore, key: ParamKey) -> Option<bool> {
+    settings.get_bool(key)
+}
+
+// ---------------------------------------------------------------------------
+// Private key helpers (mirrored from rest_parameters.rs)
+// ---------------------------------------------------------------------------
+
+fn der_to_pem(der_bytes: &[u8]) -> Result<String, ConfigError> {
+    let pkey = PKey::private_key_from_der(der_bytes).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: PRIVATE_KEY,
+            value: "(binary data)".to_string(),
+            explanation: format!("Could not parse DER private key: {e}"),
+        }
+        .build()
+    })?;
+
+    let pem_bytes = pkey.private_key_to_pem_pkcs8().map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: PRIVATE_KEY,
+            value: "(binary data)".to_string(),
+            explanation: format!("Could not convert private key to PEM: {e}"),
+        }
+        .build()
+    })?;
+
+    String::from_utf8(pem_bytes).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: PRIVATE_KEY,
+            value: "(binary data)".to_string(),
+            explanation: format!("PEM output is not valid UTF-8: {e}"),
+        }
+        .build()
+    })
+}
+
+fn read_private_key(settings: &ParamStore) -> Result<String, ConfigError> {
+    let has_private_key = settings.get(PRIVATE_KEY).is_some();
+    let has_private_key_file = get_string(settings, PRIVATE_KEY_FILE).is_some();
+
+    if has_private_key && has_private_key_file {
+        return ConflictingParametersSnafu {
+            explanation:
+                "Both 'private_key' and 'private_key_file' are set. Please provide only one."
+                    .to_string(),
+        }
+        .fail();
+    }
+
+    // Bytes (DER from Python)
+    if let Some(Setting::Bytes(private_key_bytes)) = settings.get(PRIVATE_KEY) {
+        return der_to_pem(private_key_bytes);
+    }
+
+    // String (base64-encoded)
+    if let Some(private_key_base64) = get_string(settings, PRIVATE_KEY) {
+        let private_key_bytes = general_purpose::STANDARD
+            .decode(&private_key_base64)
+            .map_err(|e| {
+                InvalidParameterValueSnafu {
+                    parameter: PRIVATE_KEY,
+                    value: "(redacted)".to_string(),
+                    explanation: format!("Could not decode base64 private key: {e}"),
+                }
+                .build()
+            })?;
+
+        if private_key_bytes.starts_with(b"-----BEGIN") {
+            return String::from_utf8(private_key_bytes).map_err(|e| {
+                InvalidParameterValueSnafu {
+                    parameter: PRIVATE_KEY,
+                    value: "(redacted)".to_string(),
+                    explanation: format!("Private key is not valid UTF-8: {e}"),
+                }
+                .build()
+            });
+        }
+
+        return der_to_pem(&private_key_bytes);
+    }
+
+    // File path
+    if let Some(private_key_file) = get_string(settings, PRIVATE_KEY_FILE) {
+        let private_key = fs::read_to_string(&private_key_file).map_err(|e| {
+            InvalidParameterValueSnafu {
+                parameter: PRIVATE_KEY_FILE,
+                value: private_key_file,
+                explanation: format!("Could not read private key file: {e}"),
+            }
+            .build()
+        })?;
+        return Ok(private_key);
+    }
+
+    MissingParameterSnafu {
+        parameter: "private_key or private_key_file",
+    }
+    .fail()
+}
+
+fn has_private_key_params(settings: &ParamStore) -> bool {
+    settings.get(PRIVATE_KEY).is_some() || get_string(settings, PRIVATE_KEY_FILE).is_some()
+}
+
+// ---------------------------------------------------------------------------
+// Server URL derivation (mirrored from rest_parameters::get_server_url)
+// ---------------------------------------------------------------------------
+
+fn derive_server_url(settings: &ParamStore) -> Result<String, ConfigError> {
+    if let Some(url) = get_string(settings, SERVER_URL) {
+        return Ok(url);
+    }
+
+    let protocol = get_string(settings, PROTOCOL).unwrap_or_else(|| "https".to_string());
+    let host =
+        get_string(settings, HOST).context(MissingParameterSnafu { parameter: HOST })?;
+    if protocol != "https" && protocol != "http" {
+        tracing::warn!(
+            "Unexpected protocol specified during server url construction: {protocol}"
+        );
+    }
+
+    let base_url = format!("{protocol}://{host}");
+    if let Some(port) = get_int(settings, PORT) {
+        return Ok(format!("{base_url}:{port}"));
+    }
+
+    Ok(base_url)
+}
+
+// ---------------------------------------------------------------------------
+// TLS / CRL config building (mirrored from tls::config / crl::config)
+// ---------------------------------------------------------------------------
+
+fn build_crl_config(settings: &ParamStore) -> CrlConfig {
+    // TODO: make matching case-insensitive (e.g. "disabled", "Enabled")
+    let check_mode = match get_string(settings, CRL_CHECK_MODE).as_deref() {
+        Some("0") | Some("DISABLED") | None => CertRevocationCheckMode::Disabled,
+        Some("1") | Some("ENABLED") => CertRevocationCheckMode::Enabled,
+        Some("2") | Some("ADVISORY") => CertRevocationCheckMode::Advisory,
+        Some(other) => {
+            tracing::warn!("Unknown crl_check_mode: {other}, using DISABLED");
+            CertRevocationCheckMode::Disabled
+        }
+    };
+
+    let enable_disk_caching = get_bool(settings, CRL_ENABLE_DISK_CACHING).unwrap_or(true);
+    let enable_memory_caching = get_bool(settings, CRL_ENABLE_MEMORY_CACHING).unwrap_or(true);
+    let cache_dir = get_string(settings, CRL_CACHE_DIR).map(PathBuf::from);
+    let validity_time = get_int(settings, CRL_VALIDITY_TIME)
+        .map(Duration::days)
+        .unwrap_or(Duration::days(10));
+    let allow_certificates_without_crl_url =
+        get_bool(settings, CRL_ALLOW_CERTIFICATES_WITHOUT_CRL_URL).unwrap_or(false);
+    let http_timeout = get_int(settings, CRL_HTTP_TIMEOUT)
+        .map(Duration::seconds)
+        .unwrap_or(Duration::seconds(30));
+    let connection_timeout = get_int(settings, CRL_CONNECTION_TIMEOUT)
+        .map(Duration::seconds)
+        .unwrap_or(Duration::seconds(10));
+
+    CrlConfig {
+        check_mode,
+        enable_disk_caching,
+        enable_memory_caching,
+        cache_dir,
+        validity_time,
+        allow_certificates_without_crl_url,
+        http_timeout,
+        connection_timeout,
+    }
+}
+
+fn build_tls_config(settings: &ParamStore) -> TlsConfig {
+    let crl_config = build_crl_config(settings);
+    let custom_root_store_path = get_string(settings, CUSTOM_ROOT_STORE_PATH).map(PathBuf::from);
+    let verify_hostname = get_bool(settings, VERIFY_HOSTNAME).unwrap_or(true);
+    let verify_certificates = get_bool(settings, VERIFY_CERTIFICATES).unwrap_or(true);
+
+    TlsConfig {
+        crl_config,
+        custom_root_store_path,
+        verify_hostname,
+        verify_certificates,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth config building (mirrored from rest_parameters::LoginMethod)
+// ---------------------------------------------------------------------------
+
+fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
+    let authenticator = get_string(settings, AUTHENTICATOR).unwrap_or_default();
+
+    let use_jwt = authenticator == "SNOWFLAKE_JWT"
+        || (authenticator.is_empty() && has_private_key_params(settings));
+
+    if use_jwt {
+        return Ok(AuthConfig::Jwt {
+            user: get_string(settings, USER)
+                .context(MissingParameterSnafu { parameter: USER })?,
+            private_key_pem: SensitiveString::from(read_private_key(settings)?),
+            passphrase: get_sensitive_string(settings, PRIVATE_KEY_PASSWORD),
+        });
+    }
+
+    match authenticator.as_str() {
+        "SNOWFLAKE_PASSWORD" | "" => Ok(AuthConfig::Password {
+            user: get_string(settings, USER)
+                .context(MissingParameterSnafu { parameter: USER })?,
+            password: get_sensitive_string(settings, PASSWORD).context(
+                MissingParameterSnafu { parameter: PASSWORD },
+            )?,
+        }),
+        "PROGRAMMATIC_ACCESS_TOKEN" => Ok(AuthConfig::Pat {
+            user: get_string(settings, USER)
+                .context(MissingParameterSnafu { parameter: USER })?,
+            token: get_sensitive_string(settings, TOKEN)
+                .context(MissingParameterSnafu { parameter: TOKEN })?,
+        }),
+        _ => InvalidParameterValueSnafu {
+            parameter: AUTHENTICATOR,
+            value: authenticator,
+            explanation:
+                "Allowed values are SNOWFLAKE_JWT, SNOWFLAKE_PASSWORD, and PROGRAMMATIC_ACCESS_TOKEN",
+        }
+        .fail(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionConfig::build
+// ---------------------------------------------------------------------------
+
+impl ConnectionConfig {
+    /// Build a typed config from a resolved settings map.
+    ///
+    /// The input should come from `ConfigResolver::resolve()`.
+    /// Runs `validate_settings` first and returns all validation errors
+    /// collected (not just the first) via `ConfigError::ValidationFailed`.
+    /// Runtime errors that go beyond static validation (e.g. base64
+    /// decoding failures, file I/O) are still returned individually.
+    pub fn build(settings: &ParamStore) -> Result<Self, ConfigError> {
+        let issues = validate_settings(settings);
+        let errors: Vec<_> = issues
+            .into_iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .collect();
+        if !errors.is_empty() {
+            return ValidationFailedSnafu { issues: errors }.fail();
+        }
+
+        let account = get_string(settings, ACCOUNT)
+            .context(MissingParameterSnafu { parameter: ACCOUNT })?;
+        let server_url = derive_server_url(settings)?;
+        let auth = build_auth_config(settings)?;
+        let tls = build_tls_config(settings);
+
+        let session = SessionContext {
+            database: get_string(settings, DATABASE),
+            schema: get_string(settings, SCHEMA),
+            warehouse: get_string(settings, WAREHOUSE),
+            role: get_string(settings, ROLE),
+        };
+
+        Ok(Self {
+            server: ServerConfig {
+                account,
+                server_url,
+            },
+            auth,
+            session,
+            tls,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// validate_settings – pre-flight check that collects all issues
+// ---------------------------------------------------------------------------
+
+/// Validate settings without building the full config.
+/// Returns a list of all issues found (errors and warnings).
+pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    // --- MissingRequired: account ---
+    if get_string(settings, ACCOUNT).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: ACCOUNT.into(),
+            message: "Missing required parameter 'account'".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- MissingRequired: user ---
+    if get_string(settings, USER).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: USER.into(),
+            message: "Missing required parameter 'user'".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- Auth-specific checks based on authenticator ---
+    let authenticator = get_string(settings, AUTHENTICATOR).unwrap_or_default();
+    match authenticator.as_str() {
+        "SNOWFLAKE_PASSWORD" | "" if has_private_key_params(settings) => {
+            // Auto-detect JWT: private key params present, no password needed
+        }
+        "SNOWFLAKE_PASSWORD" | "" => {
+            if get_string(settings, PASSWORD).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: PASSWORD.into(),
+                    message: "Missing required parameter 'password' for password authentication"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "SNOWFLAKE_JWT" => {
+            if !has_private_key_params(settings) {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: PRIVATE_KEY.into(),
+                    message:
+                        "Missing 'private_key' or 'private_key_file' for JWT authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "PROGRAMMATIC_ACCESS_TOKEN" => {
+            if get_string(settings, TOKEN).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: TOKEN.into(),
+                    message: "Missing required parameter 'token' for PAT authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        other => {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Error,
+                parameter: AUTHENTICATOR.into(),
+                message: format!(
+                    "Invalid authenticator '{other}'. Allowed: SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN"
+                ),
+                code: ValidationCode::InvalidValue,
+            });
+        }
+    }
+
+    // --- MissingRequired: host (when server_url is absent) ---
+    if get_string(settings, SERVER_URL).is_none() && get_string(settings, HOST).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: HOST.into(),
+            message: "Missing required parameter 'host' (or 'server_url')".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- InvalidValue: protocol ---
+    if let Some(protocol) = get_string(settings, PROTOCOL)
+        && protocol != "http"
+        && protocol != "https"
+    {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: PROTOCOL.into(),
+            message: format!(
+                "Invalid protocol '{protocol}'. Allowed values: 'http', 'https'"
+            ),
+            code: ValidationCode::InvalidValue,
+        });
+    }
+
+    // --- InvalidValue: crl_check_mode ---
+    // TODO: make matching case-insensitive (e.g. "disabled", "Enabled")
+    if let Some(mode) = get_string(settings, CRL_CHECK_MODE) {
+        let valid = ["DISABLED", "ENABLED", "ADVISORY", "0", "1", "2"];
+        if !valid.contains(&mode.as_str()) {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Error,
+                parameter: CRL_CHECK_MODE.into(),
+                message: format!(
+                    "Invalid crl_check_mode '{mode}'. Allowed: DISABLED, ENABLED, ADVISORY, 0, 1, 2"
+                ),
+                code: ValidationCode::InvalidValue,
+            });
+        }
+    }
+
+    // --- ConflictingParameters: private_key + private_key_file ---
+    let has_pk = settings.get(PRIVATE_KEY).is_some();
+    let has_pk_file = get_string(settings, PRIVATE_KEY_FILE).is_some();
+    if has_pk && has_pk_file {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: PRIVATE_KEY.into(),
+            message: "Both 'private_key' and 'private_key_file' are set. Please provide only one."
+                .into(),
+            code: ValidationCode::ConflictingParameters,
+        });
+    }
+
+    // --- UnknownParameter: keys not in ParamRegistry ---
+    let registry = crate::config::param_registry::registry();
+    for key in settings.keys() {
+        if !registry.is_known(key) {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Warning,
+                parameter: key.clone(),
+                message: format!("Unknown parameter '{key}'"),
+                code: ValidationCode::UnknownParameter,
+            });
+        }
+    }
+
+    issues
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_from(pairs: &[(&str, Setting)]) -> ParamStore {
+        let mut settings = ParamStore::new();
+        for (key, value) in pairs {
+            settings.insert((*key).to_string(), value.clone());
+        }
+        settings
+    }
+
+    fn minimal_password_settings() -> ParamStore {
+        settings_from(&[
+            ("account", Setting::String("myaccount".into())),
+            ("user", Setting::String("myuser".into())),
+            ("password", Setting::String("mypassword".into())),
+            ("host", Setting::String("myaccount.snowflakecomputing.com".into())),
+        ])
+    }
+
+    // -- ConnectionConfig::build tests --
+
+    #[test]
+    fn build_minimal_password_auth_succeeds() {
+        let settings = minimal_password_settings();
+        let config = ConnectionConfig::build(&settings).unwrap();
+
+        assert_eq!(config.server.account, "myaccount");
+        assert!(config.server.server_url.contains("myaccount.snowflakecomputing.com"));
+        match &config.auth {
+            AuthConfig::Password { user, password } => {
+                assert_eq!(user, "myuser");
+                assert_eq!(password.reveal(), "mypassword");
+            }
+            _ => panic!("Expected Password auth"),
+        }
+        assert_eq!(config.session.database, None);
+        assert!(config.tls.verify_hostname);
+    }
+
+    #[test]
+    fn build_missing_account_fails() {
+        let settings = settings_from(&[
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let err = ConnectionConfig::build(&settings).unwrap_err();
+        match err {
+            ConfigError::ValidationFailed { ref issues, .. } => {
+                assert!(
+                    issues
+                        .iter()
+                        .any(|i| i.parameter == "account"
+                            && i.code == ValidationCode::MissingRequired),
+                    "Expected MissingRequired for 'account', got: {issues:?}"
+                );
+            }
+            other => panic!("Expected ValidationFailed, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn build_server_url_from_host_port_protocol() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("myhost.com".into())),
+            ("port", Setting::Int(8443)),
+            ("protocol", Setting::String("https".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "https://myhost.com:8443");
+    }
+
+    #[test]
+    fn build_server_url_direct_override() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("server_url", Setting::String("https://custom.url".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "https://custom.url");
+    }
+
+    #[test]
+    fn build_session_context_populated() {
+        let mut settings = minimal_password_settings();
+        settings.insert("database".into(), Setting::String("mydb".into()));
+        settings.insert("schema".into(), Setting::String("myschema".into()));
+        settings.insert("warehouse".into(), Setting::String("mywh".into()));
+        settings.insert("role".into(), Setting::String("myrole".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.session.database.as_deref(), Some("mydb"));
+        assert_eq!(config.session.schema.as_deref(), Some("myschema"));
+        assert_eq!(config.session.warehouse.as_deref(), Some("mywh"));
+        assert_eq!(config.session.role.as_deref(), Some("myrole"));
+    }
+
+    #[test]
+    fn build_tls_booleans_from_bool_setting() {
+        let mut settings = minimal_password_settings();
+        settings.insert("verify_hostname".into(), Setting::Bool(false));
+        settings.insert("verify_certificates".into(), Setting::Bool(false));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(!config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn build_tls_booleans_from_string_fallback() {
+        let mut settings = minimal_password_settings();
+        settings.insert("verify_hostname".into(), Setting::String("false".into()));
+        settings.insert("verify_certificates".into(), Setting::String("true".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn build_pat_auth() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("token", Setting::String("tok123".into())),
+            ("authenticator", Setting::String("PROGRAMMATIC_ACCESS_TOKEN".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Pat { user, token } => {
+                assert_eq!(user, "u");
+                assert_eq!(token.reveal(), "tok123");
+            }
+            _ => panic!("Expected Pat auth"),
+        }
+    }
+
+    #[test]
+    fn build_conflicting_private_keys_fails() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("SNOWFLAKE_JWT".into())),
+            ("private_key", Setting::String("some_key".into())),
+            ("private_key_file", Setting::String("/path/to/key".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let err = ConnectionConfig::build(&settings).unwrap_err();
+        match err {
+            ConfigError::ValidationFailed { ref issues, .. } => {
+                assert!(
+                    issues
+                        .iter()
+                        .any(|i| i.code == ValidationCode::ConflictingParameters),
+                    "Expected ConflictingParameters issue, got: {issues:?}"
+                );
+            }
+            other => panic!("Expected ValidationFailed, got: {other}"),
+        }
+    }
+
+    // -- validate_settings tests --
+
+    #[test]
+    fn validate_missing_account_reports_issue() {
+        let settings = settings_from(&[
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let account_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "account" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert!(!account_issues.is_empty());
+    }
+
+    #[test]
+    fn validate_returns_all_issues_not_just_first() {
+        let settings = ParamStore::new();
+        let issues = validate_settings(&settings);
+        let error_count = issues
+            .iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .count();
+        assert!(
+            error_count >= 2,
+            "Expected at least account+user errors, got {error_count}"
+        );
+    }
+
+    #[test]
+    fn validate_conflicting_private_keys() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("SNOWFLAKE_JWT".into())),
+            ("private_key", Setting::String("k".into())),
+            ("private_key_file", Setting::String("/f".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let conflict: Vec<_> = issues
+            .iter()
+            .filter(|i| i.code == ValidationCode::ConflictingParameters)
+            .collect();
+        assert_eq!(conflict.len(), 1);
+    }
+
+    #[test]
+    fn validate_invalid_protocol() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("protocol", Setting::String("ftp".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let proto_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "protocol" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(proto_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_invalid_crl_check_mode() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("crl_check_mode", Setting::String("INVALID".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let crl_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "crl_check_mode" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(crl_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_valid_crl_check_modes() {
+        for mode in &["DISABLED", "ENABLED", "ADVISORY", "0", "1", "2"] {
+            let settings = settings_from(&[
+                ("account", Setting::String("acct".into())),
+                ("user", Setting::String("u".into())),
+                ("password", Setting::String("p".into())),
+                ("crl_check_mode", Setting::String(mode.to_string())),
+            ]);
+            let issues = validate_settings(&settings);
+            let crl_issues: Vec<_> = issues
+                .iter()
+                .filter(|i| {
+                    i.parameter == "crl_check_mode" && i.code == ValidationCode::InvalidValue
+                })
+                .collect();
+            assert!(
+                crl_issues.is_empty(),
+                "crl_check_mode '{mode}' should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_unknown_parameter_warns() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("totally_bogus_param", Setting::String("x".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let unknown: Vec<_> = issues
+            .iter()
+            .filter(|i| {
+                i.parameter == "totally_bogus_param"
+                    && i.code == ValidationCode::UnknownParameter
+                    && i.severity == ValidationSeverity::Warning
+            })
+            .collect();
+        assert_eq!(unknown.len(), 1);
+    }
+
+    #[test]
+    fn validate_invalid_authenticator() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("OAUTH".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let auth_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "authenticator" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(auth_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_clean_password_auth_no_errors() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let errors: Vec<_> = issues
+            .iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .collect();
+        assert!(errors.is_empty(), "Expected no errors: {errors:?}");
+    }
+
+    #[test]
+    fn validate_missing_host_without_server_url() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let host_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "host" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert_eq!(host_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_server_url_satisfies_host_requirement() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("server_url", Setting::String("https://custom.url".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let host_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "host" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert!(host_issues.is_empty());
+    }
+
+    #[test]
+    fn get_bool_rejects_unrecognized_string() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+            ("verify_hostname", Setting::String("ture".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        // Unrecognized string falls through to default (true), not silently false
+        assert!(config.tls.verify_hostname);
+    }
+
+    #[test]
+    fn crl_check_mode_builds_correct_enum() {
+        for (input, expected) in [
+            ("DISABLED", CertRevocationCheckMode::Disabled),
+            ("0", CertRevocationCheckMode::Disabled),
+            ("ENABLED", CertRevocationCheckMode::Enabled),
+            ("1", CertRevocationCheckMode::Enabled),
+            ("ADVISORY", CertRevocationCheckMode::Advisory),
+            ("2", CertRevocationCheckMode::Advisory),
+        ] {
+            let mut settings = minimal_password_settings();
+            settings.insert("crl_check_mode".into(), Setting::String(input.into()));
+            let config = ConnectionConfig::build(&settings).unwrap();
+            assert_eq!(
+                config.tls.crl_config.check_mode, expected,
+                "crl_check_mode '{input}' should produce {expected:?}"
+            );
+        }
+    }
+}

--- a/sf_core/src/config/mod.rs
+++ b/sf_core/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod config_manager;
+pub mod connection_config;
 pub mod param_registry;
 pub mod param_store;
 pub use param_registry::ParamKey;
@@ -68,6 +69,12 @@ pub enum ConfigError {
         "Could not determine platform config directory. Set SNOWFLAKE_HOME environment variable to specify the configuration directory."
     ))]
     ConfigDirNotFound {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Configuration validation failed"))]
+    ValidationFailed {
+        issues: Vec<crate::config::connection_config::ValidationIssue>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -14,7 +14,7 @@ use crate::apis::database_driver_v1::{
 use crate::apis::database_driver_v1::{
     connection_get_info, connection_get_parameter, connection_init, connection_new,
     connection_release, connection_set_option, connection_set_options,
-    connection_set_session_parameters,
+    connection_set_session_parameters, connection_validate_options,
 };
 use crate::apis::database_driver_v1::{
     database_init, database_new, database_release, database_set_option, database_set_options,
@@ -349,6 +349,28 @@ fn to_driver_error(error: &ApiError) -> DriverError {
                 },
             )),
         },
+        ApiError::Configuration {
+            source: ConfigError::ValidationFailed { issues, .. },
+            ..
+        } => {
+            let summary = issues
+                .iter()
+                .map(|i| format!("{}: {}", i.parameter, i.message))
+                .collect::<Vec<_>>()
+                .join("; ");
+            DriverError {
+                error_type: Some(driver_error::ErrorType::InvalidParameterValue(
+                    InvalidParameterValue {
+                        parameter: issues
+                            .first()
+                            .map(|i| i.parameter.clone())
+                            .unwrap_or_default(),
+                        value: String::new(),
+                        explanation: Some(summary),
+                    },
+                )),
+            }
+        }
     }
 }
 
@@ -416,6 +438,10 @@ fn to_driver_exception(error: ApiError) -> DriverException {
             source: ConfigError::ConnectionNotFound { .. },
             ..
         } => StatusCode::MissingParameter,
+        ApiError::Configuration {
+            source: ConfigError::ValidationFailed { .. },
+            ..
+        } => StatusCode::InvalidParameterValue,
         ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
         ApiError::Login {
             source: RestError::LoginError { .. },
@@ -837,6 +863,22 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let value = connection_get_parameter(conn_handle.into(), input.key).to_protobuf()?;
 
         Ok(ConnectionGetParameterResponse { value })
+    }
+
+    #[instrument(name = "DatabaseDriverV1::connection_validate_options", skip(input))]
+    fn connection_validate_options(
+        input: ConnectionValidateOptionsRequest,
+    ) -> Result<ConnectionValidateOptionsResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        let issues = connection_validate_options(conn_handle.into()).to_protobuf()?;
+
+        Ok(ConnectionValidateOptionsResponse {
+            issues: issues
+                .into_iter()
+                .map(core_validation_issue_to_proto)
+                .collect(),
+        })
     }
 
     #[instrument(name = "DatabaseDriverV1::statement_new", skip(input))]


### PR DESCRIPTION
Connection setup previously assembled a `LoginParameters` struct by calling a chain of `from_settings()` methods spread across `rest_parameters.rs`, `tls/config.rs`, and `crl/config.rs`, each operating on an untyped settings map. Errors were surfaced one at a time (first failure wins), and there was no way for a caller to do a pre-flight validation check without actually initiating a connection.

This change introduces `sf_core/src/config/connection_config.rs` with a `ConnectionConfig` typed struct (`ServerConfig`, `AuthConfig`, `SessionContext`, `TlsConfig`) and a `ConnectionConfig::build()` method that consolidates all of that scattered logic. Before building, it runs `validate_settings()` which collects the full set of issues in one pass — missing required parameters, invalid values (`protocol`, `crl_check_mode`, `authenticator`), conflicting parameters (`private_key` + `private_key_file`), and unknown keys not in the `ParamRegistry`. If any errors are present, `build()` returns a new `ConfigError::ValidationFailed` variant carrying all issues rather than stopping at the first. The `ValidationIssue` / `ValidationSeverity` / `ValidationCode` types are also moved here from `validation.rs`, which now re-exports them. A `get_bool()` helper accepts both `Setting::Bool` and `Setting::String("true"/"false")` for backward compatibility with TOML-loaded values predating this set of changes.

All production code references parameter names through the `param_names` constants introduced in [2/7] (e.g. `get_string(settings, ACCOUNT)` instead of `get_string(settings, "account")`), giving compile-time typo detection and IDE find-all-references support. Test code continues to use bare strings where it constructs `HashMap` fixtures directly.

`connection_init` is updated to call `ConnectionConfig::build()` and use `config.tls` directly; a transitional `login_parameters_from_config()` bridge maps the typed config to the existing `LoginParameters` struct so the REST login layer can remain unchanged. A new `ConnectionValidateOptions` RPC exposes `validate_settings()` over the wire, giving callers structured pre-flight feedback without initiating a login.

`rest_parameters.rs` will be removed in a future PR.