### PR TITLE
SNOW-3155976: Implement autocommit in python

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -48,12 +48,19 @@ ConnectionParameters = dict[str, ConnectionParamValue]
 class Connection:
     """Connection objects represent a database connection."""
 
-    def __init__(self, *, paramstyle: str | None = None, **kwargs: ConnectionParamValue) -> None:
+    def __init__(
+        self,
+        *,
+        paramstyle: str | None = None,
+        autocommit: bool | None = None,
+        **kwargs: ConnectionParamValue,
+    ) -> None:
         """
         Initialize a new connection object.
 
         Args:
             paramstyle: Binding style – ``"pyformat"`` (default), ``"format"``, ``"qmark"`` or ``"numeric"``
+            autocommit: Optional bool to enable/disable autocommit at connection time
             database: Database name
             user: Username
             password: Password
@@ -78,15 +85,9 @@ class Connection:
         # Extract session_parameters before processing other kwargs
         session_params: SessionParameters | None = kwargs.pop("session_parameters", None)  # type: ignore
 
-        # TODO: _session_parameters should be read from sf_core instead of being tracked locally
-        self._session_parameters: dict[str, Any] = {}
-
-        # Pop autocommit before the type-dispatch loop (bool is a subclass of int)
-        autocommit = kwargs.pop("autocommit", None)
         if autocommit is not None:
             if not isinstance(autocommit, bool):
                 raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
-            self._session_parameters["AUTOCOMMIT"] = autocommit
             if session_params is None:
                 session_params = {}
             session_params["AUTOCOMMIT"] = str(autocommit).lower()
@@ -226,17 +227,13 @@ class Connection:
 
     @property
     def _autocommit(self) -> bool:
-        return bool(self._session_parameters.get("AUTOCOMMIT", False))
-
-    @_autocommit.setter
-    def _autocommit(self, value: bool) -> None:
-        self._session_parameters["AUTOCOMMIT"] = value
+        value = self._get_session_parameter("AUTOCOMMIT")
+        return value is not None and value.lower() == "true"
 
     def set_autocommit(self, autocommit: bool) -> None:
         """Set the autocommit mode. Executes ALTER SESSION SET autocommit on the server."""
         if not isinstance(autocommit, bool):
             raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
-        self._autocommit = autocommit
         cur = self.cursor()
         try:
             cur.execute(f"ALTER SESSION SET autocommit={str(autocommit).lower()}")

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -78,16 +78,18 @@ class Connection:
         # Extract session_parameters before processing other kwargs
         session_params: SessionParameters | None = kwargs.pop("session_parameters", None)  # type: ignore
 
+        # TODO: _session_parameters should be read from sf_core instead of being tracked locally
+        self._session_parameters: dict[str, Any] = {}
+
         # Pop autocommit before the type-dispatch loop (bool is a subclass of int)
-        self._autocommit: bool = False
         autocommit = kwargs.pop("autocommit", None)
         if autocommit is not None:
             if not isinstance(autocommit, bool):
                 raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
-            self._autocommit = autocommit
+            self._session_parameters["AUTOCOMMIT"] = autocommit
             if session_params is None:
                 session_params = {}
-            session_params["AUTOCOMMIT"] = str(self._autocommit).lower()
+            session_params["AUTOCOMMIT"] = str(autocommit).lower()
 
         # Pre-process private_key if present - normalize for Rust core
         if "private_key" in kwargs:
@@ -222,15 +224,27 @@ class Connection:
         """
         raise NotSupportedError("ping is not implemented")
 
+    @property
+    def _autocommit(self) -> bool:
+        return bool(self._session_parameters.get("AUTOCOMMIT", False))
+
+    @_autocommit.setter
+    def _autocommit(self, value: bool) -> None:
+        self._session_parameters["AUTOCOMMIT"] = value
+
     def set_autocommit(self, autocommit: bool) -> None:
         """Set the autocommit mode. Executes ALTER SESSION SET autocommit on the server."""
         if not isinstance(autocommit, bool):
             raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
         self._autocommit = autocommit
+        cur = self.cursor()
         try:
-            self.cursor().execute(f"ALTER SESSION SET autocommit={str(autocommit).lower()}")
+            cur.execute(f"ALTER SESSION SET autocommit={str(autocommit).lower()}")
+        # TODO: Narrow exception handling once proper error propagation is implemented
         except Error as e:
             logger.warning("Autocommit feature is not enabled for this connection. Ignored: %s", e)
+        finally:
+            cur.close()
 
     def get_autocommit(self) -> bool:
         """

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -82,7 +82,9 @@ class Connection:
         self._autocommit: bool = False
         autocommit = kwargs.pop("autocommit", None)
         if autocommit is not None:
-            self._autocommit = bool(autocommit)
+            if not isinstance(autocommit, bool):
+                raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
+            self._autocommit = autocommit
             if session_params is None:
                 session_params = {}
             session_params["AUTOCOMMIT"] = str(self._autocommit).lower()

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -89,13 +89,10 @@ class Connection:
             if not isinstance(autocommit, bool):
                 raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
 
-        # PEP 249: default to manual commit mode; Snowflake server default is autocommit=true
         if session_params is None:
             session_params = {}
         if autocommit is not None:
             session_params["AUTOCOMMIT"] = str(autocommit).lower()
-        else:
-            session_params.setdefault("AUTOCOMMIT", "false")
 
         # Pre-process private_key if present - normalize for Rust core
         if "private_key" in kwargs:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -88,9 +88,14 @@ class Connection:
         if autocommit is not None:
             if not isinstance(autocommit, bool):
                 raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
-            if session_params is None:
-                session_params = {}
+
+        # PEP 249: default to manual commit mode; Snowflake server default is autocommit=true
+        if session_params is None:
+            session_params = {}
+        if autocommit is not None:
             session_params["AUTOCOMMIT"] = str(autocommit).lower()
+        else:
+            session_params.setdefault("AUTOCOMMIT", "false")
 
         # Pre-process private_key if present - normalize for Rust core
         if "private_key" in kwargs:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -102,7 +102,13 @@ class Connection:
             kwargs["private_key"] = normalize_private_key(kwargs["private_key"])
 
         for key, value in kwargs.items():
-            if isinstance(value, int):
+            # bool check must come before int because bool is a subclass of int in Python
+            if isinstance(value, bool):
+                self.db_api.connection_set_option_int(
+                    ConnectionSetOptionIntRequest(conn_handle=self.conn_handle, key=key, value=int(value))
+                )
+
+            elif isinstance(value, int):
                 self.db_api.connection_set_option_int(
                     ConnectionSetOptionIntRequest(conn_handle=self.conn_handle, key=key, value=value)
                 )

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -145,12 +145,20 @@ class Connection:
     @pep249
     def commit(self) -> None:
         """Commit any pending transaction to the database."""
-        self.cursor().execute("COMMIT")
+        cur = self.cursor()
+        try:
+            cur.execute("COMMIT")
+        finally:
+            cur.close()
 
     @pep249
     def rollback(self) -> None:
         """Roll back to the start of any pending transaction."""
-        self.cursor().execute("ROLLBACK")
+        cur = self.cursor()
+        try:
+            cur.execute("ROLLBACK")
+        finally:
+            cur.close()
 
     @pep249
     def cursor(self, cursor_class: CursorType = SnowflakeCursor) -> CursorInstance:
@@ -185,7 +193,10 @@ class Connection:
                 if exc_type is None:
                     self.commit()
                 else:
-                    self.rollback()
+                    try:
+                        self.rollback()
+                    except Exception:
+                        logger.warning("Rollback failed during exception handling", exc_info=True)
         finally:
             self.close()
 
@@ -214,12 +225,12 @@ class Connection:
     def set_autocommit(self, autocommit: bool) -> None:
         """Set the autocommit mode. Executes ALTER SESSION SET autocommit on the server."""
         if not isinstance(autocommit, bool):
-            raise ProgrammingError(f"Invalid parameter: {autocommit}")
+            raise ProgrammingError(f"Invalid autocommit parameter: {autocommit!r}")
         self._autocommit = autocommit
         try:
-            self.cursor().execute(f"ALTER SESSION SET autocommit={autocommit}")
+            self.cursor().execute(f"ALTER SESSION SET autocommit={str(autocommit).lower()}")
         except Error as e:
-            logger.debug("Autocommit feature is not enabled for this connection. Ignored: %s", e)
+            logger.warning("Autocommit feature is not enabled for this connection. Ignored: %s", e)
 
     def get_autocommit(self) -> bool:
         """

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -6,6 +6,8 @@ This module defines the Connection class as specified in PEP 249.
 
 from __future__ import annotations
 
+import logging
+
 from collections.abc import Generator, Iterable
 from io import StringIO
 from typing import Any, Callable, Union
@@ -32,9 +34,11 @@ from ._internal.binding_converters import ParamStyle
 from ._internal.decorators import backward_compatibility, internal_api, pep249
 from ._internal.text_utils import split_statements
 from .cursor import CursorInstance, CursorType, SnowflakeCursor
-from .errors import InterfaceError, NotSupportedError, ProgrammingError
+from .errors import Error, InterfaceError, NotSupportedError, ProgrammingError
 from .telemetry import TelemetryClient
 
+
+logger = logging.getLogger(__name__)
 
 SessionParameters = dict[str, Any]
 ConnectionParamValue = Union[int, str, float, bytes, SessionParameters]
@@ -74,6 +78,15 @@ class Connection:
         # Extract session_parameters before processing other kwargs
         session_params: SessionParameters | None = kwargs.pop("session_parameters", None)  # type: ignore
 
+        # Pop autocommit before the type-dispatch loop (bool is a subclass of int)
+        self._autocommit: bool = False
+        autocommit = kwargs.pop("autocommit", None)
+        if autocommit is not None:
+            self._autocommit = bool(autocommit)
+            if session_params is None:
+                session_params = {}
+            session_params["AUTOCOMMIT"] = str(self._autocommit).lower()
+
         # Pre-process private_key if present - normalize for Rust core
         if "private_key" in kwargs:
             kwargs["private_key"] = normalize_private_key(kwargs["private_key"])
@@ -109,7 +122,6 @@ class Connection:
         _sensitive_keys = {"password", "private_key"}
         self.kwargs = {k: ("***" if k in _sensitive_keys else v) for k, v in kwargs.items()}
         self._closed = False
-        self._autocommit = False
         self._messages: list[tuple[type[Exception], dict[str, str | bool]]] = []
         self._errorhandler: Callable
 
@@ -130,23 +142,13 @@ class Connection:
 
     @pep249
     def commit(self) -> None:
-        """
-        Commit any pending transaction to the database.
-
-        Raises:
-            NotSupportedError: If not implemented
-        """
-        raise NotSupportedError("commit is not implemented")
+        """Commit any pending transaction to the database."""
+        self.cursor().execute("COMMIT")
 
     @pep249
     def rollback(self) -> None:
-        """
-        Roll back to the start of any pending transaction.
-
-        Raises:
-            NotSupportedError: If not implemented
-        """
-        raise NotSupportedError("rollback is not implemented")
+        """Roll back to the start of any pending transaction."""
+        self.cursor().execute("ROLLBACK")
 
     @pep249
     def cursor(self, cursor_class: CursorType = SnowflakeCursor) -> CursorInstance:
@@ -175,26 +177,15 @@ class Connection:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """
-        Exit the runtime context for the connection.
-
-        If an exception occurred, rollback the transaction.
-        Otherwise, commit the transaction.
-        """
-        if exc_type is None:
-            # No exception, commit
-            try:
-                self.commit()
-            except NotSupportedError:
-                pass  # commit not implemented
-        else:
-            # Exception occurred, rollback
-            try:
-                self.rollback()
-            except NotSupportedError:
-                pass  # rollback not implemented
-
-        self.close()
+        """Exit the runtime context. Commit on success / rollback on exception if autocommit is OFF."""
+        try:
+            if not self._autocommit:
+                if exc_type is None:
+                    self.commit()
+                else:
+                    self.rollback()
+        finally:
+            self.close()
 
     # Optional methods that some databases might support
     def cancel(self) -> None:
@@ -219,14 +210,14 @@ class Connection:
         raise NotSupportedError("ping is not implemented")
 
     def set_autocommit(self, autocommit: bool) -> None:
-        """
-        Set the autocommit mode.
-
-        Args:
-            autocommit (bool): True to enable autocommit, False to disable
-        """
-        # TODO: SNOW-3155976 Lacks full implementation
+        """Set the autocommit mode. Executes ALTER SESSION SET autocommit on the server."""
+        if not isinstance(autocommit, bool):
+            raise ProgrammingError(f"Invalid parameter: {autocommit}")
         self._autocommit = autocommit
+        try:
+            self.cursor().execute(f"ALTER SESSION SET autocommit={autocommit}")
+        except Error as e:
+            logger.debug("Autocommit feature is not enabled for this connection. Ignored: %s", e)
 
     def get_autocommit(self) -> bool:
         """
@@ -235,18 +226,11 @@ class Connection:
         Returns:
             bool: Current autocommit setting
         """
-        # TODO: SNOW-3155976 Lacks full implementation
         return self._autocommit
 
     @pep249
     def autocommit(self, value: bool) -> None:
-        """
-        Set autocommit mode.
-
-        Args:
-            value (bool): Autocommit setting
-        """
-        self._autocommit = value
+        """Set autocommit mode."""
         self.set_autocommit(value)
 
     def is_closed(self) -> bool:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -189,7 +189,7 @@ class Connection:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Exit the runtime context. Commit on success / rollback on exception if autocommit is OFF."""
         try:
-            if not self._autocommit:
+            if not self._autocommit and not self._closed:
                 if exc_type is None:
                     self.commit()
                 else:

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -33,9 +33,8 @@ from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     StatementNewRequest,
     StatementSetSqlQueryRequest,
 )
-from ._internal.protobuf_gen.proto_exception import ProtoApplicationException
 from ._internal.type_codes import get_type_code
-from .errors import DatabaseError, InterfaceError, NotSupportedError, ProgrammingError
+from .errors import InterfaceError, NotSupportedError, ProgrammingError
 
 
 if TYPE_CHECKING:
@@ -347,10 +346,7 @@ class SnowflakeCursorBase(abc.ABC):
 
         request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
 
-        try:
-            self.execute_result = self._connection.db_api.statement_execute_query(request).result
-        except ProtoApplicationException as e:
-            raise DatabaseError(str(e)) from e
+        self.execute_result = self._connection.db_api.statement_execute_query(request).result
 
         # Reset streaming state for a new result
         self._binding_data = None

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -33,8 +33,9 @@ from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     StatementNewRequest,
     StatementSetSqlQueryRequest,
 )
+from ._internal.protobuf_gen.proto_exception import ProtoApplicationException
 from ._internal.type_codes import get_type_code
-from .errors import InterfaceError, NotSupportedError, ProgrammingError
+from .errors import DatabaseError, InterfaceError, NotSupportedError, ProgrammingError
 
 
 if TYPE_CHECKING:
@@ -323,6 +324,7 @@ class SnowflakeCursorBase(abc.ABC):
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
+        **kwargs: Any,
     ) -> SnowflakeCursorBase:
         """
         Execute a database operation (query or command).
@@ -345,7 +347,10 @@ class SnowflakeCursorBase(abc.ABC):
 
         request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
 
-        self.execute_result = self._connection.db_api.statement_execute_query(request).result
+        try:
+            self.execute_result = self._connection.db_api.statement_execute_query(request).result
+        except ProtoApplicationException as e:
+            raise DatabaseError(str(e)) from e
 
         # Reset streaming state for a new result
         self._binding_data = None

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -255,7 +255,7 @@ class TestCommitRollback:
     def test_commit_persists_inserted_rows(self, connection, connection_factory, tmp_schema):
         """Test that commit() persists data inserted in a transaction."""
         table = f"{tmp_schema}.test_commit"
-        connection.set_autocommit(False)
+        connection.autocommit(False)
         cur = connection.cursor()
         cur.execute(f"CREATE TABLE {table} (id INTEGER, name VARCHAR)")
         connection.commit()
@@ -276,7 +276,7 @@ class TestCommitRollback:
     def test_rollback_discards_inserted_rows(self, connection, tmp_schema):
         """Test that rollback() discards uncommitted inserts."""
         table = f"{tmp_schema}.test_rollback"
-        connection.set_autocommit(False)
+        connection.autocommit(False)
         cur = connection.cursor()
         cur.execute(f"CREATE TABLE {table} (id INTEGER)")
         cur.execute(f"INSERT INTO {table} VALUES (1)")
@@ -291,7 +291,7 @@ class TestCommitRollback:
     def test_rollback_discards_update(self, connection, tmp_schema):
         """Test that rollback() reverts an UPDATE to previously committed data."""
         table = f"{tmp_schema}.test_rb_upd"
-        connection.set_autocommit(False)
+        connection.autocommit(False)
         cur = connection.cursor()
         cur.execute(f"CREATE TABLE {table} (id INTEGER, val VARCHAR)")
         cur.execute(f"INSERT INTO {table} VALUES (1, 'original')")
@@ -322,7 +322,7 @@ class TestAutocommitAlterSession:
     def test_autocommit_on_persists_without_explicit_commit(self, connection, tmp_schema):
         """Test that with autocommit ON, each statement is committed automatically."""
         table = f"{tmp_schema}.test_ac_on"
-        connection.set_autocommit(True)
+        connection.autocommit(True)
         cur = connection.cursor()
         cur.execute(f"CREATE TABLE {table} (id INTEGER)")
         cur.execute(f"INSERT INTO {table} VALUES (1)")
@@ -339,7 +339,7 @@ class TestContextManagerAutocommit:
         """Test that the context manager commits DML on clean exit when autocommit is off."""
         table = f"{tmp_schema}.test_cm_commit"
         with connection_factory() as conn:
-            conn.set_autocommit(False)
+            conn.autocommit(False)
             cur = conn.cursor()
             cur.execute(f"CREATE TABLE {table} (id INTEGER)")
             conn.commit()
@@ -356,7 +356,7 @@ class TestContextManagerAutocommit:
         """Test that the context manager rolls back on exception when autocommit is off."""
         table = f"{tmp_schema}.test_cm_rb"
         with connection_factory() as setup_conn:
-            setup_conn.set_autocommit(False)
+            setup_conn.autocommit(False)
             cur = setup_conn.cursor()
             cur.execute(f"CREATE TABLE {table} (id INTEGER)")
             cur.execute(f"INSERT INTO {table} VALUES (1)")
@@ -364,7 +364,7 @@ class TestContextManagerAutocommit:
 
         try:
             with connection_factory() as conn:
-                conn.set_autocommit(False)
+                conn.autocommit(False)
                 cur = conn.cursor()
                 cur.execute(f"INSERT INTO {table} VALUES (99)")
                 raise ValueError("simulated error")
@@ -380,7 +380,7 @@ class TestContextManagerAutocommit:
         """Test that with autocommit ON, __exit__ skips explicit commit/rollback."""
         table = f"{tmp_schema}.test_cm_ac"
         with connection_factory() as conn:
-            conn.set_autocommit(True)
+            conn.autocommit(True)
             cur = conn.cursor()
             cur.execute(f"CREATE TABLE {table} (id INTEGER)")
             cur.execute(f"INSERT INTO {table} VALUES (1)")

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -252,43 +252,55 @@ class TestExecuteStream:
 class TestCommitRollback:
     """Integration tests for commit and rollback."""
 
-    def test_commit_persists_inserted_rows(self, connection):
+    def test_commit_persists_inserted_rows(self, connection, connection_factory, tmp_schema):
         """Test that commit() persists data inserted in a transaction."""
+        table = f"{tmp_schema}.test_commit"
         connection.set_autocommit(False)
         cur = connection.cursor()
-        cur.execute("CREATE TEMPORARY TABLE _test_commit (id INTEGER, name VARCHAR)")
-        cur.execute("INSERT INTO _test_commit VALUES (1, 'alice')")
+        cur.execute(f"CREATE TABLE {table} (id INTEGER, name VARCHAR)")
         connection.commit()
 
-        cur.execute("SELECT id, name FROM _test_commit WHERE id = 1")
+        cur.execute(f"INSERT INTO {table} VALUES (1, 'alice')")
+
+        # Before commit, the row should not be visible from another session
+        with connection_factory() as other_conn:
+            other_cur = other_conn.cursor()
+            other_cur.execute(f"SELECT COUNT(*) FROM {table}")
+            assert other_cur.fetchone() == (0,)
+
+        connection.commit()
+
+        cur.execute(f"SELECT id, name FROM {table} WHERE id = 1")
         assert cur.fetchone() == (1, "alice")
 
-    def test_rollback_discards_inserted_rows(self, connection):
+    def test_rollback_discards_inserted_rows(self, connection, tmp_schema):
         """Test that rollback() discards uncommitted inserts."""
+        table = f"{tmp_schema}.test_rollback"
         connection.set_autocommit(False)
         cur = connection.cursor()
-        cur.execute("CREATE TEMPORARY TABLE _test_rollback (id INTEGER)")
-        cur.execute("INSERT INTO _test_rollback VALUES (1)")
+        cur.execute(f"CREATE TABLE {table} (id INTEGER)")
+        cur.execute(f"INSERT INTO {table} VALUES (1)")
         connection.commit()
 
-        cur.execute("INSERT INTO _test_rollback VALUES (2)")
+        cur.execute(f"INSERT INTO {table} VALUES (2)")
         connection.rollback()
 
-        cur.execute("SELECT COUNT(*) FROM _test_rollback")
+        cur.execute(f"SELECT COUNT(*) FROM {table}")
         assert cur.fetchone() == (1,)
 
-    def test_rollback_discards_update(self, connection):
+    def test_rollback_discards_update(self, connection, tmp_schema):
         """Test that rollback() reverts an UPDATE to previously committed data."""
+        table = f"{tmp_schema}.test_rb_upd"
         connection.set_autocommit(False)
         cur = connection.cursor()
-        cur.execute("CREATE TEMPORARY TABLE _test_rb_upd (id INTEGER, val VARCHAR)")
-        cur.execute("INSERT INTO _test_rb_upd VALUES (1, 'original')")
+        cur.execute(f"CREATE TABLE {table} (id INTEGER, val VARCHAR)")
+        cur.execute(f"INSERT INTO {table} VALUES (1, 'original')")
         connection.commit()
 
-        cur.execute("UPDATE _test_rb_upd SET val = 'modified' WHERE id = 1")
+        cur.execute(f"UPDATE {table} SET val = 'modified' WHERE id = 1")
         connection.rollback()
 
-        cur.execute("SELECT val FROM _test_rb_upd WHERE id = 1")
+        cur.execute(f"SELECT val FROM {table} WHERE id = 1")
         assert cur.fetchone() == ("original",)
 
 
@@ -307,57 +319,70 @@ class TestAutocommitAlterSession:
         connection.set_autocommit(False)
         assert connection._get_session_parameter("AUTOCOMMIT") == "false"
 
-    def test_autocommit_on_persists_without_explicit_commit(self, connection):
+    def test_autocommit_on_persists_without_explicit_commit(self, connection, tmp_schema):
         """Test that with autocommit ON, each statement is committed automatically."""
+        table = f"{tmp_schema}.test_ac_on"
         connection.set_autocommit(True)
         cur = connection.cursor()
-        cur.execute("CREATE TEMPORARY TABLE _test_ac_on (id INTEGER)")
-        cur.execute("INSERT INTO _test_ac_on VALUES (1)")
+        cur.execute(f"CREATE TABLE {table} (id INTEGER)")
+        cur.execute(f"INSERT INTO {table} VALUES (1)")
         # No explicit commit — autocommit should handle it
 
-        cur.execute("SELECT COUNT(*) FROM _test_ac_on")
+        cur.execute(f"SELECT COUNT(*) FROM {table}")
         assert cur.fetchone() == (1,)
 
 
 class TestContextManagerAutocommit:
     """Integration tests for context manager with autocommit."""
 
-    def test_context_manager_commits_inserts_on_clean_exit(self, connection_factory):
+    def test_context_manager_commits_inserts_on_clean_exit(self, connection_factory, tmp_schema):
         """Test that the context manager commits DML on clean exit when autocommit is off."""
-        table = "_test_cm_commit"
+        table = f"{tmp_schema}.test_cm_commit"
         with connection_factory() as conn:
             conn.set_autocommit(False)
             cur = conn.cursor()
-            cur.execute(f"CREATE TEMPORARY TABLE {table} (id INTEGER)")
+            cur.execute(f"CREATE TABLE {table} (id INTEGER)")
             conn.commit()
             cur.execute(f"INSERT INTO {table} VALUES (1)")
             cur.execute(f"INSERT INTO {table} VALUES (2)")
             # clean exit should trigger commit
 
-        # Verify with a fresh connection — temp tables are session-scoped so
-        # we just confirm the context manager didn't raise
-        # (temp table is gone with the old session, but the exit was clean)
+        with connection_factory() as conn:
+            cur = conn.cursor()
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            assert cur.fetchone() == (2,)
 
-    def test_context_manager_rolls_back_on_exception(self, connection_factory):
+    def test_context_manager_rolls_back_on_exception(self, connection_factory, tmp_schema):
         """Test that the context manager rolls back on exception when autocommit is off."""
+        table = f"{tmp_schema}.test_cm_rb"
+        with connection_factory() as setup_conn:
+            setup_conn.set_autocommit(False)
+            cur = setup_conn.cursor()
+            cur.execute(f"CREATE TABLE {table} (id INTEGER)")
+            cur.execute(f"INSERT INTO {table} VALUES (1)")
+            setup_conn.commit()
+
         try:
             with connection_factory() as conn:
                 conn.set_autocommit(False)
                 cur = conn.cursor()
-                cur.execute("CREATE TEMPORARY TABLE _test_cm_rb (id INTEGER)")
-                conn.commit()
-                cur.execute("INSERT INTO _test_cm_rb VALUES (99)")
+                cur.execute(f"INSERT INTO {table} VALUES (99)")
                 raise ValueError("simulated error")
         except ValueError:
             pass
-        # The rollback ran without error; connection was closed cleanly
 
-    def test_context_manager_with_autocommit_on_does_not_commit_or_rollback(self, connection_factory):
+        with connection_factory() as conn:
+            cur = conn.cursor()
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            assert cur.fetchone() == (1,)
+
+    def test_context_manager_with_autocommit_on_does_not_commit_or_rollback(self, connection_factory, tmp_schema):
         """Test that with autocommit ON, __exit__ skips explicit commit/rollback."""
+        table = f"{tmp_schema}.test_cm_ac"
         with connection_factory() as conn:
             conn.set_autocommit(True)
             cur = conn.cursor()
-            cur.execute("CREATE TEMPORARY TABLE _test_cm_ac (id INTEGER)")
-            cur.execute("INSERT INTO _test_cm_ac VALUES (1)")
-            cur.execute("SELECT COUNT(*) FROM _test_cm_ac")
+            cur.execute(f"CREATE TABLE {table} (id INTEGER)")
+            cur.execute(f"INSERT INTO {table} VALUES (1)")
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
             assert cur.fetchone() == (1,)

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -34,23 +34,6 @@ class TestConnectionMethods:
         connection.close()
         assert connection.is_closed()
 
-    @pytest.mark.skip_reference
-    def test_commit_not_implemented(self, connection):
-        """Test that commit raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
-            connection.commit()
-        assert "commit is not implemented" in str(excinfo.value)
-
-    @pytest.mark.skip_reference
-    def test_rollback_not_implemented(self, connection):
-        """Test that rollback raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
-            connection.rollback()
-        assert "rollback is not implemented" in str(excinfo.value)
-
-
-# TODO: Tests for context manager were deleted - we might want to add them again later
-
 
 class TestConnectionOptionalMethods:
     """Test optional Connection methods."""
@@ -89,13 +72,12 @@ class TestConnectionAutocommitMethod:
 
     @pytest.mark.skip_reference
     def test_autocommit_sets_flag_and_calls_set_autocommit(self, connection, monkeypatch):
-        """Test that autocommit() sets _autocommit and delegates to set_autocommit."""
+        """Test that autocommit() delegates to set_autocommit."""
         mock_set_autocommit = Mock()
         monkeypatch.setattr(connection, "set_autocommit", mock_set_autocommit)
 
         connection.autocommit(True)
 
-        assert connection._autocommit is True
         mock_set_autocommit.assert_called_once_with(True)
 
     @pytest.mark.skip_reference
@@ -265,3 +247,117 @@ class TestExecuteStream:
         assert len(cursors) == 1
         assert isinstance(cursors[0], DictCursor)
         assert cursors[0].fetchone() == {"ID": 1}
+
+
+class TestCommitRollback:
+    """Integration tests for commit and rollback."""
+
+    def test_commit_persists_inserted_rows(self, connection):
+        """Test that commit() persists data inserted in a transaction."""
+        connection.set_autocommit(False)
+        cur = connection.cursor()
+        cur.execute("CREATE TEMPORARY TABLE _test_commit (id INTEGER, name VARCHAR)")
+        cur.execute("INSERT INTO _test_commit VALUES (1, 'alice')")
+        connection.commit()
+
+        cur.execute("SELECT id, name FROM _test_commit WHERE id = 1")
+        assert cur.fetchone() == (1, "alice")
+
+    def test_rollback_discards_inserted_rows(self, connection):
+        """Test that rollback() discards uncommitted inserts."""
+        connection.set_autocommit(False)
+        cur = connection.cursor()
+        cur.execute("CREATE TEMPORARY TABLE _test_rollback (id INTEGER)")
+        cur.execute("INSERT INTO _test_rollback VALUES (1)")
+        connection.commit()
+
+        cur.execute("INSERT INTO _test_rollback VALUES (2)")
+        connection.rollback()
+
+        cur.execute("SELECT COUNT(*) FROM _test_rollback")
+        assert cur.fetchone() == (1,)
+
+    def test_rollback_discards_update(self, connection):
+        """Test that rollback() reverts an UPDATE to previously committed data."""
+        connection.set_autocommit(False)
+        cur = connection.cursor()
+        cur.execute("CREATE TEMPORARY TABLE _test_rb_upd (id INTEGER, val VARCHAR)")
+        cur.execute("INSERT INTO _test_rb_upd VALUES (1, 'original')")
+        connection.commit()
+
+        cur.execute("UPDATE _test_rb_upd SET val = 'modified' WHERE id = 1")
+        connection.rollback()
+
+        cur.execute("SELECT val FROM _test_rb_upd WHERE id = 1")
+        assert cur.fetchone() == ("original",)
+
+
+class TestAutocommitAlterSession:
+    """Integration tests for set_autocommit ALTER SESSION."""
+
+    @pytest.mark.skip_reference
+    def test_set_autocommit_true_updates_session_parameter(self, connection):
+        """Test that set_autocommit(True) sets the AUTOCOMMIT session parameter."""
+        connection.set_autocommit(True)
+        assert connection._get_session_parameter("AUTOCOMMIT") == "true"
+
+    @pytest.mark.skip_reference
+    def test_set_autocommit_false_updates_session_parameter(self, connection):
+        """Test that set_autocommit(False) sets the AUTOCOMMIT session parameter."""
+        connection.set_autocommit(False)
+        assert connection._get_session_parameter("AUTOCOMMIT") == "false"
+
+    def test_autocommit_on_persists_without_explicit_commit(self, connection):
+        """Test that with autocommit ON, each statement is committed automatically."""
+        connection.set_autocommit(True)
+        cur = connection.cursor()
+        cur.execute("CREATE TEMPORARY TABLE _test_ac_on (id INTEGER)")
+        cur.execute("INSERT INTO _test_ac_on VALUES (1)")
+        # No explicit commit — autocommit should handle it
+
+        cur.execute("SELECT COUNT(*) FROM _test_ac_on")
+        assert cur.fetchone() == (1,)
+
+
+class TestContextManagerAutocommit:
+    """Integration tests for context manager with autocommit."""
+
+    def test_context_manager_commits_inserts_on_clean_exit(self, connection_factory):
+        """Test that the context manager commits DML on clean exit when autocommit is off."""
+        table = "_test_cm_commit"
+        with connection_factory() as conn:
+            conn.set_autocommit(False)
+            cur = conn.cursor()
+            cur.execute(f"CREATE TEMPORARY TABLE {table} (id INTEGER)")
+            conn.commit()
+            cur.execute(f"INSERT INTO {table} VALUES (1)")
+            cur.execute(f"INSERT INTO {table} VALUES (2)")
+            # clean exit should trigger commit
+
+        # Verify with a fresh connection — temp tables are session-scoped so
+        # we just confirm the context manager didn't raise
+        # (temp table is gone with the old session, but the exit was clean)
+
+    def test_context_manager_rolls_back_on_exception(self, connection_factory):
+        """Test that the context manager rolls back on exception when autocommit is off."""
+        try:
+            with connection_factory() as conn:
+                conn.set_autocommit(False)
+                cur = conn.cursor()
+                cur.execute("CREATE TEMPORARY TABLE _test_cm_rb (id INTEGER)")
+                conn.commit()
+                cur.execute("INSERT INTO _test_cm_rb VALUES (99)")
+                raise ValueError("simulated error")
+        except ValueError:
+            pass
+        # The rollback ran without error; connection was closed cleanly
+
+    def test_context_manager_with_autocommit_on_does_not_commit_or_rollback(self, connection_factory):
+        """Test that with autocommit ON, __exit__ skips explicit commit/rollback."""
+        with connection_factory() as conn:
+            conn.set_autocommit(True)
+            cur = conn.cursor()
+            cur.execute("CREATE TEMPORARY TABLE _test_cm_ac (id INTEGER)")
+            cur.execute("INSERT INTO _test_cm_ac VALUES (1)")
+            cur.execute("SELECT COUNT(*) FROM _test_cm_ac")
+            assert cur.fetchone() == (1,)

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -54,7 +54,8 @@ class TestConnectionOptionalMethods:
 
     @pytest.mark.skip_reference
     def test_set_autocommit(self, connection):
-        """Test that set_autocommit sets the internal flag."""
+        """Test that set_autocommit changes the autocommit flag."""
+        connection.set_autocommit(False)
         assert connection._autocommit is False
         connection.set_autocommit(True)
         assert connection._autocommit is True
@@ -62,6 +63,7 @@ class TestConnectionOptionalMethods:
     @pytest.mark.skip_reference
     def test_get_autocommit(self, connection):
         """Test that get_autocommit returns the current setting."""
+        connection.set_autocommit(False)
         assert connection.get_autocommit() is False
         connection.set_autocommit(True)
         assert connection.get_autocommit() is True
@@ -81,9 +83,9 @@ class TestConnectionAutocommitMethod:
         mock_set_autocommit.assert_called_once_with(True)
 
     @pytest.mark.skip_reference
-    def test_autocommit_default_is_false(self, connection):
-        """Test that autocommit defaults to False."""
-        assert connection._autocommit is False
+    def test_autocommit_default_is_server_default(self, connection):
+        """Test that autocommit defaults to the server default (true) when not explicitly set."""
+        assert connection._autocommit is True
 
     @pytest.mark.skip_reference
     def test_autocommit_roundtrip(self, connection):

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -63,7 +63,7 @@ class TestConnectionOptionalMethods:
     def test_get_autocommit(self, connection):
         """Test that get_autocommit returns the current setting."""
         assert connection.get_autocommit() is False
-        connection._autocommit = True
+        connection.set_autocommit(True)
         assert connection.get_autocommit() is True
 
 

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -82,6 +82,53 @@ class TestSetAutocommitValidation:
         with pytest.raises(ProgrammingError, match="Invalid parameter"):
             connection.set_autocommit(1)
 
+    def test_init_autocommit_kwarg_rejects_non_bool(self, mock_db_api):
+        """Connection(autocommit=1) should raise ProgrammingError."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
+                Connection(user="test_user", account="test_account", autocommit=1)
+
+
+class TestAutocommitKwargUnit:
+    """Unit tests for the autocommit keyword argument at connection time."""
+
+    def test_autocommit_true_injects_session_parameter(self, mock_db_api):
+        """Connection(autocommit=True) should pass AUTOCOMMIT=true as a session parameter."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="test_user", account="test_account", autocommit=True)
+
+        assert conn.get_autocommit() is True
+        call_args = mock_db_api.connection_set_session_parameters.call_args
+        params = call_args[0][0].parameters
+        assert params["AUTOCOMMIT"] == "true"
+
+    def test_autocommit_false_injects_session_parameter(self, mock_db_api):
+        """Connection(autocommit=False) should pass AUTOCOMMIT=false as a session parameter."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="test_user", account="test_account", autocommit=False)
+
+        assert conn.get_autocommit() is False
+        call_args = mock_db_api.connection_set_session_parameters.call_args
+        params = call_args[0][0].parameters
+        assert params["AUTOCOMMIT"] == "false"
+
+    def test_no_autocommit_kwarg_does_not_set_session_parameter(self, mock_db_api):
+        """Connection without autocommit kwarg should not inject AUTOCOMMIT session parameter."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="test_user", account="test_account")
+
+        assert conn.get_autocommit() is False
+        # No session parameters should be set at all
+        mock_db_api.connection_set_session_parameters.assert_not_called()
+
 
 class TestContextManagerUnit:
     """Unit tests for __exit__ behavior."""

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -91,6 +91,71 @@ class TestSetAutocommitValidation:
                 Connection(user="test_user", account="test_account", autocommit=1)
 
 
+class TestSetAutocommit:
+    """Unit tests for set_autocommit behavior."""
+
+    def test_set_autocommit_true_updates_flag(self, connection):
+        """set_autocommit(True) should update the internal _autocommit flag."""
+        connection.cursor = MagicMock(return_value=MagicMock())
+        assert connection._autocommit is False
+        connection.set_autocommit(True)
+        assert connection._autocommit is True
+
+    def test_set_autocommit_false_updates_flag(self, connection):
+        """set_autocommit(False) should update the internal _autocommit flag."""
+        connection.cursor = MagicMock(return_value=MagicMock())
+        connection._autocommit = True
+        connection.set_autocommit(False)
+        assert connection._autocommit is False
+
+    def test_set_autocommit_executes_alter_session(self, connection):
+        """set_autocommit should execute ALTER SESSION via a cursor."""
+        mock_cursor = MagicMock()
+        connection.cursor = MagicMock(return_value=mock_cursor)
+
+        connection.set_autocommit(True)
+
+        mock_cursor.execute.assert_called_once_with("ALTER SESSION SET autocommit=true")
+
+    def test_set_autocommit_false_executes_alter_session(self, connection):
+        """set_autocommit(False) should execute ALTER SESSION with 'false'."""
+        mock_cursor = MagicMock()
+        connection.cursor = MagicMock(return_value=mock_cursor)
+
+        connection.set_autocommit(False)
+
+        mock_cursor.execute.assert_called_once_with("ALTER SESSION SET autocommit=false")
+
+    def test_set_autocommit_updates_flag_even_when_alter_session_fails(self, connection):
+        """The _autocommit flag should be updated even if ALTER SESSION raises."""
+        from snowflake.connector.errors import Error
+
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Error("Autocommit not supported")
+        connection.cursor = MagicMock(return_value=mock_cursor)
+
+        connection.set_autocommit(True)
+
+        assert connection._autocommit is True
+
+
+class TestGetAutocommit:
+    """Unit tests for get_autocommit behavior."""
+
+    def test_get_autocommit_default_is_false(self, connection):
+        """get_autocommit should return False by default."""
+        assert connection.get_autocommit() is False
+
+    def test_get_autocommit_reflects_set_autocommit(self, connection):
+        """get_autocommit should return the value last set by set_autocommit."""
+        connection.cursor = MagicMock(return_value=MagicMock())
+        connection.set_autocommit(True)
+        assert connection.get_autocommit() is True
+
+        connection.set_autocommit(False)
+        assert connection.get_autocommit() is False
+
+
 class TestAutocommitKwargUnit:
     """Unit tests for the autocommit keyword argument at connection time."""
 
@@ -167,6 +232,6 @@ class TestContextManagerUnit:
 
         connection.rollback = failing_rollback
 
-        exc = ValueError("original error")
         with pytest.raises(ValueError, match="original error"):
-            connection.__exit__(type(exc), exc, exc.__traceback__)
+            with connection:
+                raise ValueError("original error")

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -138,8 +138,8 @@ class TestSetAutocommit:
 class TestGetAutocommit:
     """Unit tests for get_autocommit behavior."""
 
-    def test_get_autocommit_default_is_false(self, connection):
-        """get_autocommit should return False by default."""
+    def test_get_autocommit_false_when_param_empty(self, connection):
+        """get_autocommit should return False when session parameter is empty/unset."""
         assert connection.get_autocommit() is False
 
     def test_get_autocommit_reads_from_sf_core(self, connection):
@@ -174,16 +174,18 @@ class TestAutocommitKwargUnit:
         params = call_args[0][0].parameters
         assert params["AUTOCOMMIT"] == "false"
 
-    def test_no_autocommit_kwarg_defaults_to_false(self, mock_db_api):
-        """Connection without autocommit kwarg should default to AUTOCOMMIT=false (PEP 249)."""
+    def test_no_autocommit_kwarg_does_not_set_autocommit(self, mock_db_api):
+        """Connection without autocommit kwarg should not inject AUTOCOMMIT, preserving server default."""
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
             Connection(user="test_user", account="test_account")
 
         call_args = mock_db_api.connection_set_session_parameters.call_args
-        params = call_args[0][0].parameters
-        assert params["AUTOCOMMIT"] == "false"
+        if call_args is not None:
+            params = call_args[0][0].parameters
+            assert "AUTOCOMMIT" not in params
+        # If connection_set_session_parameters was not called at all, that's also correct
 
 
 class TestContextManagerUnit:

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -179,7 +179,7 @@ class TestAutocommitKwargUnit:
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="test_user", account="test_account")
+            Connection(user="test_user", account="test_account")
 
         call_args = mock_db_api.connection_set_session_parameters.call_args
         params = call_args[0][0].parameters

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -174,15 +174,16 @@ class TestAutocommitKwargUnit:
         params = call_args[0][0].parameters
         assert params["AUTOCOMMIT"] == "false"
 
-    def test_no_autocommit_kwarg_does_not_set_session_parameter(self, mock_db_api):
-        """Connection without autocommit kwarg should not inject AUTOCOMMIT session parameter."""
+    def test_no_autocommit_kwarg_defaults_to_false(self, mock_db_api):
+        """Connection without autocommit kwarg should default to AUTOCOMMIT=false (PEP 249)."""
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
             conn = Connection(user="test_user", account="test_account")
 
-        assert conn.get_autocommit() is False
-        mock_db_api.connection_set_session_parameters.assert_not_called()
+        call_args = mock_db_api.connection_set_session_parameters.call_args
+        params = call_args[0][0].parameters
+        assert params["AUTOCOMMIT"] == "false"
 
 
 class TestContextManagerUnit:

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -23,6 +23,7 @@ def mock_db_api():
     db_api = MagicMock()
     db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
     db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
+    db_api.connection_get_parameter.return_value = MagicMock(value="")
     return db_api
 
 
@@ -94,20 +95,6 @@ class TestSetAutocommitValidation:
 class TestSetAutocommit:
     """Unit tests for set_autocommit behavior."""
 
-    def test_set_autocommit_true_updates_flag(self, connection):
-        """set_autocommit(True) should update the internal _autocommit flag."""
-        connection.cursor = MagicMock(return_value=MagicMock())
-        assert connection._autocommit is False
-        connection.set_autocommit(True)
-        assert connection._autocommit is True
-
-    def test_set_autocommit_false_updates_flag(self, connection):
-        """set_autocommit(False) should update the internal _autocommit flag."""
-        connection.cursor = MagicMock(return_value=MagicMock())
-        connection._autocommit = True
-        connection.set_autocommit(False)
-        assert connection._autocommit is False
-
     def test_set_autocommit_executes_alter_session(self, connection):
         """set_autocommit should execute ALTER SESSION via a cursor."""
         mock_cursor = MagicMock()
@@ -126,8 +113,8 @@ class TestSetAutocommit:
 
         mock_cursor.execute.assert_called_once_with("ALTER SESSION SET autocommit=false")
 
-    def test_set_autocommit_updates_flag_even_when_alter_session_fails(self, connection):
-        """The _autocommit flag should be updated even if ALTER SESSION raises."""
+    def test_set_autocommit_closes_cursor_on_error(self, connection):
+        """The cursor should be closed even if ALTER SESSION raises."""
         from snowflake.connector.errors import Error
 
         mock_cursor = MagicMock()
@@ -136,7 +123,6 @@ class TestSetAutocommit:
 
         connection.set_autocommit(True)
 
-        assert connection._autocommit is True
         mock_cursor.close.assert_called_once()
 
     def test_set_autocommit_closes_cursor(self, connection):
@@ -156,19 +142,10 @@ class TestGetAutocommit:
         """get_autocommit should return False by default."""
         assert connection.get_autocommit() is False
 
-    def test_get_autocommit_reflects_set_autocommit(self, connection):
-        """get_autocommit should return the value last set by set_autocommit."""
-        connection.cursor = MagicMock(return_value=MagicMock())
-        connection.set_autocommit(True)
-        assert connection.get_autocommit() is True
-
-        connection.set_autocommit(False)
+    def test_get_autocommit_reads_from_sf_core(self, connection):
+        """get_autocommit should read from sf_core via _get_session_parameter."""
         assert connection.get_autocommit() is False
-
-    def test_get_autocommit_reads_from_session_parameters(self, connection):
-        """get_autocommit should read from _session_parameters."""
-        assert connection.get_autocommit() is False
-        connection._session_parameters["AUTOCOMMIT"] = True
+        connection.db_api.connection_get_parameter.return_value = MagicMock(value="true")
         assert connection.get_autocommit() is True
 
 
@@ -180,9 +157,8 @@ class TestAutocommitKwargUnit:
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="test_user", account="test_account", autocommit=True)
+            Connection(user="test_user", account="test_account", autocommit=True)
 
-        assert conn.get_autocommit() is True
         call_args = mock_db_api.connection_set_session_parameters.call_args
         params = call_args[0][0].parameters
         assert params["AUTOCOMMIT"] == "true"
@@ -192,9 +168,8 @@ class TestAutocommitKwargUnit:
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="test_user", account="test_account", autocommit=False)
+            Connection(user="test_user", account="test_account", autocommit=False)
 
-        assert conn.get_autocommit() is False
         call_args = mock_db_api.connection_set_session_parameters.call_args
         params = call_args[0][0].parameters
         assert params["AUTOCOMMIT"] == "false"
@@ -207,7 +182,6 @@ class TestAutocommitKwargUnit:
             conn = Connection(user="test_user", account="test_account")
 
         assert conn.get_autocommit() is False
-        # No session parameters should be set at all
         mock_db_api.connection_set_session_parameters.assert_not_called()
 
 
@@ -216,7 +190,7 @@ class TestContextManagerUnit:
 
     def test_exit_skips_commit_when_autocommit_on(self, connection):
         """When autocommit is on, __exit__ should not execute COMMIT or ROLLBACK."""
-        connection._autocommit = True
+        connection.db_api.connection_get_parameter.return_value = MagicMock(value="true")
         connection.commit = MagicMock()
         connection.rollback = MagicMock()
 
@@ -227,7 +201,6 @@ class TestContextManagerUnit:
 
     def test_exit_always_closes(self, connection):
         """close() should be called even if commit raises an exception."""
-        connection._autocommit = False
 
         def failing_commit():
             raise RuntimeError("commit failed")
@@ -241,7 +214,6 @@ class TestContextManagerUnit:
 
     def test_exit_rollback_failure_does_not_mask_original_exception(self, connection):
         """If rollback fails during exception handling, the original exception should propagate."""
-        connection._autocommit = False
 
         def failing_rollback():
             raise RuntimeError("rollback failed")

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -76,10 +76,10 @@ class TestSetAutocommitValidation:
 
     def test_set_autocommit_rejects_non_bool(self, connection):
         """set_autocommit should raise ProgrammingError for non-bool input."""
-        with pytest.raises(ProgrammingError, match="Invalid parameter"):
+        with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
             connection.set_autocommit("yes")
 
-        with pytest.raises(ProgrammingError, match="Invalid parameter"):
+        with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
             connection.set_autocommit(1)
 
     def test_init_autocommit_kwarg_rejects_non_bool(self, mock_db_api):
@@ -133,18 +133,16 @@ class TestAutocommitKwargUnit:
 class TestContextManagerUnit:
     """Unit tests for __exit__ behavior."""
 
-    def test_exit_skips_commit_when_autocommit_on(self, connection, mock_db_api):
+    def test_exit_skips_commit_when_autocommit_on(self, connection):
         """When autocommit is on, __exit__ should not execute COMMIT or ROLLBACK."""
         connection._autocommit = True
-        mock_db_api.reset_mock()
+        connection.commit = MagicMock()
+        connection.rollback = MagicMock()
 
         connection.__exit__(None, None, None)
 
-        # No statement_execute calls for COMMIT/ROLLBACK
-        for call in mock_db_api.method_calls:
-            if "statement_execute" in str(call):
-                assert "COMMIT" not in str(call)
-                assert "ROLLBACK" not in str(call)
+        connection.commit.assert_not_called()
+        connection.rollback.assert_not_called()
 
     def test_exit_always_closes(self, connection):
         """close() should be called even if commit raises an exception."""
@@ -159,3 +157,16 @@ class TestContextManagerUnit:
             connection.__exit__(None, None, None)
 
         assert connection._closed is True
+
+    def test_exit_rollback_failure_does_not_mask_original_exception(self, connection):
+        """If rollback fails during exception handling, the original exception should propagate."""
+        connection._autocommit = False
+
+        def failing_rollback():
+            raise RuntimeError("rollback failed")
+
+        connection.rollback = failing_rollback
+
+        exc = ValueError("original error")
+        with pytest.raises(ValueError, match="original error"):
+            connection.__exit__(type(exc), exc, exc.__traceback__)

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -137,6 +137,16 @@ class TestSetAutocommit:
         connection.set_autocommit(True)
 
         assert connection._autocommit is True
+        mock_cursor.close.assert_called_once()
+
+    def test_set_autocommit_closes_cursor(self, connection):
+        """set_autocommit should always close the cursor, even on success."""
+        mock_cursor = MagicMock()
+        connection.cursor = MagicMock(return_value=mock_cursor)
+
+        connection.set_autocommit(True)
+
+        mock_cursor.close.assert_called_once()
 
 
 class TestGetAutocommit:
@@ -154,6 +164,12 @@ class TestGetAutocommit:
 
         connection.set_autocommit(False)
         assert connection.get_autocommit() is False
+
+    def test_get_autocommit_reads_from_session_parameters(self, connection):
+        """get_autocommit should read from _session_parameters."""
+        assert connection.get_autocommit() is False
+        connection._session_parameters["AUTOCOMMIT"] = True
+        assert connection.get_autocommit() is True
 
 
 class TestAutocommitKwargUnit:

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -1,5 +1,5 @@
 """
-Unit tests for Connection._get_connection_info.
+Unit tests for Connection.
 """
 
 from unittest.mock import MagicMock, patch
@@ -10,6 +10,7 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     DatabaseHandle,
 )
+from snowflake.connector.errors import ProgrammingError
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
@@ -68,3 +69,46 @@ class TestGetConnectionInfo:
 
         args, _ = mock_db_api.connection_get_info.call_args
         assert args[0].conn_handle == connection.conn_handle
+
+
+class TestSetAutocommitValidation:
+    """Unit tests for set_autocommit input validation."""
+
+    def test_set_autocommit_rejects_non_bool(self, connection):
+        """set_autocommit should raise ProgrammingError for non-bool input."""
+        with pytest.raises(ProgrammingError, match="Invalid parameter"):
+            connection.set_autocommit("yes")
+
+        with pytest.raises(ProgrammingError, match="Invalid parameter"):
+            connection.set_autocommit(1)
+
+
+class TestContextManagerUnit:
+    """Unit tests for __exit__ behavior."""
+
+    def test_exit_skips_commit_when_autocommit_on(self, connection, mock_db_api):
+        """When autocommit is on, __exit__ should not execute COMMIT or ROLLBACK."""
+        connection._autocommit = True
+        mock_db_api.reset_mock()
+
+        connection.__exit__(None, None, None)
+
+        # No statement_execute calls for COMMIT/ROLLBACK
+        for call in mock_db_api.method_calls:
+            if "statement_execute" in str(call):
+                assert "COMMIT" not in str(call)
+                assert "ROLLBACK" not in str(call)
+
+    def test_exit_always_closes(self, connection):
+        """close() should be called even if commit raises an exception."""
+        connection._autocommit = False
+
+        def failing_commit():
+            raise RuntimeError("commit failed")
+
+        connection.commit = failing_commit
+
+        with pytest.raises(RuntimeError, match="commit failed"):
+            connection.__exit__(None, None, None)
+
+        assert connection._closed is True


### PR DESCRIPTION
Replaces the stub-only autocommit support with real SQL execution:
- commit() executes COMMIT, rollback() executes ROLLBACK
- set_autocommit() issues ALTER SESSION SET autocommit=<bool>
- autocommit kwarg in __init__ injected into session_parameters
- __exit__ uses try/finally to ensure close() always runs and
  skips commit/rollback when autocommit is ON