### PR TITLE
SNOW-2467780: Add decfloat support

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/ArrowVectorConverterUtil.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/ArrowVectorConverterUtil.java
@@ -76,6 +76,9 @@ public final class ArrowVectorConverterUtil {
           }
           break;
 
+        case DECFLOAT:
+          return new DecfloatToDecimalConverter(vector, idx, context);
+
         case REAL:
           return new DoubleToRealConverter(vector, idx, context);
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/DecfloatToDecimalConverter.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/converters/DecfloatToDecimalConverter.java
@@ -1,0 +1,134 @@
+package net.snowflake.client.internal.core.arrow.converters;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+import net.snowflake.client.api.exception.ErrorCode;
+import net.snowflake.client.api.exception.SFException;
+import net.snowflake.client.api.resultset.SnowflakeType;
+import net.snowflake.client.internal.util.SnowflakeUtil;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.complex.StructVector;
+
+class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
+
+  private StructVector vector;
+
+  public DecfloatToDecimalConverter(ValueVector vector, int idx, DataConversionContext context) {
+    super(SnowflakeType.DECFLOAT.name(), vector, idx, context);
+    this.vector = (StructVector) vector;
+  }
+
+  @Override
+  public BigDecimal toBigDecimal(int index) {
+    if (isNull(index)) {
+      return null;
+    }
+    Map<String, Object> value = (Map<String, Object>) vector.getObject(index);
+    byte[] significandBytes = (byte[]) value.get("significand");
+    short exponent = (short) value.get("exponent");
+    BigInteger significand = new BigInteger(significandBytes);
+    return new BigDecimal(significand, -exponent);
+  }
+
+  @Override
+  public double toDouble(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    return toBigDecimal(rowIndex).doubleValue();
+  }
+
+  @Override
+  public float toFloat(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    return toBigDecimal(rowIndex).floatValue();
+  }
+
+  @Override
+  public short toShort(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(rowIndex);
+    if (bigDecimal.scale() == 0) {
+      short shortVal = bigDecimal.shortValue();
+      if (shortVal == bigDecimal.longValue()) {
+        return shortVal;
+      } else {
+        throw new SFException(
+            ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+      }
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Short", bigDecimal.toPlainString());
+    }
+  }
+
+  @Override
+  public int toInt(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(rowIndex);
+    if (bigDecimal.scale() == 0) {
+      int intVal = bigDecimal.intValue();
+      if (intVal == bigDecimal.longValue()) {
+        return intVal;
+      } else {
+        throw new SFException(
+            ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Integer", bigDecimal.toPlainString());
+      }
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Integer", bigDecimal.toPlainString());
+    }
+  }
+
+  @Override
+  public long toLong(int rowIndex) throws SFException {
+    if (isNull(rowIndex)) {
+      return 0;
+    }
+    BigDecimal bigDecimal = toBigDecimal(rowIndex);
+    if (bigDecimal.scale() == 0) {
+      BigInteger intVal = bigDecimal.toBigIntegerExact();
+      if (intVal.bitLength() <= 63) {
+        return intVal.longValue();
+      } else {
+        throw new SFException(
+            ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+      }
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, "Long", bigDecimal.toPlainString());
+    }
+  }
+
+  @Override
+  public Object toObject(int index) throws SFException {
+    return toBigDecimal(index);
+  }
+
+  @Override
+  public String toString(int index) throws SFException {
+    if (isNull(index)) {
+      return null;
+    }
+    return toBigDecimal(index).toEngineeringString();
+  }
+
+  @Override
+  public byte[] toBytes(int index) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BYTES_STR, null);
+  }
+
+  @Override
+  public boolean toBoolean(int rowIndex) throws SFException {
+    throw new SFException(
+        ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BOOLEAN_STR, null);
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/cursor/SchemaState.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/core/arrow/cursor/SchemaState.java
@@ -94,6 +94,7 @@ public final class SchemaState {
       case VARIANT:
         return Types.VARCHAR;
       case FIXED:
+      case DECFLOAT:
         return Types.DECIMAL;
       case REAL:
         return Types.DOUBLE;

--- a/jdbc/src/test/java/net/snowflake/client/api/resultset/SnowflakeResultSetGettersTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/resultset/SnowflakeResultSetGettersTest.java
@@ -2,12 +2,16 @@ package net.snowflake.client.api.resultset;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
@@ -93,6 +97,50 @@ public class SnowflakeResultSetGettersTest extends SnowflakeIntegrationTestBase 
       assertTrue(Float.isInfinite(posInf) && posInf > 0);
       assertTrue(Float.isInfinite(negInf) && negInf < 0);
       assertTrue(Float.isNaN(nanVal));
+    }
+  }
+
+  @Test
+  public void testDecfloatIntegerGetterOverflowBehavior() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement();
+        ResultSet rs =
+            stmt.executeQuery(
+                "SELECT 123::DECFLOAT, 2147483648::DECFLOAT, 9223372036854775808::DECFLOAT")) {
+      assertTrue(rs.next());
+
+      assertEquals(123, rs.getInt(1));
+      assertEquals(123L, rs.getLong(1));
+      assertEquals((short) 123, rs.getShort(1));
+
+      assertThrows(SQLException.class, () -> rs.getInt(2));
+      assertThrows(SQLException.class, () -> rs.getShort(2));
+      assertEquals(2147483648L, rs.getLong(2));
+
+      assertThrows(SQLException.class, () -> rs.getLong(3));
+      assertThrows(SQLException.class, () -> rs.getInt(3));
+      assertThrows(SQLException.class, () -> rs.getShort(3));
+    }
+  }
+
+  @Test
+  public void testDecfloatWasNullAcrossMultipleGetters() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT NULL::DECFLOAT")) {
+      assertTrue(rs.next());
+
+      assertNull(rs.getBigDecimal(1));
+      assertTrue(rs.wasNull());
+
+      assertNull(rs.getObject(1));
+      assertTrue(rs.wasNull());
+
+      assertEquals(0.0d, rs.getDouble(1), 0.0d);
+      assertTrue(rs.wasNull());
+
+      assertNull(rs.getString(1));
+      assertTrue(rs.wasNull());
+
+      assertFalse(rs.next());
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
@@ -1,9 +1,11 @@
 package net.snowflake.client.api.statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -25,6 +27,18 @@ public class SnowflakeStatementTest extends SnowflakeIntegrationTestBase {
         assertTrue(rs.next(), "ResultSet should have one row");
         assertEquals(1, rs.getInt(1), "Result should be 1");
       }
+    }
+  }
+
+  @Test
+  public void testStatementExecuteWithDecfloatResultSet() throws Exception {
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 123.456::DECFLOAT")) {
+      assertNotNull(rs, "ResultSet should be available after executeQuery");
+      assertTrue(rs.next(), "Expected one row");
+      assertEquals(new BigDecimal("123.456"), rs.getBigDecimal(1));
+      assertFalse(rs.next(), "Expected exactly one row");
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/converters/DecfloatToDecimalConverterTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/converters/DecfloatToDecimalConverterTest.java
@@ -1,0 +1,108 @@
+package net.snowflake.client.internal.core.arrow.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.internal.core.arrow.TestHelper;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+
+public class DecfloatToDecimalConverterTest extends BaseConverterTest {
+  private final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+  @Test
+  public void testDecfloatConversionsAndDispatch() throws Exception {
+    Schema schema = setupSchema();
+
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+      StructVector vector = (StructVector) root.getVector("col_one");
+      VarBinaryVector significand = (VarBinaryVector) vector.getChild("significand");
+      SmallIntVector exponent = (SmallIntVector) vector.getChild("exponent");
+
+      vector.allocateNew();
+      significand.setSafe(0, new BigInteger("123456").toByteArray());
+      exponent.setSafe(0, (short) -3);
+      vector.setIndexDefined(0);
+
+      vector.setNull(1);
+
+      significand.setSafe(2, new BigInteger("2147483648").toByteArray());
+      exponent.setSafe(2, (short) 0);
+      vector.setIndexDefined(2);
+
+      significand.setSafe(3, new BigInteger("9223372036854775808").toByteArray());
+      exponent.setSafe(3, (short) 0);
+      vector.setIndexDefined(3);
+
+      significand.setSafe(4, new BigInteger("12345").toByteArray());
+      exponent.setSafe(4, (short) -2);
+      vector.setIndexDefined(4);
+
+      vector.setValueCount(5);
+      root.setRowCount(5);
+
+      ArrowVectorConverter converter = new DecfloatToDecimalConverter(vector, 0, this);
+      ArrowVectorConverter dispatchedConverter =
+          ArrowVectorConverterUtil.initConverter(vector, this, 0);
+      assertInstanceOf(DecfloatToDecimalConverter.class, dispatchedConverter);
+
+      assertEquals(new BigDecimal("123.456"), converter.toBigDecimal(0));
+      assertEquals(new BigDecimal("123.456"), converter.toObject(0));
+      assertEquals("123.456", converter.toString(0));
+      assertEquals(123.456d, converter.toDouble(0), 0.001d);
+      assertEquals(123.456f, converter.toFloat(0), 0.001f);
+
+      assertNull(converter.toBigDecimal(1));
+      assertNull(converter.toObject(1));
+      assertNull(converter.toString(1));
+      assertEquals(0d, converter.toDouble(1), 0d);
+      assertEquals(0f, converter.toFloat(1), 0f);
+      assertEquals(0L, converter.toLong(1));
+      assertEquals(0, converter.toInt(1));
+      assertEquals((short) 0, converter.toShort(1));
+
+      assertEquals(2147483648L, converter.toLong(2));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(2));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(2));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(3));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toInt(4));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toShort(4));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toLong(4));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBytes(0));
+      TestHelper.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(0));
+    }
+  }
+
+  private static Schema setupSchema() {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("logicalType", "DECFLOAT");
+
+    Field significandField =
+        new Field("significand", new FieldType(true, ArrowType.Binary.INSTANCE, null, null), null);
+    Field exponentField =
+        new Field("exponent", new FieldType(true, new ArrowType.Int(16, true), null, null), null);
+    Field decfloatField =
+        new Field(
+            "col_one",
+            new FieldType(true, ArrowType.Struct.INSTANCE, null, metadata),
+            Arrays.asList(significandField, exponentField));
+
+    return new Schema(Collections.singletonList(decfloatField));
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/cursor/SchemaStateTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/core/arrow/cursor/SchemaStateTest.java
@@ -44,4 +44,25 @@ public class SchemaStateTest {
       assertTrue(exception.getMessage().contains("Invalid column index"));
     }
   }
+
+  @Test
+  public void testDecfloatMapsToDecimalType() throws Exception {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("logicalType", "DECFLOAT");
+    FieldType fieldType = new FieldType(true, MinorType.VARCHAR.getType(), null, metadata);
+
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VarCharVector vector = new VarCharVector("dec_col", fieldType, allocator);
+        VectorSchemaRoot root = VectorSchemaRoot.of(vector)) {
+      vector.allocateNew();
+      vector.setSafe(0, "123.45".getBytes(StandardCharsets.UTF_8));
+      vector.setValueCount(1);
+      root.setRowCount(1);
+
+      SchemaState schema = new SchemaState(root);
+      assertArrayEquals(new String[] {"dec_col"}, schema.getColumnNames());
+      assertArrayEquals(new int[] {Types.DECIMAL}, schema.getColumnTypes());
+      assertEquals(1, schema.getColumnCount());
+    }
+  }
 }


### PR DESCRIPTION
Adds `DECFLOAT` support in JDBC result handling and expands validation coverage across converter and schema metadata.
- Maps Arrow `DECFLOAT` columns through dedicated converter `DecfloatToDecimalConverter`
- Adds API-level `DECFLOAT` checks in existing ResultSet/Statement tests