### PR TITLE
NO-SNOW: Fix unexpected_cfgs warnings for prost-generated arbitrary feature

### DIFF
--- a/proto_generator/Cargo.toml
+++ b/proto_generator/Cargo.toml
@@ -19,5 +19,9 @@ log = "0.4.28"
 env_logger="0.11.8"
 walkdir = "2.5"
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("arbitrary"))']
+
 [dev-dependencies]
 tempfile = "3.0"

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -77,6 +77,10 @@ der = "0.7"
 pkcs1 = "0.7"
 num-traits = "0.2.19"
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("arbitrary"))']
+
 [build-dependencies]
 proto_generator = { path = "../proto_generator" }
 


### PR DESCRIPTION
Declare "arbitrary" as an expected feature value in check-cfg for proto_generator and sf_core, suppressing warnings from prost-generated code that uses #[cfg_attr(feature = "arbitrary", ...)].

Made-with: Cursor