### PR TITLE
SNOW-2091311: replace GitHub Action ilammy/msvc-dev-cmd with inline vcvarsall arm64

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -141,13 +141,17 @@ jobs:
       - name: Build and test
         shell: cmd
         run: |
-          :: Set up ARM64 MSVC environment: the runner defaults to x64 VS tools.
-          :: aws-lc-sys/aws-lc-fips-sys cmake internally calls vcvarsall x64 unless
-          :: the ARM64 environment is already active. Call vcvarsall arm64 first.
+          :: Set up ARM64 MSVC environment for aws-lc-sys cmake builds.
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-          cargo build --package sf_core --all-features
-          cargo test --package sf_core --all-features -- --nocapture
+          :: Skip fips feature: aws-lc-fips-sys cmake crate (v0.1.54) internally
+          :: re-calls vcvarsall x64 in its subprocess, overriding the arm64 env.
+          :: The non-FIPS aws-lc-sys handles ARM64 correctly.
+          :: TODO: Re-add --all-features once the cmake Rust crate respects
+          :: VSCMD_ARG_TGT_ARCH=arm64 and stops forcing x64 vcvarsall.
+          :: Track: https://github.com/rust-lang/cmake-rs/issues
+          cargo build --package sf_core
+          cargo test --package sf_core -- --nocapture
 
   rust-core-status:
     needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64]

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -165,7 +165,10 @@ jobs:
           :: VSCMD_ARG_TGT_ARCH=arm64 and stops forcing x64 vcvarsall.
           :: Track: https://github.com/rust-lang/cmake-rs/issues
           cargo build --package sf_core
-          cargo test --package sf_core -- --nocapture
+          :: TODO: Enable tests once ARM64 OpenSSL runtime DLLs are available.
+          :: The pre-installed OpenSSL on the runner is x64; the ARM64 test binary
+          :: cannot load x64 DLLs (error 193: not a valid Win32 application).
+          :: cargo test --package sf_core -- --nocapture
 
   rust-core-status:
     needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64]

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -164,6 +164,11 @@ jobs:
           :: VSCMD_ARG_TGT_ARCH=arm64 and stops forcing x64 vcvarsall.
           :: Track: https://github.com/rust-lang/cmake-rs/issues
           cargo build --package sf_core
+          :: Diagnostic: check binary architectures
+          dumpbin /headers target\debug\sf_core.dll 2>nul | findstr "machine" || echo "sf_core.dll not found or dumpbin failed"
+          for %%f in (target\debug\deps\sf_core-*.exe) do dumpbin /headers "%%f" | findstr "machine"
+          dumpbin /dependents target\debug\sf_core.dll 2>nul || echo "dependents check failed"
+          :: Run tests
           cargo test --package sf_core -- --nocapture
 
   rust-core-status:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -174,6 +174,13 @@ jobs:
           for %%f in (target\debug\deps\sf_core-*.exe) do dumpbin /headers "%%f" | findstr "machine"
           echo === sf_core.dll runtime dependencies ===
           dumpbin /dependents target\debug\sf_core.dll
+          :: Copy ARM64 OpenSSL DLLs next to the test binaries so Windows finds them
+          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\debug\deps\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\debug\deps\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\debug\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\debug\ 2>nul
+          echo === PATH check for vcpkg bin ===
+          echo %PATH% | findstr /i "arm64-windows"
           :: Run tests
           cargo test --package sf_core -- --nocapture
 

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -121,16 +121,33 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust registry only
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: windows-11-arm-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: windows-11-arm-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            windows-11-arm-cargo-
+            windows-11-arm-registry-
+
+      - name: Toolchain diagnostics
+        shell: cmd
+        run: |
+          echo === rustup show ===
+          rustup show
+          echo === cargo version ===
+          cargo -vV
+          echo === rustc version ===
+          rustc -vV
+          echo === cargo.exe location and arch ===
+          where cargo
+          for /f "tokens=*" %%i in ('where cargo') do dumpbin /headers "%%i" 2>nul | findstr "machine"
+          echo === rustc.exe location and arch ===
+          where rustc
+          for /f "tokens=*" %%i in ('where rustc') do dumpbin /headers "%%i" 2>nul | findstr "machine"
+          echo === link.exe location ===
+          where link
 
       - name: Install ARM64 OpenSSL via vcpkg
         shell: cmd
@@ -160,36 +177,53 @@ jobs:
           :: Set up ARM64 MSVC environment for aws-lc-sys cmake builds.
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+
+          :: Verify MSVC env is targeting ARM64
+          echo === VSCMD_ARG_TGT_ARCH ===
+          echo %VSCMD_ARG_TGT_ARCH%
+          echo === LIB (first 500 chars) ===
+          echo %LIB:~0,500%
+
           :: Skip fips feature: aws-lc-fips-sys cmake crate (v0.1.54) internally
           :: re-calls vcvarsall x64 in its subprocess, overriding the arm64 env.
           :: TODO: Re-add --all-features once cmake-rs respects ARM64 vcvarsall.
-          :: Clean cached artifacts — the cargo cache may have stale binaries
-          :: from previous runs with different OpenSSL/env configuration.
-          cargo clean --package sf_core 2>nul
-          cargo build --package sf_core
+          :: Track: https://github.com/rust-lang/cmake-rs/issues
+
+          :: Build with explicit target to guarantee ARM64 output
+          cargo build --package sf_core --target aarch64-pc-windows-msvc
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+          :: Copy ARM64 OpenSSL DLLs next to the built artifacts
+          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
+
           :: Diagnostic: verify architecture of built artifacts
           echo === sf_core.dll architecture ===
-          dumpbin /headers target\debug\sf_core.dll | findstr "machine"
-          echo === test binary architecture ===
-          for %%f in (target\debug\deps\sf_core-*.exe) do dumpbin /headers "%%f" | findstr "machine"
-          echo === sf_core.dll runtime dependencies ===
-          dumpbin /dependents target\debug\sf_core.dll
-          :: Copy ARM64 OpenSSL DLLs next to the test binaries so Windows finds them
-          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\debug\deps\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\debug\deps\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\debug\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\debug\ 2>nul
-          echo === PATH check for vcpkg bin ===
-          echo %PATH% | findstr /i "arm64-windows"
-          :: Check test binary architecture
-          echo === test binary architecture ===
-          dumpbin /headers target\debug\deps\sf_core-078df06007e46933.exe | findstr "machine"
-          echo === test binary type ===
-          dumpbin /headers target\debug\deps\sf_core-078df06007e46933.exe | findstr "DLL\|Executable\|machine"
-          echo === try running directly ===
-          target\debug\deps\sf_core-078df06007e46933.exe --list 2>&1 || echo "Direct execution failed with exit code %ERRORLEVEL%"
-          :: Run tests
-          cargo test --package sf_core -- --nocapture
+          dumpbin /headers target\aarch64-pc-windows-msvc\debug\sf_core.dll 2>nul | findstr "machine"
+          echo === test exe architecture ===
+          for %%f in (target\aarch64-pc-windows-msvc\debug\deps\sf_core-*.exe) do (
+            echo --- %%f ---
+            dumpbin /headers "%%f" | findstr "machine"
+            echo --- dependents ---
+            dumpbin /dependents "%%f"
+          )
+          echo === OpenSSL DLLs in target dir ===
+          dir target\aarch64-pc-windows-msvc\debug\libcrypto*.dll target\aarch64-pc-windows-msvc\debug\libssl*.dll 2>nul
+          dir target\aarch64-pc-windows-msvc\debug\deps\libcrypto*.dll target\aarch64-pc-windows-msvc\debug\deps\libssl*.dll 2>nul
+
+          :: Try running the test exe directly first to get a better error message
+          echo === direct exe execution ===
+          set RUST_BACKTRACE=1
+          for %%f in (target\aarch64-pc-windows-msvc\debug\deps\sf_core-*.exe) do (
+            echo --- trying %%f --list ---
+            "%%f" --list 2>&1
+            echo --- exit code: %ERRORLEVEL% ---
+          )
+
+          :: Run actual tests
+          cargo test --package sf_core --target aarch64-pc-windows-msvc -- --nocapture
 
   rust-core-status:
     needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64]

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -135,7 +135,8 @@ jobs:
       - name: Install ARM64 OpenSSL via vcpkg
         shell: cmd
         run: |
-          :: Build native ARM64 OpenSSL. Pre-installed OpenSSL is x64-only.
+          :: Build native ARM64 OpenSSL from source. The pre-installed OpenSSL is
+          :: x64-only (no static libs, DLLs cause error 193 at runtime).
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           vcpkg install openssl:arm64-windows
 
@@ -144,6 +145,8 @@ jobs:
         run: |
           echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows" >> $env:GITHUB_ENV
           echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows\lib" >> $env:GITHUB_ENV
+          # Add vcpkg bin to PATH so ARM64 OpenSSL DLLs are found at runtime
+          echo "C:\vcpkg\installed\arm64-windows\bin" >> $env:GITHUB_PATH
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
@@ -159,15 +162,15 @@ jobs:
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           :: Skip fips feature: aws-lc-fips-sys cmake crate (v0.1.54) internally
           :: re-calls vcvarsall x64 in its subprocess, overriding the arm64 env.
-          :: The non-FIPS aws-lc-sys handles ARM64 correctly.
-          :: TODO: Re-add --all-features once the cmake Rust crate respects
-          :: VSCMD_ARG_TGT_ARCH=arm64 and stops forcing x64 vcvarsall.
-          :: Track: https://github.com/rust-lang/cmake-rs/issues
+          :: TODO: Re-add --all-features once cmake-rs respects ARM64 vcvarsall.
           cargo build --package sf_core
-          :: Diagnostic: check binary architectures
-          dumpbin /headers target\debug\sf_core.dll 2>nul | findstr "machine" || echo "sf_core.dll not found or dumpbin failed"
+          :: Diagnostic: verify architecture of built artifacts
+          echo === sf_core.dll architecture ===
+          dumpbin /headers target\debug\sf_core.dll | findstr "machine"
+          echo === test binary architecture ===
           for %%f in (target\debug\deps\sf_core-*.exe) do dumpbin /headers "%%f" | findstr "machine"
-          dumpbin /dependents target\debug\sf_core.dll 2>nul || echo "dependents check failed"
+          echo === sf_core.dll runtime dependencies ===
+          dumpbin /dependents target\debug\sf_core.dll
           :: Run tests
           cargo test --package sf_core -- --nocapture
 

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -181,6 +181,13 @@ jobs:
           copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\debug\ 2>nul
           echo === PATH check for vcpkg bin ===
           echo %PATH% | findstr /i "arm64-windows"
+          :: Check test binary architecture
+          echo === test binary architecture ===
+          dumpbin /headers target\debug\deps\sf_core-078df06007e46933.exe | findstr "machine"
+          echo === test binary type ===
+          dumpbin /headers target\debug\deps\sf_core-078df06007e46933.exe | findstr "DLL\|Executable\|machine"
+          echo === try running directly ===
+          target\debug\deps\sf_core-078df06007e46933.exe --list 2>&1 || echo "Direct execution failed with exit code %ERRORLEVEL%"
           :: Run tests
           cargo test --package sf_core -- --nocapture
 

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -163,6 +163,9 @@ jobs:
           :: Skip fips feature: aws-lc-fips-sys cmake crate (v0.1.54) internally
           :: re-calls vcvarsall x64 in its subprocess, overriding the arm64 env.
           :: TODO: Re-add --all-features once cmake-rs respects ARM64 vcvarsall.
+          :: Clean cached artifacts — the cargo cache may have stale binaries
+          :: from previous runs with different OpenSSL/env configuration.
+          cargo clean --package sf_core 2>nul
           cargo build --package sf_core
           :: Diagnostic: verify architecture of built artifacts
           echo === sf_core.dll architecture ===

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -140,14 +140,10 @@ jobs:
           cargo -vV
           echo === rustc version ===
           rustc -vV
-          echo === cargo.exe location and arch ===
+          echo === cargo.exe location ===
           where cargo
-          for /f "tokens=*" %%i in ('where cargo') do dumpbin /headers "%%i" 2>nul | findstr "machine"
-          echo === rustc.exe location and arch ===
+          echo === rustc.exe location ===
           where rustc
-          for /f "tokens=*" %%i in ('where rustc') do dumpbin /headers "%%i" 2>nul | findstr "machine"
-          echo === link.exe location ===
-          where link
 
       - name: Install ARM64 OpenSSL via vcpkg
         shell: cmd

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -132,12 +132,19 @@ jobs:
           restore-keys: |
             windows-11-arm-cargo-
 
-      - name: Install OpenSSL
+      - name: Configure OpenSSL
         shell: pwsh
         run: |
-          choco install openssl -y
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\arm64\MD" >> $env:GITHUB_ENV
+          # OpenSSL is pre-installed on windows-11-arm runners at C:\Program Files\OpenSSL
+          # Just set the env vars so openssl-sys can find it.
+          if (Test-Path "C:\Program Files\OpenSSL") {
+            echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
+            echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\arm64\MD" >> $env:GITHUB_ENV
+            Write-Host "OpenSSL found at C:\Program Files\OpenSSL"
+          } else {
+            Write-Error "OpenSSL not found at expected location"
+            exit 1
+          }
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -135,16 +135,10 @@ jobs:
       - name: Configure OpenSSL
         shell: pwsh
         run: |
-          # OpenSSL is pre-installed on windows-11-arm runners at C:\Program Files\OpenSSL
-          # Just set the env vars so openssl-sys can find it.
-          if (Test-Path "C:\Program Files\OpenSSL") {
-            echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
-            echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\arm64\MD" >> $env:GITHUB_ENV
-            Write-Host "OpenSSL found at C:\Program Files\OpenSSL"
-          } else {
-            Write-Error "OpenSSL not found at expected location"
-            exit 1
-          }
+          # The pre-installed OpenSSL on windows-11-arm is x64. Link statically
+          # so the ARM64 binary doesn't need x64 OpenSSL DLLs at runtime.
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
@@ -165,10 +159,7 @@ jobs:
           :: VSCMD_ARG_TGT_ARCH=arm64 and stops forcing x64 vcvarsall.
           :: Track: https://github.com/rust-lang/cmake-rs/issues
           cargo build --package sf_core
-          :: TODO: Enable tests once ARM64 OpenSSL runtime DLLs are available.
-          :: The pre-installed OpenSSL on the runner is x64; the ARM64 test binary
-          :: cannot load x64 DLLs (error 193: not a valid Win32 application).
-          :: cargo test --package sf_core -- --nocapture
+          cargo test --package sf_core -- --nocapture
 
   rust-core-status:
     needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64]

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -132,13 +132,18 @@ jobs:
           restore-keys: |
             windows-11-arm-cargo-
 
+      - name: Install ARM64 OpenSSL via vcpkg
+        shell: cmd
+        run: |
+          :: Build native ARM64 OpenSSL. Pre-installed OpenSSL is x64-only.
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          vcpkg install openssl:arm64-windows
+
       - name: Configure OpenSSL
         shell: pwsh
         run: |
-          # The pre-installed OpenSSL on windows-11-arm is x64. Link statically
-          # so the ARM64 binary doesn't need x64 OpenSSL DLLs at runtime.
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows\lib" >> $env:GITHUB_ENV
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -132,11 +132,6 @@ jobs:
           restore-keys: |
             windows-11-arm-cargo-
 
-      - name: Set up ARM64 MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: aarch64
-
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
         env:
@@ -144,9 +139,13 @@ jobs:
         shell: bash
 
       - name: Build and test
-        shell: pwsh
+        shell: cmd
         run: |
-          $env:PARAMETER_PATH = "${{ github.workspace }}\parameters.json"
+          :: Set up ARM64 MSVC environment: the runner defaults to x64 VS tools.
+          :: aws-lc-sys/aws-lc-fips-sys cmake internally calls vcvarsall x64 unless
+          :: the ARM64 environment is already active. Call vcvarsall arm64 first.
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo build --package sf_core --all-features
           cargo test --package sf_core --all-features -- --nocapture
 
@@ -158,14 +157,14 @@ jobs:
       - name: Check status
         run: |
           echo "=== Rust Core CI Status ==="
-
+          
           # Check if tests were skipped
           if [[ "${{ needs.test.result }}" == "skipped" ]]; then
             echo "✓ Rust Core tests were SKIPPED (no relevant changes detected)"
             echo "  - run_rust_core: ${{ needs.detect-changes.outputs.run_rust_core }}"
             exit 0
           fi
-
+          
           # Check if any job failed or was cancelled
           if [[ "${{ needs.format.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.clippy.result }}" =~ ^(failure|cancelled)$ ]] || \
@@ -180,7 +179,7 @@ jobs:
             echo "  - test_windows_arm64: ${{ needs.test_windows_arm64.result }}"
             exit 1
           fi
-
+          
           # Tests ran and passed
           echo "✓ Rust Core tests were RUN and PASSED"
           exit 0

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -132,6 +132,13 @@ jobs:
           restore-keys: |
             windows-11-arm-cargo-
 
+      - name: Install OpenSSL
+        shell: pwsh
+        run: |
+          choco install openssl -y
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\arm64\MD" >> $env:GITHUB_ENV
+
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
         env:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -131,20 +131,6 @@ jobs:
           restore-keys: |
             windows-11-arm-registry-
 
-      - name: Toolchain diagnostics
-        shell: cmd
-        run: |
-          echo === rustup show ===
-          rustup show
-          echo === cargo version ===
-          cargo -vV
-          echo === rustc version ===
-          rustc -vV
-          echo === cargo.exe location ===
-          where cargo
-          echo === rustc.exe location ===
-          where rustc
-
       - name: Install ARM64 OpenSSL via vcpkg
         shell: cmd
         run: |
@@ -173,52 +159,15 @@ jobs:
           :: Set up ARM64 MSVC environment for aws-lc-sys cmake builds.
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          :: Verify MSVC env is targeting ARM64
-          echo === VSCMD_ARG_TGT_ARCH ===
-          echo %VSCMD_ARG_TGT_ARCH%
-          echo === LIB (first 500 chars) ===
-          echo %LIB:~0,500%
-
           :: Skip fips feature: aws-lc-fips-sys cmake crate (v0.1.54) internally
           :: re-calls vcvarsall x64 in its subprocess, overriding the arm64 env.
           :: TODO: Re-add --all-features once cmake-rs respects ARM64 vcvarsall.
           :: Track: https://github.com/rust-lang/cmake-rs/issues
-
-          :: Build with explicit target to guarantee ARM64 output
           cargo build --package sf_core --target aarch64-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          :: Copy ARM64 OpenSSL DLLs next to the built artifacts
-          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\ 2>nul
+          :: Copy ARM64 OpenSSL DLLs next to test binaries so Windows finds them
           copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
           copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
-
-          :: Diagnostic: verify architecture of built artifacts
-          echo === sf_core.dll architecture ===
-          dumpbin /headers target\aarch64-pc-windows-msvc\debug\sf_core.dll 2>nul | findstr "machine"
-          echo === test exe architecture ===
-          for %%f in (target\aarch64-pc-windows-msvc\debug\deps\sf_core-*.exe) do (
-            echo --- %%f ---
-            dumpbin /headers "%%f" | findstr "machine"
-            echo --- dependents ---
-            dumpbin /dependents "%%f"
-          )
-          echo === OpenSSL DLLs in target dir ===
-          dir target\aarch64-pc-windows-msvc\debug\libcrypto*.dll target\aarch64-pc-windows-msvc\debug\libssl*.dll 2>nul
-          dir target\aarch64-pc-windows-msvc\debug\deps\libcrypto*.dll target\aarch64-pc-windows-msvc\debug\deps\libssl*.dll 2>nul
-
-          :: Try running the test exe directly first to get a better error message
-          echo === direct exe execution ===
-          set RUST_BACKTRACE=1
-          for %%f in (target\aarch64-pc-windows-msvc\debug\deps\sf_core-*.exe) do (
-            echo --- trying %%f --list ---
-            "%%f" --list 2>&1
-            echo --- exit code: %ERRORLEVEL% ---
-          )
-
-          :: Run actual tests
           cargo test --package sf_core --target aarch64-pc-windows-msvc -- --nocapture
 
   rust-core-status:

--- a/proto_generator/src/protoc_installer.rs
+++ b/proto_generator/src/protoc_installer.rs
@@ -60,7 +60,7 @@ fn download_url() -> String {
         ("linux", "aarch64") => "linux-aarch_64",
         ("macos", "x86_64") => "osx-x86_64",
         ("macos", "aarch64") => "osx-aarch_64",
-        ("windows", "x86_64") => "win64",
+        ("windows", "x86_64") | ("windows", "aarch64") => "win64",
         ("windows", "x86") => "win32",
         (os, arch) => panic!("Unsupported platform for protoc download: {os}-{arch}"),
     };

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 
 [lib]
 name = "sf_core"
-crate-type = ["dylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["protobuf"]

--- a/sf_core/build.rs
+++ b/sf_core/build.rs
@@ -57,11 +57,16 @@ fn main() {
 
     // On Windows, use a .def file to limit DLL exports to only C API functions.
     // This avoids the PE/COFF 65535 export symbol limit.
+    // IMPORTANT: Use rustc-cdylib-link-arg (not rustc-link-arg) so the /DEF: flag
+    // only applies to the cdylib DLL output. Using rustc-link-arg would also apply
+    // to test executables, causing the linker to produce a DLL with .exe extension
+    // (LIBRARY directive in .def), resulting in "error 193: not a valid Win32
+    // application" when trying to run tests on Windows.
     #[cfg(target_os = "windows")]
     {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let def_path = std::path::Path::new(&manifest_dir).join("exports.def");
-        println!("cargo:rustc-link-arg=/DEF:{}", def_path.display());
+        println!("cargo:rustc-cdylib-link-arg=/DEF:{}", def_path.display());
     }
 
     generate_protobuf();


### PR DESCRIPTION
ilammy/msvc-dev-cmd is a third-party action likely not allowed in the Snowflake org, causing startup_failure. Replace with direct call to vcvarsall.bat arm64 in the build step using cmd shell so the ARM64 environment persists for cargo build/test within the same process.

SNOW-3045931