### PR TITLE
SNOW-3155976: Read connection properties from sf_core instead of kwargs

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -354,6 +354,12 @@ message ConnectionGetInfoResponse {
   optional string server_url = 3;
   optional string session_token = 4;
   optional int64 session_id = 5;
+  optional string account = 6;
+  optional string user = 7;
+  optional string role = 8;
+  optional string database = 9;
+  optional string schema = 10;
+  optional string warehouse = 11;
 }
 
 message ConnectionGetObjectsRequest {

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -360,43 +360,50 @@ class Connection:
     @property
     def role(self) -> str | None:
         """The current role in use for the session."""
-        return self._get_connection_info().role or None
+        info = self._get_connection_info()
+        return info.role if info.HasField("role") else None
 
     @property
     def database(self) -> str | None:
         """The current database in use for the session."""
-        return self._get_connection_info().database or None
+        info = self._get_connection_info()
+        return info.database if info.HasField("database") else None
 
     @property
     def schema(self) -> str | None:
         """The current schema in use for the session."""
-        return self._get_connection_info().schema or None
+        info = self._get_connection_info()
+        return info.schema if info.HasField("schema") else None
 
     @property
     def account(self) -> str | None:
         """The Snowflake account name used by this connection."""
-        return self._get_connection_info().account or None
+        info = self._get_connection_info()
+        return info.account if info.HasField("account") else None
 
     @property
     def warehouse(self) -> str | None:
         """The current warehouse in use for the session."""
-        return self._get_connection_info().warehouse or None
+        info = self._get_connection_info()
+        return info.warehouse if info.HasField("warehouse") else None
 
     @property
     def user(self) -> str | None:
         """The user name used for authentication."""
-        return self._get_connection_info().user or None
+        info = self._get_connection_info()
+        return info.user if info.HasField("user") else None
 
     @property
     def host(self) -> str | None:
         """The host name of the Snowflake instance."""
-        return self._get_connection_info().host or None
+        info = self._get_connection_info()
+        return info.host if info.HasField("host") else None
 
     @property
     def port(self) -> int | None:
         """The port number of the Snowflake instance."""
-        port = self._get_connection_info().port
-        return port if port else None
+        info = self._get_connection_info()
+        return info.port if info.HasField("port") else None
 
     @property
     def region(self) -> str | None:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -360,49 +360,42 @@ class Connection:
     @property
     def role(self) -> str | None:
         """The current role in use for the session."""
-        return self.kwargs.get("role")  # type: ignore[return-value]
+        return self._get_connection_info().role or None
 
     @property
     def database(self) -> str | None:
         """The current database in use for the session."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("database")  # type: ignore[return-value]
+        return self._get_connection_info().database or None
 
     @property
     def schema(self) -> str | None:
         """The current schema in use for the session."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("schema")  # type: ignore[return-value]
+        return self._get_connection_info().schema or None
 
     @property
     def account(self) -> str | None:
         """The Snowflake account name used by this connection."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("account")  # type: ignore[return-value]
+        return self._get_connection_info().account or None
 
     @property
     def warehouse(self) -> str | None:
         """The current warehouse in use for the session."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("warehouse")  # type: ignore[return-value]
+        return self._get_connection_info().warehouse or None
 
     @property
     def user(self) -> str | None:
         """The user name used for authentication."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("user")  # type: ignore[return-value]
+        return self._get_connection_info().user or None
 
     @property
     def host(self) -> str | None:
         """The host name of the Snowflake instance."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("host")  # type: ignore[return-value]
+        return self._get_connection_info().host or None
 
     @property
     def port(self) -> int | None:
         """The port number of the Snowflake instance."""
-        # TODO: SNOW-3155976 Read from connection details
-        return self.kwargs.get("port")  # type: ignore[return-value]
+        return self._get_connection_info().port or None
 
     @property
     def region(self) -> str | None:
@@ -412,8 +405,10 @@ class Connection:
     @property
     def session_id(self) -> int:
         """The Snowflake session ID for this connection."""
-        # TODO: SNOW-3155976 Read from connection details
-        raise NotImplementedError("session_id is not yet implemented")
+        info = self._get_connection_info()
+        if not info.HasField("session_id"):
+            raise InterfaceError("Session ID is not available; connection may not be initialized")
+        return info.session_id
 
     @property
     def login_timeout(self) -> int | None:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -395,7 +395,8 @@ class Connection:
     @property
     def port(self) -> int | None:
         """The port number of the Snowflake instance."""
-        return self._get_connection_info().port or None
+        port = self._get_connection_info().port
+        return port if port else None
 
     @property
     def region(self) -> str | None:

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -25,6 +25,92 @@ class TestConnectionInfo:
         assert info is not None
 
 
+class TestConnectionInfoProperties:
+    """Integration tests for Connection properties backed by _get_connection_info."""
+
+    def test_account_is_set(self, connection):
+        """After connecting, account should return the account name."""
+        assert connection.account is not None
+        assert isinstance(connection.account, str)
+        assert len(connection.account) > 0
+
+    def test_user_is_set(self, connection):
+        """After connecting, user should return the authenticated user name."""
+        assert connection.user is not None
+        assert isinstance(connection.user, str)
+        assert len(connection.user) > 0
+
+    def test_host_is_set(self, connection):
+        """After connecting, host should return the Snowflake host."""
+        assert connection.host is not None
+        assert isinstance(connection.host, str)
+        assert len(connection.host) > 0
+
+    def test_role_is_set(self, connection):
+        """After connecting, role should return the active role."""
+        assert connection.role is not None
+        assert isinstance(connection.role, str)
+        assert len(connection.role) > 0
+
+    def test_database_is_set(self, connection):
+        """After connecting, database should return the active database."""
+        assert connection.database is not None
+        assert isinstance(connection.database, str)
+        assert len(connection.database) > 0
+
+    def test_schema_is_set(self, connection):
+        """After connecting, schema should return the active schema."""
+        assert connection.schema is not None
+        assert isinstance(connection.schema, str)
+        assert len(connection.schema) > 0
+
+    def test_warehouse_is_set(self, connection):
+        """After connecting, warehouse should return the active warehouse."""
+        assert connection.warehouse is not None
+        assert isinstance(connection.warehouse, str)
+        assert len(connection.warehouse) > 0
+
+    def test_session_id_is_set(self, connection):
+        """After connecting, session_id should return a positive integer."""
+        sid = connection.session_id
+        assert isinstance(sid, int)
+        assert sid > 0
+
+    def test_port_is_set(self, connection):
+        """After connecting, port should return a valid port number or None."""
+        port = connection.port
+        if port is not None:
+            assert isinstance(port, int)
+            assert port > 0
+
+
+class TestConnectionInfoReflectsSessionChanges:
+    """Integration tests verifying that properties reflect server-side session changes."""
+
+    def test_database_reflects_use_database(self, connection):
+        """After USE DATABASE, the database property should reflect the new database."""
+        original_db = connection.database
+        assert original_db is not None
+
+        cur = connection.cursor()
+        try:
+            cur.execute(f"USE DATABASE {original_db}")
+        finally:
+            cur.close()
+
+        assert connection.database is not None
+
+    def test_schema_reflects_use_schema(self, connection):
+        """After USE SCHEMA, the schema property should reflect the new schema."""
+        cur = connection.cursor()
+        try:
+            cur.execute("USE SCHEMA INFORMATION_SCHEMA")
+        finally:
+            cur.close()
+
+        assert connection.schema is not None
+
+
 class TestConnectionMethods:
     """Test Connection object methods."""
 

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -2,6 +2,8 @@
 Integration tests for PEP 249 Connection objects.
 """
 
+import uuid
+
 from io import StringIO
 from unittest.mock import Mock
 
@@ -28,47 +30,13 @@ class TestConnectionInfo:
 class TestConnectionInfoProperties:
     """Integration tests for Connection properties backed by _get_connection_info."""
 
-    def test_account_is_set(self, connection):
-        """After connecting, account should return the account name."""
-        assert connection.account is not None
-        assert isinstance(connection.account, str)
-        assert len(connection.account) > 0
-
-    def test_user_is_set(self, connection):
-        """After connecting, user should return the authenticated user name."""
-        assert connection.user is not None
-        assert isinstance(connection.user, str)
-        assert len(connection.user) > 0
-
-    def test_host_is_set(self, connection):
-        """After connecting, host should return the Snowflake host."""
-        assert connection.host is not None
-        assert isinstance(connection.host, str)
-        assert len(connection.host) > 0
-
-    def test_role_is_set(self, connection):
-        """After connecting, role should return the active role."""
-        assert connection.role is not None
-        assert isinstance(connection.role, str)
-        assert len(connection.role) > 0
-
-    def test_database_is_set(self, connection):
-        """After connecting, database should return the active database."""
-        assert connection.database is not None
-        assert isinstance(connection.database, str)
-        assert len(connection.database) > 0
-
-    def test_schema_is_set(self, connection):
-        """After connecting, schema should return the active schema."""
-        assert connection.schema is not None
-        assert isinstance(connection.schema, str)
-        assert len(connection.schema) > 0
-
-    def test_warehouse_is_set(self, connection):
-        """After connecting, warehouse should return the active warehouse."""
-        assert connection.warehouse is not None
-        assert isinstance(connection.warehouse, str)
-        assert len(connection.warehouse) > 0
+    @pytest.mark.parametrize("prop", ["account", "user", "host", "role", "database", "schema", "warehouse"])
+    def test_string_property_is_set(self, connection, prop):
+        """After connecting, string properties should return a non-empty string."""
+        value = getattr(connection, prop)
+        assert value is not None, f"connection.{prop} should not be None"
+        assert isinstance(value, str), f"connection.{prop} should be a str"
+        assert len(value) > 0, f"connection.{prop} should not be empty"
 
     def test_session_id_is_set(self, connection):
         """After connecting, session_id should return a positive integer."""
@@ -89,8 +57,6 @@ class TestConnectionInfoReflectsSessionChanges:
 
     def test_database_reflects_use_database(self, connection):
         """After USE DATABASE, the database property should reflect the new database."""
-        import uuid
-
         original_db = connection.database
         assert original_db is not None
 

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -89,16 +89,21 @@ class TestConnectionInfoReflectsSessionChanges:
 
     def test_database_reflects_use_database(self, connection):
         """After USE DATABASE, the database property should reflect the new database."""
+        import uuid
+
         original_db = connection.database
         assert original_db is not None
 
+        tmp_db = f"TEST_DB_{uuid.uuid4().hex}".upper()
         cur = connection.cursor()
         try:
-            cur.execute(f"USE DATABASE {original_db}")
+            cur.execute(f"CREATE DATABASE {tmp_db}")
+            cur.execute(f"USE DATABASE {tmp_db}")
+            assert connection.database.upper() == tmp_db
         finally:
+            cur.execute(f"USE DATABASE {original_db}")
+            cur.execute(f"DROP DATABASE IF EXISTS {tmp_db}")
             cur.close()
-
-        assert connection.database is not None
 
     def test_schema_reflects_use_schema(self, connection):
         """After USE SCHEMA, the schema property should reflect the new schema."""
@@ -108,7 +113,7 @@ class TestConnectionInfoReflectsSessionChanges:
         finally:
             cur.close()
 
-        assert connection.schema is not None
+        assert connection.schema.upper() == "INFORMATION_SCHEMA"
 
 
 class TestConnectionMethods:

--- a/python/tests/integ/test_connection_server_echoed_properties.py
+++ b/python/tests/integ/test_connection_server_echoed_properties.py
@@ -1,0 +1,186 @@
+"""
+Integration tests: connection properties must return server-echoed names.
+
+conn.database, conn.schema, etc. must reflect the canonical name returned
+by the server — not the raw value passed to connect() or the value from
+before a USE statement.
+
+We use identifiers containing dashes (e.g. ``my-db``) as test fixtures
+because they require SQL quoting, making discrepancies between the raw
+user input and the server-echoed name easy to detect.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def _unique_name(base: str) -> str:
+    """Generate a unique identifier with the given base and a UUID suffix."""
+    return f"{base}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def dashed_database(cursor):
+    """Create a temporary database whose name contains a dash.
+
+    Dashes force SQL quoting (``"my-db"``), making it easy to detect when
+    the driver returns the raw user input instead of the server-echoed name.
+    """
+    db_name = _unique_name("test-dashed-db")
+    cursor.execute(f'CREATE DATABASE "{db_name}"')
+    try:
+        yield db_name
+    finally:
+        cursor.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+
+
+@pytest.fixture
+def dashed_schema(cursor):
+    """Create a temporary schema whose name contains a dash.
+
+    See ``dashed_database`` for why dashes are used.
+    """
+    schema_name = _unique_name("test-dashed-schema")
+    cursor.execute(f'CREATE SCHEMA "{schema_name}"')
+    try:
+        yield schema_name
+    finally:
+        cursor.execute(f'DROP SCHEMA IF EXISTS "{schema_name}"')
+
+
+class TestConnectionPropertyReflectsUse:
+    """conn.database/schema must update after USE statements."""
+
+    def test_database_updates_after_use(self, connection, dashed_database):
+        """conn.database reflects the new database after USE DATABASE."""
+        with connection.cursor() as cur:
+            cur.execute(f'USE DATABASE "{dashed_database}"')
+
+        db = connection.database
+        assert db is not None
+        assert db.lower() == dashed_database.lower(), (
+            f"conn.database did not update after USE DATABASE: "
+            f"expected {dashed_database!r}, got {db!r}"
+        )
+
+    def test_schema_updates_after_use(self, connection, dashed_schema):
+        """conn.schema reflects the new schema after USE SCHEMA."""
+        with connection.cursor() as cur:
+            cur.execute(f'USE SCHEMA "{dashed_schema}"')
+
+        schema = connection.schema
+        assert schema is not None
+        assert schema.lower() == dashed_schema.lower(), (
+            f"conn.schema did not update after USE SCHEMA: "
+            f"expected {dashed_schema!r}, got {schema!r}"
+        )
+
+
+class TestConnectionPropertyIsServerEchoed:
+    """conn.database/schema must return server-echoed names, not raw input."""
+
+    def test_database_at_connect_returns_server_name(
+        self, connection_factory, dashed_database, cursor
+    ):
+        """conn.database returns the server-echoed name, not raw connect() input."""
+        cursor.execute(f'USE DATABASE "{dashed_database}"')
+
+        with connection_factory(database=dashed_database) as conn:
+            db = conn.database
+            assert db is not None
+            assert '"' not in db, (
+                f"conn.database contains quotes: {db!r}. "
+                "Expected the server-echoed name without SQL quotes."
+            )
+            assert db.lower() == dashed_database.lower()
+
+    def test_quoted_database_param_returns_server_name(
+        self, connection_factory, dashed_database, cursor
+    ):
+        """When connect() receives a pre-quoted value, conn.database still returns the unquoted server name."""
+        cursor.execute(f'USE DATABASE "{dashed_database}"')
+
+        quoted_value = f'"{dashed_database}"'
+        with connection_factory(database=quoted_value) as conn:
+            db = conn.database
+            assert db is not None
+            assert '"' not in db, (
+                f"conn.database returned raw input {db!r} instead of "
+                f"the server-echoed name for database={quoted_value!r}."
+            )
+            assert db.lower() == dashed_database.lower()
+
+
+class TestConnectionPropertyMatchesServerCase:
+    """conn.database/schema must match the exact case returned by the server."""
+
+    def test_database_case_matches_server(self, connection):
+        """conn.database has the same case as CURRENT_DATABASE()."""
+        with connection.cursor() as cur:
+            cur.execute("SELECT CURRENT_DATABASE()")
+            server_db = cur.fetchone()[0]
+
+        assert connection.database == server_db, (
+            f"conn.database case mismatch: "
+            f"driver returned {connection.database!r}, "
+            f"server returned {server_db!r}"
+        )
+
+    def test_schema_case_matches_server(self, connection):
+        """conn.schema has the same case as CURRENT_SCHEMA()."""
+        with connection.cursor() as cur:
+            cur.execute("SELECT CURRENT_SCHEMA()")
+            server_schema = cur.fetchone()[0]
+
+        assert connection.schema == server_schema, (
+            f"conn.schema case mismatch: "
+            f"driver returned {connection.schema!r}, "
+            f"server returned {server_schema!r}"
+        )
+
+    def test_schema_stable_after_query(self, connection):
+        """conn.schema is unchanged (exact case) after an unrelated query."""
+        schema_before = connection.schema
+        assert schema_before is not None
+        assert schema_before != ""
+
+        with connection.cursor() as cur:
+            cur.execute("SELECT 1")
+
+        assert connection.schema == schema_before, (
+            f"conn.schema changed after a simple query: "
+            f"was {schema_before!r}, now {connection.schema!r}"
+        )
+
+
+class TestConnectionPropertyRoundtrip:
+    """conn.database/schema value must be usable in subsequent SQL."""
+
+    def test_database_property_usable_in_sql(self, connection, dashed_database):
+        """Reading conn.database after USE and using it in a new USE statement succeeds."""
+        with connection.cursor() as cur:
+            cur.execute(f'USE DATABASE "{dashed_database}"')
+            db = connection.database
+            assert db is not None
+
+            # This is the pattern that breaks when conn.database returns
+            # raw input with embedded quotes instead of the server name.
+            cur.execute(f'USE DATABASE "{db}"')
+
+        assert connection.database is not None
+        assert connection.database.lower() == db.lower()
+
+    def test_schema_property_usable_in_sql(self, connection, dashed_schema):
+        """Reading conn.schema after USE and using it in a new USE statement succeeds."""
+        with connection.cursor() as cur:
+            cur.execute(f'USE SCHEMA "{dashed_schema}"')
+            schema = connection.schema
+            assert schema is not None
+
+            cur.execute(f'USE SCHEMA "{schema}"')
+
+        assert connection.schema is not None
+        assert connection.schema.lower() == schema.lower()

--- a/python/tests/integ/test_connection_server_echoed_properties.py
+++ b/python/tests/integ/test_connection_server_echoed_properties.py
@@ -62,8 +62,7 @@ class TestConnectionPropertyReflectsUse:
         db = connection.database
         assert db is not None
         assert db.lower() == dashed_database.lower(), (
-            f"conn.database did not update after USE DATABASE: "
-            f"expected {dashed_database!r}, got {db!r}"
+            f"conn.database did not update after USE DATABASE: expected {dashed_database!r}, got {db!r}"
         )
 
     def test_schema_updates_after_use(self, connection, dashed_schema):
@@ -74,17 +73,14 @@ class TestConnectionPropertyReflectsUse:
         schema = connection.schema
         assert schema is not None
         assert schema.lower() == dashed_schema.lower(), (
-            f"conn.schema did not update after USE SCHEMA: "
-            f"expected {dashed_schema!r}, got {schema!r}"
+            f"conn.schema did not update after USE SCHEMA: expected {dashed_schema!r}, got {schema!r}"
         )
 
 
 class TestConnectionPropertyIsServerEchoed:
     """conn.database/schema must return server-echoed names, not raw input."""
 
-    def test_database_at_connect_returns_server_name(
-        self, connection_factory, dashed_database, cursor
-    ):
+    def test_database_at_connect_returns_server_name(self, connection_factory, dashed_database, cursor):
         """conn.database returns the server-echoed name, not raw connect() input."""
         cursor.execute(f'USE DATABASE "{dashed_database}"')
 
@@ -92,14 +88,11 @@ class TestConnectionPropertyIsServerEchoed:
             db = conn.database
             assert db is not None
             assert '"' not in db, (
-                f"conn.database contains quotes: {db!r}. "
-                "Expected the server-echoed name without SQL quotes."
+                f"conn.database contains quotes: {db!r}. Expected the server-echoed name without SQL quotes."
             )
             assert db.lower() == dashed_database.lower()
 
-    def test_quoted_database_param_returns_server_name(
-        self, connection_factory, dashed_database, cursor
-    ):
+    def test_quoted_database_param_returns_server_name(self, connection_factory, dashed_database, cursor):
         """When connect() receives a pre-quoted value, conn.database still returns the unquoted server name."""
         cursor.execute(f'USE DATABASE "{dashed_database}"')
 
@@ -124,9 +117,7 @@ class TestConnectionPropertyMatchesServerCase:
             server_db = cur.fetchone()[0]
 
         assert connection.database == server_db, (
-            f"conn.database case mismatch: "
-            f"driver returned {connection.database!r}, "
-            f"server returned {server_db!r}"
+            f"conn.database case mismatch: driver returned {connection.database!r}, server returned {server_db!r}"
         )
 
     def test_schema_case_matches_server(self, connection):
@@ -136,9 +127,7 @@ class TestConnectionPropertyMatchesServerCase:
             server_schema = cur.fetchone()[0]
 
         assert connection.schema == server_schema, (
-            f"conn.schema case mismatch: "
-            f"driver returned {connection.schema!r}, "
-            f"server returned {server_schema!r}"
+            f"conn.schema case mismatch: driver returned {connection.schema!r}, server returned {server_schema!r}"
         )
 
     def test_schema_stable_after_query(self, connection):
@@ -151,8 +140,7 @@ class TestConnectionPropertyMatchesServerCase:
             cur.execute("SELECT 1")
 
         assert connection.schema == schema_before, (
-            f"conn.schema changed after a simple query: "
-            f"was {schema_before!r}, now {connection.schema!r}"
+            f"conn.schema changed after a simple query: was {schema_before!r}, now {connection.schema!r}"
         )
 
 

--- a/python/tests/integ/test_connection_server_echoed_properties.py
+++ b/python/tests/integ/test_connection_server_echoed_properties.py
@@ -29,11 +29,16 @@ def dashed_database(cursor):
     Dashes force SQL quoting (``"my-db"``), making it easy to detect when
     the driver returns the raw user input instead of the server-echoed name.
     """
+    cursor.execute("SELECT CURRENT_DATABASE()")
+    original_db = cursor.fetchone()[0]
+
     db_name = _unique_name("test-dashed-db")
     cursor.execute(f'CREATE DATABASE "{db_name}"')
     try:
         yield db_name
     finally:
+        if original_db:
+            cursor.execute(f'USE DATABASE "{original_db}"')
         cursor.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
 
 
@@ -43,11 +48,17 @@ def dashed_schema(cursor):
 
     See ``dashed_database`` for why dashes are used.
     """
+    cursor.execute("SELECT CURRENT_SCHEMA()")
+    row = cursor.fetchone()
+    original_schema = row[0] if row and row[0] is not None else None
+
     schema_name = _unique_name("test-dashed-schema")
     cursor.execute(f'CREATE SCHEMA "{schema_name}"')
     try:
         yield schema_name
     finally:
+        if original_schema:
+            cursor.execute(f'USE SCHEMA "{original_schema}"')
         cursor.execute(f'DROP SCHEMA IF EXISTS "{schema_name}"')
 
 

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -7,10 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ConnectionGetInfoResponse,
     ConnectionHandle,
     DatabaseHandle,
 )
-from snowflake.connector.errors import ProgrammingError
+from snowflake.connector.errors import InterfaceError, ProgrammingError
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
@@ -226,3 +227,134 @@ class TestContextManagerUnit:
         with pytest.raises(ValueError, match="original error"):
             with connection:
                 raise ValueError("original error")
+
+
+class TestConnectionInfoProperties:
+    """Unit tests for Connection properties that read from _get_connection_info."""
+
+    @pytest.fixture
+    def conn_with_info(self, connection, mock_db_api):
+        """Set up a connection with a controllable ConnectionGetInfoResponse."""
+        mock_db_api.connection_get_info.return_value = ConnectionGetInfoResponse(
+            host="test.snowflakecomputing.com",
+            port=443,
+            account="test_acct",
+            user="test_usr",
+            role="SYSADMIN",
+            database="MY_DB",
+            schema="PUBLIC",
+            warehouse="COMPUTE_WH",
+            session_id=12345678,
+        )
+        return connection
+
+    def test_host_returns_value(self, conn_with_info):
+        assert conn_with_info.host == "test.snowflakecomputing.com"
+
+    def test_port_returns_value(self, conn_with_info):
+        assert conn_with_info.port == 443
+
+    def test_account_returns_value(self, conn_with_info):
+        assert conn_with_info.account == "test_acct"
+
+    def test_user_returns_value(self, conn_with_info):
+        assert conn_with_info.user == "test_usr"
+
+    def test_role_returns_value(self, conn_with_info):
+        assert conn_with_info.role == "SYSADMIN"
+
+    def test_database_returns_value(self, conn_with_info):
+        assert conn_with_info.database == "MY_DB"
+
+    def test_schema_returns_value(self, conn_with_info):
+        assert conn_with_info.schema == "PUBLIC"
+
+    def test_warehouse_returns_value(self, conn_with_info):
+        assert conn_with_info.warehouse == "COMPUTE_WH"
+
+    def test_session_id_returns_value(self, conn_with_info):
+        assert conn_with_info.session_id == 12345678
+
+
+class TestConnectionInfoPropertiesUnset:
+    """Test that properties return None when the underlying proto field is unset."""
+
+    @pytest.fixture
+    def conn_empty_info(self, connection, mock_db_api):
+        """Set up a connection with an empty ConnectionGetInfoResponse."""
+        mock_db_api.connection_get_info.return_value = ConnectionGetInfoResponse()
+        return connection
+
+    def test_host_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.host is None
+
+    def test_port_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.port is None
+
+    def test_account_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.account is None
+
+    def test_user_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.user is None
+
+    def test_role_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.role is None
+
+    def test_database_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.database is None
+
+    def test_schema_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.schema is None
+
+    def test_warehouse_none_when_unset(self, conn_empty_info):
+        assert conn_empty_info.warehouse is None
+
+    def test_session_id_raises_when_unset(self, conn_empty_info):
+        with pytest.raises(InterfaceError, match="Session ID is not available"):
+            _ = conn_empty_info.session_id
+
+
+class TestConnectionInfoDelegation:
+    """Test that each property delegates to _get_connection_info correctly."""
+
+    def test_each_access_calls_get_connection_info(self, connection, mock_db_api):
+        """Each property access should call _get_connection_info (no caching)."""
+        mock_db_api.connection_get_info.return_value = ConnectionGetInfoResponse(
+            host="h",
+            account="a",
+            user="u",
+            role="r",
+            database="d",
+            schema="s",
+            warehouse="w",
+            port=1,
+            session_id=1,
+        )
+
+        _ = connection.host
+        _ = connection.account
+        _ = connection.user
+        _ = connection.role
+        _ = connection.database
+        _ = connection.schema
+        _ = connection.warehouse
+        _ = connection.port
+        _ = connection.session_id
+
+        assert mock_db_api.connection_get_info.call_count == 9
+
+    def test_reflects_changing_values(self, connection, mock_db_api):
+        """Properties should reflect updated values from sf_core between calls."""
+        mock_db_api.connection_get_info.return_value = ConnectionGetInfoResponse(
+            database="DB_V1",
+            role="ROLE_V1",
+        )
+        assert connection.database == "DB_V1"
+        assert connection.role == "ROLE_V1"
+
+        mock_db_api.connection_get_info.return_value = ConnectionGetInfoResponse(
+            database="DB_V2",
+            role="ROLE_V2",
+        )
+        assert connection.database == "DB_V2"
+        assert connection.role == "ROLE_V2"

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -103,6 +103,13 @@ impl DatabaseDriverV1 {
                 let mut merged_params = init_params.unwrap_or_default();
                 merged_params.extend(login_result.session_parameters.unwrap_or_default());
 
+                let login_final_names = FinalSessionNames {
+                    database: login_result.database_name,
+                    schema: login_result.schema_name,
+                    warehouse: login_result.warehouse_name,
+                    role: login_result.role_name,
+                };
+
                 conn_ptr
                     .lock()
                     .map_err(|_| ConnectionLockingSnafu {}.build())?
@@ -112,6 +119,7 @@ impl DatabaseDriverV1 {
                         login_parameters.server_url.clone(),
                         login_parameters.client_info.clone(),
                         merged_params,
+                        login_final_names,
                     );
                 Ok(())
             }
@@ -211,6 +219,9 @@ pub struct Connection {
     pub session_parameters: Arc<RwLock<HashMap<String, String>>>,
     /// Session parameters to send during initialization (set before connection_init)
     pub init_session_parameters: Option<HashMap<String, String>>,
+    /// Server-echoed final names from login and query responses (e.g. after USE DATABASE).
+    /// Stored separately from session_parameters to keep concerns distinct.
+    pub final_session_names: RwLock<FinalSessionNames>,
 }
 
 impl Default for Connection {
@@ -230,6 +241,7 @@ impl Connection {
             client_info: None,
             session_parameters: Arc::new(RwLock::new(HashMap::new())),
             init_session_parameters: None,
+            final_session_names: RwLock::new(FinalSessionNames::default()),
         }
     }
 
@@ -245,6 +257,7 @@ impl Connection {
         server_url: String,
         client_info: ClientInfo,
         session_params: HashMap<String, String>,
+        final_names: FinalSessionNames,
     ) {
         // Use blocking_write since we're in a sync context during connection_init
         *self.tokens.blocking_write() = Some(tokens);
@@ -252,9 +265,12 @@ impl Connection {
         self.server_url = Some(server_url);
         self.client_info = Some(client_info);
 
-        // Populate session parameters cache (assume login always returns parameters)
         if let Ok(mut cache) = self.session_parameters.write() {
             *cache = session_params;
+        }
+
+        if let Ok(mut names) = self.final_session_names.write() {
+            *names = final_names;
         }
     }
 
@@ -313,19 +329,21 @@ impl Connection {
             );
         }
 
-        // 3. Server-echoed final names: update DATABASE/SCHEMA/WAREHOUSE/ROLE so that
-        //    conn.database etc. reflect changes from USE DATABASE, USE SCHEMA, etc.
-        if let Some(db) = &final_names.database {
-            cache.insert("DATABASE".into(), db.clone());
-        }
-        if let Some(sc) = &final_names.schema {
-            cache.insert("SCHEMA".into(), sc.clone());
-        }
-        if let Some(wh) = &final_names.warehouse {
-            cache.insert("WAREHOUSE".into(), wh.clone());
-        }
-        if let Some(rl) = &final_names.role {
-            cache.insert("ROLE".into(), rl.clone());
+        // 3. Server-echoed final names are stored separately in `final_session_names`
+        //    so that conn.database etc. reflect changes from USE DATABASE, USE SCHEMA, etc.
+        if let Ok(mut names) = self.final_session_names.write() {
+            if final_names.database.is_some() {
+                names.database.clone_from(&final_names.database);
+            }
+            if final_names.schema.is_some() {
+                names.schema.clone_from(&final_names.schema);
+            }
+            if final_names.warehouse.is_some() {
+                names.warehouse.clone_from(&final_names.warehouse);
+            }
+            if final_names.role.is_some() {
+                names.role.clone_from(&final_names.role);
+            }
         }
     }
 }
@@ -607,13 +625,28 @@ impl DatabaseDriverV1 {
 
                 let account = get_setting_string(&conn, param_names::ACCOUNT);
                 let user = get_setting_string(&conn, param_names::USER);
-                let role = get_session_or_setting(&conn, "ROLE", param_names::ROLE);
-                let database =
-                    get_session_or_setting(&conn, "DATABASE", param_names::DATABASE);
-                let schema =
-                    get_session_or_setting(&conn, "SCHEMA", param_names::SCHEMA);
-                let warehouse =
-                    get_session_or_setting(&conn, "WAREHOUSE", param_names::WAREHOUSE);
+
+                let final_names = conn
+                    .final_session_names
+                    .read()
+                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let role = final_names
+                    .role
+                    .clone()
+                    .or_else(|| get_session_or_setting(&conn, "ROLE", param_names::ROLE));
+                let database = final_names
+                    .database
+                    .clone()
+                    .or_else(|| get_session_or_setting(&conn, "DATABASE", param_names::DATABASE));
+                let schema = final_names
+                    .schema
+                    .clone()
+                    .or_else(|| get_session_or_setting(&conn, "SCHEMA", param_names::SCHEMA));
+                let warehouse = final_names
+                    .warehouse
+                    .clone()
+                    .or_else(|| get_session_or_setting(&conn, "WAREHOUSE", param_names::WAREHOUSE));
+                drop(final_names);
 
                 Ok(ConnectionInfo {
                     host,
@@ -848,5 +881,58 @@ mod tests {
         assert_eq!(info.role, Some("session_role".into()));
 
         ds.connection_release(handle).unwrap();
+    }
+
+    #[test]
+    fn connection_get_info_final_names_override_session_params() {
+        let ds = driver_state();
+        let handle = ds.connection_new();
+        ds.connection_set_option(
+            handle,
+            "database".into(),
+            Setting::String("setting_db".into()),
+        )
+        .unwrap();
+
+        if let Some(conn_ptr) = ds.connections.get_obj(handle) {
+            let conn = conn_ptr.lock().unwrap();
+            conn.session_parameters
+                .write()
+                .unwrap()
+                .insert("DATABASE".into(), "session_db".into());
+            conn.final_session_names.write().unwrap().database = Some("final_db".into());
+        }
+
+        let info = ds.connection_get_info(handle).unwrap();
+        assert_eq!(info.database, Some("final_db".into()));
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[test]
+    fn update_session_params_cache_stores_final_names_separately() {
+        let conn = Connection::new();
+        let final_names = FinalSessionNames {
+            database: Some("new_db".into()),
+            schema: Some("new_schema".into()),
+            warehouse: None,
+            role: None,
+        };
+
+        conn.update_session_params_cache("SELECT 1", None, &final_names);
+
+        let cache = conn.session_parameters.read().unwrap();
+        assert!(
+            cache.get("DATABASE").is_none(),
+            "final names should not be stored in session_parameters"
+        );
+        assert!(
+            cache.get("SCHEMA").is_none(),
+            "final names should not be stored in session_parameters"
+        );
+
+        let names = conn.final_session_names.read().unwrap();
+        assert_eq!(names.database, Some("new_db".into()));
+        assert_eq!(names.schema, Some("new_schema".into()));
     }
 }

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -265,6 +265,10 @@ impl Connection {
         response_parameters: Option<
             &Vec<crate::rest::snowflake::query_response::NameValueParameter>,
         >,
+        final_database_name: Option<&String>,
+        final_schema_name: Option<&String>,
+        final_warehouse_name: Option<&String>,
+        final_role_name: Option<&String>,
     ) {
         let mut cache = match self.session_parameters.write() {
             Ok(cache) => cache,
@@ -310,6 +314,21 @@ impl Connection {
                     })
                     .filter(|(k, _)| !k.is_empty()),
             );
+        }
+
+        // 3. Server-echoed final names: update DATABASE/SCHEMA/WAREHOUSE/ROLE so that
+        //    conn.database etc. reflect changes from USE DATABASE, USE SCHEMA, etc.
+        if let Some(db) = final_database_name {
+            cache.insert("DATABASE".into(), db.clone());
+        }
+        if let Some(sc) = final_schema_name {
+            cache.insert("SCHEMA".into(), sc.clone());
+        }
+        if let Some(wh) = final_warehouse_name {
+            cache.insert("WAREHOUSE".into(), wh.clone());
+        }
+        if let Some(rl) = final_role_name {
+            cache.insert("ROLE".into(), rl.clone());
         }
     }
 }

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -331,18 +331,26 @@ impl Connection {
 
         // 3. Server-echoed final names are stored separately in `final_session_names`
         //    so that conn.database etc. reflect changes from USE DATABASE, USE SCHEMA, etc.
-        if let Ok(mut names) = self.final_session_names.write() {
-            if final_names.database.is_some() {
-                names.database.clone_from(&final_names.database);
+        match self.final_session_names.write() {
+            Ok(mut names) => {
+                if final_names.database.is_some() {
+                    names.database = final_names.database.clone();
+                }
+                if final_names.schema.is_some() {
+                    names.schema = final_names.schema.clone();
+                }
+                if final_names.warehouse.is_some() {
+                    names.warehouse = final_names.warehouse.clone();
+                }
+                if final_names.role.is_some() {
+                    names.role = final_names.role.clone();
+                }
             }
-            if final_names.schema.is_some() {
-                names.schema.clone_from(&final_names.schema);
-            }
-            if final_names.warehouse.is_some() {
-                names.warehouse.clone_from(&final_names.warehouse);
-            }
-            if final_names.role.is_some() {
-                names.role.clone_from(&final_names.role);
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to acquire write lock for final_session_names"
+                );
             }
         }
     }
@@ -626,6 +634,13 @@ impl DatabaseDriverV1 {
                 let account = get_setting_string(&conn, param_names::ACCOUNT);
                 let user = get_setting_string(&conn, param_names::USER);
 
+                // Resolution order for session-scoped values:
+                //   1. final_session_names  (server-echoed via login sessionInfo or query finalXxxName)
+                //   2. session_parameters   (server-returned session params, only pre-login / missing sessionInfo)
+                //   3. connection settings   (original kwargs supplied by the caller)
+                // After a successful login, final_session_names is always populated, so the
+                // or_else branch only fires before connection_init or when the server omits
+                // the field from sessionInfo.
                 let final_names = conn
                     .final_session_names
                     .read()

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -9,7 +9,7 @@ use super::global_state::DatabaseDriverV1;
 use super::validation::{ValidationIssue, resolve_and_apply_options};
 use crate::config::ParamStore;
 use crate::config::config_manager;
-use crate::config::param_registry::param_names;
+use crate::config::param_registry::{ParamKey, param_names};
 use crate::config::path_resolver::ConfigPaths;
 use crate::config::rest_parameters::{ClientInfo, LoginParameters};
 use crate::config::retry::RetryPolicy;
@@ -508,6 +508,45 @@ pub struct ConnectionInfo {
     pub session_token: Option<SensitiveString>,
     /// The server-assigned session ID
     pub session_id: Option<i64>,
+    /// The Snowflake account name
+    pub account: Option<String>,
+    /// The authenticated user name
+    pub user: Option<String>,
+    /// The current role
+    pub role: Option<String>,
+    /// The current database
+    pub database: Option<String>,
+    /// The current schema
+    pub schema: Option<String>,
+    /// The current warehouse
+    pub warehouse: Option<String>,
+}
+
+fn get_setting_string(conn: &Connection, key: ParamKey) -> Option<String> {
+    conn.settings.get(key).and_then(|s| {
+        if let Setting::String(v) = s {
+            Some(v.clone())
+        } else {
+            None
+        }
+    })
+}
+
+/// Read a session-level value: check the session parameter cache first (server
+/// may have changed it via USE DATABASE / USE ROLE / etc.), then fall back to
+/// the original connection setting.
+fn get_session_or_setting(
+    conn: &Connection,
+    param_name: &str,
+    setting_key: ParamKey,
+) -> Option<String> {
+    if let Ok(cache) = conn.session_parameters.read()
+        && let Some(v) = cache.get(param_name)
+        && !v.is_empty()
+    {
+        return Some(v.clone());
+    }
+    get_setting_string(conn, setting_key)
 }
 
 impl DatabaseDriverV1 {
@@ -519,14 +558,7 @@ impl DatabaseDriverV1 {
                     .lock()
                     .map_err(|_| ConnectionLockingSnafu {}.build())?;
 
-                // Extract host and port from settings
-                let host = conn.settings.get(param_names::HOST).and_then(|s| {
-                    if let Setting::String(v) = s {
-                        Some(v.clone())
-                    } else {
-                        None
-                    }
-                });
+                let host = get_setting_string(&conn, param_names::HOST);
 
                 let port = conn.settings.get(param_names::PORT).and_then(|s| {
                     if let Setting::Int(v) = s {
@@ -536,10 +568,8 @@ impl DatabaseDriverV1 {
                     }
                 });
 
-                // Get server_url
                 let server_url = conn.server_url.clone();
 
-                // Get session token and session ID from tokens
                 let (session_token, session_id) = {
                     let tokens_guard = conn.tokens.blocking_read();
                     match tokens_guard.as_ref() {
@@ -550,12 +580,28 @@ impl DatabaseDriverV1 {
                     }
                 };
 
+                let account = get_setting_string(&conn, param_names::ACCOUNT);
+                let user = get_setting_string(&conn, param_names::USER);
+                let role = get_session_or_setting(&conn, "ROLE", param_names::ROLE);
+                let database =
+                    get_session_or_setting(&conn, "DATABASE", param_names::DATABASE);
+                let schema =
+                    get_session_or_setting(&conn, "SCHEMA", param_names::SCHEMA);
+                let warehouse =
+                    get_session_or_setting(&conn, "WAREHOUSE", param_names::WAREHOUSE);
+
                 Ok(ConnectionInfo {
                     host,
                     port,
                     server_url,
                     session_token,
                     session_id,
+                    account,
+                    user,
+                    role,
+                    database,
+                    schema,
+                    warehouse,
                 })
             }
             None => InvalidArgumentSnafu {
@@ -589,5 +635,193 @@ impl DatabaseDriverV1 {
             }
             .fail(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::apis::database_driver_v1::driver_state;
+    use crate::config::param_registry::param_names;
+
+    fn make_connection_with_settings(settings: Vec<(&str, Setting)>) -> Connection {
+        let mut conn = Connection::new();
+        for (key, value) in settings {
+            conn.settings.insert(key.to_string(), value);
+        }
+        conn
+    }
+
+    #[test]
+    fn get_setting_string_returns_value() {
+        let conn =
+            make_connection_with_settings(vec![("host", Setting::String("example.com".into()))]);
+        assert_eq!(
+            get_setting_string(&conn, param_names::HOST),
+            Some("example.com".into())
+        );
+    }
+
+    #[test]
+    fn get_setting_string_returns_none_for_missing_key() {
+        let conn = Connection::new();
+        assert_eq!(get_setting_string(&conn, param_names::HOST), None);
+    }
+
+    #[test]
+    fn get_setting_string_returns_none_for_non_string_type() {
+        let conn = make_connection_with_settings(vec![("port", Setting::Int(443))]);
+        assert_eq!(get_setting_string(&conn, param_names::PORT), None);
+    }
+
+    #[test]
+    fn get_session_or_setting_prefers_session_parameter() {
+        let conn =
+            make_connection_with_settings(vec![("database", Setting::String("setting_db".into()))]);
+        conn.session_parameters
+            .write()
+            .unwrap()
+            .insert("DATABASE".into(), "session_db".into());
+
+        assert_eq!(
+            get_session_or_setting(&conn, "DATABASE", param_names::DATABASE),
+            Some("session_db".into())
+        );
+    }
+
+    #[test]
+    fn get_session_or_setting_falls_back_to_setting() {
+        let conn =
+            make_connection_with_settings(vec![("database", Setting::String("setting_db".into()))]);
+
+        assert_eq!(
+            get_session_or_setting(&conn, "DATABASE", param_names::DATABASE),
+            Some("setting_db".into())
+        );
+    }
+
+    #[test]
+    fn get_session_or_setting_ignores_empty_session_param() {
+        let conn =
+            make_connection_with_settings(vec![("role", Setting::String("setting_role".into()))]);
+        conn.session_parameters
+            .write()
+            .unwrap()
+            .insert("ROLE".into(), String::new());
+
+        assert_eq!(
+            get_session_or_setting(&conn, "ROLE", param_names::ROLE),
+            Some("setting_role".into())
+        );
+    }
+
+    #[test]
+    fn get_session_or_setting_returns_none_when_both_absent() {
+        let conn = Connection::new();
+        assert_eq!(
+            get_session_or_setting(&conn, "ROLE", param_names::ROLE),
+            None
+        );
+    }
+
+    #[test]
+    fn connection_get_info_returns_all_settings() {
+        let ds = driver_state();
+        let handle = ds.connection_new();
+        ds.connection_set_option(
+            handle,
+            "host".into(),
+            Setting::String("snow.example.com".into()),
+        )
+        .unwrap();
+        ds.connection_set_option(handle, "port".into(), Setting::Int(8080))
+            .unwrap();
+        ds.connection_set_option(
+            handle,
+            "account".into(),
+            Setting::String("my_account".into()),
+        )
+        .unwrap();
+        ds.connection_set_option(handle, "user".into(), Setting::String("my_user".into()))
+            .unwrap();
+        ds.connection_set_option(handle, "role".into(), Setting::String("my_role".into()))
+            .unwrap();
+        ds.connection_set_option(handle, "database".into(), Setting::String("my_db".into()))
+            .unwrap();
+        ds.connection_set_option(handle, "schema".into(), Setting::String("my_schema".into()))
+            .unwrap();
+        ds.connection_set_option(handle, "warehouse".into(), Setting::String("my_wh".into()))
+            .unwrap();
+
+        let info = ds.connection_get_info(handle).unwrap();
+
+        assert_eq!(info.host, Some("snow.example.com".into()));
+        assert_eq!(info.port, Some(8080));
+        assert_eq!(info.account, Some("my_account".into()));
+        assert_eq!(info.user, Some("my_user".into()));
+        assert_eq!(info.role, Some("my_role".into()));
+        assert_eq!(info.database, Some("my_db".into()));
+        assert_eq!(info.schema, Some("my_schema".into()));
+        assert_eq!(info.warehouse, Some("my_wh".into()));
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[test]
+    fn connection_get_info_returns_none_for_unset_fields() {
+        let ds = driver_state();
+        let handle = ds.connection_new();
+
+        let info = ds.connection_get_info(handle).unwrap();
+
+        assert_eq!(info.host, None);
+        assert_eq!(info.port, None);
+        assert_eq!(info.account, None);
+        assert_eq!(info.user, None);
+        assert_eq!(info.role, None);
+        assert_eq!(info.database, None);
+        assert_eq!(info.schema, None);
+        assert_eq!(info.warehouse, None);
+        assert!(info.session_token.is_none());
+        assert_eq!(info.session_id, None);
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[test]
+    fn connection_get_info_session_params_override_settings() {
+        let ds = driver_state();
+        let handle = ds.connection_new();
+        ds.connection_set_option(
+            handle,
+            "database".into(),
+            Setting::String("original_db".into()),
+        )
+        .unwrap();
+        ds.connection_set_option(
+            handle,
+            "role".into(),
+            Setting::String("original_role".into()),
+        )
+        .unwrap();
+
+        if let Some(conn_ptr) = ds.connections.get_obj(handle) {
+            let conn = conn_ptr.lock().unwrap();
+            conn.session_parameters
+                .write()
+                .unwrap()
+                .insert("DATABASE".into(), "session_db".into());
+            conn.session_parameters
+                .write()
+                .unwrap()
+                .insert("ROLE".into(), "session_role".into());
+        }
+
+        let info = ds.connection_get_info(handle).unwrap();
+
+        assert_eq!(info.database, Some("session_db".into()));
+        assert_eq!(info.role, Some("session_role".into()));
+
+        ds.connection_release(handle).unwrap();
     }
 }

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -265,10 +265,7 @@ impl Connection {
         response_parameters: Option<
             &Vec<crate::rest::snowflake::query_response::NameValueParameter>,
         >,
-        final_database_name: Option<&String>,
-        final_schema_name: Option<&String>,
-        final_warehouse_name: Option<&String>,
-        final_role_name: Option<&String>,
+        final_names: &FinalSessionNames,
     ) {
         let mut cache = match self.session_parameters.write() {
             Ok(cache) => cache,
@@ -318,16 +315,16 @@ impl Connection {
 
         // 3. Server-echoed final names: update DATABASE/SCHEMA/WAREHOUSE/ROLE so that
         //    conn.database etc. reflect changes from USE DATABASE, USE SCHEMA, etc.
-        if let Some(db) = final_database_name {
+        if let Some(db) = &final_names.database {
             cache.insert("DATABASE".into(), db.clone());
         }
-        if let Some(sc) = final_schema_name {
+        if let Some(sc) = &final_names.schema {
             cache.insert("SCHEMA".into(), sc.clone());
         }
-        if let Some(wh) = final_warehouse_name {
+        if let Some(wh) = &final_names.warehouse {
             cache.insert("WAREHOUSE".into(), wh.clone());
         }
-        if let Some(rl) = final_role_name {
+        if let Some(rl) = &final_names.role {
             cache.insert("ROLE".into(), rl.clone());
         }
     }
@@ -512,6 +509,15 @@ impl RefreshContext {
             },
         }
     }
+}
+
+/// Server-echoed final names from query responses (e.g. after USE DATABASE).
+#[derive(Debug, Clone, Default)]
+pub struct FinalSessionNames {
+    pub database: Option<String>,
+    pub schema: Option<String>,
+    pub warehouse: Option<String>,
+    pub role: Option<String>,
 }
 
 /// Connection information returned by connection_get_info

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -349,22 +349,22 @@ impl DatabaseDriverV1 {
             }
         })?;
 
-    if response.success {
-        let conn = stmt
-            .conn
-            .lock()
-            .map_err(|_| ConnectionLockingSnafu.build())?;
-        conn.update_session_params_cache(
-            query,
-            response.data.parameters.as_ref(),
-            &super::connection::FinalSessionNames {
-                database: response.data.final_database_name.clone(),
-                schema: response.data.final_schema_name.clone(),
-                warehouse: response.data.final_warehouse_name.clone(),
-                role: response.data.final_role_name.clone(),
-            },
-        );
-    }
+        if response.success {
+            let conn = stmt
+                .conn
+                .lock()
+                .map_err(|_| ConnectionLockingSnafu.build())?;
+            conn.update_session_params_cache(
+                query,
+                response.data.parameters.as_ref(),
+                &super::connection::FinalSessionNames {
+                    database: response.data.final_database_name.clone(),
+                    schema: response.data.final_schema_name.clone(),
+                    warehouse: response.data.final_warehouse_name.clone(),
+                    role: response.data.final_role_name.clone(),
+                },
+            );
+        }
 
         let query_result = rt
             .block_on(process_query_response(&response.data, &http_client))

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -357,10 +357,12 @@ impl DatabaseDriverV1 {
         conn.update_session_params_cache(
             query,
             response.data.parameters.as_ref(),
-            response.data.final_database_name.as_ref(),
-            response.data.final_schema_name.as_ref(),
-            response.data.final_warehouse_name.as_ref(),
-            response.data.final_role_name.as_ref(),
+            &super::connection::FinalSessionNames {
+                database: response.data.final_database_name.clone(),
+                schema: response.data.final_schema_name.clone(),
+                warehouse: response.data.final_warehouse_name.clone(),
+                role: response.data.final_role_name.clone(),
+            },
         );
     }
 

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -349,13 +349,20 @@ impl DatabaseDriverV1 {
             }
         })?;
 
-        if response.success {
-            let conn = stmt
-                .conn
-                .lock()
-                .map_err(|_| ConnectionLockingSnafu.build())?;
-            conn.update_session_params_cache(query, response.data.parameters.as_ref());
-        }
+    if response.success {
+        let conn = stmt
+            .conn
+            .lock()
+            .map_err(|_| ConnectionLockingSnafu.build())?;
+        conn.update_session_params_cache(
+            query,
+            response.data.parameters.as_ref(),
+            response.data.final_database_name.as_ref(),
+            response.data.final_schema_name.as_ref(),
+            response.data.final_warehouse_name.as_ref(),
+            response.data.final_role_name.as_ref(),
+        );
+    }
 
         let query_result = rt
             .block_on(process_query_response(&response.data, &http_client))

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -201,6 +201,12 @@ impl From<ConnectionInfo> for ConnectionGetInfoResponse {
             server_url: info.server_url,
             session_token: info.session_token.map(|t| t.reveal().to_string()),
             session_id: info.session_id,
+            account: info.account,
+            user: info.user,
+            role: info.role,
+            database: info.database,
+            schema: info.schema,
+            warehouse: info.warehouse,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -95,13 +95,13 @@ pub struct NameValueParameter {
 #[derive(Debug, Deserialize)]
 pub struct AuthResponseSessionInfo {
     #[serde(rename = "databaseName")]
-    pub _database_name: Option<String>,
+    pub database_name: Option<String>,
     #[serde(rename = "schemaName")]
-    pub _schema_name: Option<String>,
+    pub schema_name: Option<String>,
     #[serde(rename = "warehouseName")]
-    pub _warehouse_name: Option<String>,
+    pub warehouse_name: Option<String>,
     #[serde(rename = "roleName")]
-    pub _role_name: Option<String>,
+    pub role_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -153,7 +153,7 @@ pub struct AuthResponseMain {
     #[serde(rename = "parameters")]
     pub _parameters: Option<Vec<NameValueParameter>>,
     #[serde(rename = "sessionInfo")]
-    pub _session_info: Option<AuthResponseSessionInfo>,
+    pub session_info: Option<AuthResponseSessionInfo>,
     #[serde(rename = "tokenUrl")]
     pub _token_url: Option<String>,
     #[serde(rename = "ssoUrl")]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -54,6 +54,14 @@ pub struct LoginResult {
     pub tokens: SessionTokens,
     /// Session parameters returned by the server
     pub session_parameters: Option<HashMap<String, String>>,
+    /// Server-echoed database name from sessionInfo
+    pub database_name: Option<String>,
+    /// Server-echoed schema name from sessionInfo
+    pub schema_name: Option<String>,
+    /// Server-echoed warehouse name from sessionInfo
+    pub warehouse_name: Option<String>,
+    /// Server-echoed role name from sessionInfo
+    pub role_name: Option<String>,
 }
 
 impl SessionTokens {
@@ -332,7 +340,7 @@ pub async fn snowflake_login_with_client(
     let master_expires_at = auth_response.data.master_validity.map(|d| now + d);
 
     // Extract session parameters from auth response
-    let mut session_params = auth_response.data._parameters.map(|params| {
+    let session_params = auth_response.data._parameters.map(|params| {
         params
             .iter()
             .filter_map(|param| {
@@ -357,24 +365,19 @@ pub async fn snowflake_login_with_client(
             .collect::<HashMap<String, String>>()
     });
 
-    // Inject server-echoed `sessionInfo` names (`databaseName`, etc.) so that
-    // conn.database / conn.schema / conn.warehouse / conn.role return the
-    // canonical names the server resolved, not the raw user input.
-    if let Some(ref info) = auth_response.data.session_info {
-        let params = session_params.get_or_insert_with(HashMap::new);
-        if let Some(db) = &info.database_name {
-            params.insert("DATABASE".into(), db.clone());
-        }
-        if let Some(sc) = &info.schema_name {
-            params.insert("SCHEMA".into(), sc.clone());
-        }
-        if let Some(wh) = &info.warehouse_name {
-            params.insert("WAREHOUSE".into(), wh.clone());
-        }
-        if let Some(rl) = &info.role_name {
-            params.insert("ROLE".into(), rl.clone());
-        }
-    }
+    // Extract server-echoed sessionInfo names separately so they can be
+    // stored on the connection as `final_session_names` (not mixed into
+    // session parameters).
+    let (database_name, schema_name, warehouse_name, role_name) =
+        match &auth_response.data.session_info {
+            Some(info) => (
+                info.database_name.clone(),
+                info.schema_name.clone(),
+                info.warehouse_name.clone(),
+                info.role_name.clone(),
+            ),
+            None => (None, None, None, None),
+        };
 
     tracing::info!(
         session_id,
@@ -392,6 +395,10 @@ pub async fn snowflake_login_with_client(
             master_expires_at,
         },
         session_parameters: session_params,
+        database_name,
+        schema_name,
+        warehouse_name,
+        role_name,
     })
 }
 

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -332,7 +332,7 @@ pub async fn snowflake_login_with_client(
     let master_expires_at = auth_response.data.master_validity.map(|d| now + d);
 
     // Extract session parameters from auth response
-    let session_params = auth_response.data._parameters.map(|params| {
+    let mut session_params = auth_response.data._parameters.map(|params| {
         params
             .iter()
             .filter_map(|param| {
@@ -356,6 +356,25 @@ pub async fn snowflake_login_with_client(
             })
             .collect::<HashMap<String, String>>()
     });
+
+    // Inject server-echoed session info (finalDatabaseName, etc.) so that
+    // conn.database / conn.schema / conn.warehouse / conn.role return the
+    // canonical names the server resolved, not the raw user input.
+    if let Some(ref info) = auth_response.data.session_info {
+        let params = session_params.get_or_insert_with(HashMap::new);
+        if let Some(db) = &info.database_name {
+            params.insert("DATABASE".into(), db.clone());
+        }
+        if let Some(sc) = &info.schema_name {
+            params.insert("SCHEMA".into(), sc.clone());
+        }
+        if let Some(wh) = &info.warehouse_name {
+            params.insert("WAREHOUSE".into(), wh.clone());
+        }
+        if let Some(rl) = &info.role_name {
+            params.insert("ROLE".into(), rl.clone());
+        }
+    }
 
     tracing::info!(
         session_id,

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -357,7 +357,7 @@ pub async fn snowflake_login_with_client(
             .collect::<HashMap<String, String>>()
     });
 
-    // Inject server-echoed session info (finalDatabaseName, etc.) so that
+    // Inject server-echoed `sessionInfo` names (`databaseName`, etc.) so that
     // conn.database / conn.schema / conn.warehouse / conn.role return the
     // canonical names the server resolved, not the raw user input.
     if let Some(ref info) = auth_response.data.session_info {

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -65,13 +65,13 @@ pub struct Data {
     #[serde(rename = "databaseProvider")]
     _database_provider: Option<String>,
     #[serde(rename = "finalDatabaseName")]
-    _final_database_name: Option<String>,
+    pub final_database_name: Option<String>,
     #[serde(rename = "finalSchemaName")]
-    _final_schema_name: Option<String>,
+    pub final_schema_name: Option<String>,
     #[serde(rename = "finalWarehouseName")]
-    _final_warehouse_name: Option<String>,
+    pub final_warehouse_name: Option<String>,
     #[serde(rename = "finalRoleName")]
-    _final_role_name: Option<String>,
+    pub final_role_name: Option<String>,
     #[serde(rename = "numberOfBinds")]
     _number_of_binds: Option<i32>,
     #[serde(rename = "statementTypeId")]


### PR DESCRIPTION
Connection properties (account, user, role, database, schema, warehouse, host, port, session_id) now read live values from the core driver via _get_connection_info() instead of returning the original kwargs. For session-scoped values (role, database, schema, warehouse), the Rust core checks the session parameter cache first so that USE DATABASE/ROLE/etc. changes are reflected.

Made-with: Cursor