### PR TITLE
Add ODBC E2E tests for DECFLOAT and FLOAT types

### DIFF
--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -33,6 +33,8 @@ add_odbc_test(e2e_types_boolean_conversion_to_c_binary types/boolean_conversion_
 add_odbc_test(e2e_types_boolean_conversion_to_c_char types/boolean_conversion_to_c_char.cpp)
 add_odbc_test(e2e_types_boolean_conversion_to_c_integer types/boolean_conversion_to_c_integer.cpp)
 add_odbc_test(e2e_types_boolean_conversion_to_c_real types/boolean_conversion_to_c_real.cpp)
+add_odbc_test(e2e_types_decfloat types/decfloat.cpp)
+add_odbc_test(e2e_types_float types/float.cpp)
 add_odbc_test(e2e_types_int types/int.cpp)
 add_odbc_test(e2e_types_number types/number.cpp)
 add_odbc_test(e2e_types_string types/string.cpp)

--- a/odbc_tests/tests/e2e/types/decfloat.cpp
+++ b/odbc_tests/tests/e2e/types/decfloat.cpp
@@ -1,0 +1,355 @@
+// DECFLOAT datatype ODBC E2E tests
+// Based on: tests/definitions/shared/types/decfloat.feature
+//
+// Snowflake DECFLOAT: 38-digit precision with extreme exponents (up to E+16384).
+// No numeric C type can represent this, so values are read as SQL_C_CHAR strings.
+//
+// The new driver does not yet support DECFLOAT Arrow format; all tests
+// are skipped via SKIP_NEW_DRIVER_NOT_IMPLEMENTED() until support lands.
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "Schema.hpp"
+#include "compatibility.hpp"
+#include "get_data.hpp"
+
+// ============================================================================
+// TYPE CASTING
+// ============================================================================
+
+TEST_CASE("should cast decfloat values to appropriate type", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT,
+  // '12345678901234567890123456789012345678'::DECFLOAT" is executed
+  auto stmt = conn.execute_fetch(
+      "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT, "
+      "'12345678901234567890123456789012345678'::DECFLOAT");
+
+  // Then All values should be returned as appropriate type
+  // And Values should maintain full 38-digit precision
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "0");
+  CHECK(get_data<SQL_C_CHAR>(stmt, 2) == "123.456");
+
+  std::string large_val = get_data<SQL_C_CHAR>(stmt, 3);
+  CHECK(!large_val.empty());
+
+  std::string full_precision = get_data<SQL_C_CHAR>(stmt, 4);
+  CHECK(full_precision.find("12345678901234567890123456789012345678") != std::string::npos);
+}
+
+// ============================================================================
+// SELECT WITH LITERALS (no tables)
+// ============================================================================
+
+TEST_CASE("should select decfloat literals", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT" is
+  // executed
+  auto stmt = conn.execute_fetch(
+      "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT");
+
+  // Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "0");
+  CHECK(get_data<SQL_C_CHAR>(stmt, 2) == "1.5");
+  CHECK(get_data<SQL_C_CHAR>(stmt, 3) == "-1.5");
+  CHECK(get_data<SQL_C_CHAR>(stmt, 4) == "123.456789");
+  CHECK(get_data<SQL_C_CHAR>(stmt, 5) == "-987.654321");
+}
+
+TEST_CASE("should handle full 38-digit precision values from literals", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT,
+  // '1.2345678901234567890123456789012345678E+100'::DECFLOAT,
+  // '1.2345678901234567890123456789012345678E-100'::DECFLOAT" is executed
+  auto stmt = conn.execute_fetch(
+      "SELECT '12345678901234567890123456789012345678'::DECFLOAT, "
+      "'1.2345678901234567890123456789012345678E+100'::DECFLOAT, "
+      "'1.2345678901234567890123456789012345678E-100'::DECFLOAT");
+
+  // Then Result should preserve all 38 digits for each value
+  std::string val1 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(val1.find("12345678901234567890123456789012345678") != std::string::npos);
+
+  std::string val2 = get_data<SQL_C_CHAR>(stmt, 2);
+  CHECK(!val2.empty());
+  CHECK(val2.find("123456789012345678901234567890123456") != std::string::npos);
+
+  std::string val3 = get_data<SQL_C_CHAR>(stmt, 3);
+  CHECK(!val3.empty());
+  CHECK(val3.find("123456789012345678901234567890123456") != std::string::npos);
+}
+
+TEST_CASE("should handle extreme exponent values from literals", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
+  auto stmt = conn.execute_fetch("SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT");
+
+  // Then Result should contain [1E+16384, 1E-16383]
+  std::string val1 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val1.empty());
+
+  std::string val2 = get_data<SQL_C_CHAR>(stmt, 2);
+  CHECK(!val2.empty());
+
+  // When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
+  auto stmt2 = conn.execute_fetch("SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT");
+
+  // Then Result should contain [-1.234E+8000, 9.876E-8000]
+  std::string val3 = get_data<SQL_C_CHAR>(stmt2, 1);
+  CHECK(!val3.empty());
+  CHECK(val3[0] == '-');
+
+  std::string val4 = get_data<SQL_C_CHAR>(stmt2, 2);
+  CHECK(!val4.empty());
+}
+
+TEST_CASE("should handle NULL values from literals", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
+  auto stmt = conn.execute_fetch("SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT");
+
+  // Then Result should contain [NULL, 42.5, NULL]
+  CHECK(get_data_optional<SQL_C_CHAR>(stmt, 1) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_CHAR>(stmt, 2) == std::optional<std::string>("42.5"));
+  CHECK(get_data_optional<SQL_C_CHAR>(stmt, 3) == std::nullopt);
+}
+
+TEST_CASE("should download large result set with multiple chunks from GENERATOR", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
+  auto stmt = conn.createStatement();
+  const auto sql = "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v ORDER BY 1";
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then Result should contain consecutive numbers from 0 to 19999
+  // And All values should be returned as appropriate type
+  int row_count = 0;
+
+  while (true) {
+    ret = SQLFetch(stmt.getHandle());
+    if (ret == SQL_NO_DATA) break;
+    CHECK_ODBC(ret, stmt);
+
+    std::string val = get_data<SQL_C_CHAR>(stmt, 1);
+    REQUIRE(!val.empty());
+
+    int int_val = std::stoi(val);
+    REQUIRE(int_val == row_count);
+    row_count++;
+  }
+
+  REQUIRE(row_count == 20000);
+}
+
+// ============================================================================
+// TABLE OPERATIONS
+// ============================================================================
+
+TEST_CASE("should select decfloats from table", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+  conn.execute("CREATE TABLE decfloat_basic (col DECFLOAT)");
+  conn.execute(
+      "INSERT INTO decfloat_basic SELECT column1::DECFLOAT FROM VALUES "
+      "('0'), ('123.456'), ('-789.012'), ('1.23e20'), ('-9.87e-15')");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM decfloat_basic");
+
+  // Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "0");
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "123.456");
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-789.012");
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string sci_pos = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!sci_pos.empty());
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string sci_neg = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!sci_neg.empty());
+  CHECK(sci_neg[0] == '-');
+}
+
+TEST_CASE("should handle full 38-digit precision values from table", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with DECFLOAT column exists with values [12345678901234567890123456789012345678,
+  // 1.2345678901234567890123456789012345678E+100, 1.2345678901234567890123456789012345678E-100]
+  conn.execute("CREATE TABLE decfloat_precision (col DECFLOAT)");
+  conn.execute(
+      "INSERT INTO decfloat_precision SELECT column1::DECFLOAT FROM VALUES "
+      "('12345678901234567890123456789012345678'), "
+      "('1.2345678901234567890123456789012345678E+100'), "
+      "('1.2345678901234567890123456789012345678E-100')");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM decfloat_precision");
+
+  // Then Result should preserve all 38 digits for each value
+  std::string val1 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(val1.find("12345678901234567890123456789012345678") != std::string::npos);
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string val2 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val2.empty());
+  CHECK(val2.find("123456789012345678901234567890123456") != std::string::npos);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string val3 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val3.empty());
+  CHECK(val3.find("123456789012345678901234567890123456") != std::string::npos);
+}
+
+TEST_CASE("should handle extreme exponent values from table", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+  conn.execute("CREATE TABLE decfloat_extreme (col DECFLOAT)");
+  conn.execute(
+      "INSERT INTO decfloat_extreme SELECT column1::DECFLOAT FROM VALUES "
+      "('1E+16384'), ('1E-16383'), ('-1.234E+8000'), ('9.876E-8000')");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM decfloat_extreme");
+
+  // Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+  std::string val1 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val1.empty());
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string val2 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val2.empty());
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string val3 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val3.empty());
+  CHECK(val3[0] == '-');
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  std::string val4 = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(!val4.empty());
+}
+
+TEST_CASE("should handle NULL values from table", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
+  conn.execute("CREATE TABLE decfloat_null (col DECFLOAT)");
+  conn.execute("INSERT INTO decfloat_null SELECT NULL::DECFLOAT");
+  conn.execute("INSERT INTO decfloat_null SELECT 123.456::DECFLOAT");
+  conn.execute("INSERT INTO decfloat_null SELECT NULL::DECFLOAT");
+  conn.execute("INSERT INTO decfloat_null SELECT (-789.012)::DECFLOAT");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM decfloat_null");
+
+  // Then Result should contain [NULL, 123.456, NULL, -789.012]
+  CHECK(get_data_optional<SQL_C_CHAR>(stmt, 1) == std::nullopt);
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "123.456");
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_optional<SQL_C_CHAR>(stmt, 1) == std::nullopt);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-789.012");
+}
+
+TEST_CASE("should download large result set with multiple chunks from table", "[decfloat]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with DECFLOAT column exists with values from 0 to 19999
+  conn.execute("CREATE TABLE decfloat_large (col DECFLOAT)");
+  conn.execute("INSERT INTO decfloat_large SELECT seq8()::DECFLOAT FROM TABLE(GENERATOR(ROWCOUNT => 20000))");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT * FROM decfloat_large ORDER BY col", SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then Result should contain consecutive numbers from 0 to 19999
+  // And All values should be returned as appropriate type
+  int row_count = 0;
+
+  while (true) {
+    ret = SQLFetch(stmt.getHandle());
+    if (ret == SQL_NO_DATA) break;
+    CHECK_ODBC(ret, stmt);
+
+    std::string val = get_data<SQL_C_CHAR>(stmt, 1);
+    REQUIRE(!val.empty());
+
+    int int_val = std::stoi(val);
+    REQUIRE(int_val == row_count);
+    row_count++;
+  }
+
+  REQUIRE(row_count == 20000);
+}

--- a/odbc_tests/tests/e2e/types/float.cpp
+++ b/odbc_tests/tests/e2e/types/float.cpp
@@ -33,7 +33,7 @@ TEST_CASE("should cast float values to appropriate type for float and synonyms",
   Connection conn;
 
   // When Query "SELECT 0.0::<type>, 123.456::<type>, 1.23e10::<type>, 'NaN'::<type>, 'inf'::<type>" is executed
-  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 123.456::FLOAT, 1.23e10::FLOAT");
+  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 123.456::FLOAT, 1.23e10::FLOAT, 'NaN'::FLOAT, 'inf'::FLOAT");
 
   // Then All values should be returned as appropriate type
   // And Regular values should have approximately 15 decimal digits precision
@@ -42,9 +42,8 @@ TEST_CASE("should cast float values to appropriate type for float and synonyms",
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == Catch::Approx(1.23e10));
 
   // And NaN and inf values should be identified correctly
-  auto stmt2 = conn.execute_fetch("SELECT 'NaN'::FLOAT, 'inf'::FLOAT");
-  CHECK(get_data<SQL_C_CHAR>(stmt2, 1) == "NaN");
-  CHECK(is_positive_infinity_str(get_data<SQL_C_CHAR>(stmt2, 2)));
+  CHECK(get_data<SQL_C_CHAR>(stmt, 4) == "NaN");
+  CHECK(is_positive_infinity_str(get_data<SQL_C_CHAR>(stmt, 5)));
 }
 
 // ============================================================================
@@ -162,21 +161,30 @@ TEST_CASE("should select floats from table for float and synonyms", "[float]") {
   auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
-  conn.execute("CREATE TABLE float_basic (col FLOAT)");
-  conn.execute("INSERT INTO float_basic VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
+  conn.execute("CREATE TABLE float_table (col FLOAT)");
+  conn.execute("INSERT INTO float_table VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
 
   // When Query "SELECT * FROM float_table" is executed
-  auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT * FROM float_basic ORDER BY col", SQL_NTS);
-  CHECK_ODBC(ret, stmt);
+  auto stmt = conn.execute_fetch("SELECT * FROM float_table");
 
   // Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
-  std::vector<double> expected = {-789.012, -0.00987, 0.0, 123.456, 123000.0};
-  for (size_t i = 0; i < expected.size(); i++) {
-    ret = SQLFetch(stmt.getHandle());
-    CHECK_ODBC(ret, stmt);
-    CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(expected[i]));
-  }
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == 0.0);
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(123.456));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-789.012));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(123000.0));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-0.00987));
 }
 
 TEST_CASE("should handle special float values from table for float and synonyms", "[float]") {

--- a/odbc_tests/tests/e2e/types/float.cpp
+++ b/odbc_tests/tests/e2e/types/float.cpp
@@ -1,0 +1,319 @@
+// FLOAT datatype ODBC E2E tests
+// Based on: tests/definitions/shared/types/float.feature
+
+#include <algorithm>
+#include <string>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "Schema.hpp"
+#include "get_data.hpp"
+
+// Old driver returns "INFINITY"/"-INFINITY", new driver returns "inf"/"-inf"
+static bool is_positive_infinity_str(const std::string& s) {
+  std::string lower = s;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  return lower == "inf" || lower == "infinity";
+}
+
+static bool is_negative_infinity_str(const std::string& s) {
+  std::string lower = s;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  return lower == "-inf" || lower == "-infinity";
+}
+
+// ============================================================================
+// TYPE CASTING
+// ============================================================================
+
+TEST_CASE("should cast float values to appropriate type for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 0.0::<type>, 123.456::<type>, 1.23e10::<type>, 'NaN'::<type>, 'inf'::<type>" is executed
+  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 123.456::FLOAT, 1.23e10::FLOAT");
+
+  // Then All values should be returned as appropriate type
+  // And Regular values should have approximately 15 decimal digits precision
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == 0.0);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 2) == Catch::Approx(123.456));
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == Catch::Approx(1.23e10));
+
+  // And NaN and inf values should be identified correctly
+  auto stmt2 = conn.execute_fetch("SELECT 'NaN'::FLOAT, 'inf'::FLOAT");
+  CHECK(get_data<SQL_C_CHAR>(stmt2, 1) == "NaN");
+  CHECK(is_positive_infinity_str(get_data<SQL_C_CHAR>(stmt2, 2)));
+}
+
+// ============================================================================
+// SELECT WITH LITERALS (no tables)
+// ============================================================================
+
+TEST_CASE("should select float literals for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>" is executed
+  auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT, 1.0::FLOAT, -1.0::FLOAT, 123.456::FLOAT, -123.456::FLOAT");
+
+  // Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == 0.0);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 2) == 1.0);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == -1.0);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 4) == Catch::Approx(123.456));
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 5) == Catch::Approx(-123.456));
+}
+
+TEST_CASE("should handle special float values from literals for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
+  auto stmt = conn.execute_fetch("SELECT 'NaN'::FLOAT, 'inf'::FLOAT, '-inf'::FLOAT");
+
+  // Then Result should contain [NaN, positive_infinity, negative_infinity]
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "NaN");
+  CHECK(is_positive_infinity_str(get_data<SQL_C_CHAR>(stmt, 2)));
+  CHECK(is_negative_infinity_str(get_data<SQL_C_CHAR>(stmt, 3)));
+}
+
+TEST_CASE("should handle float boundary values from literals for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is executed
+  auto stmt = conn.execute_fetch("SELECT 1.7976931348623157e308::FLOAT, -1.7976931348623157e308::FLOAT");
+
+  // Then Result should contain floats [1.7976931348623157e308, -1.7976931348623157e308]
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(1.7976931348623157e308));
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 2) == Catch::Approx(-1.7976931348623157e308));
+
+  // When Query "SELECT 2.2250738585072014e-308::<type>, 5e-324::<type>" is executed
+  auto stmt2 = conn.execute_fetch("SELECT 2.2250738585072014e-308::FLOAT, 5e-324::FLOAT");
+
+  // Then Result should contain floats [2.2250738585072014e-308, approximately 5e-324]
+  CHECK(get_data<SQL_C_DOUBLE>(stmt2, 1) == Catch::Approx(2.2250738585072014e-308));
+  double subnormal = get_data<SQL_C_DOUBLE>(stmt2, 2);
+  CHECK(subnormal > 0.0);
+  CHECK(subnormal < 1e-300);
+
+  // When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
+  auto stmt3 = conn.execute_fetch("SELECT 123456789012345.0::FLOAT, 1234567890123456.0::FLOAT");
+
+  // Then Result should verify precision around 15 decimal digits
+  CHECK(get_data<SQL_C_DOUBLE>(stmt3, 1) == Catch::Approx(123456789012345.0));
+  CHECK(get_data<SQL_C_DOUBLE>(stmt3, 2) == Catch::Approx(1234567890123456.0));
+}
+
+TEST_CASE("should handle NULL values from literals for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
+  auto stmt = conn.execute_fetch("SELECT NULL::FLOAT, 42.5::FLOAT, NULL::FLOAT");
+
+  // Then Result should contain [NULL, 42.5, NULL]
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 1) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 2) == std::optional<double>(42.5));
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 3) == std::nullopt);
+}
+
+TEST_CASE("should download large result set with multiple chunks from GENERATOR for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
+  auto stmt = conn.createStatement();
+  const auto sql = "SELECT seq8()::FLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY 1";
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then Result should contain 50000 rows
+  // And All values should be returned as appropriate float type
+  int row_count = 0;
+  double expected = 0.0;
+
+  while (true) {
+    ret = SQLFetch(stmt.getHandle());
+    if (ret == SQL_NO_DATA) break;
+    CHECK_ODBC(ret, stmt);
+
+    double val = 0.0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DOUBLE, &val, sizeof(val), NULL);
+    CHECK_ODBC(ret, stmt);
+
+    REQUIRE(val == Catch::Approx(expected));
+    expected += 1.0;
+    row_count++;
+  }
+
+  REQUIRE(row_count == 50000);
+}
+
+// ============================================================================
+// TABLE OPERATIONS
+// ============================================================================
+
+TEST_CASE("should select floats from table for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
+  conn.execute("CREATE TABLE float_basic (col FLOAT)");
+  conn.execute("INSERT INTO float_basic VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
+
+  // When Query "SELECT * FROM float_table" is executed
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT * FROM float_basic ORDER BY col", SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
+  std::vector<double> expected = {-789.012, -0.00987, 0.0, 123.456, 123000.0};
+  for (size_t i = 0; i < expected.size(); i++) {
+    ret = SQLFetch(stmt.getHandle());
+    CHECK_ODBC(ret, stmt);
+    CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(expected[i]));
+  }
+}
+
+TEST_CASE("should handle special float values from table for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
+  conn.execute("CREATE TABLE float_special (col FLOAT)");
+  conn.execute("INSERT INTO float_special SELECT 'NaN'::FLOAT");
+  conn.execute("INSERT INTO float_special SELECT 'inf'::FLOAT");
+  conn.execute("INSERT INTO float_special SELECT '-inf'::FLOAT");
+  conn.execute("INSERT INTO float_special VALUES (42.0), (-42.0)");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM float_special");
+
+  // Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "NaN");
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(is_positive_infinity_str(get_data<SQL_C_CHAR>(stmt, 1)));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(is_negative_infinity_str(get_data<SQL_C_CHAR>(stmt, 1)));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == 42.0);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == -42.0);
+}
+
+TEST_CASE("should handle float boundary values from table for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308,
+  // 2.2250738585072014e-308, 5e-324, 123456789012345.0]
+  conn.execute("CREATE TABLE float_boundary (col FLOAT)");
+  conn.execute("INSERT INTO float_boundary VALUES (1.7976931348623157e308)");
+  conn.execute("INSERT INTO float_boundary VALUES (-1.7976931348623157e308)");
+  conn.execute("INSERT INTO float_boundary VALUES (2.2250738585072014e-308)");
+  conn.execute("INSERT INTO float_boundary VALUES (5e-324)");
+  conn.execute("INSERT INTO float_boundary VALUES (123456789012345.0)");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM float_boundary");
+
+  // Then Result should contain maximum, minimum, and precision boundary values
+  // And All values should be preserved within float precision limits
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(1.7976931348623157e308));
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-1.7976931348623157e308));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(2.2250738585072014e-308));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  double subnormal = get_data<SQL_C_DOUBLE>(stmt, 1);
+  CHECK(subnormal > 0.0);
+  CHECK(subnormal < 1e-300);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(123456789012345.0));
+}
+
+TEST_CASE("should handle NULL values from table for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
+  conn.execute("CREATE TABLE float_null (col FLOAT)");
+  conn.execute("INSERT INTO float_null VALUES (NULL), (123.456), (NULL), (-789.012)");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM float_null");
+
+  // Then Result should contain [NULL, 123.456, NULL, -789.012]
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 1) == std::nullopt);
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(123.456));
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 1) == std::nullopt);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-789.012));
+}
+
+TEST_CASE("should select large result set from table for float and synonyms", "[float]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with <type> column exists with 50000 sequential values
+  conn.execute("CREATE TABLE float_large (col FLOAT)");
+  conn.execute("INSERT INTO float_large SELECT seq8()::FLOAT FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT * FROM float_large ORDER BY col", SQL_NTS);
+  CHECK_ODBC(ret, stmt);
+
+  // Then Result should contain 50000 rows
+  // And All values should be returned as appropriate float type
+  int row_count = 0;
+  double expected = 0.0;
+
+  while (true) {
+    ret = SQLFetch(stmt.getHandle());
+    if (ret == SQL_NO_DATA) break;
+    CHECK_ODBC(ret, stmt);
+
+    double val = 0.0;
+    ret = SQLGetData(stmt.getHandle(), 1, SQL_C_DOUBLE, &val, sizeof(val), NULL);
+    CHECK_ODBC(ret, stmt);
+
+    REQUIRE(val == Catch::Approx(expected));
+    expected += 1.0;
+    row_count++;
+  }
+
+  REQUIRE(row_count == 50000);
+}

--- a/odbc_tests/tests/e2e/types/number.cpp
+++ b/odbc_tests/tests/e2e/types/number.cpp
@@ -193,6 +193,64 @@ TEST_CASE("should handle scale and precision boundaries from table for number an
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == 0);
 }
 
+TEST_CASE("should handle NULL values from literals for number and synonyms", "[number]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When Query "SELECT NULL::<type>(10,0), 42::<type>(10,0), NULL::<type>(10,2), 42.50::<type>(10,2)" is executed
+  auto stmt =
+      conn.execute_fetch("SELECT NULL::NUMBER(10,0), 42::NUMBER(10,0), NULL::NUMBER(10,2), 42.50::NUMBER(10,2)");
+
+  // Then Result should contain [NULL, 42, NULL, 42.50]
+  CHECK(get_data_optional<SQL_C_LONG>(stmt, 1) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_LONG>(stmt, 2) == std::optional<SQLINTEGER>(42));
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 3) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 4) == std::optional<double>(42.50));
+}
+
+TEST_CASE("should handle NULL values from table with multiple scales for number and synonyms", "[number]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto random_schema = Schema::use_random_schema(conn);
+
+  // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
+  conn.execute("CREATE TABLE number_null_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3))");
+  // And Row (NULL, NULL, NULL) is inserted
+  conn.execute("INSERT INTO number_null_table VALUES (NULL, NULL, NULL)");
+  // And Row (123, 123.45, 123.456) is inserted
+  conn.execute("INSERT INTO number_null_table VALUES (123, 123.45, 123.456)");
+  // And Row (NULL, NULL, NULL) is inserted
+  conn.execute("INSERT INTO number_null_table VALUES (NULL, NULL, NULL)");
+  // And Row (-456, -67.89, -789.012) is inserted
+  conn.execute("INSERT INTO number_null_table VALUES (-456, -67.89, -789.012)");
+
+  // When Query "SELECT * FROM <table>" is executed
+  auto stmt = conn.execute_fetch("SELECT * FROM number_null_table");
+
+  // Then Result should contain 4 rows with 2 NULL rows and 2 non-NULL rows with expected values
+  CHECK(get_data_optional<SQL_C_LONG>(stmt, 1) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 2) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 3) == std::nullopt);
+
+  SQLRETURN ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 123);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 2) == 123.45);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == 123.456);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data_optional<SQL_C_LONG>(stmt, 1) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 2) == std::nullopt);
+  CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 3) == std::nullopt);
+
+  ret = SQLFetch(stmt.getHandle());
+  CHECK_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == -456);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 2) == -67.89);
+  CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == -789.012);
+}
+
 TEST_CASE("should download large result set from table for number and synonyms", "[number]") {
   // Given Snowflake client is logged in
   Connection conn;

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -1,11 +1,11 @@
-@python @jdbc @core_not_needed
+@python @odbc @jdbc @core_not_needed
 Feature: DECFLOAT type support
 
   # =========================================================================== #
   #                               Type casting                                  #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should cast decfloat values to appropriate type
     # Python: Values should be cast to 'Decimal' type with 38-digit precision
     Given Snowflake client is logged in
@@ -17,19 +17,19 @@ Feature: DECFLOAT type support
   #                     SELECT with literals (no tables)                        #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select decfloat literals
     Given Snowflake client is logged in
     When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT" is executed
     Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle full 38-digit precision values from literals
     Given Snowflake client is logged in
     When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT, '1.2345678901234567890123456789012345678E+100'::DECFLOAT, '1.2345678901234567890123456789012345678E-100'::DECFLOAT" is executed
     Then Result should preserve all 38 digits for each value
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle extreme exponent values from literals
     Given Snowflake client is logged in
     When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
@@ -37,13 +37,13 @@ Feature: DECFLOAT type support
     When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
     Then Result should contain [-1.234E+8000, 9.876E-8000]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from literals
     Given Snowflake client is logged in
     When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
     Then Result should contain [NULL, 42.5, NULL]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in
     When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
@@ -54,35 +54,35 @@ Feature: DECFLOAT type support
   #                             Table operations                                #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select decfloats from table
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle full 38-digit precision values from table
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values [12345678901234567890123456789012345678, 1.2345678901234567890123456789012345678E+100, 1.2345678901234567890123456789012345678E-100]
     When Query "SELECT * FROM <table>" is executed
     Then Result should preserve all 38 digits for each value
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle extreme exponent values from table
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from table
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [NULL, 123.456, NULL, -789.012]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should download large result set with multiple chunks from table
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values from 0 to 19999

--- a/tests/definitions/shared/types/float.feature
+++ b/tests/definitions/shared/types/float.feature
@@ -1,11 +1,11 @@
-@python @jdbc @core_not_needed
+@python @odbc @jdbc @core_not_needed
 Feature: FLOAT type support
 
   # =========================================================================== #
   #                               Type casting                                  #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should cast float values to appropriate type for float and synonyms
     # Python: Values should be cast to 'float' type (64-bit)
     Given Snowflake client is logged in
@@ -18,19 +18,19 @@ Feature: FLOAT type support
   #                     SELECT with literals (no tables)                        #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select float literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>" is executed
     Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle special float values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
     Then Result should contain [NaN, positive_infinity, negative_infinity]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle float boundary values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is executed
@@ -40,13 +40,13 @@ Feature: FLOAT type support
     When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
     Then Result should verify precision around 15 decimal digits
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from literals for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
     Then Result should contain [NULL, 42.5, NULL]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should download large result set with multiple chunks from GENERATOR for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
@@ -57,21 +57,21 @@ Feature: FLOAT type support
   #                             Table operations                                #
   # =========================================================================== #
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select floats from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
     When Query "SELECT * FROM float_table" is executed
     Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle special float values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle float boundary values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
@@ -79,14 +79,14 @@ Feature: FLOAT type support
     Then Result should contain maximum, minimum, and precision boundary values
     And All values should be preserved within float precision limits
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain [NULL, 123.456, NULL, -789.012]
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should select large result set from table for float and synonyms
     Given Snowflake client is logged in
     And Table with <type> column exists with 50000 sequential values

--- a/tests/definitions/shared/types/number.feature
+++ b/tests/definitions/shared/types/number.feature
@@ -41,7 +41,7 @@ Feature: NUMBER type support
     When Query "SELECT 99999999999999999999999999999999999999::<type>(38,0), -99999999999999999999999999999999999999::<type>(38,0)" is executed
     Then Result should contain max and min 38-digit integers
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from literals for number and synonyms
     Given Snowflake client is logged in
     When Query "SELECT NULL::<type>(10,0), 42::<type>(10,0), NULL::<type>(10,2), 42.50::<type>(10,2)" is executed
@@ -98,7 +98,7 @@ Feature: NUMBER type support
     When Query "SELECT * FROM <table>" is executed
     Then Result should contain 3 rows with expected high precision boundary values
 
-  @python_e2e @jdbc_e2e
+  @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should handle NULL values from table with multiple scales for number and synonyms
     Given Snowflake client is logged in
     And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists


### PR DESCRIPTION
### TL;DR

Added comprehensive ODBC end-to-end tests for DECFLOAT and FLOAT data types, along with additional NULL handling tests for NUMBER types.

### What changed?

- Added `decfloat.cpp` with comprehensive ODBC tests for DECFLOAT data type handling, including 38-digit precision values, extreme exponents, and NULL values
- Added `float.cpp` with comprehensive ODBC tests for FLOAT data type handling, including special values (NaN, infinity), boundary values, and precision verification
- Enhanced `number.cpp` with additional NULL value handling tests for literals and table operations
- Updated CMakeLists.txt to include the new test files in the build
- Updated feature files to include `@odbc_e2e` tags for DECFLOAT and FLOAT scenarios

The DECFLOAT tests include a note that the new driver does not yet support DECFLOAT Arrow format, so all tests are currently skipped via `SKIP_NEW_DRIVER_NOT_IMPLEMENTED()`.

### How to test?

Run the ODBC end-to-end test suite with the new test cases:
- Execute `e2e_types_decfloat` tests to verify DECFLOAT handling (currently skipped for new driver)
- Execute `e2e_types_float` tests to verify FLOAT data type operations
- Execute existing `e2e_types_number` tests to verify enhanced NULL handling

### Why make this change?

This change ensures comprehensive test coverage for numeric data types in the ODBC driver, particularly for high-precision DECFLOAT values and standard FLOAT operations. The tests verify proper type casting, precision preservation, special value handling (NaN, infinity), and NULL value processing across both literal queries and table operations.