### PR TITLE
SNOW-3206252: Clear llm_model and percentage_of_prs_reviewed in Arctic Owl configs

### DIFF
--- a/.ai/review/universal-driver-security.yaml
+++ b/.ai/review/universal-driver-security.yaml
@@ -1,13 +1,11 @@
 id: universal-driver-security-rules
 friendly_name: "Universal Driver Security Rules"
 status: enabled
-percentage_of_prs_reviewed: 100
 allowed_folders:
   - "sf_core/src"
   - "odbc/src"
 excluded_folders:
   - "sf_core/src/bin"
-llm_model: "claude-sonnet-4-5"
 allowed_file_extensions:
   - ".rs"
   - ".toml"

--- a/.ai/review/universal-driver-tests.yaml
+++ b/.ai/review/universal-driver-tests.yaml
@@ -1,7 +1,6 @@
 id: universal-driver-tests-rules
 friendly_name: "Universal Driver Test Rules"
 status: enabled
-percentage_of_prs_reviewed: 100
 allowed_folders:
   - "tests/definitions"
   - "sf_core/tests"
@@ -13,7 +12,6 @@ excluded_folders:
   - "odbc_tests/cmake-build"
   - "odbc_tests/cmake-build-reference"
   - "python/tests/__pycache__"
-llm_model: "claude-sonnet-4-5"
 allowed_file_extensions:
   - ".rs"
   - ".py"


### PR DESCRIPTION
## Summary
Remove `llm_model` and `percentage_of_prs_reviewed` fields from all `.ai/review/*.yaml` ruleset config files.

## Why
These fields now have **default values** in the Arctic Owl pipeline (`snowci_actions`), making them optional:

- **`llm_model`** → defaults to `claude-sonnet-4-6`
- **`percentage_of_prs_reviewed`** → defaults to `100` (review all PRs)

Removing these fields from individual rulesets means:
1. **Less boilerplate** — teams don't need to copy-paste the same values in every ruleset
2. **Centralized model management** — when we upgrade to a new model, it takes effect everywhere automatically without requiring PRs to every repo
3. **Still customizable** — if your use case differs, you can always add these fields back to your YAML with a custom value and it will be respected

## What changed
- Removed `llm_model:` and `percentage_of_prs_reviewed:` lines from `.ai/review/*.yaml` files

## Related
- snowflake-eng/snowci_actions#507 — makes these fields optional with defaults
- SNOW-3206252