### PR TITLE
Fix ODBC coverage pipeline

### DIFF
--- a/ci/Dockerfile.rocky-old-odbc-test
+++ b/ci/Dockerfile.rocky-old-odbc-test
@@ -23,6 +23,7 @@ RUN dnf install -y \
         libstdc++-devel \
         libstdc++-static \
         libtool \
+        openssl-devel \
         python3 \
         tar \
         unixODBC-devel \

--- a/scripts/old_odbc/coverage_full.sh
+++ b/scripts/old_odbc/coverage_full.sh
@@ -41,6 +41,7 @@ docker run --rm \
     ./scripts/old_odbc/build.sh
 
 echo "=== Step 2: Building and running tests ==="
+# Don't abort if tests fail — we still want the coverage report from whatever ran.
 docker run --rm \
     -v "$PROJECT_DIR":/workspace \
     -v "$OLD_ODBC_PATH":/workspace/old_odbc \
@@ -48,7 +49,7 @@ docker run --rm \
     -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
     -w /workspace \
     rocky-old-odbc-test \
-    ./scripts/old_odbc/test.sh
+    ./scripts/old_odbc/test.sh || echo "WARNING: test step exited with non-zero status"
 
 echo "=== Step 3: Generating coverage report ==="
 docker run --rm \

--- a/scripts/old_odbc/test.sh
+++ b/scripts/old_odbc/test.sh
@@ -17,5 +17,7 @@ cmake4 -B cmake-build \
 
 export SIMBAINI=/usr/lib64/snowflake/odbc/lib/simba.snowflake.ini
 cmake4 --build cmake-build -- -j $(nproc)
-ctest4 -j $(nproc) -C Debug --test-dir cmake-build --output-on-failure
+
+# Don't fail the script on test failures — coverage should still be collected.
+ctest4 -j $(nproc) -C Debug --test-dir cmake-build --output-on-failure || true
 


### PR DESCRIPTION
Fixes old coverage pipeline for ODBC:  
\- Install test dependency openssl  
\- Collects coverage even on test failures