### PR TITLE
Python - clean up tests after reference version bump

### DIFF
--- a/python/tests/e2e/types/test_timestamp_ltz.py
+++ b/python/tests/e2e/types/test_timestamp_ltz.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from ...conftest import with_paramstyle
 from .utils import assert_connection_is_open, assert_datetime_type, assert_sequential_values, batch_insert
 
@@ -186,7 +184,6 @@ class TestTimestampLtzTable:
 
 
 @with_paramstyle("qmark")
-@pytest.mark.skip_reference
 class TestTimestampLtzBinding:
     """Tests for TIMESTAMP_LTZ type using parameter binding.
 

--- a/python/tests/integ/config/test_config_manager.py
+++ b/python/tests/integ/config/test_config_manager.py
@@ -334,7 +334,7 @@ class TestConfigManager:
         # Then The default value should be returned
         assert value == "default_value"
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver ConfigManager has no clear_cache method")
     def test_clear_cache(self):
         """Test that clear_cache resets caches."""
         # Given A ConfigManager with cached config

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -14,7 +14,7 @@ from snowflake.connector.errors import NotSupportedError
 class TestConnectionInfo:
     """Integration tests for Connection._get_connection_info."""
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no _get_connection_info method")
     def test_get_connection_info_returns_info_after_connect(self, connection):
         """Test that _get_connection_info returns info after connection is established."""
         # Given an established connection
@@ -38,21 +38,21 @@ class TestConnectionMethods:
 class TestConnectionOptionalMethods:
     """Test optional Connection methods."""
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no cancel method")
     def test_cancel_not_implemented(self, connection):
         """Test that cancel raises NotSupportedError."""
         with pytest.raises(NotSupportedError) as excinfo:
             connection.cancel()
         assert "cancel is not implemented" in str(excinfo.value)
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no ping method")
     def test_ping_not_implemented(self, connection):
         """Test that ping raises NotSupportedError."""
         with pytest.raises(NotSupportedError) as excinfo:
             connection.ping()
         assert "ping is not implemented" in str(excinfo.value)
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit method")
     def test_set_autocommit(self, connection):
         """Test that set_autocommit changes the autocommit flag."""
         connection.set_autocommit(False)
@@ -60,7 +60,7 @@ class TestConnectionOptionalMethods:
         connection.set_autocommit(True)
         assert connection._autocommit is True
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit/get_autocommit methods")
     def test_get_autocommit(self, connection):
         """Test that get_autocommit returns the current setting."""
         connection.set_autocommit(False)
@@ -72,7 +72,7 @@ class TestConnectionOptionalMethods:
 class TestConnectionAutocommitMethod:
     """Test Connection autocommit method."""
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit method")
     def test_autocommit_sets_flag_and_calls_set_autocommit(self, connection, monkeypatch):
         """Test that autocommit() delegates to set_autocommit."""
         mock_set_autocommit = Mock()
@@ -82,12 +82,12 @@ class TestConnectionAutocommitMethod:
 
         mock_set_autocommit.assert_called_once_with(True)
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver _autocommit defaults to None, not True")
     def test_autocommit_default_is_server_default(self, connection):
         """Test that autocommit defaults to the server default (true) when not explicitly set."""
         assert connection._autocommit is True
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no get_autocommit method")
     def test_autocommit_roundtrip(self, connection):
         """Test setting autocommit via autocommit() and reading via get_autocommit()."""
         connection.autocommit(True)
@@ -309,13 +309,13 @@ class TestCommitRollback:
 class TestAutocommitAlterSession:
     """Integration tests for set_autocommit ALTER SESSION."""
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit/_get_session_parameter methods")
     def test_set_autocommit_true_updates_session_parameter(self, connection):
         """Test that set_autocommit(True) sets the AUTOCOMMIT session parameter."""
         connection.set_autocommit(True)
         assert connection._get_session_parameter("AUTOCOMMIT") == "true"
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit/_get_session_parameter methods")
     def test_set_autocommit_false_updates_session_parameter(self, connection):
         """Test that set_autocommit(False) sets the AUTOCOMMIT session parameter."""
         connection.set_autocommit(False)

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -886,20 +886,23 @@ class TestCursorMethods:
         cursor.close()
         assert cursor.is_closed()
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(
+        reason="Reference driver forwards callproc to server instead of raising NotSupportedError"
+    )
     def test_callproc_not_implemented(self, cursor):
         """Test that callproc raises NotSupportedError."""
         with pytest.raises(NotSupportedError) as excinfo:
             cursor.callproc("test_proc", [1, 2, 3])
         assert "callproc is not implemented" in str(excinfo.value)
 
-    @pytest.mark.skip_reference
     def test_executemany_is_callable(self, cursor):
         """Test that executemany is callable (basic smoke test)."""
         # Just verify it's callable and accepts empty sequence without error
         cursor.executemany("INSERT INTO test VALUES (?)", [])
 
-    @pytest.mark.skip_reference
+    @pytest.mark.skip_reference(
+        reason="Reference driver returns None from nextset instead of raising NotSupportedError"
+    )
     def test_nextset_not_implemented(self, cursor):
         """Test that nextset raises NotSupportedError."""
         with pytest.raises(NotSupportedError) as excinfo:
@@ -1069,7 +1072,6 @@ class TestCursorFetch:
         result = cursor.fetchmany(0)
         assert result == []
 
-    @pytest.mark.skip_reference
     def test_fetchmany_negative_size_raises_error(self, cursor):
         """Test fetchmany with negative size raises ProgrammingError."""
         cursor.execute("SELECT 1")
@@ -1369,7 +1371,6 @@ class TestDictCursorCreation:
         with connection.cursor(DictCursor) as cur:
             assert isinstance(cur, DictCursor)
 
-    @pytest.mark.skip_reference
     def test_dict_cursor_is_base_cursor_subclass(self):
         """Test that DictCursor is a subclass of BaseCursor."""
         from snowflake.connector.cursor import DictCursor, SnowflakeCursorBase

--- a/python/tests/integ/test_session_parameters.py
+++ b/python/tests/integ/test_session_parameters.py
@@ -6,7 +6,7 @@ import pytest
 
 
 # this module is heavily dependent on _get_session_parameter, which is not a part of the reference driver
-pytestmark = pytest.mark.skip_reference
+pytestmark = pytest.mark.skip_reference(reason="Reference driver has no _get_session_parameter method")
 
 
 class TestSessionParametersGet:


### PR DESCRIPTION
Some tests were skipped as not working with reference driver 3.17, but work on 4.2. This PR addresses that + documents why the tests are skipped