### PR TITLE
[6/7] odbc: batch connection setup and normalize overrides

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -32,34 +32,59 @@ const SQL_FALSE: sql::UInteger = 0;
 /// SQLSetConnectAttr provides a value.
 const DEFAULT_LOGIN_TIMEOUT_SECS: &str = "300";
 
-/// Maps ODBC connection string parameter names to their sf_core equivalents.
-/// Parameters listed here are forwarded as-is via `connection_set_option_string`.
-/// Parameters that need special handling (type conversion, conditional skipping,
-/// side-effects) are handled separately in `connect_with_params`.
-const PARAM_MAPPINGS: &[(&str, &str)] = &[
-    ("ACCOUNT", "account"),
-    ("SERVER", "host"),
-    ("PWD", "password"),
-    ("UID", "user"),
-    ("PROTOCOL", "protocol"),
-    ("DATABASE", "database"),
-    ("WAREHOUSE", "warehouse"),
-    ("ROLE", "role"),
-    ("SCHEMA", "schema"),
-    ("AUTHENTICATOR", "authenticator"),
-    ("TOKEN", "token"),
-    ("TLS_CUSTOM_ROOT_STORE_PATH", "custom_root_store_path"),
-    ("DISABLE_SAML_URL_CHECK", "disable_saml_url_check"),
-    ("TLS_VERIFY_HOSTNAME", "verify_hostname"),
-    ("TLS_VERIFY_CERTIFICATES", "verify_certificates"),
-    ("CRL_ENABLED", "crl_enabled"),
-    ("PASSCODE", "passcode"),
-    ("PASSCODEINPASSWORD", "passcodeInPassword"),
-    (
-        "CLIENT_STORE_TEMPORARY_CREDENTIAL",
-        "client_store_temporary_credential",
-    ),
-];
+/// Normalizes `CRL_ENABLED` values to the uppercase mode strings `sf_core` accepts for
+/// `crl_check_mode` (see `build_crl_config` in `connection_config.rs`).
+fn normalize_crl_enabled_value(value: &str) -> String {
+    let v = value.trim();
+    if v.eq_ignore_ascii_case("true") || v == "1" {
+        "ENABLED".to_owned()
+    } else if v.eq_ignore_ascii_case("false") || v == "0" {
+        "DISABLED".to_owned()
+    } else {
+        v.to_ascii_uppercase()
+    }
+}
+
+fn normalize_connection_string_options(
+    connection_string_map: HashMap<String, String>,
+) -> HashMap<String, ConfigSetting> {
+    connection_string_map
+        .into_iter()
+        .filter_map(|(key, value)| normalize_connection_string_option(key, value))
+        .collect()
+}
+
+fn normalize_connection_string_option(
+    key: String,
+    value: String,
+) -> Option<(String, ConfigSetting)> {
+    let upper = key.to_ascii_uppercase();
+    if upper == "DRIVER" {
+        return None;
+    }
+
+    match upper.as_str() {
+        "PORT" => Some(("port".to_owned(), value.into())),
+        "CRL_MODE" => Some(("CRL_MODE".to_owned(), value.to_uppercase().into())),
+        "CRL_ENABLED" => Some((
+            "CRL_ENABLED".to_owned(),
+            normalize_crl_enabled_value(&value).into(),
+        )),
+        "CLIENT_STORE_TEMPORARY_CREDENTIAL" => {
+            Some(("client_store_temporary_credential".to_owned(), value.into()))
+        }
+        "LOGIN_TIMEOUT" => Some(("authentication_timeout".to_owned(), value.into())),
+        "PASSCODEINPASSWORD" => Some(("passcodeInPassword".to_owned(), value.into())),
+        "PRIV_KEY_FILE" => Some(("private_key_file".to_owned(), value.into())),
+        "PRIV_KEY_BASE64" => Some(("private_key".to_owned(), value.into())),
+        "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
+            Some(("private_key_password".to_owned(), value.into()))
+        }
+        // Forward other keys (e.g. SERVER, UID) for `sf_core` alias resolution; do not
+        // pre-canonicalize here to avoid duplicate seed keys.
+        _ => Some((upper, value.into())),
+    }
+}
 
 /// Parse connection string into key-value pairs
 fn parse_connection_string(connection_string: &str) -> HashMap<String, String> {
@@ -67,7 +92,10 @@ fn parse_connection_string(connection_string: &str) -> HashMap<String, String> {
     for pair in connection_string.split(';') {
         let parts: Vec<&str> = pair.splitn(2, '=').collect();
         if parts.len() == 2 {
-            map.insert(parts[0].trim().to_uppercase(), parts[1].trim().to_string());
+            map.insert(
+                parts[0].trim().to_ascii_uppercase(),
+                parts[1].trim().to_string(),
+            );
         }
     }
     map
@@ -113,170 +141,79 @@ fn connect_with_params(
         tracing::info!("connect_with_params: params={:?}", redacted_map);
     }
 
-    let connection = conn_from_handle(connection_handle);
-
-    // Check whether attribute-based key options supersede file-based connection string params.
-    // Matches old driver (SFConnection.cpp): if PrivKeyContent or PrivKeyBase64 was set via
-    // SQLSetConnectAttr, PRIV_KEY_FILE from the connection string is not used.
-    let attr_key_set = connection
-        .pre_connection_attrs
-        .contains_key(&ConnectionAttribute::PrivKeyContent)
-        || connection
-            .pre_connection_attrs
-            .contains_key(&ConnectionAttribute::PrivKeyBase64);
-
-    let attr_has_priv_key_password = connection
-        .pre_connection_attrs
-        .contains_key(&ConnectionAttribute::PrivKeyPassword);
-
-    let pre_attrs = connection.pre_connection_attrs.clone();
-
-    let (db_handle, conn_handle) =
-        global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-            let db_handle = c
-                .database_new(DatabaseNewRequest {})
-                .await?
-                .db_handle
-                .required("Database handle is required")?;
-            let conn_handle = c
-                .connection_new(ConnectionNewRequest {})
-                .await?
-                .conn_handle
-                .required("Connection handle is required")?;
-
-            let mut login_timeout_set = false;
-
-            for (key, value) in params {
-                if key == "DRIVER" {
-                    continue;
-                }
-
-                if let Some(core_key) = PARAM_MAPPINGS
-                    .iter()
-                    .find(|(k, _)| *k == key)
-                    .map(|(_, v)| *v)
-                {
-                    c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: core_key.to_owned(),
-                        value,
-                    })
-                    .await?;
-                    continue;
-                }
-
-                match key.as_str() {
-                    "PORT" => {
-                        let port_int: i64 = value.parse().context(InvalidPortSnafu {
-                            port: value.clone(),
-                        })?;
-                        c.connection_set_option_int(ConnectionSetOptionIntRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "port".to_owned(),
-                            value: port_int,
-                        })
-                        .await?;
-                    }
-                    "CRL_MODE" => {
-                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "crl_mode".to_owned(),
-                            value: value.to_uppercase(),
-                        })
-                        .await?;
-                    }
-                    "LOGIN_TIMEOUT" => {
-                        login_timeout_set = true;
-                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "authentication_timeout".to_owned(),
-                            value,
-                        })
-                        .await?;
-                    }
-                    "PRIV_KEY_FILE" => {
-                        if attr_key_set {
-                            tracing::debug!(
-                                "connect_with_params: skipping PRIV_KEY_FILE — attribute-based key takes priority"
-                            );
-                        } else {
-                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                                conn_handle: Some(conn_handle),
-                                key: "private_key_file".to_owned(),
-                                value,
-                            })
-                            .await?;
-                        }
-                    }
-                    "PRIV_KEY_BASE64" => {
-                        if attr_key_set {
-                            tracing::debug!(
-                                "connect_with_params: skipping PRIV_KEY_BASE64 — attribute-based key takes priority"
-                            );
-                        } else {
-                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                                conn_handle: Some(conn_handle),
-                                key: "private_key".to_owned(),
-                                value,
-                            })
-                            .await?;
-                        }
-                    }
-                    "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
-                        if attr_has_priv_key_password {
-                            tracing::debug!(
-                                "connect_with_params: skipping {key} — attribute-based password takes priority"
-                            );
-                        } else {
-                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                                conn_handle: Some(conn_handle),
-                                key: "private_key_password".to_owned(),
-                                value,
-                            })
-                            .await?;
-                        }
-                    }
-                    _ => {
-                        tracing::info!(
-                            "connect_with_params: forwarding unrecognized key {key:?} to sf_core"
-                        );
-                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key,
-                            value,
-                        })
-                        .await?;
-                    }
-                }
-            }
-
-            let login_timeout_from_attr =
-                apply_pre_connection_attrs_async(c, &pre_attrs, conn_handle).await?;
-
-            if !login_timeout_set && !login_timeout_from_attr {
-                c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                    conn_handle: Some(conn_handle),
-                    key: "authentication_timeout".to_owned(),
-                    value: DEFAULT_LOGIN_TIMEOUT_SECS.to_owned(),
-                })
-                .await?;
-            }
-
-            c.connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "client_app_id".to_owned(),
-                value: "ODBC".to_owned(),
-            })
-            .await?;
-
-            c.connection_init(ConnectionInitRequest {
-                conn_handle: Some(conn_handle),
-                db_handle: Some(db_handle),
-            })
-            .await?;
-
-            Ok::<_, crate::api::OdbcError>((db_handle, conn_handle))
+    let mut options = normalize_connection_string_options(params);
+    if let Some(config_setting::Value::StringValue(raw_port)) = options
+        .get("port")
+        .and_then(|setting| setting.value.as_ref())
+    {
+        let port_int: i64 = raw_port.parse().context(InvalidPortSnafu {
+            port: raw_port.clone(),
         })?;
+        options.insert("port".to_owned(), port_int.into());
+    }
+
+    let connection = conn_from_handle(connection_handle);
+    apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
+
+    // Check before moving `options` into the RPC call below.
+    let login_timeout_in_options = options.contains_key("authentication_timeout");
+    let login_timeout_in_attrs = connection
+        .pre_connection_attrs
+        .contains_key(&ConnectionAttribute::LoginTimeout);
+    let pre_connection_attrs = connection.pre_connection_attrs.clone();
+
+    let (db_handle, conn_handle) = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        let db_handle = c
+            .database_new(DatabaseNewRequest {})
+            .await?
+            .db_handle
+            .required("Database handle is required")?;
+        let conn_handle = c
+            .connection_new(ConnectionNewRequest {})
+            .await?
+            .conn_handle
+            .required("Connection handle is required")?;
+
+        let response = c
+            .connection_set_options(ConnectionSetOptionsRequest {
+                conn_handle: Some(conn_handle),
+                options,
+            })
+            .await?;
+
+        for warning in &response.warnings {
+            tracing::warn!("connection option warning: {}", warning.message);
+        }
+
+        // Wrapper identity and optional default login timeout (Okta SAML budget) use the
+        // same batch setter RPC as the connection string options.
+        let mut follow_up = HashMap::from([("client_app_id".to_owned(), "ODBC".to_owned().into())]);
+        if !login_timeout_in_options && !login_timeout_in_attrs {
+            follow_up.insert(
+                "authentication_timeout".to_owned(),
+                DEFAULT_LOGIN_TIMEOUT_SECS.to_owned().into(),
+            );
+        }
+        let response = c
+            .connection_set_options(ConnectionSetOptionsRequest {
+                conn_handle: Some(conn_handle),
+                options: follow_up,
+            })
+            .await?;
+        for warning in &response.warnings {
+            tracing::warn!("connection option warning: {}", warning.message);
+        }
+
+        apply_pre_connection_runtime_attrs_async(c, &pre_connection_attrs, conn_handle).await?;
+
+        c.connection_init(ConnectionInitRequest {
+            conn_handle: Some(conn_handle),
+            db_handle: Some(db_handle),
+        })
+        .await?;
+
+        Ok::<_, crate::api::OdbcError>((db_handle, conn_handle))
+    })?;
 
     tracing::info!("connect_with_params: connection_init completed");
 
@@ -316,65 +253,48 @@ fn connect_with_params(
     Ok(())
 }
 
-/// Apply pre-connection attributes to sf_core. SQLSetConnectAttr values override
-/// connection string parameters. PrivKeyContent takes priority over PrivKeyBase64.
-/// Returns `true` if LoginTimeout was set via attributes.
-async fn apply_pre_connection_attrs_async(
-    client: &sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient,
+/// Apply SQLSetConnectAttr values as overrides into the canonical options map.
+/// PrivKeyContent or PrivKeyBase64 take priority over private-key settings from
+/// the connection string. PrivKeyPassword overrides private_key_password.
+fn apply_pre_connection_overrides(
     attrs: &HashMap<ConnectionAttribute, String>,
-    conn_handle: ConnectionHandle,
-) -> OdbcResult<bool> {
+    options: &mut HashMap<String, ConfigSetting>,
+) {
+    // PrivKeyContent or PrivKeyBase64 → canonical "private_key"
+    // Suppresses connection-string private key sources.
     if let Some(content) = attrs.get(&ConnectionAttribute::PrivKeyContent) {
         use base64::{Engine as _, engine::general_purpose};
         let encoded = general_purpose::STANDARD.encode(content.as_bytes());
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "private_key".to_owned(),
-                value: encoded,
-            })
-            .await?;
-    } else if let Some(base64_key) = attrs.get(&ConnectionAttribute::PrivKeyBase64) {
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "private_key".to_owned(),
-                value: base64_key.clone(),
-            })
-            .await?;
+        options.insert("private_key".to_owned(), encoded.into());
+        options.remove("private_key_file");
+    } else if let Some(b64) = attrs.get(&ConnectionAttribute::PrivKeyBase64) {
+        options.insert("private_key".to_owned(), b64.clone().into());
+        options.remove("private_key_file");
     }
 
-    if let Some(password) = attrs.get(&ConnectionAttribute::PrivKeyPassword) {
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "private_key_password".to_owned(),
-                value: password.clone(),
-            })
-            .await?;
+    // PrivKeyPassword overrides connection-string password keys.
+    if let Some(pwd) = attrs.get(&ConnectionAttribute::PrivKeyPassword) {
+        options.insert("private_key_password".to_owned(), pwd.clone().into());
     }
 
+    // Application name
     if let Some(app) = attrs.get(&ConnectionAttribute::Application) {
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "application".to_owned(),
-                value: app.clone(),
-            })
-            .await?;
+        options.insert("application".to_owned(), app.clone().into());
     }
 
+    // LoginTimeout -> authentication_timeout (matches old driver: used as Okta SAML budget)
     if let Some(timeout) = attrs.get(&ConnectionAttribute::LoginTimeout) {
-        client
-            .connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: "authentication_timeout".to_owned(),
-                value: timeout.clone(),
-            })
-            .await?;
-        return Ok(true);
+        options.insert("authentication_timeout".to_owned(), timeout.clone().into());
     }
+}
 
+/// Apply pre-connection attributes that still require dedicated RPCs after
+/// the canonical batch `ConnectionSetOptions` payload has been sent.
+async fn apply_pre_connection_runtime_attrs_async(
+    client: &sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient,
+    attrs: &HashMap<ConnectionAttribute, String>,
+    conn_handle: ConnectionHandle,
+) -> OdbcResult<()> {
     if let Some(raw) = attrs.get(&ConnectionAttribute::Autocommit) {
         match raw
             .parse::<sql::UInteger>()
@@ -391,14 +311,14 @@ async fn apply_pre_connection_attrs_async(
             }
             None => {
                 tracing::warn!(
-                    "apply_pre_connection_attrs_async: invalid cached autocommit value {raw:?}; \
-                     skipping autocommit RPC to avoid silent promotion to ON"
+                    "apply_pre_connection_runtime_attrs_async: invalid cached autocommit value \
+                     {raw:?}; skipping autocommit RPC to avoid silent promotion to ON"
                 );
             }
         }
     }
 
-    Ok(false)
+    Ok(())
 }
 
 /// Connect using DSN (SQLConnect / SQLConnectW).
@@ -1175,7 +1095,139 @@ pub fn get_info<E: OdbcEncoding>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sf_core::protobuf::generated::database_driver_v1::config_setting;
     use test_case::test_case;
+
+    fn config_string<'a>(
+        options: &'a HashMap<String, ConfigSetting>,
+        key: &str,
+    ) -> Option<&'a str> {
+        match options.get(key)?.value.as_ref()? {
+            config_setting::Value::StringValue(value) => Some(value.as_str()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_login_timeout() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "LOGIN_TIMEOUT".to_owned(),
+            "42".to_owned(),
+        )]));
+
+        assert_eq!(
+            config_string(&options, "authentication_timeout"),
+            Some("42")
+        );
+        assert!(!options.contains_key("LOGIN_TIMEOUT"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_is_case_insensitive_for_special_keys() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("login_timeout".to_owned(), "99".to_owned()),
+            ("priv_key_base64".to_owned(), "dsn-key".to_owned()),
+        ]));
+
+        assert_eq!(
+            config_string(&options, "authentication_timeout"),
+            Some("99")
+        );
+        assert_eq!(config_string(&options, "private_key"), Some("dsn-key"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_normalizes_crl_enabled_for_core() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "CRL_ENABLED".to_owned(),
+            "true".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "CRL_ENABLED"), Some("ENABLED"));
+        assert!(!options.contains_key("crl_check_mode"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_crl_enabled_zero_maps_to_disabled() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "CRL_ENABLED".to_owned(),
+            "0".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "CRL_ENABLED"), Some("DISABLED"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_uppercases_crl_mode() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "CRL_MODE".to_owned(),
+            "enabled".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "CRL_MODE"), Some("ENABLED"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_forwards_standard_keys_for_core_aliases() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("SERVER".to_owned(), "example.com".to_owned()),
+            ("UID".to_owned(), "u".to_owned()),
+        ]));
+
+        assert_eq!(config_string(&options, "SERVER"), Some("example.com"));
+        assert_eq!(config_string(&options, "UID"), Some("u"));
+        assert!(!options.contains_key("host"));
+        assert!(!options.contains_key("user"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_passcodeinpassword() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "PASSCODEINPASSWORD".to_owned(),
+            "true".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "passcodeInPassword"), Some("true"));
+        assert!(!options.contains_key("PASSCODEINPASSWORD"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_client_store_temporary_credential() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "CLIENT_STORE_TEMPORARY_CREDENTIAL".to_owned(),
+            "true".to_owned(),
+        )]));
+
+        assert_eq!(
+            config_string(&options, "client_store_temporary_credential"),
+            Some("true")
+        );
+        assert!(!options.contains_key("CLIENT_STORE_TEMPORARY_CREDENTIAL"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_preserves_unrecognized_keys() {
+        let options = normalize_connection_string_options(HashMap::from([(
+            "QUERY_TAG".to_owned(),
+            "from-odbc".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "QUERY_TAG"), Some("from-odbc"));
+    }
+
+    #[test]
+    fn apply_pre_connection_overrides_makes_priv_key_base64_authoritative() {
+        let mut options = normalize_connection_string_options(HashMap::from([
+            ("PRIV_KEY_BASE64".to_owned(), "dsn-key".to_owned()),
+            ("PRIV_KEY_FILE".to_owned(), "/tmp/key.p8".to_owned()),
+        ]));
+        let attrs = HashMap::from([(ConnectionAttribute::PrivKeyBase64, "attr-key".to_owned())]);
+
+        apply_pre_connection_overrides(&attrs, &mut options);
+
+        assert_eq!(config_string(&options, "private_key"), Some("attr-key"));
+        assert!(!options.contains_key("private_key_file"));
+    }
 
     #[test_case("UID=admin;SERVER=foo", &[("UID", "admin"), ("SERVER", "foo")] ; "basic")]
     #[test_case("UID=admin; AUTHENTICATOR=SNOWFLAKE_JWT", &[("UID", "admin"), ("AUTHENTICATOR", "SNOWFLAKE_JWT")] ; "trims keys")]

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -416,12 +416,36 @@ static AUTHENTICATOR_PARAMETERS: LazyLock<HashSet<String>> = LazyLock::new(|| {
 impl OdbcError {
     pub fn message_text(&self) -> String {
         let trace = self.error_trace();
-        let error_message = trace
-            .last()
-            .map(|entry| entry.message.clone())
-            .unwrap_or_default();
+        let error_message = self.structured_message().unwrap_or_else(|| {
+            trace
+                .last()
+                .map(|entry| entry.message.clone())
+                .unwrap_or_default()
+        });
         let trace_text = format_error_trace(&trace);
         format!("{}\nTrace:\n{}", error_message, trace_text)
+    }
+
+    /// Extract a user-facing message from structured protobuf error fields
+    /// when available; returns `None` to fall back to the generic trace-based
+    /// message.
+    fn structured_message(&self) -> Option<String> {
+        match self {
+            OdbcError::CoreError { source, .. } => match source.as_ref() {
+                CoreProtobufError::Application { error, .. } => match error.as_ref() {
+                    ErrorType::InvalidParameterValue(ProtoInvalidParameterValue {
+                        explanation: Some(explanation),
+                        ..
+                    }) => Some(explanation.clone()),
+                    ErrorType::MissingParameter(ProtoMissingParameter { parameter }) => {
+                        Some(format!("Missing required parameter: {parameter}"))
+                    }
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     pub fn to_diagnostic_record(&self) -> DiagnosticRecord {

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -731,7 +731,7 @@ mod tests {
     use super::*;
 
     fn settings_from(pairs: &[(&str, Setting)]) -> ParamStore {
-        let mut settings = ParamStore::new();
+        let mut settings = ParamStore::with_registry_defaults();
         for (key, value) in pairs {
             settings.insert((*key).to_string(), value.clone());
         }
@@ -1204,7 +1204,7 @@ mod tests {
 
     #[test]
     fn validate_returns_all_issues_not_just_first() {
-        let settings = ParamStore::new();
+        let settings = ParamStore::with_registry_defaults();
         let issues = validate_settings(&settings);
         let error_count = issues
             .iter()


### PR DESCRIPTION
The ODBC wrapper previously translated connection-string keys by hand
and issued one `connection_set_option_*` RPC per parameter. This change
moves `driver_connect` to the batched `ConnectionSetOptions` RPC and
consolidates wrapper-specific normalization into a single preparation
step before the batch is sent.

Connection-string aliases and special cases are normalized on the ODBC
side where needed, including `LOGIN_TIMEOUT` to
`authentication_timeout`, CRL mode normalization, and canonical mapping
of private-key fields. `SQLSetConnectAttr` values are applied as
canonical overrides on the same option map so attribute-based private
key and password settings deterministically win over superseded
connection-string inputs. The wrapper still preserves the legacy default
login-timeout behavior and sends `client_app_id` separately until the
cleanup change removes that plumbing.

In the future, we are going to extend ParamDef with per-wrapper allowed
aliases and move normalization into the core.