### PR TITLE
NO-SNOW Fix potential memory corruption

### DIFF
--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -276,7 +276,11 @@ class SnowflakeCursorBase(abc.ABC):
         self._binding_data = json_bytes
 
         # Get memory address of the bytes buffer (no-copy scheme)
-        ptr_value = ctypes.cast(ctypes.c_char_p(json_bytes), ctypes.c_void_p).value
+        # Use c_char.from_buffer_copy to get a stable pointer to the data.
+        # ctypes.c_char_p would create a temporary copy whose memory could be
+        # freed before Rust reads it.
+        self._binding_buf = (ctypes.c_char * len(json_bytes)).from_buffer_copy(json_bytes)
+        ptr_value = ctypes.cast(self._binding_buf, ctypes.c_void_p).value
         if ptr_value is None:
             raise RuntimeError("Failed to obtain memory pointer for binding data")
 


### PR DESCRIPTION
## The original code
```
  json_bytes = json_str.encode("utf-8")       # Python bytes object at address A
  self._binding_data = json_bytes              # keeps address A alive

  ptr_value = ctypes.cast(ctypes.c_char_p(json_bytes), ctypes.c_void_p).value
```

What happens in that last line, left to right:

1. `ctypes.c_char_p(json_bytes)` — ctypes creates a new C string object. It copies the bytes into its own internal buffer at address B. This is a temporary object (no variable holds it).
2. `ctypes.cast(..., ctypes.c_void_p)` — returns a c_void_p whose .value is the integer address B (the copy's address).
3. `.value` — extracts the raw integer B.

Now the expression is done. The temporary c_char_p at address B has no references → eligible for GC → memory at B can be freed.

`self._binding_data = json_bytes` keeps address A alive, but the pointer we're passing to Rust is address B. Wrong address, and it can be freed at any time.

##  The fix

```
  self._binding_buf = (ctypes.c_char * len(json_bytes)).from_buffer_copy(json_bytes)
  ptr_value = ctypes.cast(self._binding_buf, ctypes.c_void_p).value
```

1. `(ctypes.c_char * len(json_bytes))` — creates a ctypes array type of the right size.
2. `.from_buffer_copy(json_bytes)` — creates an instance that owns a copy of the data at address C.
3. `self._binding_buf = ...` — stores it on self, so address C stays alive as long as the cursor lives.
4. `ctypes.cast(self._binding_buf, ctypes.c_void_p).value` — gets address C, which is guaranteed to remain valid.

##  Why it didn't crash constantly

CPython uses reference counting. The temporary c_char_p typically gets freed only when the reference count drops — which in practice often happens after the synchronous FFI call returns. So the bug is a race with the garbage collector: it works 99% of the time, but occasionally the GC runs at the wrong moment and Rust reads freed/reused memory.
