### PR TITLE
SNOW-3022768: Implement SQLFreeStmt with proper state transitions

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -48,6 +48,7 @@ enum RowStatus {
 fn next_non_empty_batch(
     mut reader: ArrowArrayStreamReader,
     rows_affected: Option<i64>,
+    prepared: bool,
 ) -> Result<(StatementState, ()), (StatementState, crate::api::OdbcError)> {
     loop {
         match reader.next() {
@@ -64,6 +65,7 @@ fn next_non_empty_batch(
                         record_batch,
                         batch_idx: 0,
                         rows_affected,
+                        prepared,
                     },
                     (),
                 ));
@@ -72,7 +74,7 @@ fn next_non_empty_batch(
                 let schema = reader.schema();
                 break NoMoreDataSnafu
                     .fail()
-                    .with_state(StatementState::Done { schema });
+                    .with_state(StatementState::Done { schema, prepared });
             }
         }
     }
@@ -83,18 +85,20 @@ fn next_non_empty_batch(
 #[allow(clippy::result_large_err)]
 fn advance_cursor(state: &mut crate::api::State<StatementState>) -> OdbcResult<()> {
     state.transition_or_err(|s| match s {
-        StatementState::NoResultSet { schema } => InvalidCursorStateSnafu
+        StatementState::NoResultSet { schema, prepared } => InvalidCursorStateSnafu
             .fail()
-            .with_state(StatementState::NoResultSet { schema }),
+            .with_state(StatementState::NoResultSet { schema, prepared }),
         StatementState::Executed {
             reader,
             rows_affected,
-        } => next_non_empty_batch(reader, rows_affected),
+            prepared,
+        } => next_non_empty_batch(reader, rows_affected, prepared),
         StatementState::Fetching {
             reader,
             record_batch,
             batch_idx,
             rows_affected,
+            prepared,
         } => {
             let new_idx = batch_idx + 1;
             if new_idx < record_batch.num_rows() {
@@ -104,11 +108,12 @@ fn advance_cursor(state: &mut crate::api::State<StatementState>) -> OdbcResult<(
                         record_batch,
                         batch_idx: new_idx,
                         rows_affected,
+                        prepared,
                     },
                     (),
                 ))
             } else {
-                next_non_empty_batch(reader, rows_affected)
+                next_non_empty_batch(reader, rows_affected, prepared)
             }
         }
         state @ StatementState::Error => StatementErrorStateSnafu.fail().with_state(state),

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -306,6 +306,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("Invalid FreeStmt option: {option}"))]
+    InvalidFreeStmtOption {
+        option: u16,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("ODBC runtime error"))]
     OdbcRuntime {
         source: crate::api::runtime::OdbcRuntimeError,
@@ -473,6 +480,7 @@ impl OdbcError {
             OdbcError::ProtoRequiredFieldMissing { .. } => SqlState::GeneralError,
             OdbcError::ArrowArrayStreamReaderCreation { .. } => SqlState::GeneralError,
             OdbcError::StatementErrorState { .. } => SqlState::GeneralError,
+            OdbcError::InvalidFreeStmtOption { .. } => SqlState::InvalidAttributeOptionIdentifier,
             OdbcError::OdbcRuntime { .. } => SqlState::FunctionSequenceError,
         }
     }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -6,7 +6,8 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::{
-    ConnectionState, OdbcResult, ParameterBinding, Statement, StatementState, stmt_from_handle,
+    ConnectionState, FreeStmtOption, OdbcResult, ParameterBinding, Statement, StatementState,
+    stmt_from_handle,
 };
 use crate::cdata_types::CDataType;
 use crate::conversion::Binding;
@@ -62,7 +63,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             let response = response?;
 
             update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings)?;
-            set_state(stmt, create_execute_state(response)?);
+            set_state(stmt, create_execute_state(response, false)?);
             Ok(())
         }
         ConnectionState::Disconnected => {
@@ -201,6 +202,12 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         return InvalidCursorStateSnafu.fail();
     }
 
+    let prepared = match stmt.state.as_ref() {
+        StatementState::Prepared { .. } => true,
+        StatementState::NoResultSet { prepared, .. } => *prepared,
+        _ => false,
+    };
+
     match &mut stmt.conn.state {
         ConnectionState::Connected {
             db_handle: _,
@@ -222,16 +229,20 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             let statement_type_id = response.result.as_ref().and_then(|r| r.statement_type_id);
             let rows_affected = response.result.as_ref().and_then(|r| r.rows_affected);
 
-            let execute_state = create_execute_state(response)?;
+            let execute_state = create_execute_state(response, prepared)?;
 
             if is_dml_statement_type(statement_type_id) && Some(0) == rows_affected {
-                let StatementState::Executed { reader, .. } = &execute_state else {
+                let StatementState::Executed {
+                    reader, prepared, ..
+                } = &execute_state
+                else {
                     unreachable!("DML always produces Executed state");
                 };
                 set_state(
                     stmt,
                     StatementState::NoResultSet {
                         schema: reader.schema(),
+                        prepared: *prepared,
                     },
                 );
                 return NoMoreDataSnafu.fail();
@@ -278,7 +289,10 @@ fn set_state(stmt: &mut Statement, state: StatementState) {
     stmt.state = state.into();
 }
 
-fn create_execute_state(response: StatementExecuteQueryResponse) -> OdbcResult<StatementState> {
+fn create_execute_state(
+    response: StatementExecuteQueryResponse,
+    prepared: bool,
+) -> OdbcResult<StatementState> {
     tracing::debug!("create_execute_state: response={:?}", response);
     let result = response.result.required("Execute result is required")?;
     let stream = result.stream.required("Stream is required")?;
@@ -289,11 +303,13 @@ fn create_execute_state(response: StatementExecuteQueryResponse) -> OdbcResult<S
     {
         return Ok(StatementState::NoResultSet {
             schema: reader.schema(),
+            prepared,
         });
     }
     Ok(StatementState::Executed {
         reader,
         rows_affected,
+        prepared,
     })
 }
 
@@ -381,23 +397,63 @@ pub fn bind_parameter(
 }
 
 /// Free statement resources based on the option
-pub fn free_stmt(statement_handle: sql::Handle, option: sql::FreeStmtOption) -> OdbcResult<()> {
+pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcResult<()> {
     tracing::debug!("free_stmt: statement_handle={statement_handle:?}, option={option:?}");
 
+    if statement_handle.is_null() {
+        return InvalidHandleSnafu.fail();
+    }
     let stmt = stmt_from_handle(statement_handle);
 
     match option {
-        sql::FreeStmtOption::Close => {
+        FreeStmtOption::Close => {
             tracing::info!("free_stmt: Closing cursor");
-            stmt.state = StatementState::Created.into();
-            stmt.get_data_state = None;
-            stmt.used_extended_fetch = false;
+            let transition = match stmt.state.as_ref() {
+                StatementState::Created | StatementState::Prepared { .. } => None,
+                StatementState::Executed {
+                    reader,
+                    prepared: true,
+                    ..
+                }
+                | StatementState::Fetching {
+                    reader,
+                    prepared: true,
+                    ..
+                } => {
+                    let schema = reader.schema();
+                    let desc_count = schema.fields().len() as sql::SmallInt;
+                    Some((StatementState::Prepared { schema }, desc_count))
+                }
+                StatementState::NoResultSet {
+                    schema,
+                    prepared: true,
+                }
+                | StatementState::Done {
+                    schema,
+                    prepared: true,
+                } => {
+                    let desc_count = schema.fields().len() as sql::SmallInt;
+                    Some((
+                        StatementState::Prepared {
+                            schema: schema.clone(),
+                        },
+                        desc_count,
+                    ))
+                }
+                _ => Some((StatementState::Created, 0)),
+            };
+            if let Some((state, desc_count)) = transition {
+                stmt.state.set(state);
+                stmt.ird.desc_count = desc_count;
+                stmt.get_data_state = None;
+                stmt.used_extended_fetch = false;
+            }
         }
-        sql::FreeStmtOption::Unbind => {
+        FreeStmtOption::Unbind => {
             tracing::info!("free_stmt: Unbinding all columns");
             stmt.ard.unbind_all();
         }
-        sql::FreeStmtOption::ResetParams => {
+        FreeStmtOption::ResetParams => {
             tracing::info!("free_stmt: Resetting all parameters");
             stmt.parameter_bindings.clear();
         }

--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -324,6 +324,33 @@ impl TryFrom<u8> for DescriptorKind {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum FreeStmtOption {
+    Close,
+    Unbind,
+    ResetParams,
+}
+
+impl TryFrom<u16> for FreeStmtOption {
+    type Error = OdbcError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(FreeStmtOption::Close),
+            2 => Ok(FreeStmtOption::Unbind),
+            3 => Ok(FreeStmtOption::ResetParams),
+            _ => {
+                tracing::warn!("Invalid FreeStmt option: {value}");
+                Err(OdbcError::InvalidFreeStmtOption {
+                    option: value,
+                    location: snafu::location!(),
+                })
+            }
+        }
+    }
+}
+
 /// Application Row Descriptor (ARD).
 ///
 /// Stores column binding information and block-cursor header fields.
@@ -531,19 +558,25 @@ pub enum StatementState {
     Executed {
         reader: ArrowArrayStreamReader,
         rows_affected: Option<i64>,
+        /// `true` when originating from `SQLPrepare`+`SQLExecute`, `false`
+        /// from `SQLExecDirect`. Used by `SQLFreeStmt(SQL_CLOSE)` to decide
+        /// whether to transition back to `Prepared` or `Created`.
+        prepared: bool,
     },
     NoResultSet {
         schema: SchemaRef,
+        prepared: bool,
     },
     Fetching {
         reader: ArrowArrayStreamReader,
         record_batch: RecordBatch,
         batch_idx: usize,
         rows_affected: Option<i64>,
+        prepared: bool,
     },
     Done {
-        #[allow(dead_code)]
         schema: SchemaRef,
+        prepared: bool,
     },
     Error,
 }
@@ -561,10 +594,12 @@ impl<T> State<T> {
         }
     }
 
-    /// # Safety
-    /// This function assumes that the state is not None, make sure to call set after taking.
+    /// Invariant: `current_state` is always `Some` between public API calls.
+    /// Every caller must call `set` before returning to restore the invariant.
     fn take(&mut self) -> T {
-        self.current_state.take().unwrap()
+        self.current_state.take().expect(
+            "State::take called on an empty state — set() was not called after a previous take()",
+        )
     }
 
     pub fn set(&mut self, state: T) {

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -86,9 +86,16 @@ pub unsafe extern "C" fn SQLFreeHandle(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFreeStmt(
     statement_handle: sql::Handle,
-    option: sql::FreeStmtOption,
+    option: sql::USmallInt,
 ) -> sql::RetCode {
-    api::statement::free_stmt(statement_handle, option).to_sql_code()
+    if statement_handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::FreeStmtOption::try_from(option)
+        .and_then(|opt| api::statement::free_stmt(statement_handle, opt));
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
 }
 
 /// # Safety

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -193,3 +193,34 @@ behavior_differences:
       NEW driver: Returns the values in proper scientific notation (e.g. "1.2e200").
       Impact: Applications that parse the DECFLOAT values will now receive values in properly formatted scientific notation.
       TODO: To be fixed in old driver (SNOW-3229401)
+
+  24:
+    name: "SQLNumResultCols returns 0 after SQL_CLOSE on prepared statement"
+    description: |
+      OLD driver: After Prepare -> Execute -> SQL_CLOSE, SQLNumResultCols returns 0.
+      The old driver does not preserve prepared statement metadata across SQL_CLOSE.
+      NEW driver: Returns the correct column count (e.g. 3 for "SELECT 1, 2, 3")
+      because SQL_CLOSE transitions the statement back to the Prepared state (S2/S3)
+      where column metadata is available, per the ODBC specification.
+      Spec reference: ODBC Statement Transitions table, SQLFreeStmt row
+      (https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/statement-transitions#sqlfreestmt)
+      states that SQL_CLOSE from S4-S7 with [p] (prepared) transitions to S2/S3.
+      SQLNumResultCols is defined to succeed in states S2-S12.
+      Impact: Applications that rely on SQLNumResultCols after SQL_CLOSE on a
+      prepared statement will now receive the correct count.
+
+  25:
+    name: "SQLDescribeCol fails after SQL_CLOSE on prepared statement"
+    description: |
+      OLD driver: After Prepare -> Execute -> SQL_CLOSE, SQLDescribeCol returns
+      SQL_ERROR. The old driver does not preserve prepared statement metadata
+      across SQL_CLOSE.
+      NEW driver: Returns SQL_SUCCESS with correct column name and type because
+      SQL_CLOSE transitions the statement back to the Prepared state (S2/S3)
+      where column metadata is available, per the ODBC specification.
+      Spec reference: ODBC Statement Transitions table, SQLFreeStmt row
+      (https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/statement-transitions#sqlfreestmt)
+      states that SQL_CLOSE from S4-S7 with [p] (prepared) transitions to S2/S3.
+      SQLDescribeCol is defined to succeed in states S2-S12 (prepared or executed).
+      Impact: Applications that call SQLDescribeCol after SQL_CLOSE on a prepared
+      statement will now receive valid metadata instead of an error.

--- a/odbc_tests/common/include/SessionParameterOverride.hpp
+++ b/odbc_tests/common/include/SessionParameterOverride.hpp
@@ -1,0 +1,54 @@
+#ifndef SESSION_PARAMETER_OVERRIDE_HPP
+#define SESSION_PARAMETER_OVERRIDE_HPP
+
+#include <sql.h>
+
+#include <string>
+
+#include "odbc_cast.hpp"
+
+// RAII guard that sets a Snowflake session parameter on construction and
+// unsets it on destruction, guaranteeing cleanup even when the test exits
+// early (e.g. via SKIP or an unexpected failure).
+//
+// The caller must supply a statement handle that remains valid for the
+// lifetime of this object. The handle's cursor is closed after each
+// ALTER SESSION so it stays usable for subsequent statements.
+class SessionParameterOverride {
+ public:
+  SessionParameterOverride(SQLHSTMT stmt, const std::string& param_name, const std::string& param_value)
+      : stmt_(stmt), param_name_(param_name) {
+    const std::string sql = "ALTER SESSION SET " + param_name_ + " = " + param_value;
+    SQLRETURN ret = SQLExecDirect(stmt_, sqlchar(sql.c_str()), SQL_NTS);
+    if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) {
+      active_ = false;
+      return;
+    }
+    active_ = true;
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+  }
+
+  ~SessionParameterOverride() {
+    if (!active_) {
+      return;
+    }
+    const std::string sql = "ALTER SESSION UNSET " + param_name_;
+    SQLExecDirect(stmt_, sqlchar(sql.c_str()), SQL_NTS);
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+  }
+
+  [[nodiscard]] bool is_active() const { return active_; }
+
+  // Non-copyable, non-movable
+  SessionParameterOverride(const SessionParameterOverride&) = delete;
+  SessionParameterOverride& operator=(const SessionParameterOverride&) = delete;
+  SessionParameterOverride(SessionParameterOverride&&) = delete;
+  SessionParameterOverride& operator=(SessionParameterOverride&&) = delete;
+
+ private:
+  SQLHSTMT stmt_;
+  std::string param_name_;
+  bool active_ = false;
+};
+
+#endif  // SESSION_PARAMETER_OVERRIDE_HPP

--- a/odbc_tests/tests/odbc-api/terminating_statement/free_stmt_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/free_stmt_tests.cpp
@@ -6,8 +6,7 @@
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "compatibility.hpp"
-#include "get_diag_rec.hpp"
+#include "SessionParameterOverride.hpp"
 #include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
@@ -18,8 +17,6 @@
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE and re-execute",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -33,14 +30,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE and re-execute",
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE without open cursor",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   // Unlike SQLCloseCursor, SQL_CLOSE does not error when no cursor is open.
   SQLRETURN ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
   REQUIRE(ret == SQL_SUCCESS);
@@ -52,14 +48,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE without open cur
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE preserves prepared statement",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -76,14 +71,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE preserves prepar
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: Fetch after SQL_CLOSE",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -100,8 +94,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: Fetch after SQL_CLOSE",
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND unbinds all columns",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLINTEGER col_val = 0;
   SQLLEN indicator = 0;
   SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &col_val, 0, &indicator);
@@ -127,8 +119,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND unbinds all col
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND without bindings",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLFreeStmt(stmt_handle(), SQL_UNBIND);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -139,14 +129,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND without binding
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND preserves prepared statement",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -160,7 +149,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND preserves prepa
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
@@ -170,8 +160,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND preserves prepa
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS resets bound parameters",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -189,8 +177,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS resets bo
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS without parameters",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -201,14 +187,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS without p
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS preserves prepared statement",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -222,8 +207,680 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS preserves
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE on prepared-but-not-executed",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE preserves column bindings",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLINTEGER col_val = 0;
+  SQLLEN indicator = 0;
+  SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &col_val, 0, &indicator);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 10"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  REQUIRE(col_val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE preserves parameter bindings",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param = 42;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE called multiple times",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE after DML",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE test_freestmt_dml (id INTEGER)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("INSERT INTO test_freestmt_dml VALUES (1)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT id FROM test_freestmt_dml"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 1);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("DROP TABLE IF EXISTS test_freestmt_dml"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQLNumResultCols after SQL_CLOSE on prepared statement",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SKIP_OLD_DRIVER("BD#24", "Old driver does not preserve column metadata after SQL_CLOSE on prepared statement");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1, 2, 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT col_count = 0;
+  ret = SQLNumResultCols(stmt_handle(), &col_count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(col_count == 3);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE from Done state",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE from Fetching state",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1 UNION ALL SELECT 2"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE resets used_extended_fetch flag",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN row_count = 0;
+  SQLUSMALLINT row_status = 0;
+  ret = SQLExtendedFetch(stmt_handle(), SQL_FETCH_NEXT, 0, &row_count, &row_status);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(row_count == 1);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE resets get_data_state",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 'abcdefghijklmnopqrstuvwxyz'"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Read with a small buffer to trigger truncation (partial GetData)
+  char small_buf[4] = {};
+  SQLLEN ind = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_CHAR, small_buf, sizeof(small_buf), &ind);
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLFreeStmt: SQL_CLOSE from prepared NoResultSet transitions to Prepared (S4->S2)",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(),
+                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE test_freestmt_nrs (id INTEGER)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), sqlchar("INSERT INTO test_freestmt_nrs VALUES (?)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER param = 1;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Re-execute should succeed: SQL_CLOSE transitions to Prepared, not Created.
+  param = 2;
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM test_freestmt_nrs"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER count = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &count, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(count == 2);
+}
+
+TEST_CASE_METHOD(TwoStmtDefaultDSNFixture, "SQLFreeStmt: SQL_CLOSE from Error state recovers to Created",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  // The Error state occurs when the Arrow stream fails during fetch.
+  // Force this by setting a short statement timeout on a large streaming query.
+  SessionParameterOverride timeout(stmt2_handle(), "STATEMENT_TIMEOUT_IN_SECONDS", "1");
+  REQUIRE(timeout.is_active());
+
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("SELECT SEQ8() FROM TABLE(GENERATOR(ROWCOUNT => 10000000000))"), SQL_NTS);
+  if (ret != SQL_SUCCESS) {
+    SKIP("Query timed out before streaming started; cannot reach Error state");
+  }
+
+  bool hit_error = false;
+  while (!hit_error) {
+    ret = SQLFetch(stmt_handle());
+    if (ret == SQL_ERROR) {
+      hit_error = true;
+    } else if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) {
+      break;
+    }
+  }
+  if (!hit_error) {
+    SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+    SKIP("Streaming did not error within expected time; cannot reach Error state");
+  }
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // SQL_CLOSE from Error transitions to Created: SQLDescribeCol should return HY010.
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: prepared flag preserved through re-execute from NoResultSet",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE OR REPLACE TEMPORARY TABLE test_freestmt_reexec (id INTEGER)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), sqlchar("INSERT INTO test_freestmt_reexec VALUES (1)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Re-execute from NoResultSet; the prepared flag should propagate.
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // SQLExecute should still work: the preserved prepared flag means
+  // SQL_CLOSE transitioned to Prepared, not Created.
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM test_freestmt_reexec"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER count = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &count, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(count == 3);
+}
+
+// ============================================================================
+// SQLFreeStmt - Cross-API Interactions after SQL_CLOSE
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQLDescribeCol after SQL_CLOSE on prepared statement",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SKIP_OLD_DRIVER("BD#25", "Old driver does not preserve column metadata after SQL_CLOSE on prepared statement");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS COL_A, 2 AS COL_B"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(reinterpret_cast<char*>(col_name)) == "COL_A");
+
+  ret = SQLDescribeCol(stmt_handle(), 2, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(reinterpret_cast<char*>(col_name)) == "COL_B");
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val1 = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val1, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val1 == 1);
+
+  SQLINTEGER val2 = 0;
+  ret = SQLGetData(stmt_handle(), 2, SQL_C_SLONG, &val2, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val2 == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: Re-prepare with different query after SQL_CLOSE",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1, 2, 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT col_count = 0;
+  ret = SQLNumResultCols(stmt_handle(), &col_count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(col_count == 3);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLFreeStmt: SQLRowCount returns HY010 after SQL_CLOSE on exec_direct statement",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN row_count = 0;
+  ret = SQLRowCount(stmt_handle(), &row_count);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLFreeStmt: SQLDescribeCol works after Prepare, fetch to Done, then SQL_CLOSE",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SKIP_OLD_DRIVER("BD#25", "Old driver does not preserve column metadata after SQL_CLOSE on prepared statement");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS COL_X"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(reinterpret_cast<char*>(col_name)) == "COL_X");
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture,
+                 "SQLFreeStmt: SQLDescribeCol fails with HY010 after SQL_CLOSE on exec_direct statement",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1 AS COL_Y"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQLDescribeCol after SQL_CLOSE from prepared Fetching state",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS COL_A UNION ALL SELECT 2"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  OLD_DRIVER_ONLY("BD#25") { REQUIRE_EXPECTED_ERROR(ret, "07009", stmt_handle(), SQL_HANDLE_STMT); }
+  NEW_DRIVER_ONLY("BD#25") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(std::string(reinterpret_cast<char*>(col_name)) == "COL_A");
+  }
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(val == 1);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(val == 2);
+
+  ret = SQLFetch(stmt_handle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQLFreeStmt - SQL_UNBIND Cursor Independence
+// These are separate TEST_CASE_METHODs instead of SECTIONs because Catch2
+// destroys and re-creates the fixture between sections, and the
+// UnixConfigInstallation destructor tears down the DSN config directory.
+// The Driver Manager caches the old config, so SQLConnect fails on re-creation.
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND does not close cursor",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_UNBIND);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_RESET_PARAMS does not close cursor",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: SQL_UNBIND followed by re-bind",
+                 "[odbc-api][freestmt][terminating_statement]") {
+  SQLINTEGER buf_a = -1;
+  SQLLEN ind_a = 0;
+  SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &buf_a, 0, &ind_a);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_UNBIND);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER buf_b = -1;
+  SQLLEN ind_b = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &buf_b, 0, &ind_b);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  REQUIRE(buf_a == -1);
+  REQUIRE(buf_b == 42);
+}
+
+// ============================================================================
+// SQLFreeStmt - Error Cases (extended)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: invalid option returns error with HY092",
+                 "[odbc-api][freestmt][terminating_statement][error]") {
+  // The Driver Manager may intercept invalid option values before they reach
+  // the driver. Both the DM (HY092) and driver (HY092) map to the same SQLSTATE.
+  const SQLRETURN ret = SQLFreeStmt(stmt_handle(), 99);
+  REQUIRE_EXPECTED_ERROR(ret, "HY092", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 // ============================================================================
@@ -259,8 +916,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeStmt: SQL_DROP frees statement ha
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: All permutations of SQL_CLOSE, SQL_UNBIND, SQL_RESET_PARAMS",
                  "[odbc-api][freestmt][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   const SQLUSMALLINT options[][3] = {
       {SQL_CLOSE, SQL_UNBIND, SQL_RESET_PARAMS}, {SQL_CLOSE, SQL_RESET_PARAMS, SQL_UNBIND},
       {SQL_UNBIND, SQL_CLOSE, SQL_RESET_PARAMS}, {SQL_UNBIND, SQL_RESET_PARAMS, SQL_CLOSE},
@@ -294,7 +949,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: All permutations of SQL_CL
     REQUIRE(col_val == 0);
 
     SQLINTEGER val = 0;
-    SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
     REQUIRE(val == 42);
 
     ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -311,8 +967,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLFreeStmt: All permutations of SQL_CL
 
 TEST_CASE("SQLFreeStmt: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][freestmt][terminating_statement][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   const SQLRETURN ret = SQLFreeStmt(SQL_NULL_HSTMT, SQL_CLOSE);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }


### PR DESCRIPTION
### TL;DR

Implements proper ODBC statement state tracking to distinguish between prepared and direct execution statements, enabling correct `SQLFreeStmt(SQL_CLOSE)` behavior that preserves prepared statement metadata.

### What changed?

Added a `prepared` boolean field to all statement states (`Executed`, `NoResultSet`, `Fetching`, `Done`) to track whether a statement originated from `SQLPrepare`+`SQLExecute` or `SQLExecDirect`. Modified `SQLFreeStmt(SQL_CLOSE)` to transition prepared statements back to the `Prepared` state instead of `Created`, preserving column metadata and descriptor information. Added proper error handling for invalid `FreeStmtOption` values with a new `InvalidFreeStmtOption` error variant. Enhanced the `FreeStmtOption` enum with validation and converted the C API to use proper type checking.

### How to test?

Run the expanded test suite in `free_stmt_tests.cpp` which includes:
- Basic `SQL_CLOSE`, `SQL_UNBIND`, and `SQL_RESET_PARAMS` operations
- Prepared statement metadata preservation after `SQL_CLOSE`
- Cross-API interactions like `SQLNumResultCols` and `SQLDescribeCol` after `SQL_CLOSE`
- State transitions from various execution states
- Error handling for invalid options
- All permutations of FreeStmt operations

### Why make this change?

This change brings the driver into compliance with the ODBC specification's statement transition table, which requires `SQLFreeStmt(SQL_CLOSE)` on prepared statements to return to the Prepared state (S2/S3) rather than Created (S1). This enables applications to access column metadata via `SQLNumResultCols` and `SQLDescribeCol` after closing a cursor on a prepared statement, which is standard ODBC behavior that many applications rely on.