### PR TITLE
[3/7] config: type and validate resolved connection settings

### DIFF
--- a/odbc/src/lib.rs
+++ b/odbc/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod api;
 pub mod c_api;
 mod conversion;

--- a/odbc/tests/odbc_api_tests.rs
+++ b/odbc/tests/odbc_api_tests.rs
@@ -69,83 +69,64 @@
 //     assert_eq!(ret, sql::SqlReturn::SUCCESS);
 // }
 
-use std::sync::LazyLock;
-
 use sf_core::{
-    protobuf::apis::database_driver_v1::database_driver_client,
+    protobuf::apis::database_driver_v1::{DatabaseDriverClientBlockingExt, database_driver_client},
     protobuf::generated::database_driver_v1::{
         ConnectionNewRequest, ConnectionSetOptionIntRequest, ConnectionSetOptionStringRequest,
         DatabaseInitRequest, DatabaseNewRequest,
     },
 };
 
-static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to create test tokio runtime")
-});
-
 #[test]
 fn smoke_connection_set_tls_config() {
-    TEST_RUNTIME.block_on(async {
-        let client = database_driver_client();
-        let db = client
-            .database_new(DatabaseNewRequest {})
-            .await
-            .expect("database_new ok");
-        client
-            .database_init(DatabaseInitRequest {
-                db_handle: db.db_handle,
-            })
-            .await
-            .expect("database_init ok");
-        let conn = client
-            .connection_new(ConnectionNewRequest {})
-            .await
-            .unwrap()
-            .conn_handle
-            .unwrap();
+    let client = database_driver_client();
+    let db = client
+        .database_new_blocking(DatabaseNewRequest {})
+        .expect("database_new ok");
+    client
+        .database_init_blocking(DatabaseInitRequest {
+            db_handle: db.db_handle,
+        })
+        .expect("database_init ok");
+    let conn = client
+        .connection_new_blocking(ConnectionNewRequest {})
+        .unwrap()
+        .conn_handle
+        .unwrap();
 
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn),
-                key: "verify_hostname".to_string(),
-                value: "true".to_string(),
-            })
-            .await
-            .expect("set verify_hostname");
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn),
-                key: "verify_certificates".to_string(),
-                value: "true".to_string(),
-            })
-            .await
-            .expect("set verify_certificates");
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn),
-                key: "crl_mode".to_string(),
-                value: "ENABLED".to_string(),
-            })
-            .await
-            .expect("set crl_mode");
-        client
-            .connection_set_option_int(ConnectionSetOptionIntRequest {
-                conn_handle: Some(conn),
-                key: "crl_http_timeout".to_string(),
-                value: 30,
-            })
-            .await
-            .expect("set crl_http_timeout");
-        client
-            .connection_set_option_int(ConnectionSetOptionIntRequest {
-                conn_handle: Some(conn),
-                key: "crl_connection_timeout".to_string(),
-                value: 10,
-            })
-            .await
-            .expect("set crl_connection_timeout");
-    });
+    client
+        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
+            conn_handle: Some(conn),
+            key: "verify_hostname".to_string(),
+            value: "true".to_string(),
+        })
+        .expect("set verify_hostname");
+    client
+        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
+            conn_handle: Some(conn),
+            key: "verify_certificates".to_string(),
+            value: "true".to_string(),
+        })
+        .expect("set verify_certificates");
+    client
+        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
+            conn_handle: Some(conn),
+            key: "crl_mode".to_string(),
+            value: "ENABLED".to_string(),
+        })
+        .expect("set crl_mode");
+    client
+        .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
+            conn_handle: Some(conn),
+            key: "crl_http_timeout".to_string(),
+            value: 30,
+        })
+        .expect("set crl_http_timeout");
+    client
+        .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
+            conn_handle: Some(conn),
+            key: "crl_connection_timeout".to_string(),
+            value: 10,
+        })
+        .expect("set crl_connection_timeout");
 }

--- a/odbc_tests/tests/integration/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/integration/authentication/private_key_auth.cpp
@@ -98,7 +98,7 @@ void verify_connection_fails_with_missing_private_key_error(ConnectionHandleWrap
     CHECK(records[0].sqlState == "01S00");
     CHECK(records[0].nativeError == 0);
     CHECK_THAT(records[0].messageText,
-               ContainsSubstring("Missing required parameter: private_key or private_key_file"));
+               ContainsSubstring("Missing required parameter: 'private_key' or 'private_key_file'"));
   }
 }
 

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -426,6 +426,14 @@ message ConnectionGetParameterResponse {
   optional string value = 1;
 }
 
+message ConnectionValidateOptionsRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionValidateOptionsResponse {
+  repeated ValidationIssue issues = 1;
+}
+
 // Statement service requests and responses
 
 message StatementNewRequest {
@@ -721,6 +729,8 @@ service DatabaseDriver {
   // gets cached session parameter. Cache is updated with subset of connection parameters
   // (chosen by server, included in HTTP response) after each query
   rpc ConnectionGetParameter(ConnectionGetParameterRequest) returns (ConnectionGetParameterResponse);
+  // pre-flight validation of connection options - reports all issues at once
+  rpc ConnectionValidateOptions(ConnectionValidateOptionsRequest) returns (ConnectionValidateOptionsResponse);
 
   // Statement operations
   rpc StatementNew(StatementNewRequest) returns (StatementNewResponse);

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -8,50 +8,21 @@ use tokio::sync::RwLock as AsyncRwLock;
 use super::Setting;
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
-use super::validation::{ValidationIssue, normalize_host_underscores, resolve_and_apply_options};
+use super::validation::{
+    ValidationIssue, ValidationSeverity, canonicalize_setting_key, normalize_host_underscores,
+    resolve_options, validate_connection_seed_write, validate_session_override_write,
+};
 use crate::config::ParamStore;
-use crate::config::config_manager;
-use crate::config::param_registry::{ParamKey, param_names};
-use crate::config::path_resolver::ConfigPaths;
-use crate::config::rest_parameters::{ClientInfo, LoginMethod, LoginParameters};
+use crate::config::connection_config::ConnectionConfig;
+use crate::config::param_registry::{ParamKey, ParamScope, param_names};
+use crate::config::resolver;
+use crate::config::rest_parameters::{ClientInfo, LoginMethod, LoginParameters, QueryParameters};
 use crate::config::retry::RetryPolicy;
 use crate::handle_manager::Handle;
 use crate::rest::snowflake::{self, RestError, SessionTokens, SnowflakeResponseError};
 use crate::sensitive::SensitiveString;
 use crate::tls::client::create_tls_client_with_config;
 use crate::token_cache::TokenCache;
-
-/// Load configuration from TOML files for a named connection.
-///
-/// Takes a mutable reference to the connection to avoid double-locking.
-/// Only sets config values for keys not already present (explicit settings win).
-pub fn connection_load_from_config(
-    conn: &mut Connection,
-    connection_name: &str,
-) -> Result<(), ApiError> {
-    let config_settings =
-        config_manager::load_connection_config(connection_name).context(ConfigurationSnafu)?;
-
-    for (key, value) in config_settings {
-        conn.settings.insert_if_absent(key, value);
-    }
-    Ok(())
-}
-
-/// Load configuration from TOML files using explicit config paths.
-pub fn connection_load_from_config_with_paths(
-    conn: &mut Connection,
-    connection_name: &str,
-    paths: &ConfigPaths,
-) -> Result<(), ApiError> {
-    let config_settings = config_manager::load_connection_config_with_paths(connection_name, paths)
-        .context(ConfigurationSnafu)?;
-
-    for (key, value) in config_settings {
-        conn.settings.insert_if_absent(key, value);
-    }
-    Ok(())
-}
 
 impl DatabaseDriverV1 {
     pub async fn connection_init(
@@ -61,36 +32,35 @@ impl DatabaseDriverV1 {
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
-                let (login_parameters, init_params) = {
-                    let mut conn = conn_ptr.lock().await;
-
-                    // Check if connection_name is set and load from config if present
-                    let connection_name =
-                        conn.settings
-                            .get(param_names::CONNECTION_NAME)
-                            .and_then(|s| {
-                                if let Setting::String(name) = s {
-                                    Some(name.clone())
-                                } else {
-                                    None
-                                }
-                            });
-
-                    if let Some(name) = connection_name {
-                        connection_load_from_config(&mut conn, &name)?;
-                    }
-
-                    normalize_host_underscores(&mut conn.settings);
-
-                    let login_parameters = LoginParameters::from_settings(&conn.settings)
-                        .context(ConfigurationSnafu)?;
+                let (config, host, port, client_info, init_params, resolved_snapshot) = {
+                    let conn = conn_ptr.lock().await;
+                    // TODO(sfc-gh-boler): Clone the mutable connection inputs under the mutex,
+                    // then drop the lock before calling resolve/build. Those paths can do
+                    // synchronous disk I/O and private-key parsing, which currently extends the
+                    // connection mutex critical section and can block the async runtime thread.
+                    let mut resolved = conn.resolved_settings().context(ConfigurationSnafu)?;
+                    normalize_host_underscores(&mut resolved);
+                    let config = ConnectionConfig::build(&resolved).context(ConfigurationSnafu)?;
+                    let host = resolved.get_string(param_names::HOST);
+                    let port = resolved.get_int(param_names::PORT);
+                    let client_info =
+                        ClientInfo::from_settings(&resolved).context(ConfigurationSnafu)?;
                     let init_params = conn.init_session_parameters.clone();
-                    (login_parameters, init_params)
+                    let resolved_snapshot = resolved.clone();
+                    (
+                        config,
+                        host,
+                        port,
+                        client_info,
+                        init_params,
+                        resolved_snapshot,
+                    )
                 };
 
-                let http_client =
-                    create_tls_client_with_config(login_parameters.client_info.tls_config.clone())
-                        .context(TlsClientCreationSnafu)?;
+                let http_client = create_tls_client_with_config(config.tls.clone())
+                    .context(TlsClientCreationSnafu)?;
+                let login_parameters =
+                    LoginParameters::from_connection_config(&config, client_info, None);
 
                 let mfa_caching_requested = matches!(
                     &login_parameters.login_method,
@@ -135,10 +105,13 @@ impl DatabaseDriverV1 {
                     .initialize(
                         login_result.tokens,
                         http_client,
+                        host,
+                        port,
                         login_parameters.server_url.clone(),
                         login_parameters.client_info.clone(),
                         merged_params,
                         login_final_names,
+                        resolved_snapshot,
                     )
                     .await;
                 Ok(())
@@ -159,7 +132,10 @@ impl DatabaseDriverV1 {
         match self.connections.get_obj(handle) {
             Some(conn_ptr) => {
                 let mut conn = conn_ptr.lock().await;
-                conn.settings.insert(key, value);
+                let post = conn.is_post_connect();
+                let (canonical, def) = canonicalize_setting_key(&key);
+                validate_connection_seed_write(post, def)?;
+                conn.connection_seed.insert(canonical, value);
                 Ok(())
             }
             None => InvalidArgumentSnafu {
@@ -177,7 +153,52 @@ impl DatabaseDriverV1 {
         match self.connections.get_obj(handle) {
             Some(conn_ptr) => {
                 let mut conn = conn_ptr.lock().await;
-                resolve_and_apply_options(&mut conn.settings, options)
+                let post = conn.is_post_connect();
+                let (resolved, issues) = resolve_options(options);
+                let error_messages: Vec<String> = issues
+                    .iter()
+                    .filter(|i| i.severity == ValidationSeverity::Error)
+                    .map(|i| i.to_string())
+                    .collect();
+                if !error_messages.is_empty() {
+                    return InvalidArgumentSnafu {
+                        argument: error_messages.join("; "),
+                    }
+                    .fail();
+                }
+                for key in resolved.keys() {
+                    let def = crate::config::param_registry::registry().resolve(key.as_str());
+                    validate_connection_seed_write(post, def)?;
+                }
+                for (key, value) in resolved {
+                    conn.connection_seed.insert(key, value);
+                }
+                Ok(issues
+                    .into_iter()
+                    .filter(|i| i.severity == ValidationSeverity::Warning)
+                    .collect())
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .fail(),
+        }
+    }
+
+    pub async fn connection_validate_options(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<Vec<ValidationIssue>, ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let conn = conn_ptr.lock().await;
+                // TODO(sfc-gh-boler): Clone `conn.connection_seed` under the mutex and run
+                // resolve/validate after releasing the lock, since layered config resolution may
+                // perform synchronous file I/O.
+                let resolved = conn.resolved_settings().context(ConfigurationSnafu)?;
+                Ok(crate::config::connection_config::validate_settings(
+                    &resolved,
+                ))
             }
             None => InvalidArgumentSnafu {
                 argument: "Connection handle not found".to_string(),
@@ -204,6 +225,39 @@ impl DatabaseDriverV1 {
         }
     }
 
+    /// Set a session-scoped parameter for the current session only (post-connect).
+    ///
+    /// Connection-scoped and statement-scoped registry parameters must use their respective
+    /// setters. Unknown keys are accepted as opaque session overrides.
+    pub async fn connection_set_session_option(
+        &self,
+        handle: Handle,
+        key: String,
+        value: Setting,
+    ) -> Result<(), ApiError> {
+        match self.connections.get_obj(handle) {
+            Some(conn_ptr) => {
+                let mut conn = conn_ptr.lock().await;
+                if !conn.is_post_connect() {
+                    return InvalidArgumentSnafu {
+                        argument:
+                            "Session options are only available after the connection is established"
+                                .to_string(),
+                    }
+                    .fail();
+                }
+                let (canonical, def) = canonicalize_setting_key(&key);
+                validate_session_override_write(def)?;
+                conn.session_overrides.insert(canonical, value);
+                Ok(())
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .fail(),
+        }
+    }
+
     pub fn connection_new(&self) -> Handle {
         self.connections.add_handle(Mutex::new(Connection::new()))
     }
@@ -220,11 +274,20 @@ impl DatabaseDriverV1 {
 }
 
 pub struct Connection {
-    pub(crate) settings: ParamStore,
+    /// Explicit connection-string / API options (merged as the top layer in [`resolver::resolve`]).
+    pub(crate) connection_seed: ParamStore,
+    /// Resolved settings snapshot captured at successful login (defaults + files + seed).
+    pub(crate) resolved_connect: Option<ParamStore>,
+    /// Typed session overrides set after connect (session scope only).
+    pub(crate) session_overrides: ParamStore,
     /// Session tokens - RwLock allows concurrent reads, exclusive writes for refresh
     pub tokens: Arc<AsyncRwLock<Option<SessionTokens>>>,
     pub http_client: Option<reqwest::Client>,
     pub retry_policy: RetryPolicy,
+    /// Effective host after layered config resolution.
+    pub host: Option<String>,
+    /// Effective port after layered config resolution.
+    pub port: Option<i64>,
     /// Server URL for refresh requests
     pub server_url: Option<String>,
     /// Client info for refresh requests
@@ -247,10 +310,14 @@ impl Default for Connection {
 impl Connection {
     pub fn new() -> Self {
         Connection {
-            settings: ParamStore::new(),
+            connection_seed: ParamStore::new(),
+            resolved_connect: None,
+            session_overrides: ParamStore::new(),
             tokens: Arc::new(AsyncRwLock::new(None)),
             http_client: None,
             retry_policy: RetryPolicy::default(),
+            host: None,
+            port: None,
             server_url: None,
             client_info: None,
             session_parameters: Arc::new(AsyncRwLock::new(HashMap::new())),
@@ -259,24 +326,55 @@ impl Connection {
         }
     }
 
-    /// Convenience setter for tests and direct call sites.
-    pub fn set_option(&mut self, key: String, value: Setting) {
-        self.settings.insert(key, value);
+    /// `true` after a successful [`Connection::initialize`] (post-login transport is ready).
+    pub(crate) fn is_post_connect(&self) -> bool {
+        self.http_client.is_some()
     }
 
+    /// Server URL + client fingerprint for query and refresh calls (transport snapshot).
+    pub(crate) fn query_transport_parameters(&self) -> Result<QueryParameters, ApiError> {
+        Ok(QueryParameters {
+            server_url: self
+                .server_url
+                .clone()
+                .context(ConnectionNotInitializedSnafu)?,
+            client_info: self
+                .client_info
+                .clone()
+                .context(ConnectionNotInitializedSnafu)?,
+        })
+    }
+
+    /// Convenience setter for tests and direct call sites.
+    pub fn set_option(&mut self, key: String, value: Setting) {
+        self.connection_seed.insert(key, value);
+    }
+
+    fn resolved_settings(&self) -> Result<ParamStore, crate::config::ConfigError> {
+        resolver::resolve(&self.connection_seed)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn initialize(
         &mut self,
         tokens: SessionTokens,
         http_client: reqwest::Client,
+        host: Option<String>,
+        port: Option<i64>,
         server_url: String,
         client_info: ClientInfo,
         session_params: HashMap<String, String>,
         final_names: FinalSessionNames,
+        resolved_connect: ParamStore,
     ) {
         *self.tokens.write().await = Some(tokens);
         self.http_client = Some(http_client);
+        self.host = host;
+        self.port = port;
         self.server_url = Some(server_url);
         self.client_info = Some(client_info);
+        self.resolved_connect = Some(resolved_connect);
+        self.session_overrides = ParamStore::new();
 
         let mut cache = self.session_parameters.write().await;
         *cache = session_params;
@@ -583,8 +681,28 @@ pub struct ConnectionInfo {
     pub warehouse: Option<String>,
 }
 
-fn get_setting_string(conn: &Connection, key: ParamKey) -> Option<String> {
-    conn.settings.get(key).and_then(|s| {
+fn setting_as_display_string(setting: &Setting) -> Option<String> {
+    match setting {
+        Setting::String(s) => Some(s.clone()),
+        Setting::Int(i) => Some(i.to_string()),
+        Setting::Bool(b) => Some(b.to_string()),
+        Setting::Double(d) => Some(d.to_string()),
+        Setting::Bytes(_) => None,
+    }
+}
+
+fn resolved_or_seed_string(conn: &Connection, key: ParamKey) -> Option<String> {
+    if let Some(resolved) = &conn.resolved_connect
+        && let Some(s) = resolved.get_string(key)
+    {
+        return Some(s);
+    }
+    conn.connection_seed.get_string(key)
+}
+
+/// Connection-scoped string from the live seed (writes rejected after connect when immutable).
+fn get_connection_seed_string(conn: &Connection, key: ParamKey) -> Option<String> {
+    conn.connection_seed.get(key).and_then(|s| {
         if let Setting::String(v) = s {
             Some(v.clone())
         } else {
@@ -593,9 +711,7 @@ fn get_setting_string(conn: &Connection, key: ParamKey) -> Option<String> {
     })
 }
 
-/// Read a session-level value: check the session parameter cache first (server
-/// may have changed it via USE DATABASE / USE ROLE / etc.), then fall back to
-/// the original connection setting.
+/// Session effective read: server cache → session overrides → resolved connect (then seed).
 fn get_session_or_setting(
     conn: &Connection,
     param_name: &str,
@@ -607,7 +723,14 @@ fn get_session_or_setting(
     {
         return Some(v.clone());
     }
-    get_setting_string(conn, setting_key)
+    if let Some(s) = conn
+        .session_overrides
+        .get(setting_key)
+        .and_then(setting_as_display_string)
+    {
+        return Some(s);
+    }
+    resolved_or_seed_string(conn, setting_key)
 }
 
 impl DatabaseDriverV1 {
@@ -620,15 +743,14 @@ impl DatabaseDriverV1 {
             Some(conn_ptr) => {
                 let conn = conn_ptr.lock().await;
 
-                let host = get_setting_string(&conn, param_names::HOST);
+                let host = conn
+                    .host
+                    .clone()
+                    .or_else(|| conn.connection_seed.get_string(param_names::HOST));
 
-                let port = conn.settings.get(param_names::PORT).and_then(|s| {
-                    if let Setting::Int(v) = s {
-                        Some(*v)
-                    } else {
-                        None
-                    }
-                });
+                let port = conn
+                    .port
+                    .or_else(|| conn.connection_seed.get_int(param_names::PORT));
 
                 let server_url = conn.server_url.clone();
 
@@ -642,13 +764,14 @@ impl DatabaseDriverV1 {
                     }
                 };
 
-                let account = get_setting_string(&conn, param_names::ACCOUNT);
-                let user = get_setting_string(&conn, param_names::USER);
+                let account = get_connection_seed_string(&conn, param_names::ACCOUNT);
+                let user = get_connection_seed_string(&conn, param_names::USER);
 
                 // Resolution order for session-scoped values:
                 //   1. final_session_names  (server-echoed via login sessionInfo or query finalXxxName)
                 //   2. session_parameters   (server-returned session params, only pre-login / missing sessionInfo)
-                //   3. connection settings   (original kwargs supplied by the caller)
+                //   3. session_overrides     (post-connect session setters)
+                //   4. resolved_connect (login snapshot) then connection_seed
                 // After a successful login, final_session_names is always populated, so the
                 // or_else branch only fires before connection_init or when the server omits
                 // the field from sessionInfo.
@@ -707,7 +830,43 @@ impl DatabaseDriverV1 {
                 let cache = conn.session_parameters.read().await;
 
                 let normalized_key = key.to_uppercase();
-                Ok(cache.get(&normalized_key).cloned())
+                if let Some(v) = cache.get(&normalized_key).filter(|s| !s.is_empty()) {
+                    return Ok(Some(v.clone()));
+                }
+                drop(cache);
+
+                let (canonical, def) = canonicalize_setting_key(&key);
+                if let Some(d) = def
+                    && d.scope == ParamScope::Session
+                {
+                    if let Some(s) = conn
+                        .session_overrides
+                        .get_any(&canonical)
+                        .and_then(setting_as_display_string)
+                    {
+                        return Ok(Some(s));
+                    }
+                    return Ok(resolved_or_seed_string(&conn, ParamKey(d.canonical_name)));
+                }
+
+                if let Some(s) = conn
+                    .session_overrides
+                    .get_any(&canonical)
+                    .and_then(setting_as_display_string)
+                {
+                    return Ok(Some(s));
+                }
+
+                Ok(conn
+                    .resolved_connect
+                    .as_ref()
+                    .and_then(|r| r.get_any(&canonical))
+                    .and_then(setting_as_display_string)
+                    .or_else(|| {
+                        conn.connection_seed
+                            .get_any(&canonical)
+                            .and_then(setting_as_display_string)
+                    }))
             }
             None => InvalidArgumentSnafu {
                 argument: "Connection handle not found".to_string(),
@@ -720,36 +879,37 @@ impl DatabaseDriverV1 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ParamStore;
     use crate::config::param_registry::param_names;
 
     fn make_connection_with_settings(settings: Vec<(&str, Setting)>) -> Connection {
         let mut conn = Connection::new();
         for (key, value) in settings {
-            conn.settings.insert(key.to_string(), value);
+            conn.connection_seed.insert(key.to_string(), value);
         }
         conn
     }
 
     #[test]
-    fn get_setting_string_returns_value() {
+    fn get_connection_seed_string_returns_value() {
         let conn =
             make_connection_with_settings(vec![("host", Setting::String("example.com".into()))]);
         assert_eq!(
-            get_setting_string(&conn, param_names::HOST),
+            get_connection_seed_string(&conn, param_names::HOST),
             Some("example.com".into())
         );
     }
 
     #[test]
-    fn get_setting_string_returns_none_for_missing_key() {
+    fn get_connection_seed_string_returns_none_for_missing_key() {
         let conn = Connection::new();
-        assert_eq!(get_setting_string(&conn, param_names::HOST), None);
+        assert_eq!(get_connection_seed_string(&conn, param_names::HOST), None);
     }
 
     #[test]
-    fn get_setting_string_returns_none_for_non_string_type() {
+    fn get_connection_seed_string_returns_none_for_non_string_type() {
         let conn = make_connection_with_settings(vec![("port", Setting::Int(443))]);
-        assert_eq!(get_setting_string(&conn, param_names::PORT), None);
+        assert_eq!(get_connection_seed_string(&conn, param_names::PORT), None);
     }
 
     #[test]
@@ -800,6 +960,100 @@ mod tests {
             get_session_or_setting(&conn, "ROLE", param_names::ROLE),
             None
         );
+    }
+
+    #[test]
+    fn get_session_or_setting_prefers_resolved_connect_over_seed() {
+        let mut conn =
+            make_connection_with_settings(vec![("database", Setting::String("seed_db".into()))]);
+        let mut resolved = ParamStore::new();
+        resolved.insert("database".into(), Setting::String("resolved_db".into()));
+        conn.resolved_connect = Some(resolved);
+        assert_eq!(
+            get_session_or_setting(&conn, "DATABASE", param_names::DATABASE),
+            Some("resolved_db".into())
+        );
+    }
+
+    #[test]
+    fn get_session_or_setting_prefers_session_overrides_over_resolved() {
+        let mut conn =
+            make_connection_with_settings(vec![("database", Setting::String("seed_db".into()))]);
+        let mut resolved = ParamStore::new();
+        resolved.insert("database".into(), Setting::String("resolved_db".into()));
+        conn.resolved_connect = Some(resolved);
+        conn.session_overrides
+            .insert("database".into(), Setting::String("override_db".into()));
+        assert_eq!(
+            get_session_or_setting(&conn, "DATABASE", param_names::DATABASE),
+            Some("override_db".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_rejects_statement_scoped_param_on_connection_seed() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+        let err = ds
+            .connection_set_option(handle, "async_execution".into(), Setting::Bool(true))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("statement-scoped"), "unexpected error: {msg}");
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_rejects_session_scoped_after_post_connect() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+        if let Some(c) = ds.connections.get_obj(handle) {
+            let mut conn = c.lock().await;
+            conn.http_client = Some(reqwest::Client::new());
+        }
+        let err = ds
+            .connection_set_option(handle, "database".into(), Setting::String("x".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("session-scoped"),
+            "unexpected: {err}"
+        );
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_rejects_immutable_connection_param_after_post_connect() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+        if let Some(c) = ds.connections.get_obj(handle) {
+            let mut conn = c.lock().await;
+            conn.http_client = Some(reqwest::Client::new());
+        }
+        let err = ds
+            .connection_set_option(handle, "account".into(), Setting::String("other".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be changed after connect"),
+            "unexpected: {err}"
+        );
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_set_session_option_rejects_before_post_connect() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+        let err = ds
+            .connection_set_session_option(handle, "database".into(), Setting::String("db".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("after the connection is established")
+        );
+        ds.connection_release(handle).unwrap();
     }
 
     #[tokio::test]

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -5,11 +5,13 @@ use super::connection::{Connection, RefreshContext};
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
 use super::query::process_query_response;
-use super::validation::{ValidationIssue, resolve_and_apply_options};
+use super::validation::{
+    ValidationIssue, ValidationSeverity, canonicalize_setting_key, resolve_options,
+    validate_statement_option_write,
+};
 use crate::chunks::ChunkDownloadData;
 use crate::config::ParamStore;
 use crate::config::param_registry::param_names;
-use crate::config::rest_parameters::QueryParameters;
 use crate::config::settings::Setting;
 use crate::handle_manager::Handle;
 use crate::rest::snowflake::query_response::Data;
@@ -183,7 +185,9 @@ impl DatabaseDriverV1 {
         match self.statements.get_obj(handle) {
             Some(stmt_ptr) => {
                 let mut stmt = stmt_ptr.lock().await;
-                stmt.settings.insert(key, value);
+                let (canonical, def) = canonicalize_setting_key(&key);
+                validate_statement_option_write(def)?;
+                stmt.settings.insert(canonical, value);
                 Ok(())
             }
             None => InvalidArgumentSnafu {
@@ -201,7 +205,29 @@ impl DatabaseDriverV1 {
         match self.statements.get_obj(handle) {
             Some(stmt_ptr) => {
                 let mut stmt = stmt_ptr.lock().await;
-                resolve_and_apply_options(&mut stmt.settings, options)
+                let (resolved, issues) = resolve_options(options);
+                let error_messages: Vec<String> = issues
+                    .iter()
+                    .filter(|i| i.severity == ValidationSeverity::Error)
+                    .map(|i| i.to_string())
+                    .collect();
+                if !error_messages.is_empty() {
+                    return InvalidArgumentSnafu {
+                        argument: error_messages.join("; "),
+                    }
+                    .fail();
+                }
+                for key in resolved.keys() {
+                    let def = crate::config::param_registry::registry().resolve(key.as_str());
+                    validate_statement_option_write(def)?;
+                }
+                for (key, value) in resolved {
+                    stmt.settings.insert(key, value);
+                }
+                Ok(issues
+                    .into_iter()
+                    .filter(|i| i.severity == ValidationSeverity::Warning)
+                    .collect())
             }
             None => InvalidArgumentSnafu {
                 argument: "Statement handle not found".to_string(),
@@ -301,7 +327,7 @@ impl DatabaseDriverV1 {
         let (query_parameters, http_client, retry_policy) = {
             let conn = stmt.conn.lock().await;
             (
-                QueryParameters::from_settings(&conn.settings).context(ConfigurationSnafu)?,
+                conn.query_transport_parameters()?,
                 conn.http_client
                     .clone()
                     .context(ConnectionNotInitializedSnafu)?,
@@ -659,6 +685,23 @@ mod tests {
             stmt.execution_mode(Some("SELECT 1")),
             QueryExecutionMode::Async
         );
+    }
+
+    #[tokio::test]
+    async fn statement_rejects_connection_scoped_param() {
+        let ds = DatabaseDriverV1::new();
+        let ch = ds.connection_new();
+        let sh = ds.statement_new(ch).unwrap();
+        let err = ds
+            .statement_set_option(sh, "host".into(), Setting::String("h".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not statement-scoped"),
+            "unexpected: {err}"
+        );
+        ds.statement_release(sh).unwrap();
+        ds.connection_release(ch).unwrap();
     }
 
     #[test]

--- a/sf_core/src/apis/database_driver_v1/validation.rs
+++ b/sf_core/src/apis/database_driver_v1/validation.rs
@@ -1,45 +1,11 @@
 use std::collections::HashMap;
-use std::fmt;
 
 use super::error::{ApiError, InvalidArgumentSnafu};
 use crate::config::ParamStore;
-use crate::config::param_registry::{self, ValueType, param_names};
+use crate::config::param_registry::{self, ParamScope, ValueType, param_names};
 use crate::config::settings::{Setting, Settings};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationSeverity {
-    Error,
-    Warning,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationCode {
-    Unspecified,
-    MissingRequired,
-    InvalidType,
-    InvalidValue,
-    UnknownParameter,
-    DeprecatedParameter,
-    ConflictingParameters,
-}
-
-#[derive(Debug, Clone)]
-pub struct ValidationIssue {
-    pub severity: ValidationSeverity,
-    pub parameter: String,
-    pub message: String,
-    pub code: ValidationCode,
-}
-
-impl fmt::Display for ValidationIssue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{:?}] {}: {}",
-            self.severity, self.parameter, self.message
-        )
-    }
-}
+pub use crate::config::connection_config::{ValidationCode, ValidationIssue, ValidationSeverity};
 
 fn setting_matches_value_type(setting: &Setting, expected: ValueType) -> bool {
     matches!(
@@ -291,6 +257,100 @@ pub fn resolve_and_apply_options(
         .into_iter()
         .filter(|i| i.severity == ValidationSeverity::Warning)
         .collect())
+}
+
+pub(crate) fn canonicalize_setting_key(
+    key: &str,
+) -> (String, Option<&'static param_registry::ParamDef>) {
+    let reg = param_registry::registry();
+    match reg.resolve(key) {
+        Some(d) => (d.canonical_name.to_string(), Some(d)),
+        None => (key.to_string(), None),
+    }
+}
+
+pub(crate) fn validate_connection_seed_write(
+    post_connect: bool,
+    def: Option<&param_registry::ParamDef>,
+) -> Result<(), ApiError> {
+    let Some(d) = def else {
+        return Ok(());
+    };
+    if d.scope == ParamScope::Statement {
+        return InvalidArgumentSnafu {
+            argument: format!(
+                "Parameter '{}' is statement-scoped; set it on a statement handle",
+                d.canonical_name
+            ),
+        }
+        .fail();
+    }
+    if post_connect {
+        if d.scope == ParamScope::Session {
+            return InvalidArgumentSnafu {
+                argument: format!(
+                    "Parameter '{}' is session-scoped; use connection_set_session_option after connect",
+                    d.canonical_name
+                ),
+            }
+            .fail();
+        }
+        if !d.mutable_after_connect {
+            return InvalidArgumentSnafu {
+                argument: format!(
+                    "Parameter '{}' cannot be changed after connect",
+                    d.canonical_name
+                ),
+            }
+            .fail();
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_session_override_write(
+    def: Option<&param_registry::ParamDef>,
+) -> Result<(), ApiError> {
+    let Some(d) = def else {
+        return Ok(());
+    };
+    if d.scope == ParamScope::Statement {
+        return InvalidArgumentSnafu {
+            argument: format!(
+                "Parameter '{}' is statement-scoped; set it on a statement handle",
+                d.canonical_name
+            ),
+        }
+        .fail();
+    }
+    if d.scope == ParamScope::Connection {
+        return InvalidArgumentSnafu {
+            argument: format!(
+                "Parameter '{}' is connection-scoped; set it via connection options before connect",
+                d.canonical_name
+            ),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_statement_option_write(
+    def: Option<&param_registry::ParamDef>,
+) -> Result<(), ApiError> {
+    let Some(d) = def else {
+        return Ok(());
+    };
+    if d.scope != ParamScope::Statement {
+        return InvalidArgumentSnafu {
+            argument: format!(
+                "Parameter '{}' is not statement-scoped; set it on the connection or session",
+                d.canonical_name
+            ),
+        }
+        .fail();
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -1,0 +1,1364 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+
+use base64::{Engine as _, engine::general_purpose};
+use chrono::Duration;
+use openssl::pkey::PKey;
+use snafu::OptionExt;
+use url::Url;
+
+use crate::config::ParamStore;
+use crate::config::param_names::*;
+use crate::config::rest_parameters::{
+    ClientInfo, DEFAULT_AUTHENTICATION_TIMEOUT_SECS, LoginMethod, LoginParameters, NativeOktaConfig,
+};
+use crate::config::settings::Setting;
+use crate::config::{
+    ConfigError, ConflictingParametersSnafu, InvalidParameterValueSnafu, MissingParameterSnafu,
+    ValidationFailedSnafu,
+};
+use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
+use crate::sensitive::SensitiveString;
+use crate::tls::config::TlsConfig;
+
+// ---------------------------------------------------------------------------
+// Typed config structs
+// ---------------------------------------------------------------------------
+
+/// Fully validated, typed connection configuration.
+#[derive(Debug)]
+pub struct ConnectionConfig {
+    pub server: ServerConfig,
+    pub auth: AuthConfig,
+    pub session: SessionContext,
+    pub tls: TlsConfig,
+}
+
+#[derive(Debug)]
+pub struct ServerConfig {
+    pub account: String,
+    pub server_url: String,
+}
+
+#[derive(Debug)]
+pub enum AuthConfig {
+    Password {
+        user: String,
+        password: SensitiveString,
+    },
+    Mfa {
+        user: String,
+        password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
+        client_store_temporary_credential: bool,
+    },
+    Jwt {
+        user: String,
+        private_key_pem: SensitiveString,
+        passphrase: Option<SensitiveString>,
+    },
+    Pat {
+        user: String,
+        token: SensitiveString,
+    },
+    NativeOkta(NativeOktaConfig),
+}
+
+#[derive(Debug)]
+pub struct SessionContext {
+    pub database: Option<String>,
+    pub schema: Option<String>,
+    pub warehouse: Option<String>,
+    pub role: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Validation types — canonical definitions, re-exported by apis::validation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationCode {
+    Unspecified,
+    MissingRequired,
+    InvalidType,
+    InvalidValue,
+    UnknownParameter,
+    DeprecatedParameter,
+    ConflictingParameters,
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    pub severity: ValidationSeverity,
+    pub parameter: String,
+    pub message: String,
+    pub code: ValidationCode,
+}
+
+impl fmt::Display for ValidationIssue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{:?}] {}: {}",
+            self.severity, self.parameter, self.message
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private key helpers (mirrored from rest_parameters.rs)
+// ---------------------------------------------------------------------------
+
+fn der_to_pem(der_bytes: &[u8]) -> Result<String, ConfigError> {
+    let pkey = PKey::private_key_from_der(der_bytes).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: String::from(PRIVATE_KEY),
+            value: "(binary data)".to_string(),
+            explanation: format!("Could not parse DER private key: {e}"),
+        }
+        .build()
+    })?;
+
+    let pem_bytes = pkey.private_key_to_pem_pkcs8().map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: String::from(PRIVATE_KEY),
+            value: "(binary data)".to_string(),
+            explanation: format!("Could not convert private key to PEM: {e}"),
+        }
+        .build()
+    })?;
+
+    String::from_utf8(pem_bytes).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: String::from(PRIVATE_KEY),
+            value: "(binary data)".to_string(),
+            explanation: format!("PEM output is not valid UTF-8: {e}"),
+        }
+        .build()
+    })
+}
+
+fn read_private_key(settings: &ParamStore) -> Result<String, ConfigError> {
+    let has_private_key = settings.get(PRIVATE_KEY).is_some();
+    let has_private_key_file = settings.get_string(PRIVATE_KEY_FILE).is_some();
+
+    if has_private_key && has_private_key_file {
+        return ConflictingParametersSnafu {
+            explanation:
+                "Both 'private_key' and 'private_key_file' are set. Please provide only one."
+                    .to_string(),
+        }
+        .fail();
+    }
+
+    // Bytes (DER from Python)
+    if let Some(Setting::Bytes(private_key_bytes)) = settings.get(PRIVATE_KEY) {
+        return der_to_pem(private_key_bytes);
+    }
+
+    // String (base64-encoded)
+    if let Some(private_key_base64) = settings.get_string(PRIVATE_KEY) {
+        let private_key_bytes = general_purpose::STANDARD
+            .decode(&private_key_base64)
+            .map_err(|e| {
+                InvalidParameterValueSnafu {
+                    parameter: String::from(PRIVATE_KEY),
+                    value: "(redacted)".to_string(),
+                    explanation: format!("Could not decode base64 private key: {e}"),
+                }
+                .build()
+            })?;
+
+        if private_key_bytes.starts_with(b"-----BEGIN") {
+            return String::from_utf8(private_key_bytes).map_err(|e| {
+                InvalidParameterValueSnafu {
+                    parameter: String::from(PRIVATE_KEY),
+                    value: "(redacted)".to_string(),
+                    explanation: format!("Private key is not valid UTF-8: {e}"),
+                }
+                .build()
+            });
+        }
+
+        return der_to_pem(&private_key_bytes);
+    }
+
+    // File path
+    if let Some(private_key_file) = settings.get_string(PRIVATE_KEY_FILE) {
+        let private_key = fs::read_to_string(&private_key_file).map_err(|e| {
+            InvalidParameterValueSnafu {
+                parameter: String::from(PRIVATE_KEY_FILE),
+                value: private_key_file,
+                explanation: format!("Could not read private key file: {e}"),
+            }
+            .build()
+        })?;
+        return Ok(private_key);
+    }
+
+    MissingParameterSnafu {
+        parameter: "private_key or private_key_file".to_string(),
+    }
+    .fail()
+}
+
+fn has_private_key_params(settings: &ParamStore) -> bool {
+    settings.get(PRIVATE_KEY).is_some() || settings.get_string(PRIVATE_KEY_FILE).is_some()
+}
+
+fn non_empty_string(settings: &ParamStore, key: crate::config::ParamKey) -> Option<String> {
+    settings.get_string(key).filter(|value| !value.is_empty())
+}
+
+// ---------------------------------------------------------------------------
+// Server URL derivation (mirrored from rest_parameters::get_server_url)
+// ---------------------------------------------------------------------------
+
+fn derive_server_url(settings: &ParamStore) -> Result<String, ConfigError> {
+    if let Some(url) = settings.get_string(SERVER_URL) {
+        return Ok(url);
+    }
+
+    let protocol = settings
+        .get_string(PROTOCOL)
+        .unwrap_or_else(|| "https".to_string());
+    let host = settings.get_string(HOST).context(MissingParameterSnafu {
+        parameter: String::from(HOST),
+    })?;
+    if protocol != "https" && protocol != "http" {
+        tracing::warn!("Unexpected protocol specified during server url construction: {protocol}");
+    }
+
+    let base_url = format!("{protocol}://{host}");
+    if let Some(port) = settings.get_int(PORT) {
+        return Ok(format!("{base_url}:{port}"));
+    }
+
+    Ok(base_url)
+}
+
+// ---------------------------------------------------------------------------
+// TLS / CRL config building (mirrored from tls::config / crl::config)
+// ---------------------------------------------------------------------------
+
+fn build_crl_config(settings: &ParamStore) -> CrlConfig {
+    // TODO: make matching case-insensitive (e.g. "disabled", "Enabled")
+    let check_mode = match settings.get_string(CRL_CHECK_MODE).as_deref() {
+        Some("0") | Some("DISABLED") | None => CertRevocationCheckMode::Disabled,
+        Some("1") | Some("ENABLED") => CertRevocationCheckMode::Enabled,
+        Some("2") | Some("ADVISORY") => CertRevocationCheckMode::Advisory,
+        Some(other) => {
+            tracing::warn!("Unknown crl_check_mode: {other}, using DISABLED");
+            CertRevocationCheckMode::Disabled
+        }
+    };
+
+    let enable_disk_caching = settings.get_bool(CRL_ENABLE_DISK_CACHING).unwrap_or(true);
+    let enable_memory_caching = settings.get_bool(CRL_ENABLE_MEMORY_CACHING).unwrap_or(true);
+    let cache_dir = settings.get_string(CRL_CACHE_DIR).map(PathBuf::from);
+    let validity_time = settings
+        .get_int(CRL_VALIDITY_TIME)
+        .map(Duration::days)
+        .unwrap_or(Duration::days(10));
+    let allow_certificates_without_crl_url = settings
+        .get_bool(CRL_ALLOW_CERTIFICATES_WITHOUT_CRL_URL)
+        .unwrap_or(false);
+    let http_timeout = settings
+        .get_int(CRL_HTTP_TIMEOUT)
+        .map(Duration::seconds)
+        .unwrap_or(Duration::seconds(30));
+    let connection_timeout = settings
+        .get_int(CRL_CONNECTION_TIMEOUT)
+        .map(Duration::seconds)
+        .unwrap_or(Duration::seconds(10));
+
+    CrlConfig {
+        check_mode,
+        enable_disk_caching,
+        enable_memory_caching,
+        cache_dir,
+        validity_time,
+        allow_certificates_without_crl_url,
+        http_timeout,
+        connection_timeout,
+    }
+}
+
+fn build_tls_config(settings: &ParamStore) -> TlsConfig {
+    let crl_config = build_crl_config(settings);
+    let custom_root_store_path = settings
+        .get_string(CUSTOM_ROOT_STORE_PATH)
+        .map(PathBuf::from);
+    let verify_hostname = settings.get_bool(VERIFY_HOSTNAME).unwrap_or(true);
+    let verify_certificates = settings.get_bool(VERIFY_CERTIFICATES).unwrap_or(true);
+
+    TlsConfig {
+        crl_config,
+        custom_root_store_path,
+        verify_hostname,
+        verify_certificates,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth config building (mirrored from rest_parameters::LoginMethod)
+// ---------------------------------------------------------------------------
+
+fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
+    let authenticator = settings.get_string(AUTHENTICATOR).unwrap_or_default();
+
+    let use_jwt = authenticator == "SNOWFLAKE_JWT"
+        || (authenticator.is_empty() && has_private_key_params(settings));
+
+    if use_jwt {
+        return Ok(AuthConfig::Jwt {
+            user: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                parameter: String::from(USER),
+            })?,
+            private_key_pem: SensitiveString::from(read_private_key(settings)?),
+            passphrase: settings.get_sensitive_string(PRIVATE_KEY_PASSWORD),
+        });
+    }
+
+    match authenticator.as_str() {
+        "SNOWFLAKE_PASSWORD" | "" => Ok(AuthConfig::Password {
+            user: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                parameter: String::from(USER),
+            })?,
+            password: settings.get_sensitive_string(PASSWORD).context(
+                MissingParameterSnafu {
+                    parameter: String::from(PASSWORD),
+                },
+            )?,
+        }),
+        "USERNAME_PASSWORD_MFA" => Ok(AuthConfig::Mfa {
+            user: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                parameter: String::from(USER),
+            })?,
+            password: settings.get_sensitive_string(PASSWORD).context(
+                MissingParameterSnafu {
+                    parameter: String::from(PASSWORD),
+                },
+            )?,
+            passcode_in_password: settings.get_bool(PASSCODE_IN_PASSWORD).unwrap_or(false),
+            passcode: settings.get_sensitive_string(PASSCODE),
+            client_store_temporary_credential: settings
+                .get_bool(CLIENT_STORE_TEMPORARY_CREDENTIAL)
+                .unwrap_or(false),
+        }),
+        "PROGRAMMATIC_ACCESS_TOKEN" => Ok(AuthConfig::Pat {
+            user: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                parameter: String::from(USER),
+            })?,
+            token: settings.get_sensitive_string(TOKEN)
+                .context(MissingParameterSnafu {
+                    parameter: String::from(TOKEN),
+                })?,
+        }),
+        _ if authenticator.to_ascii_lowercase().starts_with("https://") => {
+            let okta_url = Url::parse(&authenticator).map_err(|_| {
+                InvalidParameterValueSnafu {
+                    parameter: String::from(AUTHENTICATOR),
+                    value: authenticator.clone(),
+                    explanation: "The authenticator URL is not a valid URL".to_string(),
+                }
+                .build()
+            })?;
+
+            let authentication_timeout_secs = settings
+                .get_int(AUTHENTICATION_TIMEOUT)
+                .and_then(|v| u64::try_from(v).ok())
+                .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+
+            Ok(AuthConfig::NativeOkta(NativeOktaConfig {
+                username: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                    parameter: String::from(USER),
+                })?,
+                okta_username: settings.get_string(OKTA_USERNAME),
+                password: settings.get_sensitive_string(PASSWORD).context(
+                    MissingParameterSnafu {
+                        parameter: String::from(PASSWORD),
+                    },
+                )?,
+                okta_url,
+                disable_saml_url_check: settings
+                    .get_bool(DISABLE_SAML_URL_CHECK)
+                    .unwrap_or(false),
+                authentication_timeout_secs,
+            }))
+        }
+        _ => InvalidParameterValueSnafu {
+            parameter: String::from(AUTHENTICATOR),
+            value: authenticator,
+            explanation: "Allowed values are SNOWFLAKE_JWT, SNOWFLAKE_PASSWORD, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, or an https:// URL for native Okta SSO".to_string(),
+        }
+        .fail(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionConfig::build
+// ---------------------------------------------------------------------------
+
+impl ConnectionConfig {
+    /// Build a typed config from a resolved settings map.
+    ///
+    /// The input should come from `resolver::resolve` or `resolver::resolve_with_paths`.
+    /// Runs `validate_settings` first and returns all validation errors
+    /// collected (not just the first) via `ConfigError::ValidationFailed`.
+    /// Runtime errors that go beyond static validation (e.g. base64
+    /// decoding failures, file I/O) are still returned individually.
+    pub fn build(settings: &ParamStore) -> Result<Self, ConfigError> {
+        let issues = validate_settings(settings);
+        let errors: Vec<_> = issues
+            .into_iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .collect();
+        if !errors.is_empty() {
+            return ValidationFailedSnafu { issues: errors }.fail();
+        }
+
+        let account = settings
+            .get_string(ACCOUNT)
+            .context(MissingParameterSnafu {
+                parameter: String::from(ACCOUNT),
+            })?;
+        let server_url = derive_server_url(settings)?;
+        let auth = build_auth_config(settings)?;
+        let tls = build_tls_config(settings);
+
+        let session = SessionContext {
+            database: settings.get_string(DATABASE),
+            schema: settings.get_string(SCHEMA),
+            warehouse: settings.get_string(WAREHOUSE),
+            role: settings.get_string(ROLE),
+        };
+
+        Ok(Self {
+            server: ServerConfig {
+                account,
+                server_url,
+            },
+            auth,
+            session,
+            tls,
+        })
+    }
+}
+
+fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
+    match auth {
+        AuthConfig::Password { user, password } => LoginMethod::Password {
+            username: user.clone(),
+            password: password.clone(),
+        },
+        AuthConfig::Mfa {
+            user,
+            password,
+            passcode_in_password,
+            passcode,
+            client_store_temporary_credential,
+        } => LoginMethod::UserPasswordMfa {
+            username: user.clone(),
+            password: password.clone(),
+            passcode_in_password: *passcode_in_password,
+            passcode: passcode.clone(),
+            client_store_temporary_credential: *client_store_temporary_credential,
+        },
+        AuthConfig::Jwt {
+            user,
+            private_key_pem,
+            passphrase,
+        } => LoginMethod::PrivateKey {
+            username: user.clone(),
+            private_key: private_key_pem.clone(),
+            passphrase: passphrase.clone(),
+        },
+        AuthConfig::Pat { user, token } => LoginMethod::Pat {
+            username: user.clone(),
+            token: token.clone(),
+        },
+        AuthConfig::NativeOkta(okta) => LoginMethod::NativeOkta(NativeOktaConfig {
+            username: okta.username.clone(),
+            okta_username: okta.okta_username.clone(),
+            password: okta.password.clone(),
+            okta_url: okta.okta_url.clone(),
+            disable_saml_url_check: okta.disable_saml_url_check,
+            authentication_timeout_secs: okta.authentication_timeout_secs,
+        }),
+    }
+}
+
+impl LoginParameters {
+    /// Build Snowflake login parameters from a validated [`ConnectionConfig`].
+    ///
+    /// Session defaults (`database`, `schema`, `warehouse`, `role`) reflect the resolved
+    /// connection seed at login time (`used_at_connect` session fields).
+    pub fn from_connection_config(
+        config: &ConnectionConfig,
+        client_info: ClientInfo,
+        session_parameters: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            account_name: config.server.account.clone(),
+            login_method: login_method_from_auth_config(&config.auth),
+            server_url: config.server.server_url.clone(),
+            database: config.session.database.clone(),
+            schema: config.session.schema.clone(),
+            warehouse: config.session.warehouse.clone(),
+            role: config.session.role.clone(),
+            client_info,
+            session_parameters,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// validate_settings – pre-flight check that collects all issues
+// ---------------------------------------------------------------------------
+
+/// Validate settings without building the full config.
+/// Returns a list of all issues found (errors and warnings).
+pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    // TODO(sfc-gh-boler): Preserve the current compatibility-first coercion
+    // behavior here, but stop reporting present non-coercible values as
+    // MissingRequired. Reuse the same coercion rules used by option-setting
+    // validation so coercible legacy config values remain accepted while truly
+    // wrong-typed values can surface as InvalidType.
+
+    // --- MissingRequired: account ---
+    if settings.get_string(ACCOUNT).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: ACCOUNT.into(),
+            message: "Missing required parameter 'account'".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- MissingRequired: user ---
+    if non_empty_string(settings, USER).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: USER.into(),
+            message: "Missing required parameter 'user'".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- Auth-specific checks based on authenticator ---
+    let authenticator = settings.get_string(AUTHENTICATOR).unwrap_or_default();
+    match authenticator.as_str() {
+        "" if has_private_key_params(settings) => {
+            // Empty authenticator + private key params → auto-JWT, no password needed
+        }
+        "SNOWFLAKE_PASSWORD" if has_private_key_params(settings) => {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Error,
+                parameter: AUTHENTICATOR.into(),
+                message: "Cannot specify 'SNOWFLAKE_PASSWORD' authenticator together with \
+                          private key parameters; use 'SNOWFLAKE_JWT' or remove the private \
+                          key parameters"
+                    .into(),
+                code: ValidationCode::ConflictingParameters,
+            });
+        }
+        "SNOWFLAKE_PASSWORD" | "" => {
+            if settings.get_string(PASSWORD).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: PASSWORD.into(),
+                    message: "Missing required parameter 'password' for password authentication"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "USERNAME_PASSWORD_MFA" => {
+            if settings.get_string(PASSWORD).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: PASSWORD.into(),
+                    message: "Missing required parameter 'password' for MFA authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "SNOWFLAKE_JWT" => {
+            if !has_private_key_params(settings) {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: "private_key or private_key_file".into(),
+                    message: "Missing required parameter: 'private_key' or 'private_key_file'"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "PROGRAMMATIC_ACCESS_TOKEN" => {
+            if settings.get_string(TOKEN).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: TOKEN.into(),
+                    message: "Missing required parameter 'token' for PAT authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        other if other.to_ascii_lowercase().starts_with("https://") => {
+            if Url::parse(other).is_err() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: AUTHENTICATOR.into(),
+                    message: format!("The authenticator URL '{other}' is not a valid URL"),
+                    code: ValidationCode::InvalidValue,
+                });
+            }
+            if settings.get_string(PASSWORD).is_none() {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: PASSWORD.into(),
+                    message: "Missing required parameter 'password' for native Okta authentication"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        other => {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Error,
+                parameter: AUTHENTICATOR.into(),
+                message: format!(
+                    "Invalid authenticator '{other}'. Allowed: SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, or an https:// URL for native Okta SSO"
+                ),
+                code: ValidationCode::InvalidValue,
+            });
+        }
+    }
+
+    // --- MissingRequired: host (when server_url is absent) ---
+    if settings.get_string(SERVER_URL).is_none() && settings.get_string(HOST).is_none() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: HOST.into(),
+            message: "Missing required parameter 'host' (or 'server_url')".into(),
+            code: ValidationCode::MissingRequired,
+        });
+    }
+
+    // --- InvalidValue: protocol ---
+    if let Some(protocol) = settings.get_string(PROTOCOL)
+        && protocol != "http"
+        && protocol != "https"
+    {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: PROTOCOL.into(),
+            message: format!("Invalid protocol '{protocol}'. Allowed values: 'http', 'https'"),
+            code: ValidationCode::InvalidValue,
+        });
+    }
+
+    // --- InvalidValue: crl_check_mode ---
+    // TODO: make matching case-insensitive (e.g. "disabled", "Enabled")
+    if let Some(mode) = settings.get_string(CRL_CHECK_MODE) {
+        let valid = ["DISABLED", "ENABLED", "ADVISORY", "0", "1", "2"];
+        if !valid.contains(&mode.as_str()) {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Error,
+                parameter: CRL_CHECK_MODE.into(),
+                message: format!(
+                    "Invalid crl_check_mode '{mode}'. Allowed: DISABLED, ENABLED, ADVISORY, 0, 1, 2"
+                ),
+                code: ValidationCode::InvalidValue,
+            });
+        }
+    }
+
+    // --- ConflictingParameters: private_key + private_key_file ---
+    let has_pk = settings.get(PRIVATE_KEY).is_some();
+    let has_pk_file = settings.get_string(PRIVATE_KEY_FILE).is_some();
+    if has_pk && has_pk_file {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: PRIVATE_KEY.into(),
+            message: "Both 'private_key' and 'private_key_file' are set. Please provide only one."
+                .into(),
+            code: ValidationCode::ConflictingParameters,
+        });
+    }
+
+    // --- UnknownParameter: keys not in ParamRegistry ---
+    let registry = crate::config::param_registry::registry();
+    for key in settings.keys() {
+        if !registry.is_known(key) {
+            issues.push(ValidationIssue {
+                severity: ValidationSeverity::Warning,
+                parameter: key.clone(),
+                message: format!("Unknown parameter '{key}'"),
+                code: ValidationCode::UnknownParameter,
+            });
+        }
+    }
+
+    issues
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_from(pairs: &[(&str, Setting)]) -> ParamStore {
+        let mut settings = ParamStore::new();
+        for (key, value) in pairs {
+            settings.insert((*key).to_string(), value.clone());
+        }
+        settings
+    }
+
+    fn minimal_password_settings() -> ParamStore {
+        settings_from(&[
+            ("account", Setting::String("myaccount".into())),
+            ("user", Setting::String("myuser".into())),
+            ("password", Setting::String("mypassword".into())),
+            (
+                "host",
+                Setting::String("myaccount.snowflakecomputing.com".into()),
+            ),
+        ])
+    }
+
+    fn minimal_mfa_settings() -> ParamStore {
+        let mut settings = minimal_password_settings();
+        settings.insert(
+            "authenticator".into(),
+            Setting::String("USERNAME_PASSWORD_MFA".into()),
+        );
+        settings
+    }
+
+    // -- ConnectionConfig::build tests --
+
+    #[test]
+    fn build_minimal_password_auth_succeeds() {
+        let settings = minimal_password_settings();
+        let config = ConnectionConfig::build(&settings).unwrap();
+
+        assert_eq!(config.server.account, "myaccount");
+        assert!(
+            config
+                .server
+                .server_url
+                .contains("myaccount.snowflakecomputing.com")
+        );
+        match &config.auth {
+            AuthConfig::Password { user, password } => {
+                assert_eq!(user, "myuser");
+                assert_eq!(password.reveal(), "mypassword");
+            }
+            _ => panic!("Expected Password auth"),
+        }
+        assert_eq!(config.session.database, None);
+        assert!(config.tls.verify_hostname);
+    }
+
+    #[test]
+    fn build_missing_account_fails() {
+        let settings = settings_from(&[
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let err = ConnectionConfig::build(&settings).unwrap_err();
+        match err {
+            ConfigError::ValidationFailed { ref issues, .. } => {
+                assert!(
+                    issues
+                        .iter()
+                        .any(|i| i.parameter == "account"
+                            && i.code == ValidationCode::MissingRequired),
+                    "Expected MissingRequired for 'account', got: {issues:?}"
+                );
+            }
+            other => panic!("Expected ValidationFailed, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn build_server_url_from_host_port_protocol() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("myhost.com".into())),
+            ("port", Setting::Int(8443)),
+            ("protocol", Setting::String("https".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "https://myhost.com:8443");
+    }
+
+    #[test]
+    fn build_server_url_direct_override() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("server_url", Setting::String("https://custom.url".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "https://custom.url");
+    }
+
+    #[test]
+    fn build_session_context_populated() {
+        let mut settings = minimal_password_settings();
+        settings.insert("database".into(), Setting::String("mydb".into()));
+        settings.insert("schema".into(), Setting::String("myschema".into()));
+        settings.insert("warehouse".into(), Setting::String("mywh".into()));
+        settings.insert("role".into(), Setting::String("myrole".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.session.database.as_deref(), Some("mydb"));
+        assert_eq!(config.session.schema.as_deref(), Some("myschema"));
+        assert_eq!(config.session.warehouse.as_deref(), Some("mywh"));
+        assert_eq!(config.session.role.as_deref(), Some("myrole"));
+    }
+
+    #[test]
+    fn build_tls_booleans_from_bool_setting() {
+        let mut settings = minimal_password_settings();
+        settings.insert("verify_hostname".into(), Setting::Bool(false));
+        settings.insert("verify_certificates".into(), Setting::Bool(false));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(!config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn build_tls_booleans_from_string_fallback() {
+        let mut settings = minimal_password_settings();
+        settings.insert("verify_hostname".into(), Setting::String("false".into()));
+        settings.insert("verify_certificates".into(), Setting::String("true".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn build_pat_auth() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("token", Setting::String("tok123".into())),
+            (
+                "authenticator",
+                Setting::String("PROGRAMMATIC_ACCESS_TOKEN".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Pat { user, token } => {
+                assert_eq!(user, "u");
+                assert_eq!(token.reveal(), "tok123");
+            }
+            _ => panic!("Expected Pat auth"),
+        }
+    }
+
+    #[test]
+    fn build_mfa_auth() {
+        let config = ConnectionConfig::build(&minimal_mfa_settings()).unwrap();
+        match &config.auth {
+            AuthConfig::Mfa {
+                user,
+                password,
+                passcode_in_password,
+                passcode,
+                client_store_temporary_credential,
+            } => {
+                assert_eq!(user, "myuser");
+                assert_eq!(password.reveal(), "mypassword");
+                assert!(!passcode_in_password);
+                assert!(passcode.is_none());
+                assert!(!client_store_temporary_credential);
+            }
+            other => panic!("Expected Mfa auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_mfa_auth_with_passcode() {
+        let mut settings = minimal_mfa_settings();
+        settings.insert("passcode".into(), Setting::String("123456".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Mfa { passcode, .. } => {
+                assert_eq!(
+                    passcode.as_ref().map(|v| v.reveal().as_str()),
+                    Some("123456")
+                );
+            }
+            other => panic!("Expected Mfa auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_mfa_auth_with_passcode_in_password() {
+        let mut settings = minimal_mfa_settings();
+        settings.insert("passcodeInPassword".into(), Setting::String("true".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Mfa {
+                passcode_in_password,
+                ..
+            } => {
+                assert!(*passcode_in_password);
+            }
+            other => panic!("Expected Mfa auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_mfa_auth_with_temporary_credential_caching() {
+        let mut settings = minimal_mfa_settings();
+        settings.insert(
+            "client_store_temporary_credential".into(),
+            Setting::String("1".into()),
+        );
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Mfa {
+                client_store_temporary_credential,
+                ..
+            } => {
+                assert!(*client_store_temporary_credential);
+            }
+            other => panic!("Expected Mfa auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_native_okta_auth() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            (
+                "authenticator",
+                Setting::String("https://example.okta.com".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::NativeOkta(cfg) => {
+                assert_eq!(cfg.username, "u");
+                assert_eq!(cfg.password.reveal(), "p");
+                assert_eq!(cfg.okta_url.as_str(), "https://example.okta.com/");
+                assert!(!cfg.disable_saml_url_check);
+                assert_eq!(
+                    cfg.authentication_timeout_secs,
+                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS
+                );
+            }
+            other => panic!("Expected NativeOkta auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_conflicting_private_keys_fails() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("SNOWFLAKE_JWT".into())),
+            ("private_key", Setting::String("some_key".into())),
+            ("private_key_file", Setting::String("/path/to/key".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let err = ConnectionConfig::build(&settings).unwrap_err();
+        match err {
+            ConfigError::ValidationFailed { ref issues, .. } => {
+                assert!(
+                    issues
+                        .iter()
+                        .any(|i| i.code == ValidationCode::ConflictingParameters),
+                    "Expected ConflictingParameters issue, got: {issues:?}"
+                );
+            }
+            other => panic!("Expected ValidationFailed, got: {other}"),
+        }
+    }
+
+    // -- validate_settings tests --
+
+    #[test]
+    fn validate_missing_account_reports_issue() {
+        let settings = settings_from(&[
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let account_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "account" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert!(!account_issues.is_empty());
+    }
+
+    #[test]
+    fn validate_empty_user_reports_issue() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String(String::new())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+
+        let issues = validate_settings(&settings);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.parameter == "user" && i.code == ValidationCode::MissingRequired),
+            "Expected empty user to be treated as missing, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_returns_all_issues_not_just_first() {
+        let settings = ParamStore::new();
+        let issues = validate_settings(&settings);
+        let error_count = issues
+            .iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .count();
+        assert!(
+            error_count >= 2,
+            "Expected at least account+user errors, got {error_count}"
+        );
+    }
+
+    #[test]
+    fn validate_conflicting_private_keys() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("SNOWFLAKE_JWT".into())),
+            ("private_key", Setting::String("k".into())),
+            ("private_key_file", Setting::String("/f".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let conflict: Vec<_> = issues
+            .iter()
+            .filter(|i| i.code == ValidationCode::ConflictingParameters)
+            .collect();
+        assert_eq!(conflict.len(), 1);
+    }
+
+    #[test]
+    fn validate_explicit_password_auth_with_private_key_is_conflict() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            (
+                "authenticator",
+                Setting::String("SNOWFLAKE_PASSWORD".into()),
+            ),
+            ("private_key", Setting::String("k".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == ValidationCode::ConflictingParameters
+                    && i.parameter == "authenticator"),
+            "Expected ConflictingParameters for SNOWFLAKE_PASSWORD + private_key, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_invalid_protocol() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("protocol", Setting::String("ftp".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let proto_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "protocol" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(proto_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_invalid_crl_check_mode() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("crl_check_mode", Setting::String("INVALID".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let crl_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "crl_check_mode" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(crl_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_valid_crl_check_modes() {
+        for mode in &["DISABLED", "ENABLED", "ADVISORY", "0", "1", "2"] {
+            let settings = settings_from(&[
+                ("account", Setting::String("acct".into())),
+                ("user", Setting::String("u".into())),
+                ("password", Setting::String("p".into())),
+                ("crl_check_mode", Setting::String(mode.to_string())),
+            ]);
+            let issues = validate_settings(&settings);
+            let crl_issues: Vec<_> = issues
+                .iter()
+                .filter(|i| {
+                    i.parameter == "crl_check_mode" && i.code == ValidationCode::InvalidValue
+                })
+                .collect();
+            assert!(
+                crl_issues.is_empty(),
+                "crl_check_mode '{mode}' should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_unknown_parameter_warns() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("totally_bogus_param", Setting::String("x".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let unknown: Vec<_> = issues
+            .iter()
+            .filter(|i| {
+                i.parameter == "totally_bogus_param"
+                    && i.code == ValidationCode::UnknownParameter
+                    && i.severity == ValidationSeverity::Warning
+            })
+            .collect();
+        assert_eq!(unknown.len(), 1);
+    }
+
+    #[test]
+    fn validate_invalid_authenticator() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("OAUTH".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let auth_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "authenticator" && i.code == ValidationCode::InvalidValue)
+            .collect();
+        assert_eq!(auth_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_mfa_missing_password_reports_issue() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            (
+                "authenticator",
+                Setting::String("USERNAME_PASSWORD_MFA".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+
+        let issues = validate_settings(&settings);
+        assert!(
+            issues.iter().any(|i| {
+                i.parameter == "password"
+                    && i.code == ValidationCode::MissingRequired
+                    && i.message.contains("MFA authentication")
+            }),
+            "Expected missing password issue for MFA auth, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_invalid_authenticator_mentions_mfa() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("OAUTH".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+
+        let issues = validate_settings(&settings);
+        let auth_issue = issues
+            .iter()
+            .find(|i| i.parameter == "authenticator" && i.code == ValidationCode::InvalidValue)
+            .expect("expected invalid authenticator issue");
+
+        assert!(
+            auth_issue.message.contains("USERNAME_PASSWORD_MFA"),
+            "Expected MFA authenticator in message, got: {}",
+            auth_issue.message
+        );
+    }
+
+    #[test]
+    fn typed_mfa_auth_matches_legacy_login_method() {
+        let mut settings = minimal_mfa_settings();
+        settings.insert("passcode".into(), Setting::String("123456".into()));
+        settings.insert("passcodeInPassword".into(), Setting::String("true".into()));
+        settings.insert(
+            "client_store_temporary_credential".into(),
+            Setting::String("true".into()),
+        );
+
+        let typed =
+            login_method_from_auth_config(&ConnectionConfig::build(&settings).unwrap().auth);
+        let legacy = LoginMethod::from_settings(&settings).unwrap();
+
+        match (typed, legacy) {
+            (
+                LoginMethod::UserPasswordMfa {
+                    username: typed_username,
+                    password: typed_password,
+                    passcode_in_password: typed_passcode_in_password,
+                    passcode: typed_passcode,
+                    client_store_temporary_credential: typed_cache,
+                },
+                LoginMethod::UserPasswordMfa {
+                    username: legacy_username,
+                    password: legacy_password,
+                    passcode_in_password: legacy_passcode_in_password,
+                    passcode: legacy_passcode,
+                    client_store_temporary_credential: legacy_cache,
+                },
+            ) => {
+                assert_eq!(typed_username, legacy_username);
+                assert_eq!(typed_password.reveal(), legacy_password.reveal());
+                assert_eq!(typed_passcode_in_password, legacy_passcode_in_password);
+                assert_eq!(typed_cache, legacy_cache);
+                assert_eq!(
+                    typed_passcode.as_ref().map(|v| v.reveal().as_str()),
+                    legacy_passcode.as_ref().map(|v| v.reveal().as_str())
+                );
+            }
+            (typed, legacy) => {
+                panic!(
+                    "Expected matching MFA login methods, got typed={typed:?}, legacy={legacy:?}"
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn validate_clean_password_auth_no_errors() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let errors: Vec<_> = issues
+            .iter()
+            .filter(|i| i.severity == ValidationSeverity::Error)
+            .collect();
+        assert!(errors.is_empty(), "Expected no errors: {errors:?}");
+    }
+
+    #[test]
+    fn validate_missing_host_without_server_url() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let host_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "host" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert_eq!(host_issues.len(), 1);
+    }
+
+    #[test]
+    fn validate_server_url_satisfies_host_requirement() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("server_url", Setting::String("https://custom.url".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        let host_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.parameter == "host" && i.code == ValidationCode::MissingRequired)
+            .collect();
+        assert!(host_issues.is_empty());
+    }
+
+    #[test]
+    fn get_bool_rejects_unrecognized_string() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+            ("verify_hostname", Setting::String("ture".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        // Unrecognized string falls through to default (true), not silently false
+        assert!(config.tls.verify_hostname);
+    }
+
+    #[test]
+    fn crl_check_mode_builds_correct_enum() {
+        for (input, expected) in [
+            ("DISABLED", CertRevocationCheckMode::Disabled),
+            ("0", CertRevocationCheckMode::Disabled),
+            ("ENABLED", CertRevocationCheckMode::Enabled),
+            ("1", CertRevocationCheckMode::Enabled),
+            ("ADVISORY", CertRevocationCheckMode::Advisory),
+            ("2", CertRevocationCheckMode::Advisory),
+        ] {
+            let mut settings = minimal_password_settings();
+            settings.insert("crl_check_mode".into(), Setting::String(input.into()));
+            let config = ConnectionConfig::build(&settings).unwrap();
+            assert_eq!(
+                config.tls.crl_config.check_mode, expected,
+                "crl_check_mode '{input}' should produce {expected:?}"
+            );
+        }
+    }
+}

--- a/sf_core/src/config/mod.rs
+++ b/sf_core/src/config/mod.rs
@@ -1,10 +1,13 @@
 pub mod config_manager;
+pub mod connection_config;
 pub mod param_registry;
 pub mod param_store;
 pub use param_registry::ParamKey;
+pub use param_registry::ParamScope;
 pub use param_registry::param_names;
 pub use param_store::ParamStore;
 pub mod path_resolver;
+pub mod resolver;
 pub mod rest_parameters;
 pub mod retry;
 pub mod settings;
@@ -67,6 +70,19 @@ pub enum ConfigError {
         "Could not determine platform config directory. Set SNOWFLAKE_HOME environment variable to specify the configuration directory."
     ))]
     ConfigDirNotFound {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display(
+        "Configuration validation failed ({} issue(s)): {}",
+        issues.len(),
+        issues
+            .first()
+            .map(|i| format!("{}: {}", i.parameter, i.message))
+            .unwrap_or_default()
+    ))]
+    ValidationFailed {
+        issues: Vec<crate::config::connection_config::ValidationIssue>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -58,6 +58,10 @@ pub mod param_names {
     pub const PRIVATE_KEY_FILE: ParamKey = ParamKey("private_key_file");
     pub const PRIVATE_KEY_PASSWORD: ParamKey = ParamKey("private_key_password");
     pub const TOKEN: ParamKey = ParamKey("token");
+    pub const PASSCODE: ParamKey = ParamKey("passcode");
+    pub const PASSCODE_IN_PASSWORD: ParamKey = ParamKey("passcodeInPassword");
+    pub const CLIENT_STORE_TEMPORARY_CREDENTIAL: ParamKey =
+        ParamKey("client_store_temporary_credential");
     pub const DATABASE: ParamKey = ParamKey("database");
     pub const SCHEMA: ParamKey = ParamKey("schema");
     pub const WAREHOUSE: ParamKey = ParamKey("warehouse");
@@ -76,6 +80,17 @@ pub mod param_names {
     pub const CRL_HTTP_TIMEOUT: ParamKey = ParamKey("crl_http_timeout");
     pub const CRL_CONNECTION_TIMEOUT: ParamKey = ParamKey("crl_connection_timeout");
     pub const ASYNC_EXECUTION: ParamKey = ParamKey("async_execution");
+    pub const AUTHENTICATION_TIMEOUT: ParamKey = ParamKey("authentication_timeout");
+    pub const OKTA_USERNAME: ParamKey = ParamKey("okta_username");
+    pub const DISABLE_SAML_URL_CHECK: ParamKey = ParamKey("disable_saml_url_check");
+}
+
+/// Which API layer owns writes for a parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamScope {
+    Connection,
+    Session,
+    Statement,
 }
 
 /// Defines a single supported configuration parameter.
@@ -106,6 +121,15 @@ pub struct ParamDef {
 
     /// If deprecated, the canonical name of the replacement parameter.
     pub deprecated_by: Option<&'static str>,
+
+    /// Which API layer owns writes for this parameter.
+    pub scope: ParamScope,
+
+    /// When true, the resolved connection-seed value participates in login / new session.
+    pub used_at_connect: bool,
+
+    /// When false, connection-level setters must reject changes once connected.
+    pub mutable_after_connect: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +165,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Snowflake account identifier",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::HOST.as_str(),
@@ -151,6 +178,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Snowflake server hostname",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PORT.as_str(),
@@ -161,6 +191,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Server port number",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PROTOCOL.as_str(),
@@ -171,6 +204,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Connection protocol (http or https)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::SERVER_URL.as_str(),
@@ -181,6 +217,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Full server URL (alternative to host/port/protocol)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PRESERVE_UNDERSCORES_IN_HOSTNAME.as_str(),
@@ -191,6 +230,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Preserve underscores in the hostname derived from the account name",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     // ── Auth ────────────────────────────────────────────────────────────
     ParamDef {
@@ -202,6 +244,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Login username",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PASSWORD.as_str(),
@@ -212,6 +257,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: true,
         description: "Login password",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::AUTHENTICATOR.as_str(),
@@ -220,8 +268,11 @@ static PARAM_DEFS: &[ParamDef] = &[
         required: Required::Never,
         default: None,
         sensitive: false,
-        description: "Authentication method (SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN)",
+        description: "Authentication method (SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PRIVATE_KEY.as_str(),
@@ -232,6 +283,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: true,
         description: "Private key for key-pair authentication (base64-encoded or PEM)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PRIVATE_KEY_FILE.as_str(),
@@ -242,6 +296,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Path to private key file for key-pair authentication",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::PRIVATE_KEY_PASSWORD.as_str(),
@@ -252,6 +309,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: true,
         description: "Passphrase for encrypted private key",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::TOKEN.as_str(),
@@ -262,6 +322,87 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: true,
         description: "Programmatic access token",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::PASSCODE.as_str(),
+        aliases: &["PASSCODE"],
+        value_type: ValueType::String,
+        required: Required::Never,
+        default: None,
+        sensitive: true,
+        description: "MFA passcode for USERNAME_PASSWORD_MFA authentication",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::PASSCODE_IN_PASSWORD.as_str(),
+        aliases: &["PASSCODE_IN_PASSWORD"],
+        value_type: ValueType::Bool,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Whether the MFA passcode is appended to the password",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::CLIENT_STORE_TEMPORARY_CREDENTIAL.as_str(),
+        aliases: &["clientStoreTemporaryCredential"],
+        value_type: ValueType::Bool,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Enable MFA token caching for USERNAME_PASSWORD_MFA authentication",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::AUTHENTICATION_TIMEOUT.as_str(),
+        aliases: &[],
+        value_type: ValueType::Int,
+        required: Required::Never,
+        default: Some(|| Setting::Int(120)),
+        sensitive: false,
+        description: "Timeout in seconds for native Okta SSO authentication",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OKTA_USERNAME.as_str(),
+        aliases: &[],
+        value_type: ValueType::String,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Okta username (defaults to the Snowflake user if omitted)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::DISABLE_SAML_URL_CHECK.as_str(),
+        aliases: &[],
+        value_type: ValueType::Bool,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Skip the Okta SAML URL host-match safety check",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     // ── Session ─────────────────────────────────────────────────────────
     ParamDef {
@@ -273,6 +414,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Default database to use",
         deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: true,
     },
     ParamDef {
         canonical_name: param_names::SCHEMA.as_str(),
@@ -283,6 +427,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Default schema to use",
         deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: true,
     },
     ParamDef {
         canonical_name: param_names::WAREHOUSE.as_str(),
@@ -293,6 +440,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Default warehouse to use",
         deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: true,
     },
     ParamDef {
         canonical_name: param_names::ROLE.as_str(),
@@ -303,6 +453,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Default role to use",
         deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: true,
     },
     // ── TLS ─────────────────────────────────────────────────────────────
     ParamDef {
@@ -314,6 +467,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Path to custom root certificate store",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::VERIFY_HOSTNAME.as_str(),
@@ -324,6 +480,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Whether to verify the server hostname in TLS",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::VERIFY_CERTIFICATES.as_str(),
@@ -334,6 +493,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Whether to verify TLS certificates",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     // ── CRL ─────────────────────────────────────────────────────────────
     ParamDef {
@@ -345,6 +507,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Certificate revocation check mode (DISABLED, ENABLED, ADVISORY)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_ENABLE_DISK_CACHING.as_str(),
@@ -355,6 +520,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Enable disk caching for CRL responses",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_ENABLE_MEMORY_CACHING.as_str(),
@@ -365,6 +533,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Enable in-memory caching for CRL responses",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_CACHE_DIR.as_str(),
@@ -375,6 +546,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Directory for CRL cache files",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_VALIDITY_TIME.as_str(),
@@ -385,6 +559,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "CRL cache validity time in days",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_ALLOW_CERTIFICATES_WITHOUT_CRL_URL.as_str(),
@@ -395,6 +572,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Allow certificates that do not include a CRL distribution URL",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_HTTP_TIMEOUT.as_str(),
@@ -405,6 +585,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "HTTP timeout in seconds for CRL endpoint requests",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     ParamDef {
         canonical_name: param_names::CRL_CONNECTION_TIMEOUT.as_str(),
@@ -415,6 +598,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Connection timeout in seconds for CRL endpoints",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
     // ── Client ──────────────────────────────────────────────────────────
     ParamDef {
@@ -426,6 +612,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Named connection to load from TOML configuration files",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: false,
+        mutable_after_connect: false,
     },
     // ── Statement ──────────────────────────────────────────────────────
     ParamDef {
@@ -437,8 +626,25 @@ static PARAM_DEFS: &[ParamDef] = &[
         sensitive: false,
         description: "Execute queries asynchronously",
         deprecated_by: None,
+        scope: ParamScope::Statement,
+        used_at_connect: false,
+        mutable_after_connect: true,
     },
 ];
+
+impl ParamDef {
+    /// Whether the resolved value may participate in login / new session creation.
+    ///
+    /// [`ParamScope::Statement`] parameters are never consumed at connect regardless
+    /// of stored metadata.
+    #[inline]
+    pub fn effective_used_at_connect(&self) -> bool {
+        if self.scope == ParamScope::Statement {
+            return false;
+        }
+        self.used_at_connect
+    }
+}
 
 /// The registry singleton. Built once at startup, immutable thereafter.
 pub struct ParamRegistry {
@@ -516,6 +722,12 @@ mod tests {
             ("PRIV_KEY_FILE_PWD", "private_key_password"),
             ("PRIV_KEY_PWD", "private_key_password"),
             ("TOKEN", "token"),
+            ("PASSCODE", "passcode"),
+            ("PASSCODE_IN_PASSWORD", "passcodeInPassword"),
+            (
+                "clientStoreTemporaryCredential",
+                "client_store_temporary_credential",
+            ),
             ("TLS_CUSTOM_ROOT_STORE_PATH", "custom_root_store_path"),
             ("TLS_VERIFY_HOSTNAME", "verify_hostname"),
             ("TLS_VERIFY_CERTIFICATES", "verify_certificates"),
@@ -609,5 +821,33 @@ mod tests {
         assert!(r.is_known("SERVER"));
         assert!(r.is_known("host"));
         assert!(!r.is_known("unknown_key"));
+    }
+
+    #[test]
+    fn statement_scope_params_are_never_used_at_connect() {
+        let r = registry();
+        for p in r.all_params() {
+            if p.scope == ParamScope::Statement {
+                assert!(
+                    !p.used_at_connect,
+                    "expected used_at_connect == false for {}",
+                    p.canonical_name
+                );
+                assert!(!p.effective_used_at_connect());
+            }
+        }
+    }
+
+    #[test]
+    fn session_context_params_are_session_scoped_and_mutable_after_connect() {
+        let r = registry();
+        for key in ["database", "schema", "warehouse", "role"] {
+            let d = r
+                .resolve(key)
+                .unwrap_or_else(|| panic!("expected registry entry for {key}"));
+            assert_eq!(d.scope, ParamScope::Session, "key {key}");
+            assert!(d.used_at_connect, "key {key}");
+            assert!(d.mutable_after_connect, "key {key}");
+        }
     }
 }

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
-
 use super::param_registry::ParamKey;
 use super::settings::{Setting, Settings};
+use crate::sensitive::SensitiveString;
+use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParamStore {
     inner: HashMap<String, Setting>,
 }
@@ -19,22 +19,109 @@ impl ParamStore {
         self.inner.get(key.as_str())
     }
 
+    /// Lookup by canonical parameter name (any `&str`), for dynamic keys from wrappers.
+    pub fn get_any(&self, canonical_key: impl AsRef<str>) -> Option<&Setting> {
+        self.inner.get(canonical_key.as_ref())
+    }
+
+    /// Extract a string value for `key`, returning `None` if absent or not a string.
+    pub fn get_string(&self, key: ParamKey) -> Option<String> {
+        match self.get(key)? {
+            Setting::String(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    /// Extract an integer value for `key`.
+    ///
+    /// Returns `Some` for `Setting::Int` directly. Also accepts
+    /// `Setting::String` by attempting a decimal parse, for backward
+    /// compatibility with TOML files and connection strings where numeric
+    /// values may arrive as quoted strings (e.g. `port = "443"`).
+    /// Returns `None` if the key is absent, the value is a non-numeric
+    /// string, or the value is any other non-integer type.
+    pub fn get_int(&self, key: ParamKey) -> Option<i64> {
+        match self.get(key)? {
+            Setting::Int(i) => Some(*i),
+            Setting::String(s) => s.parse::<i64>().ok(),
+            _ => None,
+        }
+    }
+
+    /// Extract a string value for `key` and wrap it in [`SensitiveString`],
+    /// returning `None` if absent or not a string. Use for credential fields
+    /// that must never appear in debug output.
+    pub fn get_sensitive_string(&self, key: ParamKey) -> Option<SensitiveString> {
+        match self.get(key)? {
+            Setting::String(s) => Some(SensitiveString::from(s.clone())),
+            _ => None,
+        }
+    }
+
+    /// Extract a boolean value for `key`.
+    ///
+    /// Checks `Setting::Bool` first, then falls back to `Setting::String` with
+    /// `"true"` / `"1"` / `"false"` / `"0"` parsing for backward compatibility
+    /// with TOML-loaded values and ODBC connection-string encodings. Non-zero
+    /// `Setting::Int` values are also accepted. Unrecognised strings return
+    /// `None` so the caller falls through to its default rather than silently
+    /// degrading to `false`.
+    pub fn get_bool(&self, key: ParamKey) -> Option<bool> {
+        match self.get(key)? {
+            Setting::Bool(b) => Some(*b),
+            Setting::String(s) => match s.to_lowercase().as_str() {
+                "true" | "1" => Some(true),
+                "false" | "0" => Some(false),
+                _ => None,
+            },
+            Setting::Int(i) => Some(*i != 0),
+            _ => None,
+        }
+    }
+
+    /// Create a `ParamStore` pre-populated with all registry defaults.
+    ///
+    /// Use this in tests that call `ConnectionConfig::build()` directly,
+    /// bypassing `resolver::resolve`. This ensures every param that has a
+    /// registry default behaves as if `resolve` had been called, so the
+    /// production code path, which assumes defaults are present, does not
+    /// need defensive `.unwrap_or(literal)` fallbacks.
+    ///
+    /// **Do not** use this for a live connection's merged seed + file layers as if it were
+    /// the only store:
+    /// pre-populating defaults there would override TOML file settings in
+    /// `resolver::resolve_with_paths` because explicit settings are applied
+    /// last (Layer 1) and would overwrite file settings (Layer 3/2).
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn with_registry_defaults() -> Self {
+        let mut store = Self::new();
+        for param in super::param_registry::registry().all_params() {
+            if let Some(f) = param.default {
+                store.insert(param.canonical_name.to_owned(), f());
+            }
+        }
+        store
+    }
+
+    /// Insert or overwrite a setting by its canonical string key.
     pub fn insert(&mut self, key: String, value: Setting) {
         self.inner.insert(key, value);
     }
 
-    pub(crate) fn insert_if_absent(&mut self, key: String, value: Setting) {
-        self.inner.entry(key).or_insert(value);
-    }
-
     /// Copy all entries from `other` into `self`, overwriting any existing
-    /// values for the same key. This is consumed by later stack changes when
-    /// config layering moves into the resolver.
-    #[allow(dead_code)]
+    /// values for the same key. Used by `resolver::resolve_with_paths` to
+    /// apply each successive config layer onto the merged result.
     pub(crate) fn extend_from(&mut self, other: &ParamStore) {
         for (k, v) in &other.inner {
             self.inner.insert(k.clone(), v.clone());
         }
+    }
+
+    /// Iterate over all canonical key names. Used by `validate_settings` to
+    /// check for unknown parameters.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &String> {
+        self.inner.keys()
     }
 }
 

--- a/sf_core/src/config/resolver.rs
+++ b/sf_core/src/config/resolver.rs
@@ -1,0 +1,292 @@
+use crate::config::ConfigError;
+use crate::config::ParamStore;
+use crate::config::config_manager;
+use crate::config::param_names;
+use crate::config::param_registry;
+use crate::config::path_resolver::ConfigPaths;
+use crate::config::settings::Setting;
+
+/// Resolve final settings by merging explicit settings with file-based
+/// config and registry defaults.
+///
+/// Precedence (highest to lowest):
+/// 1. Explicit programmatic settings (from `SetOptions` / `SetOption*` RPCs)
+/// 2. TOML file: `connections.toml` `[connection_name]` section
+/// 3. TOML file: `config.toml` `[connections.connection_name]` section
+/// 4. Registry defaults (`ParamDef::default`)
+///
+/// `explicit` contains values set via the programmatic API (already
+/// alias-resolved and type-checked by `connection_set_options`).
+///
+/// If `connection_name` is present in `explicit`, file-based config is
+/// loaded and merged underneath.
+pub fn resolve(explicit: &ParamStore) -> Result<ParamStore, ConfigError> {
+    let paths = crate::config::path_resolver::get_config_paths()?;
+    resolve_with_paths(explicit, &paths)
+}
+
+/// Same as [`resolve`] but accepts explicit config file paths (for testing).
+pub fn resolve_with_paths(
+    explicit: &ParamStore,
+    paths: &ConfigPaths,
+) -> Result<ParamStore, ConfigError> {
+    let mut merged = ParamStore::new();
+
+    // Layer 4: Registry defaults (lowest priority)
+    for param in param_registry::registry().all_params() {
+        if let Some(default_fn) = param.default {
+            merged.insert(param.canonical_name.to_owned(), default_fn());
+        }
+    }
+
+    // Layer 3+2: TOML files (if connection_name is set)
+    if let Some(Setting::String(name)) = explicit.get(param_names::CONNECTION_NAME) {
+        let file_settings = config_manager::load_connection_config_with_paths(name, paths)?;
+        for (k, v) in file_settings {
+            merged.insert(k, v);
+        }
+    }
+
+    // Layer 1: Explicit programmatic settings (highest priority)
+    merged.extend_from(explicit);
+
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::param_names;
+    use crate::config::path_resolver::ConfigPaths;
+    use crate::config::settings::Setting;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_paths(dir: &TempDir) -> ConfigPaths {
+        ConfigPaths {
+            config_file: Some(dir.path().join("config.toml")),
+            connections_file: Some(dir.path().join("connections.toml")),
+        }
+    }
+
+    fn write_config(dir: &TempDir, filename: &str, content: &str) {
+        let path = dir.path().join(filename);
+        fs::write(&path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    #[test]
+    fn explicit_settings_override_file_settings() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+user = "file_user"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_account".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "explicit_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        if let Some(Setting::String(user)) = resolved.get(param_names::USER) {
+            assert_eq!(user, "file_user");
+        } else {
+            panic!("Expected user setting from file");
+        }
+    }
+
+    #[test]
+    fn file_settings_override_registry_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+protocol = "http"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(protocol)) = resolved.get(param_names::PROTOCOL) {
+            assert_eq!(protocol, "http");
+        } else {
+            panic!("Expected protocol setting");
+        }
+    }
+
+    #[test]
+    fn connections_toml_overrides_config_toml() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "config.toml",
+            r#"
+[connections.testconn]
+account = "config_account"
+user = "config_user"
+"#,
+        );
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "connections_account"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("testconn".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "connections_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        if let Some(Setting::String(user)) = resolved.get(param_names::USER) {
+            assert_eq!(user, "config_user");
+        } else {
+            panic!("Expected user setting");
+        }
+    }
+
+    #[test]
+    fn no_connection_name_uses_only_explicit_and_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[testconn]
+account = "file_account"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_account".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+            assert_eq!(account, "explicit_account");
+        } else {
+            panic!("Expected account setting");
+        }
+
+        // Registry default for protocol should be present
+        if let Some(Setting::String(protocol)) = resolved.get(param_names::PROTOCOL) {
+            assert_eq!(protocol, "https");
+        } else {
+            panic!("Expected default protocol setting");
+        }
+    }
+
+    fn get_str(map: &ParamStore, key: crate::config::param_registry::ParamKey) -> Option<String> {
+        match map.get(key) {
+            Some(Setting::String(v)) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn integration_full_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = make_paths(&temp_dir);
+        write_config(
+            &temp_dir,
+            "config.toml",
+            r#"
+[connections.myconn]
+account = "config_acct"
+user = "config_user"
+warehouse = "config_wh"
+"#,
+        );
+        write_config(
+            &temp_dir,
+            "connections.toml",
+            r#"
+[myconn]
+account = "conn_acct"
+database = "conn_db"
+"#,
+        );
+
+        let mut explicit = ParamStore::new();
+        explicit.insert(
+            "connection_name".to_owned(),
+            Setting::String("myconn".to_owned()),
+        );
+        explicit.insert(
+            "account".to_owned(),
+            Setting::String("explicit_acct".to_owned()),
+        );
+
+        let resolved = resolve_with_paths(&explicit, &paths).unwrap();
+
+        assert_eq!(
+            get_str(&resolved, param_names::ACCOUNT),
+            Some("explicit_acct".to_owned())
+        );
+        assert_eq!(
+            get_str(&resolved, param_names::DATABASE),
+            Some("conn_db".to_owned())
+        );
+        assert_eq!(
+            get_str(&resolved, param_names::USER),
+            Some("config_user".to_owned())
+        );
+        assert_eq!(
+            get_str(&resolved, param_names::WAREHOUSE),
+            Some("config_wh".to_owned())
+        );
+        assert_eq!(
+            get_str(&resolved, param_names::PROTOCOL),
+            Some("https".to_owned())
+        );
+    }
+}

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -44,6 +44,10 @@ pub struct QueryParameters {
 }
 
 impl QueryParameters {
+    /// Build transport parameters from an arbitrary settings bag (e.g. tests, pre-connect paths).
+    ///
+    /// After login, prefer `Connection::query_transport_parameters` (transport snapshot)
+    /// instead of re-reading merged settings.
     pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         Ok(Self {
             server_url: get_server_url(settings)?,
@@ -97,6 +101,10 @@ pub struct LoginParameters {
 }
 
 impl LoginParameters {
+    /// Build login request fields from a resolved settings map (defaults + files + connection seed).
+    ///
+    /// Session defaults (`database`, `schema`, etc.) are included only when they are part of the
+    /// resolved connect seed (`used_at_connect` session fields in the registry).
     pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         Ok(Self {
             account_name: {

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -21,6 +21,7 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use error_trace::ErrorTrace;
 use snafu::ResultExt;
+use std::sync::LazyLock;
 use tracing::instrument;
 
 fn setting_to_json(setting: Setting) -> serde_json::Value {
@@ -272,6 +273,47 @@ fn to_driver_error(error: &ApiError) -> DriverError {
                 },
             )),
         },
+        ApiError::Configuration {
+            source: ConfigError::ValidationFailed { issues, .. },
+            ..
+        } => {
+            let summary = issues
+                .iter()
+                .map(|issue| format!("{}: {}", issue.parameter, issue.message))
+                .collect::<Vec<_>>()
+                .join("; ");
+            let first_param = issues
+                .first()
+                .map(|issue| issue.parameter.clone())
+                .unwrap_or_default();
+            let first_missing_param = issues
+                .iter()
+                .find(|issue| issue.code == CoreValidationCode::MissingRequired)
+                .map(|issue| issue.parameter.clone())
+                .unwrap_or_else(|| first_param.clone());
+            if issues
+                .iter()
+                .any(|i| i.code == CoreValidationCode::MissingRequired)
+            {
+                DriverError {
+                    error_type: Some(driver_error::ErrorType::MissingParameter(
+                        MissingParameter {
+                            parameter: first_missing_param,
+                        },
+                    )),
+                }
+            } else {
+                DriverError {
+                    error_type: Some(driver_error::ErrorType::InvalidParameterValue(
+                        InvalidParameterValue {
+                            parameter: first_param,
+                            value: String::new(),
+                            explanation: Some(summary),
+                        },
+                    )),
+                }
+            }
+        }
         ApiError::InvalidArgument { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
         },
@@ -437,6 +479,19 @@ fn to_driver_exception(error: ApiError) -> DriverException {
             source: ConfigError::ConnectionNotFound { .. },
             ..
         } => StatusCode::MissingParameter,
+        ApiError::Configuration {
+            source: ConfigError::ValidationFailed { issues, .. },
+            ..
+        } if issues
+            .iter()
+            .any(|i| i.code == CoreValidationCode::MissingRequired) =>
+        {
+            StatusCode::MissingParameter
+        }
+        ApiError::Configuration {
+            source: ConfigError::ValidationFailed { .. },
+            ..
+        } => StatusCode::InvalidParameterValue,
         ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
         ApiError::Login {
             source: RestError::LoginError { .. },
@@ -1008,6 +1063,30 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(ConnectionGetParameterResponse { value })
     }
 
+    #[instrument(
+        name = "DatabaseDriverV1::connection_validate_options",
+        skip(self, input)
+    )]
+    async fn connection_validate_options(
+        &self,
+        input: ConnectionValidateOptionsRequest,
+    ) -> Result<ConnectionValidateOptionsResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        let issues = self
+            .driver
+            .connection_validate_options(conn_handle.into())
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionValidateOptionsResponse {
+            issues: issues
+                .into_iter()
+                .map(core_validation_issue_to_proto)
+                .collect(),
+        })
+    }
+
     #[instrument(name = "DatabaseDriverV1::statement_new", skip(self, input))]
     async fn statement_new(
         &self,
@@ -1382,4 +1461,200 @@ pub type DatabaseDriverClient =
 
 pub fn database_driver_client() -> DatabaseDriverClient {
     DatabaseDriverClient::new(crate::protobuf::apis::RustTransport::new())
+}
+
+// Synchronous convenience wrappers used by Rust test helpers and small
+// in-process smoke tests. Production callers should prefer the async
+// client methods directly.
+static BLOCKING_CLIENT_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create blocking protobuf client runtime")
+});
+
+/// Blocking adapters for synchronous Rust test/support code that drives
+/// the in-process protobuf client. Production async paths should call
+/// the generated async client methods directly.
+#[allow(clippy::result_large_err)]
+pub trait DatabaseDriverClientBlockingExt {
+    fn database_new_blocking(
+        &self,
+        input: DatabaseNewRequest,
+    ) -> Result<DatabaseNewResponse, proto_utils::ProtoError<DriverException>>;
+    fn database_init_blocking(
+        &self,
+        input: DatabaseInitRequest,
+    ) -> Result<DatabaseInitResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_new_blocking(
+        &self,
+        input: ConnectionNewRequest,
+    ) -> Result<ConnectionNewResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_init_blocking(
+        &self,
+        input: ConnectionInitRequest,
+    ) -> Result<ConnectionInitResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_new_blocking(
+        &self,
+        input: StatementNewRequest,
+    ) -> Result<StatementNewResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_execute_query_blocking(
+        &self,
+        input: StatementExecuteQueryRequest,
+    ) -> Result<StatementExecuteQueryResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_set_sql_query_blocking(
+        &self,
+        input: StatementSetSqlQueryRequest,
+    ) -> Result<StatementSetSqlQueryResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_release_blocking(
+        &self,
+        input: StatementReleaseRequest,
+    ) -> Result<StatementReleaseResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_result_chunks_blocking(
+        &self,
+        input: StatementResultChunksRequest,
+    ) -> Result<StatementResultChunksResponse, proto_utils::ProtoError<DriverException>>;
+    fn database_fetch_chunk_blocking(
+        &self,
+        input: DatabaseFetchChunkRequest,
+    ) -> Result<DatabaseFetchChunkResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_set_option_string_blocking(
+        &self,
+        input: ConnectionSetOptionStringRequest,
+    ) -> Result<ConnectionSetOptionStringResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_set_option_int_blocking(
+        &self,
+        input: ConnectionSetOptionIntRequest,
+    ) -> Result<ConnectionSetOptionIntResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_set_option_bytes_blocking(
+        &self,
+        input: ConnectionSetOptionBytesRequest,
+    ) -> Result<ConnectionSetOptionBytesResponse, proto_utils::ProtoError<DriverException>>;
+    fn statement_set_option_bool_blocking(
+        &self,
+        input: StatementSetOptionBoolRequest,
+    ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_release_blocking(
+        &self,
+        input: ConnectionReleaseRequest,
+    ) -> Result<ConnectionReleaseResponse, proto_utils::ProtoError<DriverException>>;
+    fn database_release_blocking(
+        &self,
+        input: DatabaseReleaseRequest,
+    ) -> Result<DatabaseReleaseResponse, proto_utils::ProtoError<DriverException>>;
+}
+
+#[allow(clippy::result_large_err)]
+impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
+    fn database_new_blocking(
+        &self,
+        input: DatabaseNewRequest,
+    ) -> Result<DatabaseNewResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.database_new(input))
+    }
+
+    fn database_init_blocking(
+        &self,
+        input: DatabaseInitRequest,
+    ) -> Result<DatabaseInitResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.database_init(input))
+    }
+
+    fn connection_new_blocking(
+        &self,
+        input: ConnectionNewRequest,
+    ) -> Result<ConnectionNewResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_new(input))
+    }
+
+    fn connection_init_blocking(
+        &self,
+        input: ConnectionInitRequest,
+    ) -> Result<ConnectionInitResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_init(input))
+    }
+
+    fn statement_new_blocking(
+        &self,
+        input: StatementNewRequest,
+    ) -> Result<StatementNewResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_new(input))
+    }
+
+    fn statement_execute_query_blocking(
+        &self,
+        input: StatementExecuteQueryRequest,
+    ) -> Result<StatementExecuteQueryResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_execute_query(input))
+    }
+
+    fn statement_set_sql_query_blocking(
+        &self,
+        input: StatementSetSqlQueryRequest,
+    ) -> Result<StatementSetSqlQueryResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_set_sql_query(input))
+    }
+
+    fn statement_release_blocking(
+        &self,
+        input: StatementReleaseRequest,
+    ) -> Result<StatementReleaseResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_release(input))
+    }
+
+    fn statement_result_chunks_blocking(
+        &self,
+        input: StatementResultChunksRequest,
+    ) -> Result<StatementResultChunksResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_result_chunks(input))
+    }
+
+    fn database_fetch_chunk_blocking(
+        &self,
+        input: DatabaseFetchChunkRequest,
+    ) -> Result<DatabaseFetchChunkResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.database_fetch_chunk(input))
+    }
+
+    fn connection_set_option_string_blocking(
+        &self,
+        input: ConnectionSetOptionStringRequest,
+    ) -> Result<ConnectionSetOptionStringResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_string(input))
+    }
+
+    fn connection_set_option_int_blocking(
+        &self,
+        input: ConnectionSetOptionIntRequest,
+    ) -> Result<ConnectionSetOptionIntResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_int(input))
+    }
+
+    fn connection_set_option_bytes_blocking(
+        &self,
+        input: ConnectionSetOptionBytesRequest,
+    ) -> Result<ConnectionSetOptionBytesResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_bytes(input))
+    }
+
+    fn statement_set_option_bool_blocking(
+        &self,
+        input: StatementSetOptionBoolRequest,
+    ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_set_option_bool(input))
+    }
+
+    fn connection_release_blocking(
+        &self,
+        input: ConnectionReleaseRequest,
+    ) -> Result<ConnectionReleaseResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_release(input))
+    }
+
+    fn database_release_blocking(
+        &self,
+        input: DatabaseReleaseRequest,
+    ) -> Result<DatabaseReleaseResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.database_release(input))
+    }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -475,7 +475,12 @@ impl Data {
 
     pub fn to_chunk_download_data(&self) -> Option<Vec<ChunkDownloadData>> {
         match (self.chunks.as_ref(), self.chunk_headers.as_ref()) {
-            (Some(chunks), Some(chunk_headers)) => {
+            (Some(chunks), chunk_headers_opt) => {
+                let empty_headers = HashMap::new();
+                let chunk_headers = chunk_headers_opt.unwrap_or(&empty_headers);
+                if chunk_headers_opt.is_none() {
+                    tracing::warn!("Chunks found without chunk headers; using empty headers");
+                }
                 let chunk_download_data = chunks
                     .iter()
                     .map(|chunk| ChunkDownloadData::new(&chunk.url, chunk_headers))
@@ -484,10 +489,6 @@ impl Data {
             }
             (None, Some(_)) => {
                 tracing::error!("Chunk headers found but chunks are missing");
-                None
-            }
-            (Some(_), None) => {
-                tracing::error!("Chunks found but chunk headers are missing");
                 None
             }
             _ => None,
@@ -883,6 +884,76 @@ mod tests {
         let (rowset, row_types) = response.data.to_json_rowset().unwrap();
         assert_eq!(rowset.len(), 2);
         assert_eq!(row_types.len(), 2);
+    }
+
+    #[test]
+    fn test_arrow_chunks_without_headers_still_build_chunk_download_data() {
+        let json = r#"{
+            "data": {
+                "queryResultFormat": "arrow",
+                "chunks": [
+                    {
+                        "url": "https://example.com/chunk-1",
+                        "rowCount": 1,
+                        "uncompressedSize": 16,
+                        "compressedSize": 16
+                    }
+                ],
+                "rowtype": [
+                    {
+                        "name": "c1",
+                        "type": "TEXT",
+                        "nullable": true,
+                        "scale": null,
+                        "byteLength": 64,
+                        "length": 16,
+                        "precision": null
+                    }
+                ]
+            },
+            "success": true
+        }"#;
+
+        let response: Response = serde_json::from_str(json).unwrap();
+        let chunk_download_data = response.data.to_chunk_download_data().unwrap();
+
+        assert_eq!(chunk_download_data.len(), 1);
+    }
+
+    #[test]
+    fn test_arrow_chunks_without_headers_use_multi_chunk_rowset_data() {
+        let json = r#"{
+            "data": {
+                "queryResultFormat": "arrow",
+                "chunks": [
+                    {
+                        "url": "https://example.com/chunk-1",
+                        "rowCount": 1,
+                        "uncompressedSize": 16,
+                        "compressedSize": 16
+                    }
+                ],
+                "rowtype": [
+                    {
+                        "name": "c1",
+                        "type": "TEXT",
+                        "nullable": true,
+                        "scale": null,
+                        "byteLength": 64,
+                        "length": 16,
+                        "precision": null
+                    }
+                ]
+            },
+            "success": true
+        }"#;
+
+        let response: Response = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(
+            response.data.to_rowset_data(),
+            RowsetData::ArrowMultiChunk { .. }
+        ));
     }
 
     #[test]

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -1,7 +1,8 @@
 use proto_utils::ProtoError;
-use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
+use sf_core::protobuf::apis::database_driver_v1::{
+    DatabaseDriverClient, DatabaseDriverClientBlockingExt, database_driver_client,
+};
 use sf_core::protobuf::generated::database_driver_v1::*;
-use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 
 use super::config::{Parameters, get_parameters, setup_logging};
 use super::private_key_helper::{self, PrivateKeyFile};
@@ -13,42 +14,27 @@ pub struct SnowflakeTestClient {
     pub parameters: Parameters,
     private_key_file: Option<PrivateKeyFile>,
     client: DatabaseDriverClient,
-    rt: tokio::runtime::Runtime,
 }
 
 impl SnowflakeTestClient {
-    fn new_runtime() -> tokio::runtime::Runtime {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create test tokio runtime")
-    }
-
     /// Creates a client with default parameters (no authentication parameters set)
     pub fn with_default_params() -> Self {
         setup_logging();
         let parameters = get_parameters();
         let client = database_driver_client();
-        let rt = Self::new_runtime();
+        let db_response = client.database_new_blocking(DatabaseNewRequest {}).unwrap();
+        let db_handle = db_response.db_handle.unwrap();
 
-        let (db_handle, conn_handle) = rt.block_on(async {
-            let db_response = client.database_new(DatabaseNewRequest {}).await.unwrap();
-            let db_handle = db_response.db_handle.unwrap();
+        client
+            .database_init_blocking(DatabaseInitRequest {
+                db_handle: Some(db_handle),
+            })
+            .unwrap();
 
-            client
-                .database_init(DatabaseInitRequest {
-                    db_handle: Some(db_handle),
-                })
-                .await
-                .unwrap();
-
-            let conn_response = client
-                .connection_new(ConnectionNewRequest {})
-                .await
-                .unwrap();
-            let conn_handle = conn_response.conn_handle.unwrap();
-            (db_handle, conn_handle)
-        });
+        let conn_response = client
+            .connection_new_blocking(ConnectionNewRequest {})
+            .unwrap();
+        let conn_handle = conn_response.conn_handle.unwrap();
 
         let test_client = Self {
             conn_handle,
@@ -56,7 +42,6 @@ impl SnowflakeTestClient {
             parameters,
             private_key_file: None,
             client,
-            rt,
         };
 
         test_client.set_options_from_parameters();
@@ -79,16 +64,13 @@ impl SnowflakeTestClient {
 
         let temp_key_file = test_client.setup_jwt_auth();
 
-        test_client.rt.block_on(async {
-            test_client
-                .client
-                .connection_init(ConnectionInitRequest {
-                    conn_handle: Some(test_client.conn_handle),
-                    db_handle: Some(test_client.db_handle),
-                })
-                .await
-                .unwrap();
-        });
+        test_client
+            .client
+            .connection_init_blocking(ConnectionInitRequest {
+                conn_handle: Some(test_client.conn_handle),
+                db_handle: Some(test_client.db_handle),
+            })
+            .unwrap();
 
         test_client.private_key_file = Some(temp_key_file);
         test_client
@@ -114,26 +96,20 @@ impl SnowflakeTestClient {
         };
 
         let client = database_driver_client();
-        let rt = Self::new_runtime();
 
-        let (db_handle, conn_handle) = rt.block_on(async {
-            let db_response = client.database_new(DatabaseNewRequest {}).await.unwrap();
-            let db_handle = db_response.db_handle.unwrap();
+        let db_response = client.database_new_blocking(DatabaseNewRequest {}).unwrap();
+        let db_handle = db_response.db_handle.unwrap();
 
-            client
-                .database_init(DatabaseInitRequest {
-                    db_handle: Some(db_handle),
-                })
-                .await
-                .unwrap();
+        client
+            .database_init_blocking(DatabaseInitRequest {
+                db_handle: Some(db_handle),
+            })
+            .unwrap();
 
-            let conn_response = client
-                .connection_new(ConnectionNewRequest {})
-                .await
-                .unwrap();
-            let conn_handle = conn_response.conn_handle.unwrap();
-            (db_handle, conn_handle)
-        });
+        let conn_response = client
+            .connection_new_blocking(ConnectionNewRequest {})
+            .unwrap();
+        let conn_handle = conn_response.conn_handle.unwrap();
 
         let test_client = Self {
             conn_handle,
@@ -141,7 +117,6 @@ impl SnowflakeTestClient {
             parameters: test_parameters,
             private_key_file: None,
             client,
-            rt,
         };
 
         test_client.set_options_from_parameters();
@@ -157,16 +132,13 @@ impl SnowflakeTestClient {
         test_client
             .set_connection_option("private_key_file", temp_key_file.path().to_str().unwrap());
 
-        test_client.rt.block_on(async {
-            test_client
-                .client
-                .connection_init(ConnectionInitRequest {
-                    conn_handle: Some(test_client.conn_handle),
-                    db_handle: Some(test_client.db_handle),
-                })
-                .await
-                .unwrap();
-        });
+        test_client
+            .client
+            .connection_init_blocking(ConnectionInitRequest {
+                conn_handle: Some(test_client.conn_handle),
+                db_handle: Some(test_client.db_handle),
+            })
+            .unwrap();
 
         test_client.private_key_file = Some(temp_key_file);
         test_client
@@ -174,16 +146,13 @@ impl SnowflakeTestClient {
 
     /// Creates a new statement handle
     pub fn new_statement(&self) -> StatementHandle {
-        self.rt.block_on(async {
-            let response = self
-                .client
-                .statement_new(StatementNewRequest {
-                    conn_handle: Some(self.conn_handle),
-                })
-                .await
-                .unwrap();
-            response.stmt_handle.unwrap()
-        })
+        let response = self
+            .client
+            .statement_new_blocking(StatementNewRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+            .unwrap();
+        response.stmt_handle.unwrap()
     }
 
     pub fn execute_statement_query(&self, stmt: &StatementHandle) -> ExecuteResult {
@@ -204,29 +173,23 @@ impl SnowflakeTestClient {
                 })),
             }
         });
-        self.rt.block_on(async {
-            self.client
-                .statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(*stmt),
-                    bindings,
-                })
-                .await
-                .unwrap()
-                .result
-                .unwrap()
-        })
+        self.client
+            .statement_execute_query_blocking(StatementExecuteQueryRequest {
+                stmt_handle: Some(*stmt),
+                bindings,
+            })
+            .unwrap()
+            .result
+            .unwrap()
     }
 
     pub fn set_sql_query(&self, stmt: &StatementHandle, query: &str) {
-        self.rt.block_on(async {
-            self.client
-                .statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(*stmt),
-                    query: query.to_string(),
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .statement_set_sql_query_blocking(StatementSetSqlQueryRequest {
+                stmt_handle: Some(*stmt),
+                query: query.to_string(),
+            })
+            .unwrap();
     }
 
     /// Builds a JSON bindings string for integer parameters.
@@ -248,98 +211,80 @@ impl SnowflakeTestClient {
     }
 
     pub fn result_chunks(&self, stmt: &StatementHandle) -> ResultChunksResult {
-        self.rt.block_on(async {
-            self.client
-                .statement_result_chunks(StatementResultChunksRequest {
-                    stmt_handle: Some(*stmt),
-                })
-                .await
-                .unwrap()
-                .result
-                .unwrap()
-        })
+        self.client
+            .statement_result_chunks_blocking(StatementResultChunksRequest {
+                stmt_handle: Some(*stmt),
+            })
+            .unwrap()
+            .result
+            .unwrap()
     }
 
     pub fn fetch_chunk(&self, chunk: ResultChunk) -> DatabaseFetchChunkResponse {
-        self.rt.block_on(async {
-            self.client
-                .database_fetch_chunk(DatabaseFetchChunkRequest {
-                    db_handle: Some(self.db_handle),
-                    chunk: Some(chunk),
-                })
-                .await
-                .unwrap()
-        })
+        self.client
+            .database_fetch_chunk_blocking(DatabaseFetchChunkRequest {
+                db_handle: Some(self.db_handle),
+                chunk: Some(chunk),
+            })
+            .unwrap()
     }
 
     pub fn release_statement(&self, stmt: &StatementHandle) {
-        self.rt.block_on(async {
-            self.client
-                .statement_release(StatementReleaseRequest {
-                    stmt_handle: Some(*stmt),
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .statement_release_blocking(StatementReleaseRequest {
+                stmt_handle: Some(*stmt),
+            })
+            .unwrap();
     }
 
     /// Executes a SQL query and returns the result
     pub fn execute_query(&self, sql: &str) -> ExecuteResult {
         let stmt_handle = self.new_statement();
 
-        self.rt.block_on(async {
-            self.client
-                .statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: sql.to_string(),
-                })
-                .await
-                .unwrap();
+        self.client
+            .statement_set_sql_query_blocking(StatementSetSqlQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                query: sql.to_string(),
+            })
+            .unwrap();
 
-            let response = self
-                .client
-                .statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings: None,
-                })
-                .await
-                .unwrap();
+        let response = self
+            .client
+            .statement_execute_query_blocking(StatementExecuteQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                bindings: None,
+            })
+            .unwrap();
 
-            response.result.unwrap()
-        })
+        response.result.unwrap()
     }
 
     pub fn execute_query_no_unwrap(&self, sql: &str) -> Result<ExecuteResult, String> {
         let stmt_handle = self.new_statement();
 
-        self.rt.block_on(async {
-            if let Err(e) = self
-                .client
-                .statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: sql.to_string(),
-                })
-                .await
-            {
-                return Err(format!("Failed to set SQL query: {e:?}"));
-            }
+        if let Err(e) = self
+            .client
+            .statement_set_sql_query_blocking(StatementSetSqlQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                query: sql.to_string(),
+            })
+        {
+            return Err(format!("Failed to set SQL query: {e:?}"));
+        }
 
-            match self
-                .client
-                .statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings: None,
-                })
-                .await
-            {
-                Ok(response) => {
-                    let proto_result = response.result.unwrap();
-                    Ok(proto_result)
-                }
-                Err(ProtoError::Application(e)) => Err(format!("Failed to execute query: {e:?}")),
-                Err(ProtoError::Transport(e)) => Err(format!("Transport error: {e:?}")),
+        match self
+            .client
+            .statement_execute_query_blocking(StatementExecuteQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                bindings: None,
+            }) {
+            Ok(response) => {
+                let proto_result = response.result.unwrap();
+                Ok(proto_result)
             }
-        })
+            Err(ProtoError::Application(e)) => Err(format!("Failed to execute query: {e:?}")),
+            Err(ProtoError::Transport(e)) => Err(format!("Transport error: {e:?}")),
+        }
     }
 
     pub fn create_temporary_stage(&self, stage_name: &str) {
@@ -349,71 +294,53 @@ impl SnowflakeTestClient {
     }
 
     pub fn connect(&self) -> Result<(), String> {
-        self.rt.block_on(async {
-            match self
-                .client
-                .connection_init(ConnectionInitRequest {
-                    conn_handle: Some(self.conn_handle),
-                    db_handle: Some(self.db_handle),
-                })
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(e) => Err(format!("Connection failed: {e:?}")),
-            }
-        })
+        match self.client.connection_init_blocking(ConnectionInitRequest {
+            conn_handle: Some(self.conn_handle),
+            db_handle: Some(self.db_handle),
+        }) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("Connection failed: {e:?}")),
+        }
     }
 
     pub fn set_connection_option(&self, option_name: &str, option_value: &str) {
-        self.rt.block_on(async {
-            self.client
-                .connection_set_option_string(ConnectionSetOptionStringRequest {
-                    conn_handle: Some(self.conn_handle),
-                    key: option_name.to_string(),
-                    value: option_value.to_string(),
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
+                conn_handle: Some(self.conn_handle),
+                key: option_name.to_string(),
+                value: option_value.to_string(),
+            })
+            .unwrap();
     }
 
     pub fn set_connection_option_int(&self, option_name: &str, option_value: i64) {
-        self.rt.block_on(async {
-            self.client
-                .connection_set_option_int(ConnectionSetOptionIntRequest {
-                    conn_handle: Some(self.conn_handle),
-                    key: option_name.to_string(),
-                    value: option_value,
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
+                conn_handle: Some(self.conn_handle),
+                key: option_name.to_string(),
+                value: option_value,
+            })
+            .unwrap();
     }
 
     pub fn set_connection_option_bytes(&self, option_name: &str, option_value: &[u8]) {
-        self.rt.block_on(async {
-            self.client
-                .connection_set_option_bytes(ConnectionSetOptionBytesRequest {
-                    conn_handle: Some(self.conn_handle),
-                    key: option_name.to_string(),
-                    value: option_value.to_vec(),
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .connection_set_option_bytes_blocking(ConnectionSetOptionBytesRequest {
+                conn_handle: Some(self.conn_handle),
+                key: option_name.to_string(),
+                value: option_value.to_vec(),
+            })
+            .unwrap();
     }
 
     pub fn set_statement_async_execution(&self, stmt: &StatementHandle, enabled: bool) {
-        self.rt.block_on(async {
-            self.client
-                .statement_set_option_bool(StatementSetOptionBoolRequest {
-                    stmt_handle: Some(*stmt),
-                    key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
-                    value: enabled,
-                })
-                .await
-                .unwrap();
-        });
+        self.client
+            .statement_set_option_bool_blocking(StatementSetOptionBoolRequest {
+                stmt_handle: Some(*stmt),
+                key: "async_execution".to_string(),
+                value: enabled,
+            })
+            .unwrap();
     }
 
     /// Stores a temporary private key file to keep it alive for the duration of the test.
@@ -508,27 +435,23 @@ impl SnowflakeTestClient {
 
 impl Drop for SnowflakeTestClient {
     fn drop(&mut self) {
-        self.rt.block_on(async {
-            // Release the connection when the client is dropped
-            if let Err(e) = self
-                .client
-                .connection_release(ConnectionReleaseRequest {
-                    conn_handle: Some(self.conn_handle),
-                })
-                .await
-            {
-                tracing::warn!("Failed to release connection in Drop: {e:?}");
-            }
-            // Release the database handle
-            if let Err(e) = self
-                .client
-                .database_release(DatabaseReleaseRequest {
-                    db_handle: Some(self.db_handle),
-                })
-                .await
-            {
-                tracing::warn!("Failed to release database handle in Drop: {e:?}");
-            }
-        });
+        // Release the connection when the client is dropped
+        if let Err(e) = self
+            .client
+            .connection_release_blocking(ConnectionReleaseRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+        {
+            tracing::warn!("Failed to release connection in Drop: {e:?}");
+        }
+        // Release the database handle
+        if let Err(e) = self
+            .client
+            .database_release_blocking(DatabaseReleaseRequest {
+                db_handle: Some(self.db_handle),
+            })
+        {
+            tracing::warn!("Failed to release database handle in Drop: {e:?}");
+        }
     }
 }

--- a/sf_core/tests/e2e/tls/crl_enabled.rs
+++ b/sf_core/tests/e2e/tls/crl_enabled.rs
@@ -2,11 +2,15 @@ use crate::common::snowflake_test_client::SnowflakeTestClient;
 
 #[test]
 fn should_connect_and_select_with_crl_enabled() {
-    // Given Snowflake client is logged in
-    let client = SnowflakeTestClient::connect_with_default_auth();
+    // Given Snowflake client is configured before connect
+    let client = SnowflakeTestClient::with_default_jwt_auth_params();
 
-    // And CRL is enabled
+    // And CRL is enabled before the connection is established
     client.set_connection_option("crl_mode", "ENABLED");
+
+    // Given Snowflake client is logged in
+    let connection_result = client.connect();
+    connection_result.expect("Login failed");
 
     // When Query "SELECT 1" is executed
     let result = client.execute_query("SELECT 1");

--- a/sf_core/tests/integration/config/config_manager.rs
+++ b/sf_core/tests/integration/config/config_manager.rs
@@ -1,11 +1,11 @@
 use sf_core::apis::database_driver_v1::Setting;
-use sf_core::apis::database_driver_v1::connection::{
-    Connection, connection_load_from_config_with_paths,
-};
 use sf_core::config::config_manager::{
     load_all_config_sections_with_paths, load_config_section_with_paths,
 };
+use sf_core::config::param_names;
+use sf_core::config::param_store::ParamStore;
 use sf_core::config::path_resolver::ConfigPaths;
+use sf_core::config::resolver;
 use std::fs;
 use tempfile::TempDir;
 
@@ -26,6 +26,14 @@ fn write_config(dir: &TempDir, filename: &str, content: &str) {
     }
 }
 
+fn make_explicit(pairs: &[(&str, &str)]) -> ParamStore {
+    let mut store = ParamStore::new();
+    for (k, v) in pairs {
+        store.insert(k.to_string(), Setting::String(v.to_string()));
+    }
+    store
+}
+
 #[test]
 fn connection_load_from_config_basic() {
     // Given A connections.toml file with test_connection defined
@@ -43,11 +51,22 @@ warehouse = "mywarehouse"
     );
 
     // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let resolved = resolver::resolve_with_paths(&explicit, &paths).unwrap();
 
     // Then The connection settings should be loaded
-    assert!(result.is_ok());
+    assert_eq!(
+        resolved.get(param_names::ACCOUNT),
+        Some(&Setting::String("myaccount".into()))
+    );
+    assert_eq!(
+        resolved.get(param_names::USER),
+        Some(&Setting::String("myuser".into()))
+    );
+    assert_eq!(
+        resolved.get(param_names::WAREHOUSE),
+        Some(&Setting::String("mywarehouse".into()))
+    );
 }
 
 #[test]
@@ -66,17 +85,22 @@ user = "config_user"
     );
 
     // And An explicit account setting on the connection
-    let mut conn = Connection::new();
-    conn.set_option(
-        "account".to_string(),
-        Setting::String("explicit_account".to_string()),
-    );
+    let explicit = make_explicit(&[
+        ("connection_name", "testconn"),
+        ("account", "explicit_account"),
+    ]);
 
     // When sf_core loads the connection config
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then The explicit setting should take precedence
     assert!(result.is_ok());
+    let resolved = result.unwrap();
+    if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+        assert_eq!(account, "explicit_account");
+    } else {
+        panic!("Expected account setting");
+    }
 }
 
 #[test]
@@ -86,8 +110,8 @@ fn connection_not_found_in_config() {
     let paths = make_paths(&temp_dir);
 
     // When sf_core loads connection named nonexistent
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "nonexistent", &paths);
+    let explicit = make_explicit(&[("connection_name", "nonexistent")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then ConnectionNotFound error should be returned
     assert!(result.is_err());
@@ -122,11 +146,17 @@ warehouse = "connections_wh"
     );
 
     // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then connections.toml values should override config.toml
     assert!(result.is_ok());
+    let resolved = result.unwrap();
+    if let Some(Setting::String(account)) = resolved.get(param_names::ACCOUNT) {
+        assert_eq!(account, "connections_account");
+    } else {
+        panic!("Expected account setting");
+    }
 }
 
 #[cfg(unix)]
@@ -149,8 +179,8 @@ account = "myaccount"
     fs::set_permissions(&connections_file, fs::Permissions::from_mode(0o666)).unwrap();
 
     // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then An insecure permissions error should be returned
     assert!(result.is_err());
@@ -175,8 +205,8 @@ validate_certs = true
     );
 
     // When sf_core loads the connection config
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then Each value should be parsed to the correct Setting type
     assert!(result.is_ok());
@@ -191,8 +221,8 @@ fn empty_config_files() {
     write_config(&temp_dir, "config.toml", "");
 
     // When sf_core loads connection named testconn
-    let mut conn = Connection::new();
-    let result = connection_load_from_config_with_paths(&mut conn, "testconn", &paths);
+    let explicit = make_explicit(&[("connection_name", "testconn")]);
+    let result = resolver::resolve_with_paths(&explicit, &paths);
 
     // Then ConnectionNotFound error should be returned
     assert!(result.is_err());


### PR DESCRIPTION
Connection setup was still driven by loosely merged settings and ad hoc
string reads, which made it hard to apply connect-time defaults
consistently, validate them in one place, and honor scope and mutability
rules after connect. This change introduces a typed `ConnectionConfig`
built from a layered `resolver`, extends parameter metadata with scope
and connect-time mutability, and routes connection and statement option
handling through that model so connect-time validation and runtime
behavior agree.

To support that flow, the protobuf/API layer now exposes structured
validation results, maps typed config validation failures to the right
driver error/status codes, and adds `connection_validate_options`. The
change also fixes Arrow chunk-result routing for large LOB queries so
chunked results still produce rows when headers are omitted, updates the
CRL test to set `crl_mode` before connect because it is a
connection-scoped immutable-after-connect setting, and adds blocking
protobuf-client adapters used only by synchronous Rust test helpers and
small smoke tests. The ODBC `string_lob` execution-order stabilization
needed for the full suite is intentionally split into the parent change.