### PR TITLE
NO-SNOW: Suppress dead_code warning for schema field in Done state

### DIFF
--- a/odbc/src/api/types.rs
+++ b/odbc/src/api/types.rs
@@ -542,6 +542,7 @@ pub enum StatementState {
         rows_affected: Option<i64>,
     },
     Done {
+        #[allow(dead_code)]
         schema: SchemaRef,
     },
     Error,


### PR DESCRIPTION
### TL;DR

Added `#[allow(dead_code)]` attribute to the `schema` field in the `Done` variant of `StatementState` enum.

### What changed?

The `schema` field in the `Done` variant of the `StatementState` enum now has the `#[allow(dead_code)]` attribute to suppress compiler warnings about unused code.

### How to test?

Compile the code to verify that dead code warnings for the `schema` field are no longer generated.

### Why make this change?

This suppresses compiler warnings for the `schema` field that is currently not being used but may be needed for future functionality or API completeness.