### PR TITLE
NO-SNOW: Fix Number Tests assertion due to the lack of local support

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
@@ -1,5 +1,19 @@
 package net.snowflake.jdbc.e2e.types;
 
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -7,17 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import net.snowflake.client.SnowflakeIntegrationTestBase;
-import org.junit.jupiter.api.Test;
 
 public class NumberTests extends SnowflakeIntegrationTestBase {
   private static final String NUMBER_TYPE = "NUMBER";
@@ -512,8 +515,19 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
     assertNotNull(stringValue, message + " (getString should not be NULL)");
     assertFalse(stringValue.isEmpty(), message + " (getString should not be empty)");
     assertDoesNotThrow(
-        () -> new BigDecimal(stringValue), message + " (getString should be parseable numeric)");
+            () -> parseLocaleDecimal(stringValue, message), message + " (getString should be parseable numeric)");
     assertFalse(resultSet.wasNull(), message + " (getString should not be NULL)");
+  }
+
+  // It's crucial to have proper local in big decimal comparison
+  private static BigDecimal parseLocaleDecimal(String value, String message) {
+    DecimalFormat df = (DecimalFormat) DecimalFormat.getInstance();
+    df.setParseBigDecimal(true);
+    try {
+      return (BigDecimal) df.parse(value);
+    } catch (ParseException e) {
+      throw new AssertionError(message + " (getString value '" + value + "' is not a parseable number)", e);
+    }
   }
 
   private static BigDecimal toBigDecimal(Object value, String message) {

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
@@ -1,7 +1,12 @@
 package net.snowflake.jdbc.e2e.types;
 
-import net.snowflake.client.SnowflakeIntegrationTestBase;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -13,14 +18,8 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
 
 public class NumberTests extends SnowflakeIntegrationTestBase {
   private static final String NUMBER_TYPE = "NUMBER";
@@ -515,7 +514,8 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
     assertNotNull(stringValue, message + " (getString should not be NULL)");
     assertFalse(stringValue.isEmpty(), message + " (getString should not be empty)");
     assertDoesNotThrow(
-            () -> parseLocaleDecimal(stringValue, message), message + " (getString should be parseable numeric)");
+        () -> parseLocaleDecimal(stringValue, message),
+        message + " (getString should be parseable numeric)");
     assertFalse(resultSet.wasNull(), message + " (getString should not be NULL)");
   }
 
@@ -526,7 +526,8 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
     try {
       return (BigDecimal) df.parse(value);
     } catch (ParseException e) {
-      throw new AssertionError(message + " (getString value '" + value + "' is not a parseable number)", e);
+      throw new AssertionError(
+          message + " (getString value '" + value + "' is not a parseable number)", e);
     }
   }
 


### PR DESCRIPTION
### Summary
Number type E2E tests were failing on environments with a non-English system locale (e.g. , as decimal separator), because new BigDecimal(stringValue) only accepts English-format strings.

Replaced the raw constructor call with a locale-aware parseLocaleDecimal() helper using DecimalFormat.getInstance() + setParseBigDecimal(true).
### Root Cause
new BigDecimal(String) throws NumberFormatException for locale-formatted numbers (e.g. 1.234,56), making the test suite non-portable across system locales.