### PR TITLE
ADR-28: Async Rust exposed at API level


### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ parameters*.json
 **/rsa_key.p8
 .DS_Store
 /.tmp
+/build
 
 # Python/Cython build artifacts
 python/src/snowflake/connector/_internal/nanoarrow_cpp/ArrowIterator/arrow_stream_iterator.cpp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,21 +860,6 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1796,12 +1772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,17 +2238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2299,7 @@ dependencies = [
  "jni",
  "proto_utils",
  "sf_core",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2535,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2797,15 +2757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "odbc"
 version = "0.1.0"
 dependencies = [
@@ -2818,6 +2769,7 @@ dependencies = [
  "serde_json",
  "sf_core",
  "snafu 0.8.9",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3532,12 +3484,6 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4372,29 +4318,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ resolver = "2"
 strip = true
 opt-level = "z"
 lto = false
+
+[profile.dev]
+opt-level = 1

--- a/jdbc_bridge/Cargo.toml
+++ b/jdbc_bridge/Cargo.toml
@@ -12,6 +12,7 @@ sf_core = { path = "../sf_core" }
 proto_utils = { path = "../proto_utils" }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 tracing = "0.1.41"
+tokio = { version = "1.50.0", features = ["rt"] }
 
 [dependencies.jni]
 version = "0.21"

--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -14,6 +14,9 @@ struct JdbcBridge {
 impl JdbcBridge {
     pub fn new() -> Self {
         Self {
+            // Single worker thread is intentional: keeps contention minimal and
+            // makes deadlocks easier to detect. Will be increased during
+            // performance optimization.
             runtime: tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
                 .enable_all()

--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -1,8 +1,43 @@
+use std::sync::LazyLock;
+
 use jni::JNIEnv;
 use jni::objects::{JByteArray, JClass, JObject, JString, JValue};
 use jni::sys::{jint, jobject};
-use proto_utils::ProtoError;
-use sf_core::protobuf::apis::call_proto;
+use proto_utils::{ProtoError, Transport};
+use sf_core::protobuf::apis::RustTransport;
+
+struct JdbcBridge {
+    runtime: tokio::runtime::Runtime,
+    transport: RustTransport,
+}
+
+impl JdbcBridge {
+    pub fn new() -> Self {
+        Self {
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("Failed to create tokio runtime"),
+            transport: RustTransport::new(),
+        }
+    }
+
+    pub fn handle_message_sync(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_bytes: Vec<u8>,
+    ) -> Result<Vec<u8>, ProtoError<Vec<u8>>> {
+        self.runtime.block_on(self.transport.handle_message(
+            service_name,
+            method_name,
+            request_bytes,
+        ))
+    }
+}
+
+static JDBC_BRIDGE: LazyLock<JdbcBridge> = LazyLock::new(JdbcBridge::new);
 
 mod slf4j_layer;
 
@@ -62,11 +97,10 @@ pub unsafe extern "system" fn Java_net_snowflake_client_internal_unicore_JNICore
         Err(_) => return std::ptr::null_mut(),
     };
 
-    // Call the protobuf API
-    let result = call_proto(
+    let result = JDBC_BRIDGE.handle_message_sync(
         &service_name_str.to_string_lossy(),
         &method_name_str.to_string_lossy(),
-        request_bytes_vec.as_slice(),
+        request_bytes_vec,
     );
 
     // Find the TransportResponse class

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 
 proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }
+tokio = { version = "1.50.0", features = ["rt"] }
 
 [[test]]
 name = "odbc_api_tests"

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -1,17 +1,17 @@
 use crate::api::InfoType;
 use crate::api::bitmask::Bitmask;
 use crate::api::error::Required;
+use crate::api::runtime::global;
 use crate::api::{
     ConnectionState, GetDataExtensions, OdbcResult, api_utils, conn_from_handle,
     error::{
-        AttributeCannotBeSetNowSnafu, InvalidPortSnafu, UnknownAttributeSnafu,
+        AttributeCannotBeSetNowSnafu, InvalidPortSnafu, OdbcRuntimeSnafu, UnknownAttributeSnafu,
         UnsupportedAttributeSnafu,
     },
     types::ConnectionAttribute,
 };
 use crate::conversion::warning::{Warning, Warnings};
 use odbc_sys as sql;
-use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use snafu::ResultExt;
 use std::collections::HashMap;
@@ -89,12 +89,6 @@ pub fn driver_connect(
     }
 
     let connection = conn_from_handle(connection_handle);
-    let db_handle = DatabaseDriverClient::database_new(DatabaseNewRequest {})?
-        .db_handle
-        .required("Database handle is required")?;
-    let conn_handle = DatabaseDriverClient::connection_new(ConnectionNewRequest {})?
-        .conn_handle
-        .required("Connection handle is required")?;
 
     // Check whether attribute-based key options supersede file-based connection string params.
     // Matches old driver (SFConnection.cpp): if PrivKeyContent or PrivKeyBase64 was set via
@@ -106,135 +100,150 @@ pub fn driver_connect(
             .pre_connection_attrs
             .contains_key(&ConnectionAttribute::PrivKeyBase64);
 
-    let mut login_timeout_set = false;
+    let attr_has_priv_key_password = connection
+        .pre_connection_attrs
+        .contains_key(&ConnectionAttribute::PrivKeyPassword);
 
-    for (key, value) in connection_string_map {
-        if key == "DRIVER" {
-            continue;
-        }
+    let pre_attrs = connection.pre_connection_attrs.clone();
 
-        if let Some(core_key) = PARAM_MAPPINGS
-            .iter()
-            .find(|(k, _)| *k == key)
-            .map(|(_, v)| *v)
-        {
-            DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-                conn_handle: Some(conn_handle),
-                key: core_key.to_owned(),
-                value,
-            })?;
-            continue;
-        }
+    let (db_handle, conn_handle) =
+        global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            let db_handle = c
+                .database_new(DatabaseNewRequest {})
+                .await?
+                .db_handle
+                .required("Database handle is required")?;
+            let conn_handle = c
+                .connection_new(ConnectionNewRequest {})
+                .await?
+                .conn_handle
+                .required("Connection handle is required")?;
 
-        match key.as_str() {
-            "PORT" => {
-                let port_int: i64 = value.parse().context(InvalidPortSnafu {
-                    port: value.clone(),
-                })?;
-                DatabaseDriverClient::connection_set_option_int(ConnectionSetOptionIntRequest {
-                    conn_handle: Some(conn_handle),
-                    key: "port".to_owned(),
-                    value: port_int,
-                })?;
-            }
-            "CRL_MODE" => {
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "crl_mode".to_owned(),
-                        value: value.to_uppercase(),
-                    },
-                )?;
-            }
-            "LOGIN_TIMEOUT" => {
-                login_timeout_set = true;
-                DatabaseDriverClient::connection_set_option_string(
-                    ConnectionSetOptionStringRequest {
-                        conn_handle: Some(conn_handle),
-                        key: "authentication_timeout".to_owned(),
-                        value,
-                    },
-                )?;
-            }
-            "PRIV_KEY_FILE" => {
-                if attr_key_set {
-                    tracing::debug!(
-                        "driver_connect: skipping PRIV_KEY_FILE — attribute-based key takes priority"
-                    );
-                } else {
-                    DatabaseDriverClient::connection_set_option_string(
-                        ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "private_key_file".to_owned(),
-                            value,
-                        },
-                    )?;
+            let mut login_timeout_set = false;
+
+            for (key, value) in connection_string_map {
+                if key == "DRIVER" {
+                    continue;
                 }
-            }
-            "PRIV_KEY_BASE64" => {
-                if attr_key_set {
-                    tracing::debug!(
-                        "driver_connect: skipping PRIV_KEY_BASE64 — attribute-based key takes priority"
-                    );
-                } else {
-                    DatabaseDriverClient::connection_set_option_string(
-                        ConnectionSetOptionStringRequest {
-                            conn_handle: Some(conn_handle),
-                            key: "private_key".to_owned(),
-                            value,
-                        },
-                    )?;
-                }
-            }
-            "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
-                if connection
-                    .pre_connection_attrs
-                    .contains_key(&ConnectionAttribute::PrivKeyPassword)
+
+                if let Some(core_key) = PARAM_MAPPINGS
+                    .iter()
+                    .find(|(k, _)| *k == key)
+                    .map(|(_, v)| *v)
                 {
-                    tracing::debug!(
-                        "driver_connect: skipping {} — attribute-based password takes priority",
-                        key
-                    );
-                } else {
-                    DatabaseDriverClient::connection_set_option_string(
-                        ConnectionSetOptionStringRequest {
+                    c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                        conn_handle: Some(conn_handle),
+                        key: core_key.to_owned(),
+                        value,
+                    })
+                    .await?;
+                    continue;
+                }
+
+                match key.as_str() {
+                    "PORT" => {
+                        let port_int: i64 = value.parse().context(InvalidPortSnafu {
+                            port: value.clone(),
+                        })?;
+                        c.connection_set_option_int(ConnectionSetOptionIntRequest {
                             conn_handle: Some(conn_handle),
-                            key: "private_key_password".to_owned(),
+                            key: "port".to_owned(),
+                            value: port_int,
+                        })
+                        .await?;
+                    }
+                    "CRL_MODE" => {
+                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                            conn_handle: Some(conn_handle),
+                            key: "crl_mode".to_owned(),
+                            value: value.to_uppercase(),
+                        })
+                        .await?;
+                    }
+                    "LOGIN_TIMEOUT" => {
+                        login_timeout_set = true;
+                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                            conn_handle: Some(conn_handle),
+                            key: "authentication_timeout".to_owned(),
                             value,
-                        },
-                    )?;
+                        })
+                        .await?;
+                    }
+                    "PRIV_KEY_FILE" => {
+                        if attr_key_set {
+                            tracing::debug!(
+                                "driver_connect: skipping PRIV_KEY_FILE — attribute-based key takes priority"
+                            );
+                        } else {
+                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                                conn_handle: Some(conn_handle),
+                                key: "private_key_file".to_owned(),
+                                value,
+                            })
+                            .await?;
+                        }
+                    }
+                    "PRIV_KEY_BASE64" => {
+                        if attr_key_set {
+                            tracing::debug!(
+                                "driver_connect: skipping PRIV_KEY_BASE64 — attribute-based key takes priority"
+                            );
+                        } else {
+                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                                conn_handle: Some(conn_handle),
+                                key: "private_key".to_owned(),
+                                value,
+                            })
+                            .await?;
+                        }
+                    }
+                    "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
+                        if attr_has_priv_key_password {
+                            tracing::debug!(
+                                "driver_connect: skipping {key} — attribute-based password takes priority"
+                            );
+                        } else {
+                            c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                                conn_handle: Some(conn_handle),
+                                key: "private_key_password".to_owned(),
+                                value,
+                            })
+                            .await?;
+                        }
+                    }
+                    _ => {
+                        tracing::warn!("driver_connect: unknown connection string key: {key:?}");
+                    }
                 }
             }
-            _ => {
-                tracing::warn!("driver_connect: unknown connection string key: {:?}", key);
+
+            let login_timeout_from_attr =
+                apply_pre_connection_attrs_async(c, &pre_attrs, conn_handle).await?;
+
+            if !login_timeout_set && !login_timeout_from_attr {
+                c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                    conn_handle: Some(conn_handle),
+                    key: "authentication_timeout".to_owned(),
+                    value: DEFAULT_LOGIN_TIMEOUT_SECS.to_owned(),
+                })
+                .await?;
             }
-        }
-    }
 
-    // Apply SQLSetConnectAttr values (override connection string parameters).
-    let login_timeout_from_attr = apply_pre_connection_attrs(connection, conn_handle)?;
+            c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "client_app_id".to_owned(),
+                value: "ODBC".to_owned(),
+            })
+            .await?;
 
-    // Old driver defaults LOGIN_TIMEOUT to 300 s (S_DEFAULT_LOGIN_TIMEOUT).
-    // If neither the connection string nor SQLSetConnectAttr provided a value,
-    // apply the same default so sf_core's Okta SAML retry budget matches.
-    if !login_timeout_set && !login_timeout_from_attr {
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "authentication_timeout".to_owned(),
-            value: DEFAULT_LOGIN_TIMEOUT_SECS.to_owned(),
+            c.connection_init(ConnectionInitRequest {
+                conn_handle: Some(conn_handle),
+                db_handle: Some(db_handle),
+            })
+            .await?;
+
+            Ok::<_, crate::api::OdbcError>((db_handle, conn_handle))
         })?;
-    }
-
-    DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-        conn_handle: Some(conn_handle),
-        key: "client_app_id".to_owned(),
-        value: "ODBC".to_owned(),
-    })?;
-
-    DatabaseDriverClient::connection_init(ConnectionInitRequest {
-        conn_handle: Some(conn_handle),
-        db_handle: Some(db_handle),
-    })?;
 
     tracing::info!("driver_connect: connection_init completed");
 
@@ -249,55 +258,59 @@ pub fn driver_connect(
 /// Apply pre-connection attributes to sf_core. SQLSetConnectAttr values override
 /// connection string parameters. PrivKeyContent takes priority over PrivKeyBase64.
 /// Returns `true` if LoginTimeout was set via attributes.
-fn apply_pre_connection_attrs(
-    connection: &mut crate::api::Connection,
+async fn apply_pre_connection_attrs_async(
+    client: &sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient,
+    attrs: &HashMap<ConnectionAttribute, String>,
     conn_handle: ConnectionHandle,
 ) -> OdbcResult<bool> {
-    let attrs = &connection.pre_connection_attrs;
-
     if let Some(content) = attrs.get(&ConnectionAttribute::PrivKeyContent) {
-        // PrivKeyContent -> private_key (PEM string sent as base64 to core)
         use base64::{Engine as _, engine::general_purpose};
         let encoded = general_purpose::STANDARD.encode(content.as_bytes());
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "private_key".to_owned(),
-            value: encoded,
-        })?;
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "private_key".to_owned(),
+                value: encoded,
+            })
+            .await?;
     } else if let Some(base64_key) = attrs.get(&ConnectionAttribute::PrivKeyBase64) {
-        // PrivKeyBase64 -> private_key (already base64-encoded)
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "private_key".to_owned(),
-            value: base64_key.clone(),
-        })?;
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "private_key".to_owned(),
+                value: base64_key.clone(),
+            })
+            .await?;
     }
 
-    // PrivKeyPassword -> private_key_password
     if let Some(password) = attrs.get(&ConnectionAttribute::PrivKeyPassword) {
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "private_key_password".to_owned(),
-            value: password.clone(),
-        })?;
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "private_key_password".to_owned(),
+                value: password.clone(),
+            })
+            .await?;
     }
 
-    // Application -> application
     if let Some(app) = attrs.get(&ConnectionAttribute::Application) {
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "application".to_owned(),
-            value: app.clone(),
-        })?;
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "application".to_owned(),
+                value: app.clone(),
+            })
+            .await?;
     }
 
-    // LoginTimeout -> authentication_timeout (matches old driver: used as Okta SAML budget)
     if let Some(timeout) = attrs.get(&ConnectionAttribute::LoginTimeout) {
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(conn_handle),
-            key: "authentication_timeout".to_owned(),
-            value: timeout.clone(),
-        })?;
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn_handle),
+                key: "authentication_timeout".to_owned(),
+                value: timeout.clone(),
+            })
+            .await?;
         return Ok(true);
     }
 
@@ -329,16 +342,24 @@ pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
         conn_handle,
     } = std::mem::replace(&mut connection.state, ConnectionState::Disconnected)
     {
-        if let Err(e) = DatabaseDriverClient::connection_release(ConnectionReleaseRequest {
-            conn_handle: Some(conn_handle),
-        }) {
-            tracing::warn!("Failed to release core connection handle: {e:?}");
-        }
-        if let Err(e) = DatabaseDriverClient::database_release(DatabaseReleaseRequest {
-            db_handle: Some(db_handle),
-        }) {
-            tracing::warn!("Failed to release core database handle: {e:?}");
-        }
+        global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            if let Err(e) = c
+                .connection_release(ConnectionReleaseRequest {
+                    conn_handle: Some(conn_handle),
+                })
+                .await
+            {
+                tracing::warn!("Failed to release core connection handle: {e:?}");
+            }
+            if let Err(e) = c
+                .database_release(DatabaseReleaseRequest {
+                    db_handle: Some(db_handle),
+                })
+                .await
+            {
+                tracing::warn!("Failed to release core database handle: {e:?}");
+            }
+        });
     }
 
     Ok(())

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -305,6 +305,13 @@ pub enum OdbcError {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("ODBC runtime error"))]
+    OdbcRuntime {
+        source: crate::api::runtime::OdbcRuntimeError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub trait Required<T>: Sized {
@@ -466,6 +473,7 @@ impl OdbcError {
             OdbcError::ProtoRequiredFieldMissing { .. } => SqlState::GeneralError,
             OdbcError::ArrowArrayStreamReaderCreation { .. } => SqlState::GeneralError,
             OdbcError::StatementErrorState { .. } => SqlState::GeneralError,
+            OdbcError::OdbcRuntime { .. } => SqlState::FunctionSequenceError,
         }
     }
 

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -2,18 +2,20 @@ use crate::api::{
     ArdDescriptor, Connection, ConnectionState, Environment, IrdDescriptor, OdbcResult, Statement,
     StatementState, conn_from_handle,
     diagnostic::DiagnosticInfo,
-    error::{DisconnectedSnafu, InvalidHandleSnafu, Required},
+    error::{DisconnectedSnafu, InvalidHandleSnafu, OdbcRuntimeSnafu, Required},
+    runtime::{env_allocated, env_freed, global},
 };
 use odbc_sys as sql;
-use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::{
     StatementNewRequest, StatementReleaseRequest,
 };
+use snafu::ResultExt;
 use tracing;
 
 /// Allocate a new environment handle
 pub fn alloc_environment() -> OdbcResult<*mut Environment> {
     tracing::info!("Allocating new environment handle");
+    env_allocated().context(OdbcRuntimeSnafu)?;
     let env = Box::new(Environment {
         odbc_version: 3,
         diagnostic_info: DiagnosticInfo::default(),
@@ -42,8 +44,11 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement<'
             db_handle: _,
             conn_handle,
         } => {
-            let response = DatabaseDriverClient::statement_new(StatementNewRequest {
-                conn_handle: Some(*conn_handle),
+            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+                c.statement_new(StatementNewRequest {
+                    conn_handle: Some(*conn_handle),
+                })
+                .await
             })?;
             let stmt_handle = response
                 .stmt_handle
@@ -83,6 +88,7 @@ pub fn free_environment(handle: sql::Handle) -> OdbcResult<()> {
     unsafe {
         drop(Box::from_raw(handle as *mut Environment));
     }
+    env_freed().context(OdbcRuntimeSnafu)?;
     Ok(())
 }
 
@@ -107,12 +113,12 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
 
     tracing::info!("Freeing statement handle");
     let stmt = unsafe { Box::from_raw(handle as *mut Statement) };
-
-    if let Err(e) = DatabaseDriverClient::statement_release(StatementReleaseRequest {
-        stmt_handle: Some(stmt.stmt_handle),
-    }) {
-        tracing::warn!("Failed to release server-side statement handle: {:?}", e);
-    }
+    global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_release(StatementReleaseRequest {
+            stmt_handle: Some(stmt.stmt_handle),
+        })
+        .await
+    })?;
     Ok(())
 }
 
@@ -173,7 +179,6 @@ pub fn sql_alloc_handle(
             Ok(())
         }
         sql::HandleType::Desc => {
-            // Not implemented yet
             tracing::warn!(
                 "SQLAllocHandle: Desc handle type not implemented: {:?}",
                 handle_type
@@ -206,10 +211,7 @@ pub fn sql_free_handle(handle_type: sql::HandleType, handle: sql::Handle) -> Odb
             tracing::info!("Freeing stmt: SQLFreeHandle: handle_type={:?}", handle_type);
             free_statement(handle)
         }
-        sql::HandleType::Desc => {
-            // Not implemented yet
-            InvalidHandleSnafu.fail()
-        }
+        sql::HandleType::Desc => InvalidHandleSnafu.fail(),
         _ => InvalidHandleSnafu.fail(),
     }
 }

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod diagnostic;
 pub mod environment;
 pub mod error;
 pub mod handle_allocation;
+pub mod runtime;
 pub mod sql_state;
 pub mod statement;
 pub mod types;

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -4,6 +4,17 @@ use std::sync::RwLock;
 use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
 use snafu::{Location, ResultExt, Snafu};
 
+/// Holds the shared tokio runtime and driver client used by all ODBC
+/// environments in this process.
+///
+/// ODBC requires an Environment handle before any Connection or Statement can
+/// be created. An application may allocate multiple Environments (e.g. for
+/// different global settings), but they all share the same underlying driver
+/// state. We therefore keep a single `OdbcGlobals` instance behind a
+/// reference-counted latch (`env_count`): the first `SQLAllocHandle(SQL_HANDLE_ENV)`
+/// creates it, and the last `SQLFreeHandle(SQL_HANDLE_ENV)` tears it down.
+/// On Windows the ODBC Driver Manager unloads the driver DLL after the last
+/// environment is freed, so we must shut down before that happens.
 pub struct OdbcGlobals {
     runtime: tokio::runtime::Runtime,
     client: DatabaseDriverClient,
@@ -69,7 +80,6 @@ pub fn global() -> Result<GlobalsGuard, OdbcRuntimeError> {
 
 pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
     let mut guard = STATE.write().map_err(|_| LockPoisonedSnafu.build())?;
-    guard.env_count += 1;
     if guard.globals.is_none() {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
@@ -79,6 +89,7 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
         let client = database_driver_client();
         guard.globals = Some(OdbcGlobals { runtime, client });
     }
+    guard.env_count += 1;
     Ok(())
 }
 
@@ -86,6 +97,7 @@ pub fn env_freed() -> Result<(), OdbcRuntimeError> {
     let mut guard = STATE.write().map_err(|_| LockPoisonedSnafu.build())?;
     guard.env_count = guard.env_count.saturating_sub(1);
     if guard.env_count == 0 {
+        tracing::info!("Last ODBC environment freed, tearing down global state");
         guard.globals = None;
     }
     Ok(())

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -1,0 +1,92 @@
+use std::ops::Deref;
+use std::sync::RwLock;
+
+use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
+use snafu::{Location, ResultExt, Snafu};
+
+pub struct OdbcGlobals {
+    runtime: tokio::runtime::Runtime,
+    client: DatabaseDriverClient,
+}
+
+impl OdbcGlobals {
+    pub fn block_on<T>(&self, f: impl AsyncFnOnce(&DatabaseDriverClient) -> T) -> T {
+        self.runtime.block_on(f(&self.client))
+    }
+}
+
+struct GlobalState {
+    env_count: usize,
+    globals: Option<OdbcGlobals>,
+}
+
+static STATE: RwLock<GlobalState> = RwLock::new(GlobalState {
+    env_count: 0,
+    globals: None,
+});
+
+pub struct GlobalsGuard(std::sync::RwLockReadGuard<'static, GlobalState>);
+
+impl Deref for GlobalsGuard {
+    type Target = OdbcGlobals;
+    fn deref(&self) -> &OdbcGlobals {
+        self.0
+            .globals
+            .as_ref()
+            .expect("GlobalsGuard created while globals are None (bug in global())")
+    }
+}
+
+#[derive(Debug, Snafu)]
+pub enum OdbcRuntimeError {
+    #[snafu(display("ODBC globals not initialized; allocate an environment handle first"))]
+    NotInitialized {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("ODBC globals RwLock poisoned"))]
+    LockPoisoned {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to create ODBC tokio runtime"))]
+    RuntimeCreation {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+pub fn global() -> Result<GlobalsGuard, OdbcRuntimeError> {
+    let guard = STATE.read().map_err(|_| LockPoisonedSnafu.build())?;
+    if guard.globals.is_none() {
+        return NotInitializedSnafu.fail();
+    }
+    Ok(GlobalsGuard(guard))
+}
+
+pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
+    let mut guard = STATE.write().map_err(|_| LockPoisonedSnafu.build())?;
+    guard.env_count += 1;
+    if guard.globals.is_none() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .context(RuntimeCreationSnafu)?;
+        let client = database_driver_client();
+        guard.globals = Some(OdbcGlobals { runtime, client });
+    }
+    Ok(())
+}
+
+pub fn env_freed() -> Result<(), OdbcRuntimeError> {
+    let mut guard = STATE.write().map_err(|_| LockPoisonedSnafu.build())?;
+    guard.env_count = guard.env_count.saturating_sub(1);
+    if guard.env_count == 0 {
+        guard.globals = None;
+    }
+    Ok(())
+}

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -2,8 +2,9 @@ use crate::api::api_utils::{cstr_to_string, utf16_to_string};
 use crate::api::error::{
     ArrowArrayStreamReaderCreationSnafu, DisconnectedSnafu, InvalidBufferLengthSnafu,
     InvalidCursorStateSnafu, InvalidHandleSnafu, InvalidParameterNumberSnafu, JsonBindingSnafu,
-    NoMoreDataSnafu, Required,
+    NoMoreDataSnafu, OdbcRuntimeSnafu, Required,
 };
+use crate::api::runtime::global;
 use crate::api::{
     ConnectionState, OdbcResult, ParameterBinding, Statement, StatementState, stmt_from_handle,
 };
@@ -13,7 +14,6 @@ use crate::write_json::odbc_bindings_to_json;
 use arrow::array::RecordBatchReader;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use odbc_sys as sql;
-use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::{
     ArrowArrayStreamPtr, BinaryDataPtr, ConnectionGetParameterRequest, ConnectionHandle,
     QueryBindings, StatementExecuteQueryRequest, StatementExecuteQueryResponse,
@@ -50,23 +50,27 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
             db_handle: _,
             conn_handle,
         } => {
-            DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
-                stmt_handle: Some(stmt.stmt_handle),
-                query: statement_text.to_string(),
-            })?;
-
             let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
+            let stmt_handle = stmt.stmt_handle;
 
-            let response =
-                DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt.stmt_handle),
+            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+                c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: statement_text.to_string(),
+                })
+                .await?;
+
+                c.statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
                     bindings,
-                });
+                })
+                .await
+            });
 
             tracing::info!("exec_direct: response={:?}", response);
             let response = response?;
 
-            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings);
+            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings)?;
             set_state(stmt, create_execute_state(response)?);
             Ok(())
         }
@@ -79,36 +83,39 @@ pub fn exec_direct(statement_handle: sql::Handle, statement_text: &str) -> OdbcR
 
 use crate::conversion::NumericSettings;
 
-fn update_numeric_settings(conn_handle: &ConnectionHandle, settings: &mut NumericSettings) {
-    if let Ok(resp) =
-        DatabaseDriverClient::connection_get_parameter(ConnectionGetParameterRequest {
-            conn_handle: Some(*conn_handle),
-            key: "ODBC_TREAT_DECIMAL_AS_INT".to_string(),
-        })
-        && let Some(value) = resp.value
-    {
-        let bool_value = value.eq_ignore_ascii_case("true");
-        settings.treat_decimal_as_int = bool_value;
-        tracing::info!(
-            "Server parameter ODBC_TREAT_DECIMAL_AS_INT = {}",
-            bool_value
-        );
-    }
+fn update_numeric_settings(
+    conn_handle: &ConnectionHandle,
+    settings: &mut NumericSettings,
+) -> OdbcResult<()> {
+    let g = global().context(OdbcRuntimeSnafu)?;
+    g.block_on(async |c| {
+        if let Ok(resp) = c
+            .connection_get_parameter(ConnectionGetParameterRequest {
+                conn_handle: Some(*conn_handle),
+                key: "ODBC_TREAT_DECIMAL_AS_INT".to_string(),
+            })
+            .await
+            && let Some(value) = resp.value
+        {
+            let bool_value = value.eq_ignore_ascii_case("true");
+            settings.treat_decimal_as_int = bool_value;
+            tracing::info!("Server parameter ODBC_TREAT_DECIMAL_AS_INT = {bool_value}");
+        }
 
-    if let Ok(resp) =
-        DatabaseDriverClient::connection_get_parameter(ConnectionGetParameterRequest {
-            conn_handle: Some(*conn_handle),
-            key: "ODBC_TREAT_BIG_NUMBER_AS_STRING".to_string(),
-        })
-        && let Some(value) = resp.value
-    {
-        let bool_value = value.eq_ignore_ascii_case("true");
-        settings.treat_big_number_as_string = bool_value;
-        tracing::info!(
-            "Server parameter ODBC_TREAT_BIG_NUMBER_AS_STRING = {}",
-            bool_value
-        );
-    }
+        if let Ok(resp) = c
+            .connection_get_parameter(ConnectionGetParameterRequest {
+                conn_handle: Some(*conn_handle),
+                key: "ODBC_TREAT_BIG_NUMBER_AS_STRING".to_string(),
+            })
+            .await
+            && let Some(value) = resp.value
+        {
+            let bool_value = value.eq_ignore_ascii_case("true");
+            settings.treat_big_number_as_string = bool_value;
+            tracing::info!("Server parameter ODBC_TREAT_BIG_NUMBER_AS_STRING = {bool_value}");
+        }
+    });
+    Ok(())
 }
 
 pub fn prepare_n(
@@ -165,15 +172,19 @@ pub fn prepare(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
         } => {
             tracing::debug!("prepare: query = {query}");
 
-            DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
-                stmt_handle: Some(stmt.stmt_handle),
-                query: query.to_string(),
-            })?;
+            let stmt_handle = stmt.stmt_handle;
+            let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+                c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: query.to_string(),
+                })
+                .await?;
 
-            let prepare_result =
-                DatabaseDriverClient::statement_prepare(StatementPrepareRequest {
-                    stmt_handle: Some(stmt.stmt_handle),
-                })?;
+                c.statement_prepare(StatementPrepareRequest {
+                    stmt_handle: Some(stmt_handle),
+                })
+                .await
+            })?;
 
             let result = prepare_result.result.required("Result is required")?;
             let stream_ptr = result.stream.required("Stream is required")?;
@@ -213,14 +224,16 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         } => {
             let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
 
-            let response =
-                DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
+            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+                c.statement_execute_query(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt.stmt_handle),
                     bindings,
-                })?;
+                })
+                .await
+            })?;
 
             tracing::info!("execute: Successfully executed statement");
-            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings);
+            update_numeric_settings(conn_handle, &mut stmt.conn.numeric_settings)?;
 
             let statement_type_id = response.result.as_ref().and_then(|r| r.statement_type_id);
             let rows_affected = response.result.as_ref().and_then(|r| r.rows_affected);

--- a/odbc/tests/odbc_api_tests.rs
+++ b/odbc/tests/odbc_api_tests.rs
@@ -69,55 +69,83 @@
 //     assert_eq!(ret, sql::SqlReturn::SUCCESS);
 // }
 
+use std::sync::LazyLock;
+
 use sf_core::{
-    protobuf::apis::database_driver_v1::DatabaseDriverClient,
+    protobuf::apis::database_driver_v1::database_driver_client,
     protobuf::generated::database_driver_v1::{
         ConnectionNewRequest, ConnectionSetOptionIntRequest, ConnectionSetOptionStringRequest,
         DatabaseInitRequest, DatabaseNewRequest,
     },
 };
 
+static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create test tokio runtime")
+});
+
 #[test]
 fn smoke_connection_set_tls_config() {
-    let db = DatabaseDriverClient::database_new(DatabaseNewRequest {}).expect("database_new ok");
-    DatabaseDriverClient::database_init(DatabaseInitRequest {
-        db_handle: db.db_handle,
-    })
-    .expect("database_init ok");
-    let conn = DatabaseDriverClient::connection_new(ConnectionNewRequest {})
-        .unwrap()
-        .conn_handle
-        .unwrap();
+    TEST_RUNTIME.block_on(async {
+        let client = database_driver_client();
+        let db = client
+            .database_new(DatabaseNewRequest {})
+            .await
+            .expect("database_new ok");
+        client
+            .database_init(DatabaseInitRequest {
+                db_handle: db.db_handle,
+            })
+            .await
+            .expect("database_init ok");
+        let conn = client
+            .connection_new(ConnectionNewRequest {})
+            .await
+            .unwrap()
+            .conn_handle
+            .unwrap();
 
-    // Option-based TLS/CRL configuration
-    DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-        conn_handle: Some(conn),
-        key: "verify_hostname".to_string(),
-        value: "true".to_string(),
-    })
-    .expect("set verify_hostname");
-    DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-        conn_handle: Some(conn),
-        key: "verify_certificates".to_string(),
-        value: "true".to_string(),
-    })
-    .expect("set verify_certificates");
-    DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-        conn_handle: Some(conn),
-        key: "crl_mode".to_string(),
-        value: "ENABLED".to_string(),
-    })
-    .expect("set crl_mode");
-    DatabaseDriverClient::connection_set_option_int(ConnectionSetOptionIntRequest {
-        conn_handle: Some(conn),
-        key: "crl_http_timeout".to_string(),
-        value: 30,
-    })
-    .expect("set crl_http_timeout");
-    DatabaseDriverClient::connection_set_option_int(ConnectionSetOptionIntRequest {
-        conn_handle: Some(conn),
-        key: "crl_connection_timeout".to_string(),
-        value: 10,
-    })
-    .expect("set crl_connection_timeout");
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn),
+                key: "verify_hostname".to_string(),
+                value: "true".to_string(),
+            })
+            .await
+            .expect("set verify_hostname");
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn),
+                key: "verify_certificates".to_string(),
+                value: "true".to_string(),
+            })
+            .await
+            .expect("set verify_certificates");
+        client
+            .connection_set_option_string(ConnectionSetOptionStringRequest {
+                conn_handle: Some(conn),
+                key: "crl_mode".to_string(),
+                value: "ENABLED".to_string(),
+            })
+            .await
+            .expect("set crl_mode");
+        client
+            .connection_set_option_int(ConnectionSetOptionIntRequest {
+                conn_handle: Some(conn),
+                key: "crl_http_timeout".to_string(),
+                value: 30,
+            })
+            .await
+            .expect("set crl_http_timeout");
+        client
+            .connection_set_option_int(ConnectionSetOptionIntRequest {
+                conn_handle: Some(conn),
+                key: "crl_connection_timeout".to_string(),
+                value: 10,
+            })
+            .await
+            .expect("set crl_connection_timeout");
+    });
 }

--- a/proto_generator/src/generators/rust_generator.rs
+++ b/proto_generator/src/generators/rust_generator.rs
@@ -165,13 +165,13 @@ use prost::Message;
         match method_error {
             Some(error) => {
                 format!(
-                    r#"	fn {name}(input: {input_type}) -> Result<{output_type}, {error}>;
+                    r#"	fn {name}(&self, input: {input_type}) -> impl std::future::Future<Output = Result<{output_type}, {error}>> + Send;
 "#
                 )
             }
             None => {
                 format!(
-                    r#"	fn {name}(input: {input_type}) -> {output_type};
+                    r#"	fn {name}(&self, input: {input_type}) -> impl std::future::Future<Output = {output_type}> + Send;
 "#
                 )
             }
@@ -194,7 +194,7 @@ use prost::Message;
 
         let mut content = format!(
             r#"pub trait {service_name}Server : {service_name} {{
-	fn handle_message(method: &str, message: Vec<u8>) -> Result<Vec<u8>, ProtoError<Vec<u8>>> {{
+	fn handle_message(&self, method: &str, message: Vec<u8>) -> impl std::future::Future<Output = Result<Vec<u8>, ProtoError<Vec<u8>>>> + Send where Self: Sync {{ async move {{
 		match method {{
 "#
         );
@@ -205,7 +205,7 @@ use prost::Message;
 
         content += r#"			_ => Err(ProtoError::Transport(format!("Unknown method: {}", method))),
 		}
-	}
+	} }
 }
 "#;
         content
@@ -230,7 +230,7 @@ use prost::Message;
 					Ok(input) => input,
 					Err(e) => return Err(ProtoError::Transport(e.to_string())),
 				}};
-				let result = Self::{name}(input);
+				let result = self.{name}(input).await;
 				match result {{
 				Ok(output) => Ok(output.encode_to_vec()),
 				Err(e) => Err(ProtoError::Application(e.encode_to_vec())),
@@ -256,9 +256,12 @@ use prost::Message;
 
         let mut content = format!(
             r#"pub struct {service_name}Client<T: Transport> {{
-	_marker: ::core::marker::PhantomData<T>,
+	transport: T,
 }}
 impl<T: Transport> {service_name}Client<T> {{
+	pub fn new(transport: T) -> Self {{
+		Self {{ transport }}
+	}}
 "#
         );
 
@@ -304,8 +307,8 @@ impl<T: Transport> {service_name}Client<T> {{
             Some(error) => {
                 format!(
                     r#"
-    pub fn {name}(input: {input_type}) -> Result<{output_type}, ProtoError<{error}>> {{
-        let result = T::handle_message("{service_name}", "{name}", input.encode_to_vec());
+    pub async fn {name}(&self, input: {input_type}) -> Result<{output_type}, ProtoError<{error}>> {{
+        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec()).await;
         match result {{
             Ok(output) => {{
                 let output = {output_type}::decode(&output[..]);
@@ -329,7 +332,7 @@ impl<T: Transport> {service_name}Client<T> {{
             }
             None => {
                 format!(
-                    r#"	fn {name}(input: {input_type}) -> {output_type};
+                    r#"	async fn {name}(&self, input: {input_type}) -> {output_type};
 "#
                 )
             }

--- a/proto_generator/src/generators/rust_generator.rs
+++ b/proto_generator/src/generators/rust_generator.rs
@@ -332,7 +332,21 @@ impl<T: Transport> {service_name}Client<T> {{
             }
             None => {
                 format!(
-                    r#"	async fn {name}(&self, input: {input_type}) -> {output_type};
+                    r#"
+    pub async fn {name}(&self, input: {input_type}) -> Result<{output_type}, ProtoError<()>> {{
+        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec()).await;
+        match result {{
+            Ok(output) => {{
+                let output = {output_type}::decode(&output[..]);
+                match output {{
+                    Ok(output) => Ok(output),
+                    Err(e) => Err(ProtoError::Transport(e.to_string())),
+                }}
+            }},
+            Err(ProtoError::Application(_)) => Err(ProtoError::Transport("Unexpected application error".to_string())),
+            Err(ProtoError::Transport(e)) => Err(ProtoError::Transport(e)),
+        }}
+    }}
 "#
                 )
             }

--- a/proto_utils/src/lib.rs
+++ b/proto_utils/src/lib.rs
@@ -6,8 +6,9 @@ pub enum ProtoError<T> {
 
 pub trait Transport {
     fn handle_message(
+        &self,
         service: &str,
         method: &str,
         message: Vec<u8>,
-    ) -> Result<Vec<u8>, ProtoError<Vec<u8>>>;
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, ProtoError<Vec<u8>>>> + Send;
 }

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1,6 +1,8 @@
 use snafu::{OptionExt, ResultExt};
 use std::future::Future;
-use std::{collections::HashMap, sync::Arc, sync::Mutex, sync::RwLock};
+use std::sync::RwLock;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
 use tokio::sync::RwLock as AsyncRwLock;
 
 use super::Setting;
@@ -51,50 +53,49 @@ pub fn connection_load_from_config_with_paths(
 }
 
 impl DatabaseDriverV1 {
-    pub fn connection_init(&self, conn_handle: Handle, _db_handle: Handle) -> Result<(), ApiError> {
+    pub async fn connection_init(
+        &self,
+        conn_handle: Handle,
+        _db_handle: Handle,
+    ) -> Result<(), ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
-                let mut conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let (login_parameters, init_params) = {
+                    let mut conn = conn_ptr.lock().await;
 
-                // Check if connection_name is set and load from config if present
-                let connection_name =
-                    conn.settings
-                        .get(param_names::CONNECTION_NAME)
-                        .and_then(|s| {
-                            if let Setting::String(name) = s {
-                                Some(name.clone())
-                            } else {
-                                None
-                            }
-                        });
+                    // Check if connection_name is set and load from config if present
+                    let connection_name =
+                        conn.settings
+                            .get(param_names::CONNECTION_NAME)
+                            .and_then(|s| {
+                                if let Setting::String(name) = s {
+                                    Some(name.clone())
+                                } else {
+                                    None
+                                }
+                            });
 
-                if let Some(name) = connection_name {
-                    connection_load_from_config(&mut conn, &name)?;
-                }
+                    if let Some(name) = connection_name {
+                        connection_load_from_config(&mut conn, &name)?;
+                    }
 
-                let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
-
-                let login_parameters =
-                    LoginParameters::from_settings(&conn.settings).context(ConfigurationSnafu)?;
-                let init_params = conn.init_session_parameters.clone();
-                drop(conn);
+                    let login_parameters = LoginParameters::from_settings(&conn.settings)
+                        .context(ConfigurationSnafu)?;
+                    let init_params = conn.init_session_parameters.clone();
+                    (login_parameters, init_params)
+                };
 
                 let http_client =
                     create_tls_client_with_config(login_parameters.client_info.tls_config.clone())
                         .context(TlsClientCreationSnafu)?;
 
-                let login_result = rt
-                    .block_on(async {
-                        crate::rest::snowflake::snowflake_login_with_client(
-                            &http_client,
-                            &login_parameters,
-                            init_params.as_ref(),
-                        )
-                        .await
-                    })
-                    .context(LoginSnafu)?;
+                let login_result = crate::rest::snowflake::snowflake_login_with_client(
+                    &http_client,
+                    &login_parameters,
+                    init_params.as_ref(),
+                )
+                .await
+                .context(LoginSnafu)?;
 
                 // Initialize connection with session parameters from login response.
                 // The server returns system-level parameters but may not echo back
@@ -112,7 +113,7 @@ impl DatabaseDriverV1 {
 
                 conn_ptr
                     .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?
+                    .await
                     .initialize(
                         login_result.tokens,
                         http_client,
@@ -120,7 +121,8 @@ impl DatabaseDriverV1 {
                         login_parameters.client_info.clone(),
                         merged_params,
                         login_final_names,
-                    );
+                    )
+                    .await;
                 Ok(())
             }
             None => InvalidArgumentSnafu {
@@ -130,7 +132,7 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn connection_set_option(
+    pub async fn connection_set_option(
         &self,
         handle: Handle,
         key: String,
@@ -138,9 +140,7 @@ impl DatabaseDriverV1 {
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(handle) {
             Some(conn_ptr) => {
-                let mut conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let mut conn = conn_ptr.lock().await;
                 conn.settings.insert(key, value);
                 Ok(())
             }
@@ -151,16 +151,14 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn connection_set_options(
+    pub async fn connection_set_options(
         &self,
         handle: Handle,
         options: HashMap<String, Setting>,
     ) -> Result<Vec<ValidationIssue>, ApiError> {
         match self.connections.get_obj(handle) {
             Some(conn_ptr) => {
-                let mut conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let mut conn = conn_ptr.lock().await;
                 resolve_and_apply_options(&mut conn.settings, options)
             }
             None => InvalidArgumentSnafu {
@@ -170,16 +168,14 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn connection_set_session_parameters(
+    pub async fn connection_set_session_parameters(
         &self,
         handle: Handle,
         parameters: HashMap<String, String>,
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(handle) {
             Some(conn_ptr) => {
-                let mut conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let mut conn = conn_ptr.lock().await;
                 conn.init_session_parameters = Some(parameters);
                 Ok(())
             }
@@ -216,7 +212,7 @@ pub struct Connection {
     /// Client info for refresh requests
     pub client_info: Option<ClientInfo>,
     /// Session parameters cache (populated after login)
-    pub session_parameters: Arc<RwLock<HashMap<String, String>>>,
+    pub session_parameters: Arc<AsyncRwLock<HashMap<String, String>>>,
     /// Session parameters to send during initialization (set before connection_init)
     pub init_session_parameters: Option<HashMap<String, String>>,
     /// Server-echoed final names from login and query responses (e.g. after USE DATABASE).
@@ -239,7 +235,7 @@ impl Connection {
             retry_policy: RetryPolicy::default(),
             server_url: None,
             client_info: None,
-            session_parameters: Arc::new(RwLock::new(HashMap::new())),
+            session_parameters: Arc::new(AsyncRwLock::new(HashMap::new())),
             init_session_parameters: None,
             final_session_names: RwLock::new(FinalSessionNames::default()),
         }
@@ -250,7 +246,7 @@ impl Connection {
         self.settings.insert(key, value);
     }
 
-    pub(crate) fn initialize(
+    pub(crate) async fn initialize(
         &mut self,
         tokens: SessionTokens,
         http_client: reqwest::Client,
@@ -260,14 +256,14 @@ impl Connection {
         final_names: FinalSessionNames,
     ) {
         // Use blocking_write since we're in a sync context during connection_init
-        *self.tokens.blocking_write() = Some(tokens);
+        *self.tokens.write().await = Some(tokens);
         self.http_client = Some(http_client);
         self.server_url = Some(server_url);
         self.client_info = Some(client_info);
 
-        if let Ok(mut cache) = self.session_parameters.write() {
-            *cache = session_params;
-        }
+        let mut cache = self.session_parameters.write().await;
+        *cache = session_params;
+        drop(cache);
 
         if let Ok(mut names) = self.final_session_names.write() {
             *names = final_names;
@@ -275,7 +271,7 @@ impl Connection {
     }
 
     /// Update the session parameters cache after a successful query.
-    pub fn update_session_params_cache(
+    pub async fn update_session_params_cache(
         &self,
         query: &str,
         response_parameters: Option<
@@ -283,10 +279,7 @@ impl Connection {
         >,
         final_names: &FinalSessionNames,
     ) {
-        let mut cache = match self.session_parameters.write() {
-            Ok(cache) => cache,
-            Err(_) => return,
-        };
+        let mut cache = self.session_parameters.write().await;
 
         // 1. ALTER SESSION SET detection: optimistically update the cache based on user's query.
         // This is necessary as Snowflake returns only part of session parameters in response.
@@ -368,7 +361,7 @@ where
     F: Fn(SensitiveString) -> Fut,
     Fut: Future<Output = Result<T, RestError>>,
 {
-    let mut ctx = RefreshContext::from_arc(conn)?;
+    let mut ctx = RefreshContext::from_arc(conn).await?;
     let mut last_error: Option<RestError> = None;
     loop {
         let token = ctx.refresh_token(last_error).await?;
@@ -420,8 +413,8 @@ pub struct RefreshContext {
 }
 
 impl RefreshContext {
-    pub fn from_arc(conn: &Arc<Mutex<Connection>>) -> Result<Self, ApiError> {
-        let guard = conn.lock().map_err(|_| ConnectionLockingSnafu.build())?;
+    pub async fn from_arc(conn: &Arc<Mutex<Connection>>) -> Result<Self, ApiError> {
+        let guard = conn.lock().await;
         Self::new(&guard)
     }
     /// Create a new `RefreshContext` by extracting connection info.
@@ -591,7 +584,7 @@ fn get_session_or_setting(
     param_name: &str,
     setting_key: ParamKey,
 ) -> Option<String> {
-    if let Ok(cache) = conn.session_parameters.read()
+    if let Ok(cache) = conn.session_parameters.try_read()
         && let Some(v) = cache.get(param_name)
         && !v.is_empty()
     {
@@ -602,12 +595,13 @@ fn get_session_or_setting(
 
 impl DatabaseDriverV1 {
     /// Get connection information for the given connection handle
-    pub fn connection_get_info(&self, conn_handle: Handle) -> Result<ConnectionInfo, ApiError> {
+    pub async fn connection_get_info(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<ConnectionInfo, ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
-                let conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let conn = conn_ptr.lock().await;
 
                 let host = get_setting_string(&conn, param_names::HOST);
 
@@ -622,7 +616,7 @@ impl DatabaseDriverV1 {
                 let server_url = conn.server_url.clone();
 
                 let (session_token, session_id) = {
-                    let tokens_guard = conn.tokens.blocking_read();
+                    let tokens_guard = conn.tokens.read().await;
                     match tokens_guard.as_ref() {
                         Some(tokens) => {
                             (Some(tokens.session_token.clone()), Some(tokens.session_id))
@@ -684,21 +678,16 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn connection_get_parameter(
+    pub async fn connection_get_parameter(
         &self,
         conn_handle: Handle,
         key: String,
     ) -> Result<Option<String>, ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
-                let conn = conn_ptr
-                    .lock()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let conn = conn_ptr.lock().await;
 
-                let cache = conn
-                    .session_parameters
-                    .read()
-                    .map_err(|_| ConnectionLockingSnafu {}.build())?;
+                let cache = conn.session_parameters.read().await;
 
                 let normalized_key = key.to_uppercase();
                 Ok(cache.get(&normalized_key).cloned())
@@ -714,7 +703,6 @@ impl DatabaseDriverV1 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::apis::database_driver_v1::driver_state;
     use crate::config::param_registry::param_names;
 
     fn make_connection_with_settings(settings: Vec<(&str, Setting)>) -> Connection {
@@ -752,7 +740,7 @@ mod tests {
         let conn =
             make_connection_with_settings(vec![("database", Setting::String("setting_db".into()))]);
         conn.session_parameters
-            .write()
+            .try_write()
             .unwrap()
             .insert("DATABASE".into(), "session_db".into());
 
@@ -778,7 +766,7 @@ mod tests {
         let conn =
             make_connection_with_settings(vec![("role", Setting::String("setting_role".into()))]);
         conn.session_parameters
-            .write()
+            .try_write()
             .unwrap()
             .insert("ROLE".into(), String::new());
 
@@ -797,36 +785,44 @@ mod tests {
         );
     }
 
-    #[test]
-    fn connection_get_info_returns_all_settings() {
-        let ds = driver_state();
+    #[tokio::test]
+    async fn connection_get_info_returns_all_settings() {
+        let ds = DatabaseDriverV1::new();
         let handle = ds.connection_new();
         ds.connection_set_option(
             handle,
             "host".into(),
             Setting::String("snow.example.com".into()),
         )
+        .await
         .unwrap();
         ds.connection_set_option(handle, "port".into(), Setting::Int(8080))
+            .await
             .unwrap();
         ds.connection_set_option(
             handle,
             "account".into(),
             Setting::String("my_account".into()),
         )
+        .await
         .unwrap();
         ds.connection_set_option(handle, "user".into(), Setting::String("my_user".into()))
+            .await
             .unwrap();
         ds.connection_set_option(handle, "role".into(), Setting::String("my_role".into()))
+            .await
             .unwrap();
         ds.connection_set_option(handle, "database".into(), Setting::String("my_db".into()))
+            .await
             .unwrap();
         ds.connection_set_option(handle, "schema".into(), Setting::String("my_schema".into()))
+            .await
             .unwrap();
         ds.connection_set_option(handle, "warehouse".into(), Setting::String("my_wh".into()))
+            .await
             .unwrap();
 
-        let info = ds.connection_get_info(handle).unwrap();
+        let info = ds.connection_get_info(handle).await.unwrap();
 
         assert_eq!(info.host, Some("snow.example.com".into()));
         assert_eq!(info.port, Some(8080));
@@ -840,12 +836,12 @@ mod tests {
         ds.connection_release(handle).unwrap();
     }
 
-    #[test]
-    fn connection_get_info_returns_none_for_unset_fields() {
-        let ds = driver_state();
+    #[tokio::test]
+    async fn connection_get_info_returns_none_for_unset_fields() {
+        let ds = DatabaseDriverV1::new();
         let handle = ds.connection_new();
 
-        let info = ds.connection_get_info(handle).unwrap();
+        let info = ds.connection_get_info(handle).await.unwrap();
 
         assert_eq!(info.host, None);
         assert_eq!(info.port, None);
@@ -861,36 +857,38 @@ mod tests {
         ds.connection_release(handle).unwrap();
     }
 
-    #[test]
-    fn connection_get_info_session_params_override_settings() {
-        let ds = driver_state();
+    #[tokio::test]
+    async fn connection_get_info_session_params_override_settings() {
+        let ds = DatabaseDriverV1::new();
         let handle = ds.connection_new();
         ds.connection_set_option(
             handle,
             "database".into(),
             Setting::String("original_db".into()),
         )
+        .await
         .unwrap();
         ds.connection_set_option(
             handle,
             "role".into(),
             Setting::String("original_role".into()),
         )
+        .await
         .unwrap();
 
         if let Some(conn_ptr) = ds.connections.get_obj(handle) {
-            let conn = conn_ptr.lock().unwrap();
+            let conn = conn_ptr.lock().await;
             conn.session_parameters
                 .write()
-                .unwrap()
+                .await
                 .insert("DATABASE".into(), "session_db".into());
             conn.session_parameters
                 .write()
-                .unwrap()
+                .await
                 .insert("ROLE".into(), "session_role".into());
         }
 
-        let info = ds.connection_get_info(handle).unwrap();
+        let info = ds.connection_get_info(handle).await.unwrap();
 
         assert_eq!(info.database, Some("session_db".into()));
         assert_eq!(info.role, Some("session_role".into()));
@@ -898,34 +896,35 @@ mod tests {
         ds.connection_release(handle).unwrap();
     }
 
-    #[test]
-    fn connection_get_info_final_names_override_session_params() {
-        let ds = driver_state();
+    #[tokio::test]
+    async fn connection_get_info_final_names_override_session_params() {
+        let ds = DatabaseDriverV1::new();
         let handle = ds.connection_new();
         ds.connection_set_option(
             handle,
             "database".into(),
             Setting::String("setting_db".into()),
         )
+        .await
         .unwrap();
 
         if let Some(conn_ptr) = ds.connections.get_obj(handle) {
-            let conn = conn_ptr.lock().unwrap();
+            let conn = conn_ptr.lock().await;
             conn.session_parameters
                 .write()
-                .unwrap()
+                .await
                 .insert("DATABASE".into(), "session_db".into());
             conn.final_session_names.write().unwrap().database = Some("final_db".into());
         }
 
-        let info = ds.connection_get_info(handle).unwrap();
+        let info = ds.connection_get_info(handle).await.unwrap();
         assert_eq!(info.database, Some("final_db".into()));
 
         ds.connection_release(handle).unwrap();
     }
 
-    #[test]
-    fn update_session_params_cache_stores_final_names_separately() {
+    #[tokio::test]
+    async fn update_session_params_cache_stores_final_names_separately() {
         let conn = Connection::new();
         let final_names = FinalSessionNames {
             database: Some("new_db".into()),
@@ -934,9 +933,10 @@ mod tests {
             role: None,
         };
 
-        conn.update_session_params_cache("SELECT 1", None, &final_names);
+        conn.update_session_params_cache("SELECT 1", None, &final_names)
+            .await;
 
-        let cache = conn.session_parameters.read().unwrap();
+        let cache = conn.session_parameters.read().await;
         assert!(
             cache.get("DATABASE").is_none(),
             "final names should not be stored in session_parameters"

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -255,7 +255,6 @@ impl Connection {
         session_params: HashMap<String, String>,
         final_names: FinalSessionNames,
     ) {
-        // Use blocking_write since we're in a sync context during connection_init
         *self.tokens.write().await = Some(tokens);
         self.http_client = Some(http_client);
         self.server_url = Some(server_url);

--- a/sf_core/src/apis/database_driver_v1/database.rs
+++ b/sf_core/src/apis/database_driver_v1/database.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
+use tokio::sync::Mutex;
 
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
@@ -13,7 +13,7 @@ impl DatabaseDriverV1 {
         self.databases.add_handle(Mutex::new(Database::new()))
     }
 
-    pub fn database_set_option(
+    pub async fn database_set_option(
         &self,
         db_handle: Handle,
         key: String,
@@ -21,7 +21,7 @@ impl DatabaseDriverV1 {
     ) -> Result<(), ApiError> {
         match self.databases.get_obj(db_handle) {
             Some(db_ptr) => {
-                let mut db = db_ptr.lock().map_err(|_| DatabaseLockingSnafu {}.build())?;
+                let mut db = db_ptr.lock().await;
                 db.settings.insert(key, value);
                 Ok(())
             }
@@ -32,14 +32,14 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn database_set_options(
+    pub async fn database_set_options(
         &self,
         db_handle: Handle,
         options: HashMap<String, Setting>,
     ) -> Result<Vec<ValidationIssue>, ApiError> {
         match self.databases.get_obj(db_handle) {
             Some(db_ptr) => {
-                let mut db = db_ptr.lock().map_err(|_| DatabaseLockingSnafu {}.build())?;
+                let mut db = db_ptr.lock().await;
                 resolve_and_apply_options(&mut db.settings, options)
             }
             None => InvalidArgumentSnafu {

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,24 +1,19 @@
-use std::sync::{LazyLock, Mutex};
+use tokio::sync::Mutex;
 
 use super::connection::Connection;
 use super::database::Database;
 use super::statement::Statement;
 use crate::handle_manager::HandleManager;
 
+#[derive(Default)]
 pub struct DatabaseDriverV1 {
     pub(super) databases: HandleManager<Mutex<Database>>,
     pub(super) connections: HandleManager<Mutex<Connection>>,
     pub(super) statements: HandleManager<Mutex<Statement>>,
 }
 
-static INSTANCE: LazyLock<DatabaseDriverV1> = LazyLock::new(DatabaseDriverV1::new);
-
-pub fn driver_state() -> &'static DatabaseDriverV1 {
-    &INSTANCE
-}
-
 impl DatabaseDriverV1 {
-    const fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             databases: HandleManager::new(),
             connections: HandleManager::new(),

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -12,6 +12,6 @@ pub use crate::config::settings::Setting;
 pub use crate::handle_manager::Handle;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use error::ApiError;
-pub use global_state::{DatabaseDriverV1, driver_state};
+pub use global_state::DatabaseDriverV1;
 pub use statement::{BindingType, ColumnMetadata, DataPtr};
 pub use validation::{ValidationCode, ValidationIssue, ValidationSeverity};

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -1,5 +1,5 @@
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::sync::Mutex;
+use tokio::sync::Mutex;
 
 use super::connection::{Connection, RefreshContext};
 use super::error::*;
@@ -31,6 +31,17 @@ pub struct DataPtr<'a> {
     /// Phantom data to enforce lifetime
     _phantom: std::marker::PhantomData<&'a [u8]>,
 }
+
+// Safety: DataPtr semantically represents a &[u8] (immutable borrowed slice),
+// which is Send. The raw pointer is only used for FFI interop and is always
+// accessed immutably within the lifetime 'a.
+//
+// Callers must ensure the backing memory is not freed or mutated while
+// any DataPtr (or Future holding one) is alive — including across .await
+// points. All current production paths run the entire async execution
+// synchronously via block_on, keeping the source data on the stack for
+// the full duration, which satisfies this requirement.
+unsafe impl Send for DataPtr<'_> {}
 
 impl<'a> DataPtr<'a> {
     /// Create a new DataPtr from a raw pointer and length
@@ -162,7 +173,7 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn statement_set_option(
+    pub async fn statement_set_option(
         &self,
         handle: Handle,
         key: String,
@@ -170,7 +181,7 @@ impl DatabaseDriverV1 {
     ) -> Result<(), ApiError> {
         match self.statements.get_obj(handle) {
             Some(stmt_ptr) => {
-                let mut stmt = stmt_ptr.lock().map_err(|_| StatementLockingSnafu.build())?;
+                let mut stmt = stmt_ptr.lock().await;
                 stmt.settings.insert(key, value);
                 Ok(())
             }
@@ -181,14 +192,14 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn statement_set_options(
+    pub async fn statement_set_options(
         &self,
         handle: Handle,
         options: HashMap<String, Setting>,
     ) -> Result<Vec<ValidationIssue>, ApiError> {
         match self.statements.get_obj(handle) {
             Some(stmt_ptr) => {
-                let mut stmt = stmt_ptr.lock().map_err(|_| StatementLockingSnafu.build())?;
+                let mut stmt = stmt_ptr.lock().await;
                 resolve_and_apply_options(&mut stmt.settings, options)
             }
             None => InvalidArgumentSnafu {
@@ -198,14 +209,14 @@ impl DatabaseDriverV1 {
         }
     }
 
-    pub fn statement_set_sql_query(
+    pub async fn statement_set_sql_query(
         &self,
         stmt_handle: Handle,
         query: String,
     ) -> Result<(), ApiError> {
         match self.statements.get_obj(stmt_handle) {
             Some(stmt_ptr) => {
-                let mut stmt = stmt_ptr.lock().map_err(|_| StatementLockingSnafu.build())?;
+                let mut stmt = stmt_ptr.lock().await;
                 stmt.query = Some(query);
                 Ok(())
             }
@@ -223,8 +234,10 @@ pub struct PrepareResult {
 }
 
 impl DatabaseDriverV1 {
-    pub fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
-        let result = self.execute_query_internal(stmt_handle, None, Some(true))?;
+    pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
+        let result = self
+            .execute_query_internal(stmt_handle, None, Some(true))
+            .await?;
         Ok(PrepareResult {
             stream: result.stream,
             columns: result.columns,
@@ -254,15 +267,16 @@ pub struct ExecuteResult {
 }
 
 impl DatabaseDriverV1 {
-    pub fn statement_execute_query<'a>(
+    pub async fn statement_execute_query<'a>(
         &self,
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
     ) -> Result<ExecuteResult, ApiError> {
         self.execute_query_internal(stmt_handle, bindings, None)
+            .await
     }
 
-    fn execute_query_internal<'a>(
+    async fn execute_query_internal<'a>(
         &self,
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
@@ -275,7 +289,7 @@ impl DatabaseDriverV1 {
             .build()
         })?;
 
-        let mut stmt = stmt_ptr.lock().map_err(|_| StatementLockingSnafu.build())?;
+        let mut stmt = stmt_ptr.lock().await;
         let query = stmt.query.as_deref().ok_or_else(|| {
             InvalidArgumentSnafu {
                 argument: "Query not found".to_string(),
@@ -283,13 +297,8 @@ impl DatabaseDriverV1 {
             .build()
         })?;
 
-        let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
-
         let (query_parameters, http_client, retry_policy) = {
-            let conn = stmt
-                .conn
-                .lock()
-                .map_err(|_| ConnectionLockingSnafu.build())?;
+            let conn = stmt.conn.lock().await;
             (
                 QueryParameters::from_settings(&conn.settings).context(ConfigurationSnafu)?,
                 conn.http_client
@@ -306,12 +315,9 @@ impl DatabaseDriverV1 {
         let query_bindings: Option<&RawValue> = if let Some(binding_type) = &bindings {
             match &binding_type {
                 BindingType::Json(data_ptr) => {
-                    // True zero-copy: pointer → &'static RawValue (no allocation, no validation).
-                    // Wrapper guarantees data lives through synchronous execute call.
                     Some(parse_json_bindings(data_ptr).context(StatementSnafu)?)
                 }
                 BindingType::Csv(_csv_ptr) => {
-                    // TODO: Implement CSV binding handling (stage upload)
                     return Err(InvalidArgumentSnafu {
                         argument: "CSV bindings are not yet implemented".to_string(),
                     }
@@ -328,8 +334,8 @@ impl DatabaseDriverV1 {
             describe_only,
         };
 
-        let response = rt.block_on(async {
-            let mut ctx = RefreshContext::from_arc(&stmt.conn)?;
+        let response = {
+            let mut ctx = RefreshContext::from_arc(&stmt.conn).await?;
             let mut last_error = None;
             loop {
                 let session_token = ctx.refresh_token(last_error).await?;
@@ -343,17 +349,14 @@ impl DatabaseDriverV1 {
                 )
                 .await
                 {
-                    Ok(result) => return Ok(result),
+                    Ok(result) => break Ok(result),
                     Err(e) => last_error = Some(e),
                 }
             }
-        })?;
+        }?;
 
         if response.success {
-            let conn = stmt
-                .conn
-                .lock()
-                .map_err(|_| ConnectionLockingSnafu.build())?;
+            let conn = stmt.conn.lock().await;
             conn.update_session_params_cache(
                 query,
                 response.data.parameters.as_ref(),
@@ -363,11 +366,12 @@ impl DatabaseDriverV1 {
                     warehouse: response.data.final_warehouse_name.clone(),
                     role: response.data.final_role_name.clone(),
                 },
-            );
+            )
+            .await;
         }
 
-        let query_result = rt
-            .block_on(process_query_response(&response.data, &http_client))
+        let query_result = process_query_response(&response.data, &http_client)
+            .await
             .context(QueryResponseProcessingSnafu)?;
 
         let rowset_stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));

--- a/sf_core/src/async_bridge.rs
+++ b/sf_core/src/async_bridge.rs
@@ -1,6 +1,0 @@
-// Returns a new tokio runtime for the current thread
-pub(crate) fn runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-}

--- a/sf_core/src/chunks.rs
+++ b/sf_core/src/chunks.rs
@@ -11,7 +11,7 @@ use arrow_ipc::reader::StreamReader;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use reqwest::Client;
 use reqwest::header::{self, HeaderMap, HeaderName, HeaderValue};
-use snafu::{Location, ResultExt, Snafu};
+use snafu::{Location, OptionExt, ResultExt, Snafu};
 
 const MAX_CHUNK_DECOMPRESSION_RETRIES: u32 = 2;
 
@@ -29,11 +29,24 @@ impl ChunkDownloadData {
         }
     }
 }
+/// Reads Arrow record batches from one or more Snowflake result-set chunks.
+///
+/// # Sync iteration constraint
+///
+/// The `Iterator` implementation for multi-chunk readers calls
+/// `Handle::block_on(get_chunk_data(...))` to download subsequent chunks.
+/// This **must not** be called from within an active tokio runtime context
+/// (e.g., inside a `Runtime::block_on` or from a spawned task), as doing so
+/// will panic (current-thread runtime) or deadlock (multi-thread runtime).
+///
+/// All current consumers (ODBC `fetch`, C API wrappers, tests) iterate the
+/// reader from a plain synchronous context, which is correct.
 pub struct ChunkReader {
     rest: VecDeque<ChunkDownloadData>,
     schema: SchemaRef,
     current_stream: Option<StreamReader<io::Cursor<Vec<u8>>>>,
     client: Option<Client>,
+    rt_handle: Option<tokio::runtime::Handle>,
 }
 
 impl ChunkReader {
@@ -42,6 +55,9 @@ impl ChunkReader {
         mut rest: VecDeque<ChunkDownloadData>,
         client: Client,
     ) -> Result<Self, ChunkError> {
+        let rt_handle = tokio::runtime::Handle::try_current()
+            .ok()
+            .context(MissingRuntimeHandleSnafu)?;
         let initial = if let Some(initial) = initial_base64_opt {
             BASE64.decode(initial).context(Base64DecodingSnafu)?
         } else {
@@ -55,6 +71,7 @@ impl ChunkReader {
             schema,
             current_stream: Some(reader),
             client: Some(client),
+            rt_handle: Some(rt_handle),
         })
     }
 
@@ -67,6 +84,7 @@ impl ChunkReader {
             schema: reader.schema().clone(),
             current_stream: Some(reader),
             client: None,
+            rt_handle: None,
         })
     }
 
@@ -76,6 +94,7 @@ impl ChunkReader {
             schema: Arc::new(Schema::new(Fields::empty())),
             current_stream: None,
             client: None,
+            rt_handle: None,
         }
     }
 }
@@ -99,7 +118,15 @@ impl Iterator for ChunkReader {
                         )));
                     }
                 };
-                let chunk_data_result = get_chunk_data_sync(client, &chunk);
+                let handle = match &self.rt_handle {
+                    Some(h) => h,
+                    None => {
+                        return Some(Err(ArrowError::ExternalError(Box::new(
+                            MissingRuntimeHandleSnafu.build(),
+                        ))));
+                    }
+                };
+                let chunk_data_result = handle.block_on(get_chunk_data(client, &chunk));
                 if let Err(e) = chunk_data_result {
                     return Some(Err(ArrowError::IpcError(e.to_string())));
                 }
@@ -120,14 +147,6 @@ impl RecordBatchReader for ChunkReader {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
-}
-
-pub fn get_chunk_data_sync(
-    client: &Client,
-    chunk: &ChunkDownloadData,
-) -> Result<Vec<u8>, ChunkError> {
-    let rt = crate::async_bridge::runtime().context(RuntimeCreationSnafu)?;
-    rt.block_on(async { get_chunk_data(client, chunk).await })
 }
 
 pub async fn get_chunk_data(
@@ -236,12 +255,6 @@ fn decode_chunk_body(body: Vec<u8>, encoding: Option<&HeaderValue>) -> Result<Ve
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
 pub enum ChunkError {
-    #[snafu(display("Failed to create runtime"))]
-    RuntimeCreation {
-        source: std::io::Error,
-        #[snafu(implicit)]
-        location: Location,
-    },
     #[snafu(display("Invalid header name for {key}"))]
     HeaderName {
         key: String,
@@ -289,6 +302,11 @@ pub enum ChunkError {
     #[snafu(display("Failed to read chunk data"))]
     ChunkReading {
         source: ArrowError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Tokio runtime handle unavailable for chunk downloads"))]
+    MissingRuntimeHandle {
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -4,7 +4,6 @@ extern crate tracing_subscriber;
 pub mod apis;
 
 pub mod arrow_utils;
-mod async_bridge;
 mod auth;
 pub mod c_api;
 mod chunks;

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -1,13 +1,13 @@
 use crate::apis::database_driver_v1::ApiError;
 use crate::apis::database_driver_v1::ColumnMetadata as NativeColumnMetadata;
 use crate::apis::database_driver_v1::ConnectionInfo;
+use crate::apis::database_driver_v1::DatabaseDriverV1;
 use crate::apis::database_driver_v1::Handle;
 use crate::apis::database_driver_v1::Setting;
 use crate::apis::database_driver_v1::error::ConfigError;
 use crate::apis::database_driver_v1::error::ConfigurationSnafu;
 use crate::apis::database_driver_v1::error::RestError;
 use crate::apis::database_driver_v1::{BindingType, DataPtr};
-use crate::apis::database_driver_v1::{DatabaseDriverV1, driver_state};
 use crate::apis::database_driver_v1::{
     ValidationCode as CoreValidationCode, ValidationIssue as CoreValidationIssue,
     ValidationSeverity as CoreValidationSeverity,
@@ -540,97 +540,132 @@ fn core_validation_issue_to_proto(issue: CoreValidationIssue) -> ValidationIssue
     }
 }
 
-pub struct DatabaseDriverImpl;
+pub struct DatabaseDriverImpl {
+    driver: DatabaseDriverV1,
+}
+
+impl Default for DatabaseDriverImpl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl DatabaseDriverImpl {
-    fn state() -> &'static DatabaseDriverV1 {
-        driver_state()
+    pub fn new() -> Self {
+        Self {
+            driver: DatabaseDriverV1::new(),
+        }
     }
 }
 
 impl DatabaseDriver for DatabaseDriverImpl {
-    #[instrument(name = "DatabaseDriverV1::database_new", skip(_input))]
-    fn database_new(_input: DatabaseNewRequest) -> Result<DatabaseNewResponse, DriverException> {
-        let handle = Self::state().database_new();
+    #[instrument(name = "DatabaseDriverV1::database_new", skip(self, _input))]
+    async fn database_new(
+        &self,
+        _input: DatabaseNewRequest,
+    ) -> Result<DatabaseNewResponse, DriverException> {
+        let handle = self.driver.database_new();
         Ok(DatabaseNewResponse {
             db_handle: Some(DatabaseHandle::from(handle)),
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_option_string", skip(input))]
-    fn database_set_option_string(
+    #[instrument(
+        name = "DatabaseDriverV1::database_set_option_string",
+        skip(self, input)
+    )]
+    async fn database_set_option_string(
+        &self,
         input: DatabaseSetOptionStringRequest,
     ) -> Result<DatabaseSetOptionStringResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_set_option(db_handle.into(), input.key, Setting::String(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionStringResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_option_bytes", skip(input))]
-    fn database_set_option_bytes(
+    #[instrument(
+        name = "DatabaseDriverV1::database_set_option_bytes",
+        skip(self, input)
+    )]
+    async fn database_set_option_bytes(
+        &self,
         input: DatabaseSetOptionBytesRequest,
     ) -> Result<DatabaseSetOptionBytesResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_set_option(db_handle.into(), input.key, Setting::Bytes(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionBytesResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_option_int", skip(input))]
-    fn database_set_option_int(
+    #[instrument(name = "DatabaseDriverV1::database_set_option_int", skip(self, input))]
+    async fn database_set_option_int(
+        &self,
         input: DatabaseSetOptionIntRequest,
     ) -> Result<DatabaseSetOptionIntResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_set_option(db_handle.into(), input.key, Setting::Int(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionIntResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_option_double", skip(input))]
-    fn database_set_option_double(
+    #[instrument(
+        name = "DatabaseDriverV1::database_set_option_double",
+        skip(self, input)
+    )]
+    async fn database_set_option_double(
+        &self,
         input: DatabaseSetOptionDoubleRequest,
     ) -> Result<DatabaseSetOptionDoubleResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_set_option(db_handle.into(), input.key, Setting::Double(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionDoubleResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_option_bool", skip(input))]
-    fn database_set_option_bool(
+    #[instrument(name = "DatabaseDriverV1::database_set_option_bool", skip(self, input))]
+    async fn database_set_option_bool(
+        &self,
         input: DatabaseSetOptionBoolRequest,
     ) -> Result<DatabaseSetOptionBoolResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_set_option(db_handle.into(), input.key, Setting::Bool(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionBoolResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_set_options", skip(input))]
-    fn database_set_options(
+    #[instrument(name = "DatabaseDriverV1::database_set_options", skip(self, input))]
+    async fn database_set_options(
+        &self,
         input: DatabaseSetOptionsRequest,
     ) -> Result<DatabaseSetOptionsResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
         let options = proto_options_to_hashmap(input.options);
 
-        let warnings = Self::state()
+        let warnings = self
+            .driver
             .database_set_options(db_handle.into(), options)
+            .await
             .to_protobuf()?;
 
         Ok(DatabaseSetOptionsResponse {
@@ -641,112 +676,140 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_init", skip(input))]
-    fn database_init(input: DatabaseInitRequest) -> Result<DatabaseInitResponse, DriverException> {
+    #[instrument(name = "DatabaseDriverV1::database_init", skip(self, input))]
+    async fn database_init(
+        &self,
+        input: DatabaseInitRequest,
+    ) -> Result<DatabaseInitResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
-            .database_init(db_handle.into())
-            .to_protobuf()?;
+        self.driver.database_init(db_handle.into()).to_protobuf()?;
         Ok(DatabaseInitResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::database_release", skip(input))]
-    fn database_release(
+    #[instrument(name = "DatabaseDriverV1::database_release", skip(self, input))]
+    async fn database_release(
+        &self,
         input: DatabaseReleaseRequest,
     ) -> Result<DatabaseReleaseResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .database_release(db_handle.into())
             .to_protobuf()?;
         Ok(DatabaseReleaseResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_new", skip(_input))]
-    fn connection_new(
+    #[instrument(name = "DatabaseDriverV1::connection_new", skip(self, _input))]
+    async fn connection_new(
+        &self,
         _input: ConnectionNewRequest,
     ) -> Result<ConnectionNewResponse, DriverException> {
-        let handle = Self::state().connection_new();
+        let handle = self.driver.connection_new();
         Ok(ConnectionNewResponse {
             conn_handle: Some(ConnectionHandle::from(handle)),
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_string", skip(input))]
-    fn connection_set_option_string(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_set_option_string",
+        skip(self, input)
+    )]
+    async fn connection_set_option_string(
+        &self,
         input: ConnectionSetOptionStringRequest,
     ) -> Result<ConnectionSetOptionStringResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_option(conn_handle.into(), input.key, Setting::String(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionStringResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_bytes", skip(input))]
-    fn connection_set_option_bytes(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_set_option_bytes",
+        skip(self, input)
+    )]
+    async fn connection_set_option_bytes(
+        &self,
         input: ConnectionSetOptionBytesRequest,
     ) -> Result<ConnectionSetOptionBytesResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_option(conn_handle.into(), input.key, Setting::Bytes(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionBytesResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_int", skip(input))]
-    fn connection_set_option_int(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_set_option_int",
+        skip(self, input)
+    )]
+    async fn connection_set_option_int(
+        &self,
         input: ConnectionSetOptionIntRequest,
     ) -> Result<ConnectionSetOptionIntResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_option(conn_handle.into(), input.key, Setting::Int(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionIntResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_double", skip(input))]
-    fn connection_set_option_double(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_set_option_double",
+        skip(self, input)
+    )]
+    async fn connection_set_option_double(
+        &self,
         input: ConnectionSetOptionDoubleRequest,
     ) -> Result<ConnectionSetOptionDoubleResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_option(conn_handle.into(), input.key, Setting::Double(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionDoubleResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_bool", skip(input))]
-    fn connection_set_option_bool(
+    #[instrument(name = "DatabaseDriverV1::connection_set_option_bool", skip(self, input))]
+    async fn connection_set_option_bool(
+        &self,
         input: ConnectionSetOptionBoolRequest,
     ) -> Result<ConnectionSetOptionBoolResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_option(conn_handle.into(), input.key, Setting::Bool(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionBoolResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_options", skip(input))]
-    fn connection_set_options(
+    #[instrument(name = "DatabaseDriverV1::connection_set_options", skip(self, input))]
+    async fn connection_set_options(
+        &self,
         input: ConnectionSetOptionsRequest,
     ) -> Result<ConnectionSetOptionsResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let options = proto_options_to_hashmap(input.options);
 
-        let warnings = Self::state()
+        let warnings = self
+            .driver
             .connection_set_options(conn_handle.into(), options)
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetOptionsResponse {
@@ -757,47 +820,54 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_init", skip(input))]
-    fn connection_init(
+    #[instrument(name = "DatabaseDriverV1::connection_init", skip(self, input))]
+    async fn connection_init(
+        &self,
         input: ConnectionInitRequest,
     ) -> Result<ConnectionInitResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_init(conn_handle.into(), db_handle.into())
+            .await
             .to_protobuf()?;
         Ok(ConnectionInitResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_release", skip(input))]
-    fn connection_release(
+    #[instrument(name = "DatabaseDriverV1::connection_release", skip(self, input))]
+    async fn connection_release(
+        &self,
         input: ConnectionReleaseRequest,
     ) -> Result<ConnectionReleaseResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_release(conn_handle.into())
             .to_protobuf()?;
         Ok(ConnectionReleaseResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_get_info", skip(input))]
-    fn connection_get_info(
+    #[instrument(name = "DatabaseDriverV1::connection_get_info", skip(self, input))]
+    async fn connection_get_info(
+        &self,
         input: ConnectionGetInfoRequest,
     ) -> Result<ConnectionGetInfoResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        let info = Self::state()
+        let info = self
+            .driver
             .connection_get_info(conn_handle.into())
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionGetInfoResponse::from(info))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_get_objects", skip(_input))]
-    fn connection_get_objects(
+    #[instrument(name = "DatabaseDriverV1::connection_get_objects", skip(self, _input))]
+    async fn connection_get_objects(
+        &self,
         _input: ConnectionGetObjectsRequest,
     ) -> Result<ConnectionGetObjectsResponse, DriverException> {
         Err(not_implemented(
@@ -805,8 +875,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_get_table_schema", skip(_input))]
-    fn connection_get_table_schema(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_get_table_schema",
+        skip(self, _input)
+    )]
+    async fn connection_get_table_schema(
+        &self,
         _input: ConnectionGetTableSchemaRequest,
     ) -> Result<ConnectionGetTableSchemaResponse, DriverException> {
         Err(not_implemented(
@@ -814,8 +888,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_get_table_types", skip(_input))]
-    fn connection_get_table_types(
+    #[instrument(
+        name = "DatabaseDriverV1::connection_get_table_types",
+        skip(self, _input)
+    )]
+    async fn connection_get_table_types(
+        &self,
         _input: ConnectionGetTableTypesRequest,
     ) -> Result<ConnectionGetTableTypesResponse, DriverException> {
         Err(not_implemented(
@@ -823,15 +901,17 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_commit", skip(_input))]
-    fn connection_commit(
+    #[instrument(name = "DatabaseDriverV1::connection_commit", skip(self, _input))]
+    async fn connection_commit(
+        &self,
         _input: ConnectionCommitRequest,
     ) -> Result<ConnectionCommitResponse, DriverException> {
         Err(not_implemented("connection_commit is not yet implemented"))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_rollback", skip(_input))]
-    fn connection_rollback(
+    #[instrument(name = "DatabaseDriverV1::connection_rollback", skip(self, _input))]
+    async fn connection_rollback(
+        &self,
         _input: ConnectionRollbackRequest,
     ) -> Result<ConnectionRollbackResponse, DriverException> {
         Err(not_implemented(
@@ -841,38 +921,47 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
     #[instrument(
         name = "DatabaseDriverV1::connection_set_session_parameters",
-        skip(input)
+        skip(self, input)
     )]
-    fn connection_set_session_parameters(
+    async fn connection_set_session_parameters(
+        &self,
         input: ConnectionSetSessionParametersRequest,
     ) -> Result<ConnectionSetSessionParametersResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        Self::state()
+        self.driver
             .connection_set_session_parameters(conn_handle.into(), input.parameters)
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionSetSessionParametersResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_get_parameter", skip(input))]
-    fn connection_get_parameter(
+    #[instrument(name = "DatabaseDriverV1::connection_get_parameter", skip(self, input))]
+    async fn connection_get_parameter(
+        &self,
         input: ConnectionGetParameterRequest,
     ) -> Result<ConnectionGetParameterResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        let value = Self::state()
+        let value = self
+            .driver
             .connection_get_parameter(conn_handle.into(), input.key)
+            .await
             .to_protobuf()?;
 
         Ok(ConnectionGetParameterResponse { value })
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_new", skip(input))]
-    fn statement_new(input: StatementNewRequest) -> Result<StatementNewResponse, DriverException> {
+    #[instrument(name = "DatabaseDriverV1::statement_new", skip(self, input))]
+    async fn statement_new(
+        &self,
+        input: StatementNewRequest,
+    ) -> Result<StatementNewResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
-        let handle = Self::state()
+        let handle = self
+            .driver
             .statement_new(conn_handle.into())
             .to_protobuf()?;
         Ok(StatementNewResponse {
@@ -880,32 +969,39 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_release", skip(input))]
-    fn statement_release(
+    #[instrument(name = "DatabaseDriverV1::statement_release", skip(self, input))]
+    async fn statement_release(
+        &self,
         input: StatementReleaseRequest,
     ) -> Result<StatementReleaseResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_release(stmt_handle.into())
             .to_protobuf()?;
         Ok(StatementReleaseResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_sql_query", skip(input))]
-    fn statement_set_sql_query(
+    #[instrument(name = "DatabaseDriverV1::statement_set_sql_query", skip(self, input))]
+    async fn statement_set_sql_query(
+        &self,
         input: StatementSetSqlQueryRequest,
     ) -> Result<StatementSetSqlQueryResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_sql_query(stmt_handle.into(), input.query)
+            .await
             .to_protobuf()?;
         Ok(StatementSetSqlQueryResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_substrait_plan", skip(_input))]
-    fn statement_set_substrait_plan(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_set_substrait_plan",
+        skip(self, _input)
+    )]
+    async fn statement_set_substrait_plan(
+        &self,
         _input: StatementSetSubstraitPlanRequest,
     ) -> Result<StatementSetSubstraitPlanResponse, DriverException> {
         // TODO: Implement when corresponding API method is available
@@ -914,13 +1010,16 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_prepare", skip(input))]
-    fn statement_prepare(
+    #[instrument(name = "DatabaseDriverV1::statement_prepare", skip(self, input))]
+    async fn statement_prepare(
+        &self,
         input: StatementPrepareRequest,
     ) -> Result<StatementPrepareResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-        let result = Self::state()
+        let result = self
+            .driver
             .statement_prepare(stmt_handle.into())
+            .await
             .to_protobuf()?;
         let result_ptr: ArrowArrayStreamPtr = Box::into_raw(result.stream).into();
         Ok(StatementPrepareResponse {
@@ -931,80 +1030,102 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_string", skip(input))]
-    fn statement_set_option_string(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_set_option_string",
+        skip(self, input)
+    )]
+    async fn statement_set_option_string(
+        &self,
         input: StatementSetOptionStringRequest,
     ) -> Result<StatementSetOptionStringResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_option(stmt_handle.into(), input.key, Setting::String(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionStringResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_bytes", skip(input))]
-    fn statement_set_option_bytes(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_set_option_bytes",
+        skip(self, input)
+    )]
+    async fn statement_set_option_bytes(
+        &self,
         input: StatementSetOptionBytesRequest,
     ) -> Result<StatementSetOptionBytesResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_option(stmt_handle.into(), input.key, Setting::Bytes(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionBytesResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_int", skip(input))]
-    fn statement_set_option_int(
+    #[instrument(name = "DatabaseDriverV1::statement_set_option_int", skip(self, input))]
+    async fn statement_set_option_int(
+        &self,
         input: StatementSetOptionIntRequest,
     ) -> Result<StatementSetOptionIntResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_option(stmt_handle.into(), input.key, Setting::Int(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionIntResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_double", skip(input))]
-    fn statement_set_option_double(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_set_option_double",
+        skip(self, input)
+    )]
+    async fn statement_set_option_double(
+        &self,
         input: StatementSetOptionDoubleRequest,
     ) -> Result<StatementSetOptionDoubleResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_option(stmt_handle.into(), input.key, Setting::Double(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionDoubleResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_bool", skip(input))]
-    fn statement_set_option_bool(
+    #[instrument(name = "DatabaseDriverV1::statement_set_option_bool", skip(self, input))]
+    async fn statement_set_option_bool(
+        &self,
         input: StatementSetOptionBoolRequest,
     ) -> Result<StatementSetOptionBoolResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
-        Self::state()
+        self.driver
             .statement_set_option(stmt_handle.into(), input.key, Setting::Bool(input.value))
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionBoolResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_options", skip(input))]
-    fn statement_set_options(
+    #[instrument(name = "DatabaseDriverV1::statement_set_options", skip(self, input))]
+    async fn statement_set_options(
+        &self,
         input: StatementSetOptionsRequest,
     ) -> Result<StatementSetOptionsResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
         let options = proto_options_to_hashmap(input.options);
 
-        let warnings = Self::state()
+        let warnings = self
+            .driver
             .statement_set_options(stmt_handle.into(), options)
+            .await
             .to_protobuf()?;
 
         Ok(StatementSetOptionsResponse {
@@ -1017,9 +1138,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
     #[instrument(
         name = "DatabaseDriverV1::statement_get_parameter_schema",
-        skip(_input)
+        skip(self, _input)
     )]
-    fn statement_get_parameter_schema(
+    async fn statement_get_parameter_schema(
+        &self,
         _input: StatementGetParameterSchemaRequest,
     ) -> Result<StatementGetParameterSchemaResponse, DriverException> {
         Err(not_implemented(
@@ -1027,8 +1149,9 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_execute_query", skip(input))]
-    fn statement_execute_query(
+    #[instrument(name = "DatabaseDriverV1::statement_execute_query", skip(self, input))]
+    async fn statement_execute_query(
+        &self,
         input: StatementExecuteQueryRequest,
     ) -> Result<StatementExecuteQueryResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
@@ -1038,8 +1161,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
             .and_then(|b| b.binding_type)
             .map(BindingType::from);
 
-        let result = Self::state()
+        let result = self
+            .driver
             .statement_execute_query(stmt_handle.into(), bindings_opt)
+            .await
             .to_protobuf()?;
         let stream_ptr: ArrowArrayStreamPtr = Box::into_raw(result.stream).into();
 
@@ -1060,8 +1185,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
         })
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_execute_partitions", skip(_input))]
-    fn statement_execute_partitions(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_execute_partitions",
+        skip(self, _input)
+    )]
+    async fn statement_execute_partitions(
+        &self,
         _input: StatementExecutePartitionsRequest,
     ) -> Result<StatementExecutePartitionsResponse, DriverException> {
         Err(not_implemented(
@@ -1069,8 +1198,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_read_partition", skip(_input))]
-    fn statement_read_partition(
+    #[instrument(
+        name = "DatabaseDriverV1::statement_read_partition",
+        skip(self, _input)
+    )]
+    async fn statement_read_partition(
+        &self,
         _input: StatementReadPartitionRequest,
     ) -> Result<StatementReadPartitionResponse, DriverException> {
         Err(not_implemented(
@@ -1078,8 +1211,9 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::config_load_all_sections", skip(input))]
-    fn config_load_all_sections(
+    #[instrument(name = "DatabaseDriverV1::config_load_all_sections", skip(self, input))]
+    async fn config_load_all_sections(
+        &self,
         input: ConfigLoadAllSectionsRequest,
     ) -> Result<ConfigLoadAllSectionsResponse, DriverException> {
         let all_sections = if input.config_file.is_some() || input.connections_file.is_some() {
@@ -1104,8 +1238,9 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(ConfigLoadAllSectionsResponse { config_json })
     }
 
-    #[instrument(name = "DatabaseDriverV1::config_get_paths", skip(_input))]
-    fn config_get_paths(
+    #[instrument(name = "DatabaseDriverV1::config_get_paths", skip(self, _input))]
+    async fn config_get_paths(
+        &self,
         _input: ConfigGetPathsRequest,
     ) -> Result<ConfigGetPathsResponse, DriverException> {
         let paths = path_resolver::get_config_paths()
@@ -1149,3 +1284,7 @@ pub type DatabaseDriverClient =
     crate::protobuf::generated::database_driver_v1::DatabaseDriverClient<
         crate::protobuf::apis::RustTransport,
     >;
+
+pub fn database_driver_client() -> DatabaseDriverClient {
+    DatabaseDriverClient::new(crate::protobuf::apis::RustTransport::new())
+}

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -783,7 +783,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(ConnectionSetOptionDoubleResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_set_option_bool", skip(self, input))]
+    #[instrument(
+        name = "DatabaseDriverV1::connection_set_option_bool",
+        skip(self, input)
+    )]
     async fn connection_set_option_bool(
         &self,
         input: ConnectionSetOptionBoolRequest,
@@ -1099,7 +1102,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(StatementSetOptionDoubleResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_set_option_bool", skip(self, input))]
+    #[instrument(
+        name = "DatabaseDriverV1::statement_set_option_bool",
+        skip(self, input)
+    )]
     async fn statement_set_option_bool(
         &self,
         input: StatementSetOptionBoolRequest,

--- a/sf_core/src/protobuf/apis/mod.rs
+++ b/sf_core/src/protobuf/apis/mod.rs
@@ -4,21 +4,34 @@ use proto_utils::*;
 
 pub mod database_driver_v1;
 
-pub fn call_proto(api: &str, method: &str, message: &[u8]) -> Result<Vec<u8>, ProtoError<Vec<u8>>> {
-    match api {
-        "DatabaseDriver" => DatabaseDriverImpl::handle_message(method, message.to_vec()),
-        _ => Err(ProtoError::Transport(format!("Unknown API: {}", api))),
+pub struct RustTransport {
+    driver: DatabaseDriverImpl,
+}
+
+impl Default for RustTransport {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-pub struct RustTransport {}
+impl RustTransport {
+    pub fn new() -> Self {
+        Self {
+            driver: DatabaseDriverImpl::new(),
+        }
+    }
+}
 
 impl Transport for RustTransport {
-    fn handle_message(
+    async fn handle_message(
+        &self,
         service: &str,
         method: &str,
         message: Vec<u8>,
     ) -> Result<Vec<u8>, ProtoError<Vec<u8>>> {
-        call_proto(service, method, &message)
+        match service {
+            "DatabaseDriver" => self.driver.handle_message(method, message).await,
+            _ => Err(ProtoError::Transport(format!("Unknown API: {}", service))),
+        }
     }
 }

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -10,6 +10,9 @@ struct CApiState {
 }
 
 static STATE: LazyLock<CApiState> = LazyLock::new(|| CApiState {
+    // Single worker thread is intentional: keeps contention minimal and
+    // makes deadlocks easier to detect. Will be increased during
+    // performance optimization.
     runtime: tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
         .enable_all()

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -1,7 +1,22 @@
 use std::os::raw::c_char;
+use std::sync::LazyLock;
 
-use crate::protobuf::apis::call_proto;
-use proto_utils::ProtoError;
+use crate::protobuf::apis::RustTransport;
+use proto_utils::{ProtoError, Transport};
+
+struct CApiState {
+    runtime: tokio::runtime::Runtime,
+    transport: RustTransport,
+}
+
+static STATE: LazyLock<CApiState> = LazyLock::new(|| CApiState {
+    runtime: tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime"),
+    transport: RustTransport::new(),
+});
 
 fn write_buffer(vec: Vec<u8>, buffer: *mut *const u8, len: *mut usize) {
     let boxed = vec.into_boxed_slice();
@@ -50,7 +65,11 @@ pub unsafe extern "C" fn sf_core_api_call_proto(
             .to_string_lossy()
             .to_string();
         let message = std::slice::from_raw_parts(request, request_len);
-        call_proto(&api, &method, message)
+        STATE.runtime.block_on(
+            STATE
+                .transport
+                .handle_message(&api, &method, message.to_vec()),
+        )
     });
 
     match result {

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -1,10 +1,23 @@
+use std::sync::LazyLock;
+
 use proto_utils::ProtoError;
-use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
+use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
 use sf_core::protobuf::generated::database_driver_v1::*;
 use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 
 use super::config::{Parameters, get_parameters, setup_logging};
 use super::private_key_helper::{self, PrivateKeyFile};
+
+static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create test tokio runtime")
+});
+
+fn rt() -> &'static tokio::runtime::Runtime {
+    &TEST_RUNTIME
+}
 
 /// Creates a connected Snowflake client with database and connection initialized
 pub struct SnowflakeTestClient {
@@ -12,6 +25,7 @@ pub struct SnowflakeTestClient {
     pub db_handle: DatabaseHandle,
     pub parameters: Parameters,
     private_key_file: Option<PrivateKeyFile>,
+    client: DatabaseDriverClient,
 }
 
 impl SnowflakeTestClient {
@@ -19,27 +33,37 @@ impl SnowflakeTestClient {
     pub fn with_default_params() -> Self {
         setup_logging();
         let parameters = get_parameters();
+        let client = database_driver_client();
 
-        let db_response = DatabaseDriverClient::database_new(DatabaseNewRequest {}).unwrap();
-        let db_handle = db_response.db_handle.unwrap();
+        let (db_handle, conn_handle) = rt().block_on(async {
+            let db_response = client.database_new(DatabaseNewRequest {}).await.unwrap();
+            let db_handle = db_response.db_handle.unwrap();
 
-        DatabaseDriverClient::database_init(DatabaseInitRequest {
-            db_handle: Some(db_handle),
-        })
-        .unwrap();
+            client
+                .database_init(DatabaseInitRequest {
+                    db_handle: Some(db_handle),
+                })
+                .await
+                .unwrap();
 
-        let conn_response = DatabaseDriverClient::connection_new(ConnectionNewRequest {}).unwrap();
-        let conn_handle = conn_response.conn_handle.unwrap();
+            let conn_response = client
+                .connection_new(ConnectionNewRequest {})
+                .await
+                .unwrap();
+            let conn_handle = conn_response.conn_handle.unwrap();
+            (db_handle, conn_handle)
+        });
 
-        let client = Self {
+        let test_client = Self {
             conn_handle,
             db_handle,
             parameters,
             private_key_file: None,
+            client,
         };
 
-        client.set_options_from_parameters();
-        client
+        test_client.set_options_from_parameters();
+        test_client
     }
 
     /// Creates a client with default parameters and JWT authentication configured
@@ -54,18 +78,23 @@ impl SnowflakeTestClient {
 
     pub fn connect_with_default_auth() -> Self {
         setup_logging();
-        let mut client = Self::with_default_params();
+        let mut test_client = Self::with_default_params();
 
-        let temp_key_file = client.setup_jwt_auth();
+        let temp_key_file = test_client.setup_jwt_auth();
 
-        DatabaseDriverClient::connection_init(ConnectionInitRequest {
-            conn_handle: Some(client.conn_handle),
-            db_handle: Some(client.db_handle),
-        })
-        .unwrap();
+        rt().block_on(async {
+            test_client
+                .client
+                .connection_init(ConnectionInitRequest {
+                    conn_handle: Some(test_client.conn_handle),
+                    db_handle: Some(test_client.db_handle),
+                })
+                .await
+                .unwrap();
+        });
 
-        client.private_key_file = Some(temp_key_file);
-        client
+        test_client.private_key_file = Some(temp_key_file);
+        test_client
     }
 
     pub fn with_int_tests_params(server_url: Option<&str>) -> Self {
@@ -87,53 +116,75 @@ impl SnowflakeTestClient {
             ..Default::default()
         };
 
-        let db_response = DatabaseDriverClient::database_new(DatabaseNewRequest {}).unwrap();
-        let db_handle = db_response.db_handle.unwrap();
+        let client = database_driver_client();
 
-        DatabaseDriverClient::database_init(DatabaseInitRequest {
-            db_handle: Some(db_handle),
-        })
-        .unwrap();
+        let (db_handle, conn_handle) = rt().block_on(async {
+            let db_response = client.database_new(DatabaseNewRequest {}).await.unwrap();
+            let db_handle = db_response.db_handle.unwrap();
 
-        let conn_response = DatabaseDriverClient::connection_new(ConnectionNewRequest {}).unwrap();
-        let conn_handle = conn_response.conn_handle.unwrap();
+            client
+                .database_init(DatabaseInitRequest {
+                    db_handle: Some(db_handle),
+                })
+                .await
+                .unwrap();
 
-        let client = Self {
+            let conn_response = client
+                .connection_new(ConnectionNewRequest {})
+                .await
+                .unwrap();
+            let conn_handle = conn_response.conn_handle.unwrap();
+            (db_handle, conn_handle)
+        });
+
+        let test_client = Self {
             conn_handle,
             db_handle,
             parameters: test_parameters,
             private_key_file: None,
+            client,
         };
 
-        client.set_options_from_parameters();
-        client
+        test_client.set_options_from_parameters();
+        test_client
     }
 
     pub fn connect_integration_test(server_url: Option<&str>) -> Self {
-        let mut client = Self::with_int_tests_params(server_url);
+        let mut test_client = Self::with_int_tests_params(server_url);
 
-        client.set_connection_option("authenticator", "SNOWFLAKE_JWT");
+        test_client.set_connection_option("authenticator", "SNOWFLAKE_JWT");
         let temp_key_file = private_key_helper::get_test_private_key_file()
             .expect("Failed to create test private key file");
-        client.set_connection_option("private_key_file", temp_key_file.path().to_str().unwrap());
+        test_client
+            .set_connection_option("private_key_file", temp_key_file.path().to_str().unwrap());
 
-        DatabaseDriverClient::connection_init(ConnectionInitRequest {
-            conn_handle: Some(client.conn_handle),
-            db_handle: Some(client.db_handle),
-        })
-        .unwrap();
+        rt().block_on(async {
+            test_client
+                .client
+                .connection_init(ConnectionInitRequest {
+                    conn_handle: Some(test_client.conn_handle),
+                    db_handle: Some(test_client.db_handle),
+                })
+                .await
+                .unwrap();
+        });
 
-        client.private_key_file = Some(temp_key_file);
-        client
+        test_client.private_key_file = Some(temp_key_file);
+        test_client
     }
 
     /// Creates a new statement handle
     pub fn new_statement(&self) -> StatementHandle {
-        let response = DatabaseDriverClient::statement_new(StatementNewRequest {
-            conn_handle: Some(self.conn_handle),
+        rt().block_on(async {
+            let response = self
+                .client
+                .statement_new(StatementNewRequest {
+                    conn_handle: Some(self.conn_handle),
+                })
+                .await
+                .unwrap();
+            response.stmt_handle.unwrap()
         })
-        .unwrap();
-        response.stmt_handle.unwrap()
     }
 
     pub fn execute_statement_query(&self, stmt: &StatementHandle) -> ExecuteResult {
@@ -154,21 +205,29 @@ impl SnowflakeTestClient {
                 })),
             }
         });
-        DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(*stmt),
-            bindings,
+        rt().block_on(async {
+            self.client
+                .statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(*stmt),
+                    bindings,
+                })
+                .await
+                .unwrap()
+                .result
+                .unwrap()
         })
-        .unwrap()
-        .result
-        .unwrap()
     }
 
     pub fn set_sql_query(&self, stmt: &StatementHandle, query: &str) {
-        DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(*stmt),
-            query: query.to_string(),
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(*stmt),
+                    query: query.to_string(),
+                })
+                .await
+                .unwrap();
+        });
     }
 
     /// Builds a JSON bindings string for integer parameters.
@@ -190,53 +249,73 @@ impl SnowflakeTestClient {
     }
 
     pub fn release_statement(&self, stmt: &StatementHandle) {
-        DatabaseDriverClient::statement_release(StatementReleaseRequest {
-            stmt_handle: Some(*stmt),
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .statement_release(StatementReleaseRequest {
+                    stmt_handle: Some(*stmt),
+                })
+                .await
+                .unwrap();
+        });
     }
 
     /// Executes a SQL query and returns the result
     pub fn execute_query(&self, sql: &str) -> ExecuteResult {
         let stmt_handle = self.new_statement();
 
-        DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            query: sql.to_string(),
+        rt().block_on(async {
+            self.client
+                .statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: sql.to_string(),
+                })
+                .await
+                .unwrap();
+
+            let response = self
+                .client
+                .statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    bindings: None,
+                })
+                .await
+                .unwrap();
+
+            response.result.unwrap()
         })
-        .unwrap();
-
-        let response =
-            DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
-                stmt_handle: Some(stmt_handle),
-                bindings: None,
-            })
-            .unwrap();
-
-        response.result.unwrap()
     }
 
     pub fn execute_query_no_unwrap(&self, sql: &str) -> Result<ExecuteResult, String> {
         let stmt_handle = self.new_statement();
 
-        if let Err(e) = DatabaseDriverClient::statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            query: sql.to_string(),
-        }) {
-            return Err(format!("Failed to set SQL query: {e:?}"));
-        }
-
-        match DatabaseDriverClient::statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            bindings: None,
-        }) {
-            Ok(response) => {
-                let proto_result = response.result.unwrap();
-                Ok(proto_result)
+        rt().block_on(async {
+            if let Err(e) = self
+                .client
+                .statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: sql.to_string(),
+                })
+                .await
+            {
+                return Err(format!("Failed to set SQL query: {e:?}"));
             }
-            Err(ProtoError::Application(e)) => Err(format!("Failed to execute query: {e:?}")),
-            Err(ProtoError::Transport(e)) => Err(format!("Transport error: {e:?}")),
-        }
+
+            match self
+                .client
+                .statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    bindings: None,
+                })
+                .await
+            {
+                Ok(response) => {
+                    let proto_result = response.result.unwrap();
+                    Ok(proto_result)
+                }
+                Err(ProtoError::Application(e)) => Err(format!("Failed to execute query: {e:?}")),
+                Err(ProtoError::Transport(e)) => Err(format!("Transport error: {e:?}")),
+            }
+        })
     }
 
     pub fn create_temporary_stage(&self, stage_name: &str) {
@@ -246,49 +325,71 @@ impl SnowflakeTestClient {
     }
 
     pub fn connect(&self) -> Result<(), String> {
-        match DatabaseDriverClient::connection_init(ConnectionInitRequest {
-            conn_handle: Some(self.conn_handle),
-            db_handle: Some(self.db_handle),
-        }) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(format!("Connection failed: {e:?}")),
-        }
+        rt().block_on(async {
+            match self
+                .client
+                .connection_init(ConnectionInitRequest {
+                    conn_handle: Some(self.conn_handle),
+                    db_handle: Some(self.db_handle),
+                })
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(e) => Err(format!("Connection failed: {e:?}")),
+            }
+        })
     }
 
     pub fn set_connection_option(&self, option_name: &str, option_value: &str) {
-        DatabaseDriverClient::connection_set_option_string(ConnectionSetOptionStringRequest {
-            conn_handle: Some(self.conn_handle),
-            key: option_name.to_string(),
-            value: option_value.to_string(),
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .connection_set_option_string(ConnectionSetOptionStringRequest {
+                    conn_handle: Some(self.conn_handle),
+                    key: option_name.to_string(),
+                    value: option_value.to_string(),
+                })
+                .await
+                .unwrap();
+        });
     }
 
     pub fn set_connection_option_int(&self, option_name: &str, option_value: i64) {
-        DatabaseDriverClient::connection_set_option_int(ConnectionSetOptionIntRequest {
-            conn_handle: Some(self.conn_handle),
-            key: option_name.to_string(),
-            value: option_value,
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .connection_set_option_int(ConnectionSetOptionIntRequest {
+                    conn_handle: Some(self.conn_handle),
+                    key: option_name.to_string(),
+                    value: option_value,
+                })
+                .await
+                .unwrap();
+        });
     }
 
     pub fn set_connection_option_bytes(&self, option_name: &str, option_value: &[u8]) {
-        DatabaseDriverClient::connection_set_option_bytes(ConnectionSetOptionBytesRequest {
-            conn_handle: Some(self.conn_handle),
-            key: option_name.to_string(),
-            value: option_value.to_vec(),
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .connection_set_option_bytes(ConnectionSetOptionBytesRequest {
+                    conn_handle: Some(self.conn_handle),
+                    key: option_name.to_string(),
+                    value: option_value.to_vec(),
+                })
+                .await
+                .unwrap();
+        });
     }
 
     pub fn set_statement_async_execution(&self, stmt: &StatementHandle, enabled: bool) {
-        DatabaseDriverClient::statement_set_option_bool(StatementSetOptionBoolRequest {
-            stmt_handle: Some(*stmt),
-            key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
-            value: enabled,
-        })
-        .unwrap();
+        rt().block_on(async {
+            self.client
+                .statement_set_option_bool(StatementSetOptionBoolRequest {
+                    stmt_handle: Some(*stmt),
+                    key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
+                    value: enabled,
+                })
+                .await
+                .unwrap();
+        });
     }
 
     /// Stores a temporary private key file to keep it alive for the duration of the test.
@@ -383,17 +484,27 @@ impl SnowflakeTestClient {
 
 impl Drop for SnowflakeTestClient {
     fn drop(&mut self) {
-        // Release the connection when the client is dropped
-        if let Err(e) = DatabaseDriverClient::connection_release(ConnectionReleaseRequest {
-            conn_handle: Some(self.conn_handle),
-        }) {
-            tracing::warn!("Failed to release connection in Drop: {e:?}");
-        }
-        // Release the database handle
-        if let Err(e) = DatabaseDriverClient::database_release(DatabaseReleaseRequest {
-            db_handle: Some(self.db_handle),
-        }) {
-            tracing::warn!("Failed to release database handle in Drop: {e:?}");
-        }
+        rt().block_on(async {
+            // Release the connection when the client is dropped
+            if let Err(e) = self
+                .client
+                .connection_release(ConnectionReleaseRequest {
+                    conn_handle: Some(self.conn_handle),
+                })
+                .await
+            {
+                tracing::warn!("Failed to release connection in Drop: {e:?}");
+            }
+            // Release the database handle
+            if let Err(e) = self
+                .client
+                .database_release(DatabaseReleaseRequest {
+                    db_handle: Some(self.db_handle),
+                })
+                .await
+            {
+                tracing::warn!("Failed to release database handle in Drop: {e:?}");
+            }
+        });
     }
 }

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -7,10 +7,11 @@ use sf_core::crl::config::CrlConfig;
 use sf_core::rest::snowflake::SessionTokens;
 use sf_core::sensitive::SensitiveString;
 use sf_core::tls::config::TlsConfig;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 use tokio::sync::RwLock as AsyncRwLock;
 
 fn test_client_info() -> ClientInfo {
@@ -156,7 +157,7 @@ async fn should_only_refresh_once_with_concurrent_401_errors() {
     );
 
     // Verify the token was updated
-    let tokens_lock = conn.lock().unwrap().tokens.clone();
+    let tokens_lock = conn.lock().await.tokens.clone();
     let final_token = tokens_lock
         .read()
         .await

--- a/tests/performance/drivers/core/app/Cargo.lock
+++ b/tests/performance/drivers/core/app/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "serde_json",
  "sf_core",
  "strum",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/tests/performance/drivers/core/app/Cargo.toml
+++ b/tests/performance/drivers/core/app/Cargo.toml
@@ -15,5 +15,6 @@ strum = { version = "0.26", features = ["derive"] }
 arrow = { version = "56.0.0", features = ["ffi"] }
 arrow-array = "56.0.0"
 regex = "1.10"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 sf_core = { path = "../../../../../sf_core" }

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -3,24 +3,50 @@
 type Result<T> = std::result::Result<T, String>;
 use arrow_array::StringArray;
 use sf_core::protobuf::apis::RustTransport;
+use sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use sf_core::rest::snowflake::STATEMENT_ASYNC_EXECUTION_OPTION;
 use std::fs;
 
 use crate::types::TestConnectionParams;
 
-pub type DatabaseDriver = DatabaseDriverClient<RustTransport>;
+pub type DatabaseDriver = DatabaseDriverClient;
 
-pub fn create_database() -> Result<DatabaseHandle> {
-    let db_response = DatabaseDriver::database_new(DatabaseNewRequest {})
+pub struct DriverRuntime {
+    runtime: tokio::runtime::Runtime,
+    client: DatabaseDriver,
+}
+
+impl DriverRuntime {
+    pub fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime");
+        let client = DatabaseDriver::new(RustTransport::new());
+        Self { runtime, client }
+    }
+
+    pub fn block_on<T>(&self, f: impl AsyncFnOnce(&DatabaseDriver) -> T) -> T {
+        self.runtime.block_on(f(&self.client))
+    }
+}
+
+pub fn create_database(rt: &DriverRuntime) -> Result<DatabaseHandle> {
+    let db_response = rt
+        .block_on(async |c| c.database_new(DatabaseNewRequest {}).await)
         .map_err(|e| format!("Database creation failed: {:?}", e))?;
 
     let db_handle = db_response
         .db_handle
         .ok_or_else(|| "Database creation failed: No handle returned".to_string())?;
 
-    DatabaseDriver::database_init(DatabaseInitRequest {
-        db_handle: Some(db_handle),
+    rt.block_on(async |c| {
+        c.database_init(DatabaseInitRequest {
+            db_handle: Some(db_handle),
+        })
+        .await
     })
     .map_err(|e| format!("Database initialization failed: {:?}", e))?;
 
@@ -28,24 +54,23 @@ pub fn create_database() -> Result<DatabaseHandle> {
 }
 
 pub fn create_connection(
+    rt: &DriverRuntime,
     db_handle: DatabaseHandle,
     params: &TestConnectionParams,
 ) -> Result<ConnectionHandle> {
-    let conn_response = DatabaseDriver::connection_new(ConnectionNewRequest {})
+    let conn_response = rt
+        .block_on(async |c| c.connection_new(ConnectionNewRequest {}).await)
         .map_err(|e| format!("Connection creation failed: {:?}", e))?;
 
     let conn_handle = conn_response
         .conn_handle
         .ok_or_else(|| "Connection creation failed: No handle returned".to_string())?;
 
-    // Set connection parameters
-    set_connection_option(&conn_handle, "account", &params.account)?;
-    set_connection_option(&conn_handle, "user", &params.user)?;
+    set_connection_option(rt, &conn_handle, "account", &params.account)?;
+    set_connection_option(rt, &conn_handle, "user", &params.user)?;
 
-    // Use JWT key-pair authentication
-    set_connection_option(&conn_handle, "authenticator", "SNOWFLAKE_JWT")?;
+    set_connection_option(rt, &conn_handle, "authenticator", "SNOWFLAKE_JWT")?;
 
-    // First check if a private key file path is provided, otherwise create from contents
     let private_key_file = if let Some(ref key_file_path) = params.private_key_file {
         key_file_path.clone()
     } else if let Some(ref key_contents) = params.private_key_contents {
@@ -54,23 +79,25 @@ pub fn create_connection(
         return Err("Neither SNOWFLAKE_TEST_PRIVATE_KEY_FILE nor SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS provided".to_string());
     };
 
-    set_connection_option(&conn_handle, "private_key_file", &private_key_file)?;
+    set_connection_option(rt, &conn_handle, "private_key_file", &private_key_file)?;
     if let Some(password) = &params.private_key_password {
-        set_connection_option(&conn_handle, "private_key_password", password)?;
+        set_connection_option(rt, &conn_handle, "private_key_password", password)?;
     }
 
-    set_connection_option(&conn_handle, "database", &params.database)?;
-    set_connection_option(&conn_handle, "schema", &params.schema)?;
-    set_connection_option(&conn_handle, "warehouse", &params.warehouse)?;
-    set_connection_option(&conn_handle, "role", &params.role)?;
-    set_connection_option(&conn_handle, "host", &params.host)?;
+    set_connection_option(rt, &conn_handle, "database", &params.database)?;
+    set_connection_option(rt, &conn_handle, "schema", &params.schema)?;
+    set_connection_option(rt, &conn_handle, "warehouse", &params.warehouse)?;
+    set_connection_option(rt, &conn_handle, "role", &params.role)?;
+    set_connection_option(rt, &conn_handle, "host", &params.host)?;
 
-    set_tls_options(&conn_handle, params)?;
+    set_tls_options(rt, &conn_handle, params)?;
 
-    // Initialize connection (performs login)
-    DatabaseDriver::connection_init(ConnectionInitRequest {
-        conn_handle: Some(conn_handle),
-        db_handle: Some(db_handle),
+    rt.block_on(async |c| {
+        c.connection_init(ConnectionInitRequest {
+            conn_handle: Some(conn_handle),
+            db_handle: Some(db_handle),
+        })
+        .await
     })
     .map_err(|e| format!("Connection initialization failed: {:?}", e))?;
 
@@ -78,31 +105,42 @@ pub fn create_connection(
 }
 
 pub fn create_statement(
+    rt: &DriverRuntime,
     conn_handle: ConnectionHandle,
     sql: &str,
     async_override: Option<bool>,
 ) -> Result<StatementHandle> {
-    let stmt_response = DatabaseDriver::statement_new(StatementNewRequest {
-        conn_handle: Some(conn_handle),
-    })
-    .map_err(|e| format!("Statement creation failed: {:?}", e))?;
+    let stmt_response = rt
+        .block_on(async |c| {
+            c.statement_new(StatementNewRequest {
+                conn_handle: Some(conn_handle),
+            })
+            .await
+        })
+        .map_err(|e| format!("Statement creation failed: {:?}", e))?;
 
     let stmt_handle = stmt_response
         .stmt_handle
         .ok_or_else(|| "Statement creation failed: No handle returned".to_string())?;
 
-    DatabaseDriver::statement_set_sql_query(StatementSetSqlQueryRequest {
-        stmt_handle: Some(stmt_handle),
-        query: sql.to_string(),
+    rt.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: sql.to_string(),
+        })
+        .await
     })
     .map_err(|e| format!("Statement SQL query set failed: {:?}", e))?;
 
     if let Some(enabled) = async_override {
         let value = if enabled { "true" } else { "false" }.to_string();
-        DatabaseDriver::statement_set_option_string(StatementSetOptionStringRequest {
-            stmt_handle: Some(stmt_handle),
-            key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
-            value,
+        rt.block_on(async |c| {
+            c.statement_set_option_string(StatementSetOptionStringRequest {
+                stmt_handle: Some(stmt_handle),
+                key: STATEMENT_ASYNC_EXECUTION_OPTION.to_string(),
+                value,
+            })
+            .await
         })
         .map_err(|e| format!("Statement option set failed: {:?}", e))?;
     }
@@ -110,28 +148,43 @@ pub fn create_statement(
     Ok(stmt_handle)
 }
 
-pub fn reset_statement_query(stmt_handle: StatementHandle, sql: &str) -> Result<()> {
-    DatabaseDriver::statement_set_sql_query(StatementSetSqlQueryRequest {
-        stmt_handle: Some(stmt_handle),
-        query: sql.to_string(),
+pub fn reset_statement_query(
+    rt: &DriverRuntime,
+    stmt_handle: StatementHandle,
+    sql: &str,
+) -> Result<()> {
+    rt.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: sql.to_string(),
+        })
+        .await
     })
     .map_err(|e| format!("Statement query reset failed: {:?}", e))?;
     Ok(())
 }
 
-pub fn get_server_version(conn_handle: ConnectionHandle) -> Result<String> {
+pub fn get_server_version(rt: &DriverRuntime, conn_handle: ConnectionHandle) -> Result<String> {
     use crate::arrow::create_arrow_reader;
 
-    let version_stmt = create_statement(conn_handle, "SELECT CURRENT_VERSION() AS VERSION", None)?;
-    let response = DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {
-        stmt_handle: Some(version_stmt),
-        bindings: None,
-    })
-    .map_err(|e| format!("Query execution failed: {:?}", e))?;
+    let version_stmt =
+        create_statement(rt, conn_handle, "SELECT CURRENT_VERSION() AS VERSION", None)?;
+
+    let response = rt
+        .block_on(async |c| {
+            c.statement_execute_query(StatementExecuteQueryRequest {
+                stmt_handle: Some(version_stmt),
+                bindings: None,
+            })
+            .await
+        })
+        .map_err(|e| format!("Query execution failed: {:?}", e))?;
 
     let result = response
         .result
         .ok_or_else(|| "No result in execute response".to_string())?;
+
+    // Arrow iteration happens outside the runtime
     let mut reader = create_arrow_reader(result)?;
 
     if let Some(batch_result) = reader.next() {
@@ -141,8 +194,11 @@ pub fn get_server_version(conn_handle: ConnectionHandle) -> Result<String> {
             if batch.num_rows() > 0 {
                 let version = column.value(0).to_string();
 
-                DatabaseDriver::statement_release(StatementReleaseRequest {
-                    stmt_handle: Some(version_stmt),
+                rt.block_on(async |c| {
+                    c.statement_release(StatementReleaseRequest {
+                        stmt_handle: Some(version_stmt),
+                    })
+                    .await
                 })
                 .ok();
 
@@ -151,8 +207,11 @@ pub fn get_server_version(conn_handle: ConnectionHandle) -> Result<String> {
         }
     }
 
-    DatabaseDriver::statement_release(StatementReleaseRequest {
-        stmt_handle: Some(version_stmt),
+    rt.block_on(async |c| {
+        c.statement_release(StatementReleaseRequest {
+            stmt_handle: Some(version_stmt),
+        })
+        .await
     })
     .ok();
 
@@ -160,6 +219,7 @@ pub fn get_server_version(conn_handle: ConnectionHandle) -> Result<String> {
 }
 
 pub fn execute_setup_queries(
+    rt: &DriverRuntime,
     conn_handle: ConnectionHandle,
     setup_queries: &[String],
 ) -> Result<()> {
@@ -175,17 +235,23 @@ pub fn execute_setup_queries(
     for (i, query) in setup_queries.iter().enumerate() {
         println!("  Setup query {}: {}", i + 1, query);
 
-        let stmt_handle = create_statement(conn_handle, query, None)
+        let stmt_handle = create_statement(rt, conn_handle, query, None)
             .map_err(|e| format!("Setup query statement creation failed: {:?}", e))?;
 
-        DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            bindings: None,
+        rt.block_on(async |c| {
+            c.statement_execute_query(StatementExecuteQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                bindings: None,
+            })
+            .await
         })
         .map_err(|e| format!("Setup query execution failed: {:?}", e))?;
 
-        DatabaseDriver::statement_release(StatementReleaseRequest {
-            stmt_handle: Some(stmt_handle),
+        rt.block_on(async |c| {
+            c.statement_release(StatementReleaseRequest {
+                stmt_handle: Some(stmt_handle),
+            })
+            .await
         })
         .ok();
     }
@@ -194,11 +260,19 @@ pub fn execute_setup_queries(
     Ok(())
 }
 
-fn set_connection_option(conn_handle: &ConnectionHandle, key: &str, value: &str) -> Result<()> {
-    DatabaseDriver::connection_set_option_string(ConnectionSetOptionStringRequest {
-        conn_handle: Some(*conn_handle),
-        key: key.to_string(),
-        value: value.to_string(),
+fn set_connection_option(
+    rt: &DriverRuntime,
+    conn_handle: &ConnectionHandle,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    rt.block_on(async |c| {
+        c.connection_set_option_string(ConnectionSetOptionStringRequest {
+            conn_handle: Some(*conn_handle),
+            key: key.to_string(),
+            value: value.to_string(),
+        })
+        .await
     })
     .map_err(|e| format!("Connection option set failed ({}): {:?}", key, e))?;
     Ok(())
@@ -215,18 +289,22 @@ fn write_private_key_to_file(private_key_contents: &[String]) -> Result<String> 
     Ok(key_file_path.display().to_string())
 }
 
-fn set_tls_options(conn_handle: &ConnectionHandle, params: &TestConnectionParams) -> Result<()> {
+fn set_tls_options(
+    rt: &DriverRuntime,
+    conn_handle: &ConnectionHandle,
+    params: &TestConnectionParams,
+) -> Result<()> {
     if let Some(ref cert_path) = params.custom_root_store_path {
-        set_connection_option(conn_handle, "custom_root_store_path", cert_path)?;
+        set_connection_option(rt, conn_handle, "custom_root_store_path", cert_path)?;
     }
     if let Some(ref verify_certs) = params.verify_certificates {
-        set_connection_option(conn_handle, "verify_certificates", verify_certs)?;
+        set_connection_option(rt, conn_handle, "verify_certificates", verify_certs)?;
     }
     if let Some(ref verify_host) = params.verify_hostname {
-        set_connection_option(conn_handle, "verify_hostname", verify_host)?;
+        set_connection_option(rt, conn_handle, "verify_hostname", verify_host)?;
     }
     if let Some(ref crl_mode) = params.crl_check_mode {
-        set_connection_option(conn_handle, "crl_check_mode", crl_mode)?;
+        set_connection_option(rt, conn_handle, "crl_check_mode", crl_mode)?;
     }
     Ok(())
 }

--- a/tests/performance/drivers/core/app/src/main.rs
+++ b/tests/performance/drivers/core/app/src/main.rs
@@ -16,7 +16,7 @@ use sf_core::protobuf::generated::database_driver_v1::*;
 
 use config::TestConfig;
 use connection::{
-    DatabaseDriver, create_connection, create_database, create_statement, execute_setup_queries,
+    DriverRuntime, create_connection, create_database, create_statement, execute_setup_queries,
 };
 use put_execution::execute_put_get_test;
 use query_execution::execute_fetch_test;
@@ -34,14 +34,18 @@ fn run() -> Result<()> {
 
     let config = TestConfig::from_env()?;
 
-    let db_handle = create_database().map_err(|e| format!("Failed to create database: {:?}", e))?;
-    let conn_handle = create_connection(db_handle, &config.params.testconnection)
+    let rt = DriverRuntime::new();
+
+    let db_handle =
+        create_database(&rt).map_err(|e| format!("Failed to create database: {:?}", e))?;
+    let conn_handle = create_connection(&rt, db_handle, &config.params.testconnection)
         .map_err(|e| format!("Failed to connect to Snowflake: {:?}", e))?;
 
-    execute_setup_queries(conn_handle, &config.setup_queries)
+    execute_setup_queries(&rt, conn_handle, &config.setup_queries)
         .map_err(|e| format!("Failed to execute setup queries: {:?}", e))?;
 
     let stmt_handle = create_statement(
+        &rt,
         conn_handle,
         &config.sql_command,
         config.statement_async_override,
@@ -50,6 +54,7 @@ fn run() -> Result<()> {
 
     match config.test_type {
         TestType::Select => execute_fetch_test(
+            &rt,
             conn_handle,
             stmt_handle,
             &config.sql_command,
@@ -58,6 +63,7 @@ fn run() -> Result<()> {
             &config.test_name,
         )?,
         TestType::PutGet => execute_put_get_test(
+            &rt,
             conn_handle,
             stmt_handle,
             &config.sql_command,
@@ -68,13 +74,19 @@ fn run() -> Result<()> {
     }
 
     // Cleanup
-    DatabaseDriver::statement_release(StatementReleaseRequest {
-        stmt_handle: Some(stmt_handle),
+    rt.block_on(async |c| {
+        c.statement_release(StatementReleaseRequest {
+            stmt_handle: Some(stmt_handle),
+        })
+        .await
     })
     .ok();
 
-    DatabaseDriver::connection_release(ConnectionReleaseRequest {
-        conn_handle: Some(conn_handle),
+    rt.block_on(async |c| {
+        c.connection_release(ConnectionReleaseRequest {
+            conn_handle: Some(conn_handle),
+        })
+        .await
     })
     .ok();
 

--- a/tests/performance/drivers/core/app/src/put_execution.rs
+++ b/tests/performance/drivers/core/app/src/put_execution.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
-use crate::connection::{DatabaseDriver, reset_statement_query};
+use crate::connection::{DriverRuntime, reset_statement_query};
 use crate::results::{
     current_unix_timestamp, print_statistics_put_get, write_csv_results_put_get,
     write_metadata_if_not_replay,
@@ -15,6 +15,7 @@ use crate::results::{
 use crate::types::PutGetResult;
 
 pub fn execute_put_get_test(
+    rt: &DriverRuntime,
     conn_handle: ConnectionHandle,
     stmt_handle: StatementHandle,
     sql_command: &str,
@@ -26,23 +27,23 @@ pub fn execute_put_get_test(
     println!("Query: {}", sql_command);
 
     // Warmup
-    run_warmup_put_get(stmt_handle, sql_command, warmup_iterations)
+    run_warmup_put_get(rt, stmt_handle, sql_command, warmup_iterations)
         .map_err(|e| format!("Warmup phase failed: {:?}", e))?;
 
     if warmup_iterations > 0 {
-        reset_statement_query(stmt_handle, sql_command)
+        reset_statement_query(rt, stmt_handle, sql_command)
             .map_err(|e| format!("Failed to reset statement after warmup: {:?}", e))?;
     }
 
     // Execute
-    let results = run_test_iterations_put_get(stmt_handle, sql_command, iterations)
+    let results = run_test_iterations_put_get(rt, stmt_handle, sql_command, iterations)
         .map_err(|e| format!("Test phase failed: {:?}", e))?;
 
     // Write & print
     let results_file = write_csv_results_put_get(&results, test_name)
         .map_err(|e| format!("Failed to write results: {:?}", e))?;
 
-    write_metadata_if_not_replay(conn_handle)?;
+    write_metadata_if_not_replay(rt, conn_handle)?;
 
     print_statistics_put_get(&results);
 
@@ -52,6 +53,7 @@ pub fn execute_put_get_test(
 }
 
 pub fn run_warmup_put_get(
+    rt: &DriverRuntime,
     stmt_handle: StatementHandle,
     sql: &str,
     warmup_iterations: usize,
@@ -61,16 +63,17 @@ pub fn run_warmup_put_get(
     }
 
     for i in 0..warmup_iterations {
-        execute_put_get_iteration(stmt_handle, sql)?;
+        execute_put_get_iteration(rt, stmt_handle, sql)?;
 
         if i < warmup_iterations - 1 {
-            reset_statement_query(stmt_handle, sql)?;
+            reset_statement_query(rt, stmt_handle, sql)?;
         }
     }
     Ok(())
 }
 
 pub fn run_test_iterations_put_get(
+    rt: &DriverRuntime,
     stmt_handle: StatementHandle,
     sql: &str,
     iterations: usize,
@@ -78,7 +81,7 @@ pub fn run_test_iterations_put_get(
     let mut results = Vec::with_capacity(iterations);
 
     for i in 0..iterations {
-        let query_time = execute_put_get_iteration(stmt_handle, sql)?;
+        let query_time = execute_put_get_iteration(rt, stmt_handle, sql)?;
 
         results.push(PutGetResult {
             timestamp: current_unix_timestamp(),
@@ -86,20 +89,27 @@ pub fn run_test_iterations_put_get(
         });
 
         if i < iterations - 1 {
-            reset_statement_query(stmt_handle, sql)?;
+            reset_statement_query(rt, stmt_handle, sql)?;
         }
     }
 
     Ok(results)
 }
 
-fn execute_put_get_iteration(stmt_handle: StatementHandle, sql: &str) -> Result<f64> {
+fn execute_put_get_iteration(
+    rt: &DriverRuntime,
+    stmt_handle: StatementHandle,
+    sql: &str,
+) -> Result<f64> {
     create_get_target_directory(sql)?;
 
     let start_query = Instant::now();
-    DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {
-        stmt_handle: Some(stmt_handle),
-        bindings: None,
+    rt.block_on(async |c| {
+        c.statement_execute_query(StatementExecuteQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            bindings: None,
+        })
+        .await
     })
     .map_err(|e| format!("PUT/GET execution failed: {:?}", e))?;
     let query_time = start_query.elapsed().as_secs_f64();

--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -5,13 +5,14 @@ use sf_core::protobuf::generated::database_driver_v1::*;
 use std::time::Instant;
 
 use crate::arrow::fetch_result_rows;
-use crate::connection::{DatabaseDriver, reset_statement_query};
+use crate::connection::{DriverRuntime, reset_statement_query};
 use crate::results::{
     current_unix_timestamp, print_statistics, write_csv_results, write_metadata_if_not_replay,
 };
 use crate::types::IterationResult;
 
 pub fn execute_fetch_test(
+    rt: &DriverRuntime,
     conn_handle: ConnectionHandle,
     stmt_handle: StatementHandle,
     sql_command: &str,
@@ -23,23 +24,23 @@ pub fn execute_fetch_test(
     println!("Query: {}", sql_command);
 
     // Warmup
-    run_warmup(stmt_handle, sql_command, warmup_iterations)
+    run_warmup(rt, stmt_handle, sql_command, warmup_iterations)
         .map_err(|e| format!("Warmup phase failed: {:?}", e))?;
 
     if warmup_iterations > 0 {
-        reset_statement_query(stmt_handle, sql_command)
+        reset_statement_query(rt, stmt_handle, sql_command)
             .map_err(|e| format!("Failed to reset statement after warmup: {:?}", e))?;
     }
 
     // Execute
-    let results = run_test_iterations(stmt_handle, sql_command, iterations)
+    let results = run_test_iterations(rt, stmt_handle, sql_command, iterations)
         .map_err(|e| format!("Test phase failed: {:?}", e))?;
 
     // Write & print
     let results_file = write_csv_results(&results, test_name)
         .map_err(|e| format!("Failed to write results: {:?}", e))?;
 
-    write_metadata_if_not_replay(conn_handle)?;
+    write_metadata_if_not_replay(rt, conn_handle)?;
 
     print_statistics(&results);
 
@@ -48,22 +49,28 @@ pub fn execute_fetch_test(
     Ok(())
 }
 
-pub fn run_warmup(stmt_handle: StatementHandle, sql: &str, warmup_iterations: usize) -> Result<()> {
+pub fn run_warmup(
+    rt: &DriverRuntime,
+    stmt_handle: StatementHandle,
+    sql: &str,
+    warmup_iterations: usize,
+) -> Result<()> {
     if warmup_iterations == 0 {
         return Ok(());
     }
 
     for i in 0..warmup_iterations {
-        let (_query_time, _fetch_time, _row_count) = execute_iteration(stmt_handle)?;
+        let (_query_time, _fetch_time, _row_count) = execute_iteration(rt, stmt_handle)?;
 
         if i < warmup_iterations - 1 {
-            reset_statement_query(stmt_handle, sql)?;
+            reset_statement_query(rt, stmt_handle, sql)?;
         }
     }
     Ok(())
 }
 
 pub fn run_test_iterations(
+    rt: &DriverRuntime,
     stmt_handle: StatementHandle,
     sql: &str,
     iterations: usize,
@@ -72,7 +79,7 @@ pub fn run_test_iterations(
     let mut expected_row_count = get_expected_row_count();
 
     for i in 0..iterations {
-        let (query_time, fetch_time, row_count) = execute_iteration(stmt_handle)?;
+        let (query_time, fetch_time, row_count) = execute_iteration(rt, stmt_handle)?;
 
         expected_row_count = validate_row_count(row_count, expected_row_count, i)?;
 
@@ -84,7 +91,7 @@ pub fn run_test_iterations(
         });
 
         if i < iterations - 1 {
-            reset_statement_query(stmt_handle, sql)?;
+            reset_statement_query(rt, stmt_handle, sql)?;
         }
     }
 
@@ -129,17 +136,23 @@ fn validate_row_count(
     }
 }
 
-fn execute_iteration(stmt_handle: StatementHandle) -> Result<(f64, f64, usize)> {
-    // Execute query (measure query execution time)
+fn execute_iteration(
+    rt: &DriverRuntime,
+    stmt_handle: StatementHandle,
+) -> Result<(f64, f64, usize)> {
     let start_query = Instant::now();
-    let response = DatabaseDriver::statement_execute_query(StatementExecuteQueryRequest {
-        stmt_handle: Some(stmt_handle),
-        bindings: None,
-    })
-    .map_err(|e| format!("Query execution failed: {:?}", e))?;
+    let response = rt
+        .block_on(async |c| {
+            c.statement_execute_query(StatementExecuteQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                bindings: None,
+            })
+            .await
+        })
+        .map_err(|e| format!("Query execution failed: {:?}", e))?;
     let query_time = start_query.elapsed().as_secs_f64();
 
-    // Fetch results (measure fetch time)
+    // Fetch results outside the runtime so ChunkReader can use its own block_on
     let start_fetch = Instant::now();
     let row_count = if let Some(result) = response.result {
         fetch_result_rows(result).map_err(|e| format!("Failed to fetch results: {:?}", e))?

--- a/tests/performance/drivers/core/app/src/results.rs
+++ b/tests/performance/drivers/core/app/src/results.rs
@@ -1,6 +1,6 @@
 //! Results output and CSV formatting
 
-use crate::connection::get_server_version as get_server_version_internal;
+use crate::connection::{DriverRuntime, get_server_version as get_server_version_internal};
 use crate::types::{IterationResult, PutGetResult};
 use sf_core::protobuf::generated::database_driver_v1::ConnectionHandle;
 use std::fs;
@@ -193,11 +193,14 @@ where
     Ok(filename.display().to_string())
 }
 
-pub fn write_metadata_if_not_replay(conn_handle: ConnectionHandle) -> Result<()> {
+pub fn write_metadata_if_not_replay(
+    rt: &DriverRuntime,
+    conn_handle: ConnectionHandle,
+) -> Result<()> {
     // In replay mode, skip server version query and use N/A
     let actual_server_version = match std::env::var("WIREMOCK_REPLAY") {
         Ok(val) if val == "true" => "N/A".to_string(),
-        _ => get_server_version_internal(conn_handle).unwrap_or_else(|e| {
+        _ => get_server_version_internal(rt, conn_handle).unwrap_or_else(|e| {
             eprintln!("⚠️  Warning: Could not retrieve server version: {}", e);
             "UNKNOWN".to_string()
         }),


### PR DESCRIPTION
## **ADR-28: Async Rust exposed at API level**

- Converts the protobuf API layer from synchronous to async/await.
- Replaced synchronization primitives: std::sync -> tokio::sync
- Refactors JDBC bridge and ODBC to manage their own tokio runtimes for bridging to synchronous C APIs. 
- Removes the centralized `async_bridge` module in favor of component-owned runtimes.

### Next up:

- Use common runtime for CRL
- Implement chunk prefetching