### PR TITLE
SNOW-2467780: Add float feature tests

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
@@ -1,0 +1,444 @@
+package net.snowflake.jdbc.e2e.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class FloatTests extends SnowflakeIntegrationTestBase {
+  private static final String FLOAT_TYPE = "FLOAT";
+  private static final int LARGE_RESULT_SET_SIZE = 50_000;
+
+  @Test
+  public void shouldCastFloatValuesToAppropriateTypeForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT 0.0::<type>, 123.456::<type>, 1.23e10::<type>, 'NaN'::<type>,
+    // 'inf'::<type>" is executed
+    // Then All values should be returned as appropriate type
+    // And Regular values should have approximately 15 decimal digits precision
+    // And NaN and inf values should be identified correctly
+    Connection connection = getDefaultConnection();
+    String sql =
+        String.format(
+            "SELECT 0.0::%1$s, 123.456::%1$s, 1.23e10::%1$s, 'NaN'::%1$s, 'inf'::%1$s", FLOAT_TYPE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+
+      assertAllFloatGetters(resultSet, 1, 0.0, "Column 1 mismatch for " + FLOAT_TYPE);
+      assertAllFloatGetters(resultSet, 2, 123.456, "Column 2 mismatch for " + FLOAT_TYPE);
+      assertAllFloatGetters(resultSet, 3, 1.23e10, "Column 3 mismatch for " + FLOAT_TYPE);
+
+      assertAllFloatGetters(resultSet, 4, Double.NaN, "Column 4 mismatch for " + FLOAT_TYPE);
+      assertAllFloatGetters(
+          resultSet, 5, Double.POSITIVE_INFINITY, "Column 5 mismatch for " + FLOAT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldSelectFloatLiteralsForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>"
+    // is executed
+    // Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
+    Connection connection = getDefaultConnection();
+    assertSingleRow(
+        connection,
+        String.format(
+            "SELECT 0.0::%1$s, 1.0::%1$s, -1.0::%1$s, 123.456::%1$s, -123.456::%1$s", FLOAT_TYPE),
+        Arrays.asList(0.0, 1.0, -1.0, 123.456, -123.456));
+  }
+
+  @Test
+  public void shouldHandleSpecialFloatValuesFromLiteralsForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
+    // Then Result should contain [NaN, positive_infinity, negative_infinity]
+    Connection connection = getDefaultConnection();
+    assertSingleRow(
+        connection,
+        String.format("SELECT 'NaN'::%1$s, 'inf'::%1$s, '-inf'::%1$s", FLOAT_TYPE),
+        Arrays.asList(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY));
+  }
+
+  @Test
+  public void shouldHandleFloatBoundaryValuesFromLiteralsForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is
+    // executed
+    // Then Result should contain floats [1.7976931348623157e308, -1.7976931348623157e308]
+    // When Query "SELECT 2.2250738585072014e-308::<type>, 5e-324::<type>" is executed
+    // Then Result should contain floats [2.2250738585072014e-308, approximately 5e-324]
+    // When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
+    // Then Result should verify precision around 15 decimal digits
+    Connection connection = getDefaultConnection();
+
+    assertSingleRow(
+        connection,
+        String.format(
+            "SELECT 1.7976931348623157e308::%1$s, -1.7976931348623157e308::%1$s", FLOAT_TYPE),
+        Arrays.asList(Double.MAX_VALUE, -Double.MAX_VALUE));
+
+    String minBoundarySql =
+        String.format("SELECT 2.2250738585072014e-308::%1$s, 5e-324::%1$s", FLOAT_TYPE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(minBoundarySql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+      assertFiniteDouble(
+          resultSet.getDouble(1), Double.MIN_NORMAL, "Column 1 mismatch for " + FLOAT_TYPE);
+      double actualSubnormal = resultSet.getDouble(2);
+      assertTrue(actualSubnormal > 0.0, "Column 2 should be positive for " + FLOAT_TYPE);
+      assertTrue(
+          actualSubnormal <= Double.MIN_VALUE, "Column 2 should be subnormal for " + FLOAT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+    }
+
+    assertSingleRow(
+        connection,
+        String.format("SELECT 123456789012345.0::%1$s, 1234567890123456.0::%1$s", FLOAT_TYPE),
+        Arrays.asList(123456789012345.0, 1234567890123456.0));
+  }
+
+  @Test
+  public void shouldHandleNULLValuesFromLiteralsForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
+    // Then Result should contain [NULL, 42.5, NULL]
+    Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT NULL::%1$s, 42.5::%1$s, NULL::%1$s", FLOAT_TYPE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
+      assertEquals(
+          0.0,
+          resultSet.getDouble(1),
+          "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
+
+      assertAllFloatGetters(resultSet, 2, 42.5, "Column 2 mismatch for " + FLOAT_TYPE);
+
+      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + FLOAT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + FLOAT_TYPE);
+      assertEquals(
+          0.0,
+          resultSet.getDouble(3),
+          "Column 3 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+      assertTrue(resultSet.wasNull(), "Column 3 getDouble should set wasNull() for " + FLOAT_TYPE);
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldDownloadLargeResultSetWithMultipleChunksFromGeneratorForFloatAndSynonyms()
+      throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is
+    // executed
+    // Then Result should contain 50000 rows
+    // And All values should be returned as appropriate float type
+    Connection connection = getDefaultConnection();
+    String sql =
+        String.format(
+            "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => %2$d)) v ORDER BY id",
+            FLOAT_TYPE, LARGE_RESULT_SET_SIZE);
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      int expected = 0;
+      while (resultSet.next()) {
+        assertFiniteDouble(
+            resultSet.getDouble(1),
+            expected,
+            "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
+        expected++;
+      }
+      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldSelectFloatsFromTableForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
+    // When Query "SELECT * FROM float_table" is executed
+    // Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + FLOAT_TYPE);
+    execute(
+        connection,
+        "INSERT INTO " + tableName + " VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
+
+    assertSingleColumnRows(
+        connection, tableName, Arrays.asList(0.0, 123.456, -789.012, 123000.0, -0.00987));
+  }
+
+  @Test
+  public void shouldHandleSpecialFloatValuesFromTableForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
+    // When Query "SELECT * FROM <table>" is executed
+    // Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + FLOAT_TYPE);
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES ('NaN'::"
+            + FLOAT_TYPE
+            + "), ('inf'::"
+            + FLOAT_TYPE
+            + "), ('-inf'::"
+            + FLOAT_TYPE
+            + "), (42.0), (-42.0)");
+
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
+      Map<String, Integer> counts = new HashMap<>();
+      while (resultSet.next()) {
+        double value = resultSet.getDouble(1);
+        String key;
+        if (Double.isNaN(value)) {
+          key = "NaN";
+        } else if (value == Double.POSITIVE_INFINITY) {
+          key = "POS_INF";
+        } else if (value == Double.NEGATIVE_INFINITY) {
+          key = "NEG_INF";
+        } else if (value == 42.0) {
+          key = "POS_42";
+        } else if (value == -42.0) {
+          key = "NEG_42";
+        } else {
+          key = "UNEXPECTED";
+        }
+        counts.put(key, counts.getOrDefault(key, 0) + 1);
+      }
+
+      assertEquals(1, counts.getOrDefault("NaN", 0), "Expected one NaN for " + FLOAT_TYPE);
+      assertEquals(
+          1, counts.getOrDefault("POS_INF", 0), "Expected one +Infinity for " + FLOAT_TYPE);
+      assertEquals(
+          1, counts.getOrDefault("NEG_INF", 0), "Expected one -Infinity for " + FLOAT_TYPE);
+      assertEquals(1, counts.getOrDefault("POS_42", 0), "Expected one 42.0 for " + FLOAT_TYPE);
+      assertEquals(1, counts.getOrDefault("NEG_42", 0), "Expected one -42.0 for " + FLOAT_TYPE);
+      assertEquals(
+          0, counts.getOrDefault("UNEXPECTED", 0), "Unexpected value returned for " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldHandleFloatBoundaryValuesFromTableForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with boundary values [1.7976931348623157e308,
+    // -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
+    // When Query "SELECT * FROM <table>" is executed
+    // Then Result should contain maximum, minimum, and precision boundary values
+    // And All values should be preserved within float precision limits
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + FLOAT_TYPE);
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " VALUES (1.7976931348623157e308), (-1.7976931348623157e308), (2.2250738585072014e-308), (5e-324), (123456789012345.0)");
+
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
+      boolean foundMax = false;
+      boolean foundMin = false;
+      boolean foundMinNormal = false;
+      boolean foundMinSubnormal = false;
+      boolean foundPrecisionValue = false;
+      int rowCount = 0;
+      while (resultSet.next()) {
+        rowCount++;
+        double value = resultSet.getDouble(1);
+        if (approximatelyEquals(value, Double.MAX_VALUE)) {
+          foundMax = true;
+        } else if (approximatelyEquals(value, -Double.MAX_VALUE)) {
+          foundMin = true;
+        } else if (approximatelyEquals(value, Double.MIN_NORMAL)) {
+          foundMinNormal = true;
+        } else if (value > 0.0 && value <= Double.MIN_VALUE) {
+          foundMinSubnormal = true;
+        } else if (approximatelyEquals(value, 123456789012345.0)) {
+          foundPrecisionValue = true;
+        }
+      }
+
+      assertEquals(5, rowCount, "Unexpected row count for " + FLOAT_TYPE);
+      assertTrue(foundMax, "Expected Double.MAX_VALUE for " + FLOAT_TYPE);
+      assertTrue(foundMin, "Expected -Double.MAX_VALUE for " + FLOAT_TYPE);
+      assertTrue(foundMinNormal, "Expected Double.MIN_NORMAL for " + FLOAT_TYPE);
+      assertTrue(foundMinSubnormal, "Expected positive subnormal value for " + FLOAT_TYPE);
+      assertTrue(foundPrecisionValue, "Expected 123456789012345.0 for " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldHandleNULLValuesFromTableForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
+    // When Query "SELECT * FROM <table>" is executed
+    // Then Result should contain [NULL, 123.456, NULL, -789.012]
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + FLOAT_TYPE);
+    execute(
+        connection, "INSERT INTO " + tableName + " VALUES (NULL), (123.456), (NULL), (-789.012)");
+
+    assertSingleColumnRows(connection, tableName, Arrays.asList(null, 123.456, null, -789.012));
+  }
+
+  @Test
+  public void shouldSelectLargeResultSetFromTableForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with <type> column exists with 50000 sequential values
+    // When Query "SELECT * FROM <table>" is executed
+    // Then Result should contain 50000 rows
+    // And All values should be returned as appropriate float type
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "col " + FLOAT_TYPE);
+    execute(
+        connection,
+        "INSERT INTO "
+            + tableName
+            + " SELECT seq8()::"
+            + FLOAT_TYPE
+            + " FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
+
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
+      int expected = 0;
+      while (resultSet.next()) {
+        assertFiniteDouble(
+            resultSet.getDouble(1),
+            expected,
+            "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
+        expected++;
+      }
+      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
+    }
+  }
+
+  private static void assertSingleRow(Connection connection, String sql, List<Double> expected)
+      throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+      for (int i = 0; i < expected.size(); i++) {
+        assertAllFloatGetters(
+            resultSet, i + 1, expected.get(i), "Column " + (i + 1) + " mismatch for " + FLOAT_TYPE);
+      }
+      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+    }
+  }
+
+  private static String createTempTable(Connection connection, String columns) throws Exception {
+    String tableName = "ud_float_" + UUID.randomUUID().toString().replace("-", "");
+    execute(connection, "CREATE TEMPORARY TABLE " + tableName + " (" + columns + ")");
+    return tableName;
+  }
+
+  private static void execute(Connection connection, String sql) throws Exception {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    }
+  }
+
+  private static void assertSingleColumnRows(
+      Connection connection, String tableName, List<Double> expectedValues) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
+      for (int i = 0; i < expectedValues.size(); i++) {
+        assertTrue(resultSet.next(), "Missing row " + i + " for " + FLOAT_TYPE);
+        Double expected = expectedValues.get(i);
+        if (expected == null) {
+          assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + FLOAT_TYPE);
+          assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
+          assertEquals(0.0, resultSet.getDouble(1), "Expected getDouble=0.0 for NULL at row " + i);
+          assertTrue(resultSet.wasNull(), "Expected wasNull() after getDouble NULL at row " + i);
+        } else {
+          assertAllFloatGetters(
+              resultSet, 1, expected, "Value mismatch for " + FLOAT_TYPE + ", row " + i);
+        }
+      }
+      assertFalse(resultSet.next(), "Unexpected extra rows for " + FLOAT_TYPE);
+    }
+  }
+
+  private static void assertAllFloatGetters(
+      ResultSet resultSet, int columnIndex, double expected, String message) throws Exception {
+    Object value = resultSet.getObject(columnIndex);
+    assertTrue(value instanceof Double, message + " (getObject should return Double)");
+    assertFalse(resultSet.wasNull(), message + " (getObject should not be NULL)");
+    assertDoubleValue(((Double) value).doubleValue(), expected, message + " (getObject)");
+
+    double doubleValue = resultSet.getDouble(columnIndex);
+    assertFalse(resultSet.wasNull(), message + " (getDouble should not be NULL)");
+    assertDoubleValue(doubleValue, expected, message + " (getDouble)");
+
+    float floatValue = resultSet.getFloat(columnIndex);
+    assertFalse(resultSet.wasNull(), message + " (getFloat should not be NULL)");
+    assertFloatValue(floatValue, expected, message + " (getFloat)");
+  }
+
+  private static void assertFiniteDouble(double actual, double expected, String message) {
+    assertTrue(Double.isFinite(actual), message + " (actual is not finite)");
+    assertEquals(expected, actual, toleranceFor(expected), message);
+  }
+
+  private static void assertDoubleValue(double actual, double expected, String message) {
+    if (Double.isNaN(expected)) {
+      assertTrue(Double.isNaN(actual), message + " (expected NaN)");
+      return;
+    }
+    if (Double.isInfinite(expected)) {
+      assertEquals(expected, actual, message + " (expected infinity)");
+      return;
+    }
+    assertFiniteDouble(actual, expected, message);
+  }
+
+  private static void assertFloatValue(float actual, double expected, String message) {
+    float expectedFloat = (float) expected;
+    if (Float.isNaN(expectedFloat)) {
+      assertTrue(Float.isNaN(actual), message + " (expected NaN)");
+      return;
+    }
+    if (Float.isInfinite(expectedFloat)) {
+      assertEquals(expectedFloat, actual, message + " (expected infinity)");
+      return;
+    }
+    assertEquals(expectedFloat, actual, floatToleranceFor(expectedFloat), message);
+  }
+
+  private static boolean approximatelyEquals(double actual, double expected) {
+    return Double.isFinite(actual) && Math.abs(actual - expected) <= toleranceFor(expected);
+  }
+
+  private static double toleranceFor(double expected) {
+    double ulpTolerance = Math.ulp(expected) * 8;
+    double relativeTolerance = Math.abs(expected) * 1e-12;
+    return Math.max(ulpTolerance, relativeTolerance);
+  }
+
+  private static float floatToleranceFor(float expected) {
+    float ulpTolerance = Math.ulp(expected) * 8;
+    float relativeTolerance = Math.abs(expected) * 1e-6f;
+    return Math.max(ulpTolerance, relativeTolerance);
+  }
+}

--- a/tests/definitions/shared/types/float.feature
+++ b/tests/definitions/shared/types/float.feature
@@ -1,11 +1,11 @@
-@python @core_not_needed
+@python @jdbc @core_not_needed
 Feature: FLOAT type support
 
   # =========================================================================== #
   #                               Type casting                                  #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should cast float values to appropriate type for float and synonyms
     # Python: Values should be cast to 'float' type (64-bit)
     Given Snowflake client is logged in
@@ -18,19 +18,19 @@ Feature: FLOAT type support
   #                     SELECT with literals (no tables)                        #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select float literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>" is executed
     Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle special float values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
     Then Result should contain [NaN, positive_infinity, negative_infinity]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle float boundary values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is executed
@@ -40,13 +40,13 @@ Feature: FLOAT type support
     When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
     Then Result should verify precision around 15 decimal digits
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle NULL values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
     Then Result should contain [NULL, 42.5, NULL]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
@@ -57,21 +57,21 @@ Feature: FLOAT type support
   #                             Table operations                                #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select floats from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
     When Query "SELECT * FROM float_table" is executed
     Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle special float values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle float boundary values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
@@ -79,14 +79,14 @@ Feature: FLOAT type support
     Then Result should contain maximum, minimum, and precision boundary values
     And All values should be preserved within float precision limits
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should handle NULL values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [NULL, 123.456, NULL, -789.012]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select large result set from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with 50000 sequential values


### PR DESCRIPTION
Adds JDBC E2E coverage for FLOAT type behavior and updates shared float Gherkin definitions to ensure scenario coverage validation is aligned.
Includes tests for casting, literals, special values (NaN, inf, -inf), boundary values, NULL handling, and large result sets for JDBC float scenarios.
Does not include parameter bindings as they are not supported yet