### PR TITLE
[core] PUT operation on GCP

### DIFF
--- a/sf_core/src/file_manager/file_transfer.rs
+++ b/sf_core/src/file_manager/file_transfer.rs
@@ -1,217 +1,74 @@
-use super::types::{EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo};
-use snafu::{Location, OptionExt, ResultExt, Snafu};
+// Cloud-agnostic dispatch layer for file transfers
+// This module routes upload/download operations to the appropriate cloud provider
 
-// AWS SDK imports
-use aws_config::{BehaviorVersion, Region};
-use aws_credential_types::Credentials;
-use aws_sdk_s3::error::SdkError;
-use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
+use super::gcs_transfer;
+use super::s3_transfer;
+use super::types::{EncryptedFileMetadata, EncryptionResult, StageInfo, StageLocationType};
+use snafu::{Location, ResultExt, Snafu};
 
-const SNOWFLAKE_UPLOAD_PROVIDER: &str = "snowflake-upload";
-const SNOWFLAKE_DOWNLOAD_PROVIDER: &str = "snowflake-download";
-const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
-
-// TODO: streaming instead of loading the whole file into memory
-
-/// Uploads a file to S3, skipping if it already exists and `overwrite` is false.
-pub async fn upload_to_s3_or_skip(
+/// Upload to cloud storage, skipping if file already exists and overwrite is false
+pub async fn upload_to_cloud_or_skip(
     encryption_result: EncryptionResult,
     stage_info: &StageInfo,
     filename: &str,
     overwrite: bool,
 ) -> Result<String, UploadFileError> {
-    // Check if the file already exists in S3
-    let s3_client = create_s3_client(stage_info, SNOWFLAKE_UPLOAD_PROVIDER).await;
-    let s3_key = format!("{}{filename}", stage_info.key_prefix);
-
-    if !overwrite && check_if_file_exists(&s3_client, stage_info, &s3_key).await? {
-        tracing::info!("File already exists in S3: {}", s3_key);
-        return Ok("SKIPPED".to_string());
-    }
-
-    // Proceed with upload if the file does not exist or overwrite is true
-    upload_to_s3(encryption_result, &s3_client, stage_info, &s3_key).await?;
-    Ok("UPLOADED".to_string())
-}
-
-/// Returns true if the file exists in S3, false if it does not.
-/// When the check cannot be performed due to 403 Forbidden (limited
-/// temporary credentials that allow PUT but not HEAD), returns false
-/// so the caller proceeds with upload.
-async fn check_if_file_exists(
-    s3_client: &S3Client,
-    stage_info: &StageInfo,
-    s3_key: &str,
-) -> Result<bool, UploadFileError> {
-    match s3_client
-        .head_object()
-        .bucket(stage_info.bucket.clone())
-        .key(s3_key)
-        .send()
-        .await
-    {
-        Ok(_) => Ok(true),
-        Err(SdkError::ServiceError(err)) if err.err().is_not_found() => Ok(false),
-        Err(SdkError::ServiceError(ref err)) if err.raw().status().as_u16() == 403 => {
-            tracing::warn!(
-                "Access denied when checking if file exists in S3 ({s3_key}), proceeding with upload"
-            );
-            Ok(false)
+    match stage_info.location_type {
+        StageLocationType::S3 => {
+            s3_transfer::upload_to_s3_or_skip(encryption_result, stage_info, filename, overwrite)
+                .await
+                .context(UploadS3Snafu)
         }
-        Err(e) => Err(aws_sdk_s3::Error::from(e)).context(S3HeadSnafu),
+        StageLocationType::Gcs => {
+            gcs_transfer::upload_to_gcs_or_skip(encryption_result, stage_info, filename, overwrite)
+                .await
+                .context(UploadGcsSnafu)
+        }
+        StageLocationType::Azure => UploadUnsupportedSnafu {
+            provider: "Azure".to_string(),
+        }
+        .fail(),
     }
 }
 
-async fn upload_to_s3(
-    encryption_result: EncryptionResult,
-    s3_client: &S3Client,
-    stage_info: &StageInfo,
-    s3_key: &str,
-) -> Result<(), UploadFileError> {
-    // Serialize encryption metadata
-    let mat_desc = serde_json::to_string(&encryption_result.metadata.material_desc)
-        .context(SerializationSnafu)?;
-
-    let put_object_request = s3_client
-        .put_object()
-        .bucket(stage_info.bucket.clone())
-        .key(s3_key)
-        .body(ByteStream::from(encryption_result.data))
-        .content_type(CONTENT_TYPE_OCTET_STREAM)
-        .metadata("sfc-digest", &encryption_result.metadata.digest)
-        .metadata("x-amz-iv", &encryption_result.metadata.iv)
-        .metadata("x-amz-key", &encryption_result.metadata.encrypted_key)
-        .metadata("x-amz-matdesc", mat_desc);
-
-    tracing::trace!("PUT object request: {:?}", put_object_request);
-
-    // Upload to S3 (with optional encryption metadata)
-    let result = put_object_request
-        .send()
-        .await
-        .map_err(aws_sdk_s3::Error::from)
-        .context(S3UploadSnafu)?;
-
-    tracing::debug!("S3 upload result: {:?}", result);
-
-    Ok(())
-}
-
-pub async fn download_from_s3(
+/// Download from cloud storage
+pub async fn download_from_cloud(
     stage_info: &StageInfo,
     filename: &str,
 ) -> Result<(Vec<u8>, EncryptedFileMetadata), DownloadFileError> {
-    let s3_client = create_s3_client(stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER).await;
-    let s3_key = format!("{}{filename}", stage_info.key_prefix);
-
-    // Download from S3
-    let response = s3_client
-        .get_object()
-        .bucket(stage_info.bucket.clone())
-        .key(&s3_key)
-        .send()
-        .await
-        .map_err(aws_sdk_s3::Error::from)
-        .context(S3DownloadSnafu)?;
-
-    // Extract metadata from S3 response and construct the metadata structure directly
-    let metadata_map = response.metadata().context(MissingFileMetadataSnafu {
-        field: "All fields".to_string(),
-    })?;
-
-    let mat_desc_str = metadata_map
-        .get("x-amz-matdesc")
-        .context(MissingFileMetadataSnafu {
-            field: "x-amz-matdesc".to_string(),
-        })?;
-
-    let material_desc: MaterialDescription =
-        serde_json::from_str(mat_desc_str).context(DeserializationSnafu)?;
-
-    // Construct the metadata structure directly without intermediate variables
-    let file_metadata = EncryptedFileMetadata {
-        encrypted_key: metadata_map
-            .get("x-amz-key")
-            .context(MissingFileMetadataSnafu {
-                field: "x-amz-key".to_string(),
-            })?
-            .to_owned(),
-        iv: metadata_map
-            .get("x-amz-iv")
-            .context(MissingFileMetadataSnafu {
-                field: "x-amz-iv".to_string(),
-            })?
-            .to_owned(),
-        material_desc,
-        digest: metadata_map
-            .get("sfc-digest")
-            .context(MissingFileMetadataSnafu {
-                field: "sfc-digest".to_string(),
-            })?
-            .to_owned(),
-    };
-
-    // Read the encrypted data from the response body
-    let encrypted_data = response
-        .body
-        .collect()
-        .await
-        .context(ByteStreamSnafu)?
-        .into_bytes()
-        .to_vec();
-
-    Ok((encrypted_data, file_metadata))
-}
-
-async fn create_s3_client(stage_info: &StageInfo, provider_name: &'static str) -> S3Client {
-    let credentials = Credentials::new(
-        &stage_info.creds.aws_key_id,
-        stage_info.creds.aws_secret_key.reveal(),
-        Some(stage_info.creds.aws_token.reveal().to_string()),
-        None,
-        provider_name,
-    );
-
-    let config = aws_config::defaults(BehaviorVersion::latest())
-        .credentials_provider(credentials)
-        .region(Region::new(stage_info.region.clone()))
-        .load()
-        .await;
-
-    let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
-    if let Some(end_point) = &stage_info.end_point {
-        let endpoint_url = if end_point.starts_with("https://") || end_point.starts_with("http://")
-        {
-            end_point.clone()
-        } else {
-            format!("https://{end_point}")
-        };
-        tracing::debug!("Using Snowflake-provided S3 endpoint: {endpoint_url}");
-        s3_config = s3_config.endpoint_url(endpoint_url);
+    match stage_info.location_type {
+        StageLocationType::S3 => s3_transfer::download_from_s3(stage_info, filename)
+            .await
+            .context(DownloadS3Snafu),
+        StageLocationType::Gcs => gcs_transfer::download_from_gcs(stage_info, filename)
+            .await
+            .context(DownloadGcsSnafu),
+        StageLocationType::Azure => DownloadUnsupportedSnafu {
+            provider: "Azure".to_string(),
+        }
+        .fail(),
     }
-
-    S3Client::from_conf(s3_config.build())
 }
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
 pub enum UploadFileError {
-    #[snafu(display("Failed to upload file to S3"))]
-    S3Upload {
-        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
-        source: Box<aws_sdk_s3::Error>,
+    #[snafu(display("S3 upload error"))]
+    UploadS3 {
+        source: s3_transfer::UploadFileError,
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Failed to check if file exists in S3"))]
-    S3Head {
-        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
-        source: Box<aws_sdk_s3::Error>,
+
+    #[snafu(display("GCS upload error"))]
+    UploadGcs {
+        source: gcs_transfer::GcsTransferError,
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Failed to serialize metadata during file upload"))]
-    Serialization {
-        source: serde_json::Error,
+
+    #[snafu(display("Unsupported cloud provider for upload: {provider}"))]
+    UploadUnsupported {
+        provider: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -219,28 +76,23 @@ pub enum UploadFileError {
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
 pub enum DownloadFileError {
-    #[snafu(display("Failed to download file from S3"))]
-    S3Download {
-        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
-        source: Box<aws_sdk_s3::Error>,
+    #[snafu(display("S3 download error"))]
+    DownloadS3 {
+        source: s3_transfer::DownloadFileError,
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Failed to deserialize metadata during file download"))]
-    Deserialization {
-        source: serde_json::Error,
+
+    #[snafu(display("GCS download error"))]
+    DownloadGcs {
+        source: gcs_transfer::GcsTransferError,
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("File metadata missing: {field}"))]
-    MissingFileMetadata {
-        field: String,
-        #[snafu(implicit)]
-        location: Location,
-    },
-    #[snafu(display("Failed to read byte stream from S3"))]
-    ByteStream {
-        source: aws_sdk_s3::primitives::ByteStreamError,
+
+    #[snafu(display("Unsupported cloud provider for download: {provider}"))]
+    DownloadUnsupported {
+        provider: String,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -1,0 +1,493 @@
+use super::types::{
+    CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
+};
+use crate::config::retry::{BackoffConfig, HttpPolicy, Jitter, RetryPolicy};
+use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
+use snafu::{Location, OptionExt, ResultExt, Snafu};
+use std::time::Duration;
+
+const GCS_DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com";
+const GCS_META_SFC_DIGEST: &str = "x-goog-meta-sfc-digest";
+const GCS_META_MATDESC: &str = "x-goog-meta-matdesc";
+const GCS_META_ENCRYPTIONDATA: &str = "x-goog-meta-encryptiondata";
+
+// Encryption metadata constants
+const ENCRYPTION_MODE: &str = "FullBlob";
+const ENCRYPTION_KEY_ID: &str = "symmKey1";
+const ENCRYPTION_ALGORITHM: &str = "AES_CBC_256";
+const ENCRYPTION_PROTOCOL_VERSION: &str = "1.0";
+const ENCRYPTION_LIBRARY: &str = "UniversalDriver";
+
+// Upload status constants
+const STATUS_SKIPPED: &str = "SKIPPED";
+const STATUS_UPLOADED: &str = "UPLOADED";
+
+// HTTP status codes
+const HTTP_STATUS_FORBIDDEN: u16 = 403;
+const HTTP_STATUS_UNAUTHORIZED: u16 = 401;
+const HTTP_STATUS_NOT_FOUND: u16 = 404;
+
+// TODO: streaming instead of loading the whole file into memory
+
+/// Create a retry policy suitable for cloud storage operations.
+/// Uses exponential backoff with decorrelated jitter to avoid thundering herd.
+fn create_cloud_retry_policy() -> RetryPolicy {
+    RetryPolicy {
+        http: HttpPolicy {
+            retry_safe_reads: true,
+            retry_idempotent_writes: true,
+            retry_post_patch: false,
+        },
+        max_attempts: 7,
+        backoff: BackoffConfig {
+            base: Duration::from_secs(1),
+            factor: 2.0,
+            cap: Duration::from_secs(16),
+            jitter: Jitter::Decorrelated,
+        },
+        max_elapsed: Duration::from_secs(120),
+    }
+}
+
+/// Build the GCS key by concatenating the stage prefix and filename.
+fn build_gcs_key(stage_info: &StageInfo, filename: &str) -> String {
+    format!("{}{}", stage_info.key_prefix, filename)
+}
+
+fn build_gcs_url(stage_info: &StageInfo, key: &str) -> String {
+    let encoded_key = urlencoding::encode(key);
+    if stage_info.use_virtual_url {
+        format!(
+            "https://{}.storage.googleapis.com/{}",
+            stage_info.bucket, encoded_key
+        )
+    } else {
+        let endpoint = stage_info
+            .end_point
+            .as_deref()
+            .unwrap_or(GCS_DEFAULT_ENDPOINT);
+        format!("{}/{}/{}", endpoint, stage_info.bucket, encoded_key)
+    }
+}
+
+/// Build the encryption metadata JSON in the format expected by GCS and other drivers.
+fn build_encryption_metadata_json(
+    metadata: &EncryptedFileMetadata,
+) -> Result<String, serde_json::Error> {
+    let json = serde_json::json!({
+        "EncryptionMode": ENCRYPTION_MODE,
+        "WrappedContentKey": {
+            "KeyId": ENCRYPTION_KEY_ID,
+            "EncryptedKey": metadata.encrypted_key,
+            "Algorithm": ENCRYPTION_ALGORITHM
+        },
+        "EncryptionAgent": {
+            "Protocol": ENCRYPTION_PROTOCOL_VERSION,
+            "EncryptionAlgorithm": ENCRYPTION_ALGORITHM
+        },
+        "ContentEncryptionIV": metadata.iv,
+        "KeyWrappingMetadata": {
+            "EncryptionLibrary": ENCRYPTION_LIBRARY
+        }
+    });
+    serde_json::to_string(&json)
+}
+
+/// Check if a file exists in GCS using HEAD request.
+/// When access is denied (403), returns false so the caller proceeds with upload.
+async fn check_file_exists_gcs(
+    client: &reqwest::Client,
+    stage_info: &StageInfo,
+    gcs_key: &str,
+) -> Result<bool, GcsTransferError> {
+    let url = build_gcs_url(stage_info, gcs_key);
+    let CloudCredentials::Gcs { access_token } = &stage_info.creds else {
+        return InvalidCredentialsSnafu.fail();
+    };
+
+    let response = client
+        .head(&url)
+        .bearer_auth(access_token.reveal())
+        .send()
+        .await
+        .context(TransportSnafu)?;
+
+    match response.status().as_u16() {
+        200..=299 => Ok(true),
+        HTTP_STATUS_NOT_FOUND => Ok(false),
+        HTTP_STATUS_FORBIDDEN => {
+            tracing::warn!(
+                "Access denied checking GCS file existence ({gcs_key}), proceeding with upload"
+            );
+            Ok(false)
+        }
+        HTTP_STATUS_UNAUTHORIZED => TokenExpiredSnafu.fail(),
+        status => UnexpectedStatusSnafu { status }.fail(),
+    }
+}
+
+/// Upload a file to GCS with retry support.
+/// Skips upload if the file already exists and overwrite is false.
+pub async fn upload_to_gcs_or_skip(
+    encryption_result: EncryptionResult,
+    stage_info: &StageInfo,
+    filename: &str,
+    overwrite: bool,
+) -> Result<String, GcsTransferError> {
+    let gcs_key = build_gcs_key(stage_info, filename);
+    // Reuse a single client for both existence check and upload
+    let client = reqwest::Client::builder().build().context(TransportSnafu)?;
+
+    // Check existence (skip if overwrite=true)
+    if !overwrite && check_file_exists_gcs(&client, stage_info, &gcs_key).await? {
+        tracing::info!("File already exists in GCS: {gcs_key}");
+        return Ok(STATUS_SKIPPED.into());
+    }
+
+    // Upload with retry
+    let url = build_gcs_url(stage_info, &gcs_key);
+    let ctx = HttpContext::new(reqwest::Method::PUT, &url).with_idempotent(true);
+
+    let gcs_retry_policy = create_cloud_retry_policy();
+
+    // Build the request with encrypted data and metadata
+    let CloudCredentials::Gcs { access_token } = &stage_info.creds else {
+        return InvalidCredentialsSnafu.fail();
+    };
+
+    let mat_desc_json = serde_json::to_string(&encryption_result.metadata.material_desc)
+        .context(SerializationSnafu)?;
+    let encryption_json =
+        build_encryption_metadata_json(&encryption_result.metadata).context(SerializationSnafu)?;
+
+    // Clone only what's needed for the retry closure
+    let data = encryption_result.data;
+    let digest = &encryption_result.metadata.digest;
+    let token = access_token.reveal();
+
+    // Execute with retry - the handler returns the response for us to check
+    let response = execute_with_retry(
+        || {
+            client
+                .put(&url)
+                .bearer_auth(token)
+                .header("content-encoding", "") // CRITICAL: prevents GCS auto-decompression
+                .header(GCS_META_SFC_DIGEST, digest)
+                .header(GCS_META_MATDESC, &mat_desc_json)
+                .header(GCS_META_ENCRYPTIONDATA, &encryption_json)
+                .body(data.clone())
+        },
+        &ctx,
+        &gcs_retry_policy,
+        |response| async move { Ok(response) },
+    )
+    .await
+    .context(HttpRetrySnafu)?;
+
+    // Check the final response status
+    match response.status().as_u16() {
+        200..=299 => Ok(STATUS_UPLOADED.into()),
+        HTTP_STATUS_UNAUTHORIZED => TokenExpiredSnafu.fail(),
+        status => {
+            let body = response.text().await.unwrap_or_default();
+            UploadSnafu { status, body }.fail()
+        }
+    }
+}
+
+/// Extract a required header value from the response, returning a descriptive error if missing.
+fn get_required_header(
+    headers: &reqwest::header::HeaderMap,
+    name: &str,
+) -> Result<String, GcsTransferError> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .context(MissingMetadataSnafu {
+            field: name.to_string(),
+        })
+}
+
+/// Parse the x-goog-meta-encryptiondata JSON to extract the encrypted key and IV.
+fn parse_encryption_data_json(json_str: &str) -> Result<(String, String), GcsTransferError> {
+    let data: serde_json::Value = serde_json::from_str(json_str).context(DeserializationSnafu)?;
+
+    let encrypted_key = data
+        .get("WrappedContentKey")
+        .and_then(|wck| wck.get("EncryptedKey"))
+        .and_then(|ek| ek.as_str())
+        .map(|s| s.to_string())
+        .context(MissingMetadataSnafu {
+            field: "WrappedContentKey.EncryptedKey".to_string(),
+        })?;
+
+    let iv = data
+        .get("ContentEncryptionIV")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .context(MissingMetadataSnafu {
+            field: "ContentEncryptionIV".to_string(),
+        })?;
+
+    Ok((encrypted_key, iv))
+}
+
+/// Download a file from GCS, extracting metadata from response headers.
+pub async fn download_from_gcs(
+    stage_info: &StageInfo,
+    filename: &str,
+) -> Result<(Vec<u8>, EncryptedFileMetadata), GcsTransferError> {
+    let gcs_key = build_gcs_key(stage_info, filename);
+    let url = build_gcs_url(stage_info, &gcs_key);
+
+    let CloudCredentials::Gcs { access_token } = &stage_info.creds else {
+        return InvalidCredentialsSnafu.fail();
+    };
+
+    let client = reqwest::Client::builder().build().context(TransportSnafu)?;
+    let response = client
+        .get(&url)
+        .bearer_auth(access_token.reveal())
+        .send()
+        .await
+        .context(TransportSnafu)?;
+
+    match response.status().as_u16() {
+        200..=299 => {}
+        HTTP_STATUS_UNAUTHORIZED => return TokenExpiredSnafu.fail(),
+        HTTP_STATUS_NOT_FOUND => return FileNotFoundSnafu { key: gcs_key }.fail(),
+        status => {
+            let body = response.text().await.unwrap_or_default();
+            return DownloadSnafu { status, body }.fail();
+        }
+    }
+
+    // CRITICAL: Clone headers BEFORE consuming the response body.
+    // response.bytes().await moves the response, making headers inaccessible.
+    let headers = response.headers().clone();
+
+    // Extract metadata from response headers
+    let digest = get_required_header(&headers, GCS_META_SFC_DIGEST)?;
+    let encryption_json = get_required_header(&headers, GCS_META_ENCRYPTIONDATA)?;
+    let mat_desc_str = get_required_header(&headers, GCS_META_MATDESC)?;
+
+    // Parse nested encryption JSON
+    let (encrypted_key, iv) = parse_encryption_data_json(&encryption_json)?;
+
+    // Parse material description
+    let material_desc: MaterialDescription =
+        serde_json::from_str(&mat_desc_str).context(DeserializationSnafu)?;
+
+    let file_metadata = EncryptedFileMetadata {
+        encrypted_key,
+        iv,
+        material_desc,
+        digest,
+    };
+
+    // Now consume the response body
+    let encrypted_data = response.bytes().await.context(TransportSnafu)?.to_vec();
+
+    Ok((encrypted_data, file_metadata))
+}
+
+#[derive(Snafu, Debug, error_trace::ErrorTrace)]
+pub enum GcsTransferError {
+    #[snafu(display("Invalid credentials for GCS"))]
+    InvalidCredentials {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("GCS access token expired"))]
+    TokenExpired {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("HTTP transport error"))]
+    Transport {
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("HTTP retry error"))]
+    HttpRetry {
+        source: HttpError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Missing GCS metadata: {field}"))]
+    MissingMetadata {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Unexpected HTTP status {status}"))]
+    UnexpectedStatus {
+        status: u16,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("GCS upload error: status {status}, {body}"))]
+    Upload {
+        status: u16,
+        body: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to serialize metadata"))]
+    Serialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("GCS download error: status {status}, {body}"))]
+    Download {
+        status: u16,
+        body: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("GCS file not found: {key}"))]
+    FileNotFound {
+        key: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to deserialize metadata"))]
+    Deserialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_gcs_url_standard() {
+        let stage_info = StageInfo {
+            location_type: super::super::types::StageLocationType::Gcs,
+            bucket: "test-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: None,
+            creds: CloudCredentials::Gcs {
+                access_token: "token".to_string().into(),
+            },
+            end_point: None,
+            use_regional_url: false,
+            use_virtual_url: false,
+        };
+
+        let url = build_gcs_url(&stage_info, "file.txt");
+        assert_eq!(url, "https://storage.googleapis.com/test-bucket/file.txt");
+    }
+
+    #[test]
+    fn test_build_gcs_url_virtual() {
+        let stage_info = StageInfo {
+            location_type: super::super::types::StageLocationType::Gcs,
+            bucket: "test-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: None,
+            creds: CloudCredentials::Gcs {
+                access_token: "token".to_string().into(),
+            },
+            end_point: None,
+            use_regional_url: false,
+            use_virtual_url: true,
+        };
+
+        let url = build_gcs_url(&stage_info, "file.txt");
+        assert_eq!(url, "https://test-bucket.storage.googleapis.com/file.txt");
+    }
+
+    #[test]
+    fn test_build_gcs_url_regional() {
+        let stage_info = StageInfo {
+            location_type: super::super::types::StageLocationType::Gcs,
+            bucket: "test-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: None,
+            creds: CloudCredentials::Gcs {
+                access_token: "token".to_string().into(),
+            },
+            end_point: Some("https://storage.us-west1.rep.googleapis.com".to_string()),
+            use_regional_url: true,
+            use_virtual_url: false,
+        };
+
+        let url = build_gcs_url(&stage_info, "file.txt");
+        assert_eq!(
+            url,
+            "https://storage.us-west1.rep.googleapis.com/test-bucket/file.txt"
+        );
+    }
+
+    #[test]
+    fn test_parse_encryption_data_json_valid() {
+        let json = r#"{
+            "EncryptionMode": "FullBlob",
+            "WrappedContentKey": {
+                "KeyId": "symmKey1",
+                "EncryptedKey": "base64key",
+                "Algorithm": "AES_CBC_256"
+            },
+            "ContentEncryptionIV": "base64iv"
+        }"#;
+
+        let (key, iv) = parse_encryption_data_json(json).unwrap();
+        assert_eq!(key, "base64key");
+        assert_eq!(iv, "base64iv");
+    }
+
+    #[test]
+    fn test_parse_encryption_data_json_missing_key() {
+        let json = r#"{
+            "EncryptionMode": "FullBlob",
+            "ContentEncryptionIV": "base64iv"
+        }"#;
+
+        let result = parse_encryption_data_json(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("WrappedContentKey.EncryptedKey")
+        );
+    }
+
+    #[test]
+    fn test_parse_encryption_data_json_missing_iv() {
+        let json = r#"{
+            "EncryptionMode": "FullBlob",
+            "WrappedContentKey": {
+                "KeyId": "symmKey1",
+                "EncryptedKey": "base64key",
+                "Algorithm": "AES_CBC_256"
+            }
+        }"#;
+
+        let result = parse_encryption_data_json(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ContentEncryptionIV")
+        );
+    }
+}

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -1,7 +1,8 @@
 mod encryption;
 mod file_transfer;
-
+mod gcs_transfer;
 mod path_expansion;
+mod s3_transfer;
 pub mod types;
 
 pub use self::types::*;
@@ -9,7 +10,9 @@ pub use self::types::*;
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
 use encryption::{EncryptionError, decrypt_file_data, encrypt_file_data};
-use file_transfer::{DownloadFileError, UploadFileError, download_from_s3, upload_to_s3_or_skip};
+use file_transfer::{
+    DownloadFileError, UploadFileError, download_from_cloud, upload_to_cloud_or_skip,
+};
 use path_expansion::{PathExpansionError, expand_filenames};
 use snafu::{Location, ResultExt, Snafu};
 use std::fs::File;
@@ -49,14 +52,14 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
 
     let (encryption_result, file_metadata) = preprocess_file_before_upload(file_buffer, &data)?;
 
-    let status = upload_to_s3_or_skip(
+    let status = upload_to_cloud_or_skip(
         encryption_result,
         &data.stage_info,
         file_metadata.target.as_str(),
         data.overwrite,
     )
     .await
-    .context(S3UploadSnafu)?;
+    .context(CloudUploadSnafu)?;
 
     // TODO: Right now empty message is hardcoded, because any error in the upload process will
     // result in an error before this point and an ERROR status is never returned.
@@ -169,11 +172,11 @@ pub async fn download_files(
 pub async fn download_single_file(
     data: SingleDownloadData,
 ) -> Result<DownloadResult, FileManagerError> {
-    // Download encrypted data and metadata from S3
+    // Download encrypted data and metadata from cloud storage
     let (encrypted_data, file_metadata) =
-        download_from_s3(&data.stage_info, data.src_location.as_str())
+        download_from_cloud(&data.stage_info, data.src_location.as_str())
             .await
-            .context(S3DownloadSnafu)?;
+            .context(CloudDownloadSnafu)?;
 
     // Decrypt the data (this gives us the compressed data)
     let compressed_data =
@@ -234,15 +237,17 @@ pub enum FileManagerError {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Failed to upload file to S3"))]
-    S3Upload {
-        source: UploadFileError,
+    #[snafu(display("Failed to upload file to cloud storage"))]
+    CloudUpload {
+        #[snafu(source(from(UploadFileError, Box::new)))]
+        source: Box<UploadFileError>,
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Failed to download file from S3"))]
-    S3Download {
-        source: DownloadFileError,
+    #[snafu(display("Failed to download file from cloud storage"))]
+    CloudDownload {
+        #[snafu(source(from(DownloadFileError, Box::new)))]
+        source: Box<DownloadFileError>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -1,0 +1,377 @@
+use super::types::{
+    CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
+};
+use snafu::{Location, OptionExt, ResultExt, Snafu};
+
+// AWS SDK imports
+use aws_config::{BehaviorVersion, Region};
+use aws_credential_types::Credentials;
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
+
+const SNOWFLAKE_UPLOAD_PROVIDER: &str = "snowflake-upload";
+const SNOWFLAKE_DOWNLOAD_PROVIDER: &str = "snowflake-download";
+const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
+
+// S3 metadata header names
+const S3_META_SFC_DIGEST: &str = "sfc-digest";
+const S3_META_IV: &str = "x-amz-iv";
+const S3_META_KEY: &str = "x-amz-key";
+const S3_META_MATDESC: &str = "x-amz-matdesc";
+
+// Upload status constants
+const STATUS_SKIPPED: &str = "SKIPPED";
+const STATUS_UPLOADED: &str = "UPLOADED";
+
+// HTTP status codes
+const HTTP_STATUS_FORBIDDEN: u16 = 403;
+
+// TODO: streaming instead of loading the whole file into memory
+
+/// Build the S3 key by concatenating the stage prefix and filename.
+fn build_s3_key(stage_info: &StageInfo, filename: &str) -> String {
+    format!("{}{}", stage_info.key_prefix, filename)
+}
+
+/// Normalize endpoint URL to include https:// scheme if not present.
+fn normalize_endpoint_url(endpoint: &str) -> String {
+    if endpoint.starts_with("https://") || endpoint.starts_with("http://") {
+        endpoint.to_string()
+    } else {
+        format!("https://{}", endpoint)
+    }
+}
+
+/// Extract a required metadata field from S3 response metadata.
+fn get_metadata_field(
+    metadata_map: &std::collections::HashMap<String, String>,
+    field_name: &str,
+) -> Result<String, DownloadFileError> {
+    metadata_map
+        .get(field_name)
+        .cloned()
+        .context(MissingFileMetadataSnafu {
+            field: field_name.to_string(),
+        })
+}
+
+/// Uploads a file to S3, skipping if it already exists and `overwrite` is false.
+pub async fn upload_to_s3_or_skip(
+    encryption_result: EncryptionResult,
+    stage_info: &StageInfo,
+    filename: &str,
+    overwrite: bool,
+) -> Result<String, UploadFileError> {
+    // Extract AWS credentials
+    let CloudCredentials::Aws {
+        key_id,
+        secret_key,
+        token,
+    } = &stage_info.creds
+    else {
+        return InvalidCredentialsUploadSnafu.fail();
+    };
+
+    // Check if the file already exists in S3
+    let s3_client = create_s3_client(
+        stage_info,
+        key_id,
+        secret_key,
+        token,
+        SNOWFLAKE_UPLOAD_PROVIDER,
+    )
+    .await?;
+    let s3_key = build_s3_key(stage_info, filename);
+
+    if !overwrite && check_if_file_exists(&s3_client, stage_info, &s3_key).await? {
+        tracing::info!("File already exists in S3: {}", s3_key);
+        return Ok(STATUS_SKIPPED.to_string());
+    }
+
+    // Proceed with upload if the file does not exist or overwrite is true
+    upload_to_s3(encryption_result, &s3_client, stage_info, &s3_key).await?;
+    Ok(STATUS_UPLOADED.to_string())
+}
+
+/// Returns true if the file exists in S3, false if it does not.
+/// When the check cannot be performed due to 403 Forbidden (limited
+/// temporary credentials that allow PUT but not HEAD), returns false
+/// so the caller proceeds with upload.
+async fn check_if_file_exists(
+    s3_client: &S3Client,
+    stage_info: &StageInfo,
+    s3_key: &str,
+) -> Result<bool, UploadFileError> {
+    match s3_client
+        .head_object()
+        .bucket(stage_info.bucket.clone())
+        .key(s3_key)
+        .send()
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(SdkError::ServiceError(err)) if err.err().is_not_found() => Ok(false),
+        Err(SdkError::ServiceError(ref err))
+            if err.raw().status().as_u16() == HTTP_STATUS_FORBIDDEN =>
+        {
+            tracing::warn!(
+                "Access denied when checking if file exists in S3 ({s3_key}), proceeding with upload"
+            );
+            Ok(false)
+        }
+        Err(e) => Err(aws_sdk_s3::Error::from(e)).context(S3HeadSnafu),
+    }
+}
+
+async fn upload_to_s3(
+    encryption_result: EncryptionResult,
+    s3_client: &S3Client,
+    stage_info: &StageInfo,
+    s3_key: &str,
+) -> Result<(), UploadFileError> {
+    // Serialize encryption metadata
+    let mat_desc = serde_json::to_string(&encryption_result.metadata.material_desc)
+        .context(SerializationSnafu)?;
+
+    let put_object_request = s3_client
+        .put_object()
+        .bucket(stage_info.bucket.clone())
+        .key(s3_key)
+        .body(ByteStream::from(encryption_result.data))
+        .content_type(CONTENT_TYPE_OCTET_STREAM)
+        .metadata(S3_META_SFC_DIGEST, &encryption_result.metadata.digest)
+        .metadata(S3_META_IV, &encryption_result.metadata.iv)
+        .metadata(S3_META_KEY, &encryption_result.metadata.encrypted_key)
+        .metadata(S3_META_MATDESC, mat_desc);
+
+    tracing::trace!("PUT object request: {:?}", put_object_request);
+
+    // Upload to S3 (with optional encryption metadata)
+    let result = put_object_request
+        .send()
+        .await
+        .map_err(aws_sdk_s3::Error::from)
+        .context(S3UploadSnafu)?;
+
+    tracing::debug!("S3 upload result: {:?}", result);
+
+    Ok(())
+}
+
+pub async fn download_from_s3(
+    stage_info: &StageInfo,
+    filename: &str,
+) -> Result<(Vec<u8>, EncryptedFileMetadata), DownloadFileError> {
+    let CloudCredentials::Aws {
+        key_id,
+        secret_key,
+        token,
+    } = &stage_info.creds
+    else {
+        return InvalidCredentialsDownloadSnafu.fail();
+    };
+
+    let s3_client = create_s3_client_for_download(stage_info, key_id, secret_key, token).await?;
+    let s3_key = build_s3_key(stage_info, filename);
+
+    let response = s3_client
+        .get_object()
+        .bucket(stage_info.bucket.clone())
+        .key(&s3_key)
+        .send()
+        .await
+        .map_err(aws_sdk_s3::Error::from)
+        .context(S3DownloadSnafu)?;
+
+    let file_metadata = extract_metadata_from_response(&response)?;
+    let encrypted_data = extract_data_from_response(response).await?;
+
+    Ok((encrypted_data, file_metadata))
+}
+
+/// Create S3 client configured for download operations.
+async fn create_s3_client_for_download(
+    stage_info: &StageInfo,
+    key_id: &str,
+    secret_key: &crate::sensitive::SensitiveString,
+    token: &crate::sensitive::SensitiveString,
+) -> Result<S3Client, DownloadFileError> {
+    let region_str = stage_info
+        .region
+        .as_ref()
+        .context(MissingRegionDownloadSnafu)?;
+
+    let credentials = Credentials::new(
+        key_id,
+        secret_key.reveal(),
+        Some(token.reveal().to_string()),
+        None,
+        SNOWFLAKE_DOWNLOAD_PROVIDER,
+    );
+
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .credentials_provider(credentials)
+        .region(Region::new(region_str.to_string()))
+        .load()
+        .await;
+
+    let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
+    if let Some(end_point) = &stage_info.end_point {
+        let endpoint_url = normalize_endpoint_url(end_point);
+        tracing::debug!("Using Snowflake-provided S3 endpoint: {endpoint_url}");
+        s3_config = s3_config.endpoint_url(endpoint_url);
+    }
+
+    Ok(S3Client::from_conf(s3_config.build()))
+}
+
+/// Extract encrypted file metadata from S3 GetObject response.
+fn extract_metadata_from_response(
+    response: &aws_sdk_s3::operation::get_object::GetObjectOutput,
+) -> Result<EncryptedFileMetadata, DownloadFileError> {
+    let metadata_map = response.metadata().context(MissingFileMetadataSnafu {
+        field: "All fields".to_string(),
+    })?;
+
+    let mat_desc_str = get_metadata_field(metadata_map, S3_META_MATDESC)?;
+    let material_desc: MaterialDescription =
+        serde_json::from_str(&mat_desc_str).context(DeserializationSnafu)?;
+
+    let encrypted_key = get_metadata_field(metadata_map, S3_META_KEY)?;
+    let iv = get_metadata_field(metadata_map, S3_META_IV)?;
+    let digest = get_metadata_field(metadata_map, S3_META_SFC_DIGEST)?;
+
+    Ok(EncryptedFileMetadata {
+        encrypted_key,
+        iv,
+        material_desc,
+        digest,
+    })
+}
+
+/// Extract encrypted data bytes from S3 GetObject response.
+async fn extract_data_from_response(
+    response: aws_sdk_s3::operation::get_object::GetObjectOutput,
+) -> Result<Vec<u8>, DownloadFileError> {
+    let bytes = response
+        .body
+        .collect()
+        .await
+        .context(ByteStreamSnafu)?
+        .into_bytes()
+        .to_vec();
+    Ok(bytes)
+}
+
+async fn create_s3_client(
+    stage_info: &StageInfo,
+    key_id: &str,
+    secret_key: &crate::sensitive::SensitiveString,
+    token: &crate::sensitive::SensitiveString,
+    provider_name: &'static str,
+) -> Result<S3Client, UploadFileError> {
+    let credentials = Credentials::new(
+        key_id,
+        secret_key.reveal(),
+        Some(token.reveal().to_string()),
+        None,
+        provider_name,
+    );
+
+    let region_str = stage_info
+        .region
+        .as_ref()
+        .context(MissingRegionUploadSnafu)?;
+
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .credentials_provider(credentials)
+        .region(Region::new(region_str.to_string()))
+        .load()
+        .await;
+
+    let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
+    if let Some(end_point) = &stage_info.end_point {
+        let endpoint_url = normalize_endpoint_url(end_point);
+        tracing::debug!("Using Snowflake-provided S3 endpoint: {endpoint_url}");
+        s3_config = s3_config.endpoint_url(endpoint_url);
+    }
+
+    Ok(S3Client::from_conf(s3_config.build()))
+}
+
+#[derive(Snafu, Debug, error_trace::ErrorTrace)]
+pub enum UploadFileError {
+    #[snafu(display("Invalid credentials for S3"))]
+    InvalidCredentialsUpload {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("S3 region is required but not provided"))]
+    MissingRegionUpload {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to upload file to S3"))]
+    S3Upload {
+        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
+        source: Box<aws_sdk_s3::Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to check if file exists in S3"))]
+    S3Head {
+        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
+        source: Box<aws_sdk_s3::Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to serialize metadata"))]
+    Serialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+#[derive(Snafu, Debug, error_trace::ErrorTrace)]
+pub enum DownloadFileError {
+    #[snafu(display("Invalid credentials for S3"))]
+    InvalidCredentialsDownload {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("S3 region is required but not provided"))]
+    MissingRegionDownload {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to download file from S3"))]
+    S3Download {
+        #[snafu(source(from(aws_sdk_s3::Error, Box::new)))]
+        source: Box<aws_sdk_s3::Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to deserialize metadata"))]
+    Deserialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("File metadata missing: {field}"))]
+    MissingFileMetadata {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to read byte stream from S3"))]
+    ByteStream {
+        source: aws_sdk_s3::primitives::ByteStreamError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -1,9 +1,25 @@
 use crate::compression_types::CompressionType;
 use crate::sensitive::SensitiveString;
 use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::pin::Pin;
+
+// Type alias for the credential refresh callback
+/// Callback to re-execute the PUT command and obtain fresh stage credentials.
+/// Returns a new StageInfo with refreshed credentials.
+/// All three existing drivers (JDBC, Python, ODBC) implement this by holding
+/// a reference to the connection/session and re-executing the original command.
+pub type CredentialRefreshFn = Box<
+    dyn Fn() -> Pin<
+            Box<
+                dyn Future<Output = Result<StageInfo, crate::file_manager::FileManagerError>>
+                    + Send,
+            >,
+        > + Send
+        + Sync,
+>;
 
 // Dedicated file transfer types
-#[derive(Debug)]
 pub struct UploadData {
     pub src_location_pattern: String,
     pub stage_info: StageInfo,
@@ -11,6 +27,26 @@ pub struct UploadData {
     pub auto_compress: bool,
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
+    /// Optional callback to refresh expired stage credentials.
+    /// When provided, enables automatic retry on 401 (token expired) errors.
+    pub credential_refresh: Option<CredentialRefreshFn>,
+}
+
+impl std::fmt::Debug for UploadData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UploadData")
+            .field("src_location_pattern", &self.src_location_pattern)
+            .field("stage_info", &self.stage_info)
+            .field("encryption_material", &"<redacted>")
+            .field("auto_compress", &self.auto_compress)
+            .field("source_compression", &self.source_compression)
+            .field("overwrite", &self.overwrite)
+            .field(
+                "credential_refresh",
+                &self.credential_refresh.as_ref().map(|_| "<function>"),
+            )
+            .finish()
+    }
 }
 
 pub struct SingleUploadData {
@@ -82,23 +118,41 @@ pub enum SourceCompressionParam {
     AutoDetect,
 }
 
-#[derive(Debug, Clone)]
-pub struct StageInfo {
-    pub bucket: String,
-    pub key_prefix: String,
-    pub region: String,
-    pub creds: Credentials,
-    /// S3 endpoint provided by Snowflake (e.g. for FIPS or regional routing).
-    /// When present, the S3 client uses this instead of the SDK default.
-    pub end_point: Option<String>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageLocationType {
+    S3,
+    Gcs,
+    Azure,
 }
 
-/// AWS credentials for S3 stage access.
 #[derive(Debug, Clone)]
-pub struct Credentials {
-    pub aws_key_id: String,
-    pub aws_secret_key: SensitiveString,
-    pub aws_token: SensitiveString,
+pub enum CloudCredentials {
+    Aws {
+        key_id: String,
+        secret_key: SensitiveString,
+        token: SensitiveString,
+    },
+    Gcs {
+        access_token: SensitiveString,
+    },
+    Azure {
+        sas_token: SensitiveString,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct StageInfo {
+    pub location_type: StageLocationType,
+    pub bucket: String,
+    pub key_prefix: String,
+    pub region: Option<String>, // Optional for GCS
+    pub creds: CloudCredentials,
+    /// Cloud storage endpoint provided by Snowflake (e.g. for FIPS, regional routing, or custom GCS endpoints).
+    /// When present, the client uses this instead of the default.
+    pub end_point: Option<String>,
+    // GCS-specific URL routing
+    pub use_regional_url: bool,
+    pub use_virtual_url: bool,
 }
 
 /// Encryption material for file transfer.
@@ -110,14 +164,14 @@ pub struct EncryptionMaterial {
 }
 
 // Result of encryption containing encrypted data and metadata
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EncryptionResult {
     pub data: Vec<u8>,
     pub metadata: EncryptedFileMetadata,
 }
 
 // Encrypted file metadata that gets bundled with the encrypted data
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EncryptedFileMetadata {
     pub encrypted_key: String, // Base64 encoded
     pub iv: String,            // Base64 encoded
@@ -126,7 +180,7 @@ pub struct EncryptedFileMetadata {
 }
 
 // Material description structure for JSON serialization
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MaterialDescription {
     #[serde(rename = "queryId")]
     pub query_id: String,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -227,23 +227,24 @@ pub struct StageInfo {
     #[serde(rename = "endPoint")]
     end_point: Option<String>,
 
-    // unused fields
     #[serde(rename = "locationType")]
-    _location_type: Option<String>,
+    location_type: Option<String>,
+    #[serde(rename = "presignedUrl")]
+    _presigned_url: Option<String>,
+    #[serde(rename = "useRegionalUrl")]
+    use_regional_url: Option<bool>,
+    #[serde(rename = "useVirtualUrl")]
+    use_virtual_url: Option<bool>,
+
+    // unused fields
     #[serde(rename = "path")]
     _path: Option<String>,
     #[serde(rename = "storageAccount")]
     _storage_account: Option<String>,
     #[serde(rename = "isClientSideEncrypted")]
     _is_client_side_encrypted: Option<bool>,
-    #[serde(rename = "presignedUrl")]
-    _presigned_url: Option<String>,
     #[serde(rename = "useS3RegionalUrl")]
     _use_s3_regional_url: Option<bool>,
-    #[serde(rename = "useRegionalUrl")]
-    _use_regional_url: Option<bool>,
-    #[serde(rename = "useVirtualUrl")]
-    _use_virtual_url: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -255,15 +256,16 @@ pub struct Credentials {
     #[serde(rename = "AWS_TOKEN")]
     aws_token: Option<String>,
 
+    #[serde(rename = "GCS_ACCESS_TOKEN")]
+    gcs_access_token: Option<String>,
+    #[serde(rename = "AZURE_SAS_TOKEN")]
+    azure_sas_token: Option<String>,
+
     // unused fields
     #[serde(rename = "AWS_ID")]
     _aws_id: Option<String>,
     #[serde(rename = "AWS_KEY")]
     _aws_key: Option<String>,
-    #[serde(rename = "AZURE_SAS_TOKEN")]
-    _azure_sas_token: Option<String>,
-    #[serde(rename = "GCS_ACCESS_TOKEN")]
-    _gcs_access_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -365,6 +367,7 @@ impl Data {
             auto_compress,
             source_compression,
             overwrite,
+            credential_refresh: None, // Will be set by the caller if needed
         })
     }
 
@@ -598,7 +601,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             .clone();
 
         let bucket_separator = location.find('/').context(InvalidFormatSnafu {
-            message: format!("Invalid S3 location format: {location}"),
+            message: format!("Invalid location format: {location}"),
         })?;
 
         let bucket = location[..bucket_separator].to_string();
@@ -607,21 +610,82 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             key_prefix.push('/');
         }
 
-        let region = value
-            .region
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "stage info -> region",
-            })?
-            .clone();
+        // Parse location type, default to S3 for backward compatibility
+        let location_type = match value.location_type.as_deref() {
+            Some("GCS") | Some("gcs") => file_manager::StageLocationType::Gcs,
+            Some("AZURE") | Some("azure") | Some("Azure") => file_manager::StageLocationType::Azure,
+            Some("S3") | Some("s3") | None => file_manager::StageLocationType::S3,
+            Some(other) => InvalidFormatSnafu {
+                message: format!("Unknown location type: {other}"),
+            }
+            .fail()?,
+        };
 
-        let creds: file_manager::Credentials = value
-            .creds
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "stage info -> credentials",
-            })?
-            .try_into()?;
+        // Region is optional for GCS, required for S3
+        let region = value.region.clone();
+
+        // Parse credentials based on location type
+        let creds_data = value.creds.as_ref().context(MissingParameterSnafu {
+            parameter: "stage info -> credentials",
+        })?;
+
+        let creds = match location_type {
+            file_manager::StageLocationType::Gcs => {
+                let access_token = creds_data
+                    .gcs_access_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> GCS_ACCESS_TOKEN",
+                    })?
+                    .clone();
+                file_manager::CloudCredentials::Gcs {
+                    access_token: access_token.into(),
+                }
+            }
+            file_manager::StageLocationType::Azure => {
+                let sas_token = creds_data
+                    .azure_sas_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> AZURE_SAS_TOKEN",
+                    })?
+                    .clone();
+                file_manager::CloudCredentials::Azure {
+                    sas_token: sas_token.into(),
+                }
+            }
+            file_manager::StageLocationType::S3 => {
+                let aws_key_id = creds_data
+                    .aws_key_id
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> AWS_KEY_ID",
+                    })?
+                    .clone();
+
+                let aws_secret_key = creds_data
+                    .aws_secret_key
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> AWS_SECRET_KEY",
+                    })?
+                    .clone();
+
+                let aws_token = creds_data
+                    .aws_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> AWS_TOKEN",
+                    })?
+                    .clone();
+
+                file_manager::CloudCredentials::Aws {
+                    key_id: aws_key_id,
+                    secret_key: aws_secret_key.into(),
+                    token: aws_token.into(),
+                }
+            }
+        };
 
         let end_point = value
             .end_point
@@ -629,51 +693,23 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             .filter(|ep| !ep.is_empty())
             .cloned();
 
+        let use_regional_url = value.use_regional_url.unwrap_or(false);
+        let use_virtual_url = value.use_virtual_url.unwrap_or(false);
+
         Ok(file_manager::StageInfo {
+            location_type,
             bucket,
             key_prefix,
             region,
             creds,
             end_point,
+            use_regional_url,
+            use_virtual_url,
         })
     }
 }
 
-impl TryFrom<&Credentials> for file_manager::Credentials {
-    type Error = QueryResponseError;
-
-    fn try_from(value: &Credentials) -> Result<Self, Self::Error> {
-        let aws_key_id = value
-            .aws_key_id
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws key id",
-            })?
-            .clone();
-
-        let aws_secret_key = value
-            .aws_secret_key
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws secret key",
-            })?
-            .clone();
-
-        let aws_token = value
-            .aws_token
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws token",
-            })?
-            .clone();
-
-        Ok(file_manager::Credentials {
-            aws_key_id,
-            aws_secret_key: aws_secret_key.into(),
-            aws_token: aws_token.into(),
-        })
-    }
-}
+// Old Credentials conversion removed - now handled directly in StageInfo TryFrom
 
 impl From<&EncryptionMaterial> for file_manager::EncryptionMaterial {
     fn from(value: &EncryptionMaterial) -> Self {


### PR DESCRIPTION
  Add Google Cloud Storage (GCS) upload and download support to the universal   
  driver's Rust core (sf_core).                                                 
                                                                                
  This extends the existing S3-only file transfer to support multiple cloud     
  providers via a dispatch pattern. The implementation was designed by analyzing
   how JDBC, ODBC, and Python Snowflake drivers handle GCS uploads, then
  converging on a unified approach that preserves cross-driver behavioral
  compatibility.

  Changes

  New files:
  - sf_core/src/file_manager/gcs_transfer.rs — GCS upload, download, and file
  existence check via reqwest direct HTTP
  - sf_core/src/file_manager/s3_transfer.rs — S3 code extracted from
  file_transfer.rs (no logic changes)

  Modified files:
  - sf_core/src/file_manager/types.rs — StageLocationType enum, CloudCredentials
   enum (replaces S3-only Credentials), CredentialRefreshFn callback type
  - sf_core/src/file_manager/file_transfer.rs — refactored to cloud-agnostic
  dispatch layer
  - sf_core/src/file_manager/mod.rs — wires up new modules, calls dispatch
  functions
  - sf_core/src/rest/snowflake/query_response.rs — activates previously unused
  locationType, GCS_ACCESS_TOKEN, useRegionalUrl, useVirtualUrl fields

  Design docs:
  - doc/gcp-upload/ — 20+ documents including driver analyses, cross-driver
  comparison, and implementation plan

  Key design decisions

  - Direct HTTP via reqwest instead of a GCS SDK — matches ODBC/Python approach,
   avoids new dependencies
  - No multipart upload for GCS — all three existing drivers use single PUT
  regardless of file size
  - Empty Content-Encoding header on all GCS uploads — prevents GCS transparent
  decompression which would break the encrypt-then-compress pipeline
  - Enum-based CloudCredentials — compile-time guarantee that the right
  credential type is used per provider
  - Retry via existing execute_with_retry — 7 attempts, 1s base, 16s cap,
  decorrelated jitter
  - Token refresh as error propagation — TokenExpired error propagates to
  caller; CredentialRefreshFn callback type defined for future wiring from
  connection layer
  - Token-only auth for MVP — presigned URL mode deferred (clear error if
  GCS_ACCESS_TOKEN absent)
  - Download extracts metadata from HTTP headers — GCS returns encryption data
  in x-goog-meta-* headers (vs S3 object metadata). Headers cloned before
  consuming response body.

  Test plan

  - All 227 existing sf_core unit tests pass (no S3 regressions)
  - cargo clippy -D clippy::all clean
  - 6 new unit tests: URL construction (standard/virtual/regional), encryption
  JSON parsing (valid/missing key/missing IV)
  - Integration tests with wiremock (follow-up)
  - E2E tests with real GCS-backed Snowflake stage (follow-up)