### PR TITLE
fix(ci): trigger ODBC CI on PRs targeting any branch

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    # Allow stacked PRs (e.g. ODBC on top of JDBC) to trigger this workflow.
+    # Allow stacked PRs to trigger this workflow.
     # detect-changes still decides whether ODBC jobs actually run.
 
 concurrency:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    # Allow stacked PRs (e.g. ODBC on top of JDBC) to trigger this workflow.
+    # detect-changes still decides whether ODBC jobs actually run.
 
 concurrency:
   # Group by PR number for PRs, or fall back to the run ID for main (which is unique, so it won't cancel)


### PR DESCRIPTION
## Summary
- Remove `branches: ["main"]` filter from `pull_request:` trigger in ODBC CI workflow
- Matches the pattern already used by Rust Core CI, Python CI, and JDBC CI
- Without this fix, stacked PRs targeting intermediate branches (e.g. `woa64-rust-core` → `woa64-fix-windows-test-paths`) never run ODBC tests, even when `sf_core/**` changes would trigger `run_odbc=true` in `detect-changes`

## Test plan
- [x] Verify Rust Core, Python, JDBC workflows already use unfiltered `pull_request:`
- [ ] After merge, confirm ODBC CI triggers on stacked PRs (e.g. PR #428)

🤖 Generated with [Claude Code](https://claude.com/claude-code)