### PR TITLE
SNOW-3111876 Add JSON to arrow conversion for TIMESTAMP_TZ

### DIFF
--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1,5 +1,7 @@
 use crate::query_types::RowType;
-use arrow::array::{Array, BooleanArray, Float64Array, Int8Array, Int64Array, StringArray};
+use arrow::array::{
+    Array, BooleanArray, Float64Array, Int8Array, Int32Array, Int64Array, StringArray,
+};
 use arrow::datatypes::{DataType, Date32Type, Field, Int32Type, Int64Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
@@ -109,6 +111,37 @@ pub fn create_field_with_type(
                         .into(),
                     )
                 })
+            };
+            Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
+        }
+        RowType::TimestampTz {
+            name,
+            nullable,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "TIMESTAMP_TZ".to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            let data_type = if scale <= &3 {
+                DataType::Struct(
+                    vec![
+                        Field::new("epoch", DataType::Int64, true).with_metadata(metadata.clone()),
+                        Field::new("timezone", DataType::Int32, true)
+                            .with_metadata(metadata.clone()),
+                    ]
+                    .into(),
+                )
+            } else {
+                DataType::Struct(
+                    vec![
+                        Field::new("epoch", DataType::Int64, true).with_metadata(metadata.clone()),
+                        Field::new("fraction", DataType::Int32, true)
+                            .with_metadata(metadata.clone()),
+                        Field::new("timezone", DataType::Int32, true)
+                            .with_metadata(metadata.clone()),
+                    ]
+                    .into(),
+                )
             };
             Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
         }
@@ -333,6 +366,102 @@ fn create_column_array(
                 _ => UnsupportedDataTypeSnafu {
                     data_type: format!("{:?}", field.data_type()),
                     row_type: "TIMESTAMP_NTZ".to_string(),
+                }
+                .fail(),
+            }
+        }
+        RowType::TimestampTz { scale, .. } => {
+            #[allow(clippy::type_complexity)]
+            let all_values: Result<Vec<((i64, i32), i32)>, ArrowUtilsError> = values
+                .into_iter()
+                .map(|v| {
+                    let (epoch_part, tz_part) = v.split_once(' ').unwrap_or((v, ""));
+                    let (epoch_str, fraction_str) =
+                        epoch_part.split_once('.').unwrap_or((epoch_part, ""));
+                    (epoch_str, fraction_str, tz_part)
+                })
+                .map(|(epoch_str, fraction_str, tz_part)| {
+                    let epoch: i64 = epoch_str.parse().context(IntegerParsingSnafu {
+                        value: epoch_str.to_string(),
+                    })?;
+                    let fraction: i32 = if fraction_str.is_empty() {
+                        0
+                    } else {
+                        let filled_with_zeros =
+                            format!("{:0<width$}", fraction_str, width = *scale as usize);
+                        filled_with_zeros
+                            .parse::<i32>()
+                            .context(IntegerParsingSnafu {
+                                value: fraction_str.to_string(),
+                            })?
+                    };
+                    let tz = if tz_part.is_empty() {
+                        // Snowflake uses zone offset [-24h, +24h], which means
+                        // [-1440,1440] in minutes. But it is aligned to be zero based
+                        // which means the values scope is [0, 2880].
+                        // This value means actually zone offset 0.
+                        1440
+                    } else {
+                        tz_part.parse::<i32>().context(IntegerParsingSnafu {
+                            value: tz_part.to_string(),
+                        })?
+                    };
+                    // wrapping first two values in a tuple makes unzipping later easier, but it's heavier
+                    // potentially could be replaced with returning three values and repackaging to three collections manually
+                    Ok(((epoch, fraction), tz))
+                })
+                .collect();
+            let all_values = all_values?;
+            let (time_part_values, tz_values): (Vec<(i64, i32)>, Vec<i32>) =
+                all_values.into_iter().unzip();
+            let (epoch_values, fraction_values): (Vec<i64>, Vec<i32>) =
+                time_part_values.into_iter().unzip();
+
+            let field = create_field(row_type)?;
+            match field.data_type() {
+                DataType::Struct(fields) if fields.len() == 2 => {
+                    let normalized_epoch_values: Vec<i64> = epoch_values
+                        .iter()
+                        .zip(fraction_values.iter())
+                        .map(|(epoch, fraction)| {
+                            epoch * 10i64.pow(*scale as u32) + *fraction as i64
+                        })
+                        .collect();
+                    let epoch_array: Arc<dyn Array> =
+                        Arc::new(arrow::array::PrimitiveArray::<Int64Type>::from(
+                            normalized_epoch_values,
+                        ));
+                    let tz_array: Arc<dyn Array> = Arc::new(Int32Array::from(tz_values));
+                    let values = vec![
+                        (fields[0].clone(), epoch_array),
+                        (fields[1].clone(), tz_array),
+                    ];
+                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                }
+                DataType::Struct(fields) if fields.len() == 3 => {
+                    let normalized_fraction_values: Vec<i32> = fraction_values
+                        .iter()
+                        .map(|f| f * 10i32.pow((9 - *scale) as u32))
+                        .collect();
+                    let epoch_array: Arc<dyn Array> =
+                        Arc::new(arrow::array::PrimitiveArray::<Int64Type>::from(
+                            epoch_values,
+                        ));
+                    let fraction_array: Arc<dyn Array> =
+                        Arc::new(arrow::array::PrimitiveArray::<Int32Type>::from(
+                            normalized_fraction_values,
+                        ));
+                    let tz_array: Arc<dyn Array> = Arc::new(Int32Array::from(tz_values));
+                    let values = vec![
+                        (fields[0].clone(), epoch_array),
+                        (fields[1].clone(), fraction_array),
+                        (fields[2].clone(), tz_array),
+                    ];
+                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                }
+                _ => UnsupportedDataTypeSnafu {
+                    data_type: format!("{:?}", field.data_type()),
+                    row_type: "TIMESTAMP_TZ".to_string(),
                 }
                 .fail(),
             }

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -33,6 +33,11 @@ pub enum RowType {
         nullable: bool,
         scale: u64,
     },
+    TimestampTz {
+        name: String,
+        nullable: bool,
+        scale: u64,
+    },
 }
 
 impl RowType {
@@ -94,6 +99,14 @@ impl RowType {
 
     pub fn timestamp_ltz(name: &str, nullable: bool, scale: u64) -> Self {
         RowType::TimestampLtz {
+            name: name.to_string(),
+            nullable,
+            scale,
+        }
+    }
+
+    pub fn timestamp_tz(name: &str, nullable: bool, scale: u64) -> Self {
+        RowType::TimestampTz {
             name: name.to_string(),
             nullable,
             scale,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -580,6 +580,10 @@ impl TryFrom<&RowType> for query_types::RowType {
                 let scale = value.scale.unwrap_or(9);
                 Ok(query_types::RowType::timestamp_ltz(&name, nullable, scale))
             }
+            "TIMESTAMP_TZ" => {
+                let scale = value.scale.unwrap_or(9);
+                Ok(query_types::RowType::timestamp_tz(&name, nullable, scale))
+            }
             "BOOLEAN" => Ok(query_types::RowType::boolean(&name, nullable)),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -124,7 +124,7 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
     match logical_type {
         "TEXT" => &["finalType", "precision", "scale"],
         "FIXED" => &["finalType", "charLength", "byteLength"],
-        "TIMESTAMP_NTZ" | "TIMESTAMP_LTZ" => &[
+        "TIMESTAMP_NTZ" | "TIMESTAMP_LTZ" | "TIMESTAMP_TZ" => &[
             "finalType",
             "charLength",
             "byteLength",
@@ -139,47 +139,40 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
 /// Asserts that two Arrow schemas match in field name, data type, nullability,
 /// and relevant metadata keys (excluding keys that are known to differ between
 /// Arrow-native and JSON-converted-to-Arrow results).
-pub fn assert_schemas_match(arrow_schema: &Schema, json_schema: &Schema) {
+pub fn assert_schemas_match(left: &Schema, right: &Schema) {
     assert_eq!(
-        arrow_schema.fields().len(),
-        json_schema.fields().len(),
-        "Schema field count mismatch: arrow has {}, json has {}",
-        arrow_schema.fields().len(),
-        json_schema.fields().len()
+        left.fields().len(),
+        right.fields().len(),
+        "Schema field count mismatch: left has {}, right has {}",
+        left.fields().len(),
+        right.fields().len()
     );
 
-    for (arrow_field, json_field) in arrow_schema
-        .fields()
-        .iter()
-        .zip(json_schema.fields().iter())
-    {
+    for (arrow_field, json_field) in left.fields().iter().zip(right.fields().iter()) {
         assert_fields_match(arrow_field, json_field);
     }
 }
 
-fn assert_fields_match(arrow_field: &FieldRef, json_field: &FieldRef) {
-    assert_eq!(arrow_field.name(), json_field.name(), "Field name mismatch");
+fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
+    assert_eq!(left.name(), right.name(), "Field name mismatch");
     assert_eq!(
-        arrow_field.is_nullable(),
-        json_field.is_nullable(),
+        left.is_nullable(),
+        right.is_nullable(),
         "Nullability mismatch for field '{}'",
-        arrow_field.name()
+        left.name()
     );
     assert_eq!(
-        discriminant(arrow_field.data_type()),
-        discriminant(json_field.data_type()),
-        "Data type variant mismatch for field '{}'",
-        arrow_field.name()
+        discriminant(left.data_type()),
+        discriminant(right.data_type()),
+        "Data type variant mismatch for field '{}', left type: {:?}, right type: {:?}",
+        left.name(),
+        left.data_type(),
+        right.data_type()
     );
-    let logical_type = arrow_field
+    let logical_type = left
         .metadata()
         .get("logicalType")
-        .unwrap_or_else(|| {
-            panic!(
-                "logicalType metadata key missing for field {}",
-                arrow_field.name()
-            )
-        });
+        .unwrap_or_else(|| panic!("logicalType metadata key missing for field {}", left.name()));
     let excluded = metadata_keys_to_exclude(logical_type);
 
     let filter_metadata = |metadata: &BTreeMap<String, String>| -> BTreeMap<String, String> {
@@ -190,12 +183,12 @@ fn assert_fields_match(arrow_field: &FieldRef, json_field: &FieldRef) {
             .collect()
     };
 
-    let arrow_meta: BTreeMap<String, String> = arrow_field
+    let arrow_meta: BTreeMap<String, String> = left
         .metadata()
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    let json_meta: BTreeMap<String, String> = json_field
+    let json_meta: BTreeMap<String, String> = right
         .metadata()
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
@@ -207,24 +200,24 @@ fn assert_fields_match(arrow_field: &FieldRef, json_field: &FieldRef) {
     assert_eq!(
         filtered_arrow,
         filtered_json,
-        "Metadata mismatch for field '{}'\n  arrow: {:?}\n  json:  {:?}",
-        arrow_field.name(),
+        "Metadata mismatch for field '{}'\n  left: {:?}\n  right:  {:?}",
+        left.name(),
         filtered_arrow,
         filtered_json
     );
-    match (arrow_field.data_type(), json_field.data_type()) {
-        (DataType::Struct(arrow_fields), DataType::Struct(json_fields)) => {
-            arrow_fields
+    match (left.data_type(), right.data_type()) {
+        (DataType::Struct(left_fields), DataType::Struct(right_fields)) => {
+            left_fields
                 .iter()
-                .zip(json_fields.iter())
+                .zip(right_fields.iter())
                 .for_each(|(a, j)| assert_fields_match(a, j));
         }
-        (arrow_data_type, json_data_type) => {
+        (left_data_type, right_data_type) => {
             assert_eq!(
-                arrow_data_type,
-                json_data_type,
+                left_data_type,
+                right_data_type,
                 "Data type mismatch for field '{}'",
-                arrow_field.name()
+                left.name()
             );
         }
     }
@@ -232,26 +225,22 @@ fn assert_fields_match(arrow_field: &FieldRef, json_field: &FieldRef) {
 
 /// Asserts that two RecordBatches match in schema (using relaxed metadata comparison)
 /// and column data.
-pub fn assert_record_batches_match(arrow_batch: &RecordBatch, json_batch: &RecordBatch) {
-    assert_schemas_match(arrow_batch.schema().as_ref(), json_batch.schema().as_ref());
+pub fn assert_record_batches_match(left: &RecordBatch, right: &RecordBatch) {
+    assert_schemas_match(left.schema().as_ref(), right.schema().as_ref());
 
     assert_eq!(
-        arrow_batch.num_columns(),
-        json_batch.num_columns(),
+        left.num_columns(),
+        right.num_columns(),
         "Column count mismatch"
     );
-    assert_eq!(
-        arrow_batch.num_rows(),
-        json_batch.num_rows(),
-        "Row count mismatch"
-    );
+    assert_eq!(left.num_rows(), right.num_rows(), "Row count mismatch");
 
-    for col_idx in 0..arrow_batch.num_columns() {
-        let arrow_col = arrow_batch.column(col_idx);
-        let json_col = json_batch.column(col_idx);
-        let schema = arrow_batch.schema();
+    for col_idx in 0..left.num_columns() {
+        let left_col = left.column(col_idx);
+        let right_col = right.column(col_idx);
+        let schema = left.schema();
         let field_name = schema.field(col_idx).name();
-        assert_arrays_match(arrow_col, json_col, field_name);
+        assert_arrays_match(left_col, right_col, field_name);
     }
 }
 

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -42,6 +42,21 @@ fn should_return_timestamp_ltz_as_arrow_even_if_json_result_set_is_returned() {
     )
 }
 
+#[test]
+fn should_return_timestamp_tz_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_timestamp_tz (TZ0 TIMESTAMP_TZ(0),\
+            TZ1 TIMESTAMP_TZ(1), TZ2 TIMESTAMP_TZ(2), TZ3 TIMESTAMP_TZ(3), TZ4 TIMESTAMP_TZ(4), TZ5 TIMESTAMP_TZ(5), TZ6 TIMESTAMP_TZ(6), TZ7 TIMESTAMP_TZ(7), TZ8 TIMESTAMP_TZ(8), TZ9 TIMESTAMP_TZ(9),\
+            TZ1a TIMESTAMP_TZ(1), TZ2a TIMESTAMP_TZ(2), TZ3a TIMESTAMP_TZ(3), TZ4a TIMESTAMP_TZ(4), TZ5a TIMESTAMP_TZ(5), TZ6a TIMESTAMP_TZ(6), TZ7a TIMESTAMP_TZ(7), TZ8a TIMESTAMP_TZ(8), TZ9a TIMESTAMP_TZ(9),\
+            TZ1b TIMESTAMP_TZ(1), TZ2b TIMESTAMP_TZ(2), TZ3b TIMESTAMP_TZ(3), TZ4b TIMESTAMP_TZ(4), TZ5b TIMESTAMP_TZ(5), TZ6b TIMESTAMP_TZ(6), TZ7b TIMESTAMP_TZ(7), TZ8b TIMESTAMP_TZ(8), TZ9b TIMESTAMP_TZ(9))",
+        "INSERT INTO json_result_set_timestamp_tz VALUES ('2026-01-01 10:10:10',\
+            '2026-01-01 11:11:11.1 +01:00', '2026-01-01 12:12:12.12+02:00', '2026-01-01 13:13:13.123 +03:00', '2026-01-01 14:14:14.1234 +04:00', '2026-01-01 15:15:15.12345 +05:00', '2026-01-01 16:16:16.123456 +06:00', '2026-01-01 17:17:17.1234567 +07:00', '2026-01-01 18:18:18.12345678 +08:00', '2026-01-01 19:19:19.123456789 +09:00',\
+            '2026-01-02 11:11:11 +01:00', '2026-01-02 12:12:12 +02:00', '2026-01-02 13:13:13 +03:00', '2026-01-02 14:14:14 +04:00', '2026-01-02 15:15:15 +05:00', '2026-01-02 16:16:16 +06:00', '2026-01-02 17:17:17 +07:00', '2026-01-02 18:18:18 +08:00', '2026-01-02 19:19:19 +09:00',\
+            '2026-01-02 11:11:11.1 +01:00', '2026-01-02 12:12:12.02 +02:00', '2026-01-03 13:13:13.003 +03:00', '2026-01-02 14:14:14.0004 +04:00', '2026-01-02 15:15:15.00005 +05:00', '2026-01-02 16:16:16.000006 +06:00', '2026-01-02 17:17:17.0000007 +07:00', '2026-01-02 18:18:18.00000008 +08:00', '2026-01-02 19:19:19.000000009 +09:00')",
+        "SELECT * FROM json_result_set_timestamp_tz",
+    )
+}
+
 fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, select_query: &str) {
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();


### PR DESCRIPTION
This PR introduces JSON conversion to Arrow. It handles both variants of TIMESTAMP TZ (scale <=3 and scale > 3), which have different representation in Arrow. Timezone is kept intact.