### PR TITLE
SNOW-2433865 reduce odbc perf test scope, fix core recorded http tests

### DIFF
--- a/tests/performance/Jenkinsfile
+++ b/tests/performance/Jenkinsfile
@@ -159,11 +159,17 @@ pipeline {
                                     // Build test command with optional TEST_ARGS
                                     def testArgs = params.TEST_ARGS?.trim() ?: ""
                                     
+                                    // ODBC has known fetch performance issues causing timeouts.
+                                    // Run a reduced set of E2E tests to stay within the 6hr limit:
+                                    if (!testArgs && params.DRIVER == 'odbc') {
+                                        testArgs = "tests/ -k '(test_select_number_50M_arrow or test_select_date_50M_arrow or test_put_files_12mx100 or test_get_files_12mx100 or 1M) and not (12mx1000 or 50M_arrow_recorded)'"
+                                        echo "ODBC: using reduced test set to avoid timeout"
+                                    }
+                                    
                                     echo "Hatch environment: ${hatchEnv}"
                                     echo "TEST_ARGS parameter: '${testArgs ?: '(empty - will run all tests)'}'"
                                     
                                     if (testArgs) {
-                                        // Pass TEST_ARGS directly as a Groovy variable, not through shell export
                                         echo "Running specific test(s): ${testArgs}"
                                         sh """
                                             source .venv/bin/activate

--- a/tests/performance/drivers/core/Dockerfile
+++ b/tests/performance/drivers/core/Dockerfile
@@ -106,4 +106,9 @@ RUN bash -c '. /etc/os-release && echo "${ID^}_$(echo $VERSION_ID | cut -d. -f1)
 
 ENV RUST_LOG=${RUST_LOG:-warn}
 
-CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && core-perf-driver
+CMD export OS_INFO=$(cat /etc/os_info) && export RUST_VERSION=$(cat /etc/rust_version) && \
+    if [ -n "$WIREMOCK_CA_CERT" ] && [ -f "$WIREMOCK_CA_CERT" ]; then \
+        CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt; \
+        printf '\n' >> "$CA_BUNDLE" && cat "$WIREMOCK_CA_CERT" >> "$CA_BUNDLE"; \
+    fi && \
+    core-perf-driver


### PR DESCRIPTION
1. As the ODBC tests for UD take a long time to complete, reduce the scope until fixed to finish in time
2. Add wiremock cert to core tests