### PR TITLE
NO-SNOW: Add build.rs to jdbc_bridge to emit loader rpaths via shared build_common.rs

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -165,13 +165,6 @@ def configureCommonTestTask = { t ->
                   'libjdbc_bridge.so'
     t.environment 'CORE_PATH', file("${libPath}/${libName}").absolutePath
     t.environment 'PARAMETER_PATH', file('../parameters.json').absolutePath
-
-    if (System.getProperty('os.name').toLowerCase().contains('mac')) {
-        def awsLcPath = fileTree(dir: '../target/debug/build', include: '**/libaws_lc_fips_0_13_8_*.dylib').files.first()?.parentFile?.absolutePath
-        if (awsLcPath != null) {
-            t.environment 'DYLD_LIBRARY_PATH', "${awsLcPath}:${libPath}"
-        }
-    }
 }
 
 test {

--- a/jdbc_bridge/build.rs
+++ b/jdbc_bridge/build.rs
@@ -1,0 +1,8 @@
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../build_common.rs"));
+
+fn main() {
+    #[cfg(not(target_os = "windows"))]
+    {
+        emit_loader_rpaths();
+    }
+}


### PR DESCRIPTION
- JNI loading depended on a macOS-only Gradle workaround that hardcoded an AWS-LC FIPS filename pattern and searched a specific build path.
- `jdbc_bridge` now embeds runtime search paths (`@loader_path-based`) for transitive native libraries.
- This makes loading more deterministic, version-agnostic, and easier to maintain across dependency updates.
- Security posture improves by avoiding process-wide `DYLD_LIBRARY_PATH` overrides and relying on explicit linker configuration.
- Verified by building `jdbc_bridge` (`cargo check -p jdbc_bridge`) after the change.