### PR TITLE
SNOW-3104121: Redact sensitive data in Debug output and logging

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -55,7 +55,10 @@ pub fn driver_connect(
                 let v = if REDACTED_KEYS.contains(&k.to_uppercase().as_str()) {
                     "****"
                 } else {
-                    connection_string_map.get(k).map(|s| s.as_str()).unwrap_or("")
+                    connection_string_map
+                        .get(k)
+                        .map(|s| s.as_str())
+                        .unwrap_or("")
                 };
                 (k, v)
             })

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -41,10 +41,27 @@ pub fn driver_connect(
     let connection_string =
         api_utils::cstr_to_string(in_connection_string, in_string_length as i32)?;
     let connection_string_map = parse_connection_string(&connection_string);
-    tracing::info!(
-        "driver_connect: connection_string={:?}",
-        connection_string_map
-    );
+    {
+        const REDACTED_KEYS: &[&str] = &[
+            "PWD",
+            "TOKEN",
+            "PRIV_KEY_FILE_PWD",
+            "PRIV_KEY_PWD",
+            "PRIV_KEY_BASE64",
+        ];
+        let redacted_map: HashMap<&String, &str> = connection_string_map
+            .keys()
+            .map(|k| {
+                let v = if REDACTED_KEYS.contains(&k.to_uppercase().as_str()) {
+                    "****"
+                } else {
+                    connection_string_map.get(k).map(|s| s.as_str()).unwrap_or("")
+                };
+                (k, v)
+            })
+            .collect();
+        tracing::info!("driver_connect: connection_string={:?}", redacted_map);
+    }
 
     let connection = conn_from_handle(connection_handle);
     let db_handle = DatabaseDriverClient::database_new(DatabaseNewRequest {})?

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -148,7 +148,10 @@ impl std::fmt::Debug for NativeOktaConfig {
             .field("password", &Redacted)
             .field("okta_url", &self.okta_url)
             .field("disable_saml_url_check", &self.disable_saml_url_check)
-            .field("authentication_timeout_secs", &self.authentication_timeout_secs)
+            .field(
+                "authentication_timeout_secs",
+                &self.authentication_timeout_secs,
+            )
             .finish()
     }
 }
@@ -179,10 +182,7 @@ impl std::fmt::Debug for LoginMethod {
                 .field("username", username)
                 .field("password", &Redacted)
                 .finish(),
-            LoginMethod::NativeOkta(config) => f
-                .debug_tuple("NativeOkta")
-                .field(config)
-                .finish(),
+            LoginMethod::NativeOkta(config) => f.debug_tuple("NativeOkta").field(config).finish(),
             LoginMethod::PrivateKey {
                 username,
                 passphrase,

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -122,7 +122,6 @@ impl LoginParameters {
 
 pub const DEFAULT_AUTHENTICATION_TIMEOUT_SECS: u64 = 120;
 
-#[derive(Debug)]
 pub struct NativeOktaConfig {
     /// Snowflake user name (used in authenticator-request to Snowflake).
     pub username: String,
@@ -140,7 +139,20 @@ pub struct NativeOktaConfig {
     pub authentication_timeout_secs: u64,
 }
 
-#[derive(Debug)]
+impl std::fmt::Debug for NativeOktaConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::redact::Redacted;
+        f.debug_struct("NativeOktaConfig")
+            .field("username", &self.username)
+            .field("okta_username", &self.okta_username)
+            .field("password", &Redacted)
+            .field("okta_url", &self.okta_url)
+            .field("disable_saml_url_check", &self.disable_saml_url_check)
+            .field("authentication_timeout_secs", &self.authentication_timeout_secs)
+            .finish()
+    }
+}
+
 pub enum LoginMethod {
     Password {
         username: String,
@@ -156,6 +168,38 @@ pub enum LoginMethod {
         username: String,
         token: String,
     },
+}
+
+impl std::fmt::Debug for LoginMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::redact::{Redacted, redact};
+        match self {
+            LoginMethod::Password { username, .. } => f
+                .debug_struct("Password")
+                .field("username", username)
+                .field("password", &Redacted)
+                .finish(),
+            LoginMethod::NativeOkta(config) => f
+                .debug_tuple("NativeOkta")
+                .field(config)
+                .finish(),
+            LoginMethod::PrivateKey {
+                username,
+                passphrase,
+                ..
+            } => f
+                .debug_struct("PrivateKey")
+                .field("username", username)
+                .field("private_key", &Redacted)
+                .field("passphrase", &redact(passphrase))
+                .finish(),
+            LoginMethod::Pat { username, .. } => f
+                .debug_struct("Pat")
+                .field("username", username)
+                .field("token", &Redacted)
+                .finish(),
+        }
+    }
 }
 
 impl LoginMethod {

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod logging;
 pub mod protobuf_apis;
 pub mod protobuf_gen;
 pub mod query_types;
+pub(crate) mod redact;
 pub mod rest;
 pub mod tls;
 pub mod token_cache;

--- a/sf_core/src/redact.rs
+++ b/sf_core/src/redact.rs
@@ -9,3 +9,31 @@ impl std::fmt::Debug for Redacted {
 pub(crate) fn redact(opt: &Option<String>) -> Option<Redacted> {
     opt.as_ref().map(|_| Redacted)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacted_debug_displays_mask() {
+        let value = Redacted;
+        assert_eq!(format!("{:?}", value), "****");
+    }
+
+    #[test]
+    fn redact_some_returns_redacted_some() {
+        let secret = Some("super-secret".to_string());
+        let redacted = redact(&secret);
+
+        assert!(redacted.is_some());
+        assert_eq!(format!("{:?}", redacted), "Some(****)");
+    }
+
+    #[test]
+    fn redact_none_returns_none() {
+        let secret: Option<String> = None;
+        let redacted = redact(&secret);
+
+        assert!(redacted.is_none());
+    }
+}

--- a/sf_core/src/redact.rs
+++ b/sf_core/src/redact.rs
@@ -1,0 +1,11 @@
+pub(crate) struct Redacted;
+
+impl std::fmt::Debug for Redacted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("****")
+    }
+}
+
+pub(crate) fn redact(opt: &Option<String>) -> Option<Redacted> {
+    opt.as_ref().map(|_| Redacted)
+}

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -34,7 +34,7 @@ pub struct AuthRequestClientEnvironment {
     pub python_compiler: Option<String>,
 }
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Serialize, Default)]
 pub struct AuthRequestData {
     #[serde(rename = "CLIENT_APP_ID")]
     pub client_app_id: String,
@@ -76,6 +76,23 @@ pub struct AuthRequestData {
     pub oauth_type: Option<String>,
     #[serde(rename = "PROVIDER", skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+}
+
+impl std::fmt::Debug for AuthRequestData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::redact::redact;
+        f.debug_struct("AuthRequestData")
+            .field("client_app_id", &self.client_app_id)
+            .field("account_name", &self.account_name)
+            .field("login_name", &self.login_name)
+            .field("password", &redact(&self.password))
+            .field("raw_saml_response", &redact(&self.raw_saml_response))
+            .field("passcode", &redact(&self.passcode))
+            .field("authenticator", &self.authenticator)
+            .field("token", &redact(&self.token))
+            .field("proof_key", &redact(&self.proof_key))
+            .finish()
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -233,8 +233,9 @@ pub async fn snowflake_login_with_client(
     };
 
     tracing::debug!(
-        "Login request: {}",
-        serde_json::to_string_pretty(&login_request).unwrap()
+        authenticator = ?login_request.data.authenticator,
+        login_name = ?login_request.data.login_name,
+        "Login request prepared (secrets redacted)"
     );
 
     let login_url = format!("{}/session/v1/login-request", login_parameters.server_url);


### PR DESCRIPTION
Introduce a lightweight Redacted helper struct and redact() function to consistently mask secrets (passwords, tokens, SAML responses, private keys) in Debug implementations and log statements.

Changes:
- Add sf_core::redact module with Redacted struct and redact() helper
- Replace #[derive(Debug)] with custom Debug impls for NativeOktaConfig, LoginMethod, and AuthRequestData to mask sensitive fields
- Redact connection string logging in ODBC driver_connect (PWD, TOKEN, PRIV_KEY_FILE_PWD, PRIV_KEY_PWD, PRIV_KEY_BASE64)
- Replace login_request JSON dump with structured log showing only authenticator and login_name