### PR TITLE
NO-SNOW: Skip long-running procedure catalog tests causing timeouts

### DIFF
--- a/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
@@ -202,6 +202,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnNam
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
                  "[odbc-api][procedurecolumns][catalog]") {
+  SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   const auto schema = Schema::use_random_schema(dbc_handle());
@@ -247,6 +248,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 TEST_CASE_METHOD(StmtDefaultDSNFixture,
                  "SQLProcedureColumns: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedurecolumns][catalog]") {
+  SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   const auto schema = Schema::use_random_schema(dbc_handle());

--- a/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
@@ -300,6 +300,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure r
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combinations are accepted",
                  "[odbc-api][procedures][catalog]") {
+  SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   const auto schema = Schema::use_random_schema(dbc_handle());
@@ -343,6 +344,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedures][catalog]") {
+  SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   const auto schema = Schema::use_random_schema(dbc_handle());


### PR DESCRIPTION
### TL;DR

Skip four long-running ODBC catalog tests that cause timeouts due to multiple round-trips

### What changed?

Added `SKIP("Long-running: multiple catalog round-trips cause timeout");` statements to four test cases:
- `SQLProcedureColumns: Various parameter combinations are accepted`
- `SQLProcedureColumns: Can call multiple times on same statement after close cursor`
- `SQLProcedures: Various parameter combinations are accepted`
- `SQLProcedures: Can call multiple times on same statement after close cursor`

### How to test?

Run the ODBC test suite to verify that these four tests are now skipped and no longer cause timeout failures in the test pipeline.

### Why make this change?

These tests perform multiple catalog round-trips which cause them to run for extended periods and eventually timeout, making them unsuitable for regular test execution. Skipping them prevents test suite failures while preserving the test code for potential future use.