### PR TITLE
[7/7] config: remove deprecated setter RPCs and legacy config plumbing

### DIFF
--- a/odbc/tests/odbc_api_tests.rs
+++ b/odbc/tests/odbc_api_tests.rs
@@ -71,9 +71,9 @@
 
 use sf_core::{
     protobuf::apis::database_driver_v1::{DatabaseDriverClientBlockingExt, database_driver_client},
+    protobuf::config_setting_ext::config_option,
     protobuf::generated::database_driver_v1::{
-        ConnectionNewRequest, ConnectionSetOptionIntRequest, ConnectionSetOptionStringRequest,
-        DatabaseInitRequest, DatabaseNewRequest,
+        ConnectionNewRequest, ConnectionSetOptionsRequest, DatabaseInitRequest, DatabaseNewRequest,
     },
 };
 
@@ -95,38 +95,17 @@ fn smoke_connection_set_tls_config() {
         .unwrap();
 
     client
-        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
+        .connection_set_options_blocking(ConnectionSetOptionsRequest {
             conn_handle: Some(conn),
-            key: "verify_hostname".to_string(),
-            value: "true".to_string(),
+            options: vec![
+                config_option("verify_hostname", "true"),
+                config_option("verify_certificates", "true"),
+                config_option("crl_mode", "ENABLED"),
+                config_option("crl_http_timeout", 30_i64),
+                config_option("crl_connection_timeout", 10_i64),
+            ]
+            .into_iter()
+            .collect(),
         })
-        .expect("set verify_hostname");
-    client
-        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn),
-            key: "verify_certificates".to_string(),
-            value: "true".to_string(),
-        })
-        .expect("set verify_certificates");
-    client
-        .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn),
-            key: "crl_mode".to_string(),
-            value: "ENABLED".to_string(),
-        })
-        .expect("set crl_mode");
-    client
-        .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
-            conn_handle: Some(conn),
-            key: "crl_http_timeout".to_string(),
-            value: 30,
-        })
-        .expect("set crl_http_timeout");
-    client
-        .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
-            conn_handle: Some(conn),
-            key: "crl_connection_timeout".to_string(),
-            value: 10,
-        })
-        .expect("set crl_connection_timeout");
+        .expect("set options");
 }

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -226,51 +226,6 @@ message DatabaseNewResponse {
   DatabaseHandle db_handle = 1;
 }
 
-message DatabaseSetOptionStringRequest {
-  DatabaseHandle db_handle = 1;
-  string key = 2;
-  string value = 3;
-}
-
-message DatabaseSetOptionStringResponse {
-}
-
-message DatabaseSetOptionBytesRequest {
-  DatabaseHandle db_handle = 1;
-  string key = 2;
-  bytes value = 3;
-}
-
-message DatabaseSetOptionBytesResponse {
-}
-
-message DatabaseSetOptionIntRequest {
-  DatabaseHandle db_handle = 1;
-  string key = 2;
-  int64 value = 3;
-}
-
-message DatabaseSetOptionIntResponse {
-}
-
-message DatabaseSetOptionDoubleRequest {
-  DatabaseHandle db_handle = 1;
-  string key = 2;
-  double value = 3;
-}
-
-message DatabaseSetOptionDoubleResponse {
-}
-
-message DatabaseSetOptionBoolRequest {
-  DatabaseHandle db_handle = 1;
-  string key = 2;
-  bool value = 3;
-}
-
-message DatabaseSetOptionBoolResponse {
-}
-
 message DatabaseInitRequest {
   DatabaseHandle db_handle = 1;
 }
@@ -292,51 +247,6 @@ message ConnectionNewRequest {
 
 message ConnectionNewResponse {
   ConnectionHandle conn_handle = 1;
-}
-
-message ConnectionSetOptionStringRequest {
-  ConnectionHandle conn_handle = 1;
-  string key = 2;
-  string value = 3;
-}
-
-message ConnectionSetOptionStringResponse {
-}
-
-message ConnectionSetOptionBytesRequest {
-  ConnectionHandle conn_handle = 1;
-  string key = 2;
-  bytes value = 3;
-}
-
-message ConnectionSetOptionBytesResponse {
-}
-
-message ConnectionSetOptionIntRequest {
-  ConnectionHandle conn_handle = 1;
-  string key = 2;
-  int64 value = 3;
-}
-
-message ConnectionSetOptionIntResponse {
-}
-
-message ConnectionSetOptionDoubleRequest {
-  ConnectionHandle conn_handle = 1;
-  string key = 2;
-  double value = 3;
-}
-
-message ConnectionSetOptionDoubleResponse {
-}
-
-message ConnectionSetOptionBoolRequest {
-  ConnectionHandle conn_handle = 1;
-  string key = 2;
-  bool value = 3;
-}
-
-message ConnectionSetOptionBoolResponse {
 }
 
 message ConnectionInitRequest {
@@ -569,51 +479,6 @@ message StatementPrepareResponse {
   PrepareResult result = 1;
 }
 
-message StatementSetOptionStringRequest {
-  StatementHandle stmt_handle = 1;
-  string key = 2;
-  string value = 3;
-}
-
-message StatementSetOptionStringResponse {
-}
-
-message StatementSetOptionBytesRequest {
-  StatementHandle stmt_handle = 1;
-  string key = 2;
-  bytes value = 3;
-}
-
-message StatementSetOptionBytesResponse {
-}
-
-message StatementSetOptionIntRequest {
-  StatementHandle stmt_handle = 1;
-  string key = 2;
-  int64 value = 3;
-}
-
-message StatementSetOptionIntResponse {
-}
-
-message StatementSetOptionDoubleRequest {
-  StatementHandle stmt_handle = 1;
-  string key = 2;
-  double value = 3;
-}
-
-message StatementSetOptionDoubleResponse {
-}
-
-message StatementSetOptionBoolRequest {
-  StatementHandle stmt_handle = 1;
-  string key = 2;
-  bool value = 3;
-}
-
-message StatementSetOptionBoolResponse {
-}
-
 message StatementGetParameterSchemaRequest {
   StatementHandle stmt_handle = 1;
 }
@@ -798,11 +663,6 @@ service DatabaseDriver {
   option (service_error) = "DriverException";
   // Database operations
   rpc DatabaseNew(DatabaseNewRequest) returns (DatabaseNewResponse);
-  rpc DatabaseSetOptionString(DatabaseSetOptionStringRequest) returns (DatabaseSetOptionStringResponse);
-  rpc DatabaseSetOptionBytes(DatabaseSetOptionBytesRequest) returns (DatabaseSetOptionBytesResponse);
-  rpc DatabaseSetOptionInt(DatabaseSetOptionIntRequest) returns (DatabaseSetOptionIntResponse);
-  rpc DatabaseSetOptionDouble(DatabaseSetOptionDoubleRequest) returns (DatabaseSetOptionDoubleResponse);
-  rpc DatabaseSetOptionBool(DatabaseSetOptionBoolRequest) returns (DatabaseSetOptionBoolResponse);
   rpc DatabaseSetOptions(DatabaseSetOptionsRequest) returns (DatabaseSetOptionsResponse);
   rpc DatabaseInit(DatabaseInitRequest) returns (DatabaseInitResponse);
   rpc DatabaseRelease(DatabaseReleaseRequest) returns (DatabaseReleaseResponse);
@@ -810,11 +670,6 @@ service DatabaseDriver {
 
   // Connection operations
   rpc ConnectionNew(ConnectionNewRequest) returns (ConnectionNewResponse);
-  rpc ConnectionSetOptionString(ConnectionSetOptionStringRequest) returns (ConnectionSetOptionStringResponse);
-  rpc ConnectionSetOptionBytes(ConnectionSetOptionBytesRequest) returns (ConnectionSetOptionBytesResponse);
-  rpc ConnectionSetOptionInt(ConnectionSetOptionIntRequest) returns (ConnectionSetOptionIntResponse);
-  rpc ConnectionSetOptionDouble(ConnectionSetOptionDoubleRequest) returns (ConnectionSetOptionDoubleResponse);
-  rpc ConnectionSetOptionBool(ConnectionSetOptionBoolRequest) returns (ConnectionSetOptionBoolResponse);
   rpc ConnectionSetOptions(ConnectionSetOptionsRequest) returns (ConnectionSetOptionsResponse);
   rpc ConnectionInit(ConnectionInitRequest) returns (ConnectionInitResponse);
   rpc ConnectionRelease(ConnectionReleaseRequest) returns (ConnectionReleaseResponse);
@@ -849,11 +704,6 @@ service DatabaseDriver {
   rpc StatementSetSqlQuery(StatementSetSqlQueryRequest) returns (StatementSetSqlQueryResponse);
   rpc StatementSetSubstraitPlan(StatementSetSubstraitPlanRequest) returns (StatementSetSubstraitPlanResponse);
   rpc StatementPrepare(StatementPrepareRequest) returns (StatementPrepareResponse);
-  rpc StatementSetOptionString(StatementSetOptionStringRequest) returns (StatementSetOptionStringResponse);
-  rpc StatementSetOptionBytes(StatementSetOptionBytesRequest) returns (StatementSetOptionBytesResponse);
-  rpc StatementSetOptionInt(StatementSetOptionIntRequest) returns (StatementSetOptionIntResponse);
-  rpc StatementSetOptionDouble(StatementSetOptionDoubleRequest) returns (StatementSetOptionDoubleResponse);
-  rpc StatementSetOptionBool(StatementSetOptionBoolRequest) returns (StatementSetOptionBoolResponse);
   rpc StatementSetOptions(StatementSetOptionsRequest) returns (StatementSetOptionsResponse);
   rpc StatementGetParameterSchema(StatementGetParameterSchemaRequest) returns (StatementGetParameterSchemaResponse);
   rpc StatementExecuteQuery(StatementExecuteQueryRequest) returns (StatementExecuteQueryResponse);

--- a/sf_core/src/apis/database_driver_v1/database.rs
+++ b/sf_core/src/apis/database_driver_v1/database.rs
@@ -20,25 +20,6 @@ impl DatabaseDriverV1 {
         self.databases.add_handle(Mutex::new(Database::new()))
     }
 
-    pub async fn database_set_option(
-        &self,
-        db_handle: Handle,
-        key: String,
-        value: Setting,
-    ) -> Result<(), ApiError> {
-        match self.databases.get_obj(db_handle) {
-            Some(db_ptr) => {
-                let mut db = db_ptr.lock().await;
-                db.settings.insert(key, value);
-                Ok(())
-            }
-            None => InvalidArgumentSnafu {
-                argument: "Database handle not found".to_string(),
-            }
-            .fail(),
-        }
-    }
-
     pub async fn database_set_options(
         &self,
         db_handle: Handle,

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -1,67 +1,13 @@
 #[cfg(test)]
 mod integration_tests {
-    use crate::config::rest_parameters::{ClientInfo, LoginMethod, LoginParameters};
-    use crate::config::settings::{Setting, Settings};
+    use crate::config::rest_parameters::ClientInfo;
     use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
     use crate::rest::snowflake;
-    use std::collections::HashMap;
-
-    /// Mock settings implementation for testing
-    struct MockSettings {
-        settings: HashMap<String, Setting>,
-    }
-
-    impl MockSettings {
-        fn new() -> Self {
-            let mut settings = HashMap::new();
-
-            // Add some default settings
-            settings.insert(
-                "account".to_string(),
-                Setting::String("test_account".to_string()),
-            );
-            settings.insert("user".to_string(), Setting::String("test_user".to_string()));
-            settings.insert(
-                "password".to_string(),
-                Setting::String("test_password".to_string()),
-            );
-            settings.insert(
-                "host".to_string(),
-                Setting::String("test.snowflakecomputing.com".to_string()),
-            );
-
-            Self { settings }
-        }
-
-        fn with_crl_enabled(mut self) -> Self {
-            self.settings.insert(
-                "crl_check_mode".to_string(),
-                Setting::String("ENABLED".to_string()),
-            );
-            self.settings.insert(
-                "crl_enable_disk_caching".to_string(),
-                Setting::String("true".to_string()),
-            );
-            self.settings
-                .insert("crl_validity_time".to_string(), Setting::Int(7));
-            self
-        }
-    }
-
-    impl Settings for MockSettings {
-        fn get(&self, key: &str) -> Option<Setting> {
-            self.settings.get(key).cloned()
-        }
-
-        fn set(&mut self, key: &str, value: Setting) {
-            self.settings.insert(key.to_string(), value);
-        }
-    }
+    use crate::tls::config::TlsConfig;
 
     #[test]
-    fn test_crl_config_from_settings_disabled() {
-        let settings = MockSettings::new();
-        let crl_config = CrlConfig::from_settings(&settings).unwrap();
+    fn test_crl_config_disabled_defaults() {
+        let crl_config = CrlConfig::default();
 
         assert_eq!(crl_config.check_mode, CertRevocationCheckMode::Disabled);
         assert!(crl_config.enable_disk_caching);
@@ -70,9 +16,13 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_crl_config_from_settings_enabled() {
-        let settings = MockSettings::new().with_crl_enabled();
-        let crl_config = CrlConfig::from_settings(&settings).unwrap();
+    fn test_crl_config_enabled() {
+        let crl_config = CrlConfig {
+            check_mode: CertRevocationCheckMode::Enabled,
+            enable_disk_caching: true,
+            validity_time: chrono::Duration::days(7),
+            ..Default::default()
+        };
 
         assert_eq!(crl_config.check_mode, CertRevocationCheckMode::Enabled);
         assert!(crl_config.enable_disk_caching);
@@ -81,8 +31,22 @@ mod integration_tests {
 
     #[test]
     fn test_client_info_with_crl_config() {
-        let settings = MockSettings::new().with_crl_enabled();
-        let client_info = ClientInfo::from_settings(&settings).unwrap();
+        let crl_config = CrlConfig {
+            check_mode: CertRevocationCheckMode::Enabled,
+            ..Default::default()
+        };
+        let client_info = ClientInfo {
+            application: "PythonConnector".to_string(),
+            version: "3.15.0".to_string(),
+            os: "Darwin".to_string(),
+            os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
+            ocsp_mode: Some("FAIL_OPEN".to_string()),
+            crl_config: crl_config.clone(),
+            tls_config: TlsConfig {
+                crl_config,
+                ..Default::default()
+            },
+        };
 
         assert_eq!(
             client_info.crl_config.check_mode,
@@ -92,23 +56,38 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_login_parameters_integration() {
-        let settings = MockSettings::new().with_crl_enabled();
-        let login_params = LoginParameters::from_settings(&settings).unwrap();
+    fn test_connection_config_integration() {
+        use crate::config::connection_config::{AuthConfig, ConnectionConfig};
+        use crate::config::param_store::ParamStore;
+        use crate::config::settings::Setting;
 
-        assert_eq!(login_params.account_name, "test_account");
+        let mut settings = ParamStore::with_registry_defaults();
+        for (k, v) in [
+            ("account", Setting::String("test_account".into())),
+            ("user", Setting::String("test_user".into())),
+            ("password", Setting::String("test_password".into())),
+            (
+                "host",
+                Setting::String("test_account.snowflakecomputing.com".into()),
+            ),
+            ("crl_check_mode", Setting::String("ENABLED".into())),
+        ] {
+            settings.insert(k.to_string(), v);
+        }
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.account, "test_account");
         assert_eq!(
-            login_params.client_info.crl_config.check_mode,
+            config.tls.crl_config.check_mode,
             CertRevocationCheckMode::Enabled
         );
 
-        // Verify the login method is correctly parsed
-        match login_params.login_method {
-            LoginMethod::Password { username, password } => {
-                assert_eq!(username, "test_user");
+        match &config.auth {
+            AuthConfig::Password { user, password } => {
+                assert_eq!(user, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }
-            _ => panic!("Expected password login method"),
+            _ => panic!("Expected password auth"),
         }
     }
 
@@ -119,7 +98,7 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Disabled,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(crate::tls::config::TlsConfig {
+        let client = crate::tls::create_tls_client_with_config(TlsConfig {
             crl_config: config,
             ..Default::default()
         })
@@ -131,7 +110,7 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Enabled,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(crate::tls::config::TlsConfig {
+        let client = crate::tls::create_tls_client_with_config(TlsConfig {
             crl_config: config,
             ..Default::default()
         })
@@ -143,7 +122,7 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Advisory,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(crate::tls::config::TlsConfig {
+        let client = crate::tls::create_tls_client_with_config(TlsConfig {
             crl_config: config,
             ..Default::default()
         })
@@ -153,8 +132,15 @@ mod integration_tests {
 
     #[test]
     fn test_user_agent_generation() {
-        let settings = MockSettings::new();
-        let client_info = ClientInfo::from_settings(&settings).unwrap();
+        let client_info = ClientInfo {
+            application: "PythonConnector".to_string(),
+            version: "3.15.0".to_string(),
+            os: "Darwin".to_string(),
+            os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
+            ocsp_mode: Some("FAIL_OPEN".to_string()),
+            crl_config: CrlConfig::default(),
+            tls_config: TlsConfig::default(),
+        };
         let user_agent = snowflake::user_agent(&client_info);
 
         assert!(user_agent.contains("PythonConnector"));
@@ -162,24 +148,15 @@ mod integration_tests {
         assert!(user_agent.contains("Darwin"));
     }
 
-    /// Test that demonstrates how CRL settings would be used in a real connection
     #[test]
-    fn test_connection_string_parsing_with_crl() {
-        let mut settings = MockSettings::new();
-
-        // Simulate parsing connection string parameters
-        settings.set("crl_check_mode", Setting::String("ADVISORY".to_string()));
-        settings.set(
-            "crl_enable_disk_caching",
-            Setting::String("false".to_string()),
-        );
-        settings.set(
-            "crl_allow_certificates_without_crl_url",
-            Setting::String("true".to_string()),
-        );
-        settings.set("crl_http_timeout", Setting::Int(45));
-
-        let crl_config = CrlConfig::from_settings(&settings).unwrap();
+    fn test_crl_config_advisory_mode() {
+        let crl_config = CrlConfig {
+            check_mode: CertRevocationCheckMode::Advisory,
+            enable_disk_caching: false,
+            allow_certificates_without_crl_url: true,
+            http_timeout: chrono::Duration::seconds(45),
+            ..Default::default()
+        };
 
         assert_eq!(crl_config.check_mode, CertRevocationCheckMode::Advisory);
         assert!(!crl_config.enable_disk_caching);

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -22,6 +22,7 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use error_trace::ErrorTrace;
 use snafu::ResultExt;
+use std::future::Future;
 use std::sync::LazyLock;
 use tracing::instrument;
 
@@ -728,90 +729,6 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(
-        name = "DatabaseDriverV1::database_set_option_string",
-        skip(self, input)
-    )]
-    async fn database_set_option_string(
-        &self,
-        input: DatabaseSetOptionStringRequest,
-    ) -> Result<DatabaseSetOptionStringResponse, DriverException> {
-        let db_handle = required(input.db_handle, "Database handle is required")?;
-
-        self.driver
-            .database_set_option(db_handle.into(), input.key, Setting::String(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(DatabaseSetOptionStringResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::database_set_option_bytes",
-        skip(self, input)
-    )]
-    async fn database_set_option_bytes(
-        &self,
-        input: DatabaseSetOptionBytesRequest,
-    ) -> Result<DatabaseSetOptionBytesResponse, DriverException> {
-        let db_handle = required(input.db_handle, "Database handle is required")?;
-
-        self.driver
-            .database_set_option(db_handle.into(), input.key, Setting::Bytes(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(DatabaseSetOptionBytesResponse {})
-    }
-
-    #[instrument(name = "DatabaseDriverV1::database_set_option_int", skip(self, input))]
-    async fn database_set_option_int(
-        &self,
-        input: DatabaseSetOptionIntRequest,
-    ) -> Result<DatabaseSetOptionIntResponse, DriverException> {
-        let db_handle = required(input.db_handle, "Database handle is required")?;
-
-        self.driver
-            .database_set_option(db_handle.into(), input.key, Setting::Int(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(DatabaseSetOptionIntResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::database_set_option_double",
-        skip(self, input)
-    )]
-    async fn database_set_option_double(
-        &self,
-        input: DatabaseSetOptionDoubleRequest,
-    ) -> Result<DatabaseSetOptionDoubleResponse, DriverException> {
-        let db_handle = required(input.db_handle, "Database handle is required")?;
-
-        self.driver
-            .database_set_option(db_handle.into(), input.key, Setting::Double(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(DatabaseSetOptionDoubleResponse {})
-    }
-
-    #[instrument(name = "DatabaseDriverV1::database_set_option_bool", skip(self, input))]
-    async fn database_set_option_bool(
-        &self,
-        input: DatabaseSetOptionBoolRequest,
-    ) -> Result<DatabaseSetOptionBoolResponse, DriverException> {
-        let db_handle = required(input.db_handle, "Database handle is required")?;
-
-        self.driver
-            .database_set_option(db_handle.into(), input.key, Setting::Bool(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(DatabaseSetOptionBoolResponse {})
-    }
-
     #[instrument(name = "DatabaseDriverV1::database_set_options", skip(self, input))]
     async fn database_set_options(
         &self,
@@ -889,96 +806,6 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(ConnectionNewResponse {
             conn_handle: Some(ConnectionHandle::from(handle)),
         })
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::connection_set_option_string",
-        skip(self, input)
-    )]
-    async fn connection_set_option_string(
-        &self,
-        input: ConnectionSetOptionStringRequest,
-    ) -> Result<ConnectionSetOptionStringResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
-
-        self.driver
-            .connection_set_option(conn_handle.into(), input.key, Setting::String(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(ConnectionSetOptionStringResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::connection_set_option_bytes",
-        skip(self, input)
-    )]
-    async fn connection_set_option_bytes(
-        &self,
-        input: ConnectionSetOptionBytesRequest,
-    ) -> Result<ConnectionSetOptionBytesResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
-
-        self.driver
-            .connection_set_option(conn_handle.into(), input.key, Setting::Bytes(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(ConnectionSetOptionBytesResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::connection_set_option_int",
-        skip(self, input)
-    )]
-    async fn connection_set_option_int(
-        &self,
-        input: ConnectionSetOptionIntRequest,
-    ) -> Result<ConnectionSetOptionIntResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
-
-        self.driver
-            .connection_set_option(conn_handle.into(), input.key, Setting::Int(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(ConnectionSetOptionIntResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::connection_set_option_double",
-        skip(self, input)
-    )]
-    async fn connection_set_option_double(
-        &self,
-        input: ConnectionSetOptionDoubleRequest,
-    ) -> Result<ConnectionSetOptionDoubleResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
-
-        self.driver
-            .connection_set_option(conn_handle.into(), input.key, Setting::Double(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(ConnectionSetOptionDoubleResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::connection_set_option_bool",
-        skip(self, input)
-    )]
-    async fn connection_set_option_bool(
-        &self,
-        input: ConnectionSetOptionBoolRequest,
-    ) -> Result<ConnectionSetOptionBoolResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
-
-        self.driver
-            .connection_set_option(conn_handle.into(), input.key, Setting::Bool(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(ConnectionSetOptionBoolResponse {})
     }
 
     #[instrument(name = "DatabaseDriverV1::connection_set_options", skip(self, input))]
@@ -1400,93 +1227,6 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(
-        name = "DatabaseDriverV1::statement_set_option_string",
-        skip(self, input)
-    )]
-    async fn statement_set_option_string(
-        &self,
-        input: StatementSetOptionStringRequest,
-    ) -> Result<StatementSetOptionStringResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        self.driver
-            .statement_set_option(stmt_handle.into(), input.key, Setting::String(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(StatementSetOptionStringResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::statement_set_option_bytes",
-        skip(self, input)
-    )]
-    async fn statement_set_option_bytes(
-        &self,
-        input: StatementSetOptionBytesRequest,
-    ) -> Result<StatementSetOptionBytesResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        self.driver
-            .statement_set_option(stmt_handle.into(), input.key, Setting::Bytes(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(StatementSetOptionBytesResponse {})
-    }
-
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_int", skip(self, input))]
-    async fn statement_set_option_int(
-        &self,
-        input: StatementSetOptionIntRequest,
-    ) -> Result<StatementSetOptionIntResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        self.driver
-            .statement_set_option(stmt_handle.into(), input.key, Setting::Int(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(StatementSetOptionIntResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::statement_set_option_double",
-        skip(self, input)
-    )]
-    async fn statement_set_option_double(
-        &self,
-        input: StatementSetOptionDoubleRequest,
-    ) -> Result<StatementSetOptionDoubleResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        self.driver
-            .statement_set_option(stmt_handle.into(), input.key, Setting::Double(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(StatementSetOptionDoubleResponse {})
-    }
-
-    #[instrument(
-        name = "DatabaseDriverV1::statement_set_option_bool",
-        skip(self, input)
-    )]
-    async fn statement_set_option_bool(
-        &self,
-        input: StatementSetOptionBoolRequest,
-    ) -> Result<StatementSetOptionBoolResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        self.driver
-            .statement_set_option(stmt_handle.into(), input.key, Setting::Bool(input.value))
-            .await
-            .to_protobuf()?;
-
-        Ok(StatementSetOptionBoolResponse {})
-    }
-
     #[instrument(name = "DatabaseDriverV1::statement_set_options", skip(self, input))]
     async fn statement_set_options(
         &self,
@@ -1696,6 +1436,16 @@ static BLOCKING_CLIENT_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::ne
         .expect("Failed to create blocking protobuf client runtime")
 });
 
+type BlockingProtoError = Box<proto_utils::ProtoError<DriverException>>;
+type BlockingProtoResult<T> = Result<T, BlockingProtoError>;
+
+fn block_on_client_call<F, T>(future: F) -> BlockingProtoResult<T>
+where
+    F: Future<Output = Result<T, proto_utils::ProtoError<DriverException>>>,
+{
+    BLOCKING_CLIENT_RUNTIME.block_on(future).map_err(Box::new)
+}
+
 /// Blocking adapters for synchronous Rust test/support code that drives
 /// the in-process protobuf client. Production async paths should call
 /// the generated async client methods directly.
@@ -1704,67 +1454,59 @@ pub trait DatabaseDriverClientBlockingExt {
     fn database_new_blocking(
         &self,
         input: DatabaseNewRequest,
-    ) -> Result<DatabaseNewResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<DatabaseNewResponse>;
     fn database_init_blocking(
         &self,
         input: DatabaseInitRequest,
-    ) -> Result<DatabaseInitResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<DatabaseInitResponse>;
     fn connection_new_blocking(
         &self,
         input: ConnectionNewRequest,
-    ) -> Result<ConnectionNewResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<ConnectionNewResponse>;
     fn connection_init_blocking(
         &self,
         input: ConnectionInitRequest,
-    ) -> Result<ConnectionInitResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<ConnectionInitResponse>;
+    fn connection_set_options_blocking(
+        &self,
+        input: ConnectionSetOptionsRequest,
+    ) -> BlockingProtoResult<ConnectionSetOptionsResponse>;
     fn statement_new_blocking(
         &self,
         input: StatementNewRequest,
-    ) -> Result<StatementNewResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<StatementNewResponse>;
     fn statement_execute_query_blocking(
         &self,
         input: StatementExecuteQueryRequest,
-    ) -> Result<StatementExecuteQueryResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<StatementExecuteQueryResponse>;
     fn statement_set_sql_query_blocking(
         &self,
         input: StatementSetSqlQueryRequest,
-    ) -> Result<StatementSetSqlQueryResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<StatementSetSqlQueryResponse>;
+    fn statement_set_options_blocking(
+        &self,
+        input: StatementSetOptionsRequest,
+    ) -> BlockingProtoResult<StatementSetOptionsResponse>;
     fn statement_release_blocking(
         &self,
         input: StatementReleaseRequest,
-    ) -> Result<StatementReleaseResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<StatementReleaseResponse>;
     fn statement_result_chunks_blocking(
         &self,
         input: StatementResultChunksRequest,
-    ) -> Result<StatementResultChunksResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<StatementResultChunksResponse>;
     fn database_fetch_chunk_blocking(
         &self,
         input: DatabaseFetchChunkRequest,
-    ) -> Result<DatabaseFetchChunkResponse, proto_utils::ProtoError<DriverException>>;
-    fn connection_set_option_string_blocking(
-        &self,
-        input: ConnectionSetOptionStringRequest,
-    ) -> Result<ConnectionSetOptionStringResponse, proto_utils::ProtoError<DriverException>>;
-    fn connection_set_option_int_blocking(
-        &self,
-        input: ConnectionSetOptionIntRequest,
-    ) -> Result<ConnectionSetOptionIntResponse, proto_utils::ProtoError<DriverException>>;
-    fn connection_set_option_bytes_blocking(
-        &self,
-        input: ConnectionSetOptionBytesRequest,
-    ) -> Result<ConnectionSetOptionBytesResponse, proto_utils::ProtoError<DriverException>>;
-    fn statement_set_option_bool_blocking(
-        &self,
-        input: StatementSetOptionBoolRequest,
-    ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<DatabaseFetchChunkResponse>;
     fn connection_release_blocking(
         &self,
         input: ConnectionReleaseRequest,
-    ) -> Result<ConnectionReleaseResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<ConnectionReleaseResponse>;
     fn database_release_blocking(
         &self,
         input: DatabaseReleaseRequest,
-    ) -> Result<DatabaseReleaseResponse, proto_utils::ProtoError<DriverException>>;
+    ) -> BlockingProtoResult<DatabaseReleaseResponse>;
 }
 
 #[allow(clippy::result_large_err)]
@@ -1772,112 +1514,98 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
     fn database_new_blocking(
         &self,
         input: DatabaseNewRequest,
-    ) -> Result<DatabaseNewResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.database_new(input))
+    ) -> BlockingProtoResult<DatabaseNewResponse> {
+        block_on_client_call(self.database_new(input))
     }
 
     fn database_init_blocking(
         &self,
         input: DatabaseInitRequest,
-    ) -> Result<DatabaseInitResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.database_init(input))
+    ) -> BlockingProtoResult<DatabaseInitResponse> {
+        block_on_client_call(self.database_init(input))
     }
 
     fn connection_new_blocking(
         &self,
         input: ConnectionNewRequest,
-    ) -> Result<ConnectionNewResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_new(input))
+    ) -> BlockingProtoResult<ConnectionNewResponse> {
+        block_on_client_call(self.connection_new(input))
     }
 
     fn connection_init_blocking(
         &self,
         input: ConnectionInitRequest,
-    ) -> Result<ConnectionInitResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_init(input))
+    ) -> BlockingProtoResult<ConnectionInitResponse> {
+        block_on_client_call(self.connection_init(input))
+    }
+
+    fn connection_set_options_blocking(
+        &self,
+        input: ConnectionSetOptionsRequest,
+    ) -> BlockingProtoResult<ConnectionSetOptionsResponse> {
+        block_on_client_call(self.connection_set_options(input))
     }
 
     fn statement_new_blocking(
         &self,
         input: StatementNewRequest,
-    ) -> Result<StatementNewResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_new(input))
+    ) -> BlockingProtoResult<StatementNewResponse> {
+        block_on_client_call(self.statement_new(input))
     }
 
     fn statement_execute_query_blocking(
         &self,
         input: StatementExecuteQueryRequest,
-    ) -> Result<StatementExecuteQueryResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_execute_query(input))
+    ) -> BlockingProtoResult<StatementExecuteQueryResponse> {
+        block_on_client_call(self.statement_execute_query(input))
     }
 
     fn statement_set_sql_query_blocking(
         &self,
         input: StatementSetSqlQueryRequest,
-    ) -> Result<StatementSetSqlQueryResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_set_sql_query(input))
+    ) -> BlockingProtoResult<StatementSetSqlQueryResponse> {
+        block_on_client_call(self.statement_set_sql_query(input))
+    }
+
+    fn statement_set_options_blocking(
+        &self,
+        input: StatementSetOptionsRequest,
+    ) -> BlockingProtoResult<StatementSetOptionsResponse> {
+        block_on_client_call(self.statement_set_options(input))
     }
 
     fn statement_release_blocking(
         &self,
         input: StatementReleaseRequest,
-    ) -> Result<StatementReleaseResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_release(input))
+    ) -> BlockingProtoResult<StatementReleaseResponse> {
+        block_on_client_call(self.statement_release(input))
     }
 
     fn statement_result_chunks_blocking(
         &self,
         input: StatementResultChunksRequest,
-    ) -> Result<StatementResultChunksResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_result_chunks(input))
+    ) -> BlockingProtoResult<StatementResultChunksResponse> {
+        block_on_client_call(self.statement_result_chunks(input))
     }
 
     fn database_fetch_chunk_blocking(
         &self,
         input: DatabaseFetchChunkRequest,
-    ) -> Result<DatabaseFetchChunkResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.database_fetch_chunk(input))
-    }
-
-    fn connection_set_option_string_blocking(
-        &self,
-        input: ConnectionSetOptionStringRequest,
-    ) -> Result<ConnectionSetOptionStringResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_string(input))
-    }
-
-    fn connection_set_option_int_blocking(
-        &self,
-        input: ConnectionSetOptionIntRequest,
-    ) -> Result<ConnectionSetOptionIntResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_int(input))
-    }
-
-    fn connection_set_option_bytes_blocking(
-        &self,
-        input: ConnectionSetOptionBytesRequest,
-    ) -> Result<ConnectionSetOptionBytesResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_set_option_bytes(input))
-    }
-
-    fn statement_set_option_bool_blocking(
-        &self,
-        input: StatementSetOptionBoolRequest,
-    ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_set_option_bool(input))
+    ) -> BlockingProtoResult<DatabaseFetchChunkResponse> {
+        block_on_client_call(self.database_fetch_chunk(input))
     }
 
     fn connection_release_blocking(
         &self,
         input: ConnectionReleaseRequest,
-    ) -> Result<ConnectionReleaseResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_release(input))
+    ) -> BlockingProtoResult<ConnectionReleaseResponse> {
+        block_on_client_call(self.connection_release(input))
     }
 
     fn database_release_blocking(
         &self,
         input: DatabaseReleaseRequest,
-    ) -> Result<DatabaseReleaseResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.database_release(input))
+    ) -> BlockingProtoResult<DatabaseReleaseResponse> {
+        block_on_client_call(self.database_release(input))
     }
 }

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -1,5 +1,5 @@
+use super::{ClientInfo, QueryParameters};
 use crate::chunks::ChunkDownloadData;
-use crate::config::rest_parameters::{ClientInfo, QueryParameters};
 use crate::config::retry::{BackoffConfig, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::error::SfError;

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -1,4 +1,5 @@
 use proto_utils::ProtoError;
+use sf_core::config::param_names;
 use sf_core::protobuf::apis::database_driver_v1::{
     DatabaseDriverClient, DatabaseDriverClientBlockingExt, database_driver_client,
 };
@@ -282,8 +283,10 @@ impl SnowflakeTestClient {
                 let proto_result = response.result.unwrap();
                 Ok(proto_result)
             }
-            Err(ProtoError::Application(e)) => Err(format!("Failed to execute query: {e:?}")),
-            Err(ProtoError::Transport(e)) => Err(format!("Transport error: {e:?}")),
+            Err(e) => match e.as_ref() {
+                ProtoError::Application(e) => Err(format!("Failed to execute query: {e:?}")),
+                ProtoError::Transport(e) => Err(format!("Transport error: {e:?}")),
+            },
         }
     }
 
@@ -304,41 +307,43 @@ impl SnowflakeTestClient {
     }
 
     pub fn set_connection_option(&self, option_name: &str, option_value: &str) {
-        self.client
-            .connection_set_option_string_blocking(ConnectionSetOptionStringRequest {
-                conn_handle: Some(self.conn_handle),
-                key: option_name.to_string(),
-                value: option_value.to_string(),
-            })
-            .unwrap();
+        self.set_connection_config_setting(option_name, option_value.to_string().into());
     }
 
     pub fn set_connection_option_int(&self, option_name: &str, option_value: i64) {
-        self.client
-            .connection_set_option_int_blocking(ConnectionSetOptionIntRequest {
-                conn_handle: Some(self.conn_handle),
-                key: option_name.to_string(),
-                value: option_value,
-            })
-            .unwrap();
+        self.set_connection_config_setting(option_name, option_value.into());
     }
 
     pub fn set_connection_option_bytes(&self, option_name: &str, option_value: &[u8]) {
         self.client
-            .connection_set_option_bytes_blocking(ConnectionSetOptionBytesRequest {
+            .connection_set_options_blocking(ConnectionSetOptionsRequest {
                 conn_handle: Some(self.conn_handle),
-                key: option_name.to_string(),
-                value: option_value.to_vec(),
+                options: [(option_name.to_string(), option_value.to_vec().into())]
+                    .into_iter()
+                    .collect(),
             })
             .unwrap();
     }
 
     pub fn set_statement_async_execution(&self, stmt: &StatementHandle, enabled: bool) {
         self.client
-            .statement_set_option_bool_blocking(StatementSetOptionBoolRequest {
+            .statement_set_options_blocking(StatementSetOptionsRequest {
                 stmt_handle: Some(*stmt),
-                key: "async_execution".to_string(),
-                value: enabled,
+                options: [(
+                    param_names::ASYNC_EXECUTION.as_str().to_string(),
+                    ConfigSetting::from(enabled),
+                )]
+                .into_iter()
+                .collect(),
+            })
+            .unwrap();
+    }
+
+    fn set_connection_config_setting(&self, key: &str, setting: ConfigSetting) {
+        self.client
+            .connection_set_options_blocking(ConnectionSetOptionsRequest {
+                conn_handle: Some(self.conn_handle),
+                options: [(key.to_string(), setting)].into_iter().collect(),
             })
             .unwrap();
     }

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -2,53 +2,48 @@
 
 type Result<T> = std::result::Result<T, String>;
 use arrow_array::StringArray;
-use sf_core::protobuf::apis::RustTransport;
-use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
+use sf_core::config::param_names;
+use sf_core::protobuf::apis::database_driver_v1::{
+    DatabaseDriverClient as BlockingDatabaseDriver, DatabaseDriverClientBlockingExt,
+    database_driver_client,
+};
 use sf_core::protobuf::generated::database_driver_v1::*;
-use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 use std::fs;
 
 use crate::types::TestConnectionParams;
 
-pub type DatabaseDriver = DatabaseDriverClient;
+pub type DatabaseDriver = BlockingDatabaseDriver;
 
 pub struct DriverRuntime {
-    runtime: tokio::runtime::Runtime,
     client: DatabaseDriver,
 }
 
 impl DriverRuntime {
     pub fn new() -> Self {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_all()
-            .build()
-            .expect("Failed to create tokio runtime");
-        let client = DatabaseDriver::new(RustTransport::new());
-        Self { runtime, client }
+        let client = database_driver_client();
+        Self { client }
     }
 
-    pub fn block_on<T>(&self, f: impl AsyncFnOnce(&DatabaseDriver) -> T) -> T {
-        self.runtime.block_on(f(&self.client))
+    pub fn client(&self) -> &DatabaseDriver {
+        &self.client
     }
 }
 
 pub fn create_database(rt: &DriverRuntime) -> Result<DatabaseHandle> {
     let db_response = rt
-        .block_on(async |c| c.database_new(DatabaseNewRequest {}).await)
+        .client
+        .database_new_blocking(DatabaseNewRequest {})
         .map_err(|e| format!("Database creation failed: {:?}", e))?;
 
     let db_handle = db_response
         .db_handle
         .ok_or_else(|| "Database creation failed: No handle returned".to_string())?;
 
-    rt.block_on(async |c| {
-        c.database_init(DatabaseInitRequest {
+    rt.client
+        .database_init_blocking(DatabaseInitRequest {
             db_handle: Some(db_handle),
         })
-        .await
-    })
-    .map_err(|e| format!("Database initialization failed: {:?}", e))?;
+        .map_err(|e| format!("Database initialization failed: {:?}", e))?;
 
     Ok(db_handle)
 }
@@ -59,18 +54,22 @@ pub fn create_connection(
     params: &TestConnectionParams,
 ) -> Result<ConnectionHandle> {
     let conn_response = rt
-        .block_on(async |c| c.connection_new(ConnectionNewRequest {}).await)
+        .client
+        .connection_new_blocking(ConnectionNewRequest {})
         .map_err(|e| format!("Connection creation failed: {:?}", e))?;
 
     let conn_handle = conn_response
         .conn_handle
         .ok_or_else(|| "Connection creation failed: No handle returned".to_string())?;
 
+    // Set connection parameters
     set_connection_option(rt, &conn_handle, "account", &params.account)?;
     set_connection_option(rt, &conn_handle, "user", &params.user)?;
 
+    // Use JWT key-pair authentication
     set_connection_option(rt, &conn_handle, "authenticator", "SNOWFLAKE_JWT")?;
 
+    // First check if a private key file path is provided, otherwise create from contents
     let private_key_file = if let Some(ref key_file_path) = params.private_key_file {
         key_file_path.clone()
     } else if let Some(ref key_contents) = params.private_key_contents {
@@ -92,14 +91,13 @@ pub fn create_connection(
 
     set_tls_options(rt, &conn_handle, params)?;
 
-    rt.block_on(async |c| {
-        c.connection_init(ConnectionInitRequest {
+    // Initialize connection (performs login)
+    rt.client
+        .connection_init_blocking(ConnectionInitRequest {
             conn_handle: Some(conn_handle),
             db_handle: Some(db_handle),
         })
-        .await
-    })
-    .map_err(|e| format!("Connection initialization failed: {:?}", e))?;
+        .map_err(|e| format!("Connection initialization failed: {:?}", e))?;
 
     Ok(conn_handle)
 }
@@ -111,11 +109,9 @@ pub fn create_statement(
     async_override: Option<bool>,
 ) -> Result<StatementHandle> {
     let stmt_response = rt
-        .block_on(async |c| {
-            c.statement_new(StatementNewRequest {
-                conn_handle: Some(conn_handle),
-            })
-            .await
+        .client
+        .statement_new_blocking(StatementNewRequest {
+            conn_handle: Some(conn_handle),
         })
         .map_err(|e| format!("Statement creation failed: {:?}", e))?;
 
@@ -123,68 +119,56 @@ pub fn create_statement(
         .stmt_handle
         .ok_or_else(|| "Statement creation failed: No handle returned".to_string())?;
 
-    rt.block_on(async |c| {
-        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+    rt.client
+        .statement_set_sql_query_blocking(StatementSetSqlQueryRequest {
             stmt_handle: Some(stmt_handle),
             query: sql.to_string(),
         })
-        .await
-    })
-    .map_err(|e| format!("Statement SQL query set failed: {:?}", e))?;
+        .map_err(|e| format!("Statement SQL query set failed: {:?}", e))?;
 
     if let Some(enabled) = async_override {
-        let value = if enabled { "true" } else { "false" }.to_string();
-        rt.block_on(async |c| {
-            c.statement_set_option_string(StatementSetOptionStringRequest {
+        let options = [(
+            param_names::ASYNC_EXECUTION.as_str().to_string(),
+            ConfigSetting::from(enabled),
+        )]
+        .into_iter()
+        .collect();
+        rt.client
+            .statement_set_options_blocking(StatementSetOptionsRequest {
                 stmt_handle: Some(stmt_handle),
-                key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
-                value,
+                options,
             })
-            .await
-        })
-        .map_err(|e| format!("Statement option set failed: {:?}", e))?;
+            .map_err(|e| format!("Statement option set failed: {:?}", e))?;
     }
 
     Ok(stmt_handle)
 }
 
-pub fn reset_statement_query(
-    rt: &DriverRuntime,
-    stmt_handle: StatementHandle,
-    sql: &str,
-) -> Result<()> {
-    rt.block_on(async |c| {
-        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+pub fn reset_statement_query(rt: &DriverRuntime, stmt_handle: StatementHandle, sql: &str) -> Result<()> {
+    rt.client
+        .statement_set_sql_query_blocking(StatementSetSqlQueryRequest {
             stmt_handle: Some(stmt_handle),
             query: sql.to_string(),
         })
-        .await
-    })
-    .map_err(|e| format!("Statement query reset failed: {:?}", e))?;
+        .map_err(|e| format!("Statement query reset failed: {:?}", e))?;
     Ok(())
 }
 
 pub fn get_server_version(rt: &DriverRuntime, conn_handle: ConnectionHandle) -> Result<String> {
     use crate::arrow::create_arrow_reader;
 
-    let version_stmt =
-        create_statement(rt, conn_handle, "SELECT CURRENT_VERSION() AS VERSION", None)?;
-
+    let version_stmt = create_statement(rt, conn_handle, "SELECT CURRENT_VERSION() AS VERSION", None)?;
     let response = rt
-        .block_on(async |c| {
-            c.statement_execute_query(StatementExecuteQueryRequest {
-                stmt_handle: Some(version_stmt),
-                bindings: None,
-            })
-            .await
+        .client
+        .statement_execute_query_blocking(StatementExecuteQueryRequest {
+            stmt_handle: Some(version_stmt),
+            bindings: None,
         })
         .map_err(|e| format!("Query execution failed: {:?}", e))?;
 
     let result = response
         .result
         .ok_or_else(|| "No result in execute response".to_string())?;
-
-    // Arrow iteration happens outside the runtime
     let mut reader = create_arrow_reader(result)?;
 
     if let Some(batch_result) = reader.next() {
@@ -194,26 +178,22 @@ pub fn get_server_version(rt: &DriverRuntime, conn_handle: ConnectionHandle) -> 
             if batch.num_rows() > 0 {
                 let version = column.value(0).to_string();
 
-                rt.block_on(async |c| {
-                    c.statement_release(StatementReleaseRequest {
+                rt.client
+                    .statement_release_blocking(StatementReleaseRequest {
                         stmt_handle: Some(version_stmt),
                     })
-                    .await
-                })
-                .ok();
+                    .ok();
 
                 return Ok(version);
             }
         }
     }
 
-    rt.block_on(async |c| {
-        c.statement_release(StatementReleaseRequest {
+    rt.client
+        .statement_release_blocking(StatementReleaseRequest {
             stmt_handle: Some(version_stmt),
         })
-        .await
-    })
-    .ok();
+        .ok();
 
     Err(format!("Could not extract version from result"))
 }
@@ -238,22 +218,18 @@ pub fn execute_setup_queries(
         let stmt_handle = create_statement(rt, conn_handle, query, None)
             .map_err(|e| format!("Setup query statement creation failed: {:?}", e))?;
 
-        rt.block_on(async |c| {
-            c.statement_execute_query(StatementExecuteQueryRequest {
+        rt.client
+            .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(stmt_handle),
                 bindings: None,
             })
-            .await
-        })
-        .map_err(|e| format!("Setup query execution failed: {:?}", e))?;
+            .map_err(|e| format!("Setup query execution failed: {:?}", e))?;
 
-        rt.block_on(async |c| {
-            c.statement_release(StatementReleaseRequest {
+        rt.client
+            .statement_release_blocking(StatementReleaseRequest {
                 stmt_handle: Some(stmt_handle),
             })
-            .await
-        })
-        .ok();
+            .ok();
     }
 
     println!("✓ Setup queries completed");
@@ -266,15 +242,15 @@ fn set_connection_option(
     key: &str,
     value: &str,
 ) -> Result<()> {
-    rt.block_on(async |c| {
-        c.connection_set_option_string(ConnectionSetOptionStringRequest {
+    let options = [(key.to_string(), ConfigSetting::from(value))]
+        .into_iter()
+        .collect();
+    rt.client
+        .connection_set_options_blocking(ConnectionSetOptionsRequest {
             conn_handle: Some(*conn_handle),
-            key: key.to_string(),
-            value: value.to_string(),
+            options,
         })
-        .await
-    })
-    .map_err(|e| format!("Connection option set failed ({}): {:?}", key, e))?;
+        .map_err(|e| format!("Connection option set failed ({}): {:?}", key, e))?;
     Ok(())
 }
 

--- a/tests/performance/drivers/core/app/src/main.rs
+++ b/tests/performance/drivers/core/app/src/main.rs
@@ -13,6 +13,7 @@ mod types;
 use test_types::TestType;
 
 type Result<T> = std::result::Result<T, String>;
+use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClientBlockingExt;
 use sf_core::protobuf::generated::database_driver_v1::*;
 
 use config::TestConfig;
@@ -79,21 +80,17 @@ fn run() -> Result<()> {
     }
 
     // Cleanup
-    rt.block_on(async |c| {
-        c.statement_release(StatementReleaseRequest {
+    rt.client()
+        .statement_release_blocking(StatementReleaseRequest {
             stmt_handle: Some(stmt_handle),
         })
-        .await
-    })
-    .ok();
+        .ok();
 
-    rt.block_on(async |c| {
-        c.connection_release(ConnectionReleaseRequest {
+    rt.client()
+        .connection_release_blocking(ConnectionReleaseRequest {
             conn_handle: Some(conn_handle),
         })
-        .await
-    })
-    .ok();
+        .ok();
 
     Ok(())
 }

--- a/tests/performance/drivers/core/app/src/put_execution.rs
+++ b/tests/performance/drivers/core/app/src/put_execution.rs
@@ -2,6 +2,7 @@
 
 type Result<T> = std::result::Result<T, String>;
 use regex::Regex;
+use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClientBlockingExt;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use std::fs;
 use std::path::Path;
@@ -122,14 +123,12 @@ fn execute_put_get_iteration(
 
     let cpu_before = process_cpu_seconds();
     let start_query = Instant::now();
-    rt.block_on(async |c| {
-        c.statement_execute_query(StatementExecuteQueryRequest {
+    rt.client()
+        .statement_execute_query_blocking(StatementExecuteQueryRequest {
             stmt_handle: Some(stmt_handle),
             bindings: None,
         })
-        .await
-    })
-    .map_err(|e| format!("PUT/GET execution failed: {e:?}"))?;
+        .map_err(|e| format!("PUT/GET execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();
     let cpu_time_s = process_cpu_seconds() - cpu_before;
     let peak_rss_mb = get_peak_rss_mb();

--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -1,6 +1,7 @@
 //! Query execution and performance measurement helpers
 
 type Result<T> = std::result::Result<T, String>;
+use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClientBlockingExt;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use std::time::{Duration, Instant};
 
@@ -162,13 +163,11 @@ fn execute_iteration(rt: &DriverRuntime, stmt_handle: StatementHandle) -> Result
 
     let start_query = Instant::now();
     let response = rt
-        .block_on(async |c| {
-            c.statement_execute_query(StatementExecuteQueryRequest {
+        .client()
+        .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(stmt_handle),
                 bindings: None,
             })
-            .await
-        })
         .map_err(|e| format!("Query execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();
 


### PR DESCRIPTION
With all wrappers migrated to batched `SetOptions`, the old single-key
setter RPCs and the compatibility plumbing built around them are now dead
weight. This change removes the per-type setter RPCs and their request /
response message types from the proto definition, deletes the single-key
setter implementations in the database, connection, and statement APIs,
and drops the transitional `rest_parameters` module and related helper
traits that duplicated config construction outside `ConnectionConfig`.

`ClientInfo` and `QueryParameters` move into `rest::snowflake`, auth and
query code consume `ConnectionConfig` and `ClientInfo` directly, and the
remaining tests are updated to go through the batched config path or
construct typed config data explicitly. The stack ends with one config
pipeline from FFI inputs to login and query execution instead of a mix of
new and legacy surfaces.