### PR TITLE
SNOW-2467847: Add missing parameter binding tests

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DecfloatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DecfloatTests.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -295,6 +297,128 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
       }
       assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for DECFLOAT");
     }
+  }
+
+  @Test
+  public void shouldSelectDecfloatUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed with bound DECFLOAT
+    // values [123.456, -789.012, 42.0]
+    // Then Result should contain [123.456, -789.012, 42.0]
+    // When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
+    // Then Result should contain [NULL]
+    Connection connection = getDefaultConnection();
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT")) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("123.456"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("-789.012"));
+      preparedStatement.setBigDecimal(3, new BigDecimal("42.0"));
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+        assertDecfloatColumn(
+            resultSet, 1, new BigDecimal("123.456"), "Column 1 mismatch for DECFLOAT");
+        assertDecfloatColumn(
+            resultSet, 2, new BigDecimal("-789.012"), "Column 2 mismatch for DECFLOAT");
+        assertDecfloatColumn(
+            resultSet, 3, new BigDecimal("42.0"), "Column 3 mismatch for DECFLOAT");
+        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+      }
+    }
+
+    try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT ?::DECFLOAT")) {
+      preparedStatement.setNull(1, Types.DECIMAL);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+        assertNull(resultSet.getObject(1), "Column 1 should be NULL for DECFLOAT");
+        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for DECFLOAT");
+        assertNull(resultSet.getBigDecimal(1), "Column 1 BigDecimal should be NULL for DECFLOAT");
+        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() after getBigDecimal");
+        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+      }
+    }
+  }
+
+  @Test
+  public void shouldSelectExtremeDecfloatValuesUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
+    // Then Result should contain [1E+16384]
+    // When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
+    // Then Result should contain [-1.234E+8000]
+    Connection connection = getDefaultConnection();
+    try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT ?::DECFLOAT")) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("1E+16384"));
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+        assertDecfloatColumn(
+            resultSet, 1, new BigDecimal("1E+16384"), "Value mismatch for DECFLOAT");
+        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+      }
+      preparedStatement.setBigDecimal(1, new BigDecimal("-1.234E+8000"));
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+        assertDecfloatColumn(
+            resultSet, 1, new BigDecimal("-1.234E+8000"), "Value mismatch for DECFLOAT");
+        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+      }
+    }
+  }
+
+  @Test
+  public void shouldInsertDecfloatUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with DECFLOAT column exists
+    // When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
+    // Then SELECT should return the same exact values
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("0"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("123.456"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("-789.012"));
+      preparedStatement.execute();
+      preparedStatement.setNull(1, Types.DECIMAL);
+      preparedStatement.execute();
+    }
+
+    assertSingleColumnRows(
+        connection,
+        tableName,
+        "ORDER BY col NULLS FIRST",
+        Arrays.asList(
+            null, new BigDecimal("-789.012"), new BigDecimal("0"), new BigDecimal("123.456")));
+  }
+
+  @Test
+  public void shouldInsertExtremeDecfloatValuesUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with DECFLOAT column exists
+    // When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
+    // And Query "SELECT * FROM <table>" is executed
+    // Then SELECT should return the same exact values
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?::DECFLOAT)")) {
+      preparedStatement.setString(1, "1E+16384");
+      preparedStatement.execute();
+      preparedStatement.setString(1, "1E-16383");
+      preparedStatement.execute();
+      preparedStatement.setString(1, "-1.234E+8000");
+      preparedStatement.execute();
+    }
+
+    assertSingleColumnRows(
+        connection,
+        tableName,
+        "ORDER BY col",
+        Arrays.asList(
+            new BigDecimal("-1.234E+8000"),
+            new BigDecimal("1E-16383"),
+            new BigDecimal("1E+16384")));
   }
 
   private static void assertSingleRowWithNulls(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
@@ -6,8 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -330,6 +332,47 @@ public class FloatTests extends SnowflakeIntegrationTestBase {
         expected++;
       }
       assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
+    }
+  }
+
+  @Test
+  public void shouldSelectFloatUsingParameterBindingForFloatAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::<type>, ?::<type>, ?::<type>" is executed with bound float values
+    // [123.456, -789.012, 42.0]
+    // Then Result should contain floats [123.456, -789.012, 42.0]
+    // When Query "SELECT ?::<type>" is executed with bound NULL value
+    // Then Result should contain NULL
+    Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT ?::%1$s, ?::%1$s, ?::%1$s", FLOAT_TYPE);
+    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      preparedStatement.setDouble(1, 123.456);
+      preparedStatement.setDouble(2, -789.012);
+      preparedStatement.setDouble(3, 42.0);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+        assertAllFloatGetters(resultSet, 1, 123.456, "Column 1 mismatch for " + FLOAT_TYPE);
+        assertAllFloatGetters(resultSet, 2, -789.012, "Column 2 mismatch for " + FLOAT_TYPE);
+        assertAllFloatGetters(resultSet, 3, 42.0, "Column 3 mismatch for " + FLOAT_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+      }
+    }
+
+    String nullSql = String.format("SELECT ?::%1$s", FLOAT_TYPE);
+    try (PreparedStatement preparedStatement = connection.prepareStatement(nullSql)) {
+      preparedStatement.setNull(1, Types.DOUBLE);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+        assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
+        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
+        assertEquals(
+            0.0,
+            resultSet.getDouble(1),
+            "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+        assertTrue(
+            resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+      }
     }
   }
 

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
@@ -10,9 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
+import java.sql.Types;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -438,6 +440,155 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
       }
       assertEquals(LARGE_RESULT_SET_SIZE, expectedRow, "Unexpected row count for " + NUMBER_TYPE);
     }
+  }
+
+  @Test
+  public void shouldSelectNumberUsingParameterBindingForNumberAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::<type>(10,0), ?::<type>(10,0), ?::<type>(10,2), ?::<type>(10,2),
+    // ?::<type>(10,0)" is executed with bound values [123, -456, 12.34, -56.78, NULL]
+    // Then Result should contain [123, -456, 12.34, -56.78, NULL]
+    Connection connection = getDefaultConnection();
+    String sql =
+        String.format(
+            "SELECT ?::%1$s(10,0), ?::%1$s(10,0), ?::%1$s(10,2), ?::%1$s(10,2), ?::%1$s(10,0)",
+            NUMBER_TYPE);
+    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("123"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("-456"));
+      preparedStatement.setBigDecimal(3, new BigDecimal("12.34"));
+      preparedStatement.setBigDecimal(4, new BigDecimal("-56.78"));
+      preparedStatement.setNull(5, Types.DECIMAL);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet, 1, new BigDecimal("123"), "Column 1 mismatch for " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet, 2, new BigDecimal("-456"), "Column 2 mismatch for " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet, 3, new BigDecimal("12.34"), "Column 3 mismatch for " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet, 4, new BigDecimal("-56.78"), "Column 4 mismatch for " + NUMBER_TYPE);
+        assertNull(resultSet.getObject(5), "Column 5 should be NULL for " + NUMBER_TYPE);
+        assertTrue(resultSet.wasNull(), "Column 5 should set wasNull() for " + NUMBER_TYPE);
+        assertNull(
+            resultSet.getBigDecimal(5), "Column 5 getBigDecimal should be NULL for " + NUMBER_TYPE);
+        assertTrue(
+            resultSet.wasNull(),
+            "Column 5 should set wasNull() after getBigDecimal for " + NUMBER_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
+      }
+    }
+  }
+
+  @Test
+  public void shouldSelectHighPrecisionNumberUsingParameterBindingForNumberAndSynonyms()
+      throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::<type>(38,0), ?::<type>(38,2)" is executed with bound values
+    // [12345678901234567890123456789012345678, 123456789012345678901234567890123456.78]
+    // Then Result should contain [12345678901234567890123456789012345678,
+    // 123456789012345678901234567890123456.78]
+    Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT ?::%1$s(38,0), ?::%1$s(38,2)", NUMBER_TYPE);
+    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("12345678901234567890123456789012345678"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("123456789012345678901234567890123456.78"));
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet,
+            1,
+            new BigDecimal("12345678901234567890123456789012345678"),
+            "Column 1 mismatch for " + NUMBER_TYPE);
+        assertDecimalColumn(
+            resultSet,
+            2,
+            new BigDecimal("123456789012345678901234567890123456.78"),
+            "Column 2 mismatch for " + NUMBER_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
+      }
+    }
+  }
+
+  @Test
+  public void shouldInsertNumberUsingParameterBindingForNumberAndSynonyms() throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with columns (<type>(10,0), <type>(10,2)) exists
+    // When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are
+    // inserted using binding
+    // Then Result should contain 5 rows with expected values
+    Connection connection = getDefaultConnection();
+    String tableName =
+        createTempTable(
+            connection, "ud_number_", String.format("c1 %1$s(10,0), c2 %1$s(10,2)", NUMBER_TYPE));
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("0"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("0.00"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("123"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("123.45"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("-456"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("-67.89"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("999999"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("999.99"));
+      preparedStatement.execute();
+      preparedStatement.setNull(1, Types.DECIMAL);
+      preparedStatement.setNull(2, Types.DECIMAL);
+      preparedStatement.execute();
+    }
+
+    assertRowsInOrder(
+        connection,
+        "SELECT * FROM " + tableName + " ORDER BY c1 NULLS LAST, c2 NULLS LAST",
+        Arrays.asList(
+            Arrays.asList(new BigDecimal("-456"), new BigDecimal("-67.89")),
+            Arrays.asList(new BigDecimal("0"), new BigDecimal("0.00")),
+            Arrays.asList(new BigDecimal("123"), new BigDecimal("123.45")),
+            Arrays.asList(new BigDecimal("999999"), new BigDecimal("999.99")),
+            Arrays.asList(null, null)));
+  }
+
+  @Test
+  public void shouldInsertHighPrecisionNumberUsingParameterBindingForNumberAndSynonyms()
+      throws Exception {
+    // Given Snowflake client is logged in
+    // And Table with columns (<type>(38,0), <type>(38,2)) exists
+    // When Rows (12345678901234567890123456789012345678,
+    // 123456789012345678901234567890123456.78), (99999999999999999999999999999999999999, 0.01),
+    // (-99999999999999999999999999999999999999, -0.01) are inserted using binding
+    // Then Result should contain 3 rows with expected values keeping the precision
+    Connection connection = getDefaultConnection();
+    String tableName =
+        createTempTable(
+            connection, "ud_number_", String.format("c1 %1$s(38,0), c2 %1$s(38,2)", NUMBER_TYPE));
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
+      preparedStatement.setBigDecimal(1, new BigDecimal("12345678901234567890123456789012345678"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("123456789012345678901234567890123456.78"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("99999999999999999999999999999999999999"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("0.01"));
+      preparedStatement.execute();
+      preparedStatement.setBigDecimal(1, new BigDecimal("-99999999999999999999999999999999999999"));
+      preparedStatement.setBigDecimal(2, new BigDecimal("-0.01"));
+      preparedStatement.execute();
+    }
+
+    assertRowsInOrder(
+        connection,
+        "SELECT * FROM " + tableName + " ORDER BY c1",
+        Arrays.asList(
+            Arrays.asList(
+                new BigDecimal("-99999999999999999999999999999999999999"), new BigDecimal("-0.01")),
+            Arrays.asList(
+                new BigDecimal("12345678901234567890123456789012345678"),
+                new BigDecimal("123456789012345678901234567890123456.78")),
+            Arrays.asList(
+                new BigDecimal("99999999999999999999999999999999999999"), new BigDecimal("0.01"))));
   }
 
   private static void assertSingleRowWithNulls(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringTests.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -180,6 +182,79 @@ public class StringTests extends SnowflakeIntegrationTestBase {
     }
   }
 
+  @Test
+  public void shouldInsertAndSelectBackHardcodedStringValuesUsingParameterBinding()
+      throws Exception {
+    // Given Snowflake client is logged in
+    // And A temporary table with VARCHAR column is created
+    // When String value 'Test binding value 日本語' is inserted using parameter binding
+    // And Query "SELECT * FROM {table}" is executed
+    // Then the result should contain the bound string value 'Test binding value 日本語'
+    Connection connection = getDefaultConnection();
+    String tableName = createTempTable(connection, "ud_string_", "id INT, col " + STRING_TYPE);
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("INSERT INTO " + tableName + " (id, col) VALUES (?, ?)")) {
+      preparedStatement.setInt(1, 1);
+      preparedStatement.setString(2, "Test binding value " + JAPANESE_TEXT);
+      preparedStatement.execute();
+    }
+    assertRowsInOrder(
+        connection,
+        "SELECT col FROM " + tableName + " ORDER BY id",
+        Arrays.asList("Test binding value " + JAPANESE_TEXT));
+  }
+
+  @Test
+  public void shouldSelectStringLiteralsUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR" is executed with bound string values
+    // ['hello', 'Hello World', '日本語テスト']
+    // Then the result should contain:
+    Connection connection = getDefaultConnection();
+    String sql = String.format("SELECT ?::%1$s, ?::%1$s, ?::%1$s", STRING_TYPE);
+    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      preparedStatement.setString(1, "hello");
+      preparedStatement.setString(2, "Hello World");
+      preparedStatement.setString(3, JAPANESE_TEXT);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+        assertStringColumn(resultSet, 1, "hello", "Column 1 mismatch for " + STRING_TYPE);
+        assertStringColumn(resultSet, 2, "Hello World", "Column 2 mismatch for " + STRING_TYPE);
+        assertStringColumn(resultSet, 3, JAPANESE_TEXT, "Column 3 mismatch for " + STRING_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+      }
+    }
+  }
+
+  @Test
+  public void shouldSelectCornerCaseStringValuesUsingParameterBinding() throws Exception {
+    // Given Snowflake client is logged in
+    // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
+    // Then the result should match the bound corner case value
+    Connection connection = getDefaultConnection();
+    assertSingleBoundStringValue(connection, "");
+    assertSingleBoundStringValue(connection, "X");
+    assertSingleBoundStringValue(connection, "   ");
+    assertSingleBoundStringValue(connection, "\t");
+    assertSingleBoundStringValue(connection, "\n");
+    assertSingleBoundStringValue(connection, SNOWMAN);
+    assertSingleBoundStringValue(connection, JAPANESE_TEXT);
+    assertSingleBoundStringValue(connection, "'");
+    assertSingleBoundStringValue(connection, "\\");
+    assertSingleBoundStringValue(connection, COMBINING_CHAR_TEXT);
+    assertSingleBoundStringValue(connection, SURROGATE_PAIR_TEXT);
+
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement(String.format("SELECT ?::%1$s", STRING_TYPE))) {
+      preparedStatement.setNull(1, Types.VARCHAR);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+        assertStringColumn(resultSet, 1, null, "NULL value mismatch for " + STRING_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+      }
+    }
+  }
+
   private static void assertSingleRow(
       Connection connection, String sql, List<String> expectedValues) throws Exception {
     try (Statement statement = connection.createStatement();
@@ -229,5 +304,18 @@ public class StringTests extends SnowflakeIntegrationTestBase {
 
     assertEquals(expected, resultSet.getString(columnIndex), message + " (getString)");
     assertFalse(resultSet.wasNull(), message + " (getString should not be NULL)");
+  }
+
+  private static void assertSingleBoundStringValue(Connection connection, String expected)
+      throws Exception {
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement(String.format("SELECT ?::%1$s", STRING_TYPE))) {
+      preparedStatement.setString(1, expected);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+        assertStringColumn(resultSet, 1, expected, "Bound value mismatch for " + STRING_TYPE);
+        assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+      }
+    }
   }
 }

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -94,7 +94,7 @@ Feature: DECFLOAT type support
   #                            Parameter binding                                #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select decfloat using parameter binding
     Given Snowflake client is logged in
     When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed with bound DECFLOAT values [123.456, -789.012, 42.0]
@@ -102,7 +102,7 @@ Feature: DECFLOAT type support
     When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
     Then Result should contain [NULL]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select extreme decfloat values using parameter binding
     Given Snowflake client is logged in
     When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
@@ -110,14 +110,14 @@ Feature: DECFLOAT type support
     When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
     Then Result should contain [-1.234E+8000]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should insert decfloat using parameter binding
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists
     When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
     Then SELECT should return the same exact values
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should insert extreme decfloat values using parameter binding
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists

--- a/tests/definitions/shared/types/float.feature
+++ b/tests/definitions/shared/types/float.feature
@@ -98,7 +98,7 @@ Feature: FLOAT type support
   #                            Parameter binding                                #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select float using parameter binding for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT ?::<type>, ?::<type>, ?::<type>" is executed with bound float values [123.456, -789.012, 42.0]

--- a/tests/definitions/shared/types/number.feature
+++ b/tests/definitions/shared/types/number.feature
@@ -121,26 +121,26 @@ Feature: NUMBER type support
   #                            Parameter binding                                #
   # =========================================================================== #
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select number using parameter binding for number and synonyms
     Given Snowflake client is logged in
     When Query "SELECT ?::<type>(10,0), ?::<type>(10,0), ?::<type>(10,2), ?::<type>(10,2), ?::<type>(10,0)" is executed with bound values [123, -456, 12.34, -56.78, NULL]
     Then Result should contain [123, -456, 12.34, -56.78, NULL]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should select high precision number using parameter binding for number and synonyms
     Given Snowflake client is logged in
     When Query "SELECT ?::<type>(38,0), ?::<type>(38,2)" is executed with bound values [12345678901234567890123456789012345678, 123456789012345678901234567890123456.78]
     Then Result should contain [12345678901234567890123456789012345678, 123456789012345678901234567890123456.78]
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should insert number using parameter binding for number and synonyms
     Given Snowflake client is logged in
     And Table with columns (<type>(10,0), <type>(10,2)) exists
     When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are inserted using binding
     Then Result should contain 5 rows with expected values
 
-  @python_e2e
+  @python_e2e @jdbc_e2e
   Scenario: should insert high precision number using parameter binding for number and synonyms
     Given Snowflake client is logged in
     And Table with columns (<type>(38,0), <type>(38,2)) exists

--- a/tests/definitions/shared/types/string.feature
+++ b/tests/definitions/shared/types/string.feature
@@ -86,7 +86,7 @@ Feature: String datatype handling
   # BINDING TESTS
   # ============================================================================
 
-  @odbc_e2e @python_e2e
+  @odbc_e2e @python_e2e @jdbc_e2e
   Scenario: should insert and select back hardcoded string values using parameter binding
     Given Snowflake client is logged in
     And A temporary table with VARCHAR column is created
@@ -95,7 +95,7 @@ Feature: String datatype handling
     Then the result should contain the bound string value 'Test binding value 日本語'
 
   
-  @odbc_e2e @python_e2e
+  @odbc_e2e @python_e2e @jdbc_e2e
   Scenario: should select string literals using parameter binding
     # SELECT binding test: Uses SELECT ?::VARCHAR to bind string values
     Given Snowflake client is logged in
@@ -104,7 +104,7 @@ Feature: String datatype handling
       | col1  | col2        | col3       |
       | hello | Hello World | 日本語テスト |
 
-  @odbc_e2e @python_e2e
+  @odbc_e2e @python_e2e @jdbc_e2e
   Scenario: should select corner case string values using parameter binding
     Given Snowflake client is logged in
     When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound


### PR DESCRIPTION
## Summary
- Adds missing JDBC E2E parameter-binding coverage for `DECFLOAT`, `FLOAT`, `NUMBER`, and `STRING` type suites.
- Extends JDBC tests to validate both `SELECT` and `INSERT` paths with `PreparedStatement`, including explicit `NULL` bindings and type casts.
- Covers precision and boundary scenarios:
  - `DECFLOAT`: normal + extreme exponent values (`1E+16384`, `1E-16383`, `-1.234E+8000`)
  - `NUMBER`: standard precision and high-precision `NUMBER(38,0)/(38,2)` round-trip values
  - `STRING`: literal binding, Unicode/Japanese, whitespace/control chars, quotes, backslash, combining/surrogate edge cases
  - `FLOAT`: numeric bindings and null handling for float and synonyms
- Updates shared Gherkin definitions to include `@jdbc_e2e` tags on existing parameter-binding scenarios so JDBC now executes the same cross-driver scenarios already covered elsewhere.
