### PR TITLE
Add VARIANT data type support for sf_core and Python driver

### DIFF
--- a/python/tests/e2e/types/test_variant.py
+++ b/python/tests/e2e/types/test_variant.py
@@ -1,0 +1,236 @@
+"""VARIANT type tests for Universal Driver.
+
+Snowflake VARIANT is a semi-structured data type that stores any JSON value:
+objects, arrays, strings, numbers, booleans, and null.
+Values are returned as JSON-serialized strings.
+Maximum size: 16 MB (compressed)
+Reference: https://docs.snowflake.com/en/sql-reference/data-types-semistructured
+"""
+
+from __future__ import annotations
+
+import json
+
+from ...conftest import with_paramstyle
+from .utils import assert_type
+
+
+# =============================================================================
+# CORNER CASE VALUES
+# =============================================================================
+# (expected_python_value, sql_expression)
+CORNER_CASE_VALUES = [
+    ({}, "PARSE_JSON('{}')"),
+    ([], "PARSE_JSON('[]')"),
+    (None, "PARSE_JSON('null')"),
+    ({"a": {"b": {"c": 1}}}, """PARSE_JSON('{"a":{"b":{"c":1}}}')"""),
+    ([1, "two", True, None], """PARSE_JSON('[1,"two",true,null]')"""),
+    (True, "PARSE_JSON('true')"),
+    (False, "PARSE_JSON('false')"),
+    (42, "PARSE_JSON('42')"),
+    (3.14, "PARSE_JSON('3.14')"),
+    (-100, "PARSE_JSON('-100')"),
+    ("hello", """PARSE_JSON('"hello"')"""),
+]
+
+# =============================================================================
+# LARGE RESULT SET SIZE
+# =============================================================================
+LARGE_RESULT_SET_SIZE = 1_000_000
+
+
+def _parse_variant(value):
+    """Parse a VARIANT result value (JSON string) into a Python object."""
+    if value is None:
+        return None
+    return json.loads(value)
+
+
+class TestVariantTypeCasting:
+    """Tests for VARIANT type casting to appropriate type."""
+
+    def test_should_cast_variant_values_to_appropriate_type(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query selecting a JSON object as VARIANT is executed
+        result = execute_query(
+            """SELECT PARSE_JSON('{"key":"value"}')::VARIANT""",
+            single_row=True,
+        )
+
+        # Then All values should be returned as string type
+        assert_type(result, str)
+
+        # And Value should be a valid JSON object
+        parsed = _parse_variant(result[0])
+        assert parsed == {"key": "value"}
+
+
+class TestVariantLiteral:
+    """Tests for VARIANT type using SELECT with literals (no tables)."""
+
+    def test_should_select_variant_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query selecting JSON object and array as VARIANT literals is executed
+        result = execute_query(
+            """SELECT PARSE_JSON('{"name":"test","count":42}')::VARIANT, PARSE_JSON('[1,2,3]')::VARIANT""",
+            single_row=True,
+        )
+
+        # Then Result should contain valid JSON object and array values
+        assert_type(result, str)
+        assert _parse_variant(result[0]) == {"name": "test", "count": 42}
+        assert _parse_variant(result[1]) == [1, 2, 3]
+
+    def test_should_select_variant_corner_case_values(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query selecting corner case VARIANT literals is executed
+        # Then Result should contain expected corner case VARIANT values
+        for expected_val, sql_expr in CORNER_CASE_VALUES:
+            result = execute_query(f"SELECT {sql_expr}::VARIANT", single_row=True)
+            assert _parse_variant(result[0]) == expected_val, (
+                f"Expected {expected_val!r}, got {_parse_variant(result[0])!r}"
+            )
+
+    def test_should_handle_null_values_from_literals(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query selecting VARIANT values with SQL NULL is executed
+        result = execute_query(
+            """SELECT PARSE_JSON('{"a":1}')::VARIANT, NULL::VARIANT, PARSE_JSON('[1]')::VARIANT""",
+            single_row=True,
+        )
+
+        # Then Result should contain JSON values and SQL NULLs in expected positions
+        assert _parse_variant(result[0]) == {"a": 1}
+        assert result[1] is None
+        assert _parse_variant(result[2]) == [1]
+
+
+class TestVariantTable:
+    """Tests for VARIANT type using table operations."""
+
+    def test_should_select_variant_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with VARIANT column exists
+        table_name = f"{tmp_schema}.variant_table"
+        execute_query(f"CREATE TABLE {table_name} (col VARIANT)")
+
+        # And VARIANT rows are inserted with PARSE_JSON values
+        test_json_strings = [
+            '{"name":"test","count":42}',
+            '[1,2,3]',
+            '"hello"',
+        ]
+        for json_str in test_json_strings:
+            execute_query(f"INSERT INTO {table_name} SELECT PARSE_JSON('{json_str}')")
+
+        # When Query selecting all rows from VARIANT table is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should contain the inserted VARIANT values as JSON strings
+        result = [_parse_variant(row[0]) for row in rows]
+        expected = [json.loads(s) for s in test_json_strings]
+        assert len(result) == len(expected)
+        for val in expected:
+            assert val in result, f"Expected {val!r} in result"
+
+    def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with VARIANT column exists
+        table_name = f"{tmp_schema}.variant_null_table"
+        execute_query(f"CREATE TABLE {table_name} (col VARIANT)")
+
+        # And VARIANT rows including NULLs are inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL)")
+        execute_query(f"INSERT INTO {table_name} SELECT PARSE_JSON('{{\"a\":1}}')")
+        execute_query(f"INSERT INTO {table_name} SELECT PARSE_JSON('[1,2]')")
+
+        # When Query selecting all rows from VARIANT table is executed
+        rows = execute_query(f"SELECT * FROM {table_name}")
+
+        # Then Result should contain NULL and non-NULL VARIANT values in any order
+        result = [_parse_variant(row[0]) for row in rows]
+        assert None in result
+        assert dict(a=1) in result
+        assert [1, 2] in result
+
+
+@with_paramstyle("qmark")
+class TestVariantBinding:
+    """Tests for VARIANT type using parameter binding."""
+
+    def test_should_select_variant_using_parameter_binding_with_parse_json(self, execute_query):
+        # Given Snowflake client is logged in
+
+        # When Query with PARSE_JSON binding is executed with a JSON string parameter
+        result = execute_query(
+            "SELECT PARSE_JSON(?)::VARIANT",
+            ('{"key":"value"}',),
+            single_row=True,
+        )
+
+        # Then Result should contain the expected JSON value
+        assert_type(result, str)
+        expected = dict(key="value")
+        assert _parse_variant(result[0]) == expected
+
+        # When Query with PARSE_JSON binding is executed with NULL parameter
+        result = execute_query("SELECT PARSE_JSON(?)::VARIANT", (None,), single_row=True)
+
+        # Then Result should contain NULL
+        assert result == (None,)
+
+    def test_should_insert_variant_using_parameter_binding(self, execute_query, executemany_insert, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with VARIANT column exists
+        table_name = f"{tmp_schema}.variant_bind_table"
+        execute_query(f"CREATE TABLE {table_name} (col VARIANT)")
+
+        # When VARIANT values are inserted using parameter binding with PARSE_JSON
+        test_json_strings = [
+            ('{"key":"value"}',),
+            ('[1,2,3]',),
+            (None,),
+        ]
+        rows = executemany_insert(
+            table_name,
+            f"INSERT INTO {table_name} SELECT PARSE_JSON(?)",
+            test_json_strings,
+        )
+
+        # Then SELECT should return the same VARIANT values
+        result = [_parse_variant(row[0]) for row in rows]
+        assert {"key": "value"} in result
+        assert [1, 2, 3] in result
+        assert None in result
+
+
+class TestVariantMultipleChunks:
+    """Tests for VARIANT type with multiple chunks downloading."""
+
+    def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
+        # Given Snowflake client is logged in
+
+        # And Table with VARIANT column exists with 1000000 generated VARIANT values
+        table_name = f"{tmp_schema}.large_variant_table"
+        execute_query(f"CREATE TABLE {table_name} (col VARIANT)")
+        execute_query(
+            f"INSERT INTO {table_name} "
+            f"SELECT PARSE_JSON('{{\"id\":' || seq8() || '}}') "
+            f"FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+        )
+
+        # When Query selecting all rows from VARIANT table is executed
+        rows = execute_query(f"SELECT col FROM {table_name}")
+
+        # Then Result should contain 1000000 VARIANT values
+        assert len(rows) == LARGE_RESULT_SET_SIZE
+        assert_type([row[0] for row in rows], str)
+        sample = _parse_variant(rows[0][0])
+        assert "id" in sample

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -64,6 +64,11 @@ pub fn create_field_with_type(row_type: &RowType, data_type: DataType) -> Field 
             ];
             Field::new(name, DataType::Struct(fields.into()), *nullable).with_metadata(metadata)
         }
+        RowType::Variant { name, nullable } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "VARIANT".to_string());
+            Field::new(name, data_type, *nullable).with_metadata(metadata)
+        }
     }
 }
 
@@ -247,6 +252,10 @@ fn create_column_array(
                 Arc::new(arrow::array::StructArray::from(values)),
             ))
         }
+        RowType::Variant { .. } => Ok((
+            create_field_with_type(row_type, DataType::Utf8),
+            Arc::new(StringArray::from(values)),
+        )),
     }
 }
 

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -28,6 +28,10 @@ pub enum RowType {
         nullable: bool,
         scale: u64,
     },
+    Variant {
+        name: String,
+        nullable: bool,
+    },
 }
 
 impl RowType {
@@ -84,6 +88,13 @@ impl RowType {
             name: name.to_string(),
             nullable,
             scale,
+        }
+    }
+
+    pub fn variant(name: &str, nullable: bool) -> Self {
+        RowType::Variant {
+            name: name.to_string(),
+            nullable,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -577,6 +577,7 @@ impl TryFrom<&RowType> for query_types::RowType {
                 Ok(query_types::RowType::timestamp_ntz(&name, nullable, scale))
             }
             "BOOLEAN" => Ok(query_types::RowType::boolean(&name, nullable)),
+            "VARIANT" => Ok(query_types::RowType::variant(&name, nullable)),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
             }

--- a/sf_core/tests/e2e/query/json_result_set.rs
+++ b/sf_core/tests/e2e/query/json_result_set.rs
@@ -50,3 +50,57 @@ fn should_return_arrow_even_if_json_result_set_is_returned_for_simple_types() {
     // And Statement should be released
     client.release_statement(&stmt);
 }
+
+#[test]
+fn should_return_arrow_even_if_json_result_set_is_returned_for_variant() {
+    // Given Snowflake client is logged in
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let stmt = client.new_statement();
+
+    // When Table json_result_set_variant (var_col VARIANT) is created
+    client.set_sql_query(
+        &stmt,
+        "CREATE OR REPLACE TABLE json_result_set_variant (var_col VARIANT)",
+    );
+    client.execute_statement_query(&stmt);
+
+    // And Row is inserted with VARIANT data
+    client.set_sql_query(
+        &stmt,
+        "INSERT INTO json_result_set_variant SELECT PARSE_JSON('{\"key\": \"value\", \"num\": 42}')",
+    );
+    client.execute_statement_query(&stmt);
+
+    // And Query "SELECT * FROM json_result_set_variant" is executed with Arrow format
+    client.set_sql_query(&stmt, "SELECT * FROM json_result_set_variant");
+    let arrow_result = client.execute_statement_query(&stmt);
+
+    // And Query result format is forced to JSON
+    client.set_sql_query(
+        &stmt,
+        "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
+    );
+    let result = client.execute_statement_query(&stmt);
+    assert_eq!(result.rows_affected(), 1, "Cannot force JSON result set");
+
+    // And Query "SELECT * FROM json_result_set_variant" is executed with JSON format
+    client.set_sql_query(&stmt, "SELECT * FROM json_result_set_variant");
+    let json_result = client.execute_statement_query(&stmt);
+
+    let mut arrow_result_helper = ArrowResultHelper::from_result(arrow_result);
+    let mut json_result_helper = ArrowResultHelper::from_result(json_result);
+
+    // Then Schema for both queries should match
+    let arrow_schema = arrow_result_helper.schema();
+    let json_schema = json_result_helper.schema();
+    assert_schemas_match(&arrow_schema, &json_schema);
+
+    let arrow_columns = arrow_result_helper.next_batch().unwrap();
+    let json_columns = json_result_helper.next_batch().unwrap();
+
+    // And the result for both queries should match
+    assert_record_batches_match(&arrow_columns, &json_columns);
+
+    // And Statement should be released
+    client.release_statement(&stmt);
+}

--- a/tests/definitions/core/query/json_result_set.feature
+++ b/tests/definitions/core/query/json_result_set.feature
@@ -13,6 +13,18 @@ Feature: JSON Result Set
     And the result for both queries should match
     And Statement should be released
 
+  @core_e2e
+  Scenario: should return arrow even if JSON result set is returned for variant
+    Given Snowflake client is logged in
+    When Table json_result_set_variant (var_col VARIANT) is created
+    And Row is inserted with VARIANT data
+    And Query "SELECT * FROM json_result_set_variant" is executed with Arrow format
+    And Query result format is forced to JSON
+    And Query "SELECT * FROM json_result_set_variant" is executed with JSON format
+    Then Schema for both queries should match
+    And the result for both queries should match
+    And Statement should be released
+
   # TODO add a test for larger result set with chunks
 
   # TODO add a test for all possible data types

--- a/tests/definitions/shared/types/variant.feature
+++ b/tests/definitions/shared/types/variant.feature
@@ -1,0 +1,100 @@
+@python
+Feature: VARIANT type support
+  # Snowflake VARIANT is a semi-structured data type that can store any JSON value:
+  # objects, arrays, strings, numbers, booleans, and null.
+  # Values are returned as JSON-serialized strings.
+  # Maximum size: 16 MB (compressed)
+  # Reference: https://docs.snowflake.com/en/sql-reference/data-types-semistructured
+
+  # =========================================================================== #
+  #                               Type casting                                  #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should cast variant values to appropriate type
+    # Python: Values should be cast to 'str' type (JSON-serialized)
+    Given Snowflake client is logged in
+    When Query selecting a JSON object as VARIANT is executed
+    Then All values should be returned as string type
+    And Value should be a valid JSON object
+
+  # =========================================================================== #
+  #                     SELECT with literals (no tables)                        #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select variant literals
+    Given Snowflake client is logged in
+    When Query selecting JSON object and array as VARIANT literals is executed
+    Then Result should contain valid JSON object and array values
+
+  @python_e2e
+  Scenario: should select variant corner case values
+    # Corner cases for VARIANT:
+    #   - Empty object
+    #   - Empty array
+    #   - JSON null
+    #   - Nested object
+    #   - Mixed array with different types
+    #   - Boolean values: true, false
+    #   - Numeric values: integer, float, negative
+    #   - String value in variant
+    Given Snowflake client is logged in
+    When Query selecting corner case VARIANT literals is executed
+    Then Result should contain expected corner case VARIANT values
+
+  @python_e2e
+  Scenario: should handle NULL values from literals
+    Given Snowflake client is logged in
+    When Query selecting VARIANT values with SQL NULL is executed
+    Then Result should contain JSON values and SQL NULLs in expected positions
+
+  # =========================================================================== #
+  #                             Table operations                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select variant values from table
+    Given Snowflake client is logged in
+    And Table with VARIANT column exists
+    And VARIANT rows are inserted with PARSE_JSON values
+    When Query selecting all rows from VARIANT table is executed
+    Then Result should contain the inserted VARIANT values as JSON strings
+
+  @python_e2e
+  Scenario: should handle NULL values from table
+    Given Snowflake client is logged in
+    And Table with VARIANT column exists
+    And VARIANT rows including NULLs are inserted
+    When Query selecting all rows from VARIANT table is executed
+    Then Result should contain NULL and non-NULL VARIANT values in any order
+
+  # =========================================================================== #
+  #                            Parameter binding                                #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should select variant using parameter binding with PARSE_JSON
+    Given Snowflake client is logged in
+    When Query with PARSE_JSON binding is executed with a JSON string parameter
+    Then Result should contain the expected JSON value
+    When Query with PARSE_JSON binding is executed with NULL parameter
+    Then Result should contain NULL
+
+  @python_e2e
+  Scenario: should insert variant using parameter binding
+    Given Snowflake client is logged in
+    And Table with VARIANT column exists
+    When VARIANT values are inserted using parameter binding with PARSE_JSON
+    Then SELECT should return the same VARIANT values
+
+  # =========================================================================== #
+  #                          Multiple chunks downloading                        #
+  # =========================================================================== #
+
+  @python_e2e
+  Scenario: should download large result set with multiple chunks from table
+    Given Snowflake client is logged in
+    And Table with VARIANT column exists with 1000000 generated VARIANT values
+    When Query selecting all rows from VARIANT table is executed
+    Then Result should contain 1000000 VARIANT values


### PR DESCRIPTION
- Add Variant to RowType enum and query response parsing so JSON-format results with VARIANT columns are handled correctly
- Add Variant arms in arrow_utils for Arrow field/array creation
- Add JSON result set parity test for VARIANT in sf_core E2E tests
- Create Gherkin feature file with 9 test scenarios covering type casting, literals, corner cases, NULL handling, tables, binding, and multi-chunk
- Implement Python E2E tests for all VARIANT scenarios