### PR TITLE
SNOW-2467884: Allow both numeric (:1) and positional (?) bindings

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -69,12 +69,16 @@ final class PreparedStatementBindingSerializer {
       logger.debug("No parameter placeholders found, skipping bindings serialization.");
       return new NativeBindings(null, null);
     }
-    if (placeholderMetadata.hasMixedPlaceholderStyles()) {
-      throw new SQLException("Mixed positional and numeric placeholders are not supported");
-    }
     logger.debug(
         "Serializing prepared bindings: placeholders={}", placeholderMetadata.placeholderCount());
 
+    byte[] jsonBytes = buildBindingsJson(placeholderMetadata, parameterValues);
+    return allocateNativeBindings(jsonBytes);
+  }
+
+  private static byte[] buildBindingsJson(
+      SqlPlaceholderMetadata placeholderMetadata, Map<Integer, ParameterValue> parameterValues)
+      throws SQLException {
     JSONStringer jsonStringer = new JSONStringer();
     jsonStringer.object();
     for (int parameterIndex : placeholderMetadata.referencedParameterIndexes()) {
@@ -95,8 +99,10 @@ final class PreparedStatementBindingSerializer {
       jsonStringer.endObject();
     }
     jsonStringer.endObject();
+    return jsonStringer.toString().getBytes(StandardCharsets.UTF_8);
+  }
 
-    byte[] jsonBytes = jsonStringer.toString().getBytes(StandardCharsets.UTF_8);
+  private static NativeBindings allocateNativeBindings(byte[] jsonBytes) throws SQLException {
     NativeBuffer nativeBuffer = NativeBuffer.fromBytes(jsonBytes);
     boolean success = false;
     try {

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.Map;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.BinaryDataPtr;
@@ -61,19 +62,23 @@ final class PreparedStatementBindingSerializer {
 
   private PreparedStatementBindingSerializer() {}
 
-  static NativeBindings serializeToNativeBindings(ParameterValue[] parameterValues)
+  static NativeBindings serialize(
+      SqlPlaceholderMetadata placeholderMetadata, Map<Integer, ParameterValue> parameterValues)
       throws SQLException {
-    if (parameterValues.length == 0) {
+    if (!placeholderMetadata.hasBindings()) {
       logger.debug("No parameter placeholders found, skipping bindings serialization.");
       return new NativeBindings(null, null);
     }
-    logger.debug("Serializing prepared bindings: placeholders={}", parameterValues.length);
+    if (placeholderMetadata.hasMixedPlaceholderStyles()) {
+      throw new SQLException("Mixed positional and numeric placeholders are not supported");
+    }
+    logger.debug(
+        "Serializing prepared bindings: placeholders={}", placeholderMetadata.placeholderCount());
 
     JSONStringer jsonStringer = new JSONStringer();
     jsonStringer.object();
-    for (int i = 0; i < parameterValues.length; i++) {
-      ParameterValue parameterValue = parameterValues[i];
-      int parameterIndex = i + 1;
+    for (int parameterIndex : placeholderMetadata.referencedParameterIndexes()) {
+      ParameterValue parameterValue = parameterValues.get(parameterIndex);
       if (parameterValue == null) {
         logger.warn(
             "Bindings serialization failed: missing parameter value for index {}", parameterIndex);

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -22,8 +22,8 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import net.snowflake.client.api.statement.SnowflakePreparedStatement;
@@ -38,23 +38,21 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       SFLoggerFactory.getLogger(SnowflakePreparedStatementImpl.class);
 
   private final String sql;
-  private final PreparedStatementBindingSerializer.ParameterValue[] parameterValues;
+  private final SqlPlaceholderMetadata placeholderMetadata;
+  private final Map<Integer, PreparedStatementBindingSerializer.ParameterValue> parameterValues;
 
   public SnowflakePreparedStatementImpl(SnowflakeConnectionImpl connection, String sql) {
     super(connection);
     this.sql = sql;
-    // TODO: Align with snowflake-jdbc by deriving bind count from server-side describe metadata
-    // rather than counting '?' directly in raw SQL text.
-    int paramCount = sql.length() - sql.replace("?", "").length();
-    this.parameterValues = new PreparedStatementBindingSerializer.ParameterValue[paramCount];
+    this.placeholderMetadata = SqlPlaceholderMetadata.analyze(sql);
+    this.parameterValues = new HashMap<>();
   }
 
   @Override
   public ResultSet executeQuery() throws SQLException {
     checkClosed();
-    // Native bindings own the off-heap payload until the RPC has consumed the pointer.
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
-        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
+        PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
       return executeQueryWithBindings(sql, nativeBindings.bindings());
     }
   }
@@ -63,7 +61,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   public int executeUpdate() throws SQLException {
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
-        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
+        PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
       return executeUpdateWithBindings(sql, nativeBindings.bindings());
     }
   }
@@ -173,8 +171,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public void clearParameters() throws SQLException {
     checkClosed();
-    logger.trace("Clearing prepared parameters: placeholders={}", parameterValues.length);
-    Arrays.fill(parameterValues, null);
+    logger.trace(
+        "Clearing prepared parameters: placeholders={}", placeholderMetadata.placeholderCount());
+    parameterValues.clear();
   }
 
   @Override
@@ -283,8 +282,12 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   public boolean execute() throws SQLException {
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
-        PreparedStatementBindingSerializer.serializeToNativeBindings(parameterValues)) {
-      return executeWithBindings(sql, nativeBindings.bindings());
+        PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
+      try (ResultSet ignored = executeQueryWithBindings(sql, nativeBindings.bindings())) {
+        // TODO: Align execute() return value and update-count behavior with snowflake-jdbc by using
+        // backend statement-type metadata (true for result sets, false for update counts).
+        return true;
+      }
     }
   }
 
@@ -454,21 +457,31 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   }
 
   private void setParameter(int parameterIndex, String bindType, Object value) throws SQLException {
-    if (parameterIndex < 1 || parameterIndex > parameterValues.length) {
+    if (parameterIndex < 1) {
       logger.warn(
           "Invalid prepared parameter index: index={}, placeholders={}",
           parameterIndex,
-          parameterValues.length);
+          placeholderMetadata.placeholderCount());
       throw new SQLException("Invalid parameter index: " + parameterIndex);
     }
-    parameterValues[parameterIndex - 1] =
-        new PreparedStatementBindingSerializer.ParameterValue(bindType, value);
+    if (placeholderMetadata.hasMixedPlaceholderStyles()) {
+      throw new SQLException("Mixed positional and numeric placeholders are not supported");
+    }
+    if (!placeholderMetadata.referencesParameterIndex(parameterIndex)) {
+      logger.debug(
+          "Ignoring extra prepared parameter to preserve legacy JDBC behavior: index={}, placeholders={}",
+          parameterIndex,
+          placeholderMetadata.placeholderCount());
+      return;
+    }
+    parameterValues.put(
+        parameterIndex, new PreparedStatementBindingSerializer.ParameterValue(bindType, value));
     logger.debug(
         "Prepared parameter set: index={}, bindType={}, isNull={}, placeholders={}",
         parameterIndex,
         bindType,
         value == null,
-        parameterValues.length);
+        placeholderMetadata.placeholderCount());
   }
 
   private <T> void setNullableParameter(

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -283,11 +283,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
         PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
-      try (ResultSet ignored = executeQueryWithBindings(sql, nativeBindings.bindings())) {
-        // TODO: Align execute() return value and update-count behavior with snowflake-jdbc by using
-        // backend statement-type metadata (true for result sets, false for update counts).
-        return true;
-      }
+      return executeWithBindings(sql, nativeBindings.bindings());
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SqlPlaceholderMetadata.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SqlPlaceholderMetadata.java
@@ -1,0 +1,136 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+final class SqlPlaceholderMetadata {
+  enum PlaceholderStyle {
+    NONE,
+    POSITIONAL,
+    NUMERIC,
+    MIXED
+  }
+
+  private final PlaceholderStyle placeholderStyle;
+  private final int positionalPlaceholderCount;
+  private final List<Integer> referencedParameterIndexes;
+  private final SortedSet<Integer> referencedNumericParameterIndexes;
+
+  private SqlPlaceholderMetadata(
+      PlaceholderStyle placeholderStyle,
+      int positionalPlaceholderCount,
+      List<Integer> referencedParameterIndexes,
+      SortedSet<Integer> referencedNumericParameterIndexes) {
+    this.placeholderStyle = placeholderStyle;
+    this.positionalPlaceholderCount = positionalPlaceholderCount;
+    this.referencedParameterIndexes = Collections.unmodifiableList(referencedParameterIndexes);
+    this.referencedNumericParameterIndexes =
+        Collections.unmodifiableSortedSet(referencedNumericParameterIndexes);
+  }
+
+  static SqlPlaceholderMetadata analyze(String sql) {
+    // TODO: Replace this with a proper SQL-aware analyzer that skips strings, comments, and other
+    // syntax edge cases. For now we only support the simple placeholder patterns covered by tests.
+    int positionalPlaceholderCount = 0;
+    SortedSet<Integer> numericParameterIndexes = new TreeSet<>();
+
+    for (int i = 0; i < sql.length(); i++) {
+      char currentChar = sql.charAt(i);
+
+      if (currentChar == '?') {
+        positionalPlaceholderCount++;
+        continue;
+      }
+
+      if (currentChar == ':'
+          && hasNextChar(sql, i)
+          && Character.isDigit(sql.charAt(i + 1))
+          && (i == 0 || sql.charAt(i - 1) != ':')) {
+        int placeholderEnd = i + 1;
+        while (placeholderEnd < sql.length() && Character.isDigit(sql.charAt(placeholderEnd))) {
+          placeholderEnd++;
+        }
+        numericParameterIndexes.add(Integer.parseInt(sql.substring(i + 1, placeholderEnd)));
+        i = placeholderEnd - 1;
+      }
+    }
+
+    PlaceholderStyle placeholderStyle =
+        determinePlaceholderStyle(positionalPlaceholderCount, numericParameterIndexes);
+    List<Integer> referencedParameterIndexes =
+        buildReferencedParameterIndexes(
+            positionalPlaceholderCount, numericParameterIndexes, placeholderStyle);
+
+    return new SqlPlaceholderMetadata(
+        placeholderStyle,
+        positionalPlaceholderCount,
+        referencedParameterIndexes,
+        numericParameterIndexes);
+  }
+
+  PlaceholderStyle placeholderStyle() {
+    return placeholderStyle;
+  }
+
+  boolean hasBindings() {
+    return placeholderStyle != PlaceholderStyle.NONE;
+  }
+
+  boolean hasMixedPlaceholderStyles() {
+    return placeholderStyle == PlaceholderStyle.MIXED;
+  }
+
+  int placeholderCount() {
+    return referencedParameterIndexes.size();
+  }
+
+  int positionalPlaceholderCount() {
+    return positionalPlaceholderCount;
+  }
+
+  Collection<Integer> referencedParameterIndexes() {
+    return referencedParameterIndexes;
+  }
+
+  boolean referencesParameterIndex(int parameterIndex) {
+    return referencedNumericParameterIndexes.contains(parameterIndex)
+        || (placeholderStyle == PlaceholderStyle.POSITIONAL
+            && parameterIndex <= positionalPlaceholderCount);
+  }
+
+  private static PlaceholderStyle determinePlaceholderStyle(
+      int positionalPlaceholderCount, SortedSet<Integer> numericParameterIndexes) {
+    if (positionalPlaceholderCount == 0 && numericParameterIndexes.isEmpty()) {
+      return PlaceholderStyle.NONE;
+    }
+    if (positionalPlaceholderCount > 0 && !numericParameterIndexes.isEmpty()) {
+      return PlaceholderStyle.MIXED;
+    }
+    if (positionalPlaceholderCount > 0) {
+      return PlaceholderStyle.POSITIONAL;
+    }
+    return PlaceholderStyle.NUMERIC;
+  }
+
+  private static List<Integer> buildReferencedParameterIndexes(
+      int positionalPlaceholderCount,
+      SortedSet<Integer> numericParameterIndexes,
+      PlaceholderStyle placeholderStyle) {
+    if (placeholderStyle == PlaceholderStyle.POSITIONAL) {
+      List<Integer> referencedParameterIndexes = new ArrayList<>(positionalPlaceholderCount);
+      for (int parameterIndex = 1; parameterIndex <= positionalPlaceholderCount; parameterIndex++) {
+        referencedParameterIndexes.add(parameterIndex);
+      }
+      return referencedParameterIndexes;
+    }
+    return new ArrayList<>(numericParameterIndexes);
+  }
+
+  private static boolean hasNextChar(String sql, int index) {
+    return index + 1 < sql.length();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
@@ -11,6 +11,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.BinaryDataPtr;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import org.junit.jupiter.api.Test;
@@ -19,25 +21,26 @@ public class PreparedStatementBindingSerializerTest {
 
   @Test
   public void testSerializeEmptyParametersReturnsNullBindings() throws Exception {
-    PreparedStatementBindingSerializer.ParameterValue[] params =
-        new PreparedStatementBindingSerializer.ParameterValue[0];
+    Map<Integer, PreparedStatementBindingSerializer.ParameterValue> params = new HashMap<>();
 
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
-        PreparedStatementBindingSerializer.serializeToNativeBindings(params)) {
+        PreparedStatementBindingSerializer.serialize(
+            SqlPlaceholderMetadata.analyze("SELECT 1"), params)) {
       assertNull(nativeBindings.bindings(), "Expected null bindings for empty parameter list");
     }
   }
 
   @Test
   public void testSerializeMissingParameterFailsWithIndex() {
-    PreparedStatementBindingSerializer.ParameterValue[] params =
-        new PreparedStatementBindingSerializer.ParameterValue[2];
-    params[0] = new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello");
+    Map<Integer, PreparedStatementBindingSerializer.ParameterValue> params = new HashMap<>();
+    params.put(1, new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello"));
 
     SQLException ex =
         assertThrows(
             SQLException.class,
-            () -> PreparedStatementBindingSerializer.serializeToNativeBindings(params));
+            () ->
+                PreparedStatementBindingSerializer.serialize(
+                    SqlPlaceholderMetadata.analyze("SELECT ?, ?"), params));
     assertTrue(
         ex.getMessage().contains("Missing value for parameter index: 2"),
         "Expected missing-parameter index in error message");
@@ -45,18 +48,17 @@ public class PreparedStatementBindingSerializerTest {
 
   @Test
   public void testSerializeCreatesJsonBindingsWithExpectedPointerMetadata() throws Exception {
-    PreparedStatementBindingSerializer.ParameterValue[] params =
-        new PreparedStatementBindingSerializer.ParameterValue[] {
-          new PreparedStatementBindingSerializer.ParameterValue("FIXED", "42"),
-          new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello")
-        };
+    Map<Integer, PreparedStatementBindingSerializer.ParameterValue> params = new HashMap<>();
+    params.put(1, new PreparedStatementBindingSerializer.ParameterValue("FIXED", "42"));
+    params.put(2, new PreparedStatementBindingSerializer.ParameterValue("TEXT", "hello"));
 
     String expectedJson =
         "{\"1\":{\"type\":\"FIXED\",\"value\":\"42\"},\"2\":{\"type\":\"TEXT\",\"value\":\"hello\"}}";
     byte[] expectedJsonBytes = expectedJson.getBytes(StandardCharsets.UTF_8);
 
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
-        PreparedStatementBindingSerializer.serializeToNativeBindings(params)) {
+        PreparedStatementBindingSerializer.serialize(
+            SqlPlaceholderMetadata.analyze("SELECT ?, ?"), params)) {
       QueryBindings bindings = nativeBindings.bindings();
       assertNotNull(bindings, "Expected non-null bindings");
       assertTrue(bindings.hasJson(), "Expected JSON query bindings");
@@ -73,6 +75,28 @@ public class PreparedStatementBindingSerializerTest {
               .order(ByteOrder.LITTLE_ENDIAN)
               .getLong();
       assertNotEquals(0L, pointerValue, "Native pointer value should not be zero");
+    }
+  }
+
+  @Test
+  public void testSerializeNumericPlaceholdersUsesReferencedIndexes() throws Exception {
+    Map<Integer, PreparedStatementBindingSerializer.ParameterValue> params = new HashMap<>();
+    params.put(2, new PreparedStatementBindingSerializer.ParameterValue("TEXT", "two"));
+    params.put(4, new PreparedStatementBindingSerializer.ParameterValue("FIXED", "4"));
+
+    String expectedJson =
+        "{\"2\":{\"type\":\"TEXT\",\"value\":\"two\"},\"4\":{\"type\":\"FIXED\",\"value\":\"4\"}}";
+    byte[] expectedJsonBytes = expectedJson.getBytes(StandardCharsets.UTF_8);
+
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serialize(
+            SqlPlaceholderMetadata.analyze("SELECT :4, :2, :4"), params)) {
+      QueryBindings bindings = nativeBindings.bindings();
+      assertNotNull(bindings, "Expected non-null bindings");
+      assertEquals(
+          expectedJsonBytes.length,
+          bindings.getJson().getLength(),
+          "JSON byte length should match numeric placeholder payload length");
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SqlPlaceholderMetadataTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SqlPlaceholderMetadataTest.java
@@ -1,0 +1,49 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class SqlPlaceholderMetadataTest {
+  @Test
+  public void testAnalyzePositionalPlaceholders() {
+    SqlPlaceholderMetadata metadata = SqlPlaceholderMetadata.analyze("SELECT ?, ?, ?");
+
+    assertEquals(
+        SqlPlaceholderMetadata.PlaceholderStyle.POSITIONAL,
+        metadata.placeholderStyle(),
+        "Expected positional placeholder style");
+    assertEquals(3, metadata.positionalPlaceholderCount(), "Expected positional placeholder count");
+    assertEquals(Arrays.asList(1, 2, 3), new ArrayList<>(metadata.referencedParameterIndexes()));
+  }
+
+  @Test
+  public void testAnalyzeNumericPlaceholdersKeepsCastHandlingSimple() {
+    SqlPlaceholderMetadata metadata = SqlPlaceholderMetadata.analyze("SELECT :2, :1::VARCHAR, :2");
+
+    assertEquals(
+        SqlPlaceholderMetadata.PlaceholderStyle.NUMERIC,
+        metadata.placeholderStyle(),
+        "Expected numeric placeholder style");
+    assertEquals(Arrays.asList(1, 2), new ArrayList<>(metadata.referencedParameterIndexes()));
+    assertTrue(metadata.referencesParameterIndex(1), "Expected parameter 1 to be referenced");
+    assertTrue(metadata.referencesParameterIndex(2), "Expected parameter 2 to be referenced");
+    assertFalse(
+        metadata.referencesParameterIndex(3), "Did not expect parameter 3 to be referenced");
+  }
+
+  @Test
+  public void testAnalyzeMixedPlaceholders() {
+    SqlPlaceholderMetadata metadata = SqlPlaceholderMetadata.analyze("SELECT ?, :1");
+
+    assertEquals(
+        SqlPlaceholderMetadata.PlaceholderStyle.MIXED,
+        metadata.placeholderStyle(),
+        "Expected mixed placeholder style");
+    assertTrue(metadata.hasMixedPlaceholderStyles(), "Expected mixed placeholder flag");
+  }
+}


### PR DESCRIPTION
### TL;DR

Added support for numeric placeholders (`:1`, `:2`) in prepared statements alongside existing positional placeholder (`?`) support, with validation to prevent mixing both styles.

### What changed?

- Introduced `SqlPlaceholderMetadata` class to analyze SQL strings and identify placeholder patterns (positional `?`, numeric `:N`, or mixed)
- Modified `PreparedStatementBindingSerializer` to accept placeholder metadata and a map of parameter values instead of an array
- Updated `SnowflakePreparedStatementImpl` to use a `HashMap` for parameter storage and validate placeholder styles
- Added validation to throw `SQLException` when mixed placeholder styles are detected
- Enhanced parameter binding to only serialize parameters that are actually referenced in the SQL