### PR TITLE
SNOW-2467768: Add null value support to Arrow conversion and DML row counting

### DIFF
--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -116,7 +116,7 @@ pub(crate) fn calculate_rows_affected(data: &Data) -> Option<i64> {
                     || DML_AFFECTED_ROWS_COLUMN_PREFIXES
                         .iter()
                         .any(|p| col_name.starts_with(p)))
-                    && let Some(value) = rowset[0].get(idx)
+                    && let Some(Some(value)) = rowset[0].get(idx)
                     && let Ok(count) = value.parse::<i64>()
                 {
                     affected_rows += count;
@@ -980,6 +980,75 @@ mod tests {
             serialized.contains(json),
             "Serialized request must contain the raw JSON verbatim.\nSerialized: {serialized}"
         );
+    }
+
+    #[test]
+    fn calculate_rows_affected_sums_non_null_dml_columns() {
+        let json = r#"{
+            "rowset": [["5", "3"]],
+            "rowtype": [
+                {"name": "number of rows inserted", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10},
+                {"name": "number of rows updated", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10}
+            ],
+            "statementTypeId": 12288
+        }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(calculate_rows_affected(&data), Some(8));
+    }
+
+    #[test]
+    fn calculate_rows_affected_skips_null_values() {
+        let json = r#"{
+            "rowset": [["5", null]],
+            "rowtype": [
+                {"name": "number of rows inserted", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10},
+                {"name": "number of rows updated", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+            ],
+            "statementTypeId": 12288
+        }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(calculate_rows_affected(&data), Some(5));
+    }
+
+    #[test]
+    fn calculate_rows_affected_all_null_returns_zero() {
+        let json = r#"{
+            "rowset": [[null]],
+            "rowtype": [
+                {"name": "number of rows inserted", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+            ],
+            "statementTypeId": 12288
+        }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(calculate_rows_affected(&data), Some(0));
+    }
+
+    #[test]
+    fn calculate_rows_affected_ignores_non_matching_null_column() {
+        let json = r#"{
+            "rowset": [["5", null]],
+            "rowtype": [
+                {"name": "number of rows inserted", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10},
+                {"name": "some_other_column", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+            ],
+            "statementTypeId": 12288
+        }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(calculate_rows_affected(&data), Some(5));
+    }
+
+    #[test]
+    fn calculate_rows_affected_non_dml_uses_total() {
+        let json = r#"{
+            "rowset": [[null]],
+            "rowtype": [
+                {"name": "result", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+            ],
+            "statementTypeId": 4096,
+            "total": 42
+        }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(calculate_rows_affected(&data), Some(42));
     }
 
     #[test]

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1,4 +1,5 @@
 use crate::query_types::RowType;
+use crate::rest::snowflake::query_response::JsonRowset;
 use arrow::array::{Array, BooleanArray, Float64Array, Int8Array, Int64Array, StringArray};
 use arrow::datatypes::{DataType, Date32Type, Field, Int32Type, Int64Type, Schema};
 use arrow::error::ArrowError;
@@ -110,7 +111,7 @@ fn parse_decimal_str(v: &str, scale: u32) -> Result<i128, ArrowUtilsError> {
 
 /// Creates an Arrow array from column values and data type
 fn create_column_array(
-    values: Vec<&str>,
+    values: Vec<Option<&str>>,
     row_type: &RowType,
 ) -> Result<(Field, Arc<dyn Array>), ArrowUtilsError> {
     match row_type {
@@ -121,41 +122,58 @@ fn create_column_array(
         RowType::Fixed {
             scale, precision, ..
         } => {
-            let decimal_values: Result<Vec<i128>, ArrowUtilsError> = values
+            let decimal_values: Result<Vec<Option<i128>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| parse_decimal_str(v, *scale as u32))
+                .map(|v| match v {
+                    Some(s) => parse_decimal_str(s, *scale as u32).map(Some),
+                    None => Ok(None),
+                })
                 .collect();
 
             let decimal_values = decimal_values?;
-            if decimal_values.is_empty() {
+            let non_null_values: Vec<i128> = decimal_values.iter().filter_map(|v| *v).collect();
+
+            if non_null_values.is_empty() {
                 return Ok((
                     create_field_with_type(row_type, DataType::Int64), // TODO is it correct? We have to assume something, but it probably doesn't matter.
-                    Arc::new(Int64Array::new_null(0)),
+                    Arc::new(Int64Array::new_null(decimal_values.len())),
                 ));
             }
-            let min_value: i128 = decimal_values.iter().min().copied().unwrap();
-            let max_value: i128 = decimal_values.iter().max().copied().unwrap();
+            let min_value = *non_null_values.iter().min().unwrap();
+            let max_value = *non_null_values.iter().max().unwrap();
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
-                let int8_values: Vec<i8> = decimal_values.into_iter().map(|v| v as i8).collect();
+                let int8_values: Vec<Option<i8>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i8))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, DataType::Int8),
                     Arc::new(Int8Array::from(int8_values)),
                 ))
             } else if min_value >= i16::MIN as i128 && max_value <= i16::MAX as i128 {
-                let int16_values: Vec<i16> = decimal_values.into_iter().map(|v| v as i16).collect();
+                let int16_values: Vec<Option<i16>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i16))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, DataType::Int16),
                     Arc::new(arrow::array::Int16Array::from(int16_values)),
                 ))
             } else if min_value >= i32::MIN as i128 && max_value <= i32::MAX as i128 {
-                let int32_values: Vec<i32> = decimal_values.into_iter().map(|v| v as i32).collect();
+                let int32_values: Vec<Option<i32>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i32))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, DataType::Int32),
                     Arc::new(arrow::array::Int32Array::from(int32_values)),
                 ))
             } else if min_value >= i64::MIN as i128 && max_value <= i64::MAX as i128 {
-                let int64_values: Vec<i64> = decimal_values.into_iter().map(|v| v as i64).collect();
+                let int64_values: Vec<Option<i64>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i64))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, DataType::Int64),
                     Arc::new(Int64Array::from(int64_values)),
@@ -175,12 +193,13 @@ fn create_column_array(
             }
         }
         RowType::Boolean { .. } => {
-            let bool_values: Result<Vec<bool>, ArrowUtilsError> = values
+            let bool_values: Result<Vec<Option<bool>>, ArrowUtilsError> = values
                 .into_iter()
                 .map(|v| match v {
-                    "true" => Ok(true),
-                    "false" => Ok(false),
-                    other => BooleanParsingSnafu {
+                    Some("true") => Ok(Some(true)),
+                    Some("false") => Ok(Some(false)),
+                    None => Ok(None),
+                    Some(other) => BooleanParsingSnafu {
                         value: other.to_string(),
                     }
                     .fail(),
@@ -192,12 +211,13 @@ fn create_column_array(
             ))
         }
         RowType::Real { .. } => {
-            let float_values: Result<Vec<f64>, ArrowUtilsError> = values
+            let float_values: Result<Vec<Option<f64>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| {
-                    v.parse::<f64>().context(FloatParsingSnafu {
-                        value: v.to_string(),
-                    })
+                .map(|v| match v {
+                    Some(s) => s.parse::<f64>().map(Some).context(FloatParsingSnafu {
+                        value: s.to_string(),
+                    }),
+                    None => Ok(None),
                 })
                 .collect();
             Ok((
@@ -206,12 +226,13 @@ fn create_column_array(
             ))
         }
         RowType::Date { .. } => {
-            let day_values: Result<Vec<i32>, ArrowUtilsError> = values
+            let day_values: Result<Vec<Option<i32>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| {
-                    v.parse::<i32>().context(IntegerParsingSnafu {
-                        value: v.to_string(),
-                    })
+                .map(|v| match v {
+                    Some(s) => s.parse::<i32>().map(Some).context(IntegerParsingSnafu {
+                        value: s.to_string(),
+                    }),
+                    None => Ok(None),
                 })
                 .collect();
             Ok((
@@ -254,7 +275,7 @@ fn create_column_array(
 /// Supports TEXT and FIXED (with scale 0) types, converting strings to appropriate Arrow types
 /// Assumes rowset and row_types have been validated to have matching column counts
 pub fn convert_string_rowset_to_arrow_reader(
-    rowset: &[Vec<String>],
+    rowset: &JsonRowset,
     row_types: &[RowType],
 ) -> Result<Box<dyn arrow::record_batch::RecordBatchReader + Send>, ArrowUtilsError> {
     // Create Arrow arrays for each column
@@ -263,7 +284,8 @@ pub fn convert_string_rowset_to_arrow_reader(
         .iter()
         .enumerate()
         .map(|(col_idx, row_type)| {
-            let values: Vec<&str> = rowset.iter().map(|row| row[col_idx].as_str()).collect();
+            let values: Vec<Option<&str>> =
+                rowset.iter().map(|row| row[col_idx].as_deref()).collect();
             create_column_array(values, row_type)
         })
         .collect();
@@ -328,17 +350,20 @@ pub enum ArrowUtilsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int16Array, Int64Array, StringArray};
+    use arrow::array::{
+        Array, BooleanArray, Decimal128Array, Float64Array, Int8Array, Int16Array, Int32Array,
+        Int64Array, StringArray,
+    };
+    use arrow::datatypes::Date32Type;
     use arrow::record_batch::RecordBatchReader;
 
     #[test]
     fn test_string_rowset_translation_with_metadata_small() {
-        // Build a Snowflake-like rowset
         let rowset = vec![
-            vec!["alpha.txt".to_string(), "7".to_string()], // SB1
-            vec!["beta.md".to_string(), "123".to_string()], // SB2
-            vec!["gamma.bin".to_string(), "32767".to_string()], // SB2
-            vec!["delta.png".to_string(), "1024".to_string()], // SB2
+            vec![Some("alpha.txt".to_string()), Some("7".to_string())],
+            vec![Some("beta.md".to_string()), Some("123".to_string())],
+            vec![Some("gamma.bin".to_string()), Some("32767".to_string())],
+            vec![Some("delta.png".to_string()), Some("1024".to_string())],
         ];
 
         // Describe columns via RowType
@@ -402,15 +427,20 @@ mod tests {
 
     #[test]
     fn test_string_rowset_translation_with_metadata_large() {
-        // Build a Snowflake-like rowset
         let rowset = vec![
-            vec!["alpha/report.csv".to_string(), "7".to_string()], // SB1
-            vec!["beta/readme.md".to_string(), "123".to_string()], // SB2
-            vec!["gamma/data.bin".to_string(), "32767".to_string()], // SB2
-            vec!["delta/image.png".to_string(), "2147483647".to_string()], // SB4
+            vec![Some("alpha/report.csv".to_string()), Some("7".to_string())],
+            vec![Some("beta/readme.md".to_string()), Some("123".to_string())],
             vec![
-                "epsilon/archive.tar.gz".to_string(),
-                "9223372036854775807".to_string(), // SB8
+                Some("gamma/data.bin".to_string()),
+                Some("32767".to_string()),
+            ],
+            vec![
+                Some("delta/image.png".to_string()),
+                Some("2147483647".to_string()),
+            ],
+            vec![
+                Some("epsilon/archive.tar.gz".to_string()),
+                Some("9223372036854775807".to_string()),
             ],
         ];
 
@@ -473,5 +503,343 @@ mod tests {
         } else {
             panic!("Expected one record batch");
         }
+    }
+
+    #[test]
+    fn test_null_handling_real() {
+        let rowset = vec![
+            vec![Some("3.125".to_string())],
+            vec![None],
+            vec![Some("99.5".to_string())],
+        ];
+        let row_types = vec![RowType::real("col_real", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(col.len(), 3);
+        assert!(!col.is_null(0));
+        assert_eq!(col.value(0), 3.125);
+        assert!(col.is_null(1));
+        assert!(!col.is_null(2));
+        assert_eq!(col.value(2), 99.5);
+    }
+
+    #[test]
+    fn test_null_handling_date() {
+        let rowset = vec![
+            vec![Some("19000".to_string())],
+            vec![None],
+            vec![Some("20000".to_string())],
+        ];
+        let row_types = vec![RowType::date("col_date", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::PrimitiveArray<Date32Type>>()
+            .unwrap();
+        assert_eq!(col.len(), 3);
+        assert!(!col.is_null(0));
+        assert_eq!(col.value(0), 19000);
+        assert!(col.is_null(1));
+        assert!(!col.is_null(2));
+        assert_eq!(col.value(2), 20000);
+    }
+
+    #[test]
+    fn test_null_handling_fixed_all_nulls() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col_fixed", true, 5, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("all-nulls Fixed should produce Int64Array fallback type");
+        assert_eq!(col.len(), 2);
+        assert!(col.is_null(0));
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn test_null_handling_multi_column() {
+        let rowset = vec![
+            vec![
+                Some("hello".to_string()),
+                Some("42".to_string()),
+                Some("true".to_string()),
+            ],
+            vec![None, None, None],
+            vec![
+                Some("world".to_string()),
+                Some("-7".to_string()),
+                Some("false".to_string()),
+            ],
+        ];
+        let row_types = vec![
+            RowType::text("col_text", true, 16, 64),
+            RowType::fixed("col_fixed", true, 5, 0),
+            RowType::boolean("col_bool", true),
+        ];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.num_rows(), 3);
+
+        let text_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(!text_col.is_null(0));
+        assert_eq!(text_col.value(0), "hello");
+        assert!(text_col.is_null(1));
+        assert!(!text_col.is_null(2));
+        assert_eq!(text_col.value(2), "world");
+
+        let fixed_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .unwrap();
+        assert!(!fixed_col.is_null(0));
+        assert_eq!(fixed_col.value(0), 42);
+        assert!(fixed_col.is_null(1));
+        assert!(!fixed_col.is_null(2));
+        assert_eq!(fixed_col.value(2), -7);
+
+        let bool_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(!bool_col.is_null(0));
+        assert!(bool_col.value(0));
+        assert!(bool_col.is_null(1));
+        assert!(!bool_col.is_null(2));
+        assert!(!bool_col.value(2));
+    }
+
+    #[test]
+    fn test_null_handling_fixed_int64_narrowing() {
+        let rowset = vec![
+            vec![None],
+            vec![Some("9223372036854775807".to_string())],
+            vec![None],
+            vec![Some("42".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 19, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("should narrow to Int64Array based on non-null values only");
+        assert_eq!(col.len(), 4);
+        assert!(col.is_null(0));
+        assert!(!col.is_null(1));
+        assert_eq!(col.value(1), 9_223_372_036_854_775_807);
+        assert!(col.is_null(2));
+        assert!(!col.is_null(3));
+        assert_eq!(col.value(3), 42);
+    }
+
+    #[test]
+    fn test_null_handling_fixed_decimal128() {
+        let rowset = vec![
+            vec![Some("170141183460469231731687303715884105727".to_string())],
+            vec![None],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 38, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("should fall through to Decimal128Array for values exceeding i64 range");
+        assert_eq!(col.len(), 2);
+        assert!(!col.is_null(0));
+        assert_eq!(
+            col.value(0),
+            170_141_183_460_469_231_731_687_303_715_884_105_727
+        );
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn test_null_handling_all_nulls_boolean() {
+        let rowset = vec![vec![None], vec![None], vec![None]];
+        let row_types = vec![RowType::boolean("col_bool", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert_eq!(col.len(), 3);
+        assert!(col.is_null(0));
+        assert!(col.is_null(1));
+        assert!(col.is_null(2));
+    }
+
+    #[test]
+    fn test_null_handling_staggered_nulls_across_columns() {
+        let rowset = vec![
+            vec![None, Some("42".to_string())],
+            vec![Some("hello".to_string()), None],
+        ];
+        let row_types = vec![
+            RowType::text("col_text", true, 16, 64),
+            RowType::fixed("col_fixed", true, 5, 0),
+        ];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_columns(), 2);
+        assert_eq!(batch.num_rows(), 2);
+
+        let text_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(text_col.is_null(0));
+        assert!(!text_col.is_null(1));
+        assert_eq!(text_col.value(1), "hello");
+
+        let fixed_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .unwrap();
+        assert!(!fixed_col.is_null(0));
+        assert_eq!(fixed_col.value(0), 42);
+        assert!(fixed_col.is_null(1));
+    }
+
+    #[test]
+    fn test_null_handling_fixed_i16_narrowing() {
+        let rowset = vec![
+            vec![Some("1000".to_string())],
+            vec![None],
+            vec![Some("-1000".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 5, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int16Array>()
+            .expect("values in i16 range should narrow to Int16Array");
+        assert_eq!(col.len(), 3);
+        assert!(!col.is_null(0));
+        assert_eq!(col.value(0), 1000);
+        assert!(col.is_null(1));
+        assert!(!col.is_null(2));
+        assert_eq!(col.value(2), -1000);
+    }
+
+    #[test]
+    fn test_null_handling_fixed_i32_narrowing() {
+        let rowset = vec![
+            vec![Some("100000".to_string())],
+            vec![None],
+            vec![Some("-100000".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 10, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("values in i32 range should narrow to Int32Array");
+        assert_eq!(col.len(), 3);
+        assert!(!col.is_null(0));
+        assert_eq!(col.value(0), 100_000);
+        assert!(col.is_null(1));
+        assert!(!col.is_null(2));
+        assert_eq!(col.value(2), -100_000);
+    }
+
+    #[test]
+    fn test_null_handling_all_nulls_text() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::text("col_text", true, 16, 64)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(col.len(), 2);
+        assert!(col.is_null(0));
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn test_null_handling_all_nulls_real() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::real("col_real", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(col.len(), 2);
+        assert!(col.is_null(0));
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn test_null_handling_all_nulls_date() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::date("col_date", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::PrimitiveArray<Date32Type>>()
+            .unwrap();
+        assert_eq!(col.len(), 2);
+        assert!(col.is_null(0));
+        assert!(col.is_null(1));
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -6,6 +6,9 @@ use snafu::{OptionExt, Snafu};
 use std::collections::HashMap;
 // TODO: Delete all unused fields when we are sure they are not needed
 
+/// A JSON rowset: each inner Vec is one row, each element is a nullable column value.
+pub type JsonRowset = Vec<Vec<Option<String>>>;
+
 #[derive(Deserialize)]
 pub struct Response {
     pub data: Data,
@@ -20,7 +23,7 @@ pub struct Response {
 #[derive(Deserialize)]
 pub struct Data {
     #[serde(rename = "rowset")]
-    pub rowset: Option<Vec<Vec<String>>>,
+    pub rowset: Option<JsonRowset>,
     #[serde(rename = "rowsetBase64")]
     pub rowset_base64: Option<String>,
     #[serde(rename = "rowtype")]
@@ -490,7 +493,7 @@ impl Data {
         if value.is_empty() { None } else { Some(value) }
     }
 
-    pub fn to_json_rowset(&self) -> Option<(&Vec<Vec<String>>, &Vec<RowType>)> {
+    pub fn to_json_rowset(&self) -> Option<(&JsonRowset, &Vec<RowType>)> {
         match (self.rowset.as_ref(), self.row_type.as_ref()) {
             (Some(rowset), Some(row_type)) => Some((rowset, row_type)),
             (Some(_), None) => {
@@ -519,7 +522,7 @@ pub enum RowsetData<'a> {
         chunk_base64: &'a str,
     },
     JsonRowset {
-        rowset: &'a Vec<Vec<String>>,
+        rowset: &'a JsonRowset,
         rowtype: &'a Vec<RowType>,
     },
     NoData,


### PR DESCRIPTION
### TL;DR

Fixed null value handling in database query results by properly parsing JSON null values and updating Arrow array creation to support nullable columns.

### What changed?

- Modified `calculate_rows_affected` function to handle null values in DML result columns by adding an extra `Some()` pattern match
- Updated Arrow array creation logic to accept `Vec<Option<&str>>` instead of `Vec<&str>` to properly represent nullable values
- Changed `JsonRowset` type definition from `Vec<Vec<String>>` to `Vec<Vec<Option<String>>>` to support null values from JSON deserialization
- Added comprehensive null handling for all Arrow data types (Fixed/integers, Boolean, Real/float, Date, Text)
- Implemented proper type narrowing for Fixed columns that considers only non-null values when determining the appropriate integer size

### How to test?

Run the new test cases that cover:
- DML operations with null values in affected row counts
- Arrow array creation with mixed null and non-null values across all supported data types
- Type narrowing behavior when nulls are present in numeric columns
- All-null column scenarios

### Why make this change?

Database query results can contain null values, but the previous implementation assumed all values were non-null strings. This caused incorrect behavior when calculating affected rows for DML operations and when converting query results to Arrow format, leading to potential crashes or incorrect data representation.