### PR TITLE
[5/7] jdbc: migrate connection setup to batch SetOptions RPC

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'org.apache.arrow:arrow-memory-core:17.0.0'
     implementation 'org.apache.arrow:arrow-memory-netty:17.0.0'
     implementation 'org.apache.arrow:arrow-c-data:17.0.0'
-    implementation 'com.google.protobuf:protobuf-java:4.32.1'
+    implementation 'com.google.protobuf:protobuf-java:4.33.2'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolver.java
@@ -29,7 +29,7 @@ final class ConnectionOptionsResolver {
     setIfAbsent(resolved, "host", parsed.getHost());
     setIfAbsent(resolved, "protocol", parsed.getScheme());
     if (parsed.getPort() > 0) {
-      setIfAbsent(resolved, "port", Integer.toString(parsed.getPort()));
+      setIfAbsentInt(resolved, "port", parsed.getPort());
     }
 
     if (parsed.getAccount() != null) {
@@ -49,6 +49,12 @@ final class ConnectionOptionsResolver {
   private static void setIfAbsent(Properties resolved, String key, String value) {
     if (value != null && !value.isEmpty() && !resolved.containsKey(key)) {
       resolved.setProperty(key, value);
+    }
+  }
+
+  private static void setIfAbsentInt(Properties resolved, String key, int value) {
+    if (!resolved.containsKey(key)) {
+      resolved.put(key, value);
     }
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -19,6 +19,7 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -33,14 +34,16 @@ import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionIntRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionStringRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue;
 import net.snowflake.client.internal.util.NotImplementedException;
 
 public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
@@ -70,41 +73,27 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
           ProtobufApis.databaseDriverV1
               .connectionNew(ConnectionNewRequest.getDefaultInstance())
               .getConnHandle();
+      Map<String, ConfigSetting> optionsMap = new HashMap<>();
       connectionOptions.forEach(
           (key, value) -> {
             if (!(key instanceof String)) {
               return;
             }
-
             String keyStr = (String) key;
-            if (value instanceof String) {
-              ConnectionSetOptionStringRequest request =
-                  ConnectionSetOptionStringRequest.newBuilder()
-                      .setConnHandle(connectionHandle)
-                      .setKey(keyStr)
-                      .setValue((String) value)
-                      .build();
-              try {
-                ProtobufApis.databaseDriverV1.connectionSetOptionString(request);
-              } catch (DatabaseDriverService.ServiceException e) {
-                throw new RuntimeException(e);
-              }
-            }
-
-            if (value instanceof Integer) {
-              ConnectionSetOptionIntRequest request =
-                  ConnectionSetOptionIntRequest.newBuilder()
-                      .setConnHandle(connectionHandle)
-                      .setKey(keyStr)
-                      .setValue((Integer) value)
-                      .build();
-              try {
-                ProtobufApis.databaseDriverV1.connectionSetOptionInt(request);
-              } catch (DatabaseDriverService.ServiceException e) {
-                throw new RuntimeException(e);
-              }
+            ConfigSetting configSetting = toConfigSetting(value);
+            if (configSetting != null) {
+              optionsMap.put(keyStr, configSetting);
             }
           });
+      if (!optionsMap.isEmpty()) {
+        ConnectionSetOptionsResponse response =
+            ProtobufApis.databaseDriverV1.connectionSetOptions(
+                ConnectionSetOptionsRequest.newBuilder()
+                    .setConnHandle(connectionHandle)
+                    .putAllOptions(optionsMap)
+                    .build());
+        logConnectionOptionWarnings(response);
+      }
       ConnectionInitRequest connectionInitRequest =
           ConnectionInitRequest.newBuilder()
               .setDbHandle(databaseHandle)
@@ -137,6 +126,37 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   public String nativeSQL(String sql) throws SQLException {
     checkClosed();
     return sql;
+  }
+
+  static ConfigSetting toConfigSetting(Object value) {
+    if (value instanceof String) {
+      return ConfigSetting.newBuilder().setStringValue((String) value).build();
+    }
+    if (value instanceof Byte
+        || value instanceof Short
+        || value instanceof Integer
+        || value instanceof Long) {
+      return ConfigSetting.newBuilder().setIntValue(((Number) value).longValue()).build();
+    }
+    if (value instanceof Boolean) {
+      return ConfigSetting.newBuilder().setBoolValue((Boolean) value).build();
+    }
+    if (value instanceof Double) {
+      return ConfigSetting.newBuilder().setDoubleValue((Double) value).build();
+    }
+    // TODO(sfc-gh-boler): Support byte[] connection properties via ConfigSetting.bytes_value.
+    return null;
+  }
+
+  private static void logConnectionOptionWarnings(ConnectionSetOptionsResponse response) {
+    for (ValidationIssue warning : response.getWarningsList()) {
+      logger.warn(
+          "Connection option warning: severity={}, parameter={}, code={}, message={}",
+          warning.getSeverity(),
+          warning.getParameter(),
+          warning.getCode(),
+          warning.getMessage());
+    }
   }
 
   @Override

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/ConnectionOptionsResolverTest.java
@@ -21,7 +21,7 @@ public class ConnectionOptionsResolverTest {
             input);
 
     assertEquals("globalaccount-12345.global.snowflakecomputing.com", resolved.get("host"));
-    assertEquals("443", resolved.get("port"));
+    assertEquals(443, resolved.get("port"));
     assertEquals("https", resolved.get("protocol"));
     assertEquals("globalaccount", resolved.get("account"));
     assertEquals("TEST_WH", resolved.get("warehouse"));
@@ -94,7 +94,7 @@ public class ConnectionOptionsResolverTest {
             "jdbc:snowflake://testaccount.snowflakecomputing.com?ssl=off", new Properties());
 
     assertEquals("http", resolved.get("protocol"));
-    assertEquals("80", resolved.get("port"));
+    assertEquals(80, resolved.get("port"));
   }
 
   @Test

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -1,0 +1,47 @@
+package net.snowflake.client.internal.api.implementation.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeConnectionImplTest {
+
+  @Test
+  public void toConfigSettingMapsLongValuesToInt64() {
+    ConfigSetting configSetting = SnowflakeConnectionImpl.toConfigSetting(1234567890123L);
+
+    assertEquals(ConfigSetting.ValueCase.INT_VALUE, configSetting.getValueCase());
+    assertEquals(1234567890123L, configSetting.getIntValue());
+  }
+
+  @Test
+  public void toConfigSettingMapsStringValuesToStringValue() {
+    ConfigSetting configSetting = SnowflakeConnectionImpl.toConfigSetting("test-account");
+
+    assertEquals(ConfigSetting.ValueCase.STRING_VALUE, configSetting.getValueCase());
+    assertEquals("test-account", configSetting.getStringValue());
+  }
+
+  @Test
+  public void toConfigSettingMapsBooleanValuesToBoolValue() {
+    ConfigSetting configSetting = SnowflakeConnectionImpl.toConfigSetting(Boolean.TRUE);
+
+    assertEquals(ConfigSetting.ValueCase.BOOL_VALUE, configSetting.getValueCase());
+    assertEquals(true, configSetting.getBoolValue());
+  }
+
+  @Test
+  public void toConfigSettingMapsDoubleValuesToDoubleValue() {
+    ConfigSetting configSetting = SnowflakeConnectionImpl.toConfigSetting(3.14d);
+
+    assertEquals(ConfigSetting.ValueCase.DOUBLE_VALUE, configSetting.getValueCase());
+    assertEquals(3.14d, configSetting.getDoubleValue());
+  }
+
+  @Test
+  public void toConfigSettingReturnsNullForUnsupportedValues() {
+    assertNull(SnowflakeConnectionImpl.toConfigSetting(new Object()));
+  }
+}


### PR DESCRIPTION
The JDBC wrapper previously looped over connection properties and made
one `connectionSetOption*` RPC call per entry, while also stringifying
some non-string values on the way across the FFI boundary. This change
replaces that flow with a single pass that builds a
`Map<String, ConfigSetting>` and sends the entire option set in one
`connectionSetOptions` call.

`Boolean`, `Integer`, `String`, and `Double` values are now mapped to
their matching `ConfigSetting` builder methods, and
`ConnectionOptionsResolver` gains a helper for storing integer defaults
without boxing them through `String`. The regenerated Java protobuf
bindings are updated to expose the batched option-setting and validation
RPCs added earlier in the stack.