### PR TITLE
NO-SNOW: Implement execute/executeUpdate with real response

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -43,12 +43,6 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.Datab
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
 import net.snowflake.client.internal.util.NotImplementedException;
 
-/**
- * Snowflake JDBC Connection implementation
- *
- * <p>This is a stub implementation that provides the basic JDBC Connection interface and delegates
- * to native Rust implementation via JNI.
- */
 public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionImpl.class);
   private final String url;

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
@@ -63,7 +63,7 @@ public class SnowflakeBasicDataSource implements SnowflakeDataSource {
         properties.setProperty(SnowflakeSessionProperty.PASSWORD.getPropertyKey(), password);
       }
 
-      Connection con = DriverManager.getConnection(getUrl(), properties);
+      Connection con = openConnection(getUrl(), properties);
       logger.trace(
           "Created a connection for {} at {}", effectiveUser, (Supplier<String>) this::getUrl);
       return con;
@@ -71,6 +71,10 @@ public class SnowflakeBasicDataSource implements SnowflakeDataSource {
       logger.error("Failed to create a connection for {} at {}: {}", effectiveUser, getUrl(), e);
       throw e;
     }
+  }
+
+  protected Connection openConnection(String url, Properties properties) throws SQLException {
+    return DriverManager.getConnection(url, properties);
   }
 
   // CommonDataSource methods ----------------------------------------------------------------------

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -10,11 +10,6 @@ import net.snowflake.client.api.connection.SnowflakeDatabaseMetaData;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.util.NotImplementedException;
 
-/**
- * Snowflake JDBC DatabaseMetaData implementation
- *
- * <p>This is a stub implementation that provides basic database metadata information.
- */
 public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, SnowflakeDatabaseMetaData {
   private static final String DatabaseProductName = "Snowflake";
   private static final String DriverName = "Snowflake";
@@ -311,7 +306,6 @@ public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, Snowflak
   @Override
   public boolean supportsMultipleResultSets() throws SQLException {
     connection.checkClosed();
-    // TODO: should it be true since we support multi statements?
     return false;
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -306,6 +306,7 @@ public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, Snowflak
   @Override
   public boolean supportsMultipleResultSets() throws SQLException {
     connection.checkClosed();
+    // TODO: it should be true when we support multi statements
     return false;
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
@@ -43,11 +43,6 @@ import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
-/**
- * Snowflake JDBC ResultSet implementation
- *
- * <p>This is a stub implementation that provides the basic JDBC ResultSet interface.
- */
 public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
 
   private final SnowflakeStatementImpl statement;
@@ -98,6 +93,7 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
       resources.closeAll();
     } finally {
       closed = true;
+      statement.removeClosedResultSet(this);
       resetStateAfterClose();
     }
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImpl.java
@@ -8,7 +8,6 @@ import java.util.List;
 import net.snowflake.client.api.resultset.FieldMetadata;
 import net.snowflake.client.api.resultset.SnowflakeResultSetMetaData;
 
-/** Simple ResultSetMetaData implementation */
 public class SnowflakeResultSetMetaDataImpl
     implements ResultSetMetaData, SnowflakeResultSetMetaData {
   private final String[] columnNames;

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -35,11 +35,12 @@ final class PreparedStatementBindingSerializer {
     }
   }
 
-  static final class SerializedBindings implements AutoCloseable {
+  /** Holds bindings plus the native buffer backing the pointer stored in the RPC payload. */
+  static final class NativeBindings implements AutoCloseable {
     private final QueryBindings bindings;
     private final NativeBuffer buffer;
 
-    SerializedBindings(QueryBindings bindings, NativeBuffer buffer) {
+    NativeBindings(QueryBindings bindings, NativeBuffer buffer) {
       this.bindings = bindings;
       this.buffer = buffer;
     }
@@ -50,6 +51,8 @@ final class PreparedStatementBindingSerializer {
 
     @Override
     public void close() {
+      // The bindings payload includes a pointer into this native buffer, so the owner must release
+      // it after the RPC has been constructed and sent.
       if (buffer != null) {
         buffer.close();
       }
@@ -58,10 +61,11 @@ final class PreparedStatementBindingSerializer {
 
   private PreparedStatementBindingSerializer() {}
 
-  static SerializedBindings serialize(ParameterValue[] parameterValues) throws SQLException {
+  static NativeBindings serializeToNativeBindings(ParameterValue[] parameterValues)
+      throws SQLException {
     if (parameterValues.length == 0) {
       logger.debug("No parameter placeholders found, skipping bindings serialization.");
-      return new SerializedBindings(null, null);
+      return new NativeBindings(null, null);
     }
     logger.debug("Serializing prepared bindings: placeholders={}", parameterValues.length);
 
@@ -102,9 +106,9 @@ final class PreparedStatementBindingSerializer {
           "Prepared bindings serialized: payloadBytes={}, pointerBytes={}",
           jsonBytes.length,
           ptrBytes.length);
-      SerializedBindings serializedBindings = new SerializedBindings(queryBindings, nativeBuffer);
+      NativeBindings nativeBindings = new NativeBindings(queryBindings, nativeBuffer);
       success = true;
-      return serializedBindings;
+      return nativeBindings;
     } finally {
       if (!success) {
         nativeBuffer.close();

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -32,11 +32,6 @@ import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.util.HexUtil;
 
-/**
- * Snowflake JDBC PreparedStatement implementation
- *
- * <p>This is a stub implementation that provides the basic JDBC PreparedStatement interface.
- */
 public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     implements PreparedStatement, SnowflakePreparedStatement {
   private static final SFLogger logger =
@@ -66,9 +61,10 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public int executeUpdate() throws SQLException {
     checkClosed();
-    execute();
-    // TODO return real number of rows affected
-    return 0;
+    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
+        PreparedStatementBindingSerializer.serialize(parameterValues)) {
+      return executeUpdateWithBindings(sql, serializedBindings.bindings());
+    }
   }
 
   @Override
@@ -287,11 +283,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     checkClosed();
     try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
         PreparedStatementBindingSerializer.serialize(parameterValues)) {
-      try (ResultSet ignored = executeQueryWithBindings(sql, serializedBindings.bindings())) {
-        // TODO: Align execute() return value and update-count behavior with snowflake-jdbc by using
-        // backend statement-type metadata (true for result sets, false for update counts).
-        return true;
-      }
+      return executeWithBindings(sql, serializedBindings.bindings());
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -52,18 +52,19 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public ResultSet executeQuery() throws SQLException {
     checkClosed();
-    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
-        PreparedStatementBindingSerializer.serialize(parameterValues)) {
-      return executeQueryWithBindings(sql, serializedBindings.bindings());
+    // Native bindings own the off-heap payload until the RPC has consumed the pointer.
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
+      return executeQueryWithBindings(sql, nativeBindings.bindings());
     }
   }
 
   @Override
   public int executeUpdate() throws SQLException {
     checkClosed();
-    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
-        PreparedStatementBindingSerializer.serialize(parameterValues)) {
-      return executeUpdateWithBindings(sql, serializedBindings.bindings());
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
+      return executeUpdateWithBindings(sql, nativeBindings.bindings());
     }
   }
 
@@ -281,9 +282,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public boolean execute() throws SQLException {
     checkClosed();
-    try (PreparedStatementBindingSerializer.SerializedBindings serializedBindings =
-        PreparedStatementBindingSerializer.serialize(parameterValues)) {
-      return executeWithBindings(sql, serializedBindings.bindings());
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
+      return executeWithBindings(sql, nativeBindings.bindings());
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.api.implementation.statement;
 
+import static net.snowflake.client.internal.api.implementation.statement.StatementTypeClassifier.NO_UPDATE_COUNT;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -7,6 +9,9 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
@@ -23,21 +28,19 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.State
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryRequest;
 
-/**
- * Snowflake JDBC Statement implementation
- *
- * <p>This is a stub implementation that provides the basic JDBC Statement interface and delegates
- * to native Rust implementation via JNI.
- */
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
 
-  public final SnowflakeConnectionImpl connection;
+  protected final SnowflakeConnectionImpl connection;
   protected boolean closed = false;
   protected int maxRows = 0;
   protected int queryTimeout = 0;
   protected int fetchSize = 0;
   protected StatementHandle statementHandle;
+  protected ResultSet currentResultSet;
+  protected long currentUpdateCount = NO_UPDATE_COUNT;
+  protected String queryId;
+  @Getter protected final Set<ResultSet> openResultSets = ConcurrentHashMap.newKeySet();
 
   public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
     this.connection = connection;
@@ -59,9 +62,32 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   protected ResultSet executeQueryWithBindings(String sql, QueryBindings bindings)
       throws SQLException {
+    checkClosed();
+    ExecuteResult executeResult = executeStatement(sql, bindings);
+    applyExecuteQueryResult(executeResult);
+    return currentResultSet;
+  }
+
+  protected int executeUpdateWithBindings(String sql, QueryBindings bindings) throws SQLException {
+    boolean hasResultSet = executeWithBindings(sql, bindings);
+    if (hasResultSet) {
+      throw new SnowflakeSQLException(
+          "executeUpdate() cannot be used for statements that produce a ResultSet");
+    }
+    return toIntUpdateCount(currentUpdateCount);
+  }
+
+  protected boolean executeWithBindings(String sql, QueryBindings bindings) throws SQLException {
+    checkClosed();
+    ExecuteResult executeResult = executeStatement(sql, bindings);
+    applyExecuteResult(executeResult);
+    return currentResultSet != null;
+  }
+
+  private ExecuteResult executeStatement(String sql, QueryBindings bindings) throws SQLException {
     boolean hasBindings = bindings != null;
-    logger.debug(
-        "Statement executeQueryWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
+    logger.debug("Statement executeWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
+    prepareForExecution();
     StatementSetSqlQueryRequest statementSetSqlQueryRequest =
         StatementSetSqlQueryRequest.newBuilder()
             .setStmtHandle(statementHandle)
@@ -92,21 +118,99 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
           "statementExecuteQuery succeeded: hasBindings={}, queryId={}",
           hasBindings,
           executeResult.getQueryId());
-      return new SnowflakeResultSetImpl(this, executeResult);
+      return executeResult;
     } catch (DatabaseDriverService.ServiceException e) {
       logger.warn("statementExecuteQuery failed: hasBindings={}", hasBindings, e);
       throw new SnowflakeSQLException("Failed to execute statement query", e);
     }
   }
 
+  private void applyExecuteQueryResult(ExecuteResult executeResult) throws SQLException {
+    queryId = executeResult.getQueryId();
+    // Match the old JDBC driver: executeQuery() historically accepted single-statement
+    // DML/DDL and surfaced a ResultSet wrapper when the server returned a stream
+    if (StatementTypeClassifier.producesResultSet(executeResult) || executeResult.hasStream()) {
+      applyResultSetExecutionResult(executeResult);
+      return;
+    }
+
+    currentResultSet = null;
+    currentUpdateCount = NO_UPDATE_COUNT;
+  }
+
+  private void applyExecuteResult(ExecuteResult executeResult) throws SQLException {
+    queryId = executeResult.getQueryId();
+    if (StatementTypeClassifier.producesResultSet(executeResult)) {
+      applyResultSetExecutionResult(executeResult);
+      return;
+    }
+
+    currentResultSet = null;
+    currentUpdateCount = StatementTypeClassifier.getUpdateCount(executeResult);
+  }
+
+  private void applyResultSetExecutionResult(ExecuteResult executeResult) throws SQLException {
+    currentResultSet = new SnowflakeResultSetImpl(this, executeResult);
+    currentUpdateCount = NO_UPDATE_COUNT;
+  }
+
+  private void prepareForExecution() throws SQLException {
+    if (currentResultSet != null && !currentResultSet.isClosed()) {
+      openResultSets.add(currentResultSet);
+    }
+    currentResultSet = null;
+    currentUpdateCount = NO_UPDATE_COUNT;
+    queryId = null;
+  }
+
+  private void clearExecutionState() throws SQLException {
+    closeCurrentResultSet();
+    for (ResultSet resultSet : openResultSets) {
+      closeResultSet(resultSet);
+    }
+    openResultSets.clear();
+    currentResultSet = null;
+    currentUpdateCount = NO_UPDATE_COUNT;
+    queryId = null;
+  }
+
+  protected void closeCurrentResultSet() throws SQLException {
+    closeResultSet(currentResultSet);
+  }
+
+  public void removeClosedResultSet(ResultSet resultSet) {
+    openResultSets.remove(resultSet);
+  }
+
+  private void closeResultSet(ResultSet resultSet) throws SQLException {
+    if (resultSet != null && !resultSet.isClosed()) {
+      resultSet.close();
+    }
+  }
+
+  private int toIntUpdateCount(long updateCount) throws SQLException {
+    if (updateCount == NO_UPDATE_COUNT) {
+      return (int) NO_UPDATE_COUNT;
+    }
+    try {
+      return Math.toIntExact(updateCount);
+    } catch (ArithmeticException e) {
+      throw new SnowflakeSQLException("Update count exceeds JDBC int range", e);
+    }
+  }
+
   @Override
   public int executeUpdate(String sql) throws SQLException {
     checkClosed();
-    return 0; // Stub: return 0 rows affected
+    return executeUpdateWithBindings(sql, null);
   }
 
   @Override
   public void close() throws SQLException {
+    if (closed) {
+      return;
+    }
+    clearExecutionState();
     closed = true;
   }
 
@@ -178,27 +282,24 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public boolean execute(String sql) throws SQLException {
     checkClosed();
-    // Stub implementation - assume all statements return result sets
-    executeQuery(sql);
-    return true;
+    return executeWithBindings(sql, null);
   }
 
   @Override
   public ResultSet getResultSet() throws SQLException {
     checkClosed();
-    return null; // No current result set in stub implementation
+    return currentResultSet;
   }
 
   @Override
   public int getUpdateCount() throws SQLException {
     checkClosed();
-    return -1; // No update count in stub implementation
+    return toIntUpdateCount(currentUpdateCount);
   }
 
   @Override
   public boolean getMoreResults() throws SQLException {
-    checkClosed();
-    return false; // No additional result sets in stub implementation
+    return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   @Override
@@ -263,6 +364,19 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public boolean getMoreResults(int current) throws SQLException {
     checkClosed();
+    if (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS) {
+      closeCurrentResultSet();
+    }
+    if (current == Statement.CLOSE_ALL_RESULTS) {
+      for (ResultSet resultSet : openResultSets) {
+        closeResultSet(resultSet);
+      }
+      openResultSets.clear();
+    }
+    // TODO: Implement multi-statement result traversal once JDBC can iterate child results beyond
+    // the first ExecuteResult returned for a statement execution.
+    currentResultSet = null;
+    currentUpdateCount = NO_UPDATE_COUNT;
     return false;
   }
 
@@ -360,7 +474,8 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   @Override
   public String getQueryID() throws SQLException {
-    throw new SQLFeatureNotSupportedException("getQueryID not supported");
+    checkClosed();
+    return queryId;
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -8,10 +8,10 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
@@ -40,7 +40,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   protected ResultSet currentResultSet;
   protected long currentUpdateCount = NO_UPDATE_COUNT;
   protected String queryId;
-  @Getter protected final Set<ResultSet> openResultSets = ConcurrentHashMap.newKeySet();
+  protected final Set<ResultSet> openResultSets = ConcurrentHashMap.newKeySet();
 
   public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
     this.connection = connection;
@@ -69,19 +69,18 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   }
 
   protected int executeUpdateWithBindings(String sql, QueryBindings bindings) throws SQLException {
-    boolean hasResultSet = executeWithBindings(sql, bindings);
-    if (hasResultSet) {
+    boolean producedResultSet = executeWithBindings(sql, bindings);
+    if (producedResultSet) {
       throw new SnowflakeSQLException(
           "executeUpdate() cannot be used for statements that produce a ResultSet");
     }
-    return toIntUpdateCount(currentUpdateCount);
+    return getCurrentUpdateCountAsInt();
   }
 
   protected boolean executeWithBindings(String sql, QueryBindings bindings) throws SQLException {
     checkClosed();
     ExecuteResult executeResult = executeStatement(sql, bindings);
-    applyExecuteResult(executeResult);
-    return currentResultSet != null;
+    return updateExecutionStateAndReturnHasResultSet(executeResult);
   }
 
   private ExecuteResult executeStatement(String sql, QueryBindings bindings) throws SQLException {
@@ -138,15 +137,17 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     currentUpdateCount = NO_UPDATE_COUNT;
   }
 
-  private void applyExecuteResult(ExecuteResult executeResult) throws SQLException {
+  private boolean updateExecutionStateAndReturnHasResultSet(ExecuteResult executeResult)
+      throws SQLException {
     queryId = executeResult.getQueryId();
     if (StatementTypeClassifier.producesResultSet(executeResult)) {
       applyResultSetExecutionResult(executeResult);
-      return;
+      return true;
     }
 
     currentResultSet = null;
     currentUpdateCount = StatementTypeClassifier.getUpdateCount(executeResult);
+    return false;
   }
 
   private void applyResultSetExecutionResult(ExecuteResult executeResult) throws SQLException {
@@ -188,7 +189,11 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     }
   }
 
-  private int toIntUpdateCount(long updateCount) throws SQLException {
+  private int getCurrentUpdateCountAsInt() throws SQLException {
+    return toJdbcIntUpdateCount(currentUpdateCount);
+  }
+
+  private int toJdbcIntUpdateCount(long updateCount) throws SQLException {
     if (updateCount == NO_UPDATE_COUNT) {
       return (int) NO_UPDATE_COUNT;
     }
@@ -294,7 +299,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public int getUpdateCount() throws SQLException {
     checkClosed();
-    return toIntUpdateCount(currentUpdateCount);
+    return getCurrentUpdateCountAsInt();
   }
 
   @Override
@@ -359,6 +364,10 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   public Connection getConnection() throws SQLException {
     checkClosed();
     return connection;
+  }
+
+  public Set<ResultSet> getOpenResultSets() {
+    return Collections.unmodifiableSet(openResultSets);
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifier.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifier.java
@@ -1,0 +1,102 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteResult;
+
+final class StatementTypeClassifier {
+  public static final long NO_UPDATE_COUNT = -1L;
+
+  private StatementTypeClassifier() {
+    // Utility class.
+  }
+
+  static boolean producesResultSet(ExecuteResult executeResult) {
+    return lookupType(executeResult).producesResultSet();
+  }
+
+  static long getUpdateCount(ExecuteResult executeResult) {
+    StatementType statementType = lookupType(executeResult);
+    if (statementType.producesResultSet()) {
+      return NO_UPDATE_COUNT;
+    }
+
+    return statementType.isDml() && executeResult.hasRowsAffected()
+        ? executeResult.getRowsAffected()
+        : 0L;
+  }
+
+  private static StatementType lookupType(ExecuteResult executeResult) {
+    if (!executeResult.hasStatementTypeId()) {
+      return StatementType.UNKNOWN;
+    }
+    return StatementType.lookupById(executeResult.getStatementTypeId());
+  }
+
+  private enum StatementType {
+    UNKNOWN(0x0000L, true),
+    SELECT(0x1000L, true),
+    DML(0x3000L, false),
+    INSERT(0x3000L + 0x100L, false),
+    UPDATE(0x3000L + 0x200L, false),
+    DELETE(0x3000L + 0x300L, false),
+    MERGE(0x3000L + 0x400L, false),
+    MULTI_INSERT(0x3000L + 0x500L, false),
+    COPY(0x3000L + 0x600L, false),
+    UNLOAD(0x3000L + 0x700L, false),
+    RECLUSTER(0x3000L + 0x800L, false),
+    SCL(0x4000L, false),
+    ALTER_SESSION(0x4000L + 0x100L, false),
+    USE(0x4000L + 0x300L, false),
+    USE_DATABASE(0x4000L + 0x300L + 0x01L, false),
+    USE_SCHEMA(0x4000L + 0x300L + 0x02L, false),
+    USE_WAREHOUSE(0x4000L + 0x300L + 0x03L, false),
+    SHOW(0x4000L + 0x400L, true),
+    DESCRIBE(0x4000L + 0x500L, true),
+    LIST(0x4000L + 0x700L + 0x01L, true),
+    TCL(0x5000L, false),
+    DDL(0x6000L, false),
+    ALTER_USER_MANAGE_PATS(0x6000L + 0x200L + 0x44L, true),
+    GET(0x7000L + 0x100L + 0x01L, true),
+    PUT(0x7000L + 0x100L + 0x02L, true),
+    REMOVE(0x7000L + 0x100L + 0x03L, true);
+
+    private static final long CATEGORY_RANGE = 0x1000L;
+
+    private final long statementTypeId;
+    private final boolean producesResultSet;
+
+    StatementType(long statementTypeId, boolean producesResultSet) {
+      this.statementTypeId = statementTypeId;
+      this.producesResultSet = producesResultSet;
+    }
+
+    static StatementType lookupById(long statementTypeId) {
+      for (StatementType type : values()) {
+        if (type.statementTypeId == statementTypeId) {
+          return type;
+        }
+      }
+
+      if (statementTypeId >= SCL.statementTypeId
+          && statementTypeId < SCL.statementTypeId + CATEGORY_RANGE) {
+        return SCL;
+      } else if (statementTypeId >= TCL.statementTypeId
+          && statementTypeId < TCL.statementTypeId + CATEGORY_RANGE) {
+        return TCL;
+      } else if (statementTypeId >= DDL.statementTypeId
+          && statementTypeId < DDL.statementTypeId + CATEGORY_RANGE) {
+        return DDL;
+      } else {
+        return UNKNOWN;
+      }
+    }
+
+    boolean producesResultSet() {
+      return producesResultSet;
+    }
+
+    boolean isDml() {
+      return statementTypeId >= DML.statementTypeId
+          && statementTypeId < DML.statementTypeId + CATEGORY_RANGE;
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifier.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifier.java
@@ -1,13 +1,11 @@
 package net.snowflake.client.internal.api.implementation.statement;
 
+import lombok.experimental.UtilityClass;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteResult;
 
-final class StatementTypeClassifier {
+@UtilityClass
+class StatementTypeClassifier {
   public static final long NO_UPDATE_COUNT = -1L;
-
-  private StatementTypeClassifier() {
-    // Utility class.
-  }
 
   static boolean producesResultSet(ExecuteResult executeResult) {
     return lookupType(executeResult).producesResultSet();

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakePreparedStatementBindingTest.java
@@ -1,8 +1,10 @@
 package net.snowflake.client.api.statement;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -223,6 +225,88 @@ public class SnowflakePreparedStatementBindingTest extends SnowflakeIntegrationT
           assertEquals(0, rs.getInt(3));
           assertEquals(0, rs.getInt(4));
         });
+  }
+
+  @Test
+  public void testPreparedStatementExecuteSelectTracksCurrentResultSet() throws Exception {
+    Connection conn = getDefaultConnection();
+    try (PreparedStatement stmt = conn.prepareStatement("SELECT ?")) {
+      stmt.setInt(1, 99);
+
+      assertTrue(stmt.execute(), "SELECT should report a ResultSet");
+
+      ResultSet rs = stmt.getResultSet();
+      assertNotNull(rs, "PreparedStatement should expose the current ResultSet");
+      assertEquals(-1, stmt.getUpdateCount(), "SELECT should not expose an update count");
+
+      assertTrue(rs.next(), "Expected one row");
+      assertEquals(99, rs.getInt(1), "Result should match the bound value");
+      assertFalse(rs.next(), "Expected exactly one row");
+    }
+  }
+
+  @Test
+  public void testPreparedStatementExecuteInsertTracksUpdateCount() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_bindings_", "v INTEGER");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setInt(1, 42);
+
+      assertFalse(insert.execute(), "INSERT should not report a ResultSet");
+      assertNull(insert.getResultSet(), "INSERT should not expose a ResultSet");
+      assertEquals(1, insert.getUpdateCount(), "INSERT should report affected rows");
+    }
+
+    verifySingleValue(conn, "SELECT v FROM " + tableName, rs -> assertEquals(42, rs.getInt(1)));
+  }
+
+  @Test
+  public void testPreparedStatementExecuteUpdateReturnsAffectedRows() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_bindings_", "v INTEGER");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setInt(1, 7);
+
+      assertEquals(1, insert.executeUpdate(), "executeUpdate should report affected rows");
+      assertNull(insert.getResultSet(), "executeUpdate should not expose a ResultSet");
+      assertEquals(1, insert.getUpdateCount(), "Statement state should retain the update count");
+    }
+
+    verifySingleValue(conn, "SELECT v FROM " + tableName, rs -> assertEquals(7, rs.getInt(1)));
+  }
+
+  @Test
+  public void testPreparedStatementExecuteQueryAllowsInsertForLegacyCompatibility()
+      throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_bindings_", "v INTEGER");
+
+    try (PreparedStatement insert =
+        conn.prepareStatement("INSERT INTO " + tableName + " (v) VALUES (?)")) {
+      insert.setInt(1, 7);
+
+      ResultSet rs = assertDoesNotThrow(() -> insert.executeQuery());
+      if (rs != null) {
+        rs.close();
+      }
+    }
+
+    verifySingleValue(conn, "SELECT v FROM " + tableName, rs -> assertEquals(7, rs.getInt(1)));
+  }
+
+  @Test
+  public void testPreparedStatementExecuteUpdateRejectsSelect() throws Exception {
+    Connection conn = getDefaultConnection();
+
+    try (PreparedStatement stmt = conn.prepareStatement("SELECT ?")) {
+      stmt.setInt(1, 99);
+
+      assertThrows(SQLException.class, stmt::executeUpdate);
+    }
   }
 
   private static Stream<SingleSetterCase> singleSetterCases() {

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeStatementTest.java
@@ -1,15 +1,20 @@
 package net.snowflake.client.api.statement;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
+import net.snowflake.client.internal.api.implementation.statement.SnowflakeStatementImpl;
 import org.junit.jupiter.api.Test;
 
 /** Tests for executing queries through the Snowflake JDBC Driver */
@@ -38,6 +43,121 @@ public class SnowflakeStatementTest extends SnowflakeIntegrationTestBase {
       assertTrue(rs.next(), "Expected one row");
       assertEquals(new BigDecimal("123.456"), rs.getBigDecimal(1));
       assertFalse(rs.next(), "Expected exactly one row");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteSelectTracksCurrentResultSet() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement()) {
+      assertTrue(stmt.execute("SELECT 1"), "SELECT should report a ResultSet");
+
+      ResultSet rs = stmt.getResultSet();
+      assertNotNull(rs, "Statement should expose the current ResultSet");
+      assertEquals(-1, stmt.getUpdateCount(), "SELECT should not expose an update count");
+      assertNotNull(((SnowflakeStatement) stmt).getQueryID(), "Query ID should be captured");
+
+      assertTrue(rs.next(), "Expected one row");
+      assertEquals(1, rs.getInt(1), "Result should be 1");
+      assertFalse(rs.next(), "Expected exactly one row");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteInsertTracksUpdateCount() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_stmt_exec_", "v INTEGER");
+
+    try (Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("INSERT INTO " + tableName + " VALUES (7)"));
+      assertNull(stmt.getResultSet(), "INSERT should not expose a ResultSet");
+      assertEquals(1, stmt.getUpdateCount(), "INSERT should report affected rows");
+      assertNotNull(((SnowflakeStatement) stmt).getQueryID(), "Query ID should be captured");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteDdlReturnsZeroUpdateCount() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_stmt_exec_", "v INTEGER");
+
+    try (Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + " (v INTEGER)"));
+      assertNull(stmt.getResultSet(), "DDL should not expose a ResultSet");
+      assertEquals(0, stmt.getUpdateCount(), "DDL should report zero affected rows");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteQueryAllowsInsertForLegacyCompatibility() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_stmt_exec_", "v INTEGER");
+
+    try (Statement stmt = conn.createStatement()) {
+      ResultSet rs =
+          assertDoesNotThrow(() -> stmt.executeQuery("INSERT INTO " + tableName + " VALUES (7)"));
+      if (rs != null) {
+        rs.close();
+      }
+    }
+
+    try (Statement verify = conn.createStatement();
+        ResultSet rs = verify.executeQuery("SELECT v FROM " + tableName)) {
+      assertTrue(rs.next(), "INSERT should still write a row");
+      assertEquals(7, rs.getInt(1), "Inserted value should be persisted");
+      assertFalse(rs.next(), "Expected exactly one row");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteUpdateRejectsSelect() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement()) {
+      assertThrows(SQLException.class, () -> stmt.executeUpdate("SELECT 1"));
+    }
+  }
+
+  @Test
+  public void testStatementExecuteReplacesPreviousResultSet() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement()) {
+      assertTrue(stmt.execute("SELECT 1"));
+      ResultSet firstResultSet = stmt.getResultSet();
+      assertNotNull(firstResultSet);
+
+      assertTrue(stmt.execute("SELECT 2"));
+      assertFalse(firstResultSet.isClosed(), "Previous ResultSet should remain open");
+      assertTrue(firstResultSet.next(), "Previous ResultSet should remain readable");
+      assertEquals(1, firstResultSet.getInt(1), "First ResultSet should retain its data");
+      assertFalse(firstResultSet.next(), "Expected exactly one row in the first ResultSet");
+
+      ResultSet secondResultSet = stmt.getResultSet();
+      assertNotNull(secondResultSet, "Statement should expose the latest ResultSet");
+      assertTrue(secondResultSet.next(), "Expected one row from the second query");
+      assertEquals(2, secondResultSet.getInt(1), "Result should be 2");
+      assertFalse(secondResultSet.next(), "Expected exactly one row");
+    }
+  }
+
+  @Test
+  public void testStatementExecuteOpenResultSetsMirrorJdbcParity() throws Exception {
+    try (Statement stmt = getDefaultConnection().createStatement()) {
+      SnowflakeStatementImpl statementImpl = stmt.unwrap(SnowflakeStatementImpl.class);
+      for (int i = 0; i < 10; i++) {
+        assertTrue(stmt.execute("SELECT 1"));
+        assertNotNull(stmt.getResultSet(), "Statement should expose the latest ResultSet");
+      }
+
+      assertEquals(9, statementImpl.getOpenResultSets().size());
+    }
+
+    try (Statement stmt = getDefaultConnection().createStatement()) {
+      SnowflakeStatementImpl statementImpl = stmt.unwrap(SnowflakeStatementImpl.class);
+      for (int i = 0; i < 10; i++) {
+        assertTrue(stmt.execute("SELECT 1"));
+        ResultSet rs = stmt.getResultSet();
+        assertNotNull(rs, "Statement should expose the latest ResultSet");
+        rs.close();
+      }
+
+      assertEquals(0, statementImpl.getOpenResultSets().size());
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
@@ -4,27 +4,78 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 
 import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
-import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 
 public class SnowflakeBasicDataSourceTest {
 
+  private static final class TestableSnowflakeBasicDataSource extends SnowflakeBasicDataSource {
+    private Connection nextConnection;
+    private Properties lastProperties;
+    private String lastUrl;
+
+    void setNextConnection(Connection nextConnection) {
+      this.nextConnection = nextConnection;
+    }
+
+    Properties getLastProperties() {
+      return lastProperties;
+    }
+
+    String getLastUrl() {
+      return lastUrl;
+    }
+
+    @Override
+    protected Connection openConnection(String url, Properties properties) throws SQLException {
+      this.lastUrl = url;
+      this.lastProperties = new Properties();
+      this.lastProperties.putAll(properties);
+      return nextConnection;
+    }
+  }
+
   private SnowflakeBasicDataSource dataSource;
+
+  private Connection createDummyConnection() {
+    return (Connection)
+        Proxy.newProxyInstance(
+            Connection.class.getClassLoader(),
+            new Class<?>[] {Connection.class},
+            (proxy, method, args) -> {
+              if ("isClosed".equals(method.getName())) {
+                return false;
+              }
+              if ("close".equals(method.getName())) {
+                return null;
+              }
+              if ("unwrap".equals(method.getName())) {
+                Class<?> iface = (Class<?>) args[0];
+                if (iface.isInstance(proxy)) {
+                  return proxy;
+                }
+                throw new SQLFeatureNotSupportedException();
+              }
+              if ("isWrapperFor".equals(method.getName())) {
+                Class<?> iface = (Class<?>) args[0];
+                return iface.isInstance(proxy);
+              }
+
+              throw new UnsupportedOperationException(
+                  "Unexpected Connection method in test: " + method.getName());
+            });
+  }
 
   @BeforeEach
   public void setUp() {
-    dataSource = new SnowflakeBasicDataSource();
+    dataSource = new TestableSnowflakeBasicDataSource();
     dataSource.setUrl("jdbc:snowflake://testaccount.snowflakecomputing.com");
   }
 
@@ -34,75 +85,65 @@ public class SnowflakeBasicDataSourceTest {
     dataSource.setUser("testuser");
     dataSource.setPassword("testpassword");
 
-    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
-    Connection mockConnection = mock(Connection.class);
-    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
-      driverManager
-          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
-          .thenReturn(mockConnection);
+    Connection mockConnection = createDummyConnection();
+    TestableSnowflakeBasicDataSource testableDataSource =
+        (TestableSnowflakeBasicDataSource) dataSource;
+    testableDataSource.setNextConnection(mockConnection);
 
-      Connection result = dataSource.getConnection();
+    Connection result = dataSource.getConnection();
 
-      assertSame(mockConnection, result);
-      Properties capturedProperties = propertiesCaptor.getValue();
-      assertEquals("testuser", capturedProperties.getProperty("user"));
-      assertEquals("testpassword", capturedProperties.getProperty("password"));
-    }
+    assertSame(mockConnection, result);
+    assertEquals(
+        "jdbc:snowflake://testaccount.snowflakecomputing.com", testableDataSource.getLastUrl());
+    Properties capturedProperties = testableDataSource.getLastProperties();
+    assertEquals("testuser", capturedProperties.getProperty("user"));
+    assertEquals("testpassword", capturedProperties.getProperty("password"));
   }
 
   @Test
   public void testGetConnectionWithUsernameAndPasswordSetsPropertiesAndReturnsConnection()
       throws Exception {
-    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
-    Connection mockConnection = mock(Connection.class);
-    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
-      driverManager
-          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
-          .thenReturn(mockConnection);
+    Connection mockConnection = createDummyConnection();
+    TestableSnowflakeBasicDataSource testableDataSource =
+        (TestableSnowflakeBasicDataSource) dataSource;
+    testableDataSource.setNextConnection(mockConnection);
 
-      Connection result = dataSource.getConnection("user1", "pass1");
+    Connection result = dataSource.getConnection("user1", "pass1");
 
-      assertSame(mockConnection, result);
-      Properties capturedProperties = propertiesCaptor.getValue();
-      assertEquals("user1", capturedProperties.getProperty("user"));
-      assertEquals("pass1", capturedProperties.getProperty("password"));
-    }
+    assertSame(mockConnection, result);
+    Properties capturedProperties = testableDataSource.getLastProperties();
+    assertEquals("user1", capturedProperties.getProperty("user"));
+    assertEquals("pass1", capturedProperties.getProperty("password"));
   }
 
   @Test
   public void testGetConnectionWithNullUsernameDoesNotSetUserProperty() throws Exception {
-    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
-    Connection mockConnection = mock(Connection.class);
-    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
-      driverManager
-          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
-          .thenReturn(mockConnection);
+    Connection mockConnection = createDummyConnection();
+    TestableSnowflakeBasicDataSource testableDataSource =
+        (TestableSnowflakeBasicDataSource) dataSource;
+    testableDataSource.setNextConnection(mockConnection);
 
-      Connection result = dataSource.getConnection(null, "pass1");
+    Connection result = dataSource.getConnection(null, "pass1");
 
-      assertSame(mockConnection, result);
-      Properties capturedProperties = propertiesCaptor.getValue();
-      assertNull(capturedProperties.getProperty("user"));
-      assertEquals("pass1", capturedProperties.getProperty("password"));
-    }
+    assertSame(mockConnection, result);
+    Properties capturedProperties = testableDataSource.getLastProperties();
+    assertNull(capturedProperties.getProperty("user"));
+    assertEquals("pass1", capturedProperties.getProperty("password"));
   }
 
   @Test
   public void testGetConnectionWithNullPasswordDoesNotSetPasswordProperty() throws Exception {
-    ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
-    Connection mockConnection = mock(Connection.class);
-    try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
-      driverManager
-          .when(() -> DriverManager.getConnection(anyString(), propertiesCaptor.capture()))
-          .thenReturn(mockConnection);
+    Connection mockConnection = createDummyConnection();
+    TestableSnowflakeBasicDataSource testableDataSource =
+        (TestableSnowflakeBasicDataSource) dataSource;
+    testableDataSource.setNextConnection(mockConnection);
 
-      Connection result = dataSource.getConnection("user1", null);
+    Connection result = dataSource.getConnection("user1", null);
 
-      assertSame(mockConnection, result);
-      Properties capturedProperties = propertiesCaptor.getValue();
-      assertEquals("user1", capturedProperties.getProperty("user"));
-      assertNull(capturedProperties.getProperty("password"));
-    }
+    assertSame(mockConnection, result);
+    Properties capturedProperties = testableDataSource.getLastProperties();
+    assertEquals("user1", capturedProperties.getProperty("user"));
+    assertNull(capturedProperties.getProperty("password"));
   }
 
   @Test

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
@@ -22,9 +22,9 @@ public class PreparedStatementBindingSerializerTest {
     PreparedStatementBindingSerializer.ParameterValue[] params =
         new PreparedStatementBindingSerializer.ParameterValue[0];
 
-    try (PreparedStatementBindingSerializer.SerializedBindings serialized =
-        PreparedStatementBindingSerializer.serialize(params)) {
-      assertNull(serialized.bindings(), "Expected null bindings for empty parameter list");
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serializeToNativeBindings(params)) {
+      assertNull(nativeBindings.bindings(), "Expected null bindings for empty parameter list");
     }
   }
 
@@ -36,7 +36,8 @@ public class PreparedStatementBindingSerializerTest {
 
     SQLException ex =
         assertThrows(
-            SQLException.class, () -> PreparedStatementBindingSerializer.serialize(params));
+            SQLException.class,
+            () -> PreparedStatementBindingSerializer.serializeToNativeBindings(params));
     assertTrue(
         ex.getMessage().contains("Missing value for parameter index: 2"),
         "Expected missing-parameter index in error message");
@@ -54,9 +55,9 @@ public class PreparedStatementBindingSerializerTest {
         "{\"1\":{\"type\":\"FIXED\",\"value\":\"42\"},\"2\":{\"type\":\"TEXT\",\"value\":\"hello\"}}";
     byte[] expectedJsonBytes = expectedJson.getBytes(StandardCharsets.UTF_8);
 
-    try (PreparedStatementBindingSerializer.SerializedBindings serialized =
-        PreparedStatementBindingSerializer.serialize(params)) {
-      QueryBindings bindings = serialized.bindings();
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serializeToNativeBindings(params)) {
+      QueryBindings bindings = nativeBindings.bindings();
       assertNotNull(bindings, "Expected non-null bindings");
       assertTrue(bindings.hasJson(), "Expected JSON query bindings");
 

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifierTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/StatementTypeClassifierTest.java
@@ -1,0 +1,87 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class StatementTypeClassifierTest {
+
+  @Test
+  void testMissingStatementTypeBehavesLikeUnknown() {
+    ExecuteResult executeResult = ExecuteResult.newBuilder().build();
+
+    assertTrue(
+        StatementTypeClassifier.producesResultSet(executeResult),
+        "Missing statement type should fall back to UNKNOWN result-set semantics");
+    assertEquals(
+        -1L,
+        StatementTypeClassifier.getUpdateCount(executeResult),
+        "Missing statement type should not expose an update count");
+  }
+
+  @Test
+  void testKnownDmlUsesRowsAffected() {
+    ExecuteResult executeResult = executeResult(0x3100L, 7L);
+
+    assertFalse(
+        StatementTypeClassifier.producesResultSet(executeResult),
+        "INSERT should not produce a result set");
+    assertEquals(
+        7L,
+        StatementTypeClassifier.getUpdateCount(executeResult),
+        "INSERT should report rows affected");
+  }
+
+  @Test
+  void testUnmappedDmlSubtypeBehavesLikeUnknown() {
+    ExecuteResult executeResult = executeResult(0x3901L, 5L);
+
+    assertTrue(
+        StatementTypeClassifier.producesResultSet(executeResult),
+        "Unmapped DML subtypes should match SFStatementType.UNKNOWN");
+    assertEquals(
+        -1L,
+        StatementTypeClassifier.getUpdateCount(executeResult),
+        "Unmapped DML subtypes should not expose an update count");
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {0x4400L, 0x4500L, 0x4701L, 0x6244L, 0x7101L, 0x7102L, 0x7103L})
+  void testResultSetProducingSpecialStatementTypes(long statementTypeId) {
+    ExecuteResult executeResult = executeResult(statementTypeId, 11L);
+
+    assertTrue(
+        StatementTypeClassifier.producesResultSet(executeResult),
+        "Special statement types that produce result sets should keep JDBC semantics");
+    assertEquals(
+        -1L,
+        StatementTypeClassifier.getUpdateCount(executeResult),
+        "Result-set-producing statements should not expose an update count");
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {0x4300L, 0x5000L, 0x6100L})
+  void testNonDmlNonResultSetStatementTypesReturnZeroUpdateCount(long statementTypeId) {
+    ExecuteResult executeResult = executeResult(statementTypeId, 13L);
+
+    assertFalse(
+        StatementTypeClassifier.producesResultSet(executeResult),
+        "SCL, TCL, and DDL statement types should not produce a result set");
+    assertEquals(
+        0L,
+        StatementTypeClassifier.getUpdateCount(executeResult),
+        "Non-DML statements should return zero update count");
+  }
+
+  private static ExecuteResult executeResult(long statementTypeId, long rowsAffected) {
+    return ExecuteResult.newBuilder()
+        .setStatementTypeId(statementTypeId)
+        .setRowsAffected(rowsAffected)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary
This change moves JDBC statement execution off placeholder behavior and onto real server responses for `Statement` and `PreparedStatement` APIs.
It adds statement-type-aware handling so the driver can correctly distinguish result-set-producing statements from DML and DDL, return update counts where appropriate, and keep statement state consistent across `execute`, `executeQuery`, and `executeUpdate`.
On top of that, it aligns `executeQuery(...)` with old-driver compatibility for single-statement DML/DDL, documents that legacy behavior explicitly in code, and adds coverage for both normal execution flows and invalid API usage.
