### PR TITLE
Switch ODBC to json binding interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ dependencies = [
  "error_trace",
  "odbc-sys",
  "proto_utils",
+ "serde_json",
  "sf_core",
  "snafu 0.8.9",
  "tracing",

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -16,6 +16,7 @@ odbc-sys = "0.25.1"
 arrow = { version = "56.0.0", features = ["ffi"] }
 chrono = "0.4.43"
 base64 = "0.22.1"
+serde_json = "1.0"
 
 proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -9,6 +9,7 @@ use crate::{
     api::{InfoType, SqlState, diagnostic::DiagnosticRecord},
     conversion::{ConversionError, error::WriteOdbcError},
     write_arrow::ArrowBindingError,
+    write_json::JsonBindingError,
 };
 use arrow::error::ArrowError;
 use odbc_sys as sql;
@@ -252,6 +253,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("Error binding JSON parameters: {source:?}"))]
+    JsonBinding {
+        source: JsonBindingError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Error binding parameters: {parameters}"))]
     ParameterBinding {
         parameters: String,
@@ -421,6 +429,7 @@ impl OdbcError {
             OdbcError::TextConversionFromUtf8 { .. } => SqlState::StringDataRightTruncated,
             OdbcError::TextConversionFromUtf16 { .. } => SqlState::StringDataRightTruncated,
             OdbcError::ArrowBinding { .. } => SqlState::GeneralError,
+            OdbcError::JsonBinding { .. } => SqlState::GeneralError,
             OdbcError::CoreError {
                 source: CoreProtobufError::Application { error, message, .. },
                 ..

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -246,6 +246,7 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[allow(dead_code)]
     #[snafu(display("Error binding arrow parameters: {source:?}"))]
     ArrowBinding {
         source: ArrowBindingError,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -53,8 +53,7 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
                 query: statement_text.to_string(),
             })?;
 
-            let (bindings, _json_owner) =
-                apply_parameter_bindings(&stmt.parameter_bindings)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
 
             let response =
                 DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
@@ -208,8 +207,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) =
-                apply_parameter_bindings(&stmt.parameter_bindings)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
 
             let response =
                 DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
@@ -300,8 +298,7 @@ fn apply_parameter_bindings(
         parameter_bindings.len()
     );
 
-    let json_string =
-        odbc_bindings_to_json(parameter_bindings).context(JsonBindingSnafu {})?;
+    let json_string = odbc_bindings_to_json(parameter_bindings).context(JsonBindingSnafu {})?;
 
     let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
     let json_data_len = json_string.len();

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -14,7 +14,7 @@ use odbc_sys as sql;
 use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::{
     ArrowArrayStreamPtr, BinaryDataPtr, ConnectionGetParameterRequest, ConnectionHandle,
-    QueryBindings, StatementExecuteQueryRequest, StatementExecuteQueryResponse, StatementHandle,
+    QueryBindings, StatementExecuteQueryRequest, StatementExecuteQueryResponse,
     StatementPrepareRequest, StatementSetSqlQueryRequest, query_bindings,
 };
 use snafu::ResultExt;

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -1,42 +1,24 @@
 use crate::api::api_utils::{cstr_to_string, utf16_to_string};
 use crate::api::error::{
-    ArrowArrayStreamReaderCreationSnafu, ArrowBindingSnafu, DisconnectedSnafu,
-    InvalidBufferLengthSnafu, InvalidCursorStateSnafu, InvalidHandleSnafu,
-    InvalidParameterNumberSnafu, NoMoreDataSnafu, Required,
+    ArrowArrayStreamReaderCreationSnafu, DisconnectedSnafu, InvalidBufferLengthSnafu,
+    InvalidCursorStateSnafu, InvalidHandleSnafu, InvalidParameterNumberSnafu, JsonBindingSnafu,
+    NoMoreDataSnafu, Required,
 };
 use crate::api::{ConnectionState, OdbcResult, ParameterBinding, StatementState, stmt_from_handle};
 use crate::cdata_types::CDataType;
 use crate::conversion::Binding;
-use crate::write_arrow::odbc_bindings_to_arrow_bindings;
+use crate::write_json::odbc_bindings_to_json;
 use arrow::array::RecordBatchReader;
-use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use odbc_sys as sql;
 use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::{
-    ArrowArrayPtr, ArrowArrayStreamPtr, ArrowSchemaPtr, ConnectionGetParameterRequest,
-    ConnectionHandle, StatementBindRequest, StatementExecuteQueryRequest,
-    StatementExecuteQueryResponse, StatementHandle, StatementPrepareRequest,
-    StatementSetSqlQueryRequest,
+    ArrowArrayStreamPtr, BinaryDataPtr, ConnectionGetParameterRequest, ConnectionHandle,
+    QueryBindings, StatementExecuteQueryRequest, StatementExecuteQueryResponse, StatementHandle,
+    StatementPrepareRequest, StatementSetSqlQueryRequest, query_bindings,
 };
 use snafu::ResultExt;
 use tracing;
-
-fn protobuf_from_ffi_arrow_array(raw: *mut FFI_ArrowArray) -> ArrowArrayPtr {
-    let len = std::mem::size_of::<*mut FFI_ArrowArray>();
-    let buf_ptr = std::ptr::addr_of!(raw) as *const u8;
-    let slice = unsafe { std::slice::from_raw_parts(buf_ptr, len) };
-    let vec = slice.to_vec();
-    ArrowArrayPtr { value: vec }
-}
-
-fn protobuf_from_ffi_arrow_schema(raw: *mut FFI_ArrowSchema) -> ArrowSchemaPtr {
-    let len = std::mem::size_of::<*mut FFI_ArrowSchema>();
-    let buf_ptr = std::ptr::addr_of!(raw) as *const u8;
-    let slice = unsafe { std::slice::from_raw_parts(buf_ptr, len) };
-    let vec = slice.to_vec();
-    ArrowSchemaPtr { value: vec }
-}
 
 pub fn exec_direct_n(
     statement_handle: sql::Handle,
@@ -71,12 +53,13 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
                 query: statement_text.to_string(),
             })?;
 
-            apply_parameter_bindings(&stmt.stmt_handle, &stmt.parameter_bindings)?;
+            let (bindings, _json_owner) =
+                apply_parameter_bindings(&stmt.parameter_bindings)?;
 
             let response =
                 DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt.stmt_handle),
-                    bindings: None,
+                    bindings,
                 });
 
             tracing::info!("exec_direct: response={:?}", response);
@@ -225,12 +208,13 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             db_handle: _,
             conn_handle,
         } => {
-            apply_parameter_bindings(&stmt.stmt_handle, &stmt.parameter_bindings)?;
+            let (bindings, _json_owner) =
+                apply_parameter_bindings(&stmt.parameter_bindings)?;
 
             let response =
                 DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt.stmt_handle),
-                    bindings: None,
+                    bindings,
                 })?;
 
             tracing::info!("execute: Successfully executed statement");
@@ -300,29 +284,40 @@ fn create_execute_state(response: StatementExecuteQueryResponse) -> OdbcResult<S
     })
 }
 
+/// Build JSON query bindings from ODBC parameter bindings.
+///
+/// Returns `(bindings, json_owner)`. The caller **must** keep `json_owner` alive
+/// until after the bindings have been consumed by `statement_execute_query`,
+/// because `BinaryDataPtr` holds a raw pointer into the owned `String`.
 fn apply_parameter_bindings(
-    stmt_handle: &StatementHandle,
     parameter_bindings: &std::collections::HashMap<u16, ParameterBinding>,
-) -> OdbcResult<()> {
+) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
     if parameter_bindings.is_empty() {
-        return Ok(());
+        return Ok((None, None));
     }
     tracing::info!(
         "apply_parameter_bindings: Found {} bound parameters",
         parameter_bindings.len()
     );
 
-    let (schema, array) =
-        odbc_bindings_to_arrow_bindings(parameter_bindings).context(ArrowBindingSnafu {})?;
+    let json_string =
+        odbc_bindings_to_json(parameter_bindings).context(JsonBindingSnafu {})?;
 
-    DatabaseDriverClient::statement_bind(StatementBindRequest {
-        stmt_handle: Some(*stmt_handle),
-        schema: Some(protobuf_from_ffi_arrow_schema(Box::into_raw(schema))),
-        array: Some(protobuf_from_ffi_arrow_array(Box::into_raw(array))),
-    })?;
+    let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
+    let json_data_len = json_string.len();
+
+    let binary_data_ptr = BinaryDataPtr {
+        value: json_data_ptr.to_le_bytes().to_vec(),
+        length: json_data_len as i64,
+    };
+
+    let bindings = QueryBindings {
+        binding_type: Some(query_bindings::BindingType::Json(binary_data_ptr)),
+    };
 
     tracing::info!("apply_parameter_bindings: Successfully bound parameters");
-    Ok(())
+
+    Ok((Some(bindings), Some(json_string)))
 }
 
 /// Bind a parameter to a prepared statement

--- a/odbc/src/lib.rs
+++ b/odbc/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 pub mod c_api;
 mod cdata_types;
 mod conversion;
+#[allow(dead_code)]
 mod write_arrow;
 mod write_json;
 

--- a/odbc/src/lib.rs
+++ b/odbc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod c_api;
 mod cdata_types;
 mod conversion;
 mod write_arrow;
+mod write_json;
 
 extern crate sf_core;
 extern crate tracing;

--- a/odbc/src/write_json.rs
+++ b/odbc/src/write_json.rs
@@ -1,0 +1,243 @@
+use std::{
+    collections::HashMap,
+    ffi::{CStr, c_char},
+    slice, str,
+};
+
+use serde_json::{Map, Value};
+
+use crate::{api::ParameterBinding, cdata_types::CDataType};
+use odbc_sys as sql;
+
+// Snowflake binding type constants
+const SF_TYPE_ANY: &str = "ANY";
+const SF_TYPE_FIXED: &str = "FIXED";
+const SF_TYPE_TEXT: &str = "TEXT";
+const SF_TYPE_REAL: &str = "REAL";
+const SF_TYPE_BOOLEAN: &str = "BOOLEAN";
+const SF_TYPE_BINARY: &str = "BINARY";
+const SF_TYPE_DATE: &str = "DATE";
+const SF_TYPE_TIME: &str = "TIME";
+const SF_TYPE_TIMESTAMP_NTZ: &str = "TIMESTAMP_NTZ";
+
+#[derive(Debug)]
+pub enum JsonBindingError {
+    InvalidParameterIndices,
+    UnsupportedParameterType(sql::SqlDataType),
+    UnsupportedCDataType(CDataType),
+    NullPointer,
+    InvalidUtf8,
+}
+
+impl std::error::Error for JsonBindingError {}
+
+impl std::fmt::Display for JsonBindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonBindingError::InvalidParameterIndices => {
+                write!(f, "Parameter bindings must be contiguous and start at 1")
+            }
+            JsonBindingError::UnsupportedParameterType(sql_type) => {
+                write!(f, "Unsupported SQL parameter type: {:?}", sql_type)
+            }
+            JsonBindingError::UnsupportedCDataType(c_type) => {
+                write!(f, "Unsupported C data type for JSON binding: {:?}", c_type)
+            }
+            JsonBindingError::NullPointer => {
+                write!(f, "Null parameter value pointer encountered")
+            }
+            JsonBindingError::InvalidUtf8 => {
+                write!(f, "Parameter value is not valid UTF-8")
+            }
+        }
+    }
+}
+
+/// Convert ODBC parameter bindings to JSON string format for server-side binding.
+///
+/// The `bindings` map must contain `ParameterBinding` instances whose
+/// `parameter_value_ptr` pointers remain valid for the duration of this call.
+///
+/// Returns a JSON string in the format:
+/// ```json
+/// {
+///   "1": {"type": "FIXED", "value": "123"},
+///   "2": {"type": "TEXT", "value": "hello"}
+/// }
+/// ```
+pub fn odbc_bindings_to_json(
+    bindings: &HashMap<u16, ParameterBinding>,
+) -> Result<String, JsonBindingError> {
+    let mut json_bindings = Map::new();
+
+    let (min_key, max_key) = bindings
+        .keys()
+        .fold((u16::MAX, 0u16), |(min, max), &k| (min.min(k), max.max(k)));
+
+    for param_num in min_key..=max_key {
+        let binding = bindings.get(&param_num).ok_or_else(|| {
+            tracing::error!(
+                "odbc_bindings_to_json: parameter #{param_num} not found. \
+                 Parameter bindings must be contiguous and start at 1.",
+            );
+            JsonBindingError::InvalidParameterIndices
+        })?;
+
+        // Check for NULL value
+        let is_null = !binding.str_len_or_ind_ptr.is_null()
+            && unsafe { *binding.str_len_or_ind_ptr == sql::NULL_DATA };
+
+        let (snowflake_type, value) = if is_null {
+            (SF_TYPE_ANY, Value::Null)
+        } else {
+            convert_binding_to_json_value(binding)?
+        };
+
+        let mut binding_obj = Map::new();
+        binding_obj.insert(
+            "type".to_string(),
+            Value::String(snowflake_type.to_string()),
+        );
+        binding_obj.insert("value".to_string(), value);
+
+        json_bindings.insert(param_num.to_string(), Value::Object(binding_obj));
+    }
+
+    serde_json::to_string(&Value::Object(json_bindings)).map_err(|e| {
+        tracing::error!("Failed to serialize bindings to JSON: {}", e);
+        // This should never happen with well-formed Value objects, but handle it gracefully
+        JsonBindingError::InvalidUtf8
+    })
+}
+
+/// Convert a single parameter binding to a Snowflake type and JSON value.
+fn convert_binding_to_json_value(
+    binding: &ParameterBinding,
+) -> Result<(&'static str, Value), JsonBindingError> {
+    let snowflake_type = snowflake_type_from_sql_type(&binding.parameter_type)?;
+
+    check_not_null(binding)?;
+
+    let value = match binding.value_type {
+        CDataType::Long => read_numeric::<i32>(binding),
+        CDataType::Short => read_numeric::<i16>(binding),
+        CDataType::SBigInt => read_numeric::<i64>(binding),
+        CDataType::Float => read_numeric::<f32>(binding),
+        CDataType::Double => read_numeric::<f64>(binding),
+        CDataType::Char => read_char_value(binding),
+        CDataType::Bit => read_bit_value(binding),
+        CDataType::Binary => read_binary_value(binding),
+        _ => {
+            tracing::error!(
+                "Unsupported C data type for JSON binding: {:?}",
+                binding.value_type
+            );
+            Err(JsonBindingError::UnsupportedCDataType(binding.value_type))
+        }
+    }?;
+
+    Ok((snowflake_type, value))
+}
+
+/// Map SQL data types to Snowflake binding type names.
+fn snowflake_type_from_sql_type(
+    sql_type: &sql::SqlDataType,
+) -> Result<&'static str, JsonBindingError> {
+    match *sql_type {
+        sql::SqlDataType::INTEGER
+        | sql::SqlDataType::SMALLINT
+        | sql::SqlDataType::EXT_BIG_INT
+        | sql::SqlDataType::EXT_TINY_INT => Ok(SF_TYPE_FIXED),
+
+        sql::SqlDataType::VARCHAR
+        | sql::SqlDataType::CHAR
+        | sql::SqlDataType::EXT_LONG_VARCHAR
+        | sql::SqlDataType::EXT_W_CHAR
+        | sql::SqlDataType::EXT_W_VARCHAR
+        | sql::SqlDataType::EXT_W_LONG_VARCHAR => Ok(SF_TYPE_TEXT),
+
+        sql::SqlDataType::REAL
+        | sql::SqlDataType::FLOAT
+        | sql::SqlDataType::DOUBLE
+        | sql::SqlDataType::DECIMAL
+        | sql::SqlDataType::NUMERIC => Ok(SF_TYPE_REAL),
+
+        sql::SqlDataType::EXT_BIT => Ok(SF_TYPE_BOOLEAN),
+
+        sql::SqlDataType::EXT_BINARY
+        | sql::SqlDataType::EXT_VAR_BINARY
+        | sql::SqlDataType::EXT_LONG_VAR_BINARY => Ok(SF_TYPE_BINARY),
+
+        sql::SqlDataType::DATE => Ok(SF_TYPE_DATE),
+        sql::SqlDataType::TIME => Ok(SF_TYPE_TIME),
+        sql::SqlDataType::TIMESTAMP | sql::SqlDataType::EXT_TIMESTAMP => Ok(SF_TYPE_TIMESTAMP_NTZ),
+
+        _ => {
+            tracing::error!("Unsupported SQL data type for JSON binding: {:?}", sql_type);
+            Err(JsonBindingError::UnsupportedParameterType(*sql_type))
+        }
+    }
+}
+
+fn check_not_null(binding: &ParameterBinding) -> Result<(), JsonBindingError> {
+    if binding.parameter_value_ptr.is_null() {
+        return Err(JsonBindingError::NullPointer);
+    }
+    Ok(())
+}
+
+/// Read a numeric value from a binding pointer and convert to a JSON string value.
+///
+/// Uses `read_unaligned` to safely handle potentially misaligned ODBC pointers.
+fn read_numeric<T: std::fmt::Display>(
+    binding: &ParameterBinding,
+) -> Result<Value, JsonBindingError> {
+    let value = unsafe { std::ptr::read_unaligned(binding.parameter_value_ptr as *const T) };
+    Ok(Value::String(value.to_string()))
+}
+
+/// Determine the actual byte length of buffer data, using the length/indicator
+/// pointer if available, falling back to `buffer_length`.
+fn buffer_data_len(binding: &ParameterBinding) -> usize {
+    if !binding.str_len_or_ind_ptr.is_null() {
+        let indicated_len = unsafe { *binding.str_len_or_ind_ptr };
+        if indicated_len >= 0 {
+            return indicated_len as usize;
+        }
+    }
+    binding.buffer_length as usize
+}
+
+/// Read a SQL_C_CHAR value as a UTF-8 string.
+fn read_char_value(binding: &ParameterBinding) -> Result<Value, JsonBindingError> {
+    let value_str = if binding.buffer_length == sql::NTS {
+        unsafe {
+            CStr::from_ptr(binding.parameter_value_ptr as *const c_char)
+                .to_string_lossy()
+                .to_string()
+        }
+    } else {
+        let len = buffer_data_len(binding);
+        let bytes = unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len) };
+        str::from_utf8(bytes)
+            .map_err(|_| JsonBindingError::InvalidUtf8)?
+            .to_string()
+    };
+
+    Ok(Value::String(value_str))
+}
+
+/// Read a SQL_C_BIT value as a boolean string ("true"/"false").
+fn read_bit_value(binding: &ParameterBinding) -> Result<Value, JsonBindingError> {
+    let value = unsafe { std::ptr::read_unaligned(binding.parameter_value_ptr as *const u8) };
+    Ok(Value::String((value != 0).to_string()))
+}
+
+/// Read a SQL_C_BINARY value as a hex-encoded string.
+fn read_binary_value(binding: &ParameterBinding) -> Result<Value, JsonBindingError> {
+    let len = buffer_data_len(binding);
+    let bytes = unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len) };
+
+    let hex_string: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+    Ok(Value::String(hex_string))
+}

--- a/odbc/src/write_json.rs
+++ b/odbc/src/write_json.rs
@@ -4,8 +4,9 @@ use std::{
     slice, str,
 };
 
+use error_trace::ErrorTrace;
 use serde_json::{Map, Value};
-use snafu::Snafu;
+use snafu::{Location, ResultExt, Snafu};
 
 use crate::{api::ParameterBinding, cdata_types::CDataType};
 use odbc_sys as sql;
@@ -20,25 +21,47 @@ const SF_TYPE_DATE: &str = "DATE";
 const SF_TYPE_TIME: &str = "TIME";
 const SF_TYPE_TIMESTAMP_NTZ: &str = "TIMESTAMP_NTZ";
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, ErrorTrace)]
 pub enum JsonBindingError {
     #[snafu(display("Parameter bindings must be contiguous and start at 1"))]
-    InvalidParameterIndices,
+    InvalidParameterIndices {
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Unsupported SQL parameter type: {sql_type:?}"))]
-    UnsupportedParameterType { sql_type: sql::SqlDataType },
+    UnsupportedParameterType {
+        sql_type: sql::SqlDataType,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Unsupported C data type for JSON binding: {c_type:?}"))]
-    UnsupportedCDataType { c_type: CDataType },
+    UnsupportedCDataType {
+        c_type: CDataType,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Null parameter value pointer encountered"))]
-    NullPointer,
+    NullPointer {
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("Parameter value is not valid UTF-8"))]
-    InvalidUtf8,
+    #[snafu(display("Parameter value is not valid UTF-8: {source}"))]
+    InvalidUtf8 {
+        source: str::Utf8Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("Failed to serialize bindings to JSON: {message}"))]
-    Serialization { message: String },
+    #[snafu(display("Failed to serialize bindings to JSON: {source}"))]
+    Serialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 /// Convert ODBC parameter bindings to JSON string format for server-side binding.
@@ -66,7 +89,7 @@ pub fn odbc_bindings_to_json(
                 "odbc_bindings_to_json: parameter #{param_num} not found. \
                  Parameter bindings must be contiguous and start at 1.",
             );
-            JsonBindingError::InvalidParameterIndices
+            InvalidParameterIndicesSnafu.build()
         })?;
 
         // Check for NULL value
@@ -89,12 +112,7 @@ pub fn odbc_bindings_to_json(
         json_bindings.insert(param_num.to_string(), Value::Object(binding_obj));
     }
 
-    serde_json::to_string(&Value::Object(json_bindings)).map_err(|e| {
-        tracing::error!("Failed to serialize bindings to JSON: {}", e);
-        JsonBindingError::Serialization {
-            message: e.to_string(),
-        }
-    })
+    serde_json::to_string(&Value::Object(json_bindings)).context(SerializationSnafu)
 }
 
 /// Convert a single parameter binding to a Snowflake type and JSON value.
@@ -119,9 +137,10 @@ fn convert_binding_to_json_value(
                 "Unsupported C data type for JSON binding: {:?}",
                 binding.value_type
             );
-            Err(JsonBindingError::UnsupportedCDataType {
+            UnsupportedCDataTypeSnafu {
                 c_type: binding.value_type,
-            })
+            }
+            .fail()
         }
     }?;
 
@@ -163,16 +182,17 @@ fn snowflake_type_from_sql_type(
 
         _ => {
             tracing::error!("Unsupported SQL data type for JSON binding: {:?}", sql_type);
-            Err(JsonBindingError::UnsupportedParameterType {
+            UnsupportedParameterTypeSnafu {
                 sql_type: *sql_type,
-            })
+            }
+            .fail()
         }
     }
 }
 
 fn check_not_null(binding: &ParameterBinding) -> Result<(), JsonBindingError> {
     if binding.parameter_value_ptr.is_null() {
-        return Err(JsonBindingError::NullPointer);
+        return NullPointerSnafu.fail();
     }
     Ok(())
 }
@@ -225,9 +245,7 @@ fn read_char_value(binding: &ParameterBinding) -> Result<Value, JsonBindingError
     } else {
         let len = buffer_data_len(binding);
         let bytes = unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len) };
-        str::from_utf8(bytes)
-            .map_err(|_| JsonBindingError::InvalidUtf8)?
-            .to_string()
+        str::from_utf8(bytes).context(InvalidUtf8Snafu)?.to_string()
     };
 
     Ok(Value::String(value_str))

--- a/odbc/src/write_json.rs
+++ b/odbc/src/write_json.rs
@@ -147,9 +147,9 @@ fn snowflake_type_from_sql_type(
         | sql::SqlDataType::EXT_W_VARCHAR
         | sql::SqlDataType::EXT_W_LONG_VARCHAR => Ok(SF_TYPE_TEXT),
 
-        sql::SqlDataType::REAL
-        | sql::SqlDataType::FLOAT
-        | sql::SqlDataType::DOUBLE => Ok(SF_TYPE_REAL),
+        sql::SqlDataType::REAL | sql::SqlDataType::FLOAT | sql::SqlDataType::DOUBLE => {
+            Ok(SF_TYPE_REAL)
+        }
 
         sql::SqlDataType::EXT_BIT => Ok(SF_TYPE_BOOLEAN),
 
@@ -203,7 +203,11 @@ fn buffer_data_len(binding: &ParameterBinding) -> usize {
         let indicated_len = unsafe { *binding.str_len_or_ind_ptr };
         if indicated_len >= 0 {
             let indicated = indicated_len as usize;
-            return if max_len > 0 { indicated.min(max_len) } else { indicated };
+            return if max_len > 0 {
+                indicated.min(max_len)
+            } else {
+                indicated
+            };
         }
     }
 

--- a/odbc/src/write_json.rs
+++ b/odbc/src/write_json.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use serde_json::{Map, Value};
+use snafu::Snafu;
 
 use crate::{api::ParameterBinding, cdata_types::CDataType};
 use odbc_sys as sql;
 
-// Snowflake binding type constants
 const SF_TYPE_ANY: &str = "ANY";
 const SF_TYPE_FIXED: &str = "FIXED";
 const SF_TYPE_TEXT: &str = "TEXT";
@@ -20,37 +20,25 @@ const SF_TYPE_DATE: &str = "DATE";
 const SF_TYPE_TIME: &str = "TIME";
 const SF_TYPE_TIMESTAMP_NTZ: &str = "TIMESTAMP_NTZ";
 
-#[derive(Debug)]
+#[derive(Debug, Snafu)]
 pub enum JsonBindingError {
+    #[snafu(display("Parameter bindings must be contiguous and start at 1"))]
     InvalidParameterIndices,
-    UnsupportedParameterType(sql::SqlDataType),
-    UnsupportedCDataType(CDataType),
+
+    #[snafu(display("Unsupported SQL parameter type: {sql_type:?}"))]
+    UnsupportedParameterType { sql_type: sql::SqlDataType },
+
+    #[snafu(display("Unsupported C data type for JSON binding: {c_type:?}"))]
+    UnsupportedCDataType { c_type: CDataType },
+
+    #[snafu(display("Null parameter value pointer encountered"))]
     NullPointer,
+
+    #[snafu(display("Parameter value is not valid UTF-8"))]
     InvalidUtf8,
-}
 
-impl std::error::Error for JsonBindingError {}
-
-impl std::fmt::Display for JsonBindingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            JsonBindingError::InvalidParameterIndices => {
-                write!(f, "Parameter bindings must be contiguous and start at 1")
-            }
-            JsonBindingError::UnsupportedParameterType(sql_type) => {
-                write!(f, "Unsupported SQL parameter type: {:?}", sql_type)
-            }
-            JsonBindingError::UnsupportedCDataType(c_type) => {
-                write!(f, "Unsupported C data type for JSON binding: {:?}", c_type)
-            }
-            JsonBindingError::NullPointer => {
-                write!(f, "Null parameter value pointer encountered")
-            }
-            JsonBindingError::InvalidUtf8 => {
-                write!(f, "Parameter value is not valid UTF-8")
-            }
-        }
-    }
+    #[snafu(display("Failed to serialize bindings to JSON: {message}"))]
+    Serialization { message: String },
 }
 
 /// Convert ODBC parameter bindings to JSON string format for server-side binding.
@@ -70,11 +58,9 @@ pub fn odbc_bindings_to_json(
 ) -> Result<String, JsonBindingError> {
     let mut json_bindings = Map::new();
 
-    let (min_key, max_key) = bindings
-        .keys()
-        .fold((u16::MAX, 0u16), |(min, max), &k| (min.min(k), max.max(k)));
+    let max_key = bindings.keys().copied().max().unwrap_or(0);
 
-    for param_num in min_key..=max_key {
+    for param_num in 1..=max_key {
         let binding = bindings.get(&param_num).ok_or_else(|| {
             tracing::error!(
                 "odbc_bindings_to_json: parameter #{param_num} not found. \
@@ -105,8 +91,9 @@ pub fn odbc_bindings_to_json(
 
     serde_json::to_string(&Value::Object(json_bindings)).map_err(|e| {
         tracing::error!("Failed to serialize bindings to JSON: {}", e);
-        // This should never happen with well-formed Value objects, but handle it gracefully
-        JsonBindingError::InvalidUtf8
+        JsonBindingError::Serialization {
+            message: e.to_string(),
+        }
     })
 }
 
@@ -132,7 +119,9 @@ fn convert_binding_to_json_value(
                 "Unsupported C data type for JSON binding: {:?}",
                 binding.value_type
             );
-            Err(JsonBindingError::UnsupportedCDataType(binding.value_type))
+            Err(JsonBindingError::UnsupportedCDataType {
+                c_type: binding.value_type,
+            })
         }
     }?;
 
@@ -147,7 +136,9 @@ fn snowflake_type_from_sql_type(
         sql::SqlDataType::INTEGER
         | sql::SqlDataType::SMALLINT
         | sql::SqlDataType::EXT_BIG_INT
-        | sql::SqlDataType::EXT_TINY_INT => Ok(SF_TYPE_FIXED),
+        | sql::SqlDataType::EXT_TINY_INT
+        | sql::SqlDataType::DECIMAL
+        | sql::SqlDataType::NUMERIC => Ok(SF_TYPE_FIXED),
 
         sql::SqlDataType::VARCHAR
         | sql::SqlDataType::CHAR
@@ -158,9 +149,7 @@ fn snowflake_type_from_sql_type(
 
         sql::SqlDataType::REAL
         | sql::SqlDataType::FLOAT
-        | sql::SqlDataType::DOUBLE
-        | sql::SqlDataType::DECIMAL
-        | sql::SqlDataType::NUMERIC => Ok(SF_TYPE_REAL),
+        | sql::SqlDataType::DOUBLE => Ok(SF_TYPE_REAL),
 
         sql::SqlDataType::EXT_BIT => Ok(SF_TYPE_BOOLEAN),
 
@@ -174,7 +163,9 @@ fn snowflake_type_from_sql_type(
 
         _ => {
             tracing::error!("Unsupported SQL data type for JSON binding: {:?}", sql_type);
-            Err(JsonBindingError::UnsupportedParameterType(*sql_type))
+            Err(JsonBindingError::UnsupportedParameterType {
+                sql_type: *sql_type,
+            })
         }
     }
 }
@@ -198,14 +189,25 @@ fn read_numeric<T: std::fmt::Display>(
 
 /// Determine the actual byte length of buffer data, using the length/indicator
 /// pointer if available, falling back to `buffer_length`.
+///
+/// Negative `buffer_length` values (e.g. `SQL_NTS`) are treated as zero.
+/// Indicated length is clamped to `buffer_length` to prevent over-reads.
 fn buffer_data_len(binding: &ParameterBinding) -> usize {
+    let max_len = if binding.buffer_length < 0 {
+        0
+    } else {
+        binding.buffer_length as usize
+    };
+
     if !binding.str_len_or_ind_ptr.is_null() {
         let indicated_len = unsafe { *binding.str_len_or_ind_ptr };
         if indicated_len >= 0 {
-            return indicated_len as usize;
+            let indicated = indicated_len as usize;
+            return if max_len > 0 { indicated.min(max_len) } else { indicated };
         }
     }
-    binding.buffer_length as usize
+
+    max_len
 }
 
 /// Read a SQL_C_CHAR value as a UTF-8 string.


### PR DESCRIPTION
Switch ODBC to json binding interface

Address review feedback on JSON binding interface

- Use snafu derive for JsonBindingError (consistency with crate conventions)
- Add Serialization error variant instead of reusing InvalidUtf8
- Validate parameter indices start at 1, not just contiguity
- Fix buffer_data_len: clamp negative buffer_length, cap indicated_len
- Move DECIMAL/NUMERIC to FIXED binding type (prevents precision loss)
- Remove binding_data field from Statement; keep JSON as local in
  apply_parameter_bindings and return it alongside bindings for lifetime
- Use u64 for pointer encoding (32-bit safety)
- Remove debug log that could leak sensitive parameter values
- Clean up unused StatementHandle import

Made-with: Cursor

Fix CI: suppress dead_code warnings for Arrow code and apply rustfmt

Made-with: Cursor

Use snafu idioms for JsonBindingError with ErrorTrace support

Made-with: Cursor