### PR TITLE
SNOW-2433865 separate driver images in perf tests, simplify recorded http tests cert handling

### DIFF
--- a/tests/performance/drivers/odbc/Dockerfile
+++ b/tests/performance/drivers/odbc/Dockerfile
@@ -74,5 +74,17 @@ ENV ODBCSYSINI=/workdir
 # Default to universal driver (can be overridden with DRIVER_TYPE=old)
 ENV DRIVER_TYPE=universal
 
-CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && /workdir/build/odbc-perf-driver
+CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && \
+    if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
+        SYS_CA=/etc/ssl/certs/ca-certificates.crt; \
+        printf '\n' >> "$SYS_CA" && cat "$WIREMOCK_CA_CERT" >> "$SYS_CA"; \
+        CACERT=/usr/lib/snowflake/odbc/lib/cacert.pem; \
+        if [ -f "$CACERT" ]; then \
+            printf '\n' >> "$CACERT" && cat "$WIREMOCK_CA_CERT" >> "$CACERT"; \
+            INI=/usr/lib/snowflake/odbc/lib/simba.snowflake.ini; \
+            printf '[Driver]\nCABundleFile=%s\nDisableOCSPCheck=true\nErrorMessagesPath=/usr/lib/snowflake/odbc/ErrorMessages/\nODBCInstLib=libodbcinst.so\n' "$CACERT" > "$INI"; \
+            export SIMBAINI="$INI"; \
+        fi; \
+    fi && \
+    /workdir/build/odbc-perf-driver
 

--- a/tests/performance/drivers/odbc/Dockerfile
+++ b/tests/performance/drivers/odbc/Dockerfile
@@ -2,7 +2,9 @@
 
 ARG BUILDPLATFORM=linux/amd64
 
-# Stage 1: Install old Snowflake ODBC driver
+# ============================================================================
+# Stage: Download and install old Snowflake ODBC driver
+# ============================================================================
 FROM --platform=${BUILDPLATFORM} artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/development-docker-virtual/rust:slim AS old_installer
 
 RUN apt-get update && apt-get install -y \
@@ -10,7 +12,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Download and install Snowflake old ODBC driver (latest version)
 RUN if [ "$(uname -m)" = "x86_64" ]; then \
         ARCH="linux"; \
         PACKAGE_ARCH="x86_64"; \
@@ -28,9 +29,11 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     dpkg -i snowflake-odbc-${LATEST_VERSION}.${PACKAGE_ARCH}.deb || true && \
     rm -f snowflake-odbc-${LATEST_VERSION}.${PACKAGE_ARCH}.deb
 
-# Stage 2: Runtime with both drivers  
-FROM --platform=${BUILDPLATFORM} artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/development-docker-virtual/rust:slim AS runtime_base
-# Install runtime dependencies
+# ============================================================================
+# Base stage: runtime deps + test app build (shared)
+# ============================================================================
+FROM --platform=${BUILDPLATFORM} artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/development-docker-virtual/rust:slim AS base
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
@@ -40,51 +43,59 @@ RUN apt-get update && apt-get install -y \
     zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-FROM runtime_base
-
 WORKDIR /workdir
 
-# Copy the universal ODBC wrapper and sf_core library
-COPY tests/performance/.tmp/libsfodbc.so /usr/lib/libsfodbc.so
-COPY tests/performance/.tmp/libsf_core.so /usr/lib/libsf_core.so
-
-# Copy Rust version from sf-core-builder
-COPY tests/performance/.tmp/rust_version /etc/rust_version
-
-# Copy old driver from installer stage
-COPY --from=old_installer /usr/lib/snowflake/ /usr/lib/snowflake/
-
-# Copy ODBC test application
 COPY tests/performance/drivers/odbc/app/ /workdir/
 
-# Build ODBC app
 RUN mkdir -p build && \
     cd build && \
     cmake .. && \
     cmake --build .
 
-# Detect OS version at build time (major version only) and write to file
 RUN bash -c '. /etc/os-release && echo "${ID^}_$(echo $VERSION_ID | cut -d. -f1)" > /etc/os_info'
 
-# Set environment variables
 ENV LD_LIBRARY_PATH=/usr/lib
 ENV ODBCINI=/workdir/odbc.ini
 ENV ODBCSYSINI=/workdir
 
-# Default to universal driver (can be overridden with DRIVER_TYPE=old)
+# ============================================================================
+# Universal driver image
+# ============================================================================
+FROM base AS universal
+
+COPY tests/performance/.tmp/libsfodbc.so /usr/lib/libsfodbc.so
+COPY tests/performance/.tmp/libsf_core.so /usr/lib/libsf_core.so
+COPY tests/performance/.tmp/rust_version /etc/rust_version
+
 ENV DRIVER_TYPE=universal
 
 CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && \
     if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
         SYS_CA=/etc/ssl/certs/ca-certificates.crt; \
         printf '\n' >> "$SYS_CA" && cat "$WIREMOCK_CA_CERT" >> "$SYS_CA"; \
-        CACERT=/usr/lib/snowflake/odbc/lib/cacert.pem; \
-        if [ -f "$CACERT" ]; then \
-            printf '\n' >> "$CACERT" && cat "$WIREMOCK_CA_CERT" >> "$CACERT"; \
-            INI=/usr/lib/snowflake/odbc/lib/simba.snowflake.ini; \
-            printf '[Driver]\nCABundleFile=%s\nDisableOCSPCheck=true\nErrorMessagesPath=/usr/lib/snowflake/odbc/ErrorMessages/\nODBCInstLib=libodbcinst.so\n' "$CACERT" > "$INI"; \
-            export SIMBAINI="$INI"; \
-        fi; \
     fi && \
     /workdir/build/odbc-perf-driver
 
+# ============================================================================
+# Old driver image
+# ============================================================================
+FROM base AS old
+
+COPY --from=old_installer /usr/lib/snowflake/ /usr/lib/snowflake/
+RUN echo "N/A" > /etc/rust_version
+
+ENV DRIVER_TYPE=old
+
+CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && \
+    if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
+        SYS_CA=/etc/ssl/certs/ca-certificates.crt; \
+        printf '\n' >> "$SYS_CA" && cat "$WIREMOCK_CA_CERT" >> "$SYS_CA"; \
+        CACERT=/usr/lib/snowflake/odbc/lib/cacert.pem; \
+        printf '\n' >> "$CACERT" && cat "$WIREMOCK_CA_CERT" >> "$CACERT"; \
+        INI_ORIG=/usr/lib/snowflake/odbc/lib/simba.snowflake.ini; \
+        INI=/tmp/simba.snowflake.wiremock.ini; \
+        if [ -f "$INI_ORIG" ]; then cp "$INI_ORIG" "$INI"; else : > "$INI"; fi; \
+        printf '\n[Driver]\nCABundleFile=%s\nDisableOCSPCheck=true\nErrorMessagesPath=/usr/lib/snowflake/odbc/ErrorMessages/\nODBCInstLib=libodbcinst.so\n' "$CACERT" >> "$INI"; \
+        export SIMBAINI="$INI"; \
+    fi && \
+    /workdir/build/odbc-perf-driver

--- a/tests/performance/drivers/odbc/app/config.cpp
+++ b/tests/performance/drivers/odbc/app/config.cpp
@@ -57,15 +57,10 @@ std::map<std::string, std::string> parse_parameters_json() {
   std::string search_str = json_str;
 
   std::vector<std::pair<std::string, std::vector<std::string>>> key_mappings = {
-      {"account", {"SNOWFLAKE_TEST_ACCOUNT", "account"}},
-      {"host", {"SNOWFLAKE_TEST_HOST", "host"}},
-      {"user", {"SNOWFLAKE_TEST_USER", "user"}},
-      {"database", {"SNOWFLAKE_TEST_DATABASE", "database"}},
-      {"schema", {"SNOWFLAKE_TEST_SCHEMA", "schema"}},
-      {"warehouse", {"SNOWFLAKE_TEST_WAREHOUSE", "warehouse"}},
-      {"role", {"SNOWFLAKE_TEST_ROLE", "role"}},
-      {"verify_certificates", {"verify_certificates"}},
-      {"verify_hostname", {"verify_hostname"}}};
+      {"account", {"SNOWFLAKE_TEST_ACCOUNT", "account"}}, {"host", {"SNOWFLAKE_TEST_HOST", "host"}},
+      {"user", {"SNOWFLAKE_TEST_USER", "user"}},          {"database", {"SNOWFLAKE_TEST_DATABASE", "database"}},
+      {"schema", {"SNOWFLAKE_TEST_SCHEMA", "schema"}},    {"warehouse", {"SNOWFLAKE_TEST_WAREHOUSE", "warehouse"}},
+      {"role", {"SNOWFLAKE_TEST_ROLE", "role"}}};
 
   for (const auto& [param_name, json_keys] : key_mappings) {
     for (const auto& json_key : json_keys) {

--- a/tests/performance/drivers/odbc/app/connection.cpp
+++ b/tests/performance/drivers/odbc/app/connection.cpp
@@ -215,9 +215,13 @@ std::string get_connection_string() {
   if (!params["warehouse"].empty()) ss << "WAREHOUSE=" << params["warehouse"] << ";";
   if (!params["role"].empty()) ss << "ROLE=" << params["role"] << ";";
 
-  // TLS verification parameters (for WireMock testing)
-  if (!params["verify_certificates"].empty()) ss << "TLS_VERIFY_CERTIFICATES=" << params["verify_certificates"] << ";";
-  if (!params["verify_hostname"].empty()) ss << "TLS_VERIFY_HOSTNAME=" << params["verify_hostname"] << ";";
+  std::string driver_type_str = get_driver_type();
+
+  const char* wiremock_proxy = std::getenv("WIREMOCK_PROXY_URL");
+  if (driver_type_str == "old" && wiremock_proxy) {
+    ss << "proxy=" << wiremock_proxy << ";";
+    std::cout << "Old driver: proxy=" << wiremock_proxy << "\n";
+  }
 
   return ss.str();
 }

--- a/tests/performance/drivers/odbc/build.sh
+++ b/tests/performance/drivers/odbc/build.sh
@@ -8,7 +8,7 @@ source "${SCRIPT_DIR}/../detect_platform.sh"
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
-echo "Building ODBC performance driver..."
+echo "Building ODBC performance drivers..."
 echo "Platform: ${BUILDPLATFORM}"
 echo ""
 
@@ -38,14 +38,14 @@ docker create --name sf-core-extract sf-core-builder:latest >/dev/null 2>&1
 if docker cp sf-core-extract:/workdir/libsfodbc.so tests/performance/.tmp/libsfodbc.so 2>/dev/null; then
     echo "✓ Extracted libsfodbc.so"
 else
-    echo "❌ Error: Could not extract libsfodbc.so"
+    echo "Error: Could not extract libsfodbc.so"
     docker rm -f sf-core-extract >/dev/null 2>&1
     exit 1
 fi
 if docker cp sf-core-extract:/workdir/libsf_core.so tests/performance/.tmp/libsf_core.so 2>/dev/null; then
     echo "✓ Extracted libsf_core.so"
 else
-    echo "❌ Error: Could not extract libsf_core.so"
+    echo "Error: Could not extract libsf_core.so"
     docker rm -f sf-core-extract >/dev/null 2>&1
     exit 1
 fi
@@ -57,12 +57,23 @@ echo "${RUST_VERSION}" > tests/performance/.tmp/rust_version
 echo "✓ Rust version: ${RUST_VERSION}"
 echo ""
 
-# Step 3: Build ODBC driver
-echo "→ Building ODBC driver..."
-echo ""
+# Step 3: Build universal driver image
+echo "→ Building universal driver image..."
 docker build -f tests/performance/drivers/odbc/Dockerfile \
   --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
-  -t odbc-perf-driver:latest .
+  --target universal \
+  -t odbc-perf-driver-universal:latest .
 
 echo ""
-echo "✓ Build complete: odbc-perf-driver:latest"
+echo "✓ Built: odbc-perf-driver-universal:latest"
+echo ""
+
+# Step 4: Build old driver image
+echo "→ Building old driver image..."
+docker build -f tests/performance/drivers/odbc/Dockerfile \
+  --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
+  --target old \
+  -t odbc-perf-driver-old:latest .
+
+echo ""
+echo "✓ Built: odbc-perf-driver-old:latest"

--- a/tests/performance/drivers/python/Dockerfile
+++ b/tests/performance/drivers/python/Dockerfile
@@ -1,7 +1,10 @@
 # Build with: cd tests/performance && hatch run build-python
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=${BUILDPLATFORM} artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/development-docker-virtual/python:3.13-slim
+# ============================================================================
+# Base stage: OS packages and test application (shared by both drivers)
+# ============================================================================
+FROM --platform=${BUILDPLATFORM} artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/development-docker-virtual/python:3.13-slim AS base
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
@@ -16,6 +19,18 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workdir
+
+RUN bash -c '. /etc/os-release && echo "${ID^}_$(echo $VERSION_ID | cut -d. -f1)" > /etc/os_info'
+
+# Copy test application
+COPY tests/performance/drivers/python/app/ /workdir/
+
+ENV PYTHONUNBUFFERED=1
+
+# ============================================================================
+# Universal driver: builds Rust core + Cython extensions
+# ============================================================================
+FROM base AS universal
 
 # Install Rust toolchain
 COPY rust-toolchain.toml ./rust-toolchain.toml
@@ -52,24 +67,29 @@ RUN cd python && \
     ln -s ../error_trace error_trace && \
     ln -s ../error_trace_derive error_trace_derive
 
-# Save Rust version for runtime reporting
 RUN rustc --version | awk '{print $2}' | cut -d. -f1,2 > /etc/rust_version
 
-# Install the driver — this builds Rust core and Cython extensions via hatch_build.py
+# Install the driver — builds Rust core and Cython extensions via hatch_build.py
 RUN pip install --no-cache-dir /workdir/python/
 
-# Copy test application
-COPY tests/performance/drivers/python/app/ /workdir/
+ENV DRIVER_TYPE=universal
 
-# Install old driver to separate directory for comparison tests
-# Using -t flag to install to old_driver_src without overwriting universal driver
-RUN pip install --no-cache-dir snowflake-connector-python -t /workdir/old_driver_src
+CMD export OS_INFO=$(cat /etc/os_info) && export BUILD_RUST_VERSION=$(cat /etc/rust_version) && \
+    if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
+        CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt; \
+        printf '\n' >> "$CA_BUNDLE" && cat "$WIREMOCK_CA_CERT" >> "$CA_BUNDLE"; \
+    fi && \
+    python main.py
 
-# Detect OS version at build time (major version only) and write to file
-RUN bash -c '. /etc/os-release && echo "${ID^}_$(echo $VERSION_ID | cut -d. -f1)" > /etc/os_info'
+# ============================================================================
+# Old driver
+# ============================================================================
+FROM base AS old
 
-# Set environment variables
-ENV PYTHONUNBUFFERED=1
+RUN pip install --no-cache-dir snowflake-connector-python
+RUN echo "N/A" > /etc/rust_version
+
+ENV DRIVER_TYPE=old
 
 CMD export OS_INFO=$(cat /etc/os_info) && export BUILD_RUST_VERSION=$(cat /etc/rust_version) && \
     if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \

--- a/tests/performance/drivers/python/Dockerfile
+++ b/tests/performance/drivers/python/Dockerfile
@@ -71,4 +71,11 @@ RUN bash -c '. /etc/os-release && echo "${ID^}_$(echo $VERSION_ID | cut -d. -f1)
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 
-CMD export OS_INFO=$(cat /etc/os_info) && export BUILD_RUST_VERSION=$(cat /etc/rust_version) && python main.py
+CMD export OS_INFO=$(cat /etc/os_info) && export BUILD_RUST_VERSION=$(cat /etc/rust_version) && \
+    if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
+        CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt; \
+        printf '\n' >> "$CA_BUNDLE" && cat "$WIREMOCK_CA_CERT" >> "$CA_BUNDLE"; \
+        export REQUESTS_CA_BUNDLE="$CA_BUNDLE"; \
+        export SSL_CERT_FILE="$CA_BUNDLE"; \
+    fi && \
+    python main.py

--- a/tests/performance/drivers/python/app/config.py
+++ b/tests/performance/drivers/python/app/config.py
@@ -78,8 +78,7 @@ class TestConfig:
             connection_params["authenticator"] = "SNOWFLAKE_JWT"
             connection_params["private_key_file"] = private_key_file
 
-        # Process TLS/certificate verification parameters (for WireMock testing)
-        _process_tls_parameters(conn_params, connection_params, self.driver_type)
+        _disable_ocsp_for_wiremock(connection_params, self.driver_type)
 
         return connection_params
     
@@ -88,58 +87,9 @@ class TestConfig:
         return "PYTHON" if self.driver_type == "universal" else "PYTHON (Old)"
 
 
-def _process_tls_parameters(conn_params, connection_params, driver_type):
-    """
-    Process TLS/certificate verification parameters for WireMock testing.
-    
-    This function handles verification parameters differently for old vs universal drivers:
-    
-    For OLD driver:
-        - Sets insecure_mode=True to disable OCSP checks (partial SSL bypass)
-        - The old driver also requires SSL patching in connection.py via _disable_ssl_verification_for_wiremock() for full SSL bypass.
-    
-    For UNIVERSAL driver:
-        - Passes verify_certificates and verify_hostname directly to sf_core
-    
-    Args:
-        conn_params: Raw connection parameters from JSON
-        connection_params: Processed connection parameters dict to update
-        driver_type: Type of driver being used ("universal" or "old")
-    """
-    if driver_type == "universal":
-        _process_tls_for_universal(conn_params, connection_params)
-    else:
-        _process_tls_for_old(conn_params, connection_params)
-
-
-def _process_tls_for_universal(conn_params, connection_params):
-    """
-    Process TLS parameters for universal driver.
-    
-    Passes verify_certificates and verify_hostname directly to sf_core.
-    """
-    if "verify_certificates" in conn_params:
-        connection_params["verify_certificates"] = conn_params["verify_certificates"]
-    
-    if "verify_hostname" in conn_params:
-        connection_params["verify_hostname"] = conn_params["verify_hostname"]
-
-
-def _process_tls_for_old(conn_params, connection_params):
-    """
-    Process TLS parameters for old driver.
-    
-    Converts verify_certificates to insecure_mode (inverted logic).
-    The old driver also requires SSL patching in connection.py for full SSL bypass.
-    """
-    if "verify_certificates" in conn_params:
-        verify_value = conn_params["verify_certificates"]
-        
-        # Convert string to boolean for insecure_mode (inverted)
-        if isinstance(verify_value, str):
-            should_disable_verify = (verify_value.lower() == "false")
-        else:
-            should_disable_verify = not verify_value
-        
-        connection_params["insecure_mode"] = should_disable_verify
+def _disable_ocsp_for_wiremock(connection_params, driver_type):
+    """Disable OCSP for the old driver when proxied through WireMock,
+    since WireMock-generated certs have no OCSP responder."""
+    if driver_type == "old" and os.getenv("HTTPS_PROXY"):
+        connection_params["insecure_mode"] = True
 

--- a/tests/performance/drivers/python/app/connection.py
+++ b/tests/performance/drivers/python/app/connection.py
@@ -1,11 +1,10 @@
 """Connection management and connector selection."""
 from importlib.metadata import version, PackageNotFoundError
-from pathlib import Path
 
 
 def create_connection(driver_type, conn_params):
     """Create and return a connection."""
-    connector = _get_connector(driver_type)
+    connector = _get_connector()
     driver_version = _get_driver_version(driver_type)
     conn = connector.connect(**conn_params)
     return conn, driver_version
@@ -19,10 +18,10 @@ def get_server_version(cursor):
         if server_version_result:
             return server_version_result[0]
         else:
-            print("⚠️  Warning: Could not retrieve server version (empty result)")
+            print("Warning: Could not retrieve server version (empty result)")
             return "UNKNOWN"
     except Exception as err:
-        print(f"⚠️  Warning: Could not retrieve server version: {err}")
+        print(f"Warning: Could not retrieve server version: {err}")
         return "UNKNOWN"
 
 
@@ -36,43 +35,22 @@ def execute_setup_queries(cursor, setup_queries):
         print(f"  Setup query {i}: {query}")
         try:
             cursor.execute(query)
-            # Consume any results to ensure the query completes
             try:
                 cursor.fetchall()
             except Exception:
-                pass  # Some queries don't return results
+                pass
         except Exception as e:
-            print(f"\n❌ ERROR: Setup query {i} failed: {query}")
+            print(f"\nERROR: Setup query {i} failed: {query}")
             print(f"   Error: {e}")
             raise
     
-    print("✓ Setup queries completed")
+    print("Setup queries completed")
 
 
-def _load_from_sources():
-    """Load old driver from old_driver_src directory."""
-    import sys
-    
-    legacy_path = Path(__file__).parent / "old_driver_src"
-    if not legacy_path.exists():
-        raise ImportError(f"Old driver directory not found: {legacy_path}")
-    
-    legacy_path_str = str(legacy_path.absolute())
-    if legacy_path_str not in sys.path:
-        sys.path.insert(0, legacy_path_str)
-    
-    import snowflake.connector as old_connector
-    
-    return old_connector
-
-
-def _get_connector(driver_type):
-    """Get the appropriate connector module based on driver type."""
-    if driver_type == "old":
-        return _load_from_sources()
-    else:  # universal
-        from snowflake import connector
-        return connector
+def _get_connector():
+    """Get the snowflake connector module (whichever is installed in this image)."""
+    from snowflake import connector
+    return connector
 
 
 def _get_driver_version(driver_type):
@@ -80,10 +58,8 @@ def _get_driver_version(driver_type):
     try:
         if driver_type == "old":
             return version("snowflake-connector-python")
-        else:  # universal
+        else:
             return version("snowflake-connector-python-ud")
     except PackageNotFoundError as err:
-        print(f"⚠️  Warning: Could not determine driver version: {err}")
+        print(f"Warning: Could not determine driver version: {err}")
         return "UNKNOWN"
-
-

--- a/tests/performance/drivers/python/app/connection.py
+++ b/tests/performance/drivers/python/app/connection.py
@@ -1,21 +1,13 @@
 """Connection management and connector selection."""
 from importlib.metadata import version, PackageNotFoundError
 from pathlib import Path
-import ssl
-import os
 
 
 def create_connection(driver_type, conn_params):
     """Create and return a connection."""
     connector = _get_connector(driver_type)
     driver_version = _get_driver_version(driver_type)
-    
-    # Disable SSL verification for old Python driver when using WireMock proxy
-    if os.getenv("HTTPS_PROXY") and driver_type == "old":
-        _disable_ssl_verification_for_wiremock(connector)
-    
     conn = connector.connect(**conn_params)
-    
     return conn, driver_version
 
 
@@ -95,26 +87,3 @@ def _get_driver_version(driver_type):
         return "UNKNOWN"
 
 
-def _disable_ssl_verification_for_wiremock(connector):
-    """
-    Disable SSL verification for old Python driver when using WireMock proxy.
-    
-    Args:
-        connector: The connector module (loaded from old_driver_src for old driver)
-    """
-    # Import ssl_wrap_socket from the connector package
-    if hasattr(connector, 'ssl_wrap_socket'):
-        ssl_wrap = connector.ssl_wrap_socket
-    else:
-        import importlib
-        module_name = connector.__name__ + '.ssl_wrap_socket'
-        ssl_wrap = importlib.import_module(module_name)
-
-    def no_verify_context(*args, **kwargs):
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        return ctx
-    
-    # Replace the SSL context builder
-    ssl_wrap._build_context_with_partial_chain = no_verify_context

--- a/tests/performance/drivers/python/build.sh
+++ b/tests/performance/drivers/python/build.sh
@@ -8,13 +8,25 @@ source "${SCRIPT_DIR}/../detect_platform.sh"
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
-echo "Building Python performance driver..."
+echo "Building Python performance drivers..."
 echo "Platform: ${BUILDPLATFORM}"
 echo ""
 
+echo "→ Building universal driver image..."
 docker build -f tests/performance/drivers/python/Dockerfile \
   --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
-  -t python-perf-driver:latest .
+  --target universal \
+  -t python-perf-driver-universal:latest .
 
 echo ""
-echo "✓ Build complete: python-perf-driver:latest"
+echo "✓ Built: python-perf-driver-universal:latest"
+echo ""
+
+echo "→ Building old driver image..."
+docker build -f tests/performance/drivers/python/Dockerfile \
+  --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
+  --target old \
+  -t python-perf-driver-old:latest .
+
+echo ""
+echo "✓ Built: python-perf-driver-old:latest"

--- a/tests/performance/runner/container.py
+++ b/tests/performance/runner/container.py
@@ -59,7 +59,10 @@ def create_perf_container(
     Returns:
         Configured DockerContainer instance
     """
-    image_name = f"{driver}-perf-driver:latest"
+    if driver == "core" or not driver_type:
+        image_name = f"{driver}-perf-driver:latest"
+    else:
+        image_name = f"{driver}-perf-driver-{driver_type}:latest"
     
     container_kwargs = {
         "mem_limit": MEMORY_LIMIT,

--- a/tests/performance/runner/modes/wiremock_runner.py
+++ b/tests/performance/runner/modes/wiremock_runner.py
@@ -1,5 +1,4 @@
 import csv
-import json
 import logging
 import shutil
 import statistics
@@ -118,7 +117,8 @@ def run_wiremock_performance_test(
                     s3_files_dir=s3_files_dir,
                     wiremock_url=wiremock.get_url(),
                     wiremock_container_name=wiremock.get_container_name(),
-                    network_mode=network
+                    network_mode=network,
+                    wiremock_manager=wiremock,
                 )
                 
                 # Step 4: Create snapshot and transform
@@ -155,7 +155,7 @@ def run_wiremock_performance_test(
         wiremock = WiremockManager(mappings_dir, network_mode=network)
         
         try:
-            wiremock.start_replay()
+            wiremock.start_replay(driver_label=driver_type)
             
             # Execute test N times with cached responses
             logger.info("")
@@ -176,7 +176,8 @@ def run_wiremock_performance_test(
                 wiremock_container_name=wiremock.get_container_name(),
                 network_mode=network,
                 is_replay=True,  # Flag to indicate replay mode
-                expected_row_count=expected_row_count  # Pass expected row count for validation
+                expected_row_count=expected_row_count,  # Pass expected row count for validation
+                wiremock_manager=wiremock,
             )
             
             # Collect and display WireMock response time metrics
@@ -517,27 +518,23 @@ def _run_test_with_proxy(
     s3_files_dir: Path = None,
     is_replay: bool = False,
     expected_row_count: int = None,
+    wiremock_manager: "WiremockManager" = None,
 ):
     """
     Run test with WireMock proxy configuration.
     
-    Adds proxy settings and disables certificate verification for drivers.
-    
-    Args:
-        wiremock_url: WireMock URL for host access (e.g., http://127.0.0.1:12345)
-        wiremock_container_name: WireMock container name for inter-container communication
-        network_mode: Docker network mode ("host" for direct host network)
-        ... (other args)
+    Sets up proxy environment variables and exports the WireMock CA certificate
+    so drivers trust the dynamically generated MITM certificates.
     """
-    # Modify parameters to disable certificate verification for WireMock
-    modified_parameters_json = _modify_parameters_for_wiremock(parameters_json, driver)
-    
     # Build environment variables for proxy and replay mode
     # With host network: use localhost; with bridge network: use container name
     proxy_url = _get_proxy_url_for_container(wiremock_url, wiremock_container_name, network_mode)
     env_vars = {
         "HTTPS_PROXY": proxy_url,
         "HTTP_PROXY": proxy_url,
+        # Lowercase variants required by the old Snowflake ODBC driver (libcurl)
+        "https_proxy": proxy_url,
+        "http_proxy": proxy_url,
     }
     
     if is_replay:
@@ -546,11 +543,22 @@ def _run_test_with_proxy(
             logger.info(f"Setting EXPECTED_ROW_COUNT={expected_row_count} for replay validation")
             env_vars["EXPECTED_ROW_COUNT"] = str(expected_row_count)
     
+    # Export the WireMock CA cert so the driver trusts the dynamically generated
+    # MITM certificates. Each Dockerfile appends this to the appropriate CA bundle.
+    if wiremock_manager:
+        try:
+            ca_cert_path = wiremock_manager.export_ca_cert(results_dir)
+            env_vars["WIREMOCK_CA_CERT"] = "/results/" + ca_cert_path.name
+            if driver == "odbc" and driver_type == "old":
+                env_vars["WIREMOCK_PROXY_URL"] = proxy_url
+        except Exception as e:
+            logger.warning(f"Failed to export WireMock CA cert: {e}")
+    
     # Execute test with common function
     execute_test(
         test_name=test_name,
         sql_command=sql_command,
-        parameters_json=modified_parameters_json,
+        parameters_json=parameters_json,
         results_dir=results_dir,
         iterations=iterations,
         warmup_iterations=warmup_iterations,
@@ -565,23 +573,3 @@ def _run_test_with_proxy(
     )
 
 
-def _modify_parameters_for_wiremock(parameters_json: str, driver: str) -> str:
-    """
-    Modify connection parameters to disable certificate verification for WireMock tests.
-    
-    Args:
-        parameters_json: Original JSON parameters
-        driver: Driver being used
-    
-    Returns:
-        Modified JSON parameters
-    """
-    params = json.loads(parameters_json)
-    
-    # Disable certificate verification for Core/Python/ODBC
-    # (WireMock needs certs server-side for HTTPS, but clients don't verify them)
-    if driver in ("core", "python", "odbc"):
-        params["testconnection"]["verify_certificates"] = "false"
-        params["testconnection"]["verify_hostname"] = "false"
-    
-    return json.dumps(params)

--- a/tests/performance/runner/modes/wiremock_runner.py
+++ b/tests/performance/runner/modes/wiremock_runner.py
@@ -180,14 +180,13 @@ def run_wiremock_performance_test(
                 wiremock_manager=wiremock,
             )
             
-            # Collect and display WireMock response time metrics
+            # Collect metrics while WireMock is still running (triggers flush to disk)
             logger.info("")
             logger.info("Collecting response time metrics...")
             metrics = wiremock.get_request_metrics()
             _log_wiremock_metrics(metrics, warmup_iterations=warmup_iterations, iterations=iterations)
             
         finally:
-            # Stop and cleanup
             cleanup_step = 4 if skip_recording else 8
             logger.info("")
             logger.info(f"Step {cleanup_step}: Cleanup...")
@@ -552,7 +551,11 @@ def _run_test_with_proxy(
             if driver == "odbc" and driver_type == "old":
                 env_vars["WIREMOCK_PROXY_URL"] = proxy_url
         except Exception as e:
-            logger.warning(f"Failed to export WireMock CA cert: {e}")
+            logger.error(
+                "Failed to export WireMock CA cert; skipping this test execution.",
+                exc_info=True,
+            )
+            return
     
     # Execute test with common function
     execute_test(

--- a/tests/performance/wiremock/extensions/ResponseTimeExtension.java
+++ b/tests/performance/wiremock/extensions/ResponseTimeExtension.java
@@ -8,19 +8,27 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 /**
  * Lightweight WireMock extension that tracks only response times.
  * All calculations (avg, percentiles, etc.) are done in Python.
+ *
+ * No file I/O happens per-request for maximum replay performance.
+ * Python triggers a single flush by sending a request to the
+ * {@value #FLUSH_PATH} stub after the test run finishes;
+ * {@link #afterComplete} detects it and calls {@link #writeStatsToFile()}.
  */
 public class ResponseTimeExtension implements ServeEventListener, Extension {
     private static final ConcurrentLinkedQueue<Long> responseTimes = new ConcurrentLinkedQueue<>();
     /** Maximum acceptable response time (5 minutes). Responses exceeding this are discarded as outliers. */
     private static final long MAX_RESPONSE_TIME_MS = 300_000;
+
+    static final String FLUSH_PATH = "/__perf/flush-stats";
 
     private static final String STATS_FILE;
     static {
@@ -30,10 +38,6 @@ public class ResponseTimeExtension implements ServeEventListener, Extension {
             : "/wiremock/response-time-stats-" + suffix + ".json";
     }
     
-    public ResponseTimeExtension() {
-        // Extension initialized
-    }
-    
     @Override
     public String getName() {
         return "response-time-tracker";
@@ -41,87 +45,67 @@ public class ResponseTimeExtension implements ServeEventListener, Extension {
     
     @Override
     public void beforeMatch(ServeEvent serveEvent, Parameters parameters) {
-        // Not needed for response time tracking
     }
     
     @Override
     public void afterMatch(ServeEvent serveEvent, Parameters parameters) {
-        // Not needed for response time tracking  
     }
     
     @Override
     public void beforeResponseSent(ServeEvent serveEvent, Parameters parameters) {
-        // Not needed for response time tracking
     }
     
     @Override
     public void afterComplete(ServeEvent serveEvent, Parameters parameters) {
-        long responseTime = 0;
-        
+        String url = serveEvent.getRequest().getUrl();
+        if (url != null && url.startsWith(FLUSH_PATH)) {
+            writeStatsToFile();
+            return;
+        }
+
+        long responseTime;
         try {
-            // Calculate actual response time from request timestamp
             long requestTime = serveEvent.getRequest().getLoggedDate().getTime();
-            long currentTime = System.currentTimeMillis();
-            responseTime = currentTime - requestTime;
+            responseTime = System.currentTimeMillis() - requestTime;
         } catch (Exception e) {
-            // Silently skip requests with timing errors
             return;
         }
-        
-        // Validate response time
-        if (responseTime < 0) {
-            return; // Skip negative times
-        }
-        
-        if (responseTime == 0) {
-            // This happens when request timestamp equals current time (same millisecond)
-            // Use 1ms as minimum to avoid division by zero and indicate request was processed
-            responseTime = 1;
-        }
-        
-        if (responseTime > MAX_RESPONSE_TIME_MS) {
+
+        if (responseTime < 0 || responseTime > MAX_RESPONSE_TIME_MS) {
             return;
         }
-        
-        responseTimes.add(responseTime);
-        writeStatsToFile();
+
+        responseTimes.add(Math.max(responseTime, 1));
     }
     
     /**
-     * Get all response times (calculations done in Python)
+     * Write statistics to file atomically (temp file + rename) to avoid partial reads.
+     * Triggered by a request to {@value #FLUSH_PATH} or from {@link #reset()}.
      */
-    public static Map<String, Object> getStats() {
-        Map<String, Object> stats = new HashMap<>();
-        
-        List<Long> times = new ArrayList<>(responseTimes);
-        stats.put("response_times", times);
-        stats.put("total_requests", times.size());
-        
-        return stats;
-    }
-    
-    /**
-     * Write statistics to file for external access
-     */
-    private static void writeStatsToFile() {
-        try (FileWriter writer = new FileWriter(STATS_FILE)) {
-            Map<String, Object> stats = getStats();
-            // Simple JSON writing (no external dependencies)
+    static synchronized void writeStatsToFile() {
+        File target = new File(STATS_FILE);
+        File tmp = new File(STATS_FILE + ".tmp");
+        try (FileWriter writer = new FileWriter(tmp)) {
+            List<Long> times = new ArrayList<>(responseTimes);
             writer.write("{\n");
-            writer.write("  \"total_requests\": " + stats.get("total_requests") + ",\n");
+            writer.write("  \"total_requests\": " + times.size() + ",\n");
             writer.write("  \"response_times\": [");
-            
-            @SuppressWarnings("unchecked")
-            List<Long> times = (List<Long>) stats.get("response_times");
+
             for (int i = 0; i < times.size(); i++) {
                 if (i > 0) writer.write(", ");
                 writer.write(times.get(i).toString());
             }
-            
+
             writer.write("]\n}\n");
             writer.flush();
         } catch (IOException e) {
             System.err.println("ResponseTimeExtension: Error writing stats file to " + STATS_FILE + ": " + e.getMessage());
+            return;
+        }
+        try {
+            Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            System.err.println("ResponseTimeExtension: Error renaming tmp stats file: " + e.getMessage());
         }
     }
     

--- a/tests/performance/wiremock/extensions/ResponseTimeExtension.java
+++ b/tests/performance/wiremock/extensions/ResponseTimeExtension.java
@@ -19,9 +19,16 @@ import java.io.IOException;
  */
 public class ResponseTimeExtension implements ServeEventListener, Extension {
     private static final ConcurrentLinkedQueue<Long> responseTimes = new ConcurrentLinkedQueue<>();
-    private static final String STATS_FILE = "/wiremock/response-time-stats.json";
     /** Maximum acceptable response time (5 minutes). Responses exceeding this are discarded as outliers. */
     private static final long MAX_RESPONSE_TIME_MS = 300_000;
+
+    private static final String STATS_FILE;
+    static {
+        String suffix = System.getProperty("response.time.stats.suffix", "");
+        STATS_FILE = suffix.isEmpty()
+            ? "/wiremock/response-time-stats.json"
+            : "/wiremock/response-time-stats-" + suffix + ".json";
+    }
     
     public ResponseTimeExtension() {
         // Extension initialized
@@ -76,14 +83,8 @@ public class ResponseTimeExtension implements ServeEventListener, Extension {
             return;
         }
         
-        // Store response time
         responseTimes.add(responseTime);
-        
-        // Write stats to file periodically (every 10 requests for responsiveness)
-        int count = responseTimes.size();
-        if (count % 10 == 0 || count == 1) {
-            writeStatsToFile();
-        }
+        writeStatsToFile();
     }
     
     /**
@@ -92,7 +93,6 @@ public class ResponseTimeExtension implements ServeEventListener, Extension {
     public static Map<String, Object> getStats() {
         Map<String, Object> stats = new HashMap<>();
         
-        // Return all response times for Python to process
         List<Long> times = new ArrayList<>(responseTimes);
         stats.put("response_times", times);
         stats.put("total_requests", times.size());

--- a/tests/performance/wiremock/generate_certs.sh
+++ b/tests/performance/wiremock/generate_certs.sh
@@ -47,7 +47,8 @@ keytool -importkeystore \
     -deststoretype jks \
     -destkeystore "$CERTS_DIR/wiremock.jks"
 
-# Clean up intermediate files
+# Clean up intermediate files (keep .crt for CA cert export to driver containers)
 rm "$CERTS_DIR/wiremock.p12" "$CERTS_DIR/wiremock.key"
 
 echo "✓ Static CA certificate generated at $CERTS_DIR/wiremock.jks"
+echo "✓ CA cert PEM available at $CERTS_DIR/wiremock.crt"

--- a/tests/performance/wiremock/wiremock_manager.py
+++ b/tests/performance/wiremock/wiremock_manager.py
@@ -92,7 +92,11 @@ class WiremockManager:
         
         # Create and start container
         # For very large datasets (50M rows), use 12GB heap / 16GB container
-        java_opts = "-Xmx12g -Xms4g -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
+        java_opts = (
+            "-Xmx12g -Xms4g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 "
+            "--add-opens java.base/sun.security.x509=ALL-UNNAMED "
+            "--add-opens java.base/sun.security.ssl=ALL-UNNAMED"
+        )
         logger.info(f"Container memory limit: 16GB")
         
         # Get host user's UID:GID to run container as non-root
@@ -134,14 +138,20 @@ class WiremockManager:
         logger.info(f"✓ WireMock recording on http://{self.host}:{self.port}{network_info}")
         return self.port
     
-    def start_replay(self) -> int:
+    def start_replay(self, driver_label: str = None) -> int:
         """
         Start WireMock in replay mode (with disableRequestJournal for performance).
+        
+        Args:
+            driver_label: Optional label (e.g. "universal", "old") used to create a
+                          per-driver wiremock stats file so concurrent/sequential runs sharing
+                          the same mappings_dir never collide.
         
         Returns:
             Port number where WireMock is listening
         """
         self.port = self._find_free_port()
+        self.driver_label = driver_label
         
         # Verify mappings exist
         mappings_subdir = self.mappings_dir / "mappings"
@@ -179,8 +189,12 @@ class WiremockManager:
             "-XX:MaxGCPauseMillis=10 "  # Target 10ms max pause (was 200ms)
             "-XX:+ParallelRefProcEnabled "  # Parallel reference processing
             "-XX:InitiatingHeapOccupancyPercent=45 "  # Earlier GC to avoid spikes
-            "-XX:G1ReservePercent=10"  # Reserve for to-space
+            "-XX:G1ReservePercent=10 "  # Reserve for to-space
+            "--add-opens java.base/sun.security.x509=ALL-UNNAMED "
+            "--add-opens java.base/sun.security.ssl=ALL-UNNAMED"
         )
+        if driver_label:
+            java_opts += f" -Dresponse.time.stats.suffix={driver_label}"
         logger.info(f"Configuring WireMock replay with low-latency JVM settings")
         logger.info(f"Container memory limit: 16GB")
         
@@ -397,6 +411,37 @@ class WiremockManager:
         response.raise_for_status()
         logger.debug("Added telemetry mock")
     
+    def export_ca_cert(self, target_dir: Path) -> Path:
+        """
+        Export WireMock's CA certificate (PEM) from the running container.
+        
+        Each driver's Dockerfile appends this cert to the system CA bundle so that
+        drivers trust the dynamically generated MITM certificates.
+        
+        Args:
+            target_dir: Directory to write the CA cert file into
+        
+        Returns:
+            Path to the exported CA cert file on the host
+        """
+        if not self.container:
+            raise RuntimeError("WireMock container not running")
+        
+        target_path = Path(target_dir) / "wiremock-ca.crt"
+        
+        try:
+            wrapped = self.container.get_wrapped_container()
+            exit_code, output = wrapped.exec_run("cat /certs/wiremock.crt")
+            if exit_code != 0:
+                raise RuntimeError(f"Failed to read CA cert from container (exit {exit_code})")
+            
+            target_path.write_bytes(output)
+            logger.info(f"✓ Exported WireMock CA cert to {target_path}")
+            return target_path
+        except Exception as e:
+            logger.error(f"Failed to export WireMock CA cert: {e}")
+            raise
+
     def _verify_jvm_config(self):
         """Verify JVM configuration was applied correctly"""
         try:
@@ -427,11 +472,10 @@ class WiremockManager:
             - response_times: List of individual response times in milliseconds
             - metrics_enabled: Always True (metrics always collected)
         """
-        # Read stats from file written by extension
-        stats_file = self.mappings_dir / "response-time-stats.json"
+        suffix = f"-{self.driver_label}" if getattr(self, "driver_label", None) else ""
+        stats_file = self.mappings_dir / f"response-time-stats{suffix}.json"
         
-        # Wait briefly for file to be created (extension writes after first request)
-        max_wait = 5  # seconds
+        max_wait = 10  # seconds
         wait_interval = 0.5
         waited = 0
         
@@ -439,28 +483,24 @@ class WiremockManager:
             time.sleep(wait_interval)
             waited += wait_interval
         
-        empty_stats = {
-            "total_requests": 0,
-            "response_times": [],
-            "metrics_enabled": True
-        }
+        if not stats_file.exists():
+            logger.warning(f"Stats file not created after {max_wait}s: {stats_file}")
+            return {"total_requests": 0, "response_times": [], "metrics_enabled": True}
+        
+        # Time for flush of the final write
+        time.sleep(1)
         
         try:
-            if stats_file.exists():
-                with open(stats_file, 'r') as f:
-                    stats = json.load(f)
-                stats["metrics_enabled"] = True
-                return stats
-            else:
-                logger.warning(f"Stats file not found: {stats_file}")
-                return empty_stats
-            
+            with open(stats_file, 'r') as f:
+                stats = json.load(f)
+            stats["metrics_enabled"] = True
+            return stats
         except Exception as e:
             logger.warning(f"Failed to read response time metrics from file: {e}")
             if stats_file.exists():
                 try:
                     logger.warning(f"Stats file content (first 200 chars): {stats_file.read_text()[:200]}")
                 except Exception:
-                    pass  # Best-effort diagnostic — don't mask the original error
-            return empty_stats
+                    pass
+            return {"total_requests": 0, "response_times": [], "metrics_enabled": True}
 

--- a/tests/performance/wiremock/wiremock_manager.py
+++ b/tests/performance/wiremock/wiremock_manager.py
@@ -226,7 +226,6 @@ class WiremockManager:
         self.container = container
         
         self.container.start()
-        logger.info("WireMock container started with memory configuration")
         
         try:
             self._wait_for_wiremock()
@@ -436,7 +435,7 @@ class WiremockManager:
                 raise RuntimeError(f"Failed to read CA cert from container (exit {exit_code})")
             
             target_path.write_bytes(output)
-            logger.info(f"✓ Exported WireMock CA cert to {target_path}")
+            logger.debug(f"Exported WireMock CA cert to {target_path}")
             return target_path
         except Exception as e:
             logger.error(f"Failed to export WireMock CA cert: {e}")
@@ -459,12 +458,39 @@ class WiremockManager:
         except Exception as e:
             logger.debug(f"Could not verify JVM config: {e}")
     
+    def flush_stats(self):
+        """
+        Trigger the ResponseTimeExtension to write collected metrics to disk.
+        """
+        if not self.port:
+            logger.warning("Cannot flush stats — WireMock not running")
+            return
+
+        flush_mapping = {
+            "request": {
+                "method": "GET",
+                "urlPath": "/__perf/flush-stats",
+            },
+            "response": {
+                "status": 200,
+                "body": "flushed",
+            },
+            "priority": 1,
+            "persistent": False,
+        }
+        base = f"http://{self.host}:{self.port}"
+        requests.post(f"{base}/__admin/mappings", json=flush_mapping).raise_for_status()
+        requests.get(f"{base}/__perf/flush-stats", timeout=10).raise_for_status()
+        time.sleep(0.5)
+
     def get_request_metrics(self) -> dict:
         """
         Retrieve request metrics from WireMock custom extension.
         
-        Uses lightweight ResponseTimeExtension which tracks only timing data
-        (not full request/response bodies). Reads stats from file written by extension.
+        Triggers a stats flush first (via ``flush_stats``), then reads the
+        resulting JSON file from the volume-mounted mappings directory.
+        
+        Must be called while the WireMock container is still running.
         
         Returns:
             Dictionary containing response time statistics:
@@ -472,23 +498,14 @@ class WiremockManager:
             - response_times: List of individual response times in milliseconds
             - metrics_enabled: Always True (metrics always collected)
         """
+        self.flush_stats()
+
         suffix = f"-{self.driver_label}" if getattr(self, "driver_label", None) else ""
         stats_file = self.mappings_dir / f"response-time-stats{suffix}.json"
         
-        max_wait = 10  # seconds
-        wait_interval = 0.5
-        waited = 0
-        
-        while not stats_file.exists() and waited < max_wait:
-            time.sleep(wait_interval)
-            waited += wait_interval
-        
         if not stats_file.exists():
-            logger.warning(f"Stats file not created after {max_wait}s: {stats_file}")
+            logger.warning(f"Stats file not found after flush: {stats_file}")
             return {"total_requests": 0, "response_times": [], "metrics_enabled": True}
-        
-        # Time for flush of the final write
-        time.sleep(1)
         
         try:
             with open(stats_file, 'r') as f:


### PR DESCRIPTION
1. Create separate images for UD/Old drivers (common base with only a difference in the driver installation) to avoid potential conflicts between drivers (there were concerns for Python)
2. The current approach for disabling cert validation in recorded HTTP tests was not working correctly for the OLD ODBC driver. Instead, wiremock generated cert will be added to the system CA bundle, as that solution works for all drivers