### PR TITLE
SNOW-3199674: introduce an initial version of DataSource API compatible with old JDBC driver

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
@@ -1,0 +1,39 @@
+package net.snowflake.client.api.datasource;
+
+import java.util.Properties;
+import javax.sql.DataSource;
+
+/**
+ * Snowflake-specific extension of {@link DataSource} that provides configuration methods for
+ * Snowflake JDBC connections.
+ *
+ * <p>Use {@link SnowflakeDataSourceFactory} to create instances of this interface.
+ */
+public interface SnowflakeDataSource extends DataSource {
+  // Only a minimal set of DataSource parameters has been migrated here.
+  // More will be added once the parameter strategy for the core driver is finalized.
+
+  void setUrl(String url);
+
+  void setUser(String user);
+
+  void setPassword(String password);
+
+  void setServerName(String serverName);
+
+  void setPortNumber(int portNumber);
+
+  void setAccount(String account);
+
+  void setDatabase(String database);
+
+  void setSchema(String schema);
+
+  void setRole(String role);
+
+  void setWarehouse(String warehouse);
+
+  String getUrl();
+
+  Properties getProperties();
+}

--- a/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSourceFactory.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSourceFactory.java
@@ -1,0 +1,19 @@
+package net.snowflake.client.api.datasource;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import net.snowflake.client.internal.api.implementation.datasource.SnowflakeBasicDataSource;
+
+/**
+ * Factory for creating {@link SnowflakeDataSource} instances.
+ *
+ * <p>This factory provides methods to create different types of Snowflake DataSource
+ * implementations. Use this factory instead of directly instantiating DataSource classes.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SnowflakeDataSourceFactory {
+
+  public static SnowflakeDataSource createDataSource() {
+    return new SnowflakeBasicDataSource();
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
@@ -1,0 +1,202 @@
+package net.snowflake.client.internal.api.implementation.datasource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import net.snowflake.client.api.datasource.SnowflakeDataSource;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+
+/**
+ * Basic implementation of {@link SnowflakeDataSource} for Snowflake JDBC connections.
+ *
+ * <p>This class provides a simple, non-pooled DataSource implementation that creates new Snowflake
+ * connections on demand. It is suitable for applications that do not require connection pooling or
+ * for use with external connection pool managers.
+ *
+ * <p><b>Note:</b> This class is not intended for direct instantiation. Use {@link
+ * net.snowflake.client.api.datasource.SnowflakeDataSourceFactory#createDataSource()} instead.
+ */
+public class SnowflakeBasicDataSource implements SnowflakeDataSource {
+
+  private static final String CONNECTION_STRING_PREFIX = "jdbc:snowflake://";
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBasicDataSource.class);
+
+  static {
+    try {
+      Class.forName("net.snowflake.client.api.driver.SnowflakeDriver");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Unable to load "
+              + "net.snowflake.client.api.driver.SnowflakeDriver. "
+              + "Please check if you have proper Snowflake JDBC "
+              + "Driver jar on the classpath",
+          e);
+    }
+  }
+
+  private final Properties properties = new Properties();
+  private String url;
+  private String serverName;
+  private String user;
+  private String password;
+  private int portNumber = 0;
+
+  // DataSource methods ----------------------------------------------------------------------------
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return getConnection(user, password);
+  }
+
+  @Override
+  public Connection getConnection(String username, String password) throws SQLException {
+    String effectiveUser = username != null ? username : user;
+    try {
+      Properties properties = getProperties();
+      if (username != null) {
+        properties.setProperty(SnowflakeSessionProperty.USER.getPropertyKey(), username);
+      }
+      if (password != null) {
+        properties.setProperty(SnowflakeSessionProperty.PASSWORD.getPropertyKey(), password);
+      }
+
+      Connection con = DriverManager.getConnection(getUrl(), properties);
+      logger.trace(
+          "Created a connection for {} at {}", effectiveUser, (Supplier<String>) this::getUrl);
+      return con;
+    } catch (SQLException e) {
+      logger.error("Failed to create a connection for {} at {}: {}", effectiveUser, getUrl(), e);
+      throw e;
+    }
+  }
+
+  // CommonDataSource methods ----------------------------------------------------------------------
+
+  @Override
+  public PrintWriter getLogWriter() throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public void setLogWriter(PrintWriter out) throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public int getLoginTimeout() {
+    try {
+      return Integer.parseInt(
+          properties.getProperty(SnowflakeSessionProperty.LOGIN_TIMEOUT.getPropertyKey()));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  @Override
+  public void setLoginTimeout(int seconds) {
+    properties.put(
+        SnowflakeSessionProperty.LOGIN_TIMEOUT.getPropertyKey(), Integer.toString(seconds));
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  // Wrapper methods -------------------------------------------------------------------------------
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) {
+    return false;
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) {
+    return null;
+  }
+
+  // SnowflakeDataSource methods -------------------------------------------------------------------
+
+  @Override
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  @Override
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public void setServerName(String serverName) {
+    this.serverName = serverName;
+  }
+
+  @Override
+  public void setPortNumber(int portNumber) {
+    this.portNumber = portNumber;
+  }
+
+  @Override
+  public void setAccount(String account) {
+    this.properties.setProperty(SnowflakeSessionProperty.ACCOUNT.getPropertyKey(), account);
+  }
+
+  @Override
+  public void setDatabase(String database) {
+    this.properties.setProperty(SnowflakeSessionProperty.DATABASE.getPropertyKey(), database);
+  }
+
+  @Override
+  public void setSchema(String schema) {
+    this.properties.setProperty(SnowflakeSessionProperty.SCHEMA.getPropertyKey(), schema);
+  }
+
+  @Override
+  public void setRole(String role) {
+    this.properties.setProperty(SnowflakeSessionProperty.ROLE.getPropertyKey(), role);
+  }
+
+  @Override
+  public void setWarehouse(String warehouse) {
+    this.properties.setProperty(SnowflakeSessionProperty.WAREHOUSE.getPropertyKey(), warehouse);
+  }
+
+  @Override
+  public String getUrl() {
+    if (url != null) {
+      return url;
+    }
+    if (serverName == null || serverName.isEmpty()) {
+      throw new IllegalStateException(
+          "Snowflake DataSource is not configured: either 'url' or 'serverName' must be set "
+              + "before obtaining a connection. ");
+    }
+    StringBuilder urlBuilder = new StringBuilder(100);
+    urlBuilder.append(CONNECTION_STRING_PREFIX);
+    urlBuilder.append(serverName);
+    if (portNumber != 0) {
+      urlBuilder.append(":").append(portNumber);
+    }
+    return urlBuilder.toString();
+  }
+
+  @Override
+  public Properties getProperties() {
+    // returns the copy to avoid access to a shared mutable field
+    Properties properties = new Properties();
+    properties.putAll(this.properties);
+    return properties;
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
@@ -1,0 +1,20 @@
+package net.snowflake.client.internal.api.implementation.datasource;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+enum SnowflakeSessionProperty {
+  USER("user"),
+  PASSWORD("password"),
+  ACCOUNT("account"),
+  DATABASE("database"),
+  SCHEMA("schema"),
+  ROLE("role"),
+  WAREHOUSE("warehouse"),
+  LOGIN_TIMEOUT("loginTimeout");
+
+  private final String propertyKey;
+}

--- a/jdbc/src/test/java/net/snowflake/client/api/datasource/DataSourceConnectionTests.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/datasource/DataSourceConnectionTests.java
@@ -1,0 +1,180 @@
+package net.snowflake.client.api.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class DataSourceConnectionTests extends SnowflakeIntegrationTestBase {
+
+  @Test
+  public void testConnectUsingDataSourceWithExplicitUrl() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    try (Connection connection = ds.getConnection()) {
+      assertNotNull(connection, "Connection should not be null");
+      assertFalse(connection.isClosed(), "Connection should be open");
+      assertQueryReturnsCurrentRole(connection);
+    }
+  }
+
+  @Test
+  public void testConnectUsingDataSourceWithServerName() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setServerName(props.getProperty("account") + ".snowflakecomputing.com");
+    ds.setUser(props.getProperty("user"));
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    try (Connection connection = ds.getConnection()) {
+      assertNotNull(connection, "Connection should not be null");
+      assertFalse(connection.isClosed(), "Connection should be open");
+      assertQueryReturnsCurrentRole(connection);
+    }
+  }
+
+  @Test
+  public void testConnectUsingDataSourceWithExplicitCredentials() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setAccount(props.getProperty("account"));
+
+    try (Connection connection =
+        ds.getConnection(props.getProperty("user"), props.getProperty("password"))) {
+      assertNotNull(connection, "Connection should not be null");
+      assertFalse(connection.isClosed(), "Connection should be open");
+      assertQueryReturnsCurrentRole(connection);
+    }
+  }
+
+  @Test
+  public void testFailToConnectWithInvalidPassword() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setPassword("INVALID_PASSWORD_THAT_WILL_NOT_MATCH");
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+
+  @Test
+  public void testFailToConnectWithInvalidUser() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser("NONEXISTENT_USER_XYZ_12345");
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+
+  @Test
+  public void testFailToConnectWhenUserIsNotSet() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+
+  @Test
+  public void testFailToConnectWhenPasswordIsNotSet() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+
+  @Test
+  public void testFailToConnectWithNullUserViaExplicitCredentials() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, () -> ds.getConnection(null, props.getProperty("password")));
+  }
+
+  @Test
+  public void testFailToConnectWithNullPasswordViaExplicitCredentials() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setAccount(props.getProperty("account"));
+
+    assertThrows(SQLException.class, () -> ds.getConnection(props.getProperty("user"), null));
+  }
+
+  @Test
+  public void testFailToConnectWithInvalidServerName() {
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setServerName("nonexistent-account-xyz-99999.snowflakecomputing.com");
+    ds.setUser("someuser");
+    ds.setPassword("somepassword");
+    ds.setAccount("nonexistent-account-xyz-99999");
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+
+  @Test
+  public void testConnectionReportsClosedAfterClose() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    Connection connection = ds.getConnection();
+    assertFalse(connection.isClosed(), "Connection should be open before close");
+    connection.close();
+    assertTrue(connection.isClosed(), "Connection should be closed after close()");
+  }
+
+  @Test
+  public void testCreateStatementOnClosedConnectionThrowsSQLException() throws Exception {
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setPassword(props.getProperty("password"));
+    ds.setAccount(props.getProperty("account"));
+
+    Connection connection = ds.getConnection();
+    connection.close();
+
+    assertThrows(SQLException.class, connection::createStatement);
+  }
+
+  private void assertQueryReturnsCurrentRole(Connection connection) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT CURRENT_ROLE()")) {
+      assertTrue(resultSet.next(), "Result set should have at least one row");
+      assertNotNull(resultSet.getString(1), "CURRENT_ROLE() should not be null");
+      assertFalse(resultSet.getString(1).isEmpty(), "CURRENT_ROLE() should not be empty");
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
@@ -1,0 +1,212 @@
+package net.snowflake.client.internal.api.implementation.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+public class SnowflakeBasicDataSourceTest {
+
+  private SnowflakeBasicDataSource dataSource;
+
+  @BeforeEach
+  public void setUp() {
+    dataSource = new SnowflakeBasicDataSource();
+    dataSource.setServerName("testaccount.snowflakecomputing.com");
+  }
+
+  @Test
+  public void testGetConnectionDelegatesToGetConnectionWithConfiguredUserAndPassword()
+      throws Exception {
+    dataSource.setUser("testuser");
+    dataSource.setPassword("testpassword");
+
+    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+    Connection mockConnection = mock(Connection.class);
+    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
+      driverManager
+          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
+          .thenReturn(mockConnection);
+
+      Connection result = dataSource.getConnection();
+
+      assertSame(mockConnection, result);
+      Properties capturedProperties = propertiesCaptor.getValue();
+      assertEquals("testuser", capturedProperties.getProperty("user"));
+      assertEquals("testpassword", capturedProperties.getProperty("password"));
+    }
+  }
+
+  @Test
+  public void testGetConnectionWithUsernameAndPasswordSetsPropertiesAndReturnsConnection()
+      throws Exception {
+    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+    Connection mockConnection = mock(Connection.class);
+    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
+      driverManager
+          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
+          .thenReturn(mockConnection);
+
+      Connection result = dataSource.getConnection("user1", "pass1");
+
+      assertSame(mockConnection, result);
+      Properties capturedProperties = propertiesCaptor.getValue();
+      assertEquals("user1", capturedProperties.getProperty("user"));
+      assertEquals("pass1", capturedProperties.getProperty("password"));
+    }
+  }
+
+  @Test
+  public void testGetConnectionWithNullUsernameDoesNotSetUserProperty() throws Exception {
+    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+    Connection mockConnection = mock(Connection.class);
+    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
+      driverManager
+          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
+          .thenReturn(mockConnection);
+
+      Connection result = dataSource.getConnection(null, "pass1");
+
+      assertSame(mockConnection, result);
+      Properties capturedProperties = propertiesCaptor.getValue();
+      assertNull(capturedProperties.getProperty("user"));
+      assertEquals("pass1", capturedProperties.getProperty("password"));
+    }
+  }
+
+  @Test
+  public void testGetConnectionWithNullPasswordDoesNotSetPasswordProperty() throws Exception {
+    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+    Connection mockConnection = mock(Connection.class);
+    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
+      driverManager
+          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
+          .thenReturn(mockConnection);
+
+      Connection result = dataSource.getConnection("user1", null);
+
+      assertSame(mockConnection, result);
+      Properties capturedProperties = propertiesCaptor.getValue();
+      assertEquals("user1", capturedProperties.getProperty("user"));
+      assertNull(capturedProperties.getProperty("password"));
+    }
+  }
+
+  @Test
+  public void testGetUrlReturnsConfiguredUrl() {
+    dataSource.setUrl("jdbc:snowflake://custom-url.snowflakecomputing.com");
+
+    assertEquals("jdbc:snowflake://custom-url.snowflakecomputing.com", dataSource.getUrl());
+  }
+
+  @Test
+  public void testGetUrlBuildsFromServerNameAndPort() {
+    dataSource.setPortNumber(443);
+
+    assertEquals("jdbc:snowflake://testaccount.snowflakecomputing.com:443", dataSource.getUrl());
+  }
+
+  @Test
+  public void testGetUrlBuildsFromServerNameWithoutPort() {
+    assertEquals("jdbc:snowflake://testaccount.snowflakecomputing.com", dataSource.getUrl());
+  }
+
+  @Test
+  public void testGetUrlThrowsWhenNeitherUrlNorServerNameIsSet() {
+    SnowflakeBasicDataSource unconfigured = new SnowflakeBasicDataSource();
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class, unconfigured::getUrl);
+    assertTrue(ex.getMessage().contains("url"));
+    assertTrue(ex.getMessage().contains("serverName"));
+  }
+
+  @Test
+  public void testGetUrlThrowsWhenServerNameIsEmpty() {
+    SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
+    ds.setServerName("");
+
+    assertThrows(IllegalStateException.class, ds::getUrl);
+  }
+
+  @Test
+  public void testGetLogWriterThrowsSQLFeatureNotSupportedException() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> dataSource.getLogWriter());
+  }
+
+  @Test
+  public void testSetLogWriterThrowsSQLFeatureNotSupportedException() {
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> dataSource.setLogWriter(new PrintWriter(System.out)));
+  }
+
+  @Test
+  public void testGetLoginTimeoutWhenNotSetReturnsZero() {
+    assertEquals(0, dataSource.getLoginTimeout());
+  }
+
+  @Test
+  public void testGetLoginTimeoutReturnsSetValue() {
+    dataSource.setLoginTimeout(30);
+
+    assertEquals(30, dataSource.getLoginTimeout());
+  }
+
+  @Test
+  public void testGetParentLoggerThrowsSQLFeatureNotSupportedException() {
+    assertThrows(SQLFeatureNotSupportedException.class, () -> dataSource.getParentLogger());
+  }
+
+  @Test
+  public void testIsWrapperForReturnsFalse() {
+    assertFalse(dataSource.isWrapperFor(Object.class));
+  }
+
+  @Test
+  public void testUnwrapReturnsNull() {
+    assertNull(dataSource.unwrap(Object.class));
+  }
+
+  @Test
+  public void testSettersStorePropertiesCorrectly() {
+    dataSource.setAccount("myaccount");
+    dataSource.setDatabase("mydb");
+    dataSource.setSchema("myschema");
+    dataSource.setRole("myrole");
+    dataSource.setWarehouse("mywh");
+
+    Properties props = dataSource.getProperties();
+    assertEquals("myaccount", props.getProperty("account"));
+    assertEquals("mydb", props.getProperty("database"));
+    assertEquals("myschema", props.getProperty("schema"));
+    assertEquals("myrole", props.getProperty("role"));
+    assertEquals("mywh", props.getProperty("warehouse"));
+  }
+
+  @Test
+  public void testGetPropertiesReturnsCopy() {
+    dataSource.setAccount("myaccount");
+
+    Properties props = dataSource.getProperties();
+    props.setProperty("injected", "value");
+
+    Properties freshProps = dataSource.getProperties();
+    assertEquals("myaccount", freshProps.getProperty("account"));
+    assertNull(freshProps.getProperty("injected"));
+  }
+}

--- a/jdbc/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jdbc/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Adds an initial implementation of javax.sql.DataSource support to the universal JDBC driver, providing API compatibility with the legacy Snowflake JDBC driver.

What's included:
- SnowflakeDataSource — public interface extending javax.sql.DataSource with Snowflake-specific configuration setters
- SnowflakeDataSourceFactory — factory for creating SnowflakeDataSource instances
- SnowflakeBasicDataSource — concrete implementation delegating to driver properties
- Unit and integration tests covering connection and configuration scenarios

Notes:
- This is an initial version; API surface mirrors the old driver's SnowflakeBasicDataSource to ease migration
- No behavioral changes to existing connection/session handling