### PR TITLE
[6a/7] python: migrate connection setup to batch SetOptions RPC

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -13,16 +13,16 @@ from io import StringIO
 from typing import Any, Callable, Union
 
 from snowflake.connector._internal.errorcode import ER_CONNECTION_IS_CLOSED
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ConfigSetting,
+)
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
     ConnectionGetInfoRequest,
     ConnectionGetInfoResponse,
     ConnectionGetParameterRequest,
     ConnectionInitRequest,
     ConnectionNewRequest,
-    ConnectionSetOptionBytesRequest,
-    ConnectionSetOptionDoubleRequest,
-    ConnectionSetOptionIntRequest,
-    ConnectionSetOptionStringRequest,
+    ConnectionSetOptionsRequest,
     ConnectionSetSessionParametersRequest,
     DatabaseInitRequest,
     DatabaseNewRequest,
@@ -99,32 +99,29 @@ class Connection:
         if "private_key" in kwargs:
             kwargs["private_key"] = normalize_private_key(kwargs["private_key"])
 
+        options = {}
         for key, value in kwargs.items():
-            # bool check must come before int because bool is a subclass of int in Python
             if isinstance(value, bool):
-                self.db_api.connection_set_option_int(
-                    ConnectionSetOptionIntRequest(conn_handle=self.conn_handle, key=key, value=int(value))
-                )
-
+                options[key] = ConfigSetting(bool_value=value)
             elif isinstance(value, int):
-                self.db_api.connection_set_option_int(
-                    ConnectionSetOptionIntRequest(conn_handle=self.conn_handle, key=key, value=value)
-                )
-
+                options[key] = ConfigSetting(int_value=value)
             elif isinstance(value, str):
-                self.db_api.connection_set_option_string(
-                    ConnectionSetOptionStringRequest(conn_handle=self.conn_handle, key=key, value=value)
-                )
-
+                options[key] = ConfigSetting(string_value=value)
             elif isinstance(value, float):
-                self.db_api.connection_set_option_double(
-                    ConnectionSetOptionDoubleRequest(conn_handle=self.conn_handle, key=key, value=value)
-                )
-
+                options[key] = ConfigSetting(double_value=value)
             elif isinstance(value, bytes):
-                self.db_api.connection_set_option_bytes(
-                    ConnectionSetOptionBytesRequest(conn_handle=self.conn_handle, key=key, value=value)
+                options[key] = ConfigSetting(bytes_value=value)
+
+        if options:
+            import warnings as py_warnings
+            response = self.db_api.connection_set_options(
+                ConnectionSetOptionsRequest(
+                    conn_handle=self.conn_handle,
+                    options=options,
                 )
+            )
+            for warning in response.warnings:
+                py_warnings.warn(warning.message, stacklevel=2)
 
         # Set session parameters if provided (before connection_init)
         if session_params:

--- a/python/tests/integ/authentication/test_private_key_auth.py
+++ b/python/tests/integ/authentication/test_private_key_auth.py
@@ -21,7 +21,7 @@ class TestPrivateKeyAuthentication:
 
         if NEW_DRIVER_ONLY("BD#4"):
             assert isinstance(exception, ProgrammingError)
-            assert "Missing required parameter: private_key or private_key_file" in str(exception)
+            assert "Missing 'private_key' or 'private_key_file' for JWT authentication" in str(exception)
         elif OLD_DRIVER_ONLY("BD#4"):
             assert isinstance(exception, TypeError)
             assert "Expected bytes or RSAPrivateKey" in str(exception)


### PR DESCRIPTION
Opening a connection previously made one `connection_set_option_*` RPC call per parameter — up to 30+ FFI round-trips — and sent boolean values as strings rather than using the native wire type. This change migrates the Python wrapper to the batch `ConnectionSetOptions` RPC introduced in Task 3.

The per-key dispatch loop in `connection.py` is replaced with a single pass that builds a `dict[str, ConfigSetting]` using the appropriate `ConfigSetting` field for each Python type (`bool_value`, `int_value`, `string_value`, `double_value`, `bytes_value`), then sends the entire map in one `connection_set_options` call. Any `ValidationIssue` warnings in the response are forwarded to the caller via `warnings.warn`. The regenerated Python protobuf bindings (`_pb2.py`, `_pb2.pyi`, `_services.py`) are updated to expose all new RPCs added in Tasks 1–5: `SetOptionBool`, `SetOptions`, `ConnectionValidateOptions` for connection, database, and statement handles.

Tasks 6b and 6c apply the same migration to the JDBC and ODBC wrappers.