### PR TITLE
SNOW-3103846 adjust validator to not allow empty gherkin steps, fix tests

### DIFF
--- a/jdbc/src/test/java/net/snowflake/client/SnowflakeIntegrationTestBase.java
+++ b/jdbc/src/test/java/net/snowflake/client/SnowflakeIntegrationTestBase.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.UUID;
@@ -108,6 +110,35 @@ public abstract class SnowflakeIntegrationTestBase {
     String tableName = tablePrefix + UUID.randomUUID().toString().replace("-", "");
     execute(connection, "CREATE TEMPORARY TABLE " + tableName + " (" + columns + ")");
     return tableName;
+  }
+
+  @FunctionalInterface
+  protected interface ResultSetConsumer {
+    void accept(ResultSet resultSet) throws Exception;
+  }
+
+  protected static void withQueryResult(
+      Connection connection, String sql, ResultSetConsumer consumer) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      consumer.accept(resultSet);
+    }
+  }
+
+  @FunctionalInterface
+  protected interface PreparedStatementSetup {
+    void accept(PreparedStatement preparedStatement) throws Exception;
+  }
+
+  protected static void withPreparedQueryResult(
+      Connection connection, String sql, PreparedStatementSetup setup, ResultSetConsumer consumer)
+      throws Exception {
+    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      setup.accept(preparedStatement);
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        consumer.accept(resultSet);
+      }
+    }
   }
 
   private void addOptionalConnectionProperties(JSONObject params, Properties props) {

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/BooleanTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/BooleanTests.java
@@ -7,10 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -24,36 +23,48 @@ public class BooleanTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastBooleanValuesToAppropriateType() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
-    // Then All values should be returned as appropriate type
-    // And Values should match [TRUE, FALSE, TRUE]
     Connection connection = getDefaultConnection();
-    assertSingleRow(
+
+    // When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
+    String sql =
+        "SELECT TRUE::" + BOOLEAN_TYPE + ", FALSE::" + BOOLEAN_TYPE + ", TRUE::" + BOOLEAN_TYPE;
+    withQueryResult(
         connection,
-        "SELECT TRUE::" + BOOLEAN_TYPE + ", FALSE::" + BOOLEAN_TYPE + ", TRUE::" + BOOLEAN_TYPE,
-        Arrays.asList(true, false, true));
+        sql,
+        resultSet -> {
+
+          // Then All values should be returned as appropriate type
+          List<Boolean> row = assertBooleanTypes(resultSet, 3);
+
+          // And Values should match [TRUE, FALSE, TRUE]
+          assertEquals(Arrays.asList(true, false, true), row);
+        });
   }
 
   @Test
   public void shouldSelectBooleanLiterals() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
-    // Then Result should contain [TRUE, FALSE]
     Connection connection = getDefaultConnection();
-    assertSingleRow(
+
+    // When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
+    String sql = "SELECT TRUE::" + BOOLEAN_TYPE + ", FALSE::" + BOOLEAN_TYPE;
+    withQueryResult(
         connection,
-        "SELECT TRUE::" + BOOLEAN_TYPE + ", FALSE::" + BOOLEAN_TYPE,
-        Arrays.asList(true, false));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [TRUE, FALSE]
+          assertSingleRow(resultSet, Arrays.asList(true, false));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromLiterals() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
-    // Then Result should contain [FALSE, NULL, TRUE, NULL]
     Connection connection = getDefaultConnection();
-    assertSingleRow(
-        connection,
+
+    // When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
+    String sql =
         "SELECT FALSE::"
             + BOOLEAN_TYPE
             + ", NULL::"
@@ -61,62 +72,93 @@ public class BooleanTests extends SnowflakeIntegrationTestBase {
             + ", TRUE::"
             + BOOLEAN_TYPE
             + ", NULL::"
-            + BOOLEAN_TYPE,
-        Arrays.asList(false, null, true, null));
+            + BOOLEAN_TYPE;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [FALSE, NULL, TRUE, NULL]
+          assertSingleRow(resultSet, Arrays.asList(false, null, true, null));
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromGenerator() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT (id % 2 = 0)::BOOLEAN FROM <generator>" is executed
-    // Then Result should contain 500000 TRUE and 500000 FALSE values
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT (id % 2 = 0)::BOOLEAN FROM <generator>" is executed
     String sql =
         "SELECT (seq8() % 2 = 0)::"
             + BOOLEAN_TYPE
             + " AS col FROM TABLE(GENERATOR(ROWCOUNT => "
             + LARGE_RESULT_SET_SIZE
             + "))";
-    assertBooleanCounts(connection, sql, LARGE_HALF_COUNT, LARGE_HALF_COUNT, 0);
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 500000 TRUE and 500000 FALSE values
+          assertBooleanResults(resultSet, LARGE_HALF_COUNT, LARGE_HALF_COUNT, 0);
+        });
   }
 
   @Test
   public void shouldSelectBooleanValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
-    // And Row (TRUE, FALSE, TRUE) is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [TRUE, FALSE, TRUE]
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
     String tableName =
         createTempTable(
             connection,
             "ud_boolean_",
             "c1 " + BOOLEAN_TYPE + ", c2 " + BOOLEAN_TYPE + ", c3 " + BOOLEAN_TYPE);
+
+    // And Row (TRUE, FALSE, TRUE) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (TRUE, FALSE, TRUE)");
-    assertSingleRow(connection, "SELECT * FROM " + tableName, Arrays.asList(true, false, true));
+
+    // When Query "SELECT * FROM <table>" is executed
+    withQueryResult(
+        connection,
+        "SELECT * FROM " + tableName,
+        resultSet -> {
+
+          // Then Result should contain [TRUE, FALSE, TRUE]
+          assertSingleRow(resultSet, Arrays.asList(true, false, true));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with BOOLEAN column exists
-    // And Rows [NULL, TRUE, FALSE] are inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [NULL, TRUE, FALSE] in any order
     Connection connection = getDefaultConnection();
+
+    // And Table with BOOLEAN column exists
     String tableName = createTempTable(connection, "ud_boolean_", "col " + BOOLEAN_TYPE);
+
+    // And Rows [NULL, TRUE, FALSE] are inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (NULL), (TRUE), (FALSE)");
-    assertBooleanCounts(connection, "SELECT col FROM " + tableName, 1, 1, 1);
+
+    // When Query "SELECT * FROM <table>" is executed
+    withQueryResult(
+        connection,
+        "SELECT col FROM " + tableName,
+        resultSet -> {
+
+          // Then Result should contain [NULL, TRUE, FALSE] in any order
+          assertBooleanResults(resultSet, 1, 1, 1);
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
-    // When Query "SELECT col FROM <table>" is executed
-    // Then Result should contain 500000 TRUE and 500000 FALSE values
     Connection connection = getDefaultConnection();
+
+    // And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
     String tableName = createTempTable(connection, "ud_boolean_", "col " + BOOLEAN_TYPE);
     execute(
         connection,
@@ -127,90 +169,103 @@ public class BooleanTests extends SnowflakeIntegrationTestBase {
             + " FROM TABLE(GENERATOR(ROWCOUNT => "
             + LARGE_RESULT_SET_SIZE
             + "))");
-    assertBooleanCounts(
-        connection, "SELECT col FROM " + tableName, LARGE_HALF_COUNT, LARGE_HALF_COUNT, 0);
+
+    // When Query "SELECT col FROM <table>" is executed
+    withQueryResult(
+        connection,
+        "SELECT col FROM " + tableName,
+        resultSet -> {
+
+          // Then Result should contain 500000 TRUE and 500000 FALSE values
+          assertBooleanResults(resultSet, LARGE_HALF_COUNT, LARGE_HALF_COUNT, 0);
+        });
   }
 
   @Test
   public void shouldSelectBooleanUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN" is executed with bound boolean values
-    // [TRUE, FALSE, TRUE]
-    // Then Result should contain [TRUE, FALSE, TRUE]
-    // When Query "SELECT ?::BOOLEAN" is executed with bound NULL value
-    // Then Result should contain [NULL]
     Connection connection = getDefaultConnection();
 
-    try (PreparedStatement preparedStatement =
-        connection.prepareStatement(
-            "SELECT ?::" + BOOLEAN_TYPE + ", ?::" + BOOLEAN_TYPE + ", ?::" + BOOLEAN_TYPE)) {
-      preparedStatement.setBoolean(1, true);
-      preparedStatement.setBoolean(2, false);
-      preparedStatement.setBoolean(3, true);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + BOOLEAN_TYPE);
-        assertBooleanColumn(resultSet, 1, true, "Column 1 mismatch for " + BOOLEAN_TYPE);
-        assertBooleanColumn(resultSet, 2, false, "Column 2 mismatch for " + BOOLEAN_TYPE);
-        assertBooleanColumn(resultSet, 3, true, "Column 3 mismatch for " + BOOLEAN_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + BOOLEAN_TYPE);
-      }
-    }
+    // When Query "SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN" is executed with bound boolean values
+    // [TRUE, FALSE, TRUE]
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::" + BOOLEAN_TYPE + ", ?::" + BOOLEAN_TYPE + ", ?::" + BOOLEAN_TYPE,
+        ps -> {
+          ps.setBoolean(1, true);
+          ps.setBoolean(2, false);
+          ps.setBoolean(3, true);
+        },
+        resultSet -> {
 
-    try (PreparedStatement preparedStatement =
-        connection.prepareStatement("SELECT ?::" + BOOLEAN_TYPE)) {
-      preparedStatement.setNull(1, Types.BOOLEAN);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + BOOLEAN_TYPE);
-        assertBooleanColumn(resultSet, 1, null, "Column 1 mismatch for " + BOOLEAN_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + BOOLEAN_TYPE);
-      }
-    }
+          // Then Result should contain [TRUE, FALSE, TRUE]
+          assertSingleRow(resultSet, Arrays.asList(true, false, true));
+        });
+
+    // When Query "SELECT ?::BOOLEAN" is executed with bound NULL value
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::" + BOOLEAN_TYPE,
+        ps -> ps.setNull(1, Types.BOOLEAN),
+        resultSet -> {
+
+          // Then Result should contain [NULL]
+          assertSingleRow(resultSet, Arrays.asList((Boolean) null));
+        });
   }
 
-  private static void assertSingleRow(
-      Connection connection, String sql, List<Boolean> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + BOOLEAN_TYPE);
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertBooleanColumn(
-            resultSet,
-            i + 1,
-            expectedValues.get(i),
-            "Column " + (i + 1) + " mismatch for " + BOOLEAN_TYPE);
-      }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + BOOLEAN_TYPE);
-    }
-  }
-
-  private static void assertBooleanCounts(
-      Connection connection, String sql, int expectedTrue, int expectedFalse, int expectedNull)
+  private static List<Boolean> assertBooleanTypes(ResultSet resultSet, int columnCount)
       throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + BOOLEAN_TYPE);
+    List<Boolean> values = new ArrayList<>();
+    for (int i = 1; i <= columnCount; i++) {
+      Object objectValue = resultSet.getObject(i);
+      assertInstanceOf(
+          Boolean.class,
+          objectValue,
+          "Column " + i + " getObject should return Boolean for " + BOOLEAN_TYPE);
+      assertFalse(resultSet.wasNull(), "Column " + i + " should not be NULL for " + BOOLEAN_TYPE);
+      values.add((Boolean) objectValue);
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + BOOLEAN_TYPE);
+    return values;
+  }
+
+  private static void assertSingleRow(ResultSet resultSet, List<Boolean> expectedValues)
+      throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + BOOLEAN_TYPE);
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertBooleanGetters(
+          resultSet,
+          i + 1,
+          expectedValues.get(i),
+          "Column " + (i + 1) + " mismatch for " + BOOLEAN_TYPE);
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + BOOLEAN_TYPE);
+  }
+
+  private static void assertBooleanResults(
+      ResultSet resultSet, int expectedTrue, int expectedFalse, int expectedNull) throws Exception {
     BooleanCounts counts = new BooleanCounts();
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      while (resultSet.next()) {
-        Object objectValue = resultSet.getObject(1);
-        if (objectValue == null) {
-          counts.nullCount++;
-          assertTrue(
-              resultSet.wasNull(), "getObject should set wasNull() for NULL " + BOOLEAN_TYPE);
-          assertFalse(
-              resultSet.getBoolean(1), "getBoolean should return false for NULL " + BOOLEAN_TYPE);
-          assertTrue(
-              resultSet.wasNull(), "getBoolean should set wasNull() for NULL " + BOOLEAN_TYPE);
+    while (resultSet.next()) {
+      Object objectValue = resultSet.getObject(1);
+      if (objectValue == null) {
+        counts.nullCount++;
+        assertTrue(resultSet.wasNull(), "getObject should set wasNull() for NULL " + BOOLEAN_TYPE);
+        assertFalse(
+            resultSet.getBoolean(1), "getBoolean should return false for NULL " + BOOLEAN_TYPE);
+        assertTrue(resultSet.wasNull(), "getBoolean should set wasNull() for NULL " + BOOLEAN_TYPE);
+      } else {
+        assertInstanceOf(
+            Boolean.class, objectValue, "getObject should return Boolean for " + BOOLEAN_TYPE);
+        assertFalse(resultSet.wasNull(), "getObject should not be NULL for " + BOOLEAN_TYPE);
+        boolean boolValue = resultSet.getBoolean(1);
+        assertFalse(resultSet.wasNull(), "getBoolean should not be NULL for " + BOOLEAN_TYPE);
+        assertEquals(objectValue, boolValue, "Boolean value mismatch");
+        if (boolValue) {
+          counts.trueCount++;
         } else {
-          assertInstanceOf(
-              Boolean.class, objectValue, "getObject should return Boolean for " + BOOLEAN_TYPE);
-          assertFalse(resultSet.wasNull(), "getObject should not be NULL for " + BOOLEAN_TYPE);
-          boolean boolValue = resultSet.getBoolean(1);
-          assertFalse(resultSet.wasNull(), "getBoolean should not be NULL for " + BOOLEAN_TYPE);
-          assertEquals(objectValue, boolValue, "Boolean value mismatch");
-          if (boolValue) {
-            counts.trueCount++;
-          } else {
-            counts.falseCount++;
-          }
+          counts.falseCount++;
         }
       }
     }
@@ -220,7 +275,7 @@ public class BooleanTests extends SnowflakeIntegrationTestBase {
     assertEquals(expectedNull, counts.nullCount, "Unexpected NULL count for " + BOOLEAN_TYPE);
   }
 
-  private static void assertBooleanColumn(
+  private static void assertBooleanGetters(
       ResultSet resultSet, int columnIndex, Boolean expected, String message) throws Exception {
     if (expected == null) {
       assertNull(resultSet.getObject(columnIndex), message + " (getObject should be NULL)");

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DateTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DateTests.java
@@ -2,6 +2,7 @@ package net.snowflake.jdbc.e2e.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,8 +10,10 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 
@@ -20,243 +23,282 @@ public class DateTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastDateValuesToAppropriateType() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE" is executed
-    // Then All values should be returned as DATE type
-    // And No precision loss should occur
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE" is executed
     String sql = "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-      assertDateGetters(resultSet, 2, LocalDate.of(1970, 1, 1));
-      assertDateGetters(resultSet, 3, LocalDate.of(1999, 12, 31));
-      assertFalse(resultSet.next());
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then All values should be returned as DATE type
+          List<LocalDate> row = assertDateTypes(resultSet, 3);
+
+          // And No precision loss should occur
+          assertEquals(
+              Arrays.asList(
+                  LocalDate.of(2024, 1, 15), LocalDate.of(1970, 1, 1), LocalDate.of(1999, 12, 31)),
+              row);
+        });
   }
 
   @Test
   public void shouldSelectDateLiterals() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE" is executed
-    // Then Result should contain dates [2024-01-15, 1970-01-01, 1999-12-31]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE" is executed
     String sql = "SELECT '2024-01-15'::DATE, '1970-01-01'::DATE, '1999-12-31'::DATE";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-      assertDateGetters(resultSet, 2, LocalDate.of(1970, 1, 1));
-      assertDateGetters(resultSet, 3, LocalDate.of(1999, 12, 31));
-      assertFalse(resultSet.next());
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [2024-01-15, 1970-01-01, 1999-12-31]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
+          assertDateGetters(resultSet, 2, LocalDate.of(1970, 1, 1));
+          assertDateGetters(resultSet, 3, LocalDate.of(1999, 12, 31));
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldSelectEpochAndPreEpochDates() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT '1970-01-01'::DATE, '1969-12-31'::DATE, '1900-01-01'::DATE" is executed
-    // Then Result should contain dates [1970-01-01, 1969-12-31, 1900-01-01]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT '1970-01-01'::DATE, '1969-12-31'::DATE, '1900-01-01'::DATE" is executed
     String sql = "SELECT '1970-01-01'::DATE, '1969-12-31'::DATE, '1900-01-01'::DATE";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
-      assertDateGetters(resultSet, 2, LocalDate.of(1969, 12, 31));
-      assertDateGetters(resultSet, 3, LocalDate.of(1900, 1, 1));
-      assertFalse(resultSet.next());
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [1970-01-01, 1969-12-31, 1900-01-01]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
+          assertDateGetters(resultSet, 2, LocalDate.of(1969, 12, 31));
+          assertDateGetters(resultSet, 3, LocalDate.of(1900, 1, 1));
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldSelectHistoricalDates() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT '0001-01-01'::DATE, '1582-10-15'::DATE" is executed
-    // Then Result should contain dates [0001-01-01, 1582-10-15]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT '0001-01-01'::DATE, '1582-10-15'::DATE" is executed
     String sql = "SELECT '0001-01-01'::DATE, '1582-10-15'::DATE";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1, 1, 1));
-      assertDateGetters(resultSet, 2, LocalDate.of(1582, 10, 15));
-      assertFalse(resultSet.next());
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [0001-01-01, 1582-10-15]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1, 1, 1));
+          assertDateGetters(resultSet, 2, LocalDate.of(1582, 10, 15));
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesForDate() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT NULL::DATE, '2024-01-15'::DATE, NULL::DATE" is executed
-    // Then Result should contain [NULL, 2024-01-15, NULL]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT NULL::DATE, '2024-01-15'::DATE, NULL::DATE" is executed
     String sql = "SELECT NULL::DATE, '2024-01-15'::DATE, NULL::DATE";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next());
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertNull(resultSet.getDate(1));
-      assertTrue(resultSet.wasNull());
-      assertNull(resultSet.getObject(1));
-      assertTrue(resultSet.wasNull());
+          // Then Result should contain [NULL, 2024-01-15, NULL]
+          assertTrue(resultSet.next());
 
-      assertDateGetters(resultSet, 2, LocalDate.of(2024, 1, 15));
+          assertNull(resultSet.getDate(1));
+          assertTrue(resultSet.wasNull());
+          assertNull(resultSet.getObject(1));
+          assertTrue(resultSet.wasNull());
 
-      assertNull(resultSet.getDate(3));
-      assertTrue(resultSet.wasNull());
+          assertDateGetters(resultSet, 2, LocalDate.of(2024, 1, 15));
 
-      assertFalse(resultSet.next());
-    }
+          assertNull(resultSet.getDate(3));
+          assertTrue(resultSet.wasNull());
+
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetForDate() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT DATEADD(day, seq4(), '1970-01-01'::DATE) as d FROM
-    // TABLE(GENERATOR(ROWCOUNT
-    // => 50000)) v ORDER BY d" is executed
-    // Then Result should contain 50000 rows with sequential dates starting from 1970-01-01
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT DATEADD(day, seq4(), '1970-01-01'::DATE) as d FROM
+    // TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY d" is executed
     String sql =
         "SELECT DATEADD(day, seq4(), '1970-01-01'::DATE) as d"
             + " FROM TABLE(GENERATOR(ROWCOUNT => "
             + LARGE_RESULT_SET_SIZE
             + ")) v ORDER BY d";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int rowCount = 0;
-      LocalDate expected = LocalDate.of(1970, 1, 1);
-      while (resultSet.next()) {
-        assertEquals(
-            Date.valueOf(expected), resultSet.getDate(1), "Date mismatch at row " + rowCount);
-        assertFalse(resultSet.wasNull());
-        expected = expected.plusDays(1);
-        rowCount++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, rowCount);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 50000 rows with sequential dates starting from 1970-01-01
+          int rowCount = 0;
+          LocalDate expected = LocalDate.of(1970, 1, 1);
+          while (resultSet.next()) {
+            assertEquals(
+                Date.valueOf(expected), resultSet.getDate(1), "Date mismatch at row " + rowCount);
+            assertFalse(resultSet.wasNull());
+            expected = expected.plusDays(1);
+            rowCount++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, rowCount);
+        });
   }
 
   @Test
   public void shouldSelectDatesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DATE column exists with values ['2024-01-15', '1970-01-01', '1999-12-31']
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain dates [1970-01-01, 1999-12-31, 2024-01-15]
     Connection connection = getDefaultConnection();
+
+    // And Table with DATE column exists with values ['2024-01-15', '1970-01-01', '1999-12-31']
     String tableName = createTempTable(connection, "ud_date_", "col DATE");
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES ('2024-01-15'), ('1970-01-01'), ('1999-12-31')");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-      assertFalse(resultSet.next());
-    }
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [1970-01-01, 1999-12-31, 2024-01-15]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldSelectDatesWithNullFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DATE column exists with values ['2024-01-15', NULL, '1999-12-31']
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain [1999-12-31, 2024-01-15, NULL]
     Connection connection = getDefaultConnection();
+
+    // And Table with DATE column exists with values ['2024-01-15', NULL, '1999-12-31']
     String tableName = createTempTable(connection, "ud_date_", "col DATE");
     execute(
         connection, "INSERT INTO " + tableName + " VALUES ('2024-01-15'), (NULL), ('1999-12-31')");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-      assertTrue(resultSet.next());
-      assertNull(resultSet.getDate(1));
-      assertTrue(resultSet.wasNull());
-      assertFalse(resultSet.next());
-    }
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [1999-12-31, 2024-01-15, NULL]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
+          assertTrue(resultSet.next());
+          assertNull(resultSet.getDate(1));
+          assertTrue(resultSet.wasNull());
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldSelectHistoricalDatesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DATE column exists with values ['0001-01-01', '0100-03-01', '1582-10-15']
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain dates [0001-01-01, 0100-03-01, 1582-10-15]
     Connection connection = getDefaultConnection();
+
+    // And Table with DATE column exists with values ['0001-01-01', '0100-03-01', '1582-10-15']
     String tableName = createTempTable(connection, "ud_date_hist_", "col DATE");
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES ('0001-01-01'), ('0100-03-01'), ('1582-10-15')");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1, 1, 1));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(100, 3, 1));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1582, 10, 15));
-      assertFalse(resultSet.next());
-    }
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [0001-01-01, 0100-03-01, 1582-10-15]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1, 1, 1));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(100, 3, 1));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1582, 10, 15));
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldSelectDateUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT ?::DATE, ?::DATE, ?::DATE" is executed with bound date values
-    // [2024-01-15, 1970-01-01, 1999-12-31]
-    // Then Result should contain [2024-01-15, 1970-01-01, 1999-12-31]
-    // When Query "SELECT ?::DATE" is executed with bound NULL value
-    // Then Result should contain [NULL]
     Connection connection = getDefaultConnection();
 
-    try (PreparedStatement ps = connection.prepareStatement("SELECT ?::DATE, ?::DATE, ?::DATE")) {
-      ps.setDate(1, Date.valueOf("2024-01-15"));
-      ps.setDate(2, Date.valueOf("1970-01-01"));
-      ps.setDate(3, Date.valueOf("1999-12-31"));
-      try (ResultSet resultSet = ps.executeQuery()) {
-        assertTrue(resultSet.next());
-        assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-        assertDateGetters(resultSet, 2, LocalDate.of(1970, 1, 1));
-        assertDateGetters(resultSet, 3, LocalDate.of(1999, 12, 31));
-        assertFalse(resultSet.next());
-      }
-    }
+    // When Query "SELECT ?::DATE, ?::DATE, ?::DATE" is executed with bound date values
+    // [2024-01-15, 1970-01-01, 1999-12-31]
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DATE, ?::DATE, ?::DATE",
+        ps -> {
+          ps.setDate(1, Date.valueOf("2024-01-15"));
+          ps.setDate(2, Date.valueOf("1970-01-01"));
+          ps.setDate(3, Date.valueOf("1999-12-31"));
+        },
+        resultSet -> {
+          // Then Result should contain [2024-01-15, 1970-01-01, 1999-12-31]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
+          assertDateGetters(resultSet, 2, LocalDate.of(1970, 1, 1));
+          assertDateGetters(resultSet, 3, LocalDate.of(1999, 12, 31));
+          assertFalse(resultSet.next());
+        });
 
-    try (PreparedStatement ps = connection.prepareStatement("SELECT ?::DATE")) {
-      ps.setNull(1, java.sql.Types.DATE);
-      try (ResultSet resultSet = ps.executeQuery()) {
-        assertTrue(resultSet.next());
-        assertNull(resultSet.getDate(1));
-        assertTrue(resultSet.wasNull());
-        assertFalse(resultSet.next());
-      }
-    }
+    // When Query "SELECT ?::DATE" is executed with bound NULL value
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DATE",
+        ps -> ps.setNull(1, java.sql.Types.DATE),
+        resultSet -> {
+          // Then Result should contain [NULL]
+          assertTrue(resultSet.next());
+          assertNull(resultSet.getDate(1));
+          assertTrue(resultSet.wasNull());
+          assertFalse(resultSet.next());
+        });
   }
 
   @Test
   public void shouldInsertDateUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DATE column exists
-    // When Date values [2024-01-15, 1970-01-01, 1999-12-31] are inserted using setDate binding
-    // And Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain dates [1970-01-01, 1999-12-31, 2024-01-15]
     Connection connection = getDefaultConnection();
+
+    // And Table with DATE column exists
     String tableName = createTempTable(connection, "ud_date_bind_", "col DATE");
 
+    // When Date values [2024-01-15, 1970-01-01, 1999-12-31] are inserted using setDate binding
     try (PreparedStatement ps =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
       ps.setDate(1, Date.valueOf("2024-01-15"));
@@ -267,17 +309,36 @@ public class DateTests extends SnowflakeIntegrationTestBase {
       ps.execute();
     }
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
-      assertTrue(resultSet.next());
-      assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
-      assertFalse(resultSet.next());
+    // And Query "SELECT * FROM <table> ORDER BY col" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain dates [1970-01-01, 1999-12-31, 2024-01-15]
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1970, 1, 1));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(1999, 12, 31));
+          assertTrue(resultSet.next());
+          assertDateGetters(resultSet, 1, LocalDate.of(2024, 1, 15));
+          assertFalse(resultSet.next());
+        });
+  }
+
+  private static List<LocalDate> assertDateTypes(ResultSet resultSet, int columnCount)
+      throws Exception {
+    assertTrue(resultSet.next());
+    List<LocalDate> values = new ArrayList<>();
+    for (int i = 1; i <= columnCount; i++) {
+      Object objectValue = resultSet.getObject(i);
+      assertInstanceOf(Date.class, objectValue, "Column " + i + " getObject should return Date");
+      assertFalse(resultSet.wasNull(), "Column " + i + " should not be NULL");
+      values.add(((Date) objectValue).toLocalDate());
     }
+    assertFalse(resultSet.next());
+    return values;
   }
 
   private static void assertDateGetters(ResultSet rs, int col, LocalDate expected)

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DecfloatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/DecfloatTests.java
@@ -10,8 +10,8 @@ import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -23,183 +23,230 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastDecfloatValuesToAppropriateType() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT,
     // '12345678901234567890123456789012345678'::DECFLOAT" is executed
-    // Then All values should be returned as appropriate type
-    // And Values should maintain full 38-digit precision
-    Connection connection = getDefaultConnection();
     String sql =
         "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT, "
             + "'12345678901234567890123456789012345678'::DECFLOAT";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertDecfloatColumn(resultSet, 1, new BigDecimal("0"), "Column 1 mismatch for DECFLOAT");
-      assertDecfloatColumn(
-          resultSet, 2, new BigDecimal("123.456"), "Column 2 mismatch for DECFLOAT");
-      assertDecfloatColumn(
-          resultSet, 3, new BigDecimal("1.23E+37"), "Column 3 mismatch for DECFLOAT");
+          // Then All values should be returned as appropriate type
+          List<BigDecimal> row = assertDecfloatTypes(resultSet, 4);
 
-      BigDecimal maxPrecision = new BigDecimal("12345678901234567890123456789012345678");
-      assertDecfloatColumn(resultSet, 4, maxPrecision, "Column 4 mismatch for DECFLOAT");
-      assertEquals(
-          38, resultSet.getBigDecimal(4).precision(), "Column 4 should preserve 38 digits");
-      assertFalse(resultSet.wasNull(), "Column 4 should not be NULL for DECFLOAT");
-      assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-    }
+          // And Values should maintain full 38-digit precision
+          List<BigDecimal> expected =
+              Arrays.asList(
+                  new BigDecimal("0"),
+                  new BigDecimal("123.456"),
+                  new BigDecimal("1.23E+37"),
+                  new BigDecimal("12345678901234567890123456789012345678"));
+          assertEquals(expected.size(), row.size(), "Column count mismatch for DECFLOAT");
+          for (int i = 0; i < expected.size(); i++) {
+            assertEquals(
+                0,
+                expected.get(i).compareTo(row.get(i)),
+                "Column " + (i + 1) + " value mismatch for DECFLOAT");
+          }
+          assertEquals(38, row.get(3).precision(), "Column 4 should preserve 38 digits");
+        });
   }
 
   @Test
   public void shouldSelectDecfloatLiterals() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT,
     // -987.654321::DECFLOAT" is executed
-    // Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
-    Connection connection = getDefaultConnection();
-    assertSingleRowWithNulls(
+    String sql =
+        "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT";
+    withQueryResult(
         connection,
-        "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT, 123.456789::DECFLOAT, -987.654321::DECFLOAT",
-        Arrays.asList(
-            new BigDecimal("0"),
-            new BigDecimal("1.5"),
-            new BigDecimal("-1.5"),
-            new BigDecimal("123.456789"),
-            new BigDecimal("-987.654321")));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain exact decimals [0, 1.5, -1.5, 123.456789, -987.654321]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("0"),
+                  new BigDecimal("1.5"),
+                  new BigDecimal("-1.5"),
+                  new BigDecimal("123.456789"),
+                  new BigDecimal("-987.654321")));
+        });
   }
 
   @Test
   public void shouldHandleFull38DigitPrecisionValuesFromLiterals() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT,
     // '1.2345678901234567890123456789012345678E+100'::DECFLOAT,
     // '1.2345678901234567890123456789012345678E-100'::DECFLOAT" is executed
-    // Then Result should preserve all 38 digits for each value
-    Connection connection = getDefaultConnection();
     String sql =
         "SELECT '12345678901234567890123456789012345678'::DECFLOAT, "
             + "'1.2345678901234567890123456789012345678E+100'::DECFLOAT, "
             + "'1.2345678901234567890123456789012345678E-100'::DECFLOAT";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-      assertDecfloatColumn(
-          resultSet,
-          1,
-          new BigDecimal("12345678901234567890123456789012345678"),
-          "Column 1 mismatch for DECFLOAT");
-      assertDecfloatColumn(
-          resultSet,
-          2,
-          new BigDecimal("1.2345678901234567890123456789012345678E+100"),
-          "Column 2 mismatch for DECFLOAT");
-      assertDecfloatColumn(
-          resultSet,
-          3,
-          new BigDecimal("1.2345678901234567890123456789012345678E-100"),
-          "Column 3 mismatch for DECFLOAT");
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertEquals(
-          38, resultSet.getBigDecimal(1).precision(), "Column 1 should preserve 38 digits");
-      assertFalse(resultSet.wasNull(), "Column 1 should not be NULL for DECFLOAT");
-      assertEquals(
-          38, resultSet.getBigDecimal(2).precision(), "Column 2 should preserve 38 digits");
-      assertFalse(resultSet.wasNull(), "Column 2 should not be NULL for DECFLOAT");
-      assertEquals(
-          38, resultSet.getBigDecimal(3).precision(), "Column 3 should preserve 38 digits");
-      assertFalse(resultSet.wasNull(), "Column 3 should not be NULL for DECFLOAT");
-      assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-    }
+          // Then Result should preserve all 38 digits for each value
+          assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+          assertDecfloatColumn(
+              resultSet,
+              1,
+              new BigDecimal("12345678901234567890123456789012345678"),
+              "Column 1 mismatch for DECFLOAT");
+          assertDecfloatColumn(
+              resultSet,
+              2,
+              new BigDecimal("1.2345678901234567890123456789012345678E+100"),
+              "Column 2 mismatch for DECFLOAT");
+          assertDecfloatColumn(
+              resultSet,
+              3,
+              new BigDecimal("1.2345678901234567890123456789012345678E-100"),
+              "Column 3 mismatch for DECFLOAT");
+
+          assertEquals(
+              38, resultSet.getBigDecimal(1).precision(), "Column 1 should preserve 38 digits");
+          assertFalse(resultSet.wasNull(), "Column 1 should not be NULL for DECFLOAT");
+          assertEquals(
+              38, resultSet.getBigDecimal(2).precision(), "Column 2 should preserve 38 digits");
+          assertFalse(resultSet.wasNull(), "Column 2 should not be NULL for DECFLOAT");
+          assertEquals(
+              38, resultSet.getBigDecimal(3).precision(), "Column 3 should preserve 38 digits");
+          assertFalse(resultSet.wasNull(), "Column 3 should not be NULL for DECFLOAT");
+          assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+        });
   }
 
   @Test
   public void shouldHandleExtremeExponentValuesFromLiterals() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
-    // Then Result should contain [1E+16384, 1E-16383]
-    // When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
-    // Then Result should contain [-1.234E+8000, 9.876E-8000]
     Connection connection = getDefaultConnection();
-    assertSingleRowWithNulls(
+
+    // When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
+    String sql1 = "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT";
+    withQueryResult(
         connection,
-        "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT",
-        Arrays.asList(new BigDecimal("1E+16384"), new BigDecimal("1E-16383")));
-    assertSingleRowWithNulls(
+        sql1,
+        resultSet -> {
+
+          // Then Result should contain [1E+16384, 1E-16383]
+          assertSingleRowWithNulls(
+              resultSet, Arrays.asList(new BigDecimal("1E+16384"), new BigDecimal("1E-16383")));
+        });
+
+    // When Query "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT" is executed
+    String sql2 = "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT";
+    withQueryResult(
         connection,
-        "SELECT '-1.234E+8000'::DECFLOAT, '9.876E-8000'::DECFLOAT",
-        Arrays.asList(new BigDecimal("-1.234E+8000"), new BigDecimal("9.876E-8000")));
+        sql2,
+        resultSet -> {
+
+          // Then Result should contain [-1.234E+8000, 9.876E-8000]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(new BigDecimal("-1.234E+8000"), new BigDecimal("9.876E-8000")));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromLiterals() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
-    // Then Result should contain [NULL, 42.5, NULL]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
     String sql = "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT";
-    assertSingleRowWithNulls(connection, sql, Arrays.asList(null, new BigDecimal("42.5"), null));
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NULL, 42.5, NULL]
+          assertSingleRowWithNulls(resultSet, Arrays.asList(null, new BigDecimal("42.5"), null));
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromGenerator() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is
     // executed
-    // Then Result should contain consecutive numbers from 0 to 19999
-    // And All values should be returned as appropriate type
-    Connection connection = getDefaultConnection();
     String sql =
         "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => "
             + LARGE_RESULT_SET_SIZE
             + ")) v ORDER BY id";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertDecfloatColumn(
-            resultSet,
-            1,
-            BigDecimal.valueOf(expected),
-            "Value mismatch for DECFLOAT, row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for DECFLOAT");
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate
+          // type
+          int expected = 0;
+          while (resultSet.next()) {
+            assertDecfloatColumn(
+                resultSet,
+                1,
+                BigDecimal.valueOf(expected),
+                "Value mismatch for DECFLOAT, row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for DECFLOAT");
+        });
   }
 
   @Test
   public void shouldSelectDecfloatsFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
     Connection connection = getDefaultConnection();
+
+    // And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES (0), (123.456), (-789.012), (1.23e20), (-9.87e-15)");
 
-    assertSingleColumnRows(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col";
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col",
-        Arrays.asList(
-            new BigDecimal("-789.012"),
-            new BigDecimal("-9.87E-15"),
-            new BigDecimal("0"),
-            new BigDecimal("123.456"),
-            new BigDecimal("1.23E+20")));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain exact decimals [0, 123.456, -789.012, 1.23e20, -9.87e-15]
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("-789.012"),
+                  new BigDecimal("-9.87E-15"),
+                  new BigDecimal("0"),
+                  new BigDecimal("123.456"),
+                  new BigDecimal("1.23E+20")));
+        });
   }
 
   @Test
   public void shouldHandleFull38DigitPrecisionValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with DECFLOAT column exists with values
     // [12345678901234567890123456789012345678, 1.2345678901234567890123456789012345678E+100,
     // 1.2345678901234567890123456789012345678E-100]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should preserve all 38 digits for each value
-    Connection connection = getDefaultConnection();
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
     execute(
         connection,
@@ -209,24 +256,30 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
             + "('1.2345678901234567890123456789012345678E+100'::DECFLOAT), "
             + "('1.2345678901234567890123456789012345678E-100'::DECFLOAT)");
 
-    assertSingleColumnRows(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col";
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col",
-        Arrays.asList(
-            new BigDecimal("1.2345678901234567890123456789012345678E-100"),
-            new BigDecimal("12345678901234567890123456789012345678"),
-            new BigDecimal("1.2345678901234567890123456789012345678E+100")));
+        sql,
+        resultSet -> {
+
+          // Then Result should preserve all 38 digits for each value
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("1.2345678901234567890123456789012345678E-100"),
+                  new BigDecimal("12345678901234567890123456789012345678"),
+                  new BigDecimal("1.2345678901234567890123456789012345678E+100")));
+        });
   }
 
   @Test
   public void shouldHandleExtremeExponentValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000,
     // 9.876E-8000]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
-    Connection connection = getDefaultConnection();
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
     execute(
         connection,
@@ -237,43 +290,54 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
             + "('-1.234E+8000'::DECFLOAT), "
             + "('9.876E-8000'::DECFLOAT)");
 
-    assertSingleColumnRows(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col";
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col",
-        Arrays.asList(
-            new BigDecimal("-1.234E+8000"),
-            new BigDecimal("1E-16383"),
-            new BigDecimal("9.876E-8000"),
-            new BigDecimal("1E+16384")));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("-1.234E+8000"),
+                  new BigDecimal("1E-16383"),
+                  new BigDecimal("9.876E-8000"),
+                  new BigDecimal("1E+16384")));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [NULL, 123.456, NULL, -789.012]
     Connection connection = getDefaultConnection();
+
+    // And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
     execute(
         connection, "INSERT INTO " + tableName + " VALUES (NULL), (123.456), (NULL), (-789.012)");
 
-    assertSingleColumnRows(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col NULLS FIRST";
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col NULLS FIRST",
-        Arrays.asList(null, null, new BigDecimal("-789.012"), new BigDecimal("123.456")));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NULL, 123.456, NULL, -789.012]
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(null, null, new BigDecimal("-789.012"), new BigDecimal("123.456")));
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DECFLOAT column exists with values from 0 to 19999
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain consecutive numbers from 0 to 19999
-    // And All values should be returned as appropriate type
     Connection connection = getDefaultConnection();
+
+    // And Table with DECFLOAT column exists with values from 0 to 19999
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
     execute(
         connection,
@@ -283,95 +347,112 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
             + LARGE_RESULT_SET_SIZE
             + "))");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT col FROM " + tableName + " ORDER BY col")) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertDecfloatColumn(
-            resultSet,
-            1,
-            BigDecimal.valueOf(expected),
-            "Value mismatch for DECFLOAT, row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for DECFLOAT");
-    }
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate
+          // type
+          int expected = 0;
+          while (resultSet.next()) {
+            assertDecfloatColumn(
+                resultSet,
+                1,
+                BigDecimal.valueOf(expected),
+                "Value mismatch for DECFLOAT, row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for DECFLOAT");
+        });
   }
 
   @Test
   public void shouldSelectDecfloatUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed with bound DECFLOAT
     // values [123.456, -789.012, 42.0]
-    // Then Result should contain [123.456, -789.012, 42.0]
-    // When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
-    // Then Result should contain [NULL]
-    Connection connection = getDefaultConnection();
-    try (PreparedStatement preparedStatement =
-        connection.prepareStatement("SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT")) {
-      preparedStatement.setBigDecimal(1, new BigDecimal("123.456"));
-      preparedStatement.setBigDecimal(2, new BigDecimal("-789.012"));
-      preparedStatement.setBigDecimal(3, new BigDecimal("42.0"));
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-        assertDecfloatColumn(
-            resultSet, 1, new BigDecimal("123.456"), "Column 1 mismatch for DECFLOAT");
-        assertDecfloatColumn(
-            resultSet, 2, new BigDecimal("-789.012"), "Column 2 mismatch for DECFLOAT");
-        assertDecfloatColumn(
-            resultSet, 3, new BigDecimal("42.0"), "Column 3 mismatch for DECFLOAT");
-        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-      }
-    }
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT",
+        ps -> {
+          ps.setBigDecimal(1, new BigDecimal("123.456"));
+          ps.setBigDecimal(2, new BigDecimal("-789.012"));
+          ps.setBigDecimal(3, new BigDecimal("42.0"));
+        },
+        resultSet -> {
+          // Then Result should contain [123.456, -789.012, 42.0]
+          assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+          assertDecfloatColumn(
+              resultSet, 1, new BigDecimal("123.456"), "Column 1 mismatch for DECFLOAT");
+          assertDecfloatColumn(
+              resultSet, 2, new BigDecimal("-789.012"), "Column 2 mismatch for DECFLOAT");
+          assertDecfloatColumn(
+              resultSet, 3, new BigDecimal("42.0"), "Column 3 mismatch for DECFLOAT");
+          assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+        });
 
-    try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT ?::DECFLOAT")) {
-      preparedStatement.setNull(1, Types.DECIMAL);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-        assertNull(resultSet.getObject(1), "Column 1 should be NULL for DECFLOAT");
-        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for DECFLOAT");
-        assertNull(resultSet.getBigDecimal(1), "Column 1 BigDecimal should be NULL for DECFLOAT");
-        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() after getBigDecimal");
-        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-      }
-    }
+    // When Query "SELECT ?::DECFLOAT" is executed with bound NULL value
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DECFLOAT",
+        ps -> ps.setNull(1, Types.DECIMAL),
+        resultSet -> {
+          // Then Result should contain [NULL]
+          assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+          assertNull(resultSet.getObject(1), "Column 1 should be NULL for DECFLOAT");
+          assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for DECFLOAT");
+          assertNull(resultSet.getBigDecimal(1), "Column 1 BigDecimal should be NULL for DECFLOAT");
+          assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() after getBigDecimal");
+          assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+        });
   }
 
   @Test
   public void shouldSelectExtremeDecfloatValuesUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
-    // Then Result should contain [1E+16384]
-    // When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
-    // Then Result should contain [-1.234E+8000]
     Connection connection = getDefaultConnection();
-    try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT ?::DECFLOAT")) {
-      preparedStatement.setBigDecimal(1, new BigDecimal("1E+16384"));
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-        assertDecfloatColumn(
-            resultSet, 1, new BigDecimal("1E+16384"), "Value mismatch for DECFLOAT");
-        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-      }
-      preparedStatement.setBigDecimal(1, new BigDecimal("-1.234E+8000"));
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-        assertDecfloatColumn(
-            resultSet, 1, new BigDecimal("-1.234E+8000"), "Value mismatch for DECFLOAT");
-        assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-      }
-    }
+
+    // When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DECFLOAT",
+        ps -> ps.setBigDecimal(1, new BigDecimal("1E+16384")),
+        resultSet -> {
+          // Then Result should contain [1E+16384]
+          assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+          assertDecfloatColumn(
+              resultSet, 1, new BigDecimal("1E+16384"), "Value mismatch for DECFLOAT");
+          assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+        });
+
+    // When Query "SELECT ?::DECFLOAT" is executed with bound value -1.234E+8000
+    withPreparedQueryResult(
+        connection,
+        "SELECT ?::DECFLOAT",
+        ps -> ps.setBigDecimal(1, new BigDecimal("-1.234E+8000")),
+        resultSet -> {
+          // Then Result should contain [-1.234E+8000]
+          assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+          assertDecfloatColumn(
+              resultSet, 1, new BigDecimal("-1.234E+8000"), "Value mismatch for DECFLOAT");
+          assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+        });
   }
 
   @Test
   public void shouldInsertDecfloatUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DECFLOAT column exists
-    // When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
-    // Then SELECT should return the same exact values
     Connection connection = getDefaultConnection();
+
+    // And Table with DECFLOAT column exists
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
+
+    // When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
       preparedStatement.setBigDecimal(1, new BigDecimal("0"));
@@ -384,23 +465,31 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
       preparedStatement.execute();
     }
 
-    assertSingleColumnRows(
+    // Then SELECT should return the same exact values
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col NULLS FIRST";
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col NULLS FIRST",
-        Arrays.asList(
-            null, new BigDecimal("-789.012"), new BigDecimal("0"), new BigDecimal("123.456")));
+        sql,
+        resultSet -> {
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  null,
+                  new BigDecimal("-789.012"),
+                  new BigDecimal("0"),
+                  new BigDecimal("123.456")));
+        });
   }
 
   @Test
   public void shouldInsertExtremeDecfloatValuesUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with DECFLOAT column exists
-    // When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
-    // And Query "SELECT * FROM <table>" is executed
-    // Then SELECT should return the same exact values
     Connection connection = getDefaultConnection();
+
+    // And Table with DECFLOAT column exists
     String tableName = createTempTable(connection, "ud_decfloat_", "col DECFLOAT");
+
+    // When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?::DECFLOAT)")) {
       preparedStatement.setString(1, "1E+16384");
@@ -411,48 +500,60 @@ public class DecfloatTests extends SnowflakeIntegrationTestBase {
       preparedStatement.execute();
     }
 
-    assertSingleColumnRows(
+    // And Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY col";
+    // Then SELECT should return the same exact values
+    withQueryResult(
         connection,
-        tableName,
-        "ORDER BY col",
-        Arrays.asList(
-            new BigDecimal("-1.234E+8000"),
-            new BigDecimal("1E-16383"),
-            new BigDecimal("1E+16384")));
+        sql,
+        resultSet -> {
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("-1.234E+8000"),
+                  new BigDecimal("1E-16383"),
+                  new BigDecimal("1E+16384")));
+        });
   }
 
-  private static void assertSingleRowWithNulls(
-      Connection connection, String sql, List<BigDecimal> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertNullableDecfloatColumn(
-            resultSet,
-            i + 1,
-            expectedValues.get(i),
-            "Value mismatch for DECFLOAT, column " + (i + 1));
-      }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
-    }
-  }
-
-  private static void assertSingleColumnRows(
-      Connection connection,
-      String tableName,
-      String orderByClause,
-      List<BigDecimal> expectedValues)
+  private static List<BigDecimal> assertDecfloatTypes(ResultSet resultSet, int columnCount)
       throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT col FROM " + tableName + " " + orderByClause)) {
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertTrue(resultSet.next(), "Missing row " + i + " for DECFLOAT");
-        assertNullableDecfloatColumn(
-            resultSet, 1, expectedValues.get(i), "Value mismatch for DECFLOAT, row " + i);
-      }
-      assertFalse(resultSet.next(), "Unexpected extra rows for DECFLOAT");
+    assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+    List<BigDecimal> values = new ArrayList<>();
+    for (int i = 1; i <= columnCount; i++) {
+      Object objectValue = resultSet.getObject(i);
+      assertInstanceOf(
+          BigDecimal.class,
+          objectValue,
+          "Column " + i + " getObject should return BigDecimal for DECFLOAT");
+      assertFalse(resultSet.wasNull(), "Column " + i + " should not be NULL for DECFLOAT");
+      values.add((BigDecimal) objectValue);
     }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+    return values;
+  }
+
+  private static void assertSingleRowWithNulls(ResultSet resultSet, List<BigDecimal> expectedValues)
+      throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: DECFLOAT");
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertNullableDecfloatColumn(
+          resultSet,
+          i + 1,
+          expectedValues.get(i),
+          "Value mismatch for DECFLOAT, column " + (i + 1));
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: DECFLOAT");
+  }
+
+  private static void assertSingleColumnRows(ResultSet resultSet, List<BigDecimal> expectedValues)
+      throws Exception {
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertTrue(resultSet.next(), "Missing row " + i + " for DECFLOAT");
+      assertNullableDecfloatColumn(
+          resultSet, 1, expectedValues.get(i), "Value mismatch for DECFLOAT, row " + i);
+    }
+    assertFalse(resultSet.next(), "Unexpected extra rows for DECFLOAT");
   }
 
   private static void assertNullableDecfloatColumn(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/FloatTests.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -24,175 +22,223 @@ public class FloatTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastFloatValuesToAppropriateTypeForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0.0::<type>, 123.456::<type>, 1.23e10::<type>, 'NaN'::<type>,
     // 'inf'::<type>" is executed
-    // Then All values should be returned as appropriate type
-    // And Regular values should have approximately 15 decimal digits precision
-    // And NaN and inf values should be identified correctly
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT 0.0::%1$s, 123.456::%1$s, 1.23e10::%1$s, 'NaN'::%1$s, 'inf'::%1$s", FLOAT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertAllFloatGetters(resultSet, 1, 0.0, "Column 1 mismatch for " + FLOAT_TYPE);
-      assertAllFloatGetters(resultSet, 2, 123.456, "Column 2 mismatch for " + FLOAT_TYPE);
-      assertAllFloatGetters(resultSet, 3, 1.23e10, "Column 3 mismatch for " + FLOAT_TYPE);
+          // Then All values should be returned as appropriate type
+          assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
 
-      assertAllFloatGetters(resultSet, 4, Double.NaN, "Column 4 mismatch for " + FLOAT_TYPE);
-      assertAllFloatGetters(
-          resultSet, 5, Double.POSITIVE_INFINITY, "Column 5 mismatch for " + FLOAT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
-    }
+          // And Regular values should have approximately 15 decimal digits precision
+          assertAllFloatGetters(resultSet, 1, 0.0, "Column 1 mismatch for " + FLOAT_TYPE);
+          assertAllFloatGetters(resultSet, 2, 123.456, "Column 2 mismatch for " + FLOAT_TYPE);
+          assertAllFloatGetters(resultSet, 3, 1.23e10, "Column 3 mismatch for " + FLOAT_TYPE);
+
+          // And NaN and inf values should be identified correctly
+          assertAllFloatGetters(resultSet, 4, Double.NaN, "Column 4 mismatch for " + FLOAT_TYPE);
+          assertAllFloatGetters(
+              resultSet, 5, Double.POSITIVE_INFINITY, "Column 5 mismatch for " + FLOAT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectFloatLiteralsForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>"
     // is executed
-    // Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
-    Connection connection = getDefaultConnection();
-    assertSingleRow(
-        connection,
+    String sql =
         String.format(
-            "SELECT 0.0::%1$s, 1.0::%1$s, -1.0::%1$s, 123.456::%1$s, -123.456::%1$s", FLOAT_TYPE),
-        Arrays.asList(0.0, 1.0, -1.0, 123.456, -123.456));
+            "SELECT 0.0::%1$s, 1.0::%1$s, -1.0::%1$s, 123.456::%1$s, -123.456::%1$s", FLOAT_TYPE);
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain floats [0.0, 1.0, -1.0, 123.456, -123.456]
+          assertSingleRow(resultSet, Arrays.asList(0.0, 1.0, -1.0, 123.456, -123.456));
+        });
   }
 
   @Test
   public void shouldHandleSpecialFloatValuesFromLiteralsForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
-    // Then Result should contain [NaN, positive_infinity, negative_infinity]
     Connection connection = getDefaultConnection();
-    assertSingleRow(
+
+    // When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
+    String sql = String.format("SELECT 'NaN'::%1$s, 'inf'::%1$s, '-inf'::%1$s", FLOAT_TYPE);
+    withQueryResult(
         connection,
-        String.format("SELECT 'NaN'::%1$s, 'inf'::%1$s, '-inf'::%1$s", FLOAT_TYPE),
-        Arrays.asList(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NaN, positive_infinity, negative_infinity]
+          assertSingleRow(
+              resultSet,
+              Arrays.asList(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY));
+        });
   }
 
   @Test
   public void shouldHandleFloatBoundaryValuesFromLiteralsForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is
-    // executed
-    // Then Result should contain floats [1.7976931348623157e308, -1.7976931348623157e308]
-    // When Query "SELECT 2.2250738585072014e-308::<type>, 5e-324::<type>" is executed
-    // Then Result should contain floats [2.2250738585072014e-308, approximately 5e-324]
-    // When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
-    // Then Result should verify precision around 15 decimal digits
     Connection connection = getDefaultConnection();
 
-    assertSingleRow(
-        connection,
+    // When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is
+    // executed
+    String maxBoundarySql =
         String.format(
-            "SELECT 1.7976931348623157e308::%1$s, -1.7976931348623157e308::%1$s", FLOAT_TYPE),
-        Arrays.asList(Double.MAX_VALUE, -Double.MAX_VALUE));
+            "SELECT 1.7976931348623157e308::%1$s, -1.7976931348623157e308::%1$s", FLOAT_TYPE);
+    withQueryResult(
+        connection,
+        maxBoundarySql,
+        resultSet -> {
 
+          // Then Result should contain floats [1.7976931348623157e308, -1.7976931348623157e308]
+          assertSingleRow(resultSet, Arrays.asList(Double.MAX_VALUE, -Double.MAX_VALUE));
+        });
+
+    // When Query "SELECT 2.2250738585072014e-308::<type>, 5e-324::<type>" is executed
     String minBoundarySql =
         String.format("SELECT 2.2250738585072014e-308::%1$s, 5e-324::%1$s", FLOAT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(minBoundarySql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
-      assertFiniteDouble(
-          resultSet.getDouble(1), Double.MIN_NORMAL, "Column 1 mismatch for " + FLOAT_TYPE);
-      double actualSubnormal = resultSet.getDouble(2);
-      assertTrue(actualSubnormal > 0.0, "Column 2 should be positive for " + FLOAT_TYPE);
-      assertTrue(
-          actualSubnormal <= Double.MIN_VALUE, "Column 2 should be subnormal for " + FLOAT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
-    }
-
-    assertSingleRow(
+    withQueryResult(
         connection,
-        String.format("SELECT 123456789012345.0::%1$s, 1234567890123456.0::%1$s", FLOAT_TYPE),
-        Arrays.asList(123456789012345.0, 1234567890123456.0));
+        minBoundarySql,
+        resultSet -> {
+
+          // Then Result should contain floats [2.2250738585072014e-308, approximately 5e-324]
+          assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+          assertFiniteDouble(
+              resultSet.getDouble(1), Double.MIN_NORMAL, "Column 1 mismatch for " + FLOAT_TYPE);
+          double actualSubnormal = resultSet.getDouble(2);
+          assertTrue(actualSubnormal > 0.0, "Column 2 should be positive for " + FLOAT_TYPE);
+          assertTrue(
+              actualSubnormal <= Double.MIN_VALUE,
+              "Column 2 should be subnormal for " + FLOAT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+        });
+
+    // When Query "SELECT 123456789012345.0::<type>, 1234567890123456.0::<type>" is executed
+    String precisionSql =
+        String.format("SELECT 123456789012345.0::%1$s, 1234567890123456.0::%1$s", FLOAT_TYPE);
+    withQueryResult(
+        connection,
+        precisionSql,
+        resultSet -> {
+
+          // Then Result should verify precision around 15 decimal digits
+          assertSingleRow(resultSet, Arrays.asList(123456789012345.0, 1234567890123456.0));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromLiteralsForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
-    // Then Result should contain [NULL, 42.5, NULL]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
     String sql = String.format("SELECT NULL::%1$s, 42.5::%1$s, NULL::%1$s", FLOAT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
-      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
-      assertEquals(
-          0.0,
-          resultSet.getDouble(1),
-          "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertAllFloatGetters(resultSet, 2, 42.5, "Column 2 mismatch for " + FLOAT_TYPE);
+          // Then Result should contain [NULL, 42.5, NULL]
+          assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+          assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
+          assertEquals(
+              0.0,
+              resultSet.getDouble(1),
+              "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+          assertTrue(
+              resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
 
-      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + FLOAT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + FLOAT_TYPE);
-      assertEquals(
-          0.0,
-          resultSet.getDouble(3),
-          "Column 3 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 3 getDouble should set wasNull() for " + FLOAT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
-    }
+          assertAllFloatGetters(resultSet, 2, 42.5, "Column 2 mismatch for " + FLOAT_TYPE);
+
+          assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + FLOAT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + FLOAT_TYPE);
+          assertEquals(
+              0.0,
+              resultSet.getDouble(3),
+              "Column 3 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+          assertTrue(
+              resultSet.wasNull(), "Column 3 getDouble should set wasNull() for " + FLOAT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromGeneratorForFloatAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is
     // executed
-    // Then Result should contain 50000 rows
-    // And All values should be returned as appropriate float type
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => %2$d)) v ORDER BY id",
             FLOAT_TYPE, LARGE_RESULT_SET_SIZE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertFiniteDouble(
-            resultSet.getDouble(1),
-            expected,
-            "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 50000 rows with all values returned as appropriate float
+          // type
+          int expected = 0;
+          while (resultSet.next()) {
+            assertFiniteDouble(
+                resultSet.getDouble(1),
+                expected,
+                "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectFloatsFromTableForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
-    // When Query "SELECT * FROM float_table" is executed
-    // Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
     String tableName = createTempTable(connection, "ud_float_", "col " + FLOAT_TYPE);
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
 
-    assertSingleColumnRows(
-        connection, tableName, Arrays.asList(0.0, 123.456, -789.012, 123000.0, -0.00987));
+    // When Query "SELECT * FROM float_table" is executed
+    String sql = "SELECT * FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain floats [0.0, 123.456, -789.012, 123000.0, -0.00987]
+          assertSingleColumnRows(
+              resultSet, Arrays.asList(0.0, 123.456, -789.012, 123000.0, -0.00987));
+        });
   }
 
   @Test
   public void shouldHandleSpecialFloatValuesFromTableForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
     String tableName = createTempTable(connection, "ud_float_", "col " + FLOAT_TYPE);
     execute(
         connection,
@@ -206,49 +252,55 @@ public class FloatTests extends SnowflakeIntegrationTestBase {
             + FLOAT_TYPE
             + "), (42.0), (-42.0)");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
-      Map<String, Integer> counts = new HashMap<>();
-      while (resultSet.next()) {
-        double value = resultSet.getDouble(1);
-        String key;
-        if (Double.isNaN(value)) {
-          key = "NaN";
-        } else if (value == Double.POSITIVE_INFINITY) {
-          key = "POS_INF";
-        } else if (value == Double.NEGATIVE_INFINITY) {
-          key = "NEG_INF";
-        } else if (value == 42.0) {
-          key = "POS_42";
-        } else if (value == -42.0) {
-          key = "NEG_42";
-        } else {
-          key = "UNEXPECTED";
-        }
-        counts.put(key, counts.getOrDefault(key, 0) + 1);
-      }
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertEquals(1, counts.getOrDefault("NaN", 0), "Expected one NaN for " + FLOAT_TYPE);
-      assertEquals(
-          1, counts.getOrDefault("POS_INF", 0), "Expected one +Infinity for " + FLOAT_TYPE);
-      assertEquals(
-          1, counts.getOrDefault("NEG_INF", 0), "Expected one -Infinity for " + FLOAT_TYPE);
-      assertEquals(1, counts.getOrDefault("POS_42", 0), "Expected one 42.0 for " + FLOAT_TYPE);
-      assertEquals(1, counts.getOrDefault("NEG_42", 0), "Expected one -42.0 for " + FLOAT_TYPE);
-      assertEquals(
-          0, counts.getOrDefault("UNEXPECTED", 0), "Unexpected value returned for " + FLOAT_TYPE);
-    }
+          // Then Result should contain [NaN, positive_infinity, negative_infinity, 42.0, -42.0]
+          Map<String, Integer> counts = new HashMap<>();
+          while (resultSet.next()) {
+            double value = resultSet.getDouble(1);
+            String key;
+            if (Double.isNaN(value)) {
+              key = "NaN";
+            } else if (value == Double.POSITIVE_INFINITY) {
+              key = "POS_INF";
+            } else if (value == Double.NEGATIVE_INFINITY) {
+              key = "NEG_INF";
+            } else if (value == 42.0) {
+              key = "POS_42";
+            } else if (value == -42.0) {
+              key = "NEG_42";
+            } else {
+              key = "UNEXPECTED";
+            }
+            counts.put(key, counts.getOrDefault(key, 0) + 1);
+          }
+
+          assertEquals(1, counts.getOrDefault("NaN", 0), "Expected one NaN for " + FLOAT_TYPE);
+          assertEquals(
+              1, counts.getOrDefault("POS_INF", 0), "Expected one +Infinity for " + FLOAT_TYPE);
+          assertEquals(
+              1, counts.getOrDefault("NEG_INF", 0), "Expected one -Infinity for " + FLOAT_TYPE);
+          assertEquals(1, counts.getOrDefault("POS_42", 0), "Expected one 42.0 for " + FLOAT_TYPE);
+          assertEquals(1, counts.getOrDefault("NEG_42", 0), "Expected one -42.0 for " + FLOAT_TYPE);
+          assertEquals(
+              0,
+              counts.getOrDefault("UNEXPECTED", 0),
+              "Unexpected value returned for " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldHandleFloatBoundaryValuesFromTableForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with <type> column exists with boundary values [1.7976931348623157e308,
     // -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain maximum, minimum, and precision boundary values
-    // And All values should be preserved within float precision limits
-    Connection connection = getDefaultConnection();
     String tableName = createTempTable(connection, "ud_float_", "col " + FLOAT_TYPE);
     execute(
         connection,
@@ -256,61 +308,74 @@ public class FloatTests extends SnowflakeIntegrationTestBase {
             + tableName
             + " VALUES (1.7976931348623157e308), (-1.7976931348623157e308), (2.2250738585072014e-308), (5e-324), (123456789012345.0)");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
-      boolean foundMax = false;
-      boolean foundMin = false;
-      boolean foundMinNormal = false;
-      boolean foundMinSubnormal = false;
-      boolean foundPrecisionValue = false;
-      int rowCount = 0;
-      while (resultSet.next()) {
-        rowCount++;
-        double value = resultSet.getDouble(1);
-        if (approximatelyEquals(value, Double.MAX_VALUE)) {
-          foundMax = true;
-        } else if (approximatelyEquals(value, -Double.MAX_VALUE)) {
-          foundMin = true;
-        } else if (approximatelyEquals(value, Double.MIN_NORMAL)) {
-          foundMinNormal = true;
-        } else if (value > 0.0 && value <= Double.MIN_VALUE) {
-          foundMinSubnormal = true;
-        } else if (approximatelyEquals(value, 123456789012345.0)) {
-          foundPrecisionValue = true;
-        }
-      }
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
 
-      assertEquals(5, rowCount, "Unexpected row count for " + FLOAT_TYPE);
-      assertTrue(foundMax, "Expected Double.MAX_VALUE for " + FLOAT_TYPE);
-      assertTrue(foundMin, "Expected -Double.MAX_VALUE for " + FLOAT_TYPE);
-      assertTrue(foundMinNormal, "Expected Double.MIN_NORMAL for " + FLOAT_TYPE);
-      assertTrue(foundMinSubnormal, "Expected positive subnormal value for " + FLOAT_TYPE);
-      assertTrue(foundPrecisionValue, "Expected 123456789012345.0 for " + FLOAT_TYPE);
-    }
+          // Then Result should contain maximum, minimum, and precision boundary values preserved
+          // within float precision limits
+          boolean foundMax = false;
+          boolean foundMin = false;
+          boolean foundMinNormal = false;
+          boolean foundMinSubnormal = false;
+          boolean foundPrecisionValue = false;
+          int rowCount = 0;
+          while (resultSet.next()) {
+            rowCount++;
+            double value = resultSet.getDouble(1);
+            if (approximatelyEquals(value, Double.MAX_VALUE)) {
+              foundMax = true;
+            } else if (approximatelyEquals(value, -Double.MAX_VALUE)) {
+              foundMin = true;
+            } else if (approximatelyEquals(value, Double.MIN_NORMAL)) {
+              foundMinNormal = true;
+            } else if (value > 0.0 && value <= Double.MIN_VALUE) {
+              foundMinSubnormal = true;
+            } else if (approximatelyEquals(value, 123456789012345.0)) {
+              foundPrecisionValue = true;
+            }
+          }
+
+          assertEquals(5, rowCount, "Unexpected row count for " + FLOAT_TYPE);
+          assertTrue(foundMax, "Expected Double.MAX_VALUE for " + FLOAT_TYPE);
+          assertTrue(foundMin, "Expected -Double.MAX_VALUE for " + FLOAT_TYPE);
+          assertTrue(foundMinNormal, "Expected Double.MIN_NORMAL for " + FLOAT_TYPE);
+          assertTrue(foundMinSubnormal, "Expected positive subnormal value for " + FLOAT_TYPE);
+          assertTrue(foundPrecisionValue, "Expected 123456789012345.0 for " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromTableForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [NULL, 123.456, NULL, -789.012]
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
     String tableName = createTempTable(connection, "ud_float_", "col " + FLOAT_TYPE);
     execute(
         connection, "INSERT INTO " + tableName + " VALUES (NULL), (123.456), (NULL), (-789.012)");
 
-    assertSingleColumnRows(connection, tableName, Arrays.asList(null, 123.456, null, -789.012));
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NULL, 123.456, NULL, -789.012]
+          assertSingleColumnRows(resultSet, Arrays.asList(null, 123.456, null, -789.012));
+        });
   }
 
   @Test
   public void shouldSelectLargeResultSetFromTableForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists with 50000 sequential values
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 50000 rows
-    // And All values should be returned as appropriate float type
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists with 50000 sequential values
     String tableName = createTempTable(connection, "ud_float_", "col " + FLOAT_TYPE);
     execute(
         connection,
@@ -320,94 +385,99 @@ public class FloatTests extends SnowflakeIntegrationTestBase {
             + FLOAT_TYPE
             + " FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertFiniteDouble(
-            resultSet.getDouble(1),
-            expected,
-            "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
-    }
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY col";
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 50000 rows with all values returned as appropriate float
+          // type
+          int expected = 0;
+          while (resultSet.next()) {
+            assertFiniteDouble(
+                resultSet.getDouble(1),
+                expected,
+                "Value mismatch for " + FLOAT_TYPE + ", row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + FLOAT_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectFloatUsingParameterBindingForFloatAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT ?::<type>, ?::<type>, ?::<type>" is executed with bound float values
     // [123.456, -789.012, 42.0]
-    // Then Result should contain floats [123.456, -789.012, 42.0]
-    // When Query "SELECT ?::<type>" is executed with bound NULL value
-    // Then Result should contain NULL
-    Connection connection = getDefaultConnection();
     String sql = String.format("SELECT ?::%1$s, ?::%1$s, ?::%1$s", FLOAT_TYPE);
-    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-      preparedStatement.setDouble(1, 123.456);
-      preparedStatement.setDouble(2, -789.012);
-      preparedStatement.setDouble(3, 42.0);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
-        assertAllFloatGetters(resultSet, 1, 123.456, "Column 1 mismatch for " + FLOAT_TYPE);
-        assertAllFloatGetters(resultSet, 2, -789.012, "Column 2 mismatch for " + FLOAT_TYPE);
-        assertAllFloatGetters(resultSet, 3, 42.0, "Column 3 mismatch for " + FLOAT_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
-      }
-    }
+    // When
+    withPreparedQueryResult(
+        connection,
+        sql,
+        ps -> {
+          ps.setDouble(1, 123.456);
+          ps.setDouble(2, -789.012);
+          ps.setDouble(3, 42.0);
+        },
+        resultSet -> {
+          // Then Result should contain floats [123.456, -789.012, 42.0]
+          assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+          assertAllFloatGetters(resultSet, 1, 123.456, "Column 1 mismatch for " + FLOAT_TYPE);
+          assertAllFloatGetters(resultSet, 2, -789.012, "Column 2 mismatch for " + FLOAT_TYPE);
+          assertAllFloatGetters(resultSet, 3, 42.0, "Column 3 mismatch for " + FLOAT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+        });
 
+    // When Query "SELECT ?::<type>" is executed with bound NULL value
     String nullSql = String.format("SELECT ?::%1$s", FLOAT_TYPE);
-    try (PreparedStatement preparedStatement = connection.prepareStatement(nullSql)) {
-      preparedStatement.setNull(1, Types.DOUBLE);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
-        assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
-        assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
-        assertEquals(
-            0.0,
-            resultSet.getDouble(1),
-            "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
-        assertTrue(
-            resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
-      }
-    }
+    withPreparedQueryResult(
+        connection,
+        nullSql,
+        ps -> ps.setNull(1, Types.DOUBLE),
+        resultSet -> {
+          // Then Result should contain NULL
+          assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+          assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + FLOAT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + FLOAT_TYPE);
+          assertEquals(
+              0.0,
+              resultSet.getDouble(1),
+              "Column 1 getDouble should return 0.0 for NULL " + FLOAT_TYPE);
+          assertTrue(
+              resultSet.wasNull(), "Column 1 getDouble should set wasNull() for " + FLOAT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+        });
   }
 
-  private static void assertSingleRow(Connection connection, String sql, List<Double> expected)
+  private static void assertSingleRow(ResultSet resultSet, List<Double> expected) throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
+    for (int i = 0; i < expected.size(); i++) {
+      assertAllFloatGetters(
+          resultSet, i + 1, expected.get(i), "Column " + (i + 1) + " mismatch for " + FLOAT_TYPE);
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
+  }
+
+  private static void assertSingleColumnRows(ResultSet resultSet, List<Double> expectedValues)
       throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + FLOAT_TYPE);
-      for (int i = 0; i < expected.size(); i++) {
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertTrue(resultSet.next(), "Missing row " + i + " for " + FLOAT_TYPE);
+      Double expected = expectedValues.get(i);
+      if (expected == null) {
+        assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + FLOAT_TYPE);
+        assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
+        assertEquals(0.0, resultSet.getDouble(1), "Expected getDouble=0.0 for NULL at row " + i);
+        assertTrue(resultSet.wasNull(), "Expected wasNull() after getDouble NULL at row " + i);
+      } else {
         assertAllFloatGetters(
-            resultSet, i + 1, expected.get(i), "Column " + (i + 1) + " mismatch for " + FLOAT_TYPE);
+            resultSet, 1, expected, "Value mismatch for " + FLOAT_TYPE + ", row " + i);
       }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + FLOAT_TYPE);
     }
-  }
-
-  private static void assertSingleColumnRows(
-      Connection connection, String tableName, List<Double> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertTrue(resultSet.next(), "Missing row " + i + " for " + FLOAT_TYPE);
-        Double expected = expectedValues.get(i);
-        if (expected == null) {
-          assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + FLOAT_TYPE);
-          assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
-          assertEquals(0.0, resultSet.getDouble(1), "Expected getDouble=0.0 for NULL at row " + i);
-          assertTrue(resultSet.wasNull(), "Expected wasNull() after getDouble NULL at row " + i);
-        } else {
-          assertAllFloatGetters(
-              resultSet, 1, expected, "Value mismatch for " + FLOAT_TYPE + ", row " + i);
-        }
-      }
-      assertFalse(resultSet.next(), "Unexpected extra rows for " + FLOAT_TYPE);
-    }
+    assertFalse(resultSet.next(), "Unexpected extra rows for " + FLOAT_TYPE);
   }
 
   private static void assertAllFloatGetters(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/IntTests.java
@@ -11,7 +11,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
@@ -26,141 +25,202 @@ public class IntTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastIntegerValuesToAppropriateTypeForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
-    // Then All values should be returned as appropriate type
-    // And No precision loss should occur
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
     String sql =
         String.format("SELECT 0::%1$s, 1000000::%1$s, 9223372036854775807::%1$s", INT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
-      assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + INT_TYPE);
-      assertAllIntegerGettersInRange(resultSet, 2, 1_000_000L, "Column 2 mismatch for " + INT_TYPE);
-      assertAllIntegerGettersInRange(
-          resultSet, 3, Long.MAX_VALUE, "Column 3 mismatch for " + INT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then All values should be returned as appropriate type with no precision loss
+          assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+          assertAllIntegerGettersInRange(resultSet, 1, 0L, "Column 1 mismatch for " + INT_TYPE);
+          assertAllIntegerGettersInRange(
+              resultSet, 2, 1_000_000L, "Column 2 mismatch for " + INT_TYPE);
+          assertAllIntegerGettersInRange(
+              resultSet, 3, Long.MAX_VALUE, "Column 3 mismatch for " + INT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectIntegerValuesForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT <query_values>" is executed
-    // Then Result should contain integers <expected_values>
     Connection connection = getDefaultConnection();
-    assertSingleRow(connection, String.format("SELECT 0::%1$s", INT_TYPE), Arrays.asList(0L));
-    assertSingleRow(
+
+    // When Query "SELECT <query_values>" is executed
+    String sql = String.format("SELECT 0::%1$s", INT_TYPE);
+    withQueryResult(
         connection,
-        String.format("SELECT -128::%1$s, 127::%1$s, 255::%1$s", INT_TYPE),
-        Arrays.asList(-128L, 127L, 255L));
-    assertSingleRow(
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers <expected_values>
+          assertSingleRow(resultSet, Arrays.asList(0L));
+        });
+
+    // When Query "SELECT -128::<type>, 127::<type>, 255::<type>" is executed
+    sql = String.format("SELECT -128::%1$s, 127::%1$s, 255::%1$s", INT_TYPE);
+    withQueryResult(
         connection,
-        String.format("SELECT -32768::%1$s, 32767::%1$s, 65535::%1$s", INT_TYPE),
-        Arrays.asList((long) Short.MIN_VALUE, (long) Short.MAX_VALUE, 65535L));
-    assertSingleRow(
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers [-128, 127, 255]
+          assertSingleRow(resultSet, Arrays.asList(-128L, 127L, 255L));
+        });
+
+    // When Query "SELECT -32768::<type>, 32767::<type>, 65535::<type>" is executed
+    sql = String.format("SELECT -32768::%1$s, 32767::%1$s, 65535::%1$s", INT_TYPE);
+    withQueryResult(
         connection,
-        String.format("SELECT -2147483648::%1$s, 2147483647::%1$s, 4294967295::%1$s", INT_TYPE),
-        Arrays.asList((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, 4294967295L));
-    assertSingleRow(
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers [-32768, 32767, 65535]
+          assertSingleRow(
+              resultSet, Arrays.asList((long) Short.MIN_VALUE, (long) Short.MAX_VALUE, 65535L));
+        });
+
+    // When Query "SELECT -2147483648::<type>, 2147483647::<type>, 4294967295::<type>" is executed
+    sql = String.format("SELECT -2147483648::%1$s, 2147483647::%1$s, 4294967295::%1$s", INT_TYPE);
+    withQueryResult(
         connection,
-        String.format("SELECT -9223372036854775808::%1$s, 9223372036854775807::%1$s", INT_TYPE),
-        Arrays.asList(Long.MIN_VALUE, Long.MAX_VALUE));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers [-2147483648, 2147483647, 4294967295]
+          assertSingleRow(
+              resultSet,
+              Arrays.asList((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, 4294967295L));
+        });
+
+    // When Query "SELECT -9223372036854775808::<type>, 9223372036854775807::<type>" is executed
+    sql = String.format("SELECT -9223372036854775808::%1$s, 9223372036854775807::%1$s", INT_TYPE);
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers [-9223372036854775808, 9223372036854775807]
+          assertSingleRow(resultSet, Arrays.asList(Long.MIN_VALUE, Long.MAX_VALUE));
+        });
   }
 
   @Test
   public void shouldHandleLargeIntegerValuesForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT -99999999999999999999999999999999999999::<type>,
     // 99999999999999999999999999999999999999::<type>" is executed
-    // Then Result should contain integers [-99999999999999999999999999999999999999,
-    // 99999999999999999999999999999999999999]
-    Connection connection = getDefaultConnection();
     String sql = String.format("SELECT %1$s::%3$s, %2$s::%3$s", SMALL_INT, LARGE_INT, INT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
-      assertInt38NumberGetters(resultSet, 1, SMALL_INT, "Column 1 mismatch for " + INT_TYPE);
-      assertInt38NumberGetters(resultSet, 2, LARGE_INT, "Column 2 mismatch for " + INT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain integers [-99999999999999999999999999999999999999,
+          // 99999999999999999999999999999999999999]
+          assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+          assertInt38NumberGetters(resultSet, 1, SMALL_INT, "Column 1 mismatch for " + INT_TYPE);
+          assertInt38NumberGetters(resultSet, 2, LARGE_INT, "Column 2 mismatch for " + INT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
-    // Then Result should contain [NULL, 42, NULL]
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT NULL::<type>, 42::<type>, NULL::<type>" is executed
     String sql = String.format("SELECT NULL::%1$s, 42::%1$s, NULL::%1$s", INT_TYPE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
-      assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + INT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + INT_TYPE);
-      assertEquals(
-          0L, resultSet.getLong(1), "Column 1 getLong should return 0 for NULL " + INT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 1 getLong should set wasNull() for " + INT_TYPE);
-      assertAllIntegerGettersInRange(resultSet, 2, 42L, "Column 2 mismatch for " + INT_TYPE);
-      assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + INT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + INT_TYPE);
-      assertEquals(
-          0L, resultSet.getLong(3), "Column 3 getLong should return 0 for NULL " + INT_TYPE);
-      assertTrue(resultSet.wasNull(), "Column 3 getLong should set wasNull() for " + INT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NULL, 42, NULL]
+          assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+          assertNull(resultSet.getObject(1), "Column 1 should be NULL for " + INT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 1 should set wasNull() for " + INT_TYPE);
+          assertEquals(
+              0L, resultSet.getLong(1), "Column 1 getLong should return 0 for NULL " + INT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 1 getLong should set wasNull() for " + INT_TYPE);
+          assertAllIntegerGettersInRange(resultSet, 2, 42L, "Column 2 mismatch for " + INT_TYPE);
+          assertNull(resultSet.getObject(3), "Column 3 should be NULL for " + INT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 3 should set wasNull() for " + INT_TYPE);
+          assertEquals(
+              0L, resultSet.getLong(3), "Column 3 getLong should return 0 for NULL " + INT_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 3 getLong should set wasNull() for " + INT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v ORDER BY
     // id" is executed
-    // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT seq8()::%1$s as id FROM TABLE(GENERATOR(ROWCOUNT => %2$d)) v ORDER BY id",
             INT_TYPE, LARGE_RESULT_SET_SIZE);
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertAllIntegerGettersInRange(
-            resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + INT_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 50000 sequentially numbered rows from 0 to 49999
+          int expected = 0;
+          while (resultSet.next()) {
+            assertAllIntegerGettersInRange(
+                resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + INT_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectValuesFromTableForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists with values <insert_values>
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain integers <expected_values>
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists with values <insert_values>
     String tableName = createTempTable(connection, "ud_int_", "col " + INT_TYPE);
 
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
     execute(
         connection,
         "INSERT INTO "
             + tableName
             + " VALUES (0), (1), (127), (255), (32767), (65535), (2147483647), (4294967295), (9223372036854775807)");
-    assertSingleColumnRows(
+    withQueryResult(
         connection,
-        tableName,
-        Arrays.asList(
-            0L,
-            1L,
-            127L,
-            255L,
-            (long) Short.MAX_VALUE,
-            65535L,
-            (long) Integer.MAX_VALUE,
-            4294967295L,
-            Long.MAX_VALUE));
+        "SELECT * FROM " + tableName + " ORDER BY col",
+        resultSet -> {
+
+          // Then Result should contain integers <expected_values>
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  0L,
+                  1L,
+                  127L,
+                  255L,
+                  (long) Short.MAX_VALUE,
+                  65535L,
+                  (long) Integer.MAX_VALUE,
+                  4294967295L,
+                  Long.MAX_VALUE));
+        });
 
     execute(connection, "TRUNCATE TABLE " + tableName);
     execute(
@@ -168,65 +228,84 @@ public class IntTests extends SnowflakeIntegrationTestBase {
         "INSERT INTO "
             + tableName
             + " VALUES (-1), (-128), (-32768), (-2147483648), (-9223372036854775808)");
-    assertSingleColumnRows(
+
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    withQueryResult(
         connection,
-        tableName,
-        Arrays.asList(
-            Long.MIN_VALUE, (long) Integer.MIN_VALUE, (long) Short.MIN_VALUE, -128L, -1L));
+        "SELECT * FROM " + tableName + " ORDER BY col",
+        resultSet -> {
+
+          // Then Result should contain integers [-9223372036854775808, -2147483648, -32768, -128,
+          // -1]
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  Long.MIN_VALUE, (long) Integer.MIN_VALUE, (long) Short.MIN_VALUE, -128L, -1L));
+        });
 
     execute(connection, "TRUNCATE TABLE " + tableName);
     execute(connection, "INSERT INTO " + tableName + " VALUES (0), (NULL), (42)");
-    assertSingleColumnRows(connection, tableName, Arrays.asList(0L, 42L, null));
+
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    withQueryResult(
+        connection,
+        "SELECT * FROM " + tableName + " ORDER BY col",
+        resultSet -> {
+
+          // Then Result should contain integers [0, 42, NULL]
+          assertSingleColumnRows(resultSet, Arrays.asList(0L, 42L, null));
+        });
   }
 
   @Test
   public void shouldSelectLargeIntegerValuesFromTableForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with <type> column exists with values [-99999999999999999999999999999999999999,
     // 99999999999999999999999999999999999999]
-    // When Query "SELECT * FROM <table> ORDER BY col" is executed
-    // Then Result should contain integers [-99999999999999999999999999999999999999,
-    // 99999999999999999999999999999999999999]
-    Connection connection = getDefaultConnection();
     String tableName = createTempTable(connection, "ud_int_", "col " + INT_TYPE);
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES (" + SMALL_INT + "), (" + LARGE_INT + ")");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      assertTrue(resultSet.next(), "Expected first row for type: " + INT_TYPE);
-      assertEquals(new BigDecimal(SMALL_INT), resultSet.getBigDecimal(1));
-      assertFalse(resultSet.wasNull(), "First row should not be NULL for " + INT_TYPE);
-      assertTrue(resultSet.next(), "Expected second row for type: " + INT_TYPE);
-      assertEquals(new BigDecimal(LARGE_INT), resultSet.getBigDecimal(1));
-      assertFalse(resultSet.wasNull(), "Second row should not be NULL for " + INT_TYPE);
-      assertFalse(resultSet.next(), "Expected exactly two rows for type: " + INT_TYPE);
-    }
+    // When Query "SELECT * FROM <table> ORDER BY col" is executed
+    withQueryResult(
+        connection,
+        "SELECT * FROM " + tableName + " ORDER BY col",
+        resultSet -> {
+
+          // Then Result should contain integers [-99999999999999999999999999999999999999,
+          // 99999999999999999999999999999999999999]
+          assertTrue(resultSet.next(), "Expected first row for type: " + INT_TYPE);
+          assertEquals(new BigDecimal(SMALL_INT), resultSet.getBigDecimal(1));
+          assertFalse(resultSet.wasNull(), "First row should not be NULL for " + INT_TYPE);
+          assertTrue(resultSet.next(), "Expected second row for type: " + INT_TYPE);
+          assertEquals(new BigDecimal(LARGE_INT), resultSet.getBigDecimal(1));
+          assertFalse(resultSet.wasNull(), "Second row should not be NULL for " + INT_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly two rows for type: " + INT_TYPE);
+        });
   }
 
   @Test
   public void shouldHandleServerSideArrowMemoryOptimizationForIntColumnsOnMultipleChunks()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with four INT columns exists
-    // And Each column contains values of different magnitudes (50000 rows to span multiple Arrow
-    // chunks)
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 50000 rows
-    // And All values should be equal to expected data
     final long expectedInt8Value = 100L;
     final long expectedInt16Value = 30_000L;
     final long expectedInt32Value = 2_000_000_000L;
     final long expectedInt64Value = 9_000_000_000_000_000_000L;
-
-    Connection connection = getDefaultConnection();
     String tableName =
         createTempTable(
             connection,
             "ud_int_arrow_",
             "col_int8 INT, col_int16 INT, col_int32 INT, col_int64 INT");
+
+    // And Each column contains values of different magnitudes (50000 rows to span multiple Arrow
+    // chunks)
     execute(
         connection,
         "INSERT INTO "
@@ -243,35 +322,39 @@ public class IntTests extends SnowflakeIntegrationTestBase {
             + LARGE_RESULT_SET_SIZE
             + "))");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName)) {
-      int rowCount = 0;
-      while (resultSet.next()) {
-        assertEquals(
-            expectedInt8Value, resultSet.getLong(1), "col_int8 mismatch at row " + rowCount);
-        assertEquals(
-            expectedInt16Value, resultSet.getLong(2), "col_int16 mismatch at row " + rowCount);
-        assertEquals(
-            expectedInt32Value, resultSet.getLong(3), "col_int32 mismatch at row " + rowCount);
-        assertEquals(
-            expectedInt64Value, resultSet.getLong(4), "col_int64 mismatch at row " + rowCount);
-        rowCount++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, rowCount, "Unexpected row count");
-    }
+    // When Query "SELECT * FROM <table>" is executed
+    withQueryResult(
+        connection,
+        "SELECT * FROM " + tableName,
+        resultSet -> {
+
+          // Then Result should contain 50000 rows with all values equal to expected data
+          int rowCount = 0;
+          while (resultSet.next()) {
+            assertEquals(
+                expectedInt8Value, resultSet.getLong(1), "col_int8 mismatch at row " + rowCount);
+            assertEquals(
+                expectedInt16Value, resultSet.getLong(2), "col_int16 mismatch at row " + rowCount);
+            assertEquals(
+                expectedInt32Value, resultSet.getLong(3), "col_int32 mismatch at row " + rowCount);
+            assertEquals(
+                expectedInt64Value, resultSet.getLong(4), "col_int64 mismatch at row " + rowCount);
+            rowCount++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, rowCount, "Unexpected row count");
+        });
   }
 
   @Test
   public void shouldInsertIntegerUsingParameterBindingForIntAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with <type> column exists
-    // When Integer values [0, -2147483648, 2147483647, 9223372036854775807] are inserted using
-    // binding
-    // And Query "SELECT * FROM <table>" is executed
-    // Then Result should contain integers [0, -2147483648, 2147483647, 9223372036854775807]
     Connection connection = getDefaultConnection();
+
+    // And Table with <type> column exists
     String tableName = createTempTable(connection, "ud_int_", "col " + INT_TYPE);
 
+    // When Integer values [0, -2147483648, 2147483647, 9223372036854775807] are inserted using
+    // binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
       preparedStatement.setLong(1, 0L);
@@ -284,45 +367,45 @@ public class IntTests extends SnowflakeIntegrationTestBase {
       preparedStatement.execute();
     }
 
-    assertSingleColumnRows(
+    // And Query "SELECT * FROM <table>" is executed
+    withQueryResult(
         connection,
-        tableName,
-        Arrays.asList((long) Integer.MIN_VALUE, 0L, (long) Integer.MAX_VALUE, Long.MAX_VALUE));
+        "SELECT * FROM " + tableName + " ORDER BY col",
+        resultSet -> {
+
+          // Then Result should contain integers [0, -2147483648, 2147483647, 9223372036854775807]
+          assertSingleColumnRows(
+              resultSet,
+              Arrays.asList(
+                  (long) Integer.MIN_VALUE, 0L, (long) Integer.MAX_VALUE, Long.MAX_VALUE));
+        });
   }
 
-  private static void assertSingleRow(Connection connection, String sql, List<Long> expected)
+  private static void assertSingleRow(ResultSet resultSet, List<Long> expected) throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
+    for (int i = 0; i < expected.size(); i++) {
+      assertAllIntegerGettersInRange(
+          resultSet, i + 1, expected.get(i), "Column mismatch for " + INT_TYPE);
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
+  }
+
+  private static void assertSingleColumnRows(ResultSet resultSet, List<Long> expectedValues)
       throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + INT_TYPE);
-      for (int i = 0; i < expected.size(); i++) {
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertTrue(resultSet.next(), "Missing row " + i + " for " + INT_TYPE);
+      Long expected = expectedValues.get(i);
+      if (expected == null) {
+        assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + INT_TYPE);
+        assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
+        assertEquals(0L, resultSet.getLong(1), "Expected getLong=0 for NULL at row " + i);
+        assertTrue(resultSet.wasNull(), "Expected wasNull() after getLong NULL at row " + i);
+      } else {
         assertAllIntegerGettersInRange(
-            resultSet, i + 1, expected.get(i), "Column mismatch for " + INT_TYPE);
+            resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + i);
       }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + INT_TYPE);
     }
-  }
-
-  private static void assertSingleColumnRows(
-      Connection connection, String tableName, List<Long> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY col")) {
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertTrue(resultSet.next(), "Missing row " + i + " for " + INT_TYPE);
-        Long expected = expectedValues.get(i);
-        if (expected == null) {
-          assertNull(resultSet.getObject(1), "Expected NULL at row " + i + " for " + INT_TYPE);
-          assertTrue(resultSet.wasNull(), "Expected wasNull() after getObject NULL at row " + i);
-          assertEquals(0L, resultSet.getLong(1), "Expected getLong=0 for NULL at row " + i);
-          assertTrue(resultSet.wasNull(), "Expected wasNull() after getLong NULL at row " + i);
-        } else {
-          assertAllIntegerGettersInRange(
-              resultSet, 1, expected, "Value mismatch for " + INT_TYPE + ", row " + i);
-        }
-      }
-      assertFalse(resultSet.next(), "Unexpected extra rows for " + INT_TYPE);
-    }
+    assertFalse(resultSet.next(), "Unexpected extra rows for " + INT_TYPE);
   }
 
   private static void assertAllIntegerGettersInRange(

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/NumberTests.java
@@ -13,7 +13,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
-import java.sql.Statement;
 import java.sql.Types;
 import java.text.DecimalFormat;
 import java.text.ParseException;
@@ -35,60 +34,71 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastNumberValuesToAppropriateTypeForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0::<type>(10,0), 123::<type>(10,0), 0.00::<type>(10,2),
     // 123.45::<type>(10,2)" is executed
-    // Then All values should be returned as appropriate type
-    // And Values should match [0, 123, 0.00, 123.45]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT 0::%1$s(10,0), 123::%1$s(10,0), 0.00::%1$s(10,2), 123.45::%1$s(10,2)",
             NUMBER_TYPE);
-    assertSingleRowWithNulls(
+
+    withQueryResult(
         connection,
         sql,
-        Arrays.asList(
-            new BigDecimal("0"),
-            new BigDecimal("123"),
-            new BigDecimal("0.00"),
-            new BigDecimal("123.45")));
+        resultSet -> {
+
+          // Then All values should be returned as appropriate type matching [0, 123, 0.00, 123.45]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("0"),
+                  new BigDecimal("123"),
+                  new BigDecimal("0.00"),
+                  new BigDecimal("123.45")));
+        });
   }
 
   @Test
   public void shouldSelectNumberLiteralsForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 0::<type>(10,0), -456::<type>(10,0), 1.50::<type>(10,2),
     // -123.45::<type>(10,2), 123.456::<type>(15,3), -789.012::<type>(15,3)" is executed
-    // Then Result should contain [0, -456, 1.50, -123.45, 123.456, -789.012]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT 0::%1$s(10,0), -456::%1$s(10,0), 1.50::%1$s(10,2), -123.45::%1$s(10,2), "
                 + "123.456::%1$s(15,3), -789.012::%1$s(15,3)",
             NUMBER_TYPE);
-    assertSingleRowWithNulls(
+
+    withQueryResult(
         connection,
         sql,
-        Arrays.asList(
-            new BigDecimal("0"),
-            new BigDecimal("-456"),
-            new BigDecimal("1.50"),
-            new BigDecimal("-123.45"),
-            new BigDecimal("123.456"),
-            new BigDecimal("-789.012")));
+        resultSet -> {
+
+          // Then Result should contain [0, -456, 1.50, -123.45, 123.456, -789.012]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("0"),
+                  new BigDecimal("-456"),
+                  new BigDecimal("1.50"),
+                  new BigDecimal("-123.45"),
+                  new BigDecimal("123.456"),
+                  new BigDecimal("-789.012")));
+        });
   }
 
   @Test
   public void shouldHandleHighPrecisionValuesFromLiteralsForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 12345678901234567890123456789012345678::<type>(38,0),
     // 123456789012345678901234567890123456.78::<type>(38,2),
     // 1234567890123456789012345678.1234567890::<type>(38,10),
     // 0.0000000000000000000000000000000000001::<type>(38,37)" is executed
-    // Then Result should contain [12345678901234567890123456789012345678,
-    // 123456789012345678901234567890123456.78, 1234567890123456789012345678.1234567890,
-    // 0.0000000000000000000000000000000000001]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT 12345678901234567890123456789012345678::%1$s(38,0), "
@@ -96,173 +106,221 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
                 + "1234567890123456789012345678.1234567890::%1$s(38,10), "
                 + "0.0000000000000000000000000000000000001::%1$s(38,37)",
             NUMBER_TYPE);
-    assertSingleRowWithNulls(
+
+    withQueryResult(
         connection,
         sql,
-        Arrays.asList(
-            new BigDecimal("12345678901234567890123456789012345678"),
-            new BigDecimal("123456789012345678901234567890123456.78"),
-            new BigDecimal("1234567890123456789012345678.1234567890"),
-            new BigDecimal("0.0000000000000000000000000000000000001")));
+        resultSet -> {
+
+          // Then Result should contain [12345678901234567890123456789012345678,
+          // 123456789012345678901234567890123456.78, 1234567890123456789012345678.1234567890,
+          // 0.0000000000000000000000000000000000001]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("12345678901234567890123456789012345678"),
+                  new BigDecimal("123456789012345678901234567890123456.78"),
+                  new BigDecimal("1234567890123456789012345678.1234567890"),
+                  new BigDecimal("0.0000000000000000000000000000000000001")));
+        });
   }
 
   @Test
   public void shouldHandleScaleAndPrecisionBoundariesFromLiteralsForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 999.99::<type>(5,2), -999.99::<type>(5,2), 99999999::<type>(8,0),
     // -99999999::<type>(8,0)" is executed
-    // Then Result should contain [999.99, -999.99, 99999999, -99999999]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT 999.99::%1$s(5,2), -999.99::%1$s(5,2), 99999999::%1$s(8,0), -99999999::%1$s(8,0)",
             NUMBER_TYPE);
-    assertSingleRowWithNulls(
+
+    withQueryResult(
         connection,
         sql,
-        Arrays.asList(
-            new BigDecimal("999.99"),
-            new BigDecimal("-999.99"),
-            new BigDecimal("99999999"),
-            new BigDecimal("-99999999")));
+        resultSet -> {
+
+          // Then Result should contain [999.99, -999.99, 99999999, -99999999]
+          assertSingleRowWithNulls(
+              resultSet,
+              Arrays.asList(
+                  new BigDecimal("999.99"),
+                  new BigDecimal("-999.99"),
+                  new BigDecimal("99999999"),
+                  new BigDecimal("-99999999")));
+        });
   }
 
   @Test
   public void shouldHandleHighPrecisionBoundariesFromLiteralsForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 99999999999999999999999999999999999999::<type>(38,0),
     // -99999999999999999999999999999999999999::<type>(38,0)" is executed
-    // Then Result should contain max and min 38-digit integers
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT %1$s::%3$s(38,0), %2$s::%3$s(38,0)", MAX_38_DIGIT, MIN_38_DIGIT, NUMBER_TYPE);
-    assertSingleRowWithNulls(
-        connection, sql, Arrays.asList(new BigDecimal(MAX_38_DIGIT), new BigDecimal(MIN_38_DIGIT)));
+
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain max and min 38-digit integers
+          assertSingleRowWithNulls(
+              resultSet, Arrays.asList(new BigDecimal(MAX_38_DIGIT), new BigDecimal(MIN_38_DIGIT)));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromLiteralsForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT NULL::<type>(10,0), 42::<type>(10,0), NULL::<type>(10,2),
     // 42.50::<type>(10,2)"
     // is executed
-    // Then Result should contain [NULL, 42, NULL, 42.50]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT NULL::%1$s(10,0), 42::%1$s(10,0), NULL::%1$s(10,2), 42.50::%1$s(10,2)",
             NUMBER_TYPE);
-    assertSingleRowWithNulls(
-        connection, sql, Arrays.asList(null, new BigDecimal("42"), null, new BigDecimal("42.50")));
+
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [NULL, 42, NULL, 42.50]
+          assertSingleRowWithNulls(
+              resultSet, Arrays.asList(null, new BigDecimal("42"), null, new BigDecimal("42.50")));
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetWithMultipleChunksFromGeneratorForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM
     // TABLE(GENERATOR(ROWCOUNT => 30000)) v" is executed
-    // Then Column 1 should contain sequential integers from 0 to 29999
-    // And Column 2 should contain sequential decimals starting from 0.12345
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT seq8()::%1$s(38,0), (seq8() + 0.12345)::%1$s(20,5) "
                 + "FROM TABLE(GENERATOR(ROWCOUNT => %2$d)) v ORDER BY 1",
             NUMBER_TYPE, LARGE_RESULT_SET_SIZE);
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int expectedRow = 0;
-      while (resultSet.next()) {
-        assertDecimalColumn(
-            resultSet,
-            1,
-            BigDecimal.valueOf(expectedRow),
-            "Column 1 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
-        assertDecimalColumn(
-            resultSet,
-            2,
-            BigDecimal.valueOf(expectedRow).add(DECIMAL_INCREMENT).setScale(5),
-            "Column 2 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
-        expectedRow++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expectedRow, "Unexpected row count for " + NUMBER_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 30000 rows with sequential integers in column 1 and
+          // sequential
+          // decimals starting from 0.12345 in column 2
+          int expectedRow = 0;
+          while (resultSet.next()) {
+            assertDecimalColumn(
+                resultSet,
+                1,
+                BigDecimal.valueOf(expectedRow),
+                "Column 1 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
+            assertDecimalColumn(
+                resultSet,
+                2,
+                BigDecimal.valueOf(expectedRow).add(DECIMAL_INCREMENT).setScale(5),
+                "Column 2 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
+            expectedRow++;
+          }
+          assertEquals(
+              LARGE_RESULT_SET_SIZE, expectedRow, "Unexpected row count for " + NUMBER_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectNumbersFromTableWithMultipleScalesForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
-    // And Row (123, 123.45, 123.456, 12345.67890) is inserted
-    // And Row (-456, -67.89, -789.012, -98765.43210) is inserted
-    // And Row (0, 0.00, 0.000, 0.00000) is inserted
-    // And Row (999999, 999.99, 1000.500, 123456.78901) is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 4 rows with expected values
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
     String tableName =
         createTempTable(
             connection,
             "ud_number_",
             String.format(
                 "c1 %1$s(10,0), c2 %1$s(10,2), c3 %1$s(15,3), c4 %1$s(20,5)", NUMBER_TYPE));
+
+    // And Row (123, 123.45, 123.456, 12345.67890) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (123, 123.45, 123.456, 12345.67890)");
+
+    // And Row (-456, -67.89, -789.012, -98765.43210) is inserted
     execute(
         connection, "INSERT INTO " + tableName + " VALUES (-456, -67.89, -789.012, -98765.43210)");
+
+    // And Row (0, 0.00, 0.000, 0.00000) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (0, 0.00, 0.000, 0.00000)");
+
+    // And Row (999999, 999.99, 1000.500, 123456.78901) is inserted
     execute(
         connection,
         "INSERT INTO " + tableName + " VALUES (999999, 999.99, 1000.500, 123456.78901)");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1, c2, c3, c4";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1, c2, c3, c4",
-        Arrays.asList(
-            Arrays.asList(
-                new BigDecimal("-456"),
-                new BigDecimal("-67.89"),
-                new BigDecimal("-789.012"),
-                new BigDecimal("-98765.43210")),
-            Arrays.asList(
-                new BigDecimal("0"),
-                new BigDecimal("0.00"),
-                new BigDecimal("0.000"),
-                new BigDecimal("0.00000")),
-            Arrays.asList(
-                new BigDecimal("123"),
-                new BigDecimal("123.45"),
-                new BigDecimal("123.456"),
-                new BigDecimal("12345.67890")),
-            Arrays.asList(
-                new BigDecimal("999999"),
-                new BigDecimal("999.99"),
-                new BigDecimal("1000.500"),
-                new BigDecimal("123456.78901"))));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 4 rows with expected values
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(
+                      new BigDecimal("-456"),
+                      new BigDecimal("-67.89"),
+                      new BigDecimal("-789.012"),
+                      new BigDecimal("-98765.43210")),
+                  Arrays.asList(
+                      new BigDecimal("0"),
+                      new BigDecimal("0.00"),
+                      new BigDecimal("0.000"),
+                      new BigDecimal("0.00000")),
+                  Arrays.asList(
+                      new BigDecimal("123"),
+                      new BigDecimal("123.45"),
+                      new BigDecimal("123.456"),
+                      new BigDecimal("12345.67890")),
+                  Arrays.asList(
+                      new BigDecimal("999999"),
+                      new BigDecimal("999.99"),
+                      new BigDecimal("1000.500"),
+                      new BigDecimal("123456.78901"))));
+        });
   }
 
   @Test
   public void shouldHandleHighPrecisionValuesFromTableForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
-    // And Row (12345678901234567890123456789012345678, 123456789012345678901234567890123456.78,
-    // 1234567890123456789012345678.1234567890, 1.2345678901234567890123456789012345678) is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain [12345678901234567890123456789012345678,
-    // 123456789012345678901234567890123456.78, 1234567890123456789012345678.1234567890,
-    // 1.2345678901234567890123456789012345678]
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
     String tableName =
         createTempTable(
             connection,
             "ud_number_",
             String.format(
                 "c1 %1$s(38,0), c2 %1$s(38,2), c3 %1$s(38,10), c4 %1$s(38,37)", NUMBER_TYPE));
+
+    // And Row (12345678901234567890123456789012345678, 123456789012345678901234567890123456.78,
+    // 1234567890123456789012345678.1234567890, 1.2345678901234567890123456789012345678) is inserted
     execute(
         connection,
         "INSERT INTO "
@@ -272,75 +330,100 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
             + "1234567890123456789012345678.1234567890, "
             + "1.2345678901234567890123456789012345678)");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1",
-        Arrays.asList(
-            Arrays.asList(
-                new BigDecimal("12345678901234567890123456789012345678"),
-                new BigDecimal("123456789012345678901234567890123456.78"),
-                new BigDecimal("1234567890123456789012345678.1234567890"),
-                new BigDecimal("1.2345678901234567890123456789012345678"))));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain [12345678901234567890123456789012345678,
+          // 123456789012345678901234567890123456.78, 1234567890123456789012345678.1234567890,
+          // 1.2345678901234567890123456789012345678]
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(
+                      new BigDecimal("12345678901234567890123456789012345678"),
+                      new BigDecimal("123456789012345678901234567890123456.78"),
+                      new BigDecimal("1234567890123456789012345678.1234567890"),
+                      new BigDecimal("1.2345678901234567890123456789012345678"))));
+        });
   }
 
   @Test
   public void shouldHandleScaleAndPrecisionBoundariesFromTableForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(5,2), <type>(8,0)) exists
-    // And Row (999.99, 99999999) is inserted
-    // And Row (-999.99, -99999999) is inserted
-    // And Row (123.45, 12345678) is inserted
-    // And Row (0.01, 0) is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 4 rows with expected boundary values
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(5,2), <type>(8,0)) exists
     String tableName =
         createTempTable(
             connection, "ud_number_", String.format("c1 %1$s(5,2), c2 %1$s(8,0)", NUMBER_TYPE));
+
+    // And Row (999.99, 99999999) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (999.99, 99999999)");
+
+    // And Row (-999.99, -99999999) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (-999.99, -99999999)");
+
+    // And Row (123.45, 12345678) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (123.45, 12345678)");
+
+    // And Row (0.01, 0) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (0.01, 0)");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1, c2";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1, c2",
-        Arrays.asList(
-            Arrays.asList(new BigDecimal("-999.99"), new BigDecimal("-99999999")),
-            Arrays.asList(new BigDecimal("0.01"), new BigDecimal("0")),
-            Arrays.asList(new BigDecimal("123.45"), new BigDecimal("12345678")),
-            Arrays.asList(new BigDecimal("999.99"), new BigDecimal("99999999"))));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 4 rows with expected boundary values
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(new BigDecimal("-999.99"), new BigDecimal("-99999999")),
+                  Arrays.asList(new BigDecimal("0.01"), new BigDecimal("0")),
+                  Arrays.asList(new BigDecimal("123.45"), new BigDecimal("12345678")),
+                  Arrays.asList(new BigDecimal("999.99"), new BigDecimal("99999999"))));
+        });
   }
 
   @Test
   public void shouldHandleHighPrecisionBoundariesFromTableForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(38,0), <type>(38,37)) exists
-    // And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678)
-    // is inserted
-    // And Row (-99999999999999999999999999999999999999,
-    // -1.2345678901234567890123456789012345678) is inserted
-    // And Row (12345678901234567890123456789012345678, 0.0000000000000000000000000000000000001)
-    // is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 3 rows with expected high precision boundary values
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(38,0), <type>(38,37)) exists
     String tableName =
         createTempTable(
             connection, "ud_number_", String.format("c1 %1$s(38,0), c2 %1$s(38,37)", NUMBER_TYPE));
+
+    // And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678)
+    // is inserted
     execute(
         connection,
         "INSERT INTO "
             + tableName
             + " VALUES (99999999999999999999999999999999999999, "
             + "1.2345678901234567890123456789012345678)");
+
+    // And Row (-99999999999999999999999999999999999999,
+    // -1.2345678901234567890123456789012345678) is inserted
     execute(
         connection,
         "INSERT INTO "
             + tableName
             + " VALUES (-99999999999999999999999999999999999999, "
             + "-1.2345678901234567890123456789012345678)");
+
+    // And Row (12345678901234567890123456789012345678, 0.0000000000000000000000000000000000001)
+    // is inserted
     execute(
         connection,
         "INSERT INTO "
@@ -348,64 +431,85 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
             + " VALUES (12345678901234567890123456789012345678, "
             + "0.0000000000000000000000000000000000001)");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1, c2";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1, c2",
-        Arrays.asList(
-            Arrays.asList(
-                new BigDecimal("-99999999999999999999999999999999999999"),
-                new BigDecimal("-1.2345678901234567890123456789012345678")),
-            Arrays.asList(
-                new BigDecimal("12345678901234567890123456789012345678"),
-                new BigDecimal("0.0000000000000000000000000000000000001")),
-            Arrays.asList(
-                new BigDecimal("99999999999999999999999999999999999999"),
-                new BigDecimal("1.2345678901234567890123456789012345678"))));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 3 rows with expected high precision boundary values
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(
+                      new BigDecimal("-99999999999999999999999999999999999999"),
+                      new BigDecimal("-1.2345678901234567890123456789012345678")),
+                  Arrays.asList(
+                      new BigDecimal("12345678901234567890123456789012345678"),
+                      new BigDecimal("0.0000000000000000000000000000000000001")),
+                  Arrays.asList(
+                      new BigDecimal("99999999999999999999999999999999999999"),
+                      new BigDecimal("1.2345678901234567890123456789012345678"))));
+        });
   }
 
   @Test
   public void shouldHandleNULLValuesFromTableWithMultipleScalesForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
-    // And Row (NULL, NULL, NULL) is inserted
-    // And Row (123, 123.45, 123.456) is inserted
-    // And Row (NULL, NULL, NULL) is inserted
-    // And Row (-456, -67.89, -789.012) is inserted
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Result should contain 4 rows with 2 NULL rows and 2 non-NULL rows with expected values
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
     String tableName =
         createTempTable(
             connection,
             "ud_number_",
             String.format("c1 %1$s(10,0), c2 %1$s(10,2), c3 %1$s(15,3)", NUMBER_TYPE));
+
+    // And Row (NULL, NULL, NULL) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (NULL, NULL, NULL)");
+
+    // And Row (123, 123.45, 123.456) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (123, 123.45, 123.456)");
+
+    // And Row (NULL, NULL, NULL) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (NULL, NULL, NULL)");
+
+    // And Row (-456, -67.89, -789.012) is inserted
     execute(connection, "INSERT INTO " + tableName + " VALUES (-456, -67.89, -789.012)");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM <table>" is executed
+    String sql =
+        "SELECT * FROM " + tableName + " ORDER BY c1 NULLS FIRST, c2 NULLS FIRST, c3 NULLS FIRST";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1 NULLS FIRST, c2 NULLS FIRST, c3 NULLS FIRST",
-        Arrays.asList(
-            Arrays.asList(null, null, null),
-            Arrays.asList(null, null, null),
-            Arrays.asList(
-                new BigDecimal("-456"), new BigDecimal("-67.89"), new BigDecimal("-789.012")),
-            Arrays.asList(
-                new BigDecimal("123"), new BigDecimal("123.45"), new BigDecimal("123.456"))));
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 4 rows with 2 NULL rows and 2 non-NULL rows with expected
+          // values
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(null, null, null),
+                  Arrays.asList(null, null, null),
+                  Arrays.asList(
+                      new BigDecimal("-456"), new BigDecimal("-67.89"), new BigDecimal("-789.012")),
+                  Arrays.asList(
+                      new BigDecimal("123"), new BigDecimal("123.45"), new BigDecimal("123.456"))));
+        });
   }
 
   @Test
   public void shouldDownloadLargeResultSetFromTableForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from
     // 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
-    // When Query "SELECT * FROM <table>" is executed
-    // Then Column 1 should contain sequential integers from 0 to 29999
-    // And Column 2 should contain sequential decimals starting from 0.12345
-    Connection connection = getDefaultConnection();
     String tableName =
         createTempTable(
             connection, "ud_number_", String.format("c1 %1$s(38,0), c2 %1$s(20,5)", NUMBER_TYPE));
@@ -421,107 +525,128 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
             + LARGE_RESULT_SET_SIZE
             + "))");
 
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY c1")) {
-      int expectedRow = 0;
-      while (resultSet.next()) {
-        assertDecimalColumn(
-            resultSet,
-            1,
-            BigDecimal.valueOf(expectedRow),
-            "Column 1 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
-        assertDecimalColumn(
-            resultSet,
-            2,
-            BigDecimal.valueOf(expectedRow).add(DECIMAL_INCREMENT).setScale(5),
-            "Column 2 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
-        expectedRow++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expectedRow, "Unexpected row count for " + NUMBER_TYPE);
-    }
+    // When Query "SELECT * FROM <table>" is executed
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1";
+
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then Result should contain 30000 rows with sequential integers in column 1 and
+          // sequential
+          // decimals starting from 0.12345 in column 2
+          int expectedRow = 0;
+          while (resultSet.next()) {
+            assertDecimalColumn(
+                resultSet,
+                1,
+                BigDecimal.valueOf(expectedRow),
+                "Column 1 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
+            assertDecimalColumn(
+                resultSet,
+                2,
+                BigDecimal.valueOf(expectedRow).add(DECIMAL_INCREMENT).setScale(5),
+                "Column 2 mismatch for " + NUMBER_TYPE + ", row " + expectedRow);
+            expectedRow++;
+          }
+          assertEquals(
+              LARGE_RESULT_SET_SIZE, expectedRow, "Unexpected row count for " + NUMBER_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectNumberUsingParameterBindingForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT ?::<type>(10,0), ?::<type>(10,0), ?::<type>(10,2), ?::<type>(10,2),
     // ?::<type>(10,0)" is executed with bound values [123, -456, 12.34, -56.78, NULL]
-    // Then Result should contain [123, -456, 12.34, -56.78, NULL]
-    Connection connection = getDefaultConnection();
     String sql =
         String.format(
             "SELECT ?::%1$s(10,0), ?::%1$s(10,0), ?::%1$s(10,2), ?::%1$s(10,2), ?::%1$s(10,0)",
             NUMBER_TYPE);
-    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-      preparedStatement.setBigDecimal(1, new BigDecimal("123"));
-      preparedStatement.setBigDecimal(2, new BigDecimal("-456"));
-      preparedStatement.setBigDecimal(3, new BigDecimal("12.34"));
-      preparedStatement.setBigDecimal(4, new BigDecimal("-56.78"));
-      preparedStatement.setNull(5, Types.DECIMAL);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet, 1, new BigDecimal("123"), "Column 1 mismatch for " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet, 2, new BigDecimal("-456"), "Column 2 mismatch for " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet, 3, new BigDecimal("12.34"), "Column 3 mismatch for " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet, 4, new BigDecimal("-56.78"), "Column 4 mismatch for " + NUMBER_TYPE);
-        assertNull(resultSet.getObject(5), "Column 5 should be NULL for " + NUMBER_TYPE);
-        assertTrue(resultSet.wasNull(), "Column 5 should set wasNull() for " + NUMBER_TYPE);
-        assertNull(
-            resultSet.getBigDecimal(5), "Column 5 getBigDecimal should be NULL for " + NUMBER_TYPE);
-        assertTrue(
-            resultSet.wasNull(),
-            "Column 5 should set wasNull() after getBigDecimal for " + NUMBER_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
-      }
-    }
+    withPreparedQueryResult(
+        connection,
+        sql,
+        ps -> {
+          ps.setBigDecimal(1, new BigDecimal("123"));
+          ps.setBigDecimal(2, new BigDecimal("-456"));
+          ps.setBigDecimal(3, new BigDecimal("12.34"));
+          ps.setBigDecimal(4, new BigDecimal("-56.78"));
+          ps.setNull(5, Types.DECIMAL);
+        },
+        resultSet -> {
+
+          // Then Result should contain [123, -456, 12.34, -56.78, NULL]
+          assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet, 1, new BigDecimal("123"), "Column 1 mismatch for " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet, 2, new BigDecimal("-456"), "Column 2 mismatch for " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet, 3, new BigDecimal("12.34"), "Column 3 mismatch for " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet, 4, new BigDecimal("-56.78"), "Column 4 mismatch for " + NUMBER_TYPE);
+          assertNull(resultSet.getObject(5), "Column 5 should be NULL for " + NUMBER_TYPE);
+          assertTrue(resultSet.wasNull(), "Column 5 should set wasNull() for " + NUMBER_TYPE);
+          assertNull(
+              resultSet.getBigDecimal(5),
+              "Column 5 getBigDecimal should be NULL for " + NUMBER_TYPE);
+          assertTrue(
+              resultSet.wasNull(),
+              "Column 5 should set wasNull() after getBigDecimal for " + NUMBER_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectHighPrecisionNumberUsingParameterBindingForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT ?::<type>(38,0), ?::<type>(38,2)" is executed with bound values
     // [12345678901234567890123456789012345678, 123456789012345678901234567890123456.78]
-    // Then Result should contain [12345678901234567890123456789012345678,
-    // 123456789012345678901234567890123456.78]
-    Connection connection = getDefaultConnection();
     String sql = String.format("SELECT ?::%1$s(38,0), ?::%1$s(38,2)", NUMBER_TYPE);
-    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-      preparedStatement.setBigDecimal(1, new BigDecimal("12345678901234567890123456789012345678"));
-      preparedStatement.setBigDecimal(2, new BigDecimal("123456789012345678901234567890123456.78"));
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet,
-            1,
-            new BigDecimal("12345678901234567890123456789012345678"),
-            "Column 1 mismatch for " + NUMBER_TYPE);
-        assertDecimalColumn(
-            resultSet,
-            2,
-            new BigDecimal("123456789012345678901234567890123456.78"),
-            "Column 2 mismatch for " + NUMBER_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
-      }
-    }
+    withPreparedQueryResult(
+        connection,
+        sql,
+        ps -> {
+          ps.setBigDecimal(1, new BigDecimal("12345678901234567890123456789012345678"));
+          ps.setBigDecimal(2, new BigDecimal("123456789012345678901234567890123456.78"));
+        },
+        resultSet -> {
+
+          // Then Result should contain [12345678901234567890123456789012345678,
+          // 123456789012345678901234567890123456.78]
+          assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet,
+              1,
+              new BigDecimal("12345678901234567890123456789012345678"),
+              "Column 1 mismatch for " + NUMBER_TYPE);
+          assertDecimalColumn(
+              resultSet,
+              2,
+              new BigDecimal("123456789012345678901234567890123456.78"),
+              "Column 2 mismatch for " + NUMBER_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
+        });
   }
 
   @Test
   public void shouldInsertNumberUsingParameterBindingForNumberAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(10,0), <type>(10,2)) exists
-    // When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are
-    // inserted using binding
-    // Then Result should contain 5 rows with expected values
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(10,0), <type>(10,2)) exists
     String tableName =
         createTempTable(
             connection, "ud_number_", String.format("c1 %1$s(10,0), c2 %1$s(10,2)", NUMBER_TYPE));
+
+    // When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are
+    // inserted using binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
       preparedStatement.setBigDecimal(1, new BigDecimal("0"));
@@ -541,30 +666,38 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
       preparedStatement.execute();
     }
 
-    assertRowsInOrder(
+    // Then Result should contain 5 rows with expected values
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1 NULLS LAST, c2 NULLS LAST";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1 NULLS LAST, c2 NULLS LAST",
-        Arrays.asList(
-            Arrays.asList(new BigDecimal("-456"), new BigDecimal("-67.89")),
-            Arrays.asList(new BigDecimal("0"), new BigDecimal("0.00")),
-            Arrays.asList(new BigDecimal("123"), new BigDecimal("123.45")),
-            Arrays.asList(new BigDecimal("999999"), new BigDecimal("999.99")),
-            Arrays.asList(null, null)));
+        sql,
+        resultSet -> {
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  Arrays.asList(new BigDecimal("-456"), new BigDecimal("-67.89")),
+                  Arrays.asList(new BigDecimal("0"), new BigDecimal("0.00")),
+                  Arrays.asList(new BigDecimal("123"), new BigDecimal("123.45")),
+                  Arrays.asList(new BigDecimal("999999"), new BigDecimal("999.99")),
+                  Arrays.asList(null, null)));
+        });
   }
 
   @Test
   public void shouldInsertHighPrecisionNumberUsingParameterBindingForNumberAndSynonyms()
       throws Exception {
     // Given Snowflake client is logged in
-    // And Table with columns (<type>(38,0), <type>(38,2)) exists
-    // When Rows (12345678901234567890123456789012345678,
-    // 123456789012345678901234567890123456.78), (99999999999999999999999999999999999999, 0.01),
-    // (-99999999999999999999999999999999999999, -0.01) are inserted using binding
-    // Then Result should contain 3 rows with expected values keeping the precision
     Connection connection = getDefaultConnection();
+
+    // And Table with columns (<type>(38,0), <type>(38,2)) exists
     String tableName =
         createTempTable(
             connection, "ud_number_", String.format("c1 %1$s(38,0), c2 %1$s(38,2)", NUMBER_TYPE));
+
+    // When Rows (12345678901234567890123456789012345678,
+    // 123456789012345678901234567890123456.78), (99999999999999999999999999999999999999, 0.01),
+    // (-99999999999999999999999999999999999999, -0.01) are inserted using binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
       preparedStatement.setBigDecimal(1, new BigDecimal("12345678901234567890123456789012345678"));
@@ -578,60 +711,63 @@ public class NumberTests extends SnowflakeIntegrationTestBase {
       preparedStatement.execute();
     }
 
-    assertRowsInOrder(
+    // Then Result should contain 3 rows with expected values keeping the precision
+    String sql = "SELECT * FROM " + tableName + " ORDER BY c1";
+
+    withQueryResult(
         connection,
-        "SELECT * FROM " + tableName + " ORDER BY c1",
-        Arrays.asList(
-            Arrays.asList(
-                new BigDecimal("-99999999999999999999999999999999999999"), new BigDecimal("-0.01")),
-            Arrays.asList(
-                new BigDecimal("12345678901234567890123456789012345678"),
-                new BigDecimal("123456789012345678901234567890123456.78")),
-            Arrays.asList(
-                new BigDecimal("99999999999999999999999999999999999999"), new BigDecimal("0.01"))));
-  }
-
-  private static void assertSingleRowWithNulls(
-      Connection connection, String sql, List<BigDecimal> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
-      for (int i = 0; i < expectedValues.size(); i++) {
-        BigDecimal expected = expectedValues.get(i);
-        if (expected == null) {
-          assertNull(resultSet.getObject(i + 1), "Expected NULL for column " + (i + 1));
-          assertTrue(resultSet.wasNull(), "Expected wasNull() for NULL column " + (i + 1));
-          assertNull(
-              resultSet.getBigDecimal(i + 1), "Expected getBigDecimal NULL for column " + (i + 1));
-          assertTrue(
-              resultSet.wasNull(),
-              "Expected wasNull() after getBigDecimal NULL for column " + (i + 1));
-        } else {
-          assertDecimalColumn(
+        sql,
+        resultSet -> {
+          assertRowsInOrder(
               resultSet,
-              i + 1,
-              expected,
-              "Value mismatch for " + NUMBER_TYPE + ", column " + (i + 1));
-        }
-      }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
-    }
+              Arrays.asList(
+                  Arrays.asList(
+                      new BigDecimal("-99999999999999999999999999999999999999"),
+                      new BigDecimal("-0.01")),
+                  Arrays.asList(
+                      new BigDecimal("12345678901234567890123456789012345678"),
+                      new BigDecimal("123456789012345678901234567890123456.78")),
+                  Arrays.asList(
+                      new BigDecimal("99999999999999999999999999999999999999"),
+                      new BigDecimal("0.01"))));
+        });
   }
 
-  private static void assertRowsInOrder(
-      Connection connection, String sql, List<List<BigDecimal>> expectedRows) throws Exception {
-    List<List<BigDecimal>> actualRows = new ArrayList<>();
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      ResultSetMetaData metaData = resultSet.getMetaData();
-      int columnCount = metaData.getColumnCount();
-      while (resultSet.next()) {
-        List<BigDecimal> row = new ArrayList<>();
-        for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
-          row.add(resultSet.getBigDecimal(columnIndex));
-        }
-        actualRows.add(row);
+  private static void assertSingleRowWithNulls(ResultSet resultSet, List<BigDecimal> expectedValues)
+      throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + NUMBER_TYPE);
+    for (int i = 0; i < expectedValues.size(); i++) {
+      BigDecimal expected = expectedValues.get(i);
+      if (expected == null) {
+        assertNull(resultSet.getObject(i + 1), "Expected NULL for column " + (i + 1));
+        assertTrue(resultSet.wasNull(), "Expected wasNull() for NULL column " + (i + 1));
+        assertNull(
+            resultSet.getBigDecimal(i + 1), "Expected getBigDecimal NULL for column " + (i + 1));
+        assertTrue(
+            resultSet.wasNull(),
+            "Expected wasNull() after getBigDecimal NULL for column " + (i + 1));
+      } else {
+        assertDecimalColumn(
+            resultSet,
+            i + 1,
+            expected,
+            "Value mismatch for " + NUMBER_TYPE + ", column " + (i + 1));
       }
+    }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + NUMBER_TYPE);
+  }
+
+  private static void assertRowsInOrder(ResultSet resultSet, List<List<BigDecimal>> expectedRows)
+      throws Exception {
+    List<List<BigDecimal>> actualRows = new ArrayList<>();
+    ResultSetMetaData metaData = resultSet.getMetaData();
+    int columnCount = metaData.getColumnCount();
+    while (resultSet.next()) {
+      List<BigDecimal> row = new ArrayList<>();
+      for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
+        row.add(resultSet.getBigDecimal(columnIndex));
+      }
+      actualRows.add(row);
     }
 
     assertEquals(expectedRows.size(), actualRows.size(), "Unexpected row count for " + NUMBER_TYPE);

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringLobTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringLobTests.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 
@@ -19,35 +18,59 @@ public class StringLobTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldHandleLobStringAtHistorical16MbLimit() throws Exception {
     // Given Snowflake client is logged in
-    // And A temporary table with VARCHAR column is created
-    // When A string of 16777216 ASCII characters is generated and inserted
-    // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
-    // Then the result should show length 16777216
-    // And the returned string should exactly match the generated string
     Connection connection = getDefaultConnection();
+
+    // And A temporary table with VARCHAR column is created
     String tableName = createTempTable(connection, "ud_string_lob_", "val VARCHAR");
 
+    // When A string of 16777216 ASCII characters is generated and inserted
     String generated = generateExpectedString(LOB_16MB_SIZE);
     insertGeneratedLiteral(connection, tableName, generated);
 
-    assertLargeLob(connection, tableName, LOB_16MB_SIZE, generated);
+    // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
+    String sql = "SELECT val, LENGTH(val) as len FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+          assertTrue(resultSet.next(), "Expected one row for string LOB");
+
+          // Then the result should show length 16777216
+          assertLobLength(resultSet, LOB_16MB_SIZE);
+
+          // And the returned string should exactly match the generated string
+          assertLobValue(resultSet, LOB_16MB_SIZE, generated);
+          assertFalse(resultSet.next(), "Expected exactly one row for string LOB");
+        });
   }
 
   @Test
   public void shouldHandleLobStringAtMaximum128MbLimitWithIncreasedLobSize() throws Exception {
     // Given Snowflake client is logged in
-    // And A temporary table with VARCHAR column is created
-    // When A string of 134217728 ASCII characters is generated and inserted
-    // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
-    // Then the result should show length 134217728
-    // And the returned string should exactly match the generated string
     Connection connection = getDefaultConnection();
+
+    // And A temporary table with VARCHAR column is created
     String tableName = createTempTable(connection, "ud_string_lob_", "val VARCHAR(134217728)");
 
+    // When A string of 134217728 ASCII characters is generated and inserted
     String generated = generateExpectedString(LOB_128MB_SIZE);
     insertGeneratedLiteral(connection, tableName, generated);
 
-    assertLargeLob(connection, tableName, LOB_128MB_SIZE, generated);
+    // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
+    String sql = "SELECT val, LENGTH(val) as len FROM " + tableName;
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+          assertTrue(resultSet.next(), "Expected one row for string LOB");
+
+          // Then the result should show length 134217728
+          assertLobLength(resultSet, LOB_128MB_SIZE);
+
+          // And the returned string should exactly match the generated string
+          assertLobValue(resultSet, LOB_128MB_SIZE, generated);
+          assertFalse(resultSet.next(), "Expected exactly one row for string LOB");
+        });
   }
 
   private void insertGeneratedLiteral(Connection connection, String tableName, String generated)
@@ -58,22 +81,18 @@ public class StringLobTests extends SnowflakeIntegrationTestBase {
         "INSERT INTO " + tableName + " SELECT REPEAT('" + CHARS64 + "', " + repeatCount + ")");
   }
 
-  private static void assertLargeLob(
-      Connection connection, String tableName, int expectedLength, String expectedValue)
+  private static void assertLobLength(ResultSet resultSet, int expectedLength) throws Exception {
+    long actualLength = resultSet.getLong(2);
+    assertFalse(resultSet.wasNull(), "LOB length should not be NULL");
+    assertEquals(expectedLength, actualLength, "Unexpected LOB length");
+  }
+
+  private static void assertLobValue(ResultSet resultSet, int expectedLength, String expectedValue)
       throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet =
-            statement.executeQuery("SELECT val, LENGTH(val) as len FROM " + tableName)) {
-      assertTrue(resultSet.next(), "Expected one row for string LOB");
-      String actualValue = resultSet.getString(1);
-      assertFalse(resultSet.wasNull(), "LOB value should not be NULL");
-      long actualLength = resultSet.getLong(2);
-      assertFalse(resultSet.wasNull(), "LOB length should not be NULL");
-      assertEquals(expectedLength, actualLength, "Unexpected LOB length");
-      assertEquals(expectedLength, actualValue.length(), "Unexpected fetched LOB value length");
-      assertEquals(expectedValue, actualValue, "Fetched LOB value mismatch");
-      assertFalse(resultSet.next(), "Expected exactly one row for string LOB");
-    }
+    String actualValue = resultSet.getString(1);
+    assertFalse(resultSet.wasNull(), "LOB value should not be NULL");
+    assertEquals(expectedLength, actualValue.length(), "Unexpected fetched LOB value length");
+    assertEquals(expectedValue, actualValue, "Fetched LOB value mismatch");
   }
 
   private static String generateExpectedString(int targetLength) {

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/types/StringTests.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
@@ -28,87 +27,113 @@ public class StringTests extends SnowflakeIntegrationTestBase {
   @Test
   public void shouldCastStringValuesToAppropriateTypeForStringAndSynonyms() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
-    // Then All values should be returned as appropriate type
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
     String sql =
         String.format(
             "SELECT 'hello'::%1$s, 'Hello World'::%1$s, '%2$s'::%1$s", STRING_TYPE, JAPANESE_TEXT);
-    assertSingleRow(connection, sql, Arrays.asList("hello", "Hello World", JAPANESE_TEXT));
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then All values should be returned as appropriate type
+          assertSingleRow(resultSet, Arrays.asList("hello", "Hello World", JAPANESE_TEXT));
+        });
   }
 
   @Test
   public void shouldSelectHardcodedStringLiterals() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3"
     // is executed
-    // Then the result should contain:
-    Connection connection = getDefaultConnection();
-    assertSingleRow(
+    String sql = "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3";
+    withQueryResult(
         connection,
-        "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3",
-        Arrays.asList("hello", "Hello World", "Snowflake Driver Test"));
+        sql,
+        resultSet -> {
+
+          // Then the result should contain:
+          assertSingleRow(
+              resultSet, Arrays.asList("hello", "Hello World", "Snowflake Driver Test"));
+        });
   }
 
   @Test
   public void shouldSelectStringLiteralsWithCornerCaseValues() throws Exception {
     // Given Snowflake client is logged in
-    // When Query selecting corner case string literals is executed
-    // Then the result should contain expected corner case string values
     Connection connection = getDefaultConnection();
+
+    // When Query selecting corner case string literals is executed
     String sql =
         String.format(
             "SELECT ''::%1$s, 'X'::%1$s, '   '::%1$s, CHAR(9)::%1$s, CHAR(10)::%1$s, '%2$s'::%1$s,"
                 + " '%3$s'::%1$s, ''''::%1$s, CHAR(92)::%1$s, NULL::%1$s, '%4$s'::%1$s, '%5$s'::%1$s",
             STRING_TYPE, SNOWMAN, JAPANESE_TEXT, COMBINING_CHAR_TEXT, SURROGATE_PAIR_TEXT);
-    assertSingleRow(
+    withQueryResult(
         connection,
         sql,
-        Arrays.asList(
-            "",
-            "X",
-            "   ",
-            "\t",
-            "\n",
-            SNOWMAN,
-            JAPANESE_TEXT,
-            "'",
-            "\\",
-            null,
-            COMBINING_CHAR_TEXT,
-            SURROGATE_PAIR_TEXT));
+        resultSet -> {
+
+          // Then the result should contain expected corner case string values
+          assertSingleRow(
+              resultSet,
+              Arrays.asList(
+                  "",
+                  "X",
+                  "   ",
+                  "\t",
+                  "\n",
+                  SNOWMAN,
+                  JAPANESE_TEXT,
+                  "'",
+                  "\\",
+                  null,
+                  COMBINING_CHAR_TEXT,
+                  SURROGATE_PAIR_TEXT));
+        });
   }
 
   @Test
   public void shouldSelectHardcodedStringValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And A temporary table with VARCHAR column is created
-    // And The table is populated with string values
-    // When Query "SELECT * FROM {table}" is executed
-    // Then the result should contain the inserted hardcoded string values
     Connection connection = getDefaultConnection();
+
+    // And A temporary table with VARCHAR column is created
     String tableName = createTempTable(connection, "ud_string_", "id INT, col " + STRING_TYPE);
+
+    // And The table is populated with string values
     execute(
         connection,
         "INSERT INTO "
             + tableName
             + " VALUES (1, 'hello'), (2, 'Hello World'), (3, 'Snowflake Driver Test')");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM {table}" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY id";
+    withQueryResult(
         connection,
-        "SELECT col FROM " + tableName + " ORDER BY id",
-        Arrays.asList("hello", "Hello World", "Snowflake Driver Test"));
+        sql,
+        resultSet -> {
+
+          // Then the result should contain the inserted hardcoded string values
+          assertRowsInOrder(
+              resultSet, Arrays.asList("hello", "Hello World", "Snowflake Driver Test"));
+        });
   }
 
   @Test
   public void shouldSelectCornerCaseStringValuesFromTable() throws Exception {
     // Given Snowflake client is logged in
-    // And A temporary table with VARCHAR column is created
-    // And The table is populated with corner case string values
-    // When Query "SELECT * FROM {table}" is executed
-    // Then the result should contain the inserted corner case string values
     Connection connection = getDefaultConnection();
+
+    // And A temporary table with VARCHAR column is created
     String tableName = createTempTable(connection, "ud_string_", "id INT, col " + STRING_TYPE);
+
+    // And The table is populated with corner case string values
     execute(
         connection,
         "INSERT INTO "
@@ -134,104 +159,128 @@ public class StringTests extends SnowflakeIntegrationTestBase {
             + SURROGATE_PAIR_TEXT
             + "'");
 
-    assertRowsInOrder(
+    // When Query "SELECT * FROM {table}" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY id";
+    withQueryResult(
         connection,
-        "SELECT col FROM " + tableName + " ORDER BY id",
-        Arrays.asList(
-            "",
-            "X",
-            "   ",
-            "\t",
-            "\n",
-            SNOWMAN,
-            JAPANESE_TEXT,
-            "'",
-            "\\",
-            null,
-            COMBINING_CHAR_TEXT,
-            SURROGATE_PAIR_TEXT));
+        sql,
+        resultSet -> {
+
+          // Then the result should contain the inserted corner case string values
+          assertRowsInOrder(
+              resultSet,
+              Arrays.asList(
+                  "",
+                  "X",
+                  "   ",
+                  "\t",
+                  "\n",
+                  SNOWMAN,
+                  JAPANESE_TEXT,
+                  "'",
+                  "\\",
+                  null,
+                  COMBINING_CHAR_TEXT,
+                  SURROGATE_PAIR_TEXT));
+        });
   }
 
   @Test
   public void shouldDownloadStringDataInMultipleChunks() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT
     // => 10000)) v ORDER BY id" is executed
-    // Then there are 10000 rows returned
-    // And all returned string values should match the generated values in order
-    Connection connection = getDefaultConnection();
     String sql =
         "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val "
             + "FROM TABLE(GENERATOR(ROWCOUNT => "
             + LARGE_RESULT_SET_SIZE
             + ")) v ORDER BY id";
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      int expected = 0;
-      while (resultSet.next()) {
-        assertEquals(expected, resultSet.getLong(1), "ID mismatch at row " + expected);
-        assertFalse(resultSet.wasNull(), "ID should not be NULL at row " + expected);
-        assertStringColumn(
-            resultSet,
-            2,
-            String.valueOf(expected),
-            "String value mismatch for " + STRING_TYPE + ", row " + expected);
-        expected++;
-      }
-      assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + STRING_TYPE);
-    }
+    withQueryResult(
+        connection,
+        sql,
+        resultSet -> {
+
+          // Then there are 10000 rows returned and all string values should match the
+          // generated values in order
+          int expected = 0;
+          while (resultSet.next()) {
+            assertEquals(expected, resultSet.getLong(1), "ID mismatch at row " + expected);
+            assertFalse(resultSet.wasNull(), "ID should not be NULL at row " + expected);
+            assertStringColumn(
+                resultSet,
+                2,
+                String.valueOf(expected),
+                "String value mismatch for " + STRING_TYPE + ", row " + expected);
+            expected++;
+          }
+          assertEquals(LARGE_RESULT_SET_SIZE, expected, "Unexpected row count for " + STRING_TYPE);
+        });
   }
 
   @Test
   public void shouldInsertAndSelectBackHardcodedStringValuesUsingParameterBinding()
       throws Exception {
     // Given Snowflake client is logged in
-    // And A temporary table with VARCHAR column is created
-    // When String value 'Test binding value 日本語' is inserted using parameter binding
-    // And Query "SELECT * FROM {table}" is executed
-    // Then the result should contain the bound string value 'Test binding value 日本語'
     Connection connection = getDefaultConnection();
+
+    // And A temporary table with VARCHAR column is created
     String tableName = createTempTable(connection, "ud_string_", "id INT, col " + STRING_TYPE);
+
+    // When String value 'Test binding value 日本語' is inserted using parameter binding
     try (PreparedStatement preparedStatement =
         connection.prepareStatement("INSERT INTO " + tableName + " (id, col) VALUES (?, ?)")) {
       preparedStatement.setInt(1, 1);
       preparedStatement.setString(2, "Test binding value " + JAPANESE_TEXT);
       preparedStatement.execute();
     }
-    assertRowsInOrder(
+
+    // And Query "SELECT * FROM {table}" is executed
+    String sql = "SELECT col FROM " + tableName + " ORDER BY id";
+    withQueryResult(
         connection,
-        "SELECT col FROM " + tableName + " ORDER BY id",
-        Arrays.asList("Test binding value " + JAPANESE_TEXT));
+        sql,
+        resultSet -> {
+
+          // Then the result should contain the bound string value 'Test binding value 日本語'
+          assertRowsInOrder(resultSet, Arrays.asList("Test binding value " + JAPANESE_TEXT));
+        });
   }
 
   @Test
   public void shouldSelectStringLiteralsUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
     // When Query "SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR" is executed with bound string values
     // ['hello', 'Hello World', '日本語テスト']
-    // Then the result should contain:
-    Connection connection = getDefaultConnection();
     String sql = String.format("SELECT ?::%1$s, ?::%1$s, ?::%1$s", STRING_TYPE);
-    try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-      preparedStatement.setString(1, "hello");
-      preparedStatement.setString(2, "Hello World");
-      preparedStatement.setString(3, JAPANESE_TEXT);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
-        assertStringColumn(resultSet, 1, "hello", "Column 1 mismatch for " + STRING_TYPE);
-        assertStringColumn(resultSet, 2, "Hello World", "Column 2 mismatch for " + STRING_TYPE);
-        assertStringColumn(resultSet, 3, JAPANESE_TEXT, "Column 3 mismatch for " + STRING_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
-      }
-    }
+    // When
+    withPreparedQueryResult(
+        connection,
+        sql,
+        ps -> {
+          ps.setString(1, "hello");
+          ps.setString(2, "Hello World");
+          ps.setString(3, JAPANESE_TEXT);
+        },
+        resultSet -> {
+          // Then the result should contain:
+          assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+          assertStringColumn(resultSet, 1, "hello", "Column 1 mismatch for " + STRING_TYPE);
+          assertStringColumn(resultSet, 2, "Hello World", "Column 2 mismatch for " + STRING_TYPE);
+          assertStringColumn(resultSet, 3, JAPANESE_TEXT, "Column 3 mismatch for " + STRING_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+        });
   }
 
   @Test
   public void shouldSelectCornerCaseStringValuesUsingParameterBinding() throws Exception {
     // Given Snowflake client is logged in
-    // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
-    // Then the result should match the bound corner case value
     Connection connection = getDefaultConnection();
+
+    // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
     assertSingleBoundStringValue(connection, "");
     assertSingleBoundStringValue(connection, "X");
     assertSingleBoundStringValue(connection, "   ");
@@ -244,47 +293,39 @@ public class StringTests extends SnowflakeIntegrationTestBase {
     assertSingleBoundStringValue(connection, COMBINING_CHAR_TEXT);
     assertSingleBoundStringValue(connection, SURROGATE_PAIR_TEXT);
 
-    try (PreparedStatement preparedStatement =
-        connection.prepareStatement(String.format("SELECT ?::%1$s", STRING_TYPE))) {
-      preparedStatement.setNull(1, Types.VARCHAR);
-      try (ResultSet resultSet = preparedStatement.executeQuery()) {
-        assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
-        assertStringColumn(resultSet, 1, null, "NULL value mismatch for " + STRING_TYPE);
-        assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
-      }
-    }
+    // Then the result should match the bound corner case value
+    withPreparedQueryResult(
+        connection,
+        String.format("SELECT ?::%1$s", STRING_TYPE),
+        ps -> ps.setNull(1, Types.VARCHAR),
+        resultSet -> {
+          assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+          assertStringColumn(resultSet, 1, null, "NULL value mismatch for " + STRING_TYPE);
+          assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+        });
   }
 
-  private static void assertSingleRow(
-      Connection connection, String sql, List<String> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertStringColumn(
-            resultSet,
-            i + 1,
-            expectedValues.get(i),
-            "Column " + (i + 1) + " mismatch for " + STRING_TYPE);
-      }
-      assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
+  private static void assertSingleRow(ResultSet resultSet, List<String> expectedValues)
+      throws Exception {
+    assertTrue(resultSet.next(), "Expected one row for type: " + STRING_TYPE);
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertStringColumn(
+          resultSet,
+          i + 1,
+          expectedValues.get(i),
+          "Column " + (i + 1) + " mismatch for " + STRING_TYPE);
     }
+    assertFalse(resultSet.next(), "Expected exactly one row for type: " + STRING_TYPE);
   }
 
-  private static void assertRowsInOrder(
-      Connection connection, String sql, List<String> expectedValues) throws Exception {
-    try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(sql)) {
-      for (int i = 0; i < expectedValues.size(); i++) {
-        assertTrue(resultSet.next(), "Missing row " + i + " for " + STRING_TYPE);
-        assertStringColumn(
-            resultSet,
-            1,
-            expectedValues.get(i),
-            "Value mismatch for " + STRING_TYPE + ", row " + i);
-      }
-      assertFalse(resultSet.next(), "Unexpected extra rows for " + STRING_TYPE);
+  private static void assertRowsInOrder(ResultSet resultSet, List<String> expectedValues)
+      throws Exception {
+    for (int i = 0; i < expectedValues.size(); i++) {
+      assertTrue(resultSet.next(), "Missing row " + i + " for " + STRING_TYPE);
+      assertStringColumn(
+          resultSet, 1, expectedValues.get(i), "Value mismatch for " + STRING_TYPE + ", row " + i);
     }
+    assertFalse(resultSet.next(), "Unexpected extra rows for " + STRING_TYPE);
   }
 
   private static void assertStringColumn(

--- a/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
@@ -141,17 +141,3 @@ TEST_CASE("should return correct rowset for GET", "[put_get]") {
   OLD_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_MESSAGE_IDX) == "DECRYPTED"); }
   NEW_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_MESSAGE_IDX) == ""); }
 }
-
-TEST_CASE("should return correct column metadata for PUT", "[put_get]") {
-  SKIP("SNOW-2391324: Metadata check not implemented in new driver (SQLDescribeCol returns IM001)");
-  // Given Snowflake client is logged in
-  // When File is uploaded to stage
-  // Then Column metadata for PUT command should be correct
-}
-
-TEST_CASE("should return correct column metadata for GET", "[put_get]") {
-  SKIP("SNOW-2391324: Metadata check not implemented in new driver (SQLDescribeCol returns IM001)");
-  // Given File is uploaded to stage
-  // When File is downloaded using GET command
-  // Then Column metadata for GET command should be correct
-}

--- a/odbc_tests/tests/e2e/put_get/put_get_source_compression.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_source_compression.cpp
@@ -174,10 +174,10 @@ TEST_CASE("should compress uncompressed file when SOURCE_COMPRESSION set to NONE
 }
 
 TEST_CASE("should return error for unsupported compression type", "[put_get]") {
+  // Given Snowflake client is logged in
   Connection conn;
   const std::string stage = create_stage(conn, unique_stage_name("ODBCTST_SC_UNSUPPORTED"));
 
-  // Given Snowflake client is logged in
   // And File compressed with unsupported format
   auto [filename, file] = test_file("LZMA");
 

--- a/odbc_tests/tests/e2e/query/basic_execute_query.cpp
+++ b/odbc_tests/tests/e2e/query/basic_execute_query.cpp
@@ -102,8 +102,11 @@ TEST_CASE("should execute CREATE and DROP TABLE statements", "[query]") {
   auto random_schema = Schema::use_random_schema(conn);
 
   // When CREATE TABLE statement is executed
-  // Then the table should be created successfully
   conn.execute("CREATE TABLE basic_exec_test (id INT, name VARCHAR(100))");
+
+  // Then the table should be created successfully
+  auto verify_stmt = conn.execute_fetch("SELECT COUNT(*) FROM basic_exec_test");
+  CHECK(get_data<SQL_C_LONG>(verify_stmt, 1) == 0);
 
   // And DROP TABLE statement should complete successfully
   conn.execute("DROP TABLE basic_exec_test");

--- a/odbc_tests/tests/e2e/query/sql_bind_col.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_col.cpp
@@ -2117,11 +2117,9 @@ TEST_CASE("SQLBindCol supports SQL_C_NUMERIC binding.", "[query][bind_col]") {
 // =============================================================================
 
 TEST_CASE("SQLBindCol works with SQLFetchScroll.", "[query][bind_col]") {
-  // Doc: "SQLBindCol is used to associate, or bind, columns in the result set
-  //       to data buffers and length/indicator buffers in the application.
-  //       When the application calls SQLFetch, SQLFetchScroll, or SQLSetPos to
-  //       fetch data, the driver returns the data for the bound columns in the
-  //       specified buffers."
+  // Doc: "SQLBindCol is used to associate, or bind, columns in the result set to data buffers
+  //       and length/indicator buffers in the application." The driver returns the data for the
+  //       bound columns in the specified buffers when SQLFetch, SQLFetchScroll, or SQLSetPos is called.
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlbindcol-function#comments
 
   // Given Snowflake client is logged in

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -54,8 +54,7 @@ TEST_CASE("SQLSetStmtAttr sets supported cursor types.") {
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When SQLSetStmtAttr is called with SQL_ATTR_CURSOR_TYPE to set the cursor type
-  // And SQLGetStmtAttr is called to get the current cursor type
+  // When SQLSetStmtAttr is called with SQL_ATTR_CURSOR_TYPE and SQLGetStmtAttr is called to get the current cursor type
   SQLULEN cursor_type = -1;
   SQLINTEGER length = 0;
 
@@ -1031,12 +1030,10 @@ TEST_CASE("SQLFetch moves cursor forward when no columns are bound.", "[query]")
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When SQLExecDirect is called to execute a query that returns 3 rows
+  // When SQLExecDirect is called to execute a query that returns 3 rows with no columns bound
   SQLRETURN ret = SQLExecDirect(
       stmt.getHandle(), (SQLCHAR*)"SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 3)) ORDER BY id", SQL_NTS);
   CHECK_ODBC(ret, stmt);
-
-  // And no columns are bound
 
   // Then SQLFetch should return SQL_SUCCESS for each row
   ret = SQLFetch(stmt.getHandle());
@@ -1056,7 +1053,6 @@ TEST_CASE("SQLFetch moves cursor forward when no columns are bound.", "[query]")
   REQUIRE(ret == SQL_NO_DATA);
 
   // And SQLGetData can still retrieve data after moving cursor without bound columns
-  // Reset and test again
   ret = SQLFreeStmt(stmt.getHandle(), SQL_CLOSE);
   CHECK_ODBC(ret, stmt);
 

--- a/odbc_tests/tests/e2e/query/sql_get_data.cpp
+++ b/odbc_tests/tests/e2e/query/sql_get_data.cpp
@@ -707,6 +707,7 @@ TEST_CASE("SQLGetData retrieves data in increasing column number order.", "[quer
   SQLINTEGER value = 0;
   SQLLEN indicator = 0;
 
+  // Then each column should return its correct value
   SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
   CHECK_ODBC(ret, stmt);
   CHECK(value == 1);
@@ -1332,7 +1333,7 @@ TEST_CASE("SQLGetData with SQL_ARD_TYPE uses the type from the ARD descriptor.",
 TEST_CASE("SQLGetData with SQL_ARD_TYPE returns 07009 error when ARD is unmodified.", "[query][get_data]") {
   // Doc: "If TargetType is SQL_ARD_TYPE, the driver uses the type identifier
   //       specified in the SQL_DESC_CONCISE_TYPE field of the ARD."
-  // When no descriptor fields have been set, SQL_DESC_CONCISE_TYPE defaults to
+  // Note: when no descriptor fields have been set, SQL_DESC_CONCISE_TYPE defaults to
   // SQL_C_DEFAULT, but the current implementation returns error 07009 (Invalid descriptor index).
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function#arguments
 
@@ -1468,6 +1469,8 @@ TEST_CASE("SQLGetData returns SQL_NULL_DATA for NULL value regardless of TargetT
   SQLLEN int_ind = 0;
   ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &int_value, sizeof(int_value), &int_ind);
   CHECK_ODBC(ret, stmt);
+
+  // Then both should return SQL_NULL_DATA indicator
   CHECK(int_ind == SQL_NULL_DATA);
 }
 
@@ -1498,12 +1501,14 @@ TEST_CASE("SQLGetData retrieves same data for same column on same row with SQL_G
   SQLLEN col2_ind = 0;
   ret = SQLGetData(stmt.getHandle(), 2, SQL_C_CHAR, col2, sizeof(col2), &col2_ind);
   CHECK_ODBC(ret, stmt);
-  CHECK(std::string((char*)col2) == "hello");
 
   SQLINTEGER col1 = 0;
   SQLLEN col1_ind = 0;
   ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &col1, sizeof(col1), &col1_ind);
   CHECK_ODBC(ret, stmt);
+
+  // Then both columns should return their correct values
+  CHECK(std::string((char*)col2) == "hello");
   CHECK(col1 == 42);
 }
 
@@ -1667,13 +1672,14 @@ TEST_CASE("SQLGetData converts same integer to multiple C types.", "[query][get_
   // Given Snowflake client is logged in
   Connection conn;
 
-  // Test SQL_C_LONG
+  // When SQLGetData retrieves the same integer value using different C types
   {
     auto stmt = conn.execute_fetch("SELECT 42 AS value");
     SQLINTEGER value = 0;
     SQLLEN indicator = 0;
     SQLRETURN ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
     CHECK_ODBC(ret, stmt);
+    // Then each C type conversion should return the correct value
     CHECK(value == 42);
   }
 

--- a/odbc_tests/tests/e2e/types/boolean.cpp
+++ b/odbc_tests/tests/e2e/types/boolean.cpp
@@ -19,10 +19,14 @@ TEST_CASE("should cast boolean values to appropriate type", "[boolean]") {
   const auto stmt = conn.execute_fetch("SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN");
 
   // Then All values should be returned as appropriate type
+  auto col1 = get_data<SQL_C_BIT>(stmt, 1);
+  auto col2 = get_data<SQL_C_BIT>(stmt, 2);
+  auto col3 = get_data<SQL_C_BIT>(stmt, 3);
+
   // And Values should match [TRUE, FALSE, TRUE]
-  REQUIRE(get_data<SQL_C_BIT>(stmt, 1) == 1);
-  REQUIRE(get_data<SQL_C_BIT>(stmt, 2) == 0);
-  REQUIRE(get_data<SQL_C_BIT>(stmt, 3) == 1);
+  REQUIRE(col1 == 1);
+  REQUIRE(col2 == 0);
+  REQUIRE(col3 == 1);
 }
 
 TEST_CASE("should select boolean literals", "[boolean]") {

--- a/odbc_tests/tests/e2e/types/boolean_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/boolean_conversion_to_c_char.cpp
@@ -48,6 +48,7 @@ TEST_CASE("should handle NULL boolean with character C types", "[datatype][boole
   // Given Snowflake client is logged in
   Connection conn;
 
+  // When Query "SELECT NULL::BOOLEAN" is executed
   auto check_null = [&](SQLSMALLINT c_type) {
     const auto stmt = conn.execute_fetch("SELECT NULL::BOOLEAN");
     char buffer[100] = {};
@@ -57,7 +58,6 @@ TEST_CASE("should handle NULL boolean with character C types", "[datatype][boole
     REQUIRE(indicator == SQL_NULL_DATA);
   };
 
-  // When Query "SELECT NULL::BOOLEAN" is executed
   // Then SQL_C_CHAR should return SQL_NULL_DATA indicator
   check_null(SQL_C_CHAR);
   // And SQL_C_WCHAR should return SQL_NULL_DATA indicator

--- a/odbc_tests/tests/e2e/types/boolean_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/boolean_conversion_to_c_integer.cpp
@@ -84,7 +84,6 @@ TEST_CASE("should handle NULL boolean with integer C types", "[datatype][boolean
   Connection conn;
 
   // When Query "SELECT NULL::BOOLEAN" is executed
-  // Then All integer C type conversions should return SQL_NULL_DATA indicator
   auto check_null = [&](SQLSMALLINT c_type) {
     const auto stmt = conn.execute_fetch("SELECT NULL::BOOLEAN");
     char buffer[100] = {};
@@ -94,6 +93,7 @@ TEST_CASE("should handle NULL boolean with integer C types", "[datatype][boolean
     REQUIRE(indicator == SQL_NULL_DATA);
   };
 
+  // Then All integer C type conversions should return SQL_NULL_DATA indicator
   check_null(SQL_C_LONG);
   check_null(SQL_C_SLONG);
   check_null(SQL_C_ULONG);

--- a/odbc_tests/tests/e2e/types/boolean_conversion_to_c_real.cpp
+++ b/odbc_tests/tests/e2e/types/boolean_conversion_to_c_real.cpp
@@ -63,9 +63,6 @@ TEST_CASE("should handle NULL boolean with numeric and binary C types", "[dataty
   Connection conn;
 
   // When Query "SELECT NULL::BOOLEAN" is executed
-  // Then SQL_C_FLOAT should return SQL_NULL_DATA indicator
-  // And SQL_C_DOUBLE should return SQL_NULL_DATA indicator
-  // And SQL_C_NUMERIC should return SQL_NULL_DATA indicator
   auto check_null = [&](SQLSMALLINT c_type) {
     const auto stmt = conn.execute_fetch("SELECT NULL::BOOLEAN");
     char buffer[100] = {};
@@ -75,7 +72,10 @@ TEST_CASE("should handle NULL boolean with numeric and binary C types", "[dataty
     REQUIRE(indicator == SQL_NULL_DATA);
   };
 
+  // Then SQL_C_FLOAT should return SQL_NULL_DATA indicator
   check_null(SQL_C_FLOAT);
+  // And SQL_C_DOUBLE should return SQL_NULL_DATA indicator
   check_null(SQL_C_DOUBLE);
+  // And SQL_C_NUMERIC should return SQL_NULL_DATA indicator
   check_null(SQL_C_NUMERIC);
 }

--- a/odbc_tests/tests/e2e/types/int.cpp
+++ b/odbc_tests/tests/e2e/types/int.cpp
@@ -15,8 +15,7 @@ TEST_CASE("should cast integer values to appropriate type for int and synonyms",
   // When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
   auto stmt = conn.execute_fetch("SELECT 0::INT, 1000000::INT, 9223372036854775807::BIGINT");
 
-  // Then All values should be returned as appropriate type
-  // And No precision loss should occur
+  // Then All values should be returned as appropriate type with no precision loss
   CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == 0);
   CHECK(get_data<SQL_C_SBIGINT>(stmt, 2) == 1000000);
   CHECK(get_data<SQL_C_SBIGINT>(stmt, 3) == 9223372036854775807LL);
@@ -158,7 +157,7 @@ TEST_CASE("should handle server-side Arrow memory optimization for int columns o
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Result should contain 50000 rows
+  // Then Result should contain 50000 rows with all values equal to expected data
   int row_count = 0;
 
   while (true) {
@@ -178,7 +177,6 @@ TEST_CASE("should handle server-side Arrow memory optimization for int columns o
     ret = SQLGetData(stmt.getHandle(), 4, SQL_C_SBIGINT, &col4, sizeof(col4), NULL);
     CHECK_ODBC(ret, stmt);
 
-    // And All values should be equal to expected data
     REQUIRE(col1 == expected_col1);
     REQUIRE(col2 == expected_col2);
     REQUIRE(col3 == expected_col3);

--- a/odbc_tests/tests/e2e/types/number.cpp
+++ b/odbc_tests/tests/e2e/types/number.cpp
@@ -12,8 +12,7 @@ TEST_CASE("should cast number values to appropriate type for number and synonyms
   // When Query "SELECT 0::<type>(10,0), 123::<type>(10,0), 0.00::<type>(10,2), 123.45::<type>(10,2)" is executed
   auto stmt = conn.execute_fetch("SELECT 0::NUMBER(10,0), 123::NUMBER(10,0), 0.00::NUMBER(10,2), 123.45::NUMBER(10,2)");
 
-  // Then All values should be returned as appropriate type
-  // And Values should match [0, 123, 0.00, 123.45]
+  // Then All values should be returned as appropriate type matching [0, 123, 0.00, 123.45]
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 0);
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == 123);
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == 0.0);
@@ -68,8 +67,8 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR 
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Column 1 should contain sequential integers from 0 to 29999
-  // And Column 2 should contain sequential decimals starting from 0.12345
+  // Then Result should contain 30000 rows with sequential integers in column 1 and sequential decimals starting from
+  // 0.12345 in column 2
   int row_count = 0;
   int64_t expected_int = 0;
   double expected_decimal = 0.12345;
@@ -211,8 +210,8 @@ TEST_CASE("should download large result set from table for number and synonyms",
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then Column 1 should contain sequential integers from 0 to 29999
-  // And Column 2 should contain sequential decimals starting from 0.12345
+  // Then Result should contain 30000 rows with sequential integers in column 1 and sequential decimals starting from
+  // 0.12345 in column 2
   int row_count = 0;
   int64_t expected_int = 0;
   double expected_decimal = 0.12345;

--- a/odbc_tests/tests/e2e/types/string.cpp
+++ b/odbc_tests/tests/e2e/types/string.cpp
@@ -301,8 +301,6 @@ TEST_CASE("should select corner case string values using parameter binding", "[.
   auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
-
-  // Helper lambda to test a single bound value
   auto test_bound_value = [&](const std::string& value, const std::string& expected) {
     auto stmt = conn.createStatement();
     SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR", SQL_NTS);
@@ -344,8 +342,6 @@ TEST_CASE("should select corner case string values using parameter binding", "[.
   };
 
   // Then the result should match the bound corner case value
-
-  // Test empty string
   test_bound_value("", "");
 
   // Test single character
@@ -419,7 +415,7 @@ TEST_CASE("should download string data in multiple chunks", "[datatype][string][
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
   CHECK_ODBC(ret, stmt);
 
-  // Then there are 10000 rows returned
+  // Then there are 10000 rows returned and all string values should match the generated values in order
   int row_count = 0;
   while (true) {
     ret = SQLFetch(stmt.getHandle());
@@ -432,7 +428,6 @@ TEST_CASE("should download string data in multiple chunks", "[datatype][string][
     row_count++;
   }
 
-  // And all returned string values should match the generated values in order
   CHECK(row_count == num_values);
 }
 
@@ -526,7 +521,7 @@ TEST_CASE("should download string data in multiple chunks using SQLBindCol", "[d
   ret = SQLBindCol(stmt.getHandle(), 2, SQL_C_CHAR, str_buffer, sizeof(str_buffer), &str_indicator);
   CHECK_ODBC(ret, stmt);
 
-  // Then there are 10000 rows returned
+  // Then there are 10000 rows returned and all string values should match the generated values in order
   int row_count = 0;
   while (true) {
     ret = SQLFetch(stmt.getHandle());
@@ -544,6 +539,5 @@ TEST_CASE("should download string data in multiple chunks using SQLBindCol", "[d
     row_count++;
   }
 
-  // And all returned string values should match the generated values in order
   CHECK(row_count == expected_row_count);
 }

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
@@ -306,7 +306,6 @@ TEST_CASE("should convert strings to integer types using SQLBindCol", "[datatype
   auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_LONG
-  // Then the bound integer value should match the string representation
   {
     auto stmt = conn.createStatement();
     SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '12345' AS str_num", SQL_NTS);
@@ -320,6 +319,7 @@ TEST_CASE("should convert strings to integer types using SQLBindCol", "[datatype
     ret = SQLFetch(stmt.getHandle());
     CHECK_ODBC(ret, stmt);
 
+    // Then the bound integer value should match the string representation
     CHECK(value == 12345);
     CHECK(indicator == sizeof(SQLINTEGER));
   }

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
@@ -613,7 +613,6 @@ TEST_CASE("should convert strings to interval types using SQLBindCol",
   auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval value is executed with SQLBindCol for SQL_C_INTERVAL_YEAR
-  // Then the bound interval value should match the string representation
   {
     auto stmt = conn.createStatement();
     SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '5' AS interval_year", SQL_NTS);
@@ -627,6 +626,7 @@ TEST_CASE("should convert strings to interval types using SQLBindCol",
     ret = SQLFetch(stmt.getHandle());
     CHECK_ODBC(ret, stmt);
 
+    // Then the bound interval value should match the string representation
     CHECK(interval.interval_type == SQL_IS_YEAR);
     CHECK(interval.intval.year_month.year == 5);
     CHECK(indicator == sizeof(SQL_INTERVAL_STRUCT));

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
@@ -84,12 +84,11 @@ TEST_CASE("should fail converting string literals to floating point types when d
   auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing floating point numbers is executed
-  // Then values within range should convert successfully
-  // And values exceeding SQL_C_DOUBLE range should fail with numeric out of range
   SECTION("SQL_C_DOUBLE") {
     auto stmt = conn.execute_fetch(
         "SELECT '1.7976931348623157e308' AS max_double, '1.7976931348623157e309' AS more_than_max_double, "
         "'-1.7976931348623157E+308' AS min_double, '-1.7976931348623158e308' AS less_than_min_double");
+    // Then values within range should convert successfully and values exceeding SQL_C_DOUBLE range should fail
     CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 1) == 1.7976931348623157e308);
     check_numeric_out_of_range<SQL_C_DOUBLE>(stmt, 2);
     CHECK(check_no_truncation<SQL_C_DOUBLE>(stmt, 3) == -1.7976931348623157e308);
@@ -215,8 +214,7 @@ TEST_CASE("should handle NULL string when converting to floating point types",
   // When Query selecting NULL is executed
   auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_double");
 
-  // And Attempt to get data as SQL_C_DOUBLE
-  // Then NULL should return SQL_NULL_DATA indicator
+  // Then SQL_C_DOUBLE should return SQL_NULL_DATA indicator
   {
     SQLDOUBLE value = 999.0;
     SQLLEN indicator;
@@ -236,7 +234,6 @@ TEST_CASE("should convert strings to floating point types using SQLBindCol", "[d
   auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_DOUBLE
-  // Then the bound double value should match the string representation
   {
     auto stmt = conn.createStatement();
     SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '987.654' AS str_num", SQL_NTS);
@@ -250,6 +247,7 @@ TEST_CASE("should convert strings to floating point types using SQLBindCol", "[d
     ret = SQLFetch(stmt.getHandle());
     CHECK_ODBC(ret, stmt);
 
+    // Then the bound double value should match the string representation
     CHECK(value == Catch::Approx(987.654).epsilon(0.001));
     CHECK(indicator == sizeof(SQLDOUBLE));
   }

--- a/odbc_tests/tests/e2e/types/string_lob.cpp
+++ b/odbc_tests/tests/e2e/types/string_lob.cpp
@@ -43,14 +43,13 @@ static std::string generate_random_ascii_string(std::mt19937& gen, size_t length
 
 TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][string][lob]") {
   // Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
-  // Given Snowflake client is logged in
-
   // TODO: Reenable this test for the new driver
   // The test is flaky because the driver does not handle async query responses correctly
   // When we insert the string, the driver does not wait for the insert to complete before returning
   // Test flakiness occurs more often on Windows
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
+  // Given Snowflake client is logged in
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 
@@ -106,13 +105,13 @@ TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][stri
 
 TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB size", "[datatype][string][lob]") {
   // Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
-  // Given Snowflake client is logged in
-
   // TODO: Reenable this test for the new driver
   // The test is flaky because the driver does not handle async query responses correctly
   // When we insert the string, the driver does not wait for the insert to complete before returning
   // Test flakiness occurs more often on Windows
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
   Connection conn;
   auto random_schema = Schema::use_random_schema(conn);
 

--- a/odbc_tests/tests/integration/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/integration/authentication/private_key_auth.cpp
@@ -123,9 +123,10 @@ void verify_private_key_forwarded_to_core(ConnectionHandleWrapper& dbc, const st
 
 TEST_CASE("should fail JWT authentication when no private file provided", "[private_key_auth]") {
   // Given Authentication is set to JWT
-  // When Trying to Connect with no private file provided
   /* TODO: Explicit config installation */
   std::string connection_string = get_jwt_connection_string_without_private_key();
+
+  // When Trying to Connect with no private file provided
   auto env = setup_environment_integration();
   auto dbc = get_connection_handle_integration(env);
 

--- a/python/tests/e2e/put_get/test_put_get_auto_compress.py
+++ b/python/tests/e2e/put_get/test_put_get_auto_compress.py
@@ -7,10 +7,12 @@ from tests.e2e.put_get.put_get_helper import (
     create_temporary_stage_and_upload_file,
     get_file_from_stage,
 )
+from tests.e2e.types.utils import assert_connection_is_open
 from tests.utils import shared_test_data_dir
 
 
 def test_should_compress_the_file_before_uploading_to_stage_when_auto_compress_set_to_true(
+    execute_query,
     connection,
 ):
     uncompressed_file_path = shared_test_data_dir() / "compression" / "test_data.csv"
@@ -19,7 +21,7 @@ def test_should_compress_the_file_before_uploading_to_stage_when_auto_compress_s
     compressed_filename = "test_data.csv.gz"
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # When File is uploaded to stage with AUTO_COMPRESS set to true
         stage_name, _ = create_temporary_stage_and_upload_file(
@@ -56,6 +58,7 @@ def test_should_compress_the_file_before_uploading_to_stage_when_auto_compress_s
 
 
 def test_should_not_compress_the_file_before_uploading_to_stage_when_auto_compress_set_to_false(
+    execute_query,
     connection,
 ):
     uncompressed_file_path = shared_test_data_dir() / "compression" / "test_data.csv"
@@ -64,7 +67,7 @@ def test_should_not_compress_the_file_before_uploading_to_stage_when_auto_compre
 
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # When File is uploaded to stage with AUTO_COMPRESS set to false
         stage_name, _ = create_temporary_stage_and_upload_file(

--- a/python/tests/e2e/put_get/test_put_get_basic_operations.py
+++ b/python/tests/e2e/put_get/test_put_get_basic_operations.py
@@ -11,6 +11,7 @@ from tests.e2e.put_get.put_get_helper import (
     get_file_from_stage,
     list_stage_contents,
 )
+from tests.e2e.types.utils import assert_connection_is_open
 from tests.utils import shared_test_data_dir
 
 
@@ -81,12 +82,12 @@ def test_should_get_file_uploaded_to_stage(connection):
                 assert content == "1,2,3"
 
 
-def test_should_return_correct_rowset_for_put(connection):
+def test_should_return_correct_rowset_for_put(execute_query, connection):
     test_file_path = shared_test_data_dir() / "compression" / "test_data.csv"
 
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # When File is uploaded to stage
         _, upload_result = create_temporary_stage_and_upload_file(
@@ -139,12 +140,12 @@ def test_should_return_correct_rowset_for_get(connection):
             assert get_result[3] == ""
 
 
-def test_should_return_correct_column_metadata_for_put(connection):
+def test_should_return_correct_column_metadata_for_put(execute_query, connection):
     test_file_path = shared_test_data_dir() / "compression" / "test_data.csv"
 
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # When File is uploaded to stage
         _, upload_result = create_temporary_stage_and_upload_file(
@@ -194,10 +195,10 @@ def test_should_return_correct_column_metadata_for_get(connection):
             auto_compress=True,
             overwrite=True,
         )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # When File is downloaded using GET command
-            download_dir = Path(temp_dir)
 
+        # When File is downloaded using GET command
+        with tempfile.TemporaryDirectory() as temp_dir:
+            download_dir = Path(temp_dir)
             get_result = get_file_from_stage(cursor, stage_name, filename, download_dir)
 
             # Then Column metadata for GET command should be correct
@@ -258,13 +259,13 @@ def test_should_get_file_from_subdirectory_in_stage(connection):
             assert content == "1,2,3"
 
 
-def test_should_upload_file_to_subdirectory_in_stage(connection):
+def test_should_upload_file_to_subdirectory_in_stage(execute_query, connection):
     test_file_path = shared_test_data_dir() / "compression" / "test_data.csv"
     filename = test_file_path.name
 
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # When File is uploaded to a subdirectory in stage
         stage_name = create_temporary_stage(cursor, "TEST_SUBDIR_UPLOAD")

--- a/python/tests/e2e/put_get/test_put_get_source_compression.py
+++ b/python/tests/e2e/put_get/test_put_get_source_compression.py
@@ -7,6 +7,7 @@ from tests.e2e.put_get.put_get_helper import (
     as_file_uri,
     create_temporary_stage,
 )
+from tests.e2e.types.utils import assert_connection_is_open
 from tests.utils import shared_test_data_dir
 
 
@@ -21,11 +22,11 @@ from tests.utils import shared_test_data_dir
     ],
 )
 def test_should_auto_detect_standard_compression_types_when_source_compression_set_to_auto_detect(
-    connection, expected_compression, filename
+    execute_query, connection, expected_compression, filename
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And File with standard type (GZIP, BZIP2, BROTLI, ZSTD, DEFLATE)
         stage_name, test_file_path = create_stage_and_get_compression_file(
@@ -78,11 +79,11 @@ def test_should_auto_detect_standard_compression_types_when_source_compression_s
     ],
 )
 def test_should_upload_compressed_files_with_source_compression_set_to_explicit_types(
-    connection, compression, filename
+    execute_query, connection, compression, filename
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And File with standard type (GZIP, BZIP2, BROTLI, ZSTD, DEFLATE, RAW_DEFLATE)
         stage_name, test_file_path = create_stage_and_get_compression_file(
@@ -111,11 +112,12 @@ def test_should_upload_compressed_files_with_source_compression_set_to_explicit_
 
 
 def test_should_not_compress_file_when_source_compression_set_to_auto_detect_and_auto_compress_set_to_false(
+    execute_query,
     connection,
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And Uncompressed file
         stage_name, test_file_path = create_stage_and_get_compression_file(
@@ -136,11 +138,12 @@ def test_should_not_compress_file_when_source_compression_set_to_auto_detect_and
 
 
 def test_should_not_compress_file_when_source_compression_set_to_none_and_auto_compress_set_to_false(
+    execute_query,
     connection,
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And Uncompressed file
         stage_name, test_file_path = create_stage_and_get_compression_file(
@@ -160,11 +163,12 @@ def test_should_not_compress_file_when_source_compression_set_to_none_and_auto_c
 
 
 def test_should_compress_uncompressed_file_when_source_compression_set_to_auto_detect_and_auto_compress_set_to_true(
+    execute_query,
     connection,
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And Uncompressed file
         stage_name, test_file_path = create_stage_and_get_compression_file(cursor, "TEST_STAGE_AUTO_COMPRESS", "NONE")
@@ -184,11 +188,12 @@ def test_should_compress_uncompressed_file_when_source_compression_set_to_auto_d
 
 
 def test_should_compress_uncompressed_file_when_source_compression_set_to_none_and_auto_compress_set_to_true(
+    execute_query,
     connection,
 ):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And Uncompressed file
         stage_name, test_file_path = create_stage_and_get_compression_file(
@@ -208,10 +213,10 @@ def test_should_compress_uncompressed_file_when_source_compression_set_to_none_a
         assert_put_compression_result(result, filename, "NONE", expected_target, "GZIP")
 
 
-def test_should_return_error_for_unsupported_compression_type(connection):
+def test_should_return_error_for_unsupported_compression_type(execute_query, connection):
     with connection.cursor() as cursor:
         # Given Snowflake client is logged in
-        assert cursor is not None
+        assert_connection_is_open(execute_query)
 
         # And File compressed with unsupported format
         stage_name, test_file_path = create_stage_and_get_compression_file(cursor, "TEST_STAGE_UNSUPPORTED", "LZMA")

--- a/python/tests/e2e/query/test_basic_execute_query.py
+++ b/python/tests/e2e/query/test_basic_execute_query.py
@@ -16,15 +16,16 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e.types.utils import assert_sequential_values
+from tests.e2e.types.utils import assert_connection_is_open, assert_sequential_values
 
 
 class TestSelectQueries:
     """Tests for basic SELECT query execution."""
 
-    def test_should_execute_simple_select_returning_single_value(self, cursor):
+    def test_should_execute_simple_select_returning_single_value(self, execute_query, cursor):
         """Test simple SELECT returning single value."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 1 AS value" is executed
         cursor.execute("SELECT 1 AS value")
@@ -34,9 +35,10 @@ class TestSelectQueries:
         assert result is not None
         assert result[0] == 1
 
-    def test_should_execute_select_returning_multiple_columns(self, cursor):
+    def test_should_execute_select_returning_multiple_columns(self, execute_query, cursor):
         """Test SELECT returning multiple columns."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 1 AS col1, 'hello' AS col2, '3.14' AS col3" is executed
         cursor.execute("SELECT 1 AS col1, 'hello' AS col2, '3.14' AS col3")
@@ -51,9 +53,10 @@ class TestSelectQueries:
         assert result[1] == "hello"
         assert result[2] == "3.14"
 
-    def test_should_execute_select_returning_multiple_rows(self, cursor):
+    def test_should_execute_select_returning_multiple_rows(self, execute_query, cursor):
         """Test SELECT returning multiple rows using GENERATOR."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) v ORDER BY id" is executed
         cursor.execute("SELECT seq8() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) v ORDER BY id")
@@ -64,9 +67,10 @@ class TestSelectQueries:
         values = [row[0] for row in rows]
         assert_sequential_values(values, 5)
 
-    def test_should_execute_select_returning_empty_result_set(self, cursor):
+    def test_should_execute_select_returning_empty_result_set(self, execute_query, cursor):
         """Test SELECT returning empty result set."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 1 WHERE 1=0" is executed
         cursor.execute("SELECT 1 WHERE 1=0")
@@ -75,9 +79,10 @@ class TestSelectQueries:
         # Then the result set should be empty
         assert result == []
 
-    def test_should_execute_select_returning_null_values(self, cursor):
+    def test_should_execute_select_returning_null_values(self, execute_query, cursor):
         """Test SELECT returning NULL values."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT NULL AS col1, 42 AS col2, NULL AS col3" is executed
         cursor.execute("SELECT NULL AS col1, 42 AS col2, NULL AS col3")
@@ -93,9 +98,10 @@ class TestSelectQueries:
 class TestDDLStatements:
     """Tests for DDL (Data Definition Language) statements."""
 
-    def test_should_execute_create_and_drop_table_statements(self, cursor, tmp_schema):
+    def test_should_execute_create_and_drop_table_statements(self, execute_query, cursor, tmp_schema):
         """Test CREATE and DROP TABLE statements."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
         table_name = f"{tmp_schema}.test_basic_ddl"
 
         # When CREATE TABLE statement is executed
@@ -115,9 +121,10 @@ class TestDDLStatements:
 class TestDMLStatements:
     """Tests for DML (Data Manipulation Language) statements."""
 
-    def test_should_execute_insert_and_retrieve_inserted_data(self, cursor, tmp_schema):
+    def test_should_execute_insert_and_retrieve_inserted_data(self, execute_query, cursor, tmp_schema):
         """Test INSERT and retrieve inserted data."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table is created
         table_name = f"{tmp_schema}.test_basic_dml"
@@ -142,24 +149,27 @@ class TestDMLStatements:
 class TestErrorHandling:
     """Tests for error handling."""
 
-    def test_should_return_error_for_invalid_sql_syntax(self, cursor):
+    def test_should_return_error_for_invalid_sql_syntax(self, execute_query, cursor):
         """Test error handling for invalid SQL syntax."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
-        # When Invalid SQL "SELCT INVALID SYNTAX" is executed
-        # Then An error should be returned
         from snowflake.connector import ProgrammingError
 
+        # When Invalid SQL "SELCT INVALID SYNTAX" is executed
+        invalid_sql = "SELCT INVALID SYNTAX"
+        # Then An error should be returned
         with pytest.raises(ProgrammingError):
-            cursor.execute("SELCT INVALID SYNTAX")
+            cursor.execute(invalid_sql)
 
 
 class TestSequentialExecution:
     """Tests for sequential query execution."""
 
-    def test_should_execute_multiple_queries_sequentially_on_same_connection(self, cursor):
+    def test_should_execute_multiple_queries_sequentially_on_same_connection(self, execute_query, cursor):
         """Test multiple queries executed sequentially on same connection."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Multiple queries are executed sequentially
         cursor.execute("SELECT 1 AS first_query")

--- a/python/tests/e2e/query/test_client_side_binding.py
+++ b/python/tests/e2e/query/test_client_side_binding.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import pytest
 
+from tests.e2e.types.utils import assert_connection_is_open
+
 from ...conftest import with_paramstyle
 
 
@@ -19,9 +21,10 @@ from ...conftest import with_paramstyle
 class TestPyformatPositionalBinding:
     """Tests for pyformat %s positional binding (client-side interpolation)."""
 
-    def test_should_bind_basic_types_with_positional_pyformat(self, cursor):
+    def test_should_bind_basic_types_with_positional_pyformat(self, execute_query, cursor):
         """Test basic type binding with %s placeholders."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT %s, %s, %s, %s, %s" is executed
         #   with positional parameters [42, 3.14, "hello", True, None]
@@ -38,54 +41,60 @@ class TestPyformatPositionalBinding:
         assert result[3] is True
         assert result[4] is None
 
-    def test_should_bind_string_with_single_quote(self, cursor):
+    def test_should_bind_string_with_single_quote(self, execute_query, cursor):
         """Test string binding with single quote character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter "it's a test"
         cursor.execute("SELECT %s", ("it's a test",))
         result = cursor.fetchone()
         # Then Result should contain the exact string "it's a test"
         assert result == ("it's a test",)
 
-    def test_should_bind_string_with_double_quote(self, cursor):
+    def test_should_bind_string_with_double_quote(self, execute_query, cursor):
         """Test string binding with double quote character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter containing double quotes
         cursor.execute("SELECT %s", ('hello "world"',))
         result = cursor.fetchone()
         # Then Result should contain the exact string with double quotes
         assert result == ('hello "world"',)
 
-    def test_should_bind_string_with_backslash(self, cursor):
+    def test_should_bind_string_with_backslash(self, execute_query, cursor):
         """Test string binding with backslash character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter "path\to\file"
         cursor.execute("SELECT %s", ("path\\to\\file",))
         result = cursor.fetchone()
         # Then Result should contain the exact string with backslashes
         assert result == ("path\\to\\file",)
 
-    def test_should_bind_string_with_newline(self, cursor):
+    def test_should_bind_string_with_newline(self, execute_query, cursor):
         """Test string binding with newline character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter containing newline
         cursor.execute("SELECT %s", ("line1\nline2",))
         result = cursor.fetchone()
         # Then Result should contain the exact string with newline
         assert result == ("line1\nline2",)
 
-    def test_should_bind_string_with_tab(self, cursor):
+    def test_should_bind_string_with_tab(self, execute_query, cursor):
         """Test string binding with tab character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter containing tab
         cursor.execute("SELECT %s", ("col1\tcol2",))
         result = cursor.fetchone()
         # Then Result should contain the exact string with tab
         assert result == ("col1\tcol2",)
 
-    def test_should_bind_string_with_carriage_return(self, cursor):
+    def test_should_bind_string_with_carriage_return(self, execute_query, cursor):
         """Test string binding with carriage return character."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter containing carriage return
         cursor.execute("SELECT %s", ("line1\rline2",))
         result = cursor.fetchone()
@@ -97,9 +106,10 @@ class TestPyformatPositionalBinding:
 class TestPyformatNamedBinding:
     """Tests for pyformat %(name)s named binding (client-side interpolation)."""
 
-    def test_should_bind_basic_types_with_named_pyformat(self, cursor):
+    def test_should_bind_basic_types_with_named_pyformat(self, execute_query, cursor):
         """Test basic type binding with %(name)s placeholders."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT %(a)s, %(b)s, %(c)s" is executed
         #   with named parameters (a=100, b="test", c=True)
@@ -111,9 +121,10 @@ class TestPyformatNamedBinding:
         # Then Result should contain values matching the bound parameters
         assert result == (100, "test", True)
 
-    def test_should_bind_same_parameter_multiple_times(self, cursor):
+    def test_should_bind_same_parameter_multiple_times(self, execute_query, cursor):
         """Test that the same named parameter can be used multiple times."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %(val)s, %(val)s, %(val)s" is executed
         #   with named parameter (val=42)
         sql = "SELECT %(val)s, %(val)s, %(val)s"
@@ -123,9 +134,10 @@ class TestPyformatNamedBinding:
         # Then Result should contain [42, 42, 42]
         assert result == (42, 42, 42)
 
-    def test_should_bind_with_mixed_order_named_params(self, cursor):
+    def test_should_bind_with_mixed_order_named_params(self, execute_query, cursor):
         """Test named parameters used in different order than dict."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %(z)s, %(a)s, %(m)s" is executed
         #   with named parameters (a=1, m=2, z=3)
         sql = "SELECT %(z)s, %(a)s, %(m)s"
@@ -140,9 +152,10 @@ class TestPyformatNamedBinding:
 class TestEscapeHandling:
     """Tests for proper escape handling in client-side binding."""
 
-    def test_should_escape_special_characters(self, cursor, tmp_schema):
+    def test_should_escape_special_characters(self, execute_query, cursor, tmp_schema):
         """Test that special characters are properly escaped."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (name VARCHAR) exists
         table_name = f"{tmp_schema}.test_escape"
         cursor.execute(f"CREATE TABLE {table_name} (name VARCHAR)")
@@ -173,20 +186,18 @@ class TestEscapeHandling:
         for expected in test_strings:
             assert expected in results, f"String {expected!r} not found in results"
 
-    def test_should_prevent_sql_injection_with_positional_binding(self, cursor, tmp_schema):
+    def test_should_prevent_sql_injection_with_positional_binding(self, execute_query, cursor, tmp_schema):
         """Test that SQL injection attempts are safely escaped."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
-        # And Rows are inserted
         table_name = f"{tmp_schema}.test_injection"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
+        # And Rows are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (1, "test1"))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (2, "test2"))
 
         # When Query with "WHERE id = %s" is executed with SQL injection string "1 or 1=1"
-
-        # The injection string '1 or 1=1' will be quoted as a string literal,
-        # which then cannot be converted to NUMBER, causing a type error.
         with pytest.raises(Exception) as excinfo:
             cursor.execute(f"SELECT * FROM {table_name} WHERE id = %s", ("1 or 1=1",))
 
@@ -196,13 +207,14 @@ class TestEscapeHandling:
             f"Expected numeric type error, got: {excinfo.value}"
         )
 
-    def test_should_prevent_sql_injection_with_named_binding(self, cursor, tmp_schema):
+    def test_should_prevent_sql_injection_with_named_binding(self, execute_query, cursor, tmp_schema):
         """Test that SQL injection attempts are safely escaped with named params."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
-        # And Rows are inserted
         table_name = f"{tmp_schema}.test_injection_named"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
+        # And Rows are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%(id)s, %(name)s)", dict(id=1, name="test1"))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%(id)s, %(name)s)", dict(id=2, name="test2"))
 
@@ -216,9 +228,10 @@ class TestEscapeHandling:
             f"Expected numeric type error, got: {excinfo.value}"
         )
 
-    def test_should_handle_complex_escape_sequence(self, cursor):
+    def test_should_handle_complex_escape_sequence(self, execute_query, cursor):
         """Test complex string with multiple escape sequences."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with a complex string
         #   containing quotes, backslashes, and newlines
         complex_string = "',an\\\\escaped\"line\n"
@@ -232,72 +245,80 @@ class TestEscapeHandling:
 class TestQuoteHandling:
     """Tests for proper quote handling in client-side binding."""
 
-    def test_should_quote_null_as_null(self, cursor):
+    def test_should_quote_null_as_null(self, execute_query, cursor):
         """Test that None is converted to NULL."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter None
         cursor.execute("SELECT %s", (None,))
         result = cursor.fetchone()
         # Then Result should contain NULL
         assert result == (None,)
 
-    def test_should_quote_boolean_true(self, cursor):
+    def test_should_quote_boolean_true(self, execute_query, cursor):
         """Test that True is properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter True
         cursor.execute("SELECT %s", (True,))
         result = cursor.fetchone()
         # Then Result should contain True
         assert result == (True,)
 
-    def test_should_quote_boolean_false(self, cursor):
+    def test_should_quote_boolean_false(self, execute_query, cursor):
         """Test that False is properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter False
         cursor.execute("SELECT %s", (False,))
         result = cursor.fetchone()
         # Then Result should contain False
         assert result == (False,)
 
-    def test_should_quote_integer(self, cursor):
+    def test_should_quote_integer(self, execute_query, cursor):
         """Test that integers are properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter 12345
         cursor.execute("SELECT %s", (12345,))
         result = cursor.fetchone()
         # Then Result should contain 12345
         assert result == (12345,)
 
-    def test_should_quote_negative_integer(self, cursor):
+    def test_should_quote_negative_integer(self, execute_query, cursor):
         """Test that negative integers are properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter -12345
         cursor.execute("SELECT %s", (-12345,))
         result = cursor.fetchone()
         # Then Result should contain -12345
         assert result == (-12345,)
 
-    def test_should_quote_float(self, cursor):
+    def test_should_quote_float(self, execute_query, cursor):
         """Test that floats are properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter 3.14159
         cursor.execute("SELECT %s", (3.14159,))
         result = cursor.fetchone()
         # Then Result should contain approximately 3.14159
         assert abs(float(result[0]) - 3.14159) < 0.00001  # Snowflake may return Decimal
 
-    def test_should_quote_empty_string(self, cursor):
+    def test_should_quote_empty_string(self, execute_query, cursor):
         """Test that empty string is properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter ""
         cursor.execute("SELECT %s", ("",))
         result = cursor.fetchone()
         # Then Result should contain empty string
         assert result == ("",)
 
-    def test_should_quote_binary_data(self, cursor):
+    def test_should_quote_binary_data(self, execute_query, cursor):
         """Test that binary data is properly handled."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s::BINARY" is executed with binary parameter
         binary_data = b"\x00\x01\x02\xff"
         cursor.execute("SELECT %s::BINARY", (binary_data,))
@@ -310,13 +331,14 @@ class TestQuoteHandling:
 class TestListBinding:
     """Tests for list binding in IN clauses."""
 
-    def test_should_bind_list_for_in_clause(self, cursor, tmp_schema):
+    def test_should_bind_list_for_in_clause(self, execute_query, cursor, tmp_schema):
         """Test list parameter for IN clause."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
-        # And Rows [1, "Alice"], [2, "Bob"], [3, "Charlie"] are inserted
         table_name = f"{tmp_schema}.test_list_in"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
+        # And Rows [1, "Alice"], [2, "Bob"], [3, "Charlie"] are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (1, "Alice"))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (2, "Bob"))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (3, "Charlie"))
@@ -335,9 +357,10 @@ class TestListBinding:
 class TestTableOperationsWithPyformat:
     """Tests for table operations using pyformat binding."""
 
-    def test_should_insert_with_positional_pyformat(self, cursor, tmp_schema):
+    def test_should_insert_with_positional_pyformat(self, execute_query, cursor, tmp_schema):
         """Test INSERT with %s positional binding."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_insert_pyformat"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
@@ -351,9 +374,10 @@ class TestTableOperationsWithPyformat:
         result = cursor.fetchone()
         assert result == (1, "Alice")
 
-    def test_should_insert_with_named_pyformat(self, cursor, tmp_schema):
+    def test_should_insert_with_named_pyformat(self, execute_query, cursor, tmp_schema):
         """Test INSERT with %(name)s named binding."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_insert_named"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
@@ -371,13 +395,14 @@ class TestTableOperationsWithPyformat:
         result = cursor.fetchone()
         assert result == (1, "Alice")
 
-    def test_should_update_with_pyformat(self, cursor, tmp_schema):
+    def test_should_update_with_pyformat(self, execute_query, cursor, tmp_schema):
         """Test UPDATE with pyformat binding."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
-        # And Row [1, "Alice"] is inserted
         table_name = f"{tmp_schema}.test_update_pyformat"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
+        # And Row [1, "Alice"] is inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (1, "Alice"))
 
         # When Query "UPDATE table SET name = %s WHERE id = %s"
@@ -389,13 +414,14 @@ class TestTableOperationsWithPyformat:
         result = cursor.fetchone()
         assert result == (1, "Alice Updated")
 
-    def test_should_delete_with_pyformat(self, cursor, tmp_schema):
+    def test_should_delete_with_pyformat(self, execute_query, cursor, tmp_schema):
         """Test DELETE with pyformat binding."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
-        # And Rows [1, "Alice"] and [2, "Bob"] are inserted
         table_name = f"{tmp_schema}.test_delete_pyformat"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
+        # And Rows [1, "Alice"] and [2, "Bob"] are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (1, "Alice"))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s)", (2, "Bob"))
 
@@ -408,13 +434,14 @@ class TestTableOperationsWithPyformat:
         assert len(result) == 1
         assert result[0] == (2, "Bob")
 
-    def test_should_select_where_with_pyformat(self, cursor, tmp_schema):
+    def test_should_select_where_with_pyformat(self, execute_query, cursor, tmp_schema):
         """Test SELECT WHERE with pyformat binding."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR, age NUMBER) exists
-        # And Rows [1, "Alice", 30], [2, "Bob", 25], [3, "Charlie", 35] are inserted
         table_name = f"{tmp_schema}.test_select_pyformat"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR, age NUMBER)")
+        # And Rows [1, "Alice", 30], [2, "Bob", 25], [3, "Charlie", 35] are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s, %s)", (1, "Alice", 30))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s, %s)", (2, "Bob", 25))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s, %s, %s)", (3, "Charlie", 35))
@@ -434,9 +461,10 @@ class TestTableOperationsWithPyformat:
 class TestExecutemanyWithPyformat:
     """Tests for executemany with pyformat binding."""
 
-    def test_should_executemany_with_dict_params(self, cursor, tmp_schema):
+    def test_should_executemany_with_dict_params(self, execute_query, cursor, tmp_schema):
         """Test executemany with dictionary parameters."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_executemany_dict"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
@@ -451,9 +479,10 @@ class TestExecutemanyWithPyformat:
         result = cursor.fetchall()
         assert result == [(1, "Alice"), (2, "Bob"), (3, "Charlie")]
 
-    def test_should_executemany_with_tuple_params(self, cursor, tmp_schema):
+    def test_should_executemany_with_tuple_params(self, execute_query, cursor, tmp_schema):
         """Test executemany with tuple parameters."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_executemany_tuple"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")
@@ -473,9 +502,10 @@ class TestExecutemanyWithPyformat:
 class TestFormatBinding:
     """Tests for format paramstyle (%s only, no named parameters)."""
 
-    def test_should_bind_with_format_style(self, cursor):
+    def test_should_bind_with_format_style(self, execute_query, cursor):
         """Test basic binding with format paramstyle."""
         # Given Snowflake client is logged in with format paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s, %s, %s" is executed with parameters (1, "test", True)
         sql = "SELECT %s, %s, %s"
         params = (1, "test", True)
@@ -484,9 +514,10 @@ class TestFormatBinding:
         # Then Result should contain [1, "test", True]
         assert result == (1, "test", True)
 
-    def test_should_escape_special_chars_with_format(self, cursor):
+    def test_should_escape_special_chars_with_format(self, execute_query, cursor):
         """Test escape handling with format paramstyle."""
         # Given Snowflake client is logged in with format paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with parameter "it's a 'test'"
         cursor.execute("SELECT %s", ("it's a 'test'",))
         result = cursor.fetchone()
@@ -498,34 +529,44 @@ class TestFormatBinding:
 class TestClientSideBindingErrors:
     """Tests for error handling in client-side binding."""
 
-    def test_should_raise_error_for_too_many_positional_parameters(self, cursor):
+    def test_should_raise_error_for_too_many_positional_parameters(self, execute_query, cursor):
         """Test that too many positional parameters raises TypeError."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s, %s" is executed with 3 parameters
+        sql = "SELECT %s, %s"
+        params = (1, 2, 3)
         # Then TypeError should be raised indicating not all arguments converted
         with pytest.raises(TypeError, match="not all arguments converted"):
-            cursor.execute("SELECT %s, %s", (1, 2, 3))
+            cursor.execute(sql, params)
 
-    def test_should_raise_error_for_not_enough_positional_parameters(self, cursor):
+    def test_should_raise_error_for_not_enough_positional_parameters(self, execute_query, cursor):
         """Test that not enough positional parameters raises TypeError."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s, %s, %s" is executed with 2 parameters
+        sql = "SELECT %s, %s, %s"
+        params = (1, 2)
         # Then TypeError should be raised indicating not enough arguments
         with pytest.raises(TypeError, match="not enough arguments"):
-            cursor.execute("SELECT %s, %s, %s", (1, 2))
+            cursor.execute(sql, params)
 
-    def test_should_raise_error_for_missing_named_parameter(self, cursor):
+    def test_should_raise_error_for_missing_named_parameter(self, execute_query, cursor):
         """Test that missing named parameter raises KeyError."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %(name)s, %(age)s" is executed
         #   with only (name="Alice")
+        sql = "SELECT %(name)s, %(age)s"
+        params = dict(name="Alice")
         # Then KeyError should be raised for missing parameter
         with pytest.raises(KeyError):
-            cursor.execute("SELECT %(name)s, %(age)s", dict(name="Alice"))
+            cursor.execute(sql, params)
 
-    def test_should_ignore_extra_named_parameters(self, cursor):
+    def test_should_ignore_extra_named_parameters(self, execute_query, cursor):
         """Test that extra named parameters are silently ignored (Python behavior)."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %(name)s" is executed
         #   with (name="Alice", extra="ignored")
         cursor.execute("SELECT %(name)s", dict(name="Alice", extra="ignored"))
@@ -539,34 +580,39 @@ class TestInvalidParamstyle:
 
     def test_should_raise_error_for_invalid_paramstyle(self, connection_factory):
         """Test that invalid paramstyle raises ProgrammingError."""
+        # Given Snowflake client is logged in
         from snowflake.connector import ProgrammingError
 
-        # Given Connection is created with paramstyle "invalid"
+        # When Connection is created with paramstyle "invalid"
+        invalid_paramstyle = "invalid"
+
         # Then ProgrammingError should be raised indicating invalid paramstyle
         with pytest.raises(ProgrammingError, match="Invalid paramstyle"):
-            connection_factory(paramstyle="invalid")
+            connection_factory(paramstyle=invalid_paramstyle)
 
 
 @with_paramstyle("pyformat")
 class TestDecimalBinding:
     """Tests for Decimal type binding."""
 
-    def test_should_bind_decimal_value(self, cursor):
+    def test_should_bind_decimal_value(self, execute_query, cursor):
         """Test that Decimal values are properly handled."""
         from decimal import Decimal
 
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s" is executed with Decimal("123.456")
         cursor.execute("SELECT %s", (Decimal("123.456"),))
         result = cursor.fetchone()
         # Then Result should contain approximately 123.456
         assert abs(float(result[0]) - 123.456) < 0.001
 
-    def test_should_bind_decimal_with_high_precision(self, cursor):
+    def test_should_bind_decimal_with_high_precision(self, execute_query, cursor):
         """Test Decimal with high precision."""
         from decimal import Decimal
 
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %s::NUMBER(38,18)" is executed with high-precision Decimal
         value = Decimal("12345678901234567890.123456789012345678")
         cursor.execute("SELECT %s::NUMBER(38,18)", (value,))
@@ -579,13 +625,14 @@ class TestDecimalBinding:
 class TestLiteralPercentInQuery:
     """Tests for queries containing literal percent signs."""
 
-    def test_should_handle_like_with_percent_wildcard(self, cursor, tmp_schema):
+    def test_should_handle_like_with_percent_wildcard(self, execute_query, cursor, tmp_schema):
         """Test LIKE queries with %% escaped percent signs."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (name VARCHAR) exists
-        # And Rows ["Alice"], ["Bob"], ["Charlie"] are inserted
         table_name = f"{tmp_schema}.test_like_percent"
         cursor.execute(f"CREATE TABLE {table_name} (name VARCHAR)")
+        # And Rows ["Alice"], ["Bob"], ["Charlie"] are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Alice",))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Bob",))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Charlie",))
@@ -599,13 +646,14 @@ class TestLiteralPercentInQuery:
         assert result[0][0] == "Alice"
         assert result[1][0] == "Charlie"
 
-    def test_should_handle_like_with_param_and_percent(self, cursor, tmp_schema):
+    def test_should_handle_like_with_param_and_percent(self, execute_query, cursor, tmp_schema):
         """Test LIKE with both parameter and literal percent."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (name VARCHAR) exists
-        # And Rows ["Alice"], ["Bob"] are inserted
         table_name = f"{tmp_schema}.test_like_mixed"
         cursor.execute(f"CREATE TABLE {table_name} (name VARCHAR)")
+        # And Rows ["Alice"], ["Bob"] are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Alice",))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Bob",))
 
@@ -624,13 +672,14 @@ class TestLiteralPercentInQuery:
 class TestListBindingWithSpecialChars:
     """Tests for list binding with special characters (escaping)."""
 
-    def test_should_bind_list_with_special_chars_in_strings(self, cursor, tmp_schema):
+    def test_should_bind_list_with_special_chars_in_strings(self, execute_query, cursor, tmp_schema):
         """Test list binding where strings contain special characters."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (name VARCHAR) exists
-        # And Rows with special characters are inserted
         table_name = f"{tmp_schema}.test_list_special"
         cursor.execute(f"CREATE TABLE {table_name} (name VARCHAR)")
+        # And Rows with special characters are inserted
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("it's Alice",))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Bob\\n",))
         cursor.execute(f"INSERT INTO {table_name} VALUES (%s)", ("Charlie",))
@@ -653,24 +702,28 @@ class TestFormatParamstyleErrors:
     """Tests for error handling with format paramstyle."""
 
     @pytest.mark.skip_reference(reason="Universal driver has stricter format paramstyle validation")
-    def test_should_reject_dict_params_with_format_paramstyle(self, cursor):
+    def test_should_reject_dict_params_with_format_paramstyle(self, execute_query, cursor):
         """Test that dict parameters raise ProgrammingError with format paramstyle."""
         from snowflake.connector import ProgrammingError
 
         # Given Snowflake client is logged in with format paramstyle
+        assert_connection_is_open(execute_query)
         # When Query "SELECT %(name)s" is executed with dict parameters
+        sql = "SELECT %(name)s"
+        params = dict(name="Alice")
         # Then ProgrammingError should be raised indicating dict parameters not supported
         with pytest.raises(ProgrammingError, match="Dict parameters not supported"):
-            cursor.execute("SELECT %(name)s", dict(name="Alice"))
+            cursor.execute(sql, params)
 
 
 @with_paramstyle("pyformat")
 class TestExecutemanyRowcount:
     """Tests for executemany rowcount accumulation."""
 
-    def test_should_accumulate_rowcount_in_executemany(self, cursor, tmp_schema):
+    def test_should_accumulate_rowcount_in_executemany(self, execute_query, cursor, tmp_schema):
         """Test that executemany accumulates rowcount across iterations."""
         # Given Snowflake client is logged in with pyformat paramstyle
+        assert_connection_is_open(execute_query)
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_executemany_rowcount"
         cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR)")

--- a/python/tests/e2e/query/test_large_result_set.py
+++ b/python/tests/e2e/query/test_large_result_set.py
@@ -1,10 +1,10 @@
-from tests.e2e.types.utils import assert_sequential_values
+from tests.e2e.types.utils import assert_connection_is_open, assert_sequential_values
 
 
 class TestLargeResultSet:
-    def test_should_process_one_million_row_result_set(self, cursor):
+    def test_should_process_one_million_row_result_set(self, execute_query, cursor):
         # Given Snowflake client is logged in
-        assert not cursor.connection.is_closed(), "Connection should be open"
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id" is executed
 

--- a/python/tests/e2e/query/test_parameter_binding.py
+++ b/python/tests/e2e/query/test_parameter_binding.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import pytest
 
+from tests.e2e.types.utils import assert_connection_is_open
+
 from ...conftest import with_paramstyle
 
 
@@ -19,8 +21,9 @@ class TestBasicTypeBinding:
     """Tests for binding basic Python types to Snowflake."""
 
     @with_paramstyle("qmark")
-    def test_should_bind_basic_types_with_positional_parameters(self, cursor):
+    def test_should_bind_basic_types_with_positional_parameters(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?, ?, ?, ?, ?" is executed with positional parameters [42, 3.14, "hello", True, None]
         sql = "SELECT ?, ?, ?, ?, ?"
@@ -37,8 +40,9 @@ class TestBasicTypeBinding:
         assert result[4] is None
 
     @with_paramstyle("numeric")
-    def test_should_bind_positional_parameters_with_numeric_placeholders(self, cursor):
+    def test_should_bind_positional_parameters_with_numeric_placeholders(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT :1, :2, :3" is executed with positional parameters [100, "test", True]
         sql = "SELECT :1, :2, :3"
@@ -54,8 +58,9 @@ class TestBasicTypeBinding:
 class TestTableOperations:
     """Tests for parameter binding with table operations."""
 
-    def test_should_insert_single_row_with_parameter_binding(self, cursor, tmp_schema):
+    def test_should_insert_single_row_with_parameter_binding(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR, active BOOLEAN) exists
         table_name = f"{tmp_schema}.test_binding_insert"
@@ -72,8 +77,9 @@ class TestTableOperations:
         assert len(result) == 1
         assert result[0] == (1, "Alice", True)
 
-    def test_should_insert_multiple_rows_sequentially_with_parameter_binding(self, cursor, tmp_schema):
+    def test_should_insert_multiple_rows_sequentially_with_parameter_binding(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_binding_multiple"
@@ -92,8 +98,9 @@ class TestTableOperations:
         assert len(result) == 3
         assert result == rows
 
-    def test_should_update_row_with_parameter_binding(self, cursor, tmp_schema):
+    def test_should_update_row_with_parameter_binding(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_binding_update"
@@ -112,8 +119,9 @@ class TestTableOperations:
         # Then Result should contain [1, "Alice Updated"]
         assert result == (1, "Alice Updated")
 
-    def test_should_delete_row_with_parameter_binding(self, cursor, tmp_schema):
+    def test_should_delete_row_with_parameter_binding(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_binding_delete"
@@ -134,8 +142,9 @@ class TestTableOperations:
         assert len(result) == 1
         assert result[0] == (2, "Bob")
 
-    def test_should_select_with_where_clause_parameter_binding(self, cursor, tmp_schema):
+    def test_should_select_with_where_clause_parameter_binding(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR, age NUMBER) exists
         table_name = f"{tmp_schema}.test_binding_select_where"
@@ -160,8 +169,9 @@ class TestTableOperations:
 class TestEdgeCases:
     """Tests for edge cases in parameter binding."""
 
-    def test_should_handle_null_values_in_parameter_binding(self, cursor):
+    def test_should_handle_null_values_in_parameter_binding(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?, ?, ?" is executed with parameters [None, 42, None]
         cursor.execute("SELECT ?, ?, ?", (None, 42, None))
@@ -170,8 +180,9 @@ class TestEdgeCases:
         # Then Result should contain [NULL, 42, NULL]
         assert result == (None, 42, None)
 
-    def test_should_handle_special_characters_in_string_binding(self, cursor):
+    def test_should_handle_special_characters_in_string_binding(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::VARCHAR" is executed with parameter containing special characters
         special_strings = [
@@ -189,8 +200,9 @@ class TestEdgeCases:
             # Then Result should contain the exact special character string
             assert result == (special_str,), f"Failed for: {special_str!r}"
 
-    def test_should_handle_unicode_characters_in_parameter_binding(self, cursor):
+    def test_should_handle_unicode_characters_in_parameter_binding(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::VARCHAR, ?::VARCHAR" is executed with parameters ["日本語", "⛄"]
         cursor.execute("SELECT ?::VARCHAR, ?::VARCHAR", ("日本語", "⛄"))
@@ -199,8 +211,9 @@ class TestEdgeCases:
         # Then Result should contain Unicode strings ["日本語", "⛄"]
         assert result == ("日本語", "⛄")
 
-    def test_should_bind_zero_values(self, cursor):
+    def test_should_bind_zero_values(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?, ?::FLOAT, ?::VARCHAR" is executed with parameters [0, 0.0, ""]
         cursor.execute("SELECT ?, ?::FLOAT, ?::VARCHAR", (0, 0.0, ""))
@@ -209,8 +222,9 @@ class TestEdgeCases:
         # Then Result should contain zero and empty values [0, 0.0, ""]
         assert result == (0, 0.0, "")
 
-    def test_should_handle_mixed_type_casting_with_parameter_binding(self, cursor):
+    def test_should_handle_mixed_type_casting_with_parameter_binding(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::NUMBER, ?::VARCHAR, ?::BOOLEAN" is executed with parameters [42, "hello", True]
         cursor.execute("SELECT ?::NUMBER, ?::VARCHAR, ?::BOOLEAN", (42, "hello", True))
@@ -219,28 +233,35 @@ class TestEdgeCases:
         # Then Result should match the type-casted parameters [42, "hello", True]
         assert result == (42, "hello", True)
 
-    def test_should_raise_error_when_placeholder_count_mismatches_argument_count(self, cursor):
+    def test_should_raise_error_when_placeholder_count_mismatches_argument_count(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query with 2 placeholders is executed with 3 arguments
-        # Then Query should successfully execute
         cursor.execute("SELECT ?, ?", (1, 2, 3))
+        result = cursor.fetchone()
 
-        # When Query with 3 placeholders is executed with 1 argument
-        # Then Error should be raised for too few arguments
+        # Then Query should successfully execute
+        assert result is not None
+
         from snowflake.connector import DatabaseError
 
+        # When Query with 3 placeholders is executed with 1 argument
+        sql = "SELECT ?, ?, ?"
+        params = (1,)
+        # Then Error should be raised for too few arguments
         with pytest.raises(DatabaseError):
-            cursor.execute("SELECT ?, ?, ?", (1,))
+            cursor.execute(sql, params)
 
 
 @with_paramstyle("qmark")
 class TestArrayBinding:
     """Tests for multirow binding (executemany functionality)."""
 
-    def test_should_insert_multiple_rows_using_multirow_binding(self, cursor, tmp_schema):
+    def test_should_insert_multiple_rows_using_multirow_binding(self, execute_query, cursor, tmp_schema):
         """Test multirow binding with basic INSERT."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_executemany"
@@ -257,18 +278,21 @@ class TestArrayBinding:
         # Then Result should contain 3 rows with correct values
         assert result == rows
 
-    def test_should_handle_empty_sequence_in_multirow_binding(self, cursor):
+    def test_should_handle_empty_sequence_in_multirow_binding(self, execute_query, cursor):
         """Test multirow binding with empty sequence is no-op."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Multirow binding is called with empty sequence
         cursor.executemany("INSERT INTO table VALUES (?)", [])
 
         # Then No error should be raised
+        assert cursor is not None
 
-    def test_should_validate_parameter_length_in_multirow_binding(self, cursor):
+    def test_should_validate_parameter_length_in_multirow_binding(self, execute_query, cursor):
         """Test multirow binding raises error for inconsistent lengths."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
         from snowflake.connector import InterfaceError
 
         # When Multirow binding is called with inconsistent parameter lengths [(1, "a"), (2, "b", "extra")]
@@ -278,9 +302,10 @@ class TestArrayBinding:
         # Then Error should be raised indicating parameter sequence length mismatch
         assert "Bulk data size don't match" in str(excinfo.value)
 
-    def test_should_handle_null_values_in_multirow_binding(self, cursor, tmp_schema):
+    def test_should_handle_null_values_in_multirow_binding(self, execute_query, cursor, tmp_schema):
         """Test multirow binding handles NULL values."""
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, value VARCHAR) exists
         table_name = f"{tmp_schema}.test_nulls"
@@ -301,8 +326,9 @@ class TestArrayBinding:
 class TestBackwardCompatibility:
     """Tests for backward compatibility with old connector parameter format."""
 
-    def test_should_handle_both_tuple_and_list_parameter_formats(self, cursor):
+    def test_should_handle_both_tuple_and_list_parameter_formats(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?, ?" is executed with tuple parameters (1, "test")
         sql = "SELECT ?, ?"
@@ -321,8 +347,9 @@ class TestBackwardCompatibility:
 class TestComplexScenarios:
     """Tests for complex parameter binding scenarios."""
 
-    def test_should_bind_many_parameters(self, cursor):
+    def test_should_bind_many_parameters(self, execute_query, cursor):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query with 20 positional parameters is executed with values [0..19]
         num_params = 20
@@ -334,8 +361,9 @@ class TestComplexScenarios:
         # Then Result should contain all 20 values in order
         assert result == params
 
-    def test_should_bind_parameters_with_or_clause_for_multiple_value_matching(self, cursor, tmp_schema):
+    def test_should_bind_parameters_with_or_clause_for_multiple_value_matching(self, execute_query, cursor, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with columns (id NUMBER, name VARCHAR) exists
         table_name = f"{tmp_schema}.test_in_clause"

--- a/python/tests/e2e/tls/test_crl_enabled.py
+++ b/python/tests/e2e/tls/test_crl_enabled.py
@@ -1,9 +1,12 @@
 import pytest
 
+from tests.e2e.types.utils import assert_connection_is_open
+
 
 @pytest.mark.skip_reference(reason="CRL e2e applies to universal driver")
-def test_should_connect_and_select_with_crl_enabled(connection_factory):
+def test_should_connect_and_select_with_crl_enabled(execute_query, connection_factory):
     # Given Snowflake client is logged in
+    assert_connection_is_open(execute_query)
     with connection_factory(crl_check_mode="ENABLED") as conn:
         cur = conn.cursor()
 

--- a/python/tests/e2e/types/test_binary.py
+++ b/python/tests/e2e/types/test_binary.py
@@ -14,7 +14,7 @@ Reference: https://docs.snowflake.com/en/sql-reference/data-types-text#binary
 import pytest
 
 from ...conftest import with_paramstyle
-from .utils import assert_sequential_values, assert_type
+from .utils import assert_connection_is_open, assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -68,6 +68,7 @@ class TestBinaryTypeCasting:
     @binary_type_parametrize
     def test_should_cast_binary_values_to_appropriate_type(self, execute_query, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT TO_BINARY('48656C6C6F', 'HEX')::BINARY,
         # TO_BINARY('V29ybGQ=', 'BASE64')::BINARY" is executed
@@ -87,6 +88,7 @@ class TestBinaryLiteral:
     @binary_type_parametrize
     def test_should_select_binary_literals(self, execute_query, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Queries selecting binary literals are executed:
         sql = (
@@ -103,6 +105,7 @@ class TestBinaryLiteral:
     @binary_type_parametrize
     def test_should_handle_binary_corner_case_values_from_literals(self, execute_query, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         for expected_val, sql_val in CORNER_CASE_VALUES:
             # When Query selecting corner case binary literals is executed
@@ -114,6 +117,7 @@ class TestBinaryLiteral:
     @binary_type_parametrize
     def test_should_handle_null_binary_values_from_literals(self, execute_query, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT NULL::{type}, X'ABCD', NULL::{type}" is executed
         sql = f"SELECT NULL::{binary_type}, X'ABCD', NULL::{binary_type}"
@@ -129,6 +133,7 @@ class TestBinaryTable:
     @binary_type_parametrize
     def test_should_select_binary_values_from_table(self, execute_query, tmp_schema, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with BINARY column is created
         table_name = f"{tmp_schema}.binary_table_test"
@@ -150,6 +155,7 @@ class TestBinaryTable:
     @binary_type_parametrize
     def test_should_select_corner_case_binary_values_from_table(self, execute_query, tmp_schema, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with BINARY column is created
         table_name = f"{tmp_schema}.binary_corner_case_table_test"
@@ -172,6 +178,7 @@ class TestBinaryTable:
     @binary_type_parametrize
     def test_should_select_null_binary_values_from_table(self, execute_query, tmp_schema, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with BINARY column is created
         table_name = f"{tmp_schema}.binary_null_table_test"
@@ -199,6 +206,7 @@ class TestBinaryTable:
         # Tests BINARY(n) with specific length constraints
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY) exists
         table_name = f"{tmp_schema}.binary_length_test"
@@ -229,6 +237,7 @@ class TestBinaryBinding:
         # SELECT binding test: Uses SELECT ?::BINARY to bind binary values
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::BINARY, ?::BINARY, ?::BINARY" is executed with bound binary values
         # [0x48656C6C6F, 0x576F726C64, 0x0123456789ABCDEF]
@@ -247,6 +256,7 @@ class TestBinaryBinding:
         self, execute_query, executemany_insert, tmp_schema, binary_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BINARY column exists
         table_name = f"{tmp_schema}.binary_bind_insert_test"
@@ -270,6 +280,7 @@ class TestBinaryBinding:
     @binary_type_parametrize
     def test_should_bind_corner_case_binary_values(self, execute_query, binary_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         for corner_case, _ in CORNER_CASE_VALUES:
             # When Query "SELECT ?::BINARY" is executed with each corner case binary value bound
@@ -286,6 +297,7 @@ class TestBinaryMultipleChunks:
         # ~30000 values ensures data is downloaded in at least two chunks
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8() AS id, TO_BINARY(LPAD(TO_VARCHAR(seq8()), 10, '0'), 'UTF-8')
         # AS bin_val FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v ORDER BY id" is executed
@@ -300,12 +312,14 @@ class TestBinaryMultipleChunks:
         rows = execute_query(sql)
 
         # Then there are 30000 rows returned
+        assert len(rows) == LARGE_RESULT_SET_SIZE
 
         # And all returned binary values should match the generated values in order
         assert_sequential_values(rows, LARGE_RESULT_SET_SIZE, transform=lambda i: (i, str(i).zfill(10).encode("utf-8")))
 
     def test_should_download_binary_data_in_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with (bin_data BINARY) exists with 30000 sequential binary values
         table_name = f"{tmp_schema}.binary_chunks_table"
@@ -322,5 +336,7 @@ class TestBinaryMultipleChunks:
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY bin_data")
 
         # Then there are 30000 rows returned
+        assert len(rows) == LARGE_RESULT_SET_SIZE
+
         # And all returned binary values should match the inserted values in order
         assert_sequential_values(rows, LARGE_RESULT_SET_SIZE, transform=lambda i: (str(i).zfill(10).encode("utf-8"),))

--- a/python/tests/e2e/types/test_binary_lob.py
+++ b/python/tests/e2e/types/test_binary_lob.py
@@ -7,6 +7,9 @@ This module tests large BINARY values at the following limits:
 Reference: https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03/bcr-1942
 """
 
+from .utils import assert_connection_is_open
+
+
 # =============================================================================
 # LOB SIZE LIMITS
 # =============================================================================
@@ -50,6 +53,7 @@ class TestBinaryLob:
         # This is the limit before enabling the 2025_03 behavior change bundle
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BINARY column exists
         table_name = f"{tmp_schema}.lob_8mb_table"
@@ -77,6 +81,7 @@ class TestBinaryLob:
         # Requires 2025_03 behavior change bundle
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BINARY(67108864) column exists
         table_name = f"{tmp_schema}.lob_64mb_table"

--- a/python/tests/e2e/types/test_boolean.py
+++ b/python/tests/e2e/types/test_boolean.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ...conftest import with_paramstyle
-from .utils import assert_type
+from .utils import assert_connection_is_open, assert_type
 
 
 # =============================================================================
@@ -17,6 +17,7 @@ class TestBooleanTypeCasting:
 
     def test_should_cast_boolean_values_to_appropriate_type(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
         result = execute_query("SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN", single_row=True)
@@ -33,6 +34,7 @@ class TestBooleanLiteral:
 
     def test_should_select_boolean_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
         result = execute_query("SELECT TRUE::BOOLEAN, FALSE::BOOLEAN", single_row=True)
@@ -43,6 +45,7 @@ class TestBooleanLiteral:
 
     def test_should_handle_null_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN" is executed
         result = execute_query("SELECT FALSE::BOOLEAN, NULL::BOOLEAN, TRUE::BOOLEAN, NULL::BOOLEAN", single_row=True)
@@ -53,6 +56,7 @@ class TestBooleanLiteral:
 
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT (id % 2 = 0)::BOOLEAN FROM <generator>" is executed
 
@@ -72,6 +76,7 @@ class TestBooleanTable:
 
     def test_should_select_boolean_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
         table_name = f"{tmp_schema}.boolean_table"
@@ -89,6 +94,7 @@ class TestBooleanTable:
 
     def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BOOLEAN column exists
         table_name = f"{tmp_schema}.null_table"
@@ -107,6 +113,7 @@ class TestBooleanTable:
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
 
@@ -135,6 +142,7 @@ class TestBooleanBinding:
 
     def test_should_select_boolean_using_parameter_binding(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::BOOLEAN, ?::BOOLEAN, ?::BOOLEAN" is executed
         # with bound boolean values [TRUE, FALSE, TRUE]
@@ -152,6 +160,7 @@ class TestBooleanBinding:
 
     def test_should_insert_boolean_using_parameter_binding(self, execute_query, executemany_insert, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with BOOLEAN column exists
         table_name = f"{tmp_schema}.boolean_bind_table"

--- a/python/tests/e2e/types/test_boolean_numpy.py
+++ b/python/tests/e2e/types/test_boolean_numpy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from .utils import assert_type
+from .utils import assert_connection_is_open, assert_type
 
 
 # NumPy is optional for these tests
@@ -15,8 +15,9 @@ class TestBooleanNumPy:
     """Test suite for BOOLEAN type NumPy conversion (Python-specific)."""
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_should_cast_boolean_to_numpy_bool_type(self, cursor_with_numpy):
+    def test_should_cast_boolean_to_numpy_bool_type(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN, FALSE::BOOLEAN" is executed
         sql = "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN, FALSE::BOOLEAN"

--- a/python/tests/e2e/types/test_decfloat.py
+++ b/python/tests/e2e/types/test_decfloat.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from decimal import Decimal
 
 from ...conftest import with_paramstyle
-from .utils import assert_sequential_values, assert_type
+from .utils import assert_connection_is_open, assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -48,6 +48,7 @@ class TestDecfloatTypeCasting:
 
     def test_should_cast_decfloat_values_to_appropriate_type(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0::DECFLOAT, 123.456::DECFLOAT, 1.23e37::DECFLOAT,
         # '12345678901234567890123456789012345678'::DECFLOAT" is executed
@@ -66,6 +67,7 @@ class TestDecfloatLiteral:
 
     def test_should_select_decfloat_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0::DECFLOAT, 1.5::DECFLOAT, -1.5::DECFLOAT,
         # 123.456789::DECFLOAT, -987.654321::DECFLOAT" is executed
@@ -85,6 +87,7 @@ class TestDecfloatLiteral:
 
     def test_should_handle_full_38_digit_precision_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT '12345678901234567890123456789012345678'::DECFLOAT,
         # '1.2345678901234567890123456789012345678E+100'::DECFLOAT,
@@ -102,6 +105,7 @@ class TestDecfloatLiteral:
 
     def test_should_handle_extreme_exponent_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT '1E+16384'::DECFLOAT, '1E-16383'::DECFLOAT" is executed
         result = execute_query(
@@ -123,6 +127,7 @@ class TestDecfloatLiteral:
 
     def test_should_handle_null_values_from_literals(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT" is executed
         result = execute_query("SELECT NULL::DECFLOAT, 42.5::DECFLOAT, NULL::DECFLOAT", single_row=True)
@@ -133,6 +138,7 @@ class TestDecfloatLiteral:
 
     def test_should_download_large_result_set_with_multiple_chunks_from_generator(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
 
@@ -145,9 +151,8 @@ class TestDecfloatLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Result should contain consecutive numbers from 0 to 19999
+        # Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate type
         values = [row[0] for row in rows]
-        # And All values should be returned as appropriate type
         assert_type(values, Decimal)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=Decimal)
 
@@ -157,6 +162,7 @@ class TestDecfloatTable:
 
     def test_should_select_decfloats_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
         table_name = f"{tmp_schema}.decfloat_table"
@@ -181,6 +187,7 @@ class TestDecfloatTable:
 
     def test_should_handle_full_38_digit_precision_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists with values
         # [12345678901234567890123456789012345678,
@@ -202,6 +209,7 @@ class TestDecfloatTable:
 
     def test_should_handle_extreme_exponent_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists with values
         # [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
@@ -226,6 +234,7 @@ class TestDecfloatTable:
 
     def test_should_handle_null_values_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
         table_name = f"{tmp_schema}.null_table"
@@ -242,6 +251,7 @@ class TestDecfloatTable:
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table(self, execute_query, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists with values from 0 to 19999
 
@@ -258,9 +268,8 @@ class TestDecfloatTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
-        # Then Result should contain consecutive numbers from 0 to 19999
+        # Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate type
         values = [row[0] for row in rows]
-        # And All values should be returned as appropriate type
         assert_type(values, Decimal)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=Decimal)
 
@@ -271,6 +280,7 @@ class TestDecfloatBinding:
 
     def test_should_select_decfloat_using_parameter_binding(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::DECFLOAT, ?::DECFLOAT, ?::DECFLOAT" is executed
         # with bound DECFLOAT values [123.456, -789.012, 42.0]
@@ -292,6 +302,7 @@ class TestDecfloatBinding:
 
     def test_should_select_extreme_decfloat_values_using_parameter_binding(self, execute_query):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::DECFLOAT" is executed with bound value 1E+16384
         result = execute_query(
@@ -317,6 +328,7 @@ class TestDecfloatBinding:
 
     def test_should_insert_decfloat_using_parameter_binding(self, execute_query, executemany_insert, tmp_schema):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists
         table_name = f"{tmp_schema}.decfloat_bind_table"
@@ -341,6 +353,7 @@ class TestDecfloatBinding:
         self, execute_query, executemany_insert, tmp_schema
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with DECFLOAT column exists
         table_name = f"{tmp_schema}.decfloat_extreme_bind_table"

--- a/python/tests/e2e/types/test_decfloat_numpy.py
+++ b/python/tests/e2e/types/test_decfloat_numpy.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pytest
 
-from .utils import assert_floats_equal, assert_type
+from .utils import assert_connection_is_open, assert_floats_equal, assert_type
 
 
 # NumPy is optional for these tests
@@ -26,8 +26,9 @@ class TestDecfloatNumPy:
     """Test suite for DECFLOAT type NumPy conversion (Python-specific)."""
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_should_cast_decfloat_values_to_numpy_float64(self, cursor_with_numpy):
+    def test_should_cast_decfloat_values_to_numpy_float64(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 1.234::DECFLOAT, 123.456::DECFLOAT, -789.012::DECFLOAT" is executed
         sql = "SELECT 1.234::DECFLOAT, 123.456::DECFLOAT, -789.012::DECFLOAT"
@@ -41,8 +42,9 @@ class TestDecfloatNumPy:
         assert_floats_equal(result, (1.234, 123.456, -789.012))
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_numpy_handles_extreme_exponents_within_float64_range(self, cursor_with_numpy):
+    def test_numpy_handles_extreme_exponents_within_float64_range(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query with exponents within float64 range is executed
         sql = "SELECT '1.23e100'::DECFLOAT, '9.87e-100'::DECFLOAT"
@@ -56,8 +58,9 @@ class TestDecfloatNumPy:
         assert_floats_equal(result, (1.23e100, 9.87e-100))
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_numpy_overflows_extreme_exponents_beyond_float64_range(self, cursor_with_numpy):
+    def test_numpy_overflows_extreme_exponents_beyond_float64_range(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query with exponents exceeding float64 range is executed
         sql = "SELECT '1e16384'::DECFLOAT, '1e-16383'::DECFLOAT"
@@ -65,6 +68,7 @@ class TestDecfloatNumPy:
         result = cursor_with_numpy.fetchone()
 
         # Then e16384 exceeds float64 max (~e308) and becomes infinity
-        # And e-16383 is below float64 min (~e-308) and becomes 0
         assert_floats_equal(result, (float("inf"), 0.0))
+
+        # And e-16383 is below float64 min (~e-308) and becomes 0
         assert_type(result, np.float64)

--- a/python/tests/e2e/types/test_float.py
+++ b/python/tests/e2e/types/test_float.py
@@ -15,6 +15,7 @@ import pytest
 from ...conftest import with_paramstyle
 from .utils import (
     FLOAT_MIN_NORMAL,
+    assert_connection_is_open,
     assert_floats_equal,
     assert_sequential_values,
     assert_type,
@@ -67,6 +68,7 @@ class TestFloatTypeCasting:
     @float_type_parametrize
     def test_should_cast_float_values_to_appropriate_type_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0.0::<type>, 123.456::<type>, 1.23e10::<type>, 'NaN'::<type>, 'inf'::<type>" is executed
         sql = (
@@ -79,8 +81,10 @@ class TestFloatTypeCasting:
         assert_type(result, float)
 
         # And Regular values should have approximately 15 decimal digits precision
+        assert_floats_equal(result[:3], (0.0, 123.456, 1.23e10))
+
         # And NaN and inf values should be identified correctly
-        assert_floats_equal(result, (0.0, 123.456, 1.23e10, nan, inf))
+        assert_floats_equal(result[3:], (nan, inf))
 
 
 class TestFloatLiteral:
@@ -89,6 +93,7 @@ class TestFloatLiteral:
     @float_type_parametrize
     def test_should_select_float_literals_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0.0::<type>, 1.0::<type>, -1.0::<type>, 123.456::<type>, -123.456::<type>" is executed
         sql = (
@@ -104,6 +109,7 @@ class TestFloatLiteral:
     @float_type_parametrize
     def test_should_handle_special_float_values_from_literals_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
         sql = f"SELECT 'NaN'::{float_type}, 'inf'::{float_type}, '-inf'::{float_type}"
@@ -116,6 +122,7 @@ class TestFloatLiteral:
     @float_type_parametrize
     def test_should_handle_float_boundary_values_from_literals_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 1.7976931348623157e308::<type>, -1.7976931348623157e308::<type>" is executed
         sql = f"SELECT {FLOAT_MAX}::{float_type}, {FLOAT_MIN}::{float_type}"
@@ -141,6 +148,7 @@ class TestFloatLiteral:
     @float_type_parametrize
     def test_should_handle_null_values_from_literals_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT NULL::<type>, 42.5::<type>, NULL::<type>" is executed
         sql = f"SELECT NULL::{float_type}, 42.5::{float_type}, NULL::{float_type}"
@@ -155,6 +163,7 @@ class TestFloatLiteral:
         self, execute_query, float_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
 
@@ -167,8 +176,7 @@ class TestFloatLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Result should contain 50000 rows
-        # And All values should be returned as appropriate float type
+        # Then Result should contain 50000 rows with all values returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=float, compare=floats_equal)
@@ -180,6 +188,7 @@ class TestFloatTable:
     @float_type_parametrize
     def test_should_select_floats_from_table_for_float_and_synonyms(self, execute_query, tmp_schema, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
         table_name = f"{tmp_schema}.float_table_{float_type.replace(' ', '_').lower()}"
@@ -201,6 +210,7 @@ class TestFloatTable:
         self, execute_query, tmp_schema, float_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
         table_name = f"{tmp_schema}.special_float_table_{float_type.replace(' ', '_').lower()}"
@@ -227,6 +237,7 @@ class TestFloatTable:
         self, execute_query, tmp_schema, float_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists with boundary values
         # [1.7976931348623157e308, -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
@@ -247,12 +258,13 @@ class TestFloatTable:
         result = [row[0] for row in rows]
 
         # Then Result should contain maximum, minimum, and precision boundary values
-        # And All values should be preserved within float precision limits
+        # preserved within float precision limits
         assert_floats_equal(result, boundary_values)
 
     @float_type_parametrize
     def test_should_handle_null_values_from_table_for_float_and_synonyms(self, execute_query, tmp_schema, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
         table_name = f"{tmp_schema}.null_table_{float_type.replace(' ', '_').lower()}"
@@ -272,6 +284,7 @@ class TestFloatTable:
         self, execute_query, tmp_schema, float_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists with 50000 sequential values
 
@@ -288,8 +301,7 @@ class TestFloatTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY col")
 
-        # Then Result should contain 50000 rows
-        # And All values should be returned as appropriate float type
+        # Then Result should contain 50000 rows with all values returned as appropriate float type
         values = [row[0] for row in rows]
         assert_type(values, float)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=float, compare=floats_equal)
@@ -302,6 +314,7 @@ class TestFloatBinding:
     @float_type_parametrize
     def test_should_select_float_using_parameter_binding_for_float_and_synonyms(self, execute_query, float_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::<type>, ?::<type>, ?::<type>" is executed
         # with bound float values [123.456, -789.012, 42.0]
@@ -328,6 +341,7 @@ class TestFloatBinding:
         self, execute_query, executemany_insert, tmp_schema, float_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with <type> column exists
         table_name = f"{tmp_schema}.float_bind_table_{float_type.replace(' ', '_').lower()}"

--- a/python/tests/e2e/types/test_float_numpy.py
+++ b/python/tests/e2e/types/test_float_numpy.py
@@ -10,7 +10,7 @@ from math import inf, nan
 
 import pytest
 
-from .utils import assert_floats_equal, assert_type
+from .utils import assert_connection_is_open, assert_floats_equal, assert_type
 
 
 # NumPy is optional for these tests
@@ -32,8 +32,11 @@ class TestFloatNumPy:
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
     @float_type_parametrize
-    def test_should_cast_float_values_to_numpy_float64_for_float_and_synonyms(self, cursor_with_numpy, float_type):
+    def test_should_cast_float_values_to_numpy_float64_for_float_and_synonyms(
+        self, execute_query, cursor_with_numpy, float_type
+    ):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0.0::<type>, 123.456::<type>, -789.012::<type>, 1.23e10::<type>" is executed
         sql = f"SELECT 0.0::{float_type}, 123.456::{float_type}, -789.012::{float_type}, 1.23e10::{float_type}"
@@ -48,8 +51,11 @@ class TestFloatNumPy:
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
     @float_type_parametrize
-    def test_should_handle_special_float_values_with_numpy_for_float_and_synonyms(self, cursor_with_numpy, float_type):
+    def test_should_handle_special_float_values_with_numpy_for_float_and_synonyms(
+        self, execute_query, cursor_with_numpy, float_type
+    ):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 'NaN'::<type>, 'inf'::<type>, '-inf'::<type>" is executed
         sql = f"SELECT 'NaN'::{float_type}, 'inf'::{float_type}, '-inf'::{float_type}"

--- a/python/tests/e2e/types/test_int.py
+++ b/python/tests/e2e/types/test_int.py
@@ -85,10 +85,8 @@ class TestIntTypeCasting:
         sql = f"SELECT 0::{int_type}, 1000000::{int_type}, {INT64_SIGNED_MAX}::{int_type}"
         result = execute_query(sql, single_row=True)
 
-        # Then All values should be returned as appropriate type
+        # Then All values should be returned as appropriate type with no precision loss
         assert_type(result, int)
-
-        # And No precision loss should occur
         assert result == (0, 1000000, INT64_SIGNED_MAX)
 
 
@@ -285,10 +283,9 @@ class TestIntTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name}")
 
-        # Then Result should contain 50000 rows
+        # Then Result should contain 50000 rows with all values equal to expected data
         assert len(rows) == LARGE_RESULT_SET_SIZE
 
-        # And All values should be equal to expected data
         for row in rows:
             assert row == (100, 30000, 2000000000, 9000000000000000000)
 

--- a/python/tests/e2e/types/test_number.py
+++ b/python/tests/e2e/types/test_number.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 import pytest
 
 from ...conftest import with_paramstyle
-from .utils import assert_sequential_values, assert_type
+from .utils import assert_connection_is_open, assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -75,16 +75,16 @@ class TestNumberTypeCasting:
     @number_type_parametrize
     def test_should_cast_number_values_to_appropriate_type_for_number_and_synonyms(self, execute_query, num_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0::<type>(10,0), 123::<type>(10,0), 0.00::<type>(10,2), 123.45::<type>(10,2)" is executed
         sql = f"SELECT 0::{num_type}(10,0), 123::{num_type}(10,0), 0.00::{num_type}(10,2), 123.45::{num_type}(10,2)"
         result = execute_query(sql, single_row=True)
 
-        # Then All values should be returned as appropriate type
+        # Then All values should be returned as appropriate type matching [0, 123, 0.00, 123.45]
         assert_type(result[:2], int)  # scale=0 → int
         assert_type(result[2:], Decimal)  # scale>0 → Decimal
 
-        # And Values should match [0, 123, 0.00, 123.45]
         assert result == (0, 123, Decimal("0.00"), Decimal("123.45"))
 
 
@@ -94,6 +94,7 @@ class TestNumberLiteral:
     @number_type_parametrize
     def test_should_select_number_literals_for_number_and_synonyms(self, execute_query, num_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0::<type>(10,0), -456::<type>(10,0), 1.50::<type>(10,2), -123.45::<type>(10,2),
         # 123.456::<type>(15,3), -789.012::<type>(15,3)" is executed
@@ -114,6 +115,7 @@ class TestNumberLiteral:
     @number_type_parametrize
     def test_should_handle_high_precision_values_from_literals_for_number_and_synonyms(self, execute_query, num_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 12345678901234567890123456789012345678::<type>(38,0),
         # 123456789012345678901234567890123456.78::<type>(38,2),
@@ -141,6 +143,7 @@ class TestNumberLiteral:
         self, execute_query, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 999.99::<type>(5,2), -999.99::<type>(5,2), 99999999::<type>(8,0),
         # -99999999::<type>(8,0)" is executed
@@ -161,6 +164,7 @@ class TestNumberLiteral:
         self, execute_query, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 99999999999999999999999999999999999999::<type>(38,0),
         # -99999999999999999999999999999999999999::<type>(38,0)" is executed
@@ -175,6 +179,7 @@ class TestNumberLiteral:
     @number_type_parametrize
     def test_should_handle_null_values_from_literals_for_number_and_synonyms(self, execute_query, num_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT NULL::<type>(10,0), 42::<type>(10,0), NULL::<type>(10,2), 42.50::<type>(10,2)" is executed
         sql = f"SELECT NULL::{num_type}(10,0), 42::{num_type}(10,0), NULL::{num_type}(10,2), 42.50::{num_type}(10,2)"
@@ -191,6 +196,7 @@ class TestNumberLiteral:
         self, execute_query, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query
         # "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v"
@@ -208,13 +214,13 @@ class TestNumberLiteral:
         )
         rows = execute_query(sql)
 
-        # Then Column 1 should contain sequential integers from 0 to 29999
+        # Then Result should contain 30000 rows with sequential integers in column 1
+        # and sequential decimals starting from 0.12345 in column 2
         col0_values = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col0_values, int)
         assert_sequential_values(col0_values, LARGE_RESULT_SET_SIZE)
 
-        # And Column 2 should contain sequential decimals starting from 0.12345
         col1_values = [row[1] for row in rows]
         # Python: scale>0 -> Decimal
         assert_type(col1_values, Decimal)
@@ -233,6 +239,7 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
         table_name = f"{tmp_schema}.number_table_{num_type.lower()}"
@@ -244,18 +251,36 @@ class TestNumberTable:
             f"col_scale5 {num_type}(20,5))"
         )
 
-        # And Row (123, 123.45, 123.456, 12345.67890) is inserted
-        # And Row (-456, -67.89, -789.012, -98765.43210) is inserted
-        # And Row (0, 0.00, 0.000, 0.00000) is inserted
-        # And Row (999999, 999.99, 1000.500, 123456.78901) is inserted
         test_data = [
             (123, Decimal("123.45"), Decimal("123.456"), Decimal("12345.67890")),
             (-456, Decimal("-67.89"), Decimal("-789.012"), Decimal("-98765.43210")),
             (0, Decimal("0.00"), Decimal("0.000"), Decimal("0.00000")),
             (999999, Decimal("999.99"), Decimal("1000.500"), Decimal("123456.78901")),
         ]
-        for row in test_data:
-            execute_query(f"INSERT INTO {table_name} VALUES ({row[0]}, {row[1]}, {row[2]}, {row[3]})")
+
+        # And Row (123, 123.45, 123.456, 12345.67890) is inserted
+        execute_query(
+            f"INSERT INTO {table_name} VALUES ("
+            f"{test_data[0][0]}, {test_data[0][1]}, {test_data[0][2]}, {test_data[0][3]})"
+        )
+
+        # And Row (-456, -67.89, -789.012, -98765.43210) is inserted
+        execute_query(
+            f"INSERT INTO {table_name} VALUES ("
+            f"{test_data[1][0]}, {test_data[1][1]}, {test_data[1][2]}, {test_data[1][3]})"
+        )
+
+        # And Row (0, 0.00, 0.000, 0.00000) is inserted
+        execute_query(
+            f"INSERT INTO {table_name} VALUES ("
+            f"{test_data[2][0]}, {test_data[2][1]}, {test_data[2][2]}, {test_data[2][3]})"
+        )
+
+        # And Row (999999, 999.99, 1000.500, 123456.78901) is inserted
+        execute_query(
+            f"INSERT INTO {table_name} VALUES ("
+            f"{test_data[3][0]}, {test_data[3][1]}, {test_data[3][2]}, {test_data[3][3]})"
+        )
 
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name}")
@@ -272,6 +297,7 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
         table_name = f"{tmp_schema}.precision_table_{num_type.lower()}"
@@ -314,23 +340,26 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(5,2), <type>(8,0)) exists
         table_name = f"{tmp_schema}.boundary_table_{num_type.lower()}"
         execute_query(f"CREATE TABLE {table_name} (col_5_2 {num_type}(5,2), col_8_0 {num_type}(8,0))")
 
-        # And Row (999.99, 99999999) is inserted
-        # And Row (-999.99, -99999999) is inserted
-        # And Row (123.45, 12345678) is inserted
-        # And Row (0.01, 0) is inserted
         test_data = [
             (NUMBER_5_2_MAX, NUMBER_8_0_MAX),
             (NUMBER_5_2_MIN, NUMBER_8_0_MIN),
             (Decimal("123.45"), 12345678),
             (Decimal("0.01"), 0),
         ]
-        for row in test_data:
-            execute_query(f"INSERT INTO {table_name} VALUES ({row[0]}, {row[1]})")
+        # And Row (999.99, 99999999) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[0][0]}, {test_data[0][1]})")
+        # And Row (-999.99, -99999999) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[1][0]}, {test_data[1][1]})")
+        # And Row (123.45, 12345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[2][0]}, {test_data[2][1]})")
+        # And Row (0.01, 0) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[3][0]}, {test_data[3][1]})")
 
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name}")
@@ -347,21 +376,23 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(38,0), <type>(38,37)) exists
         table_name = f"{tmp_schema}.high_precision_boundary_table_{num_type.lower()}"
         execute_query(f"CREATE TABLE {table_name} (col_38_0 {num_type}(38,0), col_38_37 {num_type}(38,37))")
 
-        # And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678) is inserted
-        # And Row (-99999999999999999999999999999999999999, -1.2345678901234567890123456789012345678) is inserted
-        # And Row (12345678901234567890123456789012345678, 0.0000000000000000000000000000000000001) is inserted
         test_data = [
             (NUMBER_38_0_MAX, NUMBER_38_DIGITS_SCALE37),
             (NUMBER_38_0_MIN, -NUMBER_38_DIGITS_SCALE37),
             (NUMBER_38_DIGITS_INT, NUMBER_38_37_MIN_POSITIVE),
         ]
-        for row in test_data:
-            execute_query(f"INSERT INTO {table_name} VALUES ({row[0]}, {row[1]})")
+        # And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[0][0]}, {test_data[0][1]})")
+        # And Row (-99999999999999999999999999999999999999, -1.2345678901234567890123456789012345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[1][0]}, {test_data[1][1]})")
+        # And Row (12345678901234567890123456789012345678, 0.0000000000000000000000000000000000001) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({test_data[2][0]}, {test_data[2][1]})")
 
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name}")
@@ -378,6 +409,7 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
         table_name = f"{tmp_schema}.null_table_{num_type.lower()}"
@@ -389,12 +421,12 @@ class TestNumberTable:
         )
 
         # And Row (NULL, NULL, NULL) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL, NULL, NULL)")
         # And Row (123, 123.45, 123.456) is inserted
-        # And Row (NULL, NULL, NULL) is inserted
-        # And Row (-456, -67.89, -789.012) is inserted
-        execute_query(f"INSERT INTO {table_name} VALUES (NULL, NULL, NULL)")
         execute_query(f"INSERT INTO {table_name} VALUES (123, 123.45, 123.456)")
+        # And Row (NULL, NULL, NULL) is inserted
         execute_query(f"INSERT INTO {table_name} VALUES (NULL, NULL, NULL)")
+        # And Row (-456, -67.89, -789.012) is inserted
         execute_query(f"INSERT INTO {table_name} VALUES (-456, -67.89, -789.012)")
 
         # When Query "SELECT * FROM <table>" is executed
@@ -419,6 +451,7 @@ class TestNumberTable:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows,
         # from 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
@@ -439,13 +472,13 @@ class TestNumberTable:
         # When Query "SELECT * FROM <table>" is executed
         rows = execute_query(f"SELECT * FROM {table_name} ORDER BY 1")
 
-        # Then Column 1 should contain sequential integers from 0 to 29999
+        # Then Result should contain 30000 rows with sequential integers in column 1
+        # and sequential decimals starting from 0.12345 in column 2
         col1 = [row[0] for row in rows]
         # Python: scale=0 -> int
         assert_type(col1, int)
         assert_sequential_values(col1, LARGE_RESULT_SET_SIZE)
 
-        # And Column 2 should contain sequential decimals starting from 0.12345
         col2 = [row[1] for row in rows]
         # Python: scale>0 -> Decimal
         assert_type(col2, Decimal)
@@ -463,6 +496,7 @@ class TestNumberBinding:
     @number_type_parametrize
     def test_should_select_number_using_parameter_binding_for_number_and_synonyms(self, execute_query, num_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::<type>(10,0), ?::<type>(10,0), ?::<type>(10,2), ?::<type>(10,2), ?::<type>(10,0)"
         # is executed with bound values [123, -456, 12.34, -56.78, NULL]
@@ -486,6 +520,7 @@ class TestNumberBinding:
         self, execute_query, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::<type>(38,0), ?::<type>(38,2)" is executed
         # with bound values [12345678901234567890123456789012345678, 123456789012345678901234567890123456.78]
@@ -507,6 +542,7 @@ class TestNumberBinding:
         self, execute_query, executemany_insert, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(10,0), <type>(10,2)) exists
         table_name = f"{tmp_schema}.number_bind_{num_type.lower()}"
@@ -538,6 +574,7 @@ class TestNumberBinding:
         self, execute_query, tmp_schema, num_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And Table with columns (<type>(38,0), <type>(38,2)) exists
         table_name = f"{tmp_schema}.high_precision_bind_{num_type.lower()}"

--- a/python/tests/e2e/types/test_number_numpy.py
+++ b/python/tests/e2e/types/test_number_numpy.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import pytest
 
-from .utils import assert_floats_equal, assert_type
+from .utils import assert_connection_is_open, assert_floats_equal, assert_type
 
 
 # NumPy is optional for these tests
@@ -35,8 +35,9 @@ class TestNumberNumPy:
     """Test suite for NUMBER type NumPy conversion (Python-specific)."""
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_should_cast_number_scale0_to_numpy_int64(self, cursor_with_numpy):
+    def test_should_cast_number_scale0_to_numpy_int64(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0::NUMBER(10,0), 123::NUMBER(10,0), -456::NUMBER(10,0),
         # 999999::NUMBER(10,0)" is executed
@@ -51,8 +52,9 @@ class TestNumberNumPy:
         assert result == (0, 123, -456, 999999)
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_should_cast_number_scale3_to_numpy_float64(self, cursor_with_numpy):
+    def test_should_cast_number_scale3_to_numpy_float64(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 0.000::NUMBER(15,3), 123.456::NUMBER(15,3),
         # -789.012::NUMBER(15,3)" is executed
@@ -67,8 +69,9 @@ class TestNumberNumPy:
         assert_floats_equal(result, (0.0, 123.456, -789.012))
 
     @pytest.mark.skip("SNOW-2997786 - use_numpy is currently hardcoded to False in cursor")
-    def test_numpy_handles_high_precision_integers_within_int64_range(self, cursor_with_numpy):
+    def test_numpy_handles_high_precision_integers_within_int64_range(self, execute_query, cursor_with_numpy):
         # Given Snowflake client is logged in with NumPy mode enabled
+        assert_connection_is_open(execute_query)
 
         # When Query with 18-digit integer (within int64 range) is executed
         sql = "SELECT 123456789012345678::NUMBER(18,0)"

--- a/python/tests/e2e/types/test_string.py
+++ b/python/tests/e2e/types/test_string.py
@@ -14,7 +14,7 @@ Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
 import pytest
 
 from ...conftest import with_paramstyle
-from .utils import assert_sequential_values, assert_type
+from .utils import assert_connection_is_open, assert_sequential_values, assert_type
 
 
 # =============================================================================
@@ -82,6 +82,7 @@ class TestStringTypeCasting:
     @string_type_parametrize
     def test_should_cast_string_values_to_appropriate_type_for_string_and_synonyms(self, execute_query, string_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
         sql = f"SELECT 'hello'::{string_type}(32), 'Hello World'::{string_type}(32), '日本語テスト'::{string_type}(32)"
@@ -98,6 +99,7 @@ class TestStringLiteral:
     @string_type_parametrize
     def test_should_select_hardcoded_string_literals(self, execute_query, string_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3" is executed
         sql = (
@@ -116,12 +118,13 @@ class TestStringLiteral:
         # Corner cases: empty string, single character, whitespace-only, unicode characters, escape sequences
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query selecting corner case string literals is executed
-
+        type_cast = f"::{string_type}(32)"
         # Then the result should contain expected corner case string values
         for expected_val, sql_val in CORNER_CASE_VALUES:
-            result = execute_query(f"SELECT {sql_val}::{string_type}(32)", single_row=True)
+            result = execute_query(f"SELECT {sql_val}{type_cast}", single_row=True)
             assert result == (expected_val,), f"Expected {expected_val!r}, got {result[0]!r}"
 
 
@@ -131,6 +134,7 @@ class TestStringTable:
     @string_type_parametrize
     def test_should_select_hardcoded_string_values_from_table(self, execute_query, tmp_schema, string_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with VARCHAR column is created
         table_name = f"{tmp_schema}.string_table_test"
@@ -152,6 +156,7 @@ class TestStringTable:
     @string_type_parametrize
     def test_should_select_corner_case_string_values_from_table(self, execute_query, tmp_schema, string_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with VARCHAR column is created
         table_name = f"{tmp_schema}.string_corner_case_table_test"
@@ -181,6 +186,7 @@ class TestStringBinding:
         self, execute_query, executemany_insert, tmp_schema, string_type
     ):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with VARCHAR column is created
         table_name = f"{tmp_schema}.string_bind_table_test"
@@ -204,6 +210,7 @@ class TestStringBinding:
         # SELECT binding test: Uses SELECT ?::VARCHAR to bind string values
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR" is executed
         # with bound string values ['hello', 'Hello World', '日本語テスト']
@@ -220,11 +227,11 @@ class TestStringBinding:
     @string_type_parametrize
     def test_should_select_corner_case_string_values_using_parameter_binding(self, execute_query, string_type):
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
         for corner_case, _ in CORNER_CASE_VALUES:
             result = execute_query(f"SELECT ?::{string_type}(32)", (corner_case,), single_row=True)
-
             # Then the result should match the bound corner case value
             assert result == (corner_case,)
 
@@ -237,6 +244,7 @@ class TestStringMultipleChunks:
         # ~10000 values ensures data is downloaded in at least two chunks
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val
         # FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
@@ -251,8 +259,7 @@ class TestStringMultipleChunks:
         )
         rows = execute_query(sql)
 
-        # Then there are 10000 rows returned
+        # Then there are 10000 rows returned and all string values should match the generated values in order
         assert len(rows) == LARGE_RESULT_SET_SIZE
 
-        # And all returned string values should match the generated values in order
         assert_sequential_values(rows, LARGE_RESULT_SET_SIZE, transform=lambda i: (i, str(i)))

--- a/python/tests/e2e/types/test_string_lob.py
+++ b/python/tests/e2e/types/test_string_lob.py
@@ -7,6 +7,9 @@ This module tests large VARCHAR values at the following limits:
 Reference: https://docs.snowflake.com/en/sql-reference/data-types-text
 """
 
+from .utils import assert_connection_is_open
+
+
 # =============================================================================
 # LOB SIZE LIMITS
 # =============================================================================
@@ -40,6 +43,7 @@ class TestStringLob:
         # Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with VARCHAR column is created
         table_name = f"{tmp_schema}.lob_16mb_table"
@@ -66,6 +70,7 @@ class TestStringLob:
         # Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
 
         # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
 
         # And A temporary table with VARCHAR column is created
         table_name = f"{tmp_schema}.lob_128mb_table"

--- a/python/tests/e2e/types/test_timestamp_ltz.py
+++ b/python/tests/e2e/types/test_timestamp_ltz.py
@@ -65,6 +65,8 @@ class TestTimestampLtzTypeCasting:
         result = execute_query(f"SELECT '{TS_2024_JAN_STR}'::TIMESTAMP_LTZ", single_row=True)
 
         # Then All values should be returned as appropriate type
+        assert_datetime_type(result)
+
         # And Values should have timezone info
         assert_datetime_type(result, require_tzinfo=True)
 

--- a/python/tests/integ/config/test_config_manager.py
+++ b/python/tests/integ/config/test_config_manager.py
@@ -80,9 +80,10 @@ class TestConfigOption:
         )
 
         # When ConfigManager retrieves the option
+        retrieve = option.value
         # Then ConfigSourceError should be raised
         with pytest.raises(CSError) as exc_info:
-            option.value()
+            retrieve()
         assert "is not part of" in str(exc_info.value)
 
     def test_config_value_from_file(self, config_env):
@@ -144,8 +145,10 @@ mykey = "file_value"
         os.environ["CUSTOM_ENV_VAR"] = "custom_value"
 
         # When ConfigManager retrieves option with env_name set to CUSTOM_ENV_VAR
+        result = option.value()
+
         # Then The custom env var value should be returned
-        assert option.value() == "custom_value"
+        assert result == "custom_value"
 
     def test_custom_env_name_with_parse_str(self, config_env):
         """Test that parse_str is applied to custom env var values."""
@@ -163,9 +166,11 @@ mykey = "file_value"
         os.environ["CUSTOM_ENV_VAR"] = "123"
 
         # When ConfigManager retrieves option with parse_str set to int
+        result = option.value()
+
         # Then The parsed integer value should be returned
-        assert option.value() == 123
-        assert isinstance(option.value(), int)
+        assert result == 123
+        assert isinstance(result, int)
 
 
 class TestDefaultEnvName:
@@ -232,8 +237,10 @@ class TestDefaultEnvName:
         )
 
         # When Retrieving the option value
+        result = option.value()
+
         # Then The explicit env var value should be returned
-        assert option.value() == "from_explicit"
+        assert result == "from_explicit"
 
     def test_default_env_var_priority_over_config_file(self, config_env):
         """Test that default env var takes priority over config file value."""

--- a/sf_core/tests/integration/authentication/native_okta.rs
+++ b/sf_core/tests/integration/authentication/native_okta.rs
@@ -52,15 +52,12 @@ impl OktaTestFixture {
         self.client.connect()
     }
 
-    fn connect_expecting_success(&self, context: &str) {
-        let result = self.connect();
+    fn assert_success(result: Result<(), String>, context: &str) {
         assert!(result.is_ok(), "Expected {context}, got: {result:?}");
     }
 
-    fn connect_expecting_error(&self, patterns: &[&str], context: &str) {
-        let error = self
-            .connect()
-            .expect_err(&format!("Expected {context} to fail"));
+    fn assert_error(result: Result<(), String>, patterns: &[&str], context: &str) {
+        let error = result.expect_err(&format!("Expected {context} to fail"));
         let matches = patterns.iter().any(|p| error.contains(p));
         assert!(matches, "Expected {context}, got: {error}");
     }
@@ -72,15 +69,14 @@ impl OktaTestFixture {
 
 #[test]
 fn should_login_with_native_okta_using_saml_flow() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake and Okta mappings
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake and Okta mappings
     let fixture = OktaTestFixture::new().with_successful_okta_flow();
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Login is successful
-    fixture.connect_expecting_success("Okta login to succeed");
+    OktaTestFixture::assert_success(result, "Okta login to succeed");
 }
 
 // =============================================================================
@@ -89,19 +85,20 @@ fn should_login_with_native_okta_using_saml_flow() {
 
 #[test]
 fn should_fail_with_bad_credentials_when_okta_returns_401() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token endpoint returning 401 Unauthorized
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token endpoint returning 401 Unauthorized
     fixture.mock.mount(okta::okta_token_401());
     fixture.set_option("user", "invalid_user");
     fixture.set_option("password", "wrong_password");
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with bad credentials error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["BadCredentials", "401", "credentials"],
         "bad credentials error",
     );
@@ -109,19 +106,20 @@ fn should_fail_with_bad_credentials_when_okta_returns_401() {
 
 #[test]
 fn should_fail_with_bad_credentials_when_okta_returns_403() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token endpoint returning 403 Forbidden
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token endpoint returning 403 Forbidden
     fixture.mock.mount(okta::okta_token_403());
     fixture.set_option("user", "forbidden_user");
     fixture.set_option("password", "forbidden_password");
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with bad credentials error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["BadCredentials", "403", "credentials"],
         "bad credentials error",
     );
@@ -133,19 +131,19 @@ fn should_fail_with_bad_credentials_when_okta_returns_403() {
 
 #[test]
 fn should_fail_when_okta_returns_mfa_required_status() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token endpoint returning MFA_REQUIRED status
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token endpoint returning MFA_REQUIRED status
     fixture.mock.mount(okta::okta_token_mfa_required());
     fixture.set_option("user", "mfa_user");
     fixture.set_option("password", "mfa_password");
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with MFA required error
-    fixture.connect_expecting_error(&["MfaRequired", "MFA", "mfa"], "MFA required error");
+    OktaTestFixture::assert_error(result, &["MfaRequired", "MFA", "mfa"], "MFA required error");
 }
 
 // =============================================================================
@@ -155,10 +153,9 @@ fn should_fail_when_okta_returns_mfa_required_status() {
 #[test]
 fn should_fail_when_tokenurl_does_not_match_configured_okta_url_origin() {
     // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request with mismatched tokenUrl
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
     let fixture = OktaTestFixture::new();
+
+    // And Wiremock has Snowflake authenticator-request with mismatched tokenUrl
     fixture
         .mock
         .mount(okta::authenticator_request_mismatched_token_url(
@@ -166,8 +163,11 @@ fn should_fail_when_tokenurl_does_not_match_configured_okta_url_origin() {
         ));
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with IdP URL mismatch error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["IdpUrlMismatch", "mismatch", "does not match"],
         "IdP URL mismatch error",
     );
@@ -176,10 +176,9 @@ fn should_fail_when_tokenurl_does_not_match_configured_okta_url_origin() {
 #[test]
 fn should_fail_when_ssourl_does_not_match_configured_okta_url_origin() {
     // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request with mismatched ssoUrl
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
     let fixture = OktaTestFixture::new();
+
+    // And Wiremock has Snowflake authenticator-request with mismatched ssoUrl
     fixture
         .mock
         .mount(okta::authenticator_request_mismatched_sso_url(
@@ -187,8 +186,11 @@ fn should_fail_when_ssourl_does_not_match_configured_okta_url_origin() {
         ));
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with IdP URL mismatch error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["IdpUrlMismatch", "mismatch", "does not match"],
         "IdP URL mismatch error",
     );
@@ -200,19 +202,21 @@ fn should_fail_when_ssourl_does_not_match_configured_okta_url_origin() {
 
 #[test]
 fn should_fail_when_saml_postback_url_does_not_match_snowflake_server() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token success mapping
-    // And Wiremock has Okta SSO returning SAML with mismatched postback URL
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token success mapping
     fixture.mock.mount(okta::okta_token_success());
+
+    // And Wiremock has Okta SSO returning SAML with mismatched postback URL
     fixture.mock.mount(okta::okta_sso_mismatched_postback());
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with SAML destination mismatch error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["SamlDestinationMismatch", "postback", "destination"],
         "SAML destination mismatch error",
     );
@@ -220,40 +224,46 @@ fn should_fail_when_saml_postback_url_does_not_match_snowflake_server() {
 
 #[test]
 fn should_succeed_with_mismatched_postback_when_disable_saml_url_check_is_true() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token success mapping
-    // And Wiremock has Okta SSO returning SAML with mismatched postback URL
-    // And Wiremock has Snowflake login success for Okta
-    // And Snowflake client is configured for native Okta with disable_saml_url_check
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token success mapping
     fixture.mock.mount(okta::okta_token_success());
+
+    // And Wiremock has Okta SSO returning SAML with mismatched postback URL
     fixture.mock.mount(okta::okta_sso_mismatched_postback());
+
+    // And Wiremock has Snowflake login success for Okta
     fixture.mock.mount(okta::login_success());
+
+    // And Snowflake client is configured for native Okta with disable_saml_url_check
     fixture.set_option("disable_saml_url_check", "true");
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Login is successful
-    fixture.connect_expecting_success("Okta login to succeed with disable_saml_url_check");
+    OktaTestFixture::assert_success(result, "Okta login to succeed with disable_saml_url_check");
 }
 
 #[test]
 fn should_fail_when_saml_html_is_missing_form_action() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token success mapping
-    // And Wiremock has Okta SSO returning SAML HTML without form action
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token success mapping
     fixture.mock.mount(okta::okta_token_success());
+
+    // And Wiremock has Okta SSO returning SAML HTML without form action
     fixture.mock.mount(okta::okta_sso_missing_form_action());
     fixture.set_option("authentication_timeout", "5");
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Connection fails with missing SAML postback error
-    fixture.connect_expecting_error(
+    OktaTestFixture::assert_error(
+        result,
         &["MissingSamlPostback", "postback", "form action"],
         "missing SAML postback error",
     );
@@ -265,23 +275,25 @@ fn should_fail_when_saml_html_is_missing_form_action() {
 
 #[test]
 fn should_use_cookietoken_when_sessiontoken_is_missing() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token endpoint returning cookieToken instead of sessionToken
-    // And Wiremock has Okta SSO success mapping
-    // And Wiremock has Snowflake login success for Okta
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token endpoint returning cookieToken instead of sessionToken
     fixture.mock.mount(okta::okta_token_cookie_token());
+
+    // And Wiremock has Okta SSO success mapping
     fixture
         .mock
         .mount(okta::okta_sso_success(&fixture.mock.http_url()));
+
+    // And Wiremock has Snowflake login success for Okta
     fixture.mock.mount(okta::login_success());
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Login is successful
-    fixture.connect_expecting_success("Okta login with cookieToken to succeed");
+    OktaTestFixture::assert_success(result, "Okta login with cookieToken to succeed");
 }
 
 // =============================================================================
@@ -290,23 +302,29 @@ fn should_use_cookietoken_when_sessiontoken_is_missing() {
 
 #[test]
 fn should_retry_saml_fetch_with_fresh_token_on_transient_error() {
-    // Given Wiremock is running
-    // And Wiremock has Snowflake authenticator-request mapping
-    // And Wiremock has Okta token success mapping
-    // And Wiremock has Okta SSO returning 503 on first attempt
-    // And Wiremock has Okta SSO returning success on retry
-    // And Wiremock has Snowflake login success for Okta
-    // And Snowflake client is configured for native Okta
-    // And TLS certificate verification is disabled for the Okta HTTPS mock
+    // Given Wiremock is running with Snowflake authenticator-request mapping
     let fixture = OktaTestFixture::new().with_authenticator_request();
+
+    // And Wiremock has Okta token success mapping
     fixture.mock.mount(okta::okta_token_success());
+
+    // And Wiremock has Okta SSO returning 503 on first attempt
+    fixture.mock.mount(okta::okta_sso_503_once());
+
+    // And Wiremock has Okta SSO returning success on retry
     fixture
         .mock
         .mount(okta::okta_sso_success(&fixture.mock.http_url()));
-    fixture.mock.mount(okta::okta_sso_503_once());
+
+    // And Wiremock has Snowflake login success for Okta
     fixture.mock.mount(okta::login_success());
 
     // When Trying to Connect
+    let result = fixture.connect();
+
     // Then Login is successful
-    fixture.connect_expecting_success("Okta login to succeed after retrying transient error");
+    OktaTestFixture::assert_success(
+        result,
+        "Okta login to succeed after retrying transient error",
+    );
 }

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -142,16 +142,16 @@ async fn should_only_refresh_once_with_concurrent_401_errors() {
         }));
     }
 
-    // Then only one refresh attempt should be made
-    // And all requests should succeed after the refresh
+    // Then all requests should succeed after the refresh
     let mut success_count = 0;
     for (i, handle) in handles.into_iter().enumerate() {
         let result = handle.await.expect("task panicked");
-        assert!(result.is_ok(), "Request {} failed: {:?}", i, result);
+        assert!(result.is_ok(), "Request {i} failed: {result:?}");
         success_count += 1;
     }
     assert_eq!(success_count, 3, "Expected all 3 requests to succeed");
 
+    // And only one refresh attempt should be made
     assert_eq!(
         refresh_attempts.load(Ordering::SeqCst),
         1,

--- a/tests/definitions/core/session/session_refresh.feature
+++ b/tests/definitions/core/session/session_refresh.feature
@@ -29,5 +29,5 @@ Feature: Session Token Refresh
   Scenario: should only refresh once with concurrent 401 errors
     Given a connection with an expired session token
     When multiple concurrent requests receive 401 errors
-    Then only one refresh attempt should be made
-    And all requests should succeed after the refresh
+    Then all requests should succeed after the refresh
+    And only one refresh attempt should be made

--- a/tests/definitions/core/token_cache/token_cache.feature
+++ b/tests/definitions/core/token_cache/token_cache.feature
@@ -110,6 +110,7 @@ Feature: SSO/MFA Token caching
   @core_unit
   Scenario: Should support configurable retry parameters
     Given a file-based credential store with custom retry settings
+    When the credential store is initialized
     Then the retry count, delay, and stale lock timeout should match
 
   # --- file_cache.rs: concurrency_tests ---
@@ -173,6 +174,7 @@ Feature: SSO/MFA Token caching
   @core_unit
   Scenario: Should report persistence as until delete via adapter
     Given a file-based credential builder
+    When the persistence type is queried
     Then its persistence should be UntilDelete
 
   @core_unit

--- a/tests/definitions/odbc/query/sql_fetch.feature
+++ b/tests/definitions/odbc/query/sql_fetch.feature
@@ -21,8 +21,7 @@ Feature: ODBC SQLFetch function behavior
   @odbc_e2e
   Scenario: SQLSetStmtAttr sets supported cursor types.
     Given Snowflake client is logged in
-    When SQLSetStmtAttr is called with SQL_ATTR_CURSOR_TYPE to set the cursor type
-    And SQLGetStmtAttr is called to get the current cursor type
+    When SQLSetStmtAttr is called with SQL_ATTR_CURSOR_TYPE and SQLGetStmtAttr is called to get the current cursor type
     Then default cursor type is SQL_CURSOR_FORWARD_ONLY
     And SQL_CURSOR_STATIC is not supported
     And SQL_CURSOR_KEYSET_DRIVEN is not supported
@@ -252,11 +251,10 @@ Feature: ODBC SQLFetch function behavior
   @odbc_e2e
   Scenario: SQLFetch moves cursor forward when no columns are bound.
     Given Snowflake client is logged in
-    When SQLExecDirect is called to execute a query that returns 3 rows
-    And no columns are bound
+    When SQLExecDirect is called to execute a query that returns 3 rows with no columns bound
     Then SQLFetch should return SQL_SUCCESS for each row
     And SQLFetch should return SQL_NO_DATA after all rows are consumed
-    And SQLGetData can still retrieve data after moving cursor without bound columns Reset and test again
+    And SQLGetData can still retrieve data after moving cursor without bound columns
 
   @odbc_e2e
   Scenario: SQLFetch supports separate length and indicator buffers via descriptor.

--- a/tests/definitions/odbc/query/sql_get_data.feature
+++ b/tests/definitions/odbc/query/sql_get_data.feature
@@ -180,6 +180,7 @@ Feature: ODBC SQLGetData function behavior
   Scenario: SQLGetData retrieves data in increasing column number order.
     Given Snowflake client is logged in
     When SQLGetData is called in increasing column order
+    Then each column should return its correct value
 
   @odbc_e2e
   Scenario: SQLGetInfo returns SQL_GETDATA_EXTENSIONS bitmask.
@@ -355,12 +356,14 @@ Feature: ODBC SQLGetData function behavior
     Given Snowflake client is logged in
     When SQLGetData is called with SQL_C_CHAR for a NULL column
     And when called with SQL_C_LONG for a NULL column
+    Then both should return SQL_NULL_DATA indicator
 
   @odbc_e2e
   Scenario: SQLGetData retrieves same data for same column on same row with SQL_GD_ANY_ORDER.
     Given Snowflake client is logged in
     And SQL_GD_ANY_ORDER is supported
     When SQLGetData retrieves column 2 first, then column 1
+    Then both columns should return their correct values
 
   @odbc_e2e
   Scenario: SQLGetData on a bound column when SQL_GD_BOUND is supported.
@@ -394,3 +397,5 @@ Feature: ODBC SQLGetData function behavior
   @odbc_e2e
   Scenario: SQLGetData converts same integer to multiple C types.
     Given Snowflake client is logged in
+    When SQLGetData retrieves the same integer value using different C types
+    Then each C type conversion should return the correct value

--- a/tests/definitions/odbc/types/string.feature
+++ b/tests/definitions/odbc/types/string.feature
@@ -33,5 +33,4 @@ Feature: ODBC-specific string datatype handling
     And Expected row count is defined
     When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY 1" is executed
     And Columns are bound using SQLBindCol
-    Then there are 10000 rows returned
-    And all returned string values should match the generated values in order
+    Then there are 10000 rows returned and all string values should match the generated values in order

--- a/tests/definitions/odbc/types/string_conversion_to_c_real.feature
+++ b/tests/definitions/odbc/types/string_conversion_to_c_real.feature
@@ -23,8 +23,7 @@ Feature: ODBC string to floating point type conversions
   Scenario: should fail converting string literals to floating point types when data is out of range
     Given Snowflake client is logged in
     When Query selecting string literals representing floating point numbers is executed
-    Then values within range should convert successfully
-    And values exceeding SQL_C_DOUBLE range should fail with numeric out of range
+    Then values within range should convert successfully and values exceeding SQL_C_DOUBLE range should fail
     And values exceeding SQL_C_FLOAT range should fail with numeric out of range
 
   # ============================================================================
@@ -83,8 +82,7 @@ Feature: ODBC string to floating point type conversions
   Scenario: should handle NULL string when converting to floating point types
     Given Snowflake client is logged in
     When Query selecting NULL is executed
-    And Attempt to get data as SQL_C_DOUBLE
-    Then NULL should return SQL_NULL_DATA indicator
+    Then SQL_C_DOUBLE should return SQL_NULL_DATA indicator
 
   # ============================================================================
   # CONVERSION WITH SQLBindCol - Floating point types

--- a/tests/definitions/python/query/client_side_binding.feature
+++ b/tests/definitions/python/query/client_side_binding.feature
@@ -276,7 +276,8 @@ Feature: Client-side binding (pyformat/format paramstyles)
 
   @python_e2e
   Scenario: should raise error for invalid paramstyle
-    Given Connection is created with paramstyle "invalid"
+    Given Snowflake client is logged in
+    When Connection is created with paramstyle "invalid"
     Then ProgrammingError should be raised indicating invalid paramstyle
 
   @python_e2e

--- a/tests/definitions/shared/authentication/native_okta.feature
+++ b/tests/definitions/shared/authentication/native_okta.feature
@@ -32,10 +32,7 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should login with native okta using saml flow
-    Given Wiremock is running
-    And Wiremock has Snowflake and Okta mappings
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
+    Given Wiremock is running with Snowflake and Okta mappings
     When Trying to Connect
     Then Login is successful
 
@@ -45,21 +42,15 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should fail with bad credentials when okta returns 401
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token endpoint returning 401 Unauthorized
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with bad credentials error
 
   @core_int
   Scenario: should fail with bad credentials when okta returns 403
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token endpoint returning 403 Forbidden
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with bad credentials error
 
@@ -69,11 +60,8 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should fail when okta returns MFA_REQUIRED status
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token endpoint returning MFA_REQUIRED status
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with MFA required error
 
@@ -85,8 +73,6 @@ Feature: Native Okta Authentication
   Scenario: should fail when tokenUrl does not match configured okta url origin
     Given Wiremock is running
     And Wiremock has Snowflake authenticator-request with mismatched tokenUrl
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with IdP URL mismatch error
 
@@ -94,8 +80,6 @@ Feature: Native Okta Authentication
   Scenario: should fail when ssoUrl does not match configured okta url origin
     Given Wiremock is running
     And Wiremock has Snowflake authenticator-request with mismatched ssoUrl
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with IdP URL mismatch error
 
@@ -105,35 +89,27 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should fail when saml postback url does not match snowflake server
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token success mapping
     And Wiremock has Okta SSO returning SAML with mismatched postback URL
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with SAML destination mismatch error
 
   @core_int
   Scenario: should succeed with mismatched postback when disable_saml_url_check is true
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token success mapping
     And Wiremock has Okta SSO returning SAML with mismatched postback URL
     And Wiremock has Snowflake login success for Okta
     And Snowflake client is configured for native Okta with disable_saml_url_check
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Login is successful
 
   @core_int
   Scenario: should fail when saml html is missing form action
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token success mapping
     And Wiremock has Okta SSO returning SAML HTML without form action
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Connection fails with missing SAML postback error
 
@@ -143,13 +119,10 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should use cookieToken when sessionToken is missing
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token endpoint returning cookieToken instead of sessionToken
     And Wiremock has Okta SSO success mapping
     And Wiremock has Snowflake login success for Okta
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Login is successful
 
@@ -159,13 +132,10 @@ Feature: Native Okta Authentication
 
   @core_int
   Scenario: should retry saml fetch with fresh token on transient error
-    Given Wiremock is running
-    And Wiremock has Snowflake authenticator-request mapping
+    Given Wiremock is running with Snowflake authenticator-request mapping
     And Wiremock has Okta token success mapping
     And Wiremock has Okta SSO returning 503 on first attempt
     And Wiremock has Okta SSO returning success on retry
     And Wiremock has Snowflake login success for Okta
-    And Snowflake client is configured for native Okta
-    And TLS certificate verification is disabled for the Okta HTTPS mock
     When Trying to Connect
     Then Login is successful

--- a/tests/definitions/shared/put_get/put_get_basic_operations.feature
+++ b/tests/definitions/shared/put_get/put_get_basic_operations.feature
@@ -32,13 +32,13 @@ Feature: PUT/GET basic operations
     When File is downloaded using GET command
     Then Rowset for GET command should be correct
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e
   Scenario: should return correct column metadata for PUT
     Given Snowflake client is logged in
     When File is uploaded to stage
     Then Column metadata for PUT command should be correct
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e
   Scenario: should return correct column metadata for GET
     Given File is uploaded to stage
     When File is downloaded using GET command

--- a/tests/definitions/shared/types/decfloat.feature
+++ b/tests/definitions/shared/types/decfloat.feature
@@ -47,8 +47,7 @@ Feature: DECFLOAT type support
   Scenario: should download large result set with multiple chunks from GENERATOR
     Given Snowflake client is logged in
     When Query "SELECT seq8()::DECFLOAT as id FROM TABLE(GENERATOR(ROWCOUNT => 20000)) v" is executed
-    Then Result should contain consecutive numbers from 0 to 19999
-    And All values should be returned as appropriate type
+    Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate type
 
   # =========================================================================== #
   #                             Table operations                                #
@@ -87,8 +86,7 @@ Feature: DECFLOAT type support
     Given Snowflake client is logged in
     And Table with DECFLOAT column exists with values from 0 to 19999
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain consecutive numbers from 0 to 19999
-    And All values should be returned as appropriate type
+    Then Result should contain consecutive numbers from 0 to 19999 returned as appropriate type
 
   # =========================================================================== #
   #                            Parameter binding                                #

--- a/tests/definitions/shared/types/float.feature
+++ b/tests/definitions/shared/types/float.feature
@@ -50,8 +50,7 @@ Feature: FLOAT type support
   Scenario: should download large result set with multiple chunks from GENERATOR for float and synonyms
     Given Snowflake client is logged in
     When Query "SELECT seq8()::<type> as id FROM TABLE(GENERATOR(ROWCOUNT => 50000)) v" is executed
-    Then Result should contain 50000 rows
-    And All values should be returned as appropriate float type
+    Then Result should contain 50000 rows with all values returned as appropriate float type
 
   # =========================================================================== #
   #                             Table operations                                #
@@ -76,8 +75,7 @@ Feature: FLOAT type support
     Given Snowflake client is logged in
     And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308, 2.2250738585072014e-308, 5e-324, 123456789012345.0]
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain maximum, minimum, and precision boundary values
-    And All values should be preserved within float precision limits
+    Then Result should contain maximum, minimum, and precision boundary values preserved within float precision limits
 
   @python_e2e @jdbc_e2e
   Scenario: should handle NULL values from table for float and synonyms
@@ -91,8 +89,7 @@ Feature: FLOAT type support
     Given Snowflake client is logged in
     And Table with <type> column exists with 50000 sequential values
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain 50000 rows
-    And All values should be returned as appropriate float type
+    Then Result should contain 50000 rows with all values returned as appropriate float type
 
   # =========================================================================== #
   #                            Parameter binding                                #

--- a/tests/definitions/shared/types/int.feature
+++ b/tests/definitions/shared/types/int.feature
@@ -10,8 +10,7 @@ Feature: INT type support
     # Python: Values should be cast to 'int' type
     Given Snowflake client is logged in
     When Query "SELECT 0::<type>, 1000000::<type>, 9223372036854775807::<type>" is executed
-    Then All values should be returned as appropriate type
-    And No precision loss should occur
+    Then All values should be returned as appropriate type with no precision loss
 
   # =========================================================================== #
   #                     SELECT with literals (no tables)                        #
@@ -84,8 +83,7 @@ Feature: INT type support
       | col_int32 | -2B to 2B       | Int32      |
       | col_int64 | -9Q to 9Q       | Int64      |
     When Query "SELECT * FROM <table>" is executed
-    Then Result should contain 50000 rows
-    And All values should be equal to expected data
+    Then Result should contain 50000 rows with all values equal to expected data
 
   # =========================================================================== #
   #                            Parameter binding                                #

--- a/tests/definitions/shared/types/number.feature
+++ b/tests/definitions/shared/types/number.feature
@@ -10,8 +10,7 @@ Feature: NUMBER type support
     # Python: scale=0 → int, scale>0 → Decimal
     Given Snowflake client is logged in
     When Query "SELECT 0::<type>(10,0), 123::<type>(10,0), 0.00::<type>(10,2), 123.45::<type>(10,2)" is executed
-    Then All values should be returned as appropriate type
-    And Values should match [0, 123, 0.00, 123.45]
+    Then All values should be returned as appropriate type matching [0, 123, 0.00, 123.45]
 
   # =========================================================================== #
   #                     SELECT with literals (no tables)                        #
@@ -51,8 +50,7 @@ Feature: NUMBER type support
   Scenario: should download large result set with multiple chunks from GENERATOR for number and synonyms
     Given Snowflake client is logged in
     When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5) FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v" is executed
-    Then Column 1 should contain sequential integers from 0 to 29999
-    And Column 2 should contain sequential decimals starting from 0.12345
+    Then Result should contain 30000 rows with sequential integers in column 1 and sequential decimals starting from 0.12345 in column 2
 
   # =========================================================================== #
   #                             Table operations                                #
@@ -114,8 +112,7 @@ Feature: NUMBER type support
     Given Snowflake client is logged in
     And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
     When Query "SELECT * FROM <table>" is executed
-    Then Column 1 should contain sequential integers from 0 to 29999
-    And Column 2 should contain sequential decimals starting from 0.12345
+    Then Result should contain 30000 rows with sequential integers in column 1 and sequential decimals starting from 0.12345 in column 2
 
   # =========================================================================== #
   #                            Parameter binding                                #

--- a/tests/definitions/shared/types/string.feature
+++ b/tests/definitions/shared/types/string.feature
@@ -134,5 +134,4 @@ Feature: String datatype handling
     # ~10000 values ensures data is downloaded in at least two chunks
     Given Snowflake client is logged in
     When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id" is executed
-    Then there are 10000 rows returned
-    And all returned string values should match the generated values in order
+    Then there are 10000 rows returned and all string values should match the generated values in order

--- a/tests/tests_format_validator/src/feature_parser.rs
+++ b/tests/tests_format_validator/src/feature_parser.rs
@@ -56,6 +56,38 @@ pub enum StepType {
     But,
 }
 
+impl Scenario {
+    /// Checks that the scenario has at least one When and one Then step.
+    /// Returns a list of error messages for any missing mandatory step types.
+    pub fn validate_mandatory_steps(&self) -> Vec<String> {
+        let mut errors = Vec::new();
+
+        let has_when = self
+            .steps
+            .iter()
+            .any(|s| matches!(s.step_type, StepType::When));
+        let has_then = self
+            .steps
+            .iter()
+            .any(|s| matches!(s.step_type, StepType::Then));
+
+        if !has_when {
+            errors.push(format!(
+                "Scenario '{}' is missing a mandatory 'When' step",
+                self.name
+            ));
+        }
+        if !has_then {
+            errors.push(format!(
+                "Scenario '{}' is missing a mandatory 'Then' step",
+                self.name
+            ));
+        }
+
+        errors
+    }
+}
+
 impl Feature {
     pub fn parse_from_file(path: &Path) -> Result<Feature> {
         let content = std::fs::read_to_string(path)

--- a/tests/tests_format_validator/src/main.rs
+++ b/tests/tests_format_validator/src/main.rs
@@ -57,6 +57,13 @@ fn main() -> anyhow::Result<()> {
         total_features += 1;
         println!("\n📋 Feature: {}", result.feature_file.display());
 
+        if !result.scenario_structure_errors.is_empty() {
+            has_failures = true;
+            for error in &result.scenario_structure_errors {
+                println!("  ❌ {error}");
+            }
+        }
+
         for validation in &result.validations {
             if validation.test_file_found {
                 // Check if this validation has any issues
@@ -65,8 +72,9 @@ fn main() -> anyhow::Result<()> {
                     .iter()
                     .any(|w| w.contains("No test method found for scenario"));
                 let has_missing_steps = !validation.missing_steps.is_empty();
+                let has_empty_steps = !validation.empty_steps.is_empty();
 
-                if has_missing_methods || has_missing_steps {
+                if has_missing_methods || has_missing_steps || has_empty_steps {
                     has_failures = true;
                     println!(
                         "  ❌ {:?}: {} (validation failed)",
@@ -81,30 +89,49 @@ fn main() -> anyhow::Result<()> {
                     );
                 }
 
-                if !validation.missing_steps.is_empty() {
+                if !validation.missing_steps.is_empty() || !validation.empty_steps.is_empty() {
                     if !validation.missing_steps_by_method.is_empty() {
-                        println!("     ⚠️  Missing steps by method:");
                         for method_validation in &validation.missing_steps_by_method {
                             let line_info = if let Some(line_number) = method_validation.line_number
                             {
-                                format!(" at line {}", line_number)
+                                format!(" at line {line_number}")
                             } else {
                                 String::new()
                             };
-                            println!(
-                                "       In method '{}'{} (scenario: {}):",
-                                method_validation.method_name,
-                                line_info,
-                                method_validation.scenario_name
-                            );
-                            for step in &method_validation.missing_steps {
-                                println!("         - {}", step);
+                            if !method_validation.missing_steps.is_empty() {
+                                println!("     ⚠️  Missing steps by method:");
+                                println!(
+                                    "       In method '{}'{} (scenario: {}):",
+                                    method_validation.method_name,
+                                    line_info,
+                                    method_validation.scenario_name
+                                );
+                                for step in &method_validation.missing_steps {
+                                    println!("         - {step}");
+                                }
+                            }
+                            if !method_validation.empty_steps.is_empty() {
+                                println!(
+                                    "     ⚠️  Empty steps (no implementation code after step comment):"
+                                );
+                                println!(
+                                    "       In method '{}'{} (scenario: {}):",
+                                    method_validation.method_name,
+                                    line_info,
+                                    method_validation.scenario_name
+                                );
+                                for step in &method_validation.empty_steps {
+                                    println!("         - {step}");
+                                }
                             }
                         }
                     } else {
                         println!("     ⚠️  Issues:");
                         for step in &validation.missing_steps {
-                            println!("       - {}", step);
+                            println!("       - {step}");
+                        }
+                        for step in &validation.empty_steps {
+                            println!("       - EMPTY STEP: {step}");
                         }
                     }
                 }
@@ -112,7 +139,7 @@ fn main() -> anyhow::Result<()> {
                 if args.verbose && !validation.implemented_steps.is_empty() {
                     println!("     ✅ Implemented steps:");
                     for step in &validation.implemented_steps {
-                        println!("       - {}", step);
+                        println!("       - {step}");
                     }
                 }
             } else {

--- a/tests/tests_format_validator/src/step_finder.rs
+++ b/tests/tests_format_validator/src/step_finder.rs
@@ -92,6 +92,14 @@ impl LanguageConfig {
     }
 }
 
+/// Parsed step position within method lines, tracking where the comment starts
+/// and where the code region after it begins.
+struct StepPosition {
+    text: String,
+    comment_start: usize,
+    code_search_start: usize,
+}
+
 /// Generic method boundary finder that works across languages
 struct MethodBoundaryFinder {
     config: LanguageConfig,
@@ -446,7 +454,62 @@ impl MethodBoundaryFinder {
         Ok(Some((start_idx, end_idx)))
     }
 
-    /// Generic method to extract steps from boundaries with custom comment prefix
+    /// Parse all Gherkin step comments (with continuation line handling) from a slice
+    /// of method lines. Returns normalized step positions that both step extraction
+    /// and empty-step detection can consume.
+    fn parse_step_positions(
+        method_lines: &[&str],
+        comment_prefix: &str,
+    ) -> Result<Vec<StepPosition>> {
+        let gherkin_comment_regex = Regex::new(&format!(
+            r"{}\s*(Given|When|Then|And|But)\s+(.+)",
+            regex::escape(comment_prefix)
+        ))?;
+        let continuation_regex = Regex::new(&format!(r"{}\s+(.+)", regex::escape(comment_prefix)))?;
+
+        let mut step_positions: Vec<StepPosition> = Vec::new();
+        let mut i = 0;
+        while i < method_lines.len() {
+            let line = method_lines[i].trim();
+            if let Some(captures) = gherkin_comment_regex.captures(line) {
+                let comment_start = i;
+                let step_type = &captures[1];
+                let mut step_text = captures[2].to_string();
+
+                i += 1;
+                while i < method_lines.len() {
+                    let next_line = method_lines[i].trim();
+                    if next_line.starts_with(comment_prefix) {
+                        if let Some(cont_captures) = continuation_regex.captures(next_line) {
+                            if !gherkin_comment_regex.is_match(next_line) {
+                                step_text.push(' ');
+                                step_text.push_str(cont_captures[1].trim());
+                                i += 1;
+                            } else {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+
+                step_positions.push(StepPosition {
+                    text: format!("{step_type} {step_text}"),
+                    comment_start,
+                    code_search_start: i,
+                });
+            } else {
+                i += 1;
+            }
+        }
+
+        Ok(step_positions)
+    }
+
+    /// Extract step text strings from method boundaries.
     fn extract_steps_from_boundaries_generic(
         &self,
         content: &str,
@@ -455,97 +518,57 @@ impl MethodBoundaryFinder {
         comment_prefix: &str,
     ) -> Result<Vec<String>> {
         let lines: Vec<&str> = content.lines().collect();
-        let mut steps = Vec::new();
-
-        // Create regex for Gherkin comments
-        let comment_regex = format!(
-            r"{}\s*(Given|When|Then|And|But)\s+(.+)",
-            regex::escape(comment_prefix)
-        );
-        let gherkin_comment_regex = Regex::new(&comment_regex)?;
-
-        let continuation_regex = format!(r"{}\s+(.+)", regex::escape(comment_prefix));
-        let continuation_comment_regex = Regex::new(&continuation_regex)?;
-
-        // Extract steps only from within the method boundaries, handling multiline comments
         let method_lines: Vec<&str> = lines
             .iter()
             .take(end_idx)
             .skip(start_idx)
             .cloned()
             .collect();
-        let mut i = 0;
-        while i < method_lines.len() {
-            let line = method_lines[i].trim();
-            if let Some(captures) = gherkin_comment_regex.captures(line) {
-                let step_type = &captures[1];
-                let mut step_text = captures[2].to_string();
 
-                // Check for continuation lines - only if next line is purely a comment
-                i += 1;
-                while i < method_lines.len() {
-                    let next_line = method_lines[i].trim();
-                    // Only treat as continuation if the line starts with comment prefix (no code before comment)
-                    if next_line.starts_with(comment_prefix) {
-                        if let Some(cont_captures) = continuation_comment_regex.captures(next_line)
-                        {
-                            // Check if this is a continuation (doesn't start with Given/When/Then/And/But)
-                            let cont_text = cont_captures[1].trim();
-                            if !gherkin_comment_regex.is_match(next_line) {
-                                step_text.push(' ');
-                                step_text.push_str(cont_text);
-                                i += 1;
-                            } else {
-                                // This is a new step, don't consume it
-                                break;
-                            }
-                        } else {
-                            // No more continuation lines
-                            break;
-                        }
-                    } else {
-                        // Next line is not a pure comment line, stop looking for continuations
-                        break;
-                    }
-                }
-
-                steps.push(format!("{} {}", step_type, step_text));
-            } else {
-                i += 1;
-            }
-        }
-
-        Ok(steps)
+        let step_positions = Self::parse_step_positions(&method_lines, comment_prefix)?;
+        Ok(step_positions.into_iter().map(|sp| sp.text).collect())
     }
 
-    /// Generic method to find steps within a specific method with custom comment prefix
-    fn find_steps_in_method_generic(
+    /// Find Gherkin step comments that are not followed by any implementation code
+    /// before the next step comment or end of method.
+    fn find_empty_steps_from_boundaries_generic(
         &self,
         content: &str,
-        method_name: &str,
+        start_idx: usize,
+        end_idx: usize,
         comment_prefix: &str,
     ) -> Result<Vec<String>> {
-        if let Some((start_idx, end_idx)) = self.find_method_boundaries(content, method_name)? {
-            let steps = self.extract_steps_from_boundaries_generic(
-                content,
-                start_idx,
-                end_idx,
-                comment_prefix,
-            )?;
-            if steps.is_empty() {
-                // Fallback: search from method start to file end (handles async blocks/macros)
-                let lines: Vec<&str> = content.lines().collect();
-                return self.extract_steps_from_boundaries_generic(
-                    content,
-                    start_idx,
-                    lines.len(),
-                    comment_prefix,
-                );
+        let lines: Vec<&str> = content.lines().collect();
+        let method_lines: Vec<&str> = lines
+            .iter()
+            .take(end_idx)
+            .skip(start_idx)
+            .cloned()
+            .collect();
+
+        let step_positions = Self::parse_step_positions(&method_lines, comment_prefix)?;
+        let mut empty_steps = Vec::new();
+
+        for (idx, step) in step_positions.iter().enumerate() {
+            let code_end = if idx + 1 < step_positions.len() {
+                step_positions[idx + 1].comment_start
+            } else {
+                method_lines.len()
+            };
+
+            let has_code = method_lines[step.code_search_start..code_end]
+                .iter()
+                .any(|line| {
+                    let trimmed = line.trim();
+                    !trimmed.is_empty() && !trimmed.starts_with(comment_prefix)
+                });
+
+            if !has_code {
+                empty_steps.push(step.text.clone());
             }
-            Ok(steps)
-        } else {
-            Ok(vec![]) // Method not found
         }
+
+        Ok(empty_steps)
     }
 }
 
@@ -629,27 +652,81 @@ impl StepFinder {
         Ok(steps)
     }
 
-    /// Find implemented steps within a specific test method
-    pub fn find_steps_in_method(&self, file_path: &Path, method_name: &str) -> Result<Vec<String>> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Failed to read test file: {}", file_path.display()))?;
-
-        let comment_prefix = match self.language {
+    fn comment_prefix(&self) -> &'static str {
+        match self.language {
             Language::Python => "#",
-            _ => "//", // Rust, ODBC, JDBC, CSharp, JavaScript all use //
-        };
+            _ => "//",
+        }
+    }
 
-        let config = match self.language {
+    fn language_config(&self) -> LanguageConfig {
+        match self.language {
             Language::Rust => LanguageConfig::rust(),
             Language::Odbc => LanguageConfig::odbc(),
             Language::Jdbc => LanguageConfig::jdbc(),
             Language::Python => LanguageConfig::python(),
             Language::CSharp => LanguageConfig::csharp(),
             Language::JavaScript => LanguageConfig::javascript(),
-        };
+        }
+    }
 
-        let boundary_finder = MethodBoundaryFinder::new(config);
-        boundary_finder.find_steps_in_method_generic(&content, method_name, comment_prefix)
+    /// Find implemented steps within a specific test method
+    pub fn find_steps_in_method(&self, file_path: &Path, method_name: &str) -> Result<Vec<String>> {
+        let (steps, _) = self.find_steps_and_empty_steps_in_method(file_path, method_name)?;
+        Ok(steps)
+    }
+
+    /// Find Gherkin step comments in a method that have no implementation code following them
+    pub fn find_empty_steps_in_method(
+        &self,
+        file_path: &Path,
+        method_name: &str,
+    ) -> Result<Vec<String>> {
+        let (_, empty_steps) = self.find_steps_and_empty_steps_in_method(file_path, method_name)?;
+        Ok(empty_steps)
+    }
+
+    /// Find both implemented steps and empty steps in a single pass, reading the file
+    /// and computing method boundaries only once.
+    pub fn find_steps_and_empty_steps_in_method(
+        &self,
+        file_path: &Path,
+        method_name: &str,
+    ) -> Result<(Vec<String>, Vec<String>)> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Failed to read test file: {}", file_path.display()))?;
+
+        let comment_prefix = self.comment_prefix();
+        let boundary_finder = MethodBoundaryFinder::new(self.language_config());
+
+        if let Some((start_idx, end_idx)) =
+            boundary_finder.find_method_boundaries(&content, method_name)?
+        {
+            let mut steps = boundary_finder.extract_steps_from_boundaries_generic(
+                &content,
+                start_idx,
+                end_idx,
+                comment_prefix,
+            )?;
+            if steps.is_empty() {
+                let lines: Vec<&str> = content.lines().collect();
+                steps = boundary_finder.extract_steps_from_boundaries_generic(
+                    &content,
+                    start_idx,
+                    lines.len(),
+                    comment_prefix,
+                )?;
+            }
+            let empty_steps = boundary_finder.find_empty_steps_from_boundaries_generic(
+                &content,
+                start_idx,
+                end_idx,
+                comment_prefix,
+            )?;
+            Ok((steps, empty_steps))
+        } else {
+            Ok((vec![], vec![]))
+        }
     }
 
     /// Find test functions/methods with line numbers that match a scenario name
@@ -687,7 +764,10 @@ impl StepFinder {
         let matching_methods = all_methods
             .into_iter()
             .filter(|(method_name, _line)| {
-                strings_match_normalized(clean_method_name(method_name), &snake_scenario)
+                strings_match_normalized(
+                    clean_method_name(method_name),
+                    clean_method_name(&snake_scenario),
+                )
             })
             .collect();
 

--- a/tests/tests_format_validator/src/validator.rs
+++ b/tests/tests_format_validator/src/validator.rs
@@ -19,6 +19,7 @@ pub struct GherkinValidator {
 pub struct ValidationResult {
     pub feature_file: PathBuf,
     pub validations: Vec<LanguageValidation>,
+    pub scenario_structure_errors: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,6 +31,7 @@ pub struct LanguageValidation {
     pub implemented_steps: Vec<String>,
     pub warnings: Vec<String>,
     pub missing_steps_by_method: Vec<MethodValidation>,
+    pub empty_steps: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -37,6 +39,7 @@ pub struct MethodValidation {
     pub method_name: String,
     pub scenario_name: String,
     pub missing_steps: Vec<String>,
+    pub empty_steps: Vec<String>,
     pub line_number: Option<usize>,
 }
 
@@ -878,6 +881,7 @@ impl GherkinValidator {
                     implemented_steps: Vec::new(),
                     warnings: Vec::new(),
                     missing_steps_by_method: Vec::new(),
+                    empty_steps: Vec::new(),
                 });
             }
         } else if validations.is_empty() && !tag_errors.is_empty() {
@@ -890,12 +894,20 @@ impl GherkinValidator {
                 implemented_steps: Vec::new(),
                 warnings: Vec::new(),
                 missing_steps_by_method: Vec::new(),
+                empty_steps: Vec::new(),
             });
         }
+
+        let scenario_structure_errors: Vec<String> = feature
+            .scenarios
+            .iter()
+            .flat_map(|scenario| scenario.validate_mandatory_steps())
+            .collect();
 
         Ok(ValidationResult {
             feature_file: feature.file_path.clone(),
             validations,
+            scenario_structure_errors,
         })
     }
 
@@ -916,6 +928,7 @@ impl GherkinValidator {
             // Check if we need to validate specific scenarios or the whole file
             let mut all_implemented_steps = Vec::new();
             let mut all_missing_steps = Vec::new();
+            let mut all_empty_steps = Vec::new();
             let mut warnings = Vec::new();
             let mut missing_steps_by_method = Vec::new();
 
@@ -1060,12 +1073,21 @@ impl GherkinValidator {
                             }
                         }
 
-                        // If there are missing steps in this method, record them
-                        if !method_missing_steps.is_empty() {
+                        // Check for empty steps (step comments with no implementation code)
+                        let method_empty_steps = step_finder
+                            .find_empty_steps_in_method(actual_test_file_path, &method_name)?;
+                        for empty_step in &method_empty_steps {
+                            if !all_empty_steps.contains(empty_step) {
+                                all_empty_steps.push(empty_step.clone());
+                            }
+                        }
+
+                        if !method_missing_steps.is_empty() || !method_empty_steps.is_empty() {
                             missing_steps_by_method.push(MethodValidation {
                                 method_name: method_name.clone(),
                                 scenario_name: scenario.name.clone(),
                                 missing_steps: method_missing_steps,
+                                empty_steps: method_empty_steps,
                                 line_number: Some(line_number),
                             });
                         }
@@ -1081,16 +1103,18 @@ impl GherkinValidator {
                 implemented_steps: all_implemented_steps,
                 warnings,
                 missing_steps_by_method,
+                empty_steps: all_empty_steps,
             })
         } else {
             Ok(LanguageValidation {
                 language,
                 test_file_found: false,
                 test_file_path: None,
-                missing_steps: Vec::new(), // Don't list individual steps when file doesn't exist
+                missing_steps: Vec::new(),
                 implemented_steps: Vec::new(),
                 warnings: vec![format!("No test file found for feature: {}", feature.name)],
                 missing_steps_by_method: Vec::new(),
+                empty_steps: Vec::new(),
             })
         }
     }

--- a/tests/tests_format_validator/tests/validator_tests.rs
+++ b/tests/tests_format_validator/tests/validator_tests.rs
@@ -1289,6 +1289,727 @@ Feature: JDBC Logout
     Ok(())
 }
 
+// ===== Empty Steps Validation Tests =====
+
+#[test]
+fn should_report_empty_steps_in_rust_when_step_comment_has_no_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "empty_steps_rust",
+        r#"@core
+Feature: Empty Steps Rust Test
+
+  @core_e2e
+  Scenario: should detect empty steps in rust
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "empty_steps_rust",
+        r#"
+#[test]
+fn should_detect_empty_steps_in_rust() {
+    // Given I have valid credentials
+    let credentials = setup_valid_credentials();
+
+    // When I attempt to login
+
+    // Then login should succeed
+    assert!(login_succeeded());
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert!(
+        validation.missing_steps.is_empty(),
+        "Should have no missing steps, but has: {:?}",
+        validation.missing_steps
+    );
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have exactly 1 empty step, but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(
+        validation.empty_steps[0].contains("When"),
+        "Empty step should be the 'When' step, got: {}",
+        validation.empty_steps[0]
+    );
+
+    assert_eq!(validation.missing_steps_by_method.len(), 1);
+    let method_validation = &validation.missing_steps_by_method[0];
+    assert_eq!(method_validation.empty_steps.len(), 1);
+    assert!(method_validation.empty_steps[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_report_empty_steps_in_jdbc_when_step_comment_has_no_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "empty_steps_jdbc",
+        r#"@jdbc
+Feature: Empty Steps JDBC Test
+
+  @jdbc_int
+  Scenario: should detect empty steps in jdbc
+    Given Snowflake client is logged in
+    When Query is executed
+    Then result should be correct
+"#,
+    )?;
+
+    workspace.create_java_test(
+        "auth",
+        "EmptyStepsJdbc",
+        r#"
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class EmptyStepsJdbcTest {
+    @Test
+    public void shouldDetectEmptyStepsInJdbc() throws Exception {
+        // Given Snowflake client is logged in
+        Connection connection = getDefaultConnection();
+
+        // When Query is executed
+
+        // Then result should be correct
+        assertTrue(result.isSuccess());
+    }
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert!(
+        validation.missing_steps.is_empty(),
+        "Should have no missing steps, but has: {:?}",
+        validation.missing_steps
+    );
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have exactly 1 empty step, but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_report_empty_steps_in_odbc_when_step_comment_has_no_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "empty_steps_odbc",
+        r#"@odbc
+Feature: Empty Steps ODBC Test
+
+  @odbc_e2e
+  Scenario: should detect empty steps in odbc
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+"#,
+    )?;
+
+    workspace.create_cpp_test(
+        "auth",
+        "empty_steps_odbc",
+        r#"
+#include <catch2/catch.hpp>
+
+TEST_CASE("should detect empty steps in odbc") {
+    // Given I have valid credentials
+    auto credentials = setup_valid_credentials();
+
+    // When I attempt to login
+
+    // Then login should succeed
+    REQUIRE(login_succeeded());
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert!(
+        validation.missing_steps.is_empty(),
+        "Should have no missing steps, but has: {:?}",
+        validation.missing_steps
+    );
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have exactly 1 empty step, but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_report_empty_steps_in_python_when_step_comment_has_no_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "empty_steps_python",
+        r#"@python
+Feature: Empty Steps Python Test
+
+  @python_e2e
+  Scenario: should detect empty steps in python
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+"#,
+    )?;
+
+    workspace.create_python_test(
+        "auth",
+        "empty_steps_python",
+        r#"
+def test_should_detect_empty_steps_in_python():
+    # Given I have valid credentials
+    credentials = setup_valid_credentials()
+
+    # When I attempt to login
+
+    # Then login should succeed
+    assert login_succeeded()
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert!(
+        validation.missing_steps.is_empty(),
+        "Should have no missing steps, but has: {:?}",
+        validation.missing_steps
+    );
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have exactly 1 empty step, but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_not_report_empty_steps_when_all_steps_have_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "no_empty_steps",
+        r#"@core @jdbc @odbc @python
+Feature: No Empty Steps Test
+
+  @core_e2e @jdbc_int @odbc_e2e @python_e2e
+  Scenario: should have no empty steps
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+    And I should have access
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "no_empty_steps",
+        r#"
+#[test]
+fn should_have_no_empty_steps() {
+    // Given I have valid credentials
+    let credentials = setup_valid_credentials();
+
+    // When I attempt to login
+    let result = attempt_login(&credentials);
+
+    // Then login should succeed
+    assert!(result.is_ok());
+
+    // And I should have access
+    assert!(has_access(&result.unwrap()));
+}
+"#,
+    )?;
+
+    workspace.create_java_test(
+        "auth",
+        "NoEmptySteps",
+        r#"
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class NoEmptyStepsTest {
+    @Test
+    public void shouldHaveNoEmptySteps() throws Exception {
+        // Given I have valid credentials
+        Credentials credentials = setupValidCredentials();
+
+        // When I attempt to login
+        LoginResult result = attemptLogin(credentials);
+
+        // Then login should succeed
+        assertTrue(result.isSuccess());
+
+        // And I should have access
+        assertTrue(result.hasAccess());
+    }
+}
+"#,
+    )?;
+
+    workspace.create_cpp_test(
+        "auth",
+        "no_empty_steps",
+        r#"
+#include <catch2/catch.hpp>
+
+TEST_CASE("should have no empty steps") {
+    // Given I have valid credentials
+    auto credentials = setup_valid_credentials();
+
+    // When I attempt to login
+    auto result = attempt_login(credentials);
+
+    // Then login should succeed
+    REQUIRE(result.is_success());
+
+    // And I should have access
+    REQUIRE(has_access(result));
+}
+"#,
+    )?;
+
+    workspace.create_python_test(
+        "auth",
+        "no_empty_steps",
+        r#"
+def test_should_have_no_empty_steps():
+    # Given I have valid credentials
+    credentials = setup_valid_credentials()
+
+    # When I attempt to login
+    result = attempt_login(credentials)
+
+    # Then login should succeed
+    assert result.is_success()
+
+    # And I should have access
+    assert result.has_access()
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    for validation in &results[0].validations {
+        assert!(
+            validation.test_file_found,
+            "Language {:?} should find test file",
+            validation.language
+        );
+        assert!(
+            validation.missing_steps.is_empty(),
+            "Language {:?} should have no missing steps, but has: {:?}",
+            validation.language,
+            validation.missing_steps
+        );
+        assert!(
+            validation.empty_steps.is_empty(),
+            "Language {:?} should have no empty steps, but has: {:?}",
+            validation.language,
+            validation.empty_steps
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn should_report_multiple_empty_steps_in_same_method() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "multi_empty",
+        r#"@core
+Feature: Multiple Empty Steps Test
+
+  @core_e2e
+  Scenario: should detect multiple empty steps
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+    And I should have access
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "multi_empty",
+        r#"
+#[test]
+fn should_detect_multiple_empty_steps() {
+    // Given I have valid credentials
+
+    // When I attempt to login
+
+    // Then login should succeed
+    assert!(login_succeeded());
+
+    // And I should have access
+    assert!(has_access());
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert_eq!(
+        validation.empty_steps.len(),
+        2,
+        "Should have 2 empty steps (Given and When), but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps.iter().any(|s| s.contains("Given")));
+    assert!(validation.empty_steps.iter().any(|s| s.contains("When")));
+
+    Ok(())
+}
+
+#[test]
+fn should_report_last_step_as_empty_when_no_code_follows() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "last_empty",
+        r#"@core
+Feature: Last Empty Step Test
+
+  @core_e2e
+  Scenario: should detect last empty step
+    Given I have valid credentials
+    When I attempt to login
+    Then login should succeed
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "last_empty",
+        r#"
+#[test]
+fn should_detect_last_empty_step() {
+    // Given I have valid credentials
+    let credentials = setup_valid_credentials();
+
+    // When I attempt to login
+    let result = attempt_login(&credentials);
+
+    // Then login should succeed
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have 1 empty step (Then), but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps[0].contains("Then"));
+
+    Ok(())
+}
+
+#[test]
+fn should_not_count_continuation_comments_as_code() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "continuation_empty",
+        r#"@jdbc
+Feature: Continuation Comment Test
+
+  @jdbc_int
+  Scenario: should not count continuations as code
+    Given Snowflake client is logged in
+    When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
+    Then All values should be returned as appropriate type
+"#,
+    )?;
+
+    workspace.create_java_test(
+        "auth",
+        "ContinuationEmpty",
+        r#"
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ContinuationEmptyTest {
+    @Test
+    public void shouldNotCountContinuationsAsCode() throws Exception {
+        // Given Snowflake client is logged in
+        Connection connection = getDefaultConnection();
+
+        // When Query "SELECT 'hello'::<type>, 'Hello World'::<type>,
+        // '日本語テスト'::<type>" is executed
+
+        // Then All values should be returned as appropriate type
+        assertSingleRow(resultSet, Arrays.asList("hello", "Hello World"));
+    }
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    let validation = &results[0].validations[0];
+    assert!(validation.test_file_found);
+    assert_eq!(
+        validation.empty_steps.len(),
+        1,
+        "Should have 1 empty step (When with continuation), but has: {:?}",
+        validation.empty_steps
+    );
+    assert!(validation.empty_steps[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_fail_when_scenario_missing_when_step() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "missing_when",
+        r#"@core
+Feature: Missing When Test
+
+  @core_e2e
+  Scenario: should fail without when
+    Given Snowflake client is logged in
+    Then Something should happen
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "missing_when",
+        r#"
+#[test]
+fn should_fail_without_when() {
+    // Given Snowflake client is logged in
+    let client = connect();
+
+    // Then Something should happen
+    assert!(client.is_connected());
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].scenario_structure_errors.len(), 1);
+    assert!(results[0].scenario_structure_errors[0].contains("When"));
+
+    Ok(())
+}
+
+#[test]
+fn should_fail_when_scenario_missing_then_step() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "missing_then",
+        r#"@core
+Feature: Missing Then Test
+
+  @core_e2e
+  Scenario: should fail without then
+    Given Snowflake client is logged in
+    When Something is executed
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "missing_then",
+        r#"
+#[test]
+fn should_fail_without_then() {
+    // Given Snowflake client is logged in
+    let client = connect();
+
+    // When Something is executed
+    client.execute("SELECT 1");
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].scenario_structure_errors.len(), 1);
+    assert!(results[0].scenario_structure_errors[0].contains("Then"));
+
+    Ok(())
+}
+
+#[test]
+fn should_fail_when_scenario_missing_both_when_and_then() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "missing_both",
+        r#"@core
+Feature: Missing Both Test
+
+  @core_e2e
+  Scenario: should fail without when and then
+    Given Snowflake client is logged in
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "missing_both",
+        r#"
+#[test]
+fn should_fail_without_when_and_then() {
+    // Given Snowflake client is logged in
+    let client = connect();
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].scenario_structure_errors.len(), 2);
+    assert!(
+        results[0]
+            .scenario_structure_errors
+            .iter()
+            .any(|e| e.contains("When"))
+    );
+    assert!(
+        results[0]
+            .scenario_structure_errors
+            .iter()
+            .any(|e| e.contains("Then"))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn should_pass_when_scenario_has_when_and_then() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "complete_steps",
+        r#"@core
+Feature: Complete Steps Test
+
+  @core_e2e
+  Scenario: should pass with all steps
+    Given Snowflake client is logged in
+    When Something is executed
+    Then Result should be correct
+"#,
+    )?;
+
+    workspace.create_rust_test(
+        "auth",
+        "complete_steps",
+        r#"
+#[test]
+fn should_pass_with_all_steps() {
+    // Given Snowflake client is logged in
+    let client = connect();
+
+    // When Something is executed
+    let result = client.execute("SELECT 1");
+
+    // Then Result should be correct
+    assert!(result.is_ok());
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let results = validator.validate_all_features()?;
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].scenario_structure_errors.is_empty());
+
+    Ok(())
+}
+
 // ===== Helper Structs and Test Data =====
 
 /// Helper to create a temporary workspace with features and test files
@@ -1312,6 +2033,8 @@ impl TestWorkspace {
         fs::create_dir_all(workspace_root.join("jdbc/src/test/java/e2e/query"))?;
         fs::create_dir_all(workspace_root.join("odbc_tests/tests/e2e/auth"))?;
         fs::create_dir_all(workspace_root.join("odbc_tests/tests/e2e/query"))?;
+        fs::create_dir_all(workspace_root.join("python/tests/e2e/auth"))?;
+        fs::create_dir_all(workspace_root.join("python/tests/e2e/query"))?;
 
         // Create BehaviorDifferences.yaml file for tests
         let breaking_change_file = workspace_root.join("odbc_tests/BehaviorDifferences.yaml");
@@ -1375,6 +2098,17 @@ impl TestWorkspace {
             .join("odbc_tests/tests/e2e")
             .join(subdir)
             .join(format!("{}.cpp", name));
+        fs::write(test_path, content)?;
+        Ok(())
+    }
+
+    fn create_python_test(&self, subdir: &str, name: &str, content: &str) -> Result<()> {
+        let test_path = self
+            .workspace_root
+            .join("python/tests/e2e")
+            .join(subdir)
+            .join(format!("test_{name}.py"));
+        fs::create_dir_all(test_path.parent().unwrap())?;
         fs::write(test_path, content)?;
         Ok(())
     }


### PR DESCRIPTION
1. Each Gherkin step comment should be followed by relevant code, as this rule was not followed, validator is expanded to verify that and existing tests are fixed