### PR TITLE
feat: shared Deadline across session renewal and HTTP retries

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -10,7 +10,7 @@ use super::global_state::CONN_HANDLE_MANAGER;
 use crate::config::config_manager;
 use crate::config::path_resolver::ConfigPaths;
 use crate::config::rest_parameters::{ClientInfo, LoginParameters};
-use crate::config::retry::RetryPolicy;
+use crate::config::retry::{Deadline, RetryPolicy};
 use crate::rest::snowflake::{self, RestError, SessionTokens, SnowflakeResponseError};
 use crate::tls::client::create_tls_client_with_config;
 use reqwest;
@@ -280,15 +280,20 @@ impl Connection {
 /// 1. Reads the session token (allows concurrent readers)
 /// 2. Runs the provided function with that token
 /// 3. On SessionExpired error, acquires write lock, refreshes, and retries
+///
+/// The `deadline` bounds the total wall-clock time across all attempts
+/// (including any session refresh). Pass `Deadline::new(policy.max_elapsed)`
+/// at the call site.
 pub async fn with_valid_session<F, Fut, T>(
     conn: &Arc<Mutex<Connection>>,
+    deadline: Deadline,
     f: F,
 ) -> Result<T, ApiError>
 where
     F: Fn(String) -> Fut,
     Fut: Future<Output = Result<T, RestError>>,
 {
-    let mut ctx = RefreshContext::from_arc(conn)?;
+    let mut ctx = RefreshContext::from_arc(conn, deadline)?;
     let mut last_error: Option<RestError> = None;
     loop {
         let token = ctx.refresh_token(last_error).await?;
@@ -305,11 +310,13 @@ where
 /// a loop-based API:
 ///
 /// ```ignore
-/// let mut ctx = RefreshContext::new(&conn)?;
+/// let deadline = Deadline::new(retry_policy.max_elapsed);
+/// let mut ctx = RefreshContext::new(&conn, deadline)?;
 /// let mut last_error: Option<RestError> = None;
 /// loop {
 ///     let token = ctx.refresh_token(last_error).await?;
-///     match do_something(token).await {
+///     let scoped = ctx.scoped_policy(&retry_policy);
+///     match do_something(token, &scoped).await {
 ///         Ok(result) => return Ok(result),
 ///         Err(e) => last_error = Some(e),
 ///     }
@@ -320,7 +327,10 @@ where
 /// On subsequent calls with a `SessionExpired` error, acquires write lock and refreshes.
 /// On non-SessionExpired errors, propagates the error immediately.
 /// Only one refresh attempt is allowed; a second SessionExpired error is propagated.
-/// Tracks the state of the refresh lifecycle.
+///
+/// A shared [`Deadline`] bounds total wall-clock time across all attempts.
+/// Call [`scoped_policy`](RefreshContext::scoped_policy) to obtain a
+/// `RetryPolicy` whose `max_elapsed` is clamped to the remaining budget.
 enum RefreshState {
     /// No token has been issued yet (initial call).
     Initial,
@@ -337,15 +347,17 @@ pub struct RefreshContext {
     server_url: String,
     client_info: ClientInfo,
     state: RefreshState,
+    /// Shared wall-clock deadline for the entire operation (retries + refresh).
+    deadline: Deadline,
 }
 
 impl RefreshContext {
-    pub fn from_arc(conn: &Arc<Mutex<Connection>>) -> Result<Self, ApiError> {
+    pub fn from_arc(conn: &Arc<Mutex<Connection>>, deadline: Deadline) -> Result<Self, ApiError> {
         let guard = conn.lock().map_err(|_| ConnectionLockingSnafu.build())?;
-        Self::new(&guard)
+        Self::new(&guard, deadline)
     }
     /// Create a new `RefreshContext` by extracting connection info.
-    pub fn new(conn: &Connection) -> Result<Self, ApiError> {
+    pub fn new(conn: &Connection, deadline: Deadline) -> Result<Self, ApiError> {
         Ok(Self {
             tokens_lock: conn.tokens.clone(),
             http_client: conn
@@ -361,7 +373,17 @@ impl RefreshContext {
                 .clone()
                 .context(ConnectionNotInitializedSnafu)?,
             state: RefreshState::Initial,
+            deadline,
         })
+    }
+
+    /// Return a clone of `base` with `max_elapsed` clamped to the remaining
+    /// deadline budget. Every inner retry loop should use this instead of the
+    /// original policy so that all layers share the same wall-clock budget.
+    pub fn scoped_policy(&self, base: &RetryPolicy) -> RetryPolicy {
+        let mut policy = base.clone();
+        policy.max_elapsed = self.deadline.remaining();
+        policy
     }
 
     /// Get a valid session token, optionally refreshing if the previous call failed.
@@ -376,6 +398,15 @@ impl RefreshContext {
         &mut self,
         last_error: Option<RestError>,
     ) -> Result<String, ApiError> {
+        // Check the shared wall-clock deadline before any work.
+        if self.deadline.is_expired() {
+            return OperationDeadlineExceededSnafu {
+                budget: self.deadline.budget(),
+                elapsed: self.deadline.elapsed(),
+            }
+            .fail();
+        }
+
         match &self.state {
             // No token issued yet - read the current session token
             RefreshState::Initial => {

--- a/sf_core/src/apis/database_driver_v1/error.rs
+++ b/sf_core/src/apis/database_driver_v1/error.rs
@@ -101,4 +101,13 @@ pub enum ApiError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display(
+        "Operation deadline exceeded after {elapsed:?} (budget {budget:?})"
+    ))]
+    OperationDeadlineExceeded {
+        budget: std::time::Duration,
+        elapsed: std::time::Duration,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -3,6 +3,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use super::Handle;
 use super::connection::RefreshContext;
+use crate::config::retry::Deadline;
 use super::error::*;
 use super::global_state::{CONN_HANDLE_MANAGER, STMT_HANDLE_MANAGER};
 use crate::apis::database_driver_v1::query::process_query_response;
@@ -334,17 +335,19 @@ pub fn statement_execute_query<'a>(
     };
 
     let response = rt.block_on(async {
-        let mut ctx = RefreshContext::from_arc(&stmt.conn)?;
+        let deadline = Deadline::new(retry_policy.max_elapsed);
+        let mut ctx = RefreshContext::from_arc(&stmt.conn, deadline)?;
         let mut last_error = None;
         loop {
             let session_token = ctx.refresh_token(last_error).await?;
+            let scoped_policy = ctx.scoped_policy(&retry_policy);
             match snowflake_query_with_client(
                 &http_client,
                 query_parameters.clone(),
                 session_token,
                 query.clone(),
                 query_bindings,
-                &retry_policy,
+                &scoped_policy,
                 execution_mode,
             )
             .await

--- a/sf_core/src/config/retry.rs
+++ b/sf_core/src/config/retry.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Global retry policy used by the driver. Keep it minimal at the HTTP layer;
 /// layers above (Snowflake query logic, etc.) can compose their own semantics.
@@ -39,6 +39,49 @@ pub struct HttpPolicy {
     pub retry_idempotent_writes: bool,
     /// Enable retries for POST/PATCH (generally off).
     pub retry_post_patch: bool,
+}
+
+/// A shared wall-clock deadline for an entire operation (retries + refresh included).
+///
+/// Created once at the top-level call site and threaded through every layer.
+/// Each layer calls [`remaining()`](Deadline::remaining) to learn how much time
+/// is left, so session refresh, Okta renewal, and HTTP retries all draw from
+/// the same budget.
+#[derive(Clone, Debug)]
+pub struct Deadline {
+    start: Instant,
+    budget: Duration,
+}
+
+impl Deadline {
+    /// Start a new deadline with the given total budget.
+    pub fn new(budget: Duration) -> Self {
+        Self {
+            start: Instant::now(),
+            budget,
+        }
+    }
+
+    /// How much time remains before the deadline expires.
+    /// Returns `Duration::ZERO` when expired.
+    pub fn remaining(&self) -> Duration {
+        self.budget.saturating_sub(self.start.elapsed())
+    }
+
+    /// Returns `true` when the budget has been fully consumed.
+    pub fn is_expired(&self) -> bool {
+        self.start.elapsed() >= self.budget
+    }
+
+    /// The original budget this deadline was created with.
+    pub fn budget(&self) -> Duration {
+        self.budget
+    }
+
+    /// How much time has elapsed since this deadline was created.
+    pub fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
 }
 
 impl Default for RetryPolicy {

--- a/sf_core/src/protobuf_apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf_apis/database_driver_v1.rs
@@ -251,6 +251,9 @@ fn to_driver_error(error: &ApiError) -> DriverError {
         ApiError::InvalidRefreshState { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
         },
+        ApiError::OperationDeadlineExceeded { .. } => DriverError {
+            error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
+        },
         ApiError::Configuration {
             source: ConfigError::ConfigFileRead { .. },
             ..
@@ -335,6 +338,7 @@ fn to_driver_exception(error: ApiError) -> DriverException {
         ApiError::Query { .. } => StatusCode::InternalError,
         ApiError::MasterTokenExpired { .. } => StatusCode::AuthenticationError,
         ApiError::InvalidRefreshState { .. } => StatusCode::InternalError,
+        ApiError::OperationDeadlineExceeded { .. } => StatusCode::InternalError,
     };
 
     let message = error.to_string();

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -2,7 +2,7 @@
 
 use sf_core::apis::database_driver_v1::{Connection, with_valid_session};
 use sf_core::config::rest_parameters::ClientInfo;
-use sf_core::config::retry::RetryPolicy;
+use sf_core::config::retry::{Deadline, RetryPolicy};
 use sf_core::crl::config::CrlConfig;
 use sf_core::rest::snowflake::SessionTokens;
 use sf_core::tls::config::TlsConfig;
@@ -110,7 +110,8 @@ async fn should_only_refresh_once_with_concurrent_401_errors() {
         let conn = conn.clone();
         let server_addr = addr;
         handles.push(tokio::spawn(async move {
-            with_valid_session(&conn, |token| {
+            let deadline = Deadline::new(std::time::Duration::from_secs(120));
+            with_valid_session(&conn, deadline, |token| {
                 let query_addr = server_addr;
                 async move {
                     // Make a query request


### PR DESCRIPTION
Introduce a Deadline struct that bounds total wall-clock time for an entire operation (HTTP retries + session refresh combined). Previously the session-renewal outer loop and the HTTP-retry inner loop had independent budgets, making the worst-case wait ~240s instead of 120s.

Now a single Deadline is created at the top-level call site and threaded through RefreshContext. Each inner retry loop receives a scoped policy with max_elapsed clamped to deadline.remaining(), so all layers draw from the same clock.

Changes:
- Add Deadline struct to sf_core/src/config/retry.rs
- Thread Deadline into RefreshContext (from_arc, new, scoped_policy)
- Check deadline expiry in refresh_token() before attempting refresh
- Add OperationDeadlineExceeded error variant to ApiError
- Update statement_execute_query to create Deadline and use scoped_policy
- Update with_valid_session to accept Deadline parameter
- Update protobuf error mapping for new variant
- Update integration test for new with_valid_session signature