### PR TITLE
SNOW-3111876 Support null values in JSON rowset deserialization

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "brotli",
     "zstandard",
     "tomlkit",
+    "tzdata",
 ]
 dev = [
     "ruff",

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 class TestCriticalUserJourneys:
     def test_desc_command(self, cursor):
         # When DESC SCHEMA command is executed
-        cursor.execute("ALTER SESSION SET TIMEZONE = 'UTC';")
+        cursor.execute("ALTER SESSION SET TIMEZONE = 'America/Los_Angeles';")
         rows = cursor.execute("desc schema snowflake.INFORMATION_SCHEMA").fetchall()
 
         # Then Schema properties are returned with correct types
@@ -19,7 +19,8 @@ class TestCriticalUserJourneys:
 
     def test_show_command(self, tmp_schema, cursor):
         # When SHOW SCHEMAS command is executed
-        r = cursor.execute("show schemas in database identifier(current_database())").fetchall()
+        (db_name,) = cursor.execute("SELECT current_database()").fetchone()
+        r = cursor.execute(f"SHOW SCHEMAS IN DATABASE {db_name}").fetchall()
 
         # Then Result contains INFORMATION_SCHEMA and PUBLIC schemas
         schema_names = [row[1].upper() for row in r]

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -25,3 +25,4 @@ class TestCriticalUserJourneys:
         schema_names = [row[1].upper() for row in r]
         assert "INFORMATION_SCHEMA" in schema_names
         assert "PUBLIC" in schema_names
+        assert tmp_schema.upper() in schema_names

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -19,8 +19,7 @@ class TestCriticalUserJourneys:
 
     def test_show_command(self, tmp_schema, cursor):
         # When SHOW SCHEMAS command is executed
-        current_database = cursor.execute("select current_database()").fetchone()[0]
-        r = cursor.execute(f"show schemas in database {current_database}").fetchall()
+        r = cursor.execute("show schemas in database identifier(current_database())").fetchall()
 
         # Then Result contains INFORMATION_SCHEMA and PUBLIC schemas
         schema_names = [row[1].upper() for row in r]

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -1,9 +1,11 @@
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 
 class TestCriticalUserJourneys:
     def test_desc_command(self, cursor):
         # When DESC SCHEMA command is executed
+        la_tz = ZoneInfo("America/Los_Angeles")
         cursor.execute("ALTER SESSION SET TIMEZONE = 'America/Los_Angeles';")
         rows = cursor.execute("desc schema snowflake.INFORMATION_SCHEMA").fetchall()
 
@@ -15,7 +17,7 @@ class TestCriticalUserJourneys:
         assert isinstance(kind, str)
 
         assert isinstance(created_on, datetime)
-        assert created_on == datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+        assert created_on == datetime(1969, 12, 31, 16, 0, tzinfo=la_tz)
 
     def test_show_command(self, tmp_schema, cursor):
         # When SHOW SCHEMAS command is executed

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -19,11 +19,12 @@ class TestCriticalUserJourneys:
 
     def test_show_command(self, tmp_schema, cursor):
         # When SHOW SCHEMAS command is executed
-        (db_name,) = cursor.execute("SELECT current_database()").fetchone()
-        r = cursor.execute(f"SHOW SCHEMAS IN DATABASE {db_name}").fetchall()
+        r = cursor.execute("SHOW SCHEMAS").fetchall()
 
         # Then Result contains INFORMATION_SCHEMA and PUBLIC schemas
         schema_names = [row[1].upper() for row in r]
         assert "INFORMATION_SCHEMA" in schema_names
         assert "PUBLIC" in schema_names
-        assert tmp_schema.upper() in schema_names
+        filtered = cursor.execute(f"SHOW SCHEMAS LIKE '{tmp_schema}'").fetchall()
+        assert len(filtered) == 1
+        assert filtered[0][1].upper() == tmp_schema.upper()

--- a/python/tests/e2e/query/test_cuj.py
+++ b/python/tests/e2e/query/test_cuj.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+
+
+class TestCriticalUserJourneys:
+    def test_desc_command(self, cursor):
+        # When DESC SCHEMA command is executed
+        cursor.execute("ALTER SESSION SET TIMEZONE = 'UTC';")
+        rows = cursor.execute("desc schema snowflake.INFORMATION_SCHEMA").fetchall()
+
+        # Then Schema properties are returned with correct types
+        assert len(rows) > 0
+        row = rows[0]
+        created_on, name, kind = row[:3]
+        assert isinstance(name, str)
+        assert isinstance(kind, str)
+
+        assert isinstance(created_on, datetime)
+        assert created_on == datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    def test_show_command(self, tmp_schema, cursor):
+        # When SHOW SCHEMAS command is executed
+        current_database = cursor.execute("select current_database()").fetchone()[0]
+        r = cursor.execute(f"show schemas in database {current_database}").fetchall()
+
+        # Then Result contains INFORMATION_SCHEMA and PUBLIC schemas
+        schema_names = [row[1].upper() for row in r]
+        assert "INFORMATION_SCHEMA" in schema_names
+        assert "PUBLIC" in schema_names

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -893,6 +893,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "tomlkit" },
+    { name = "tzdata" },
     { name = "zstandard" },
 ]
 
@@ -918,6 +919,7 @@ requires-dist = [
     { name = "tomlkit", marker = "extra == 'test'" },
     { name = "types-protobuf", marker = "extra == 'dev'" },
     { name = "types-pytz", marker = "extra == 'dev'" },
+    { name = "tzdata", marker = "extra == 'test'" },
     { name = "zstandard", marker = "extra == 'test'" },
 ]
 provides-extras = ["dev", "test"]
@@ -1028,6 +1030,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -1058,13 +1058,13 @@ mod tests {
         );
     }
 
-    fn make_data(json: &str) -> Data {
-        serde_json::from_str(json).unwrap()
+    fn deserialize_query_response(json: &str) -> Data {
+        serde_json::from_str(json).expect("test JSON must be valid query response Data")
     }
 
     #[test]
     fn calculate_rows_affected_sums_dml_columns() {
-        let data = make_data(
+        let data = deserialize_query_response(
             r#"{
                 "statementTypeId": 12544,
                 "rowset": [["10", "3"]],
@@ -1079,7 +1079,7 @@ mod tests {
 
     #[test]
     fn calculate_rows_affected_skips_null_cells() {
-        let data = make_data(
+        let data = deserialize_query_response(
             r#"{
                 "statementTypeId": 12544,
                 "rowset": [["5", null]],
@@ -1094,7 +1094,7 @@ mod tests {
 
     #[test]
     fn calculate_rows_affected_all_null_cells() {
-        let data = make_data(
+        let data = deserialize_query_response(
             r#"{
                 "statementTypeId": 12544,
                 "rowset": [[null]],
@@ -1108,7 +1108,7 @@ mod tests {
 
     #[test]
     fn calculate_rows_affected_select_uses_total() {
-        let data = make_data(
+        let data = deserialize_query_response(
             r#"{
                 "total": 42
             }"#,

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -130,7 +130,7 @@ pub(crate) fn calculate_rows_affected(data: &Data) -> Option<i64> {
                     || DML_AFFECTED_ROWS_COLUMN_PREFIXES
                         .iter()
                         .any(|p| col_name.starts_with(p)))
-                    && let Some(value) = rowset[0].get(idx)
+                    && let Some(Some(value)) = rowset[0].get(idx)
                     && let Ok(count) = value.parse::<i64>()
                 {
                     affected_rows += count;
@@ -1056,5 +1056,63 @@ mod tests {
             !serialized.contains("bindings"),
             "None bindings should be omitted from serialized output.\nSerialized: {serialized}"
         );
+    }
+
+    fn make_data(json: &str) -> Data {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn calculate_rows_affected_sums_dml_columns() {
+        let data = make_data(
+            r#"{
+                "statementTypeId": 12544,
+                "rowset": [["10", "3"]],
+                "rowtype": [
+                    {"name": "number of rows inserted", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10},
+                    {"name": "number of rows updated", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10}
+                ]
+            }"#,
+        );
+        assert_eq!(calculate_rows_affected(&data), Some(13));
+    }
+
+    #[test]
+    fn calculate_rows_affected_skips_null_cells() {
+        let data = make_data(
+            r#"{
+                "statementTypeId": 12544,
+                "rowset": [["5", null]],
+                "rowtype": [
+                    {"name": "number of rows inserted", "type": "FIXED", "nullable": false, "scale": 0, "precision": 10},
+                    {"name": "number of rows deleted", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+                ]
+            }"#,
+        );
+        assert_eq!(calculate_rows_affected(&data), Some(5));
+    }
+
+    #[test]
+    fn calculate_rows_affected_all_null_cells() {
+        let data = make_data(
+            r#"{
+                "statementTypeId": 12544,
+                "rowset": [[null]],
+                "rowtype": [
+                    {"name": "number of rows inserted", "type": "FIXED", "nullable": true, "scale": 0, "precision": 10}
+                ]
+            }"#,
+        );
+        assert_eq!(calculate_rows_affected(&data), Some(0));
+    }
+
+    #[test]
+    fn calculate_rows_affected_select_uses_total() {
+        let data = make_data(
+            r#"{
+                "total": 42
+            }"#,
+        );
+        assert_eq!(calculate_rows_affected(&data), Some(42));
     }
 }

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -220,6 +220,23 @@ pub fn create_field_with_type(
     }
 }
 
+/// Maps a FIXED column's precision to the narrowest integer Arrow type that can
+/// hold all possible values for that precision. Used for the all-null path so
+/// the schema stays consistent with what the non-null path would produce.
+fn integer_type_for_precision(precision: u64) -> DataType {
+    if precision <= 2 {
+        DataType::Int8
+    } else if precision <= 4 {
+        DataType::Int16
+    } else if precision <= 9 {
+        DataType::Int32
+    } else if precision <= 18 {
+        DataType::Int64
+    } else {
+        DataType::Decimal128(precision as u8, 0)
+    }
+}
+
 fn cast_fixed_to_arrow<T>(
     row_type: &RowType,
     data_type: DataType,
@@ -398,10 +415,36 @@ fn create_column_array(
                         ),
                     ));
                 }
-                return Ok((
-                    create_field_with_type(row_type, Some(DataType::Int64))?,
-                    Arc::new(Int64Array::new_null(len)),
-                ));
+                let inferred = integer_type_for_precision(*precision);
+                return match inferred {
+                    DataType::Int8 => Ok((
+                        create_field_with_type(row_type, Some(DataType::Int8))?,
+                        Arc::new(Int8Array::new_null(len)),
+                    )),
+                    DataType::Int16 => Ok((
+                        create_field_with_type(row_type, Some(DataType::Int16))?,
+                        Arc::new(Int16Array::new_null(len)),
+                    )),
+                    DataType::Int32 => Ok((
+                        create_field_with_type(row_type, Some(DataType::Int32))?,
+                        Arc::new(Int32Array::new_null(len)),
+                    )),
+                    DataType::Int64 => Ok((
+                        create_field_with_type(row_type, Some(DataType::Int64))?,
+                        Arc::new(Int64Array::new_null(len)),
+                    )),
+                    dt @ DataType::Decimal128(p, s) => Ok((
+                        create_field_with_type(row_type, Some(dt))?,
+                        Arc::new(
+                            arrow::array::Decimal128Array::new_null(len)
+                                .with_precision_and_scale(p, s)
+                                .context(ArrowSnafu {})?,
+                        ),
+                    )),
+                    _ => unreachable!(
+                        "integer_type_for_precision only returns Int8/16/32/64 or Decimal128"
+                    ),
+                };
             }
             let min_value = min_value.unwrap();
             let max_value = max_value.unwrap();
@@ -581,15 +624,16 @@ fn create_column_array(
         }
         RowType::TimestampTz { scale, .. } => {
             #[allow(clippy::type_complexity)]
-            let all_values: Result<Vec<((i64, i32), i32)>, ArrowUtilsError> = values
+            let all_values: Result<Vec<Option<((i64, i32), i32)>>, ArrowUtilsError> = values
                 .into_iter()
                 .map(|v| {
+                    let v = match v {
+                        None => return Ok(None),
+                        Some(s) => s,
+                    };
                     let (epoch_part, tz_part) = v.split_once(' ').unwrap_or((v, ""));
                     let (epoch_str, fraction_str) =
                         epoch_part.split_once('.').unwrap_or((epoch_part, ""));
-                    (epoch_str, fraction_str, tz_part)
-                })
-                .map(|(epoch_str, fraction_str, tz_part)| {
                     let epoch: i64 = epoch_str.parse().context(IntegerParsingSnafu {
                         value: epoch_str.to_string(),
                     })?;
@@ -615,39 +659,59 @@ fn create_column_array(
                             value: tz_part.to_string(),
                         })?
                     };
-                    // wrapping first two values in a tuple makes unzipping later easier, but it's heavier
-                    // potentially could be replaced with returning three values and repackaging to three collections manually
-                    Ok(((epoch, fraction), tz))
+                    Ok(Some(((epoch, fraction), tz)))
                 })
                 .collect();
             let all_values = all_values?;
-            let (time_part_values, tz_values): (Vec<(i64, i32)>, Vec<i32>) =
-                all_values.into_iter().unzip();
-            let (epoch_values, fraction_values): (Vec<i64>, Vec<i32>) =
-                time_part_values.into_iter().unzip();
 
             let field = create_field(row_type)?;
             match field.data_type() {
                 DataType::Struct(fields) if fields.len() == 2 => {
-                    let normalized_epoch_values: Vec<i64> = epoch_values
+                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let normalized_epoch_values: Vec<i64> = all_values
                         .iter()
-                        .zip(fraction_values.iter())
-                        .map(|(epoch, fraction)| {
-                            epoch * 10i64.pow(*scale as u32) + *fraction as i64
+                        .map(|v| {
+                            v.map_or(0, |((epoch, fraction), _)| {
+                                epoch * 10i64.pow(*scale as u32) + fraction as i64
+                            })
                         })
+                        .collect();
+                    let tz_values: Vec<i32> = all_values
+                        .iter()
+                        .map(|v| v.map_or(0, |(_, tz)| tz))
                         .collect();
                     let epoch_array: Arc<dyn Array> =
                         Arc::new(arrow::array::PrimitiveArray::<Int64Type>::from(
                             normalized_epoch_values,
                         ));
                     let tz_array: Arc<dyn Array> = Arc::new(Int32Array::from(tz_values));
-                    let values = vec![
+                    let arrays = vec![
                         (fields[0].clone(), epoch_array),
                         (fields[1].clone(), tz_array),
                     ];
-                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                    let struct_array = arrow::array::StructArray::from(arrays);
+                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let nullable_struct = arrow::array::StructArray::new(
+                        struct_array.fields().clone(),
+                        struct_array.columns().to_vec(),
+                        Some(null_buffer),
+                    );
+                    Ok((field, Arc::new(nullable_struct)))
                 }
                 DataType::Struct(fields) if fields.len() == 3 => {
+                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let epoch_values: Vec<i64> = all_values
+                        .iter()
+                        .map(|v| v.map_or(0, |((e, _), _)| e))
+                        .collect();
+                    let fraction_values: Vec<i32> = all_values
+                        .iter()
+                        .map(|v| v.map_or(0, |((_, f), _)| f))
+                        .collect();
+                    let tz_values: Vec<i32> = all_values
+                        .iter()
+                        .map(|v| v.map_or(0, |(_, tz)| tz))
+                        .collect();
                     let normalized_fraction_values: Vec<i32> = fraction_values
                         .iter()
                         .map(|f| f * 10i32.pow((9 - *scale) as u32))
@@ -661,12 +725,19 @@ fn create_column_array(
                             normalized_fraction_values,
                         ));
                     let tz_array: Arc<dyn Array> = Arc::new(Int32Array::from(tz_values));
-                    let values = vec![
+                    let arrays = vec![
                         (fields[0].clone(), epoch_array),
                         (fields[1].clone(), fraction_array),
                         (fields[2].clone(), tz_array),
                     ];
-                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                    let struct_array = arrow::array::StructArray::from(arrays);
+                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let nullable_struct = arrow::array::StructArray::new(
+                        struct_array.fields().clone(),
+                        struct_array.columns().to_vec(),
+                        Some(null_buffer),
+                    );
+                    Ok((field, Arc::new(nullable_struct)))
                 }
                 _ => UnsupportedDataTypeSnafu {
                     data_type: format!("{:?}", field.data_type()),
@@ -878,7 +949,6 @@ pub enum ArrowUtilsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int8Array, Int16Array, Int64Array, StringArray};
     use arrow::record_batch::RecordBatchReader;
 
     #[test]
@@ -1090,6 +1160,48 @@ mod tests {
         let col = batch.column(0);
         assert_eq!(col.null_count(), 2);
         assert_eq!(*col.data_type(), DataType::Int64);
+    }
+
+    #[test]
+    fn test_all_null_fixed_column_int8() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 2, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Int8);
+    }
+
+    #[test]
+    fn test_all_null_fixed_column_int16() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 4, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Int16);
+    }
+
+    #[test]
+    fn test_all_null_fixed_column_int32() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 9, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Int32);
     }
 
     #[test]

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -586,7 +586,7 @@ fn create_column_array(
                     Ok((field, Arc::new(Int64Array::from(normalized_epoch_values))))
                 }
                 DataType::Struct(fields) => {
-                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let validity_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
                     let epoch_values: Vec<i64> =
                         all_values.iter().map(|v| v.map_or(0, |(e, _)| e)).collect();
                     let fraction_values: Vec<i32> =
@@ -608,7 +608,7 @@ fn create_column_array(
                         (fields[1].clone(), fraction_array),
                     ];
                     let struct_array = arrow::array::StructArray::from(arrays);
-                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let null_buffer = arrow::buffer::NullBuffer::from(validity_mask);
                     let nullable_struct = arrow::array::StructArray::new(
                         struct_array.fields().clone(),
                         struct_array.columns().to_vec(),
@@ -668,7 +668,7 @@ fn create_column_array(
             let field = create_field(row_type)?;
             match field.data_type() {
                 DataType::Struct(fields) if fields.len() == 2 => {
-                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let validity_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
                     let normalized_epoch_values: Vec<i64> = all_values
                         .iter()
                         .map(|v| {
@@ -691,7 +691,7 @@ fn create_column_array(
                         (fields[1].clone(), tz_array),
                     ];
                     let struct_array = arrow::array::StructArray::from(arrays);
-                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let null_buffer = arrow::buffer::NullBuffer::from(validity_mask);
                     let nullable_struct = arrow::array::StructArray::new(
                         struct_array.fields().clone(),
                         struct_array.columns().to_vec(),
@@ -700,7 +700,7 @@ fn create_column_array(
                     Ok((field, Arc::new(nullable_struct)))
                 }
                 DataType::Struct(fields) if fields.len() == 3 => {
-                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let validity_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
                     let epoch_values: Vec<i64> = all_values
                         .iter()
                         .map(|v| v.map_or(0, |((e, _), _)| e))
@@ -732,7 +732,7 @@ fn create_column_array(
                         (fields[2].clone(), tz_array),
                     ];
                     let struct_array = arrow::array::StructArray::from(arrays);
-                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let null_buffer = arrow::buffer::NullBuffer::from(validity_mask);
                     let nullable_struct = arrow::array::StructArray::new(
                         struct_array.fields().clone(),
                         struct_array.columns().to_vec(),
@@ -880,7 +880,6 @@ fn create_column_array(
 }
 
 /// Converts a string rowset with RowType metadata to Arrow format.
-/// Supports TEXT, FIXED, BOOLEAN, REAL, DATE, TIMESTAMP_NTZ, TIMESTAMP_LTZ, and TIMESTAMP_TZ types.
 /// Null values in the rowset are preserved as Arrow nulls.
 /// Assumes rowset and row_types have been validated to have matching column counts.
 pub fn convert_string_rowset_to_arrow_reader(

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -344,7 +344,7 @@ fn minimal_twos_complement(bytes: &[u8]) -> Vec<u8> {
 
 /// Creates an Arrow array from column values and data type
 fn create_column_array(
-    values: Vec<&str>,
+    values: Vec<Option<&str>>,
     row_type: &RowType,
 ) -> Result<(Field, Arc<dyn Array>), ArrowUtilsError> {
     match row_type {
@@ -352,41 +352,71 @@ fn create_column_array(
         RowType::Fixed {
             scale, precision, ..
         } => {
-            let decimal_values: Result<Vec<i128>, ArrowUtilsError> = values
+            let len = values.len();
+            let decimal_values: Result<Vec<Option<i128>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| parse_decimal_str(v, *scale as u32))
+                .map(|v| match v {
+                    None => Ok(None),
+                    Some(s) => Ok(Some(parse_decimal_str(s, *scale as u32)?)),
+                })
                 .collect();
 
             let decimal_values = decimal_values?;
-            if decimal_values.is_empty() {
+            let non_null: Vec<i128> = decimal_values.iter().filter_map(|v| *v).collect();
+            if non_null.is_empty() {
+                if *scale > 0 {
+                    return Ok((
+                        create_field_with_type(
+                            row_type,
+                            Some(DataType::Decimal128(*precision as u8, *scale as i8)),
+                        )?,
+                        Arc::new(
+                            arrow::array::Decimal128Array::new_null(len)
+                                .with_precision_and_scale(*precision as u8, *scale as i8)
+                                .context(ArrowSnafu {})?,
+                        ),
+                    ));
+                }
                 return Ok((
-                    create_field_with_type(row_type, Some(DataType::Int64))?, // TODO is it correct? We have to assume something, but it probably doesn't matter.
-                    Arc::new(Int64Array::new_null(0)),
+                    create_field_with_type(row_type, Some(DataType::Int64))?,
+                    Arc::new(Int64Array::new_null(len)),
                 ));
             }
-            let min_value: i128 = decimal_values.iter().min().copied().unwrap();
-            let max_value: i128 = decimal_values.iter().max().copied().unwrap();
+            let min_value: i128 = non_null.iter().min().copied().unwrap();
+            let max_value: i128 = non_null.iter().max().copied().unwrap();
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
-                let int8_values: Vec<i8> = decimal_values.into_iter().map(|v| v as i8).collect();
+                let int8_values: Vec<Option<i8>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i8))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, Some(DataType::Int8))?,
                     Arc::new(Int8Array::from(int8_values)),
                 ))
             } else if min_value >= i16::MIN as i128 && max_value <= i16::MAX as i128 {
-                let int16_values: Vec<i16> = decimal_values.into_iter().map(|v| v as i16).collect();
+                let int16_values: Vec<Option<i16>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i16))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, Some(DataType::Int16))?,
                     Arc::new(arrow::array::Int16Array::from(int16_values)),
                 ))
             } else if min_value >= i32::MIN as i128 && max_value <= i32::MAX as i128 {
-                let int32_values: Vec<i32> = decimal_values.into_iter().map(|v| v as i32).collect();
+                let int32_values: Vec<Option<i32>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i32))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, Some(DataType::Int32))?,
                     Arc::new(arrow::array::Int32Array::from(int32_values)),
                 ))
             } else if min_value >= i64::MIN as i128 && max_value <= i64::MAX as i128 {
-                let int64_values: Vec<i64> = decimal_values.into_iter().map(|v| v as i64).collect();
+                let int64_values: Vec<Option<i64>> = decimal_values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as i64))
+                    .collect();
                 Ok((
                     create_field_with_type(row_type, Some(DataType::Int64))?,
                     Arc::new(Int64Array::from(int64_values)),
@@ -406,12 +436,13 @@ fn create_column_array(
             }
         }
         RowType::Boolean { .. } => {
-            let bool_values: Result<Vec<bool>, ArrowUtilsError> = values
+            let bool_values: Result<Vec<Option<bool>>, ArrowUtilsError> = values
                 .into_iter()
                 .map(|v| match v {
-                    "true" => Ok(true),
-                    "false" => Ok(false),
-                    other => BooleanParsingSnafu {
+                    None => Ok(None),
+                    Some("true") | Some("1") => Ok(Some(true)),
+                    Some("false") | Some("0") => Ok(Some(false)),
+                    Some(other) => BooleanParsingSnafu {
                         value: other.to_string(),
                     }
                     .fail(),
@@ -423,12 +454,13 @@ fn create_column_array(
             ))
         }
         RowType::Real { .. } => {
-            let float_values: Result<Vec<f64>, ArrowUtilsError> = values
+            let float_values: Result<Vec<Option<f64>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| {
-                    v.parse::<f64>().context(FloatParsingSnafu {
-                        value: v.to_string(),
-                    })
+                .map(|v| match v {
+                    None => Ok(None),
+                    Some(s) => Ok(Some(s.parse::<f64>().context(FloatParsingSnafu {
+                        value: s.to_string(),
+                    })?)),
                 })
                 .collect();
             Ok((
@@ -437,12 +469,13 @@ fn create_column_array(
             ))
         }
         RowType::Date { .. } => {
-            let day_values: Result<Vec<i32>, ArrowUtilsError> = values
+            let day_values: Result<Vec<Option<i32>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| {
-                    v.parse::<i32>().context(IntegerParsingSnafu {
-                        value: v.to_string(),
-                    })
+                .map(|v| match v {
+                    None => Ok(None),
+                    Some(s) => Ok(Some(s.parse::<i32>().context(IntegerParsingSnafu {
+                        value: s.to_string(),
+                    })?)),
                 })
                 .collect();
             Ok((
@@ -453,18 +486,21 @@ fn create_column_array(
             ))
         }
         RowType::TimestampNtz { scale, .. } | RowType::TimestampLtz { scale, .. } => {
-            let all_values: Result<Vec<(i64, i32)>, ArrowUtilsError> = values
+            let all_values: Result<Vec<Option<(i64, i32)>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| (v, v.split_once(".")))
-                .map(|(orig, split)| match split {
-                    None => (orig, None),
-                    Some((epoch, fraction)) => (epoch, Some(fraction)),
-                })
-                .map(|(epoch, fraction)| {
-                    let epoch: i64 = epoch.parse().context(IntegerParsingSnafu {
-                        value: epoch.to_string(),
+                .map(|v| {
+                    let v = match v {
+                        None => return Ok(None),
+                        Some(s) => s,
+                    };
+                    let (epoch_str, fraction_str) = match v.split_once(".") {
+                        None => (v, None),
+                        Some((epoch, fraction)) => (epoch, Some(fraction)),
+                    };
+                    let epoch: i64 = epoch_str.parse().context(IntegerParsingSnafu {
+                        value: epoch_str.to_string(),
                     })?;
-                    let fraction: i32 = match fraction {
+                    let fraction: i32 = match fraction_str {
                         None => Ok(0),
                         Some(f) => {
                             let filled_with_zeros =
@@ -478,26 +514,30 @@ fn create_column_array(
                             Ok(parsed_fraction)
                         }
                     }?;
-                    Ok((epoch, fraction))
+                    Ok(Some((epoch, fraction)))
                 })
                 .collect();
             let all_values = all_values?;
-            let (epoch_values, fraction_values): (Vec<i64>, Vec<i32>) =
-                all_values.into_iter().unzip();
 
             let field = create_field(row_type)?;
             match field.data_type() {
                 DataType::Int64 => {
-                    let normalized_epoch_values: Vec<i64> = epoch_values
+                    let normalized_epoch_values: Vec<Option<i64>> = all_values
                         .iter()
-                        .zip(fraction_values.iter())
-                        .map(|(epoch, fraction)| {
-                            epoch * 10i64.pow(*scale as u32) + *fraction as i64
+                        .map(|v| {
+                            v.map(|(epoch, fraction)| {
+                                epoch * 10i64.pow(*scale as u32) + fraction as i64
+                            })
                         })
                         .collect();
                     Ok((field, Arc::new(Int64Array::from(normalized_epoch_values))))
                 }
                 DataType::Struct(fields) => {
+                    let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    let epoch_values: Vec<i64> =
+                        all_values.iter().map(|v| v.map_or(0, |(e, _)| e)).collect();
+                    let fraction_values: Vec<i32> =
+                        all_values.iter().map(|v| v.map_or(0, |(_, f)| f)).collect();
                     let normalized_fraction_values: Vec<i32> = fraction_values
                         .iter()
                         .map(|f| f * 10i32.pow((9 - *scale) as u32))
@@ -510,11 +550,18 @@ fn create_column_array(
                         Arc::new(arrow::array::PrimitiveArray::<Int32Type>::from(
                             normalized_fraction_values,
                         ));
-                    let values = vec![
+                    let arrays = vec![
                         (fields[0].clone(), epoch_array),
                         (fields[1].clone(), fraction_array),
                     ];
-                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                    let struct_array = arrow::array::StructArray::from(arrays);
+                    let null_buffer = arrow::buffer::NullBuffer::from(null_mask);
+                    let nullable_struct = arrow::array::StructArray::new(
+                        struct_array.fields().clone(),
+                        struct_array.columns().to_vec(),
+                        Some(null_buffer),
+                    );
+                    Ok((field, Arc::new(nullable_struct)))
                 }
                 _ => UnsupportedDataTypeSnafu {
                     data_type: format!("{:?}", field.data_type()),
@@ -720,7 +767,7 @@ fn create_column_array(
 /// Supports TEXT and FIXED (with scale 0) types, converting strings to appropriate Arrow types
 /// Assumes rowset and row_types have been validated to have matching column counts
 pub fn convert_string_rowset_to_arrow_reader(
-    rowset: &[Vec<String>],
+    rowset: &[Vec<Option<String>>],
     row_types: &[RowType],
 ) -> Result<Box<dyn arrow::record_batch::RecordBatchReader + Send>, ArrowUtilsError> {
     // Create Arrow arrays for each column
@@ -729,7 +776,8 @@ pub fn convert_string_rowset_to_arrow_reader(
         .iter()
         .enumerate()
         .map(|(col_idx, row_type)| {
-            let values: Vec<&str> = rowset.iter().map(|row| row[col_idx].as_str()).collect();
+            let values: Vec<Option<&str>> =
+                rowset.iter().map(|row| row[col_idx].as_deref()).collect();
             create_column_array(values, row_type)
         })
         .collect();
@@ -827,10 +875,10 @@ mod tests {
     fn test_string_rowset_translation_with_metadata_small() {
         // Build a Snowflake-like rowset
         let rowset = vec![
-            vec!["alpha.txt".to_string(), "7".to_string()], // SB1
-            vec!["beta.md".to_string(), "123".to_string()], // SB2
-            vec!["gamma.bin".to_string(), "32767".to_string()], // SB2
-            vec!["delta.png".to_string(), "1024".to_string()], // SB2
+            vec![Some("alpha.txt".to_string()), Some("7".to_string())], // SB1
+            vec![Some("beta.md".to_string()), Some("123".to_string())], // SB2
+            vec![Some("gamma.bin".to_string()), Some("32767".to_string())], // SB2
+            vec![Some("delta.png".to_string()), Some("1024".to_string())], // SB2
         ];
 
         // Describe columns via RowType
@@ -896,13 +944,19 @@ mod tests {
     fn test_string_rowset_translation_with_metadata_large() {
         // Build a Snowflake-like rowset
         let rowset = vec![
-            vec!["alpha/report.csv".to_string(), "7".to_string()], // SB1
-            vec!["beta/readme.md".to_string(), "123".to_string()], // SB2
-            vec!["gamma/data.bin".to_string(), "32767".to_string()], // SB2
-            vec!["delta/image.png".to_string(), "2147483647".to_string()], // SB4
+            vec![Some("alpha/report.csv".to_string()), Some("7".to_string())], // SB1
+            vec![Some("beta/readme.md".to_string()), Some("123".to_string())], // SB2
             vec![
-                "epsilon/archive.tar.gz".to_string(),
-                "9223372036854775807".to_string(), // SB8
+                Some("gamma/data.bin".to_string()),
+                Some("32767".to_string()),
+            ], // SB2
+            vec![
+                Some("delta/image.png".to_string()),
+                Some("2147483647".to_string()),
+            ], // SB4
+            vec![
+                Some("epsilon/archive.tar.gz".to_string()),
+                Some("9223372036854775807".to_string()), // SB8
             ],
         ];
 
@@ -965,5 +1019,242 @@ mod tests {
         } else {
             panic!("Expected one record batch");
         }
+    }
+
+    #[test]
+    fn test_null_values_in_text_column() {
+        let rowset = vec![
+            vec![Some("hello".to_string())],
+            vec![None],
+            vec![Some("world".to_string())],
+        ];
+        let row_types = vec![RowType::text("col", true, 16, 64)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert_eq!(col.value(0), "hello");
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+        assert_eq!(col.value(2), "world");
+    }
+
+    #[test]
+    fn test_null_values_in_fixed_column() {
+        let rowset = vec![
+            vec![Some("42".to_string())],
+            vec![None],
+            vec![Some("100".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col", true, 5, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 3);
+        let col = batch.column(0);
+        let arr = col.as_any().downcast_ref::<Int8Array>().unwrap();
+        assert!(arr.is_valid(0));
+        assert_eq!(arr.value(0), 42);
+        assert!(arr.is_null(1));
+        assert!(arr.is_valid(2));
+        assert_eq!(arr.value(2), 100);
+    }
+
+    #[test]
+    fn test_all_null_fixed_column() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 10, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Int64);
+    }
+
+    #[test]
+    fn test_all_null_fixed_column_with_scale() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 10, 2)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Decimal128(10, 2));
+    }
+
+    #[test]
+    fn test_null_values_in_boolean_column() {
+        let rowset = vec![
+            vec![Some("true".to_string())],
+            vec![None],
+            vec![Some("false".to_string())],
+        ];
+        let row_types = vec![RowType::boolean("col", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!(col.value(0));
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+        assert!(!col.value(2));
+    }
+
+    #[test]
+    fn test_null_values_in_real_column() {
+        let rowset = vec![
+            vec![Some("1.5".to_string())],
+            vec![None],
+            vec![Some("2.5".to_string())],
+        ];
+        let row_types = vec![RowType::real("col", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!((col.value(0) - 1.5).abs() < f64::EPSILON);
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+        assert!((col.value(2) - 2.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_null_values_in_date_column() {
+        let rowset = vec![
+            vec![Some("19000".to_string())],
+            vec![None],
+            vec![Some("19500".to_string())],
+        ];
+        let row_types = vec![RowType::date("col", true)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch.column(0);
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+    }
+
+    #[test]
+    fn test_null_values_in_timestamp_ntz_int64() {
+        let rowset = vec![
+            vec![Some("1234567.890".to_string())],
+            vec![None],
+            vec![Some("9876543.210".to_string())],
+        ];
+        // scale <= 7 uses Int64 representation
+        let row_types = vec![RowType::timestamp_ntz("col", true, 3)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+    }
+
+    #[test]
+    fn test_null_values_in_timestamp_ltz_struct() {
+        let rowset = vec![
+            vec![Some("1234567.890000000".to_string())],
+            vec![None],
+            vec![Some("9876543.210000000".to_string())],
+        ];
+        // scale > 7 uses Struct representation
+        let row_types = vec![RowType::timestamp_ltz("col", true, 9)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch.column(0);
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+    }
+
+    #[test]
+    fn test_mixed_nulls_across_multiple_columns() {
+        // Simulates a SHOW SCHEMAS-like result with mixed types and nulls
+        let rowset = vec![
+            vec![
+                Some("schema_a".to_string()),
+                Some("5".to_string()),
+                Some("a comment".to_string()),
+            ],
+            vec![Some("schema_b".to_string()), None, None],
+        ];
+        let row_types = vec![
+            RowType::text("name", false, 64, 256),
+            RowType::fixed("count", true, 5, 0),
+            RowType::text("comment", true, 256, 1024),
+        ];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 3);
+
+        // name column: no nulls
+        let names = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(names.is_valid(0));
+        assert!(names.is_valid(1));
+        assert_eq!(names.value(0), "schema_a");
+        assert_eq!(names.value(1), "schema_b");
+
+        // count column: second row null
+        let counts = batch.column(1);
+        assert!(counts.is_valid(0));
+        assert!(counts.is_null(1));
+
+        // comment column: second row null
+        let comments = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(comments.is_valid(0));
+        assert_eq!(comments.value(0), "a comment");
+        assert!(comments.is_null(1));
     }
 }

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1281,6 +1281,29 @@ mod tests {
     }
 
     #[test]
+    fn test_null_values_in_timestamp_ltz_int64() {
+        let rowset = vec![
+            vec![Some("1234567.890".to_string())],
+            vec![None],
+            vec![Some("9876543.210".to_string())],
+        ];
+        let row_types = vec![RowType::timestamp_ltz("col", true, 3)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert!(col.is_valid(0));
+        assert!(col.is_null(1));
+        assert!(col.is_valid(2));
+    }
+
+    #[test]
     fn test_null_values_in_timestamp_ntz_struct_column() {
         let rowset = vec![
             vec![Some("1609459200.123456789".to_string())],

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -450,20 +450,6 @@ fn create_column_array(
             let min_value = min_value.unwrap();
             let max_value = max_value.unwrap();
 
-            if *scale > 0 {
-                return Ok((
-                    create_field_with_type(
-                        row_type,
-                        Some(DataType::Decimal128(*precision as u8, *scale as i8)),
-                    )?,
-                    Arc::new(
-                        arrow::array::Decimal128Array::from(decimal_values)
-                            .with_precision_and_scale(*precision as u8, *scale as i8)
-                            .context(ArrowSnafu {})?,
-                    ),
-                ));
-            }
-
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
                 cast_fixed_to_arrow::<arrow::datatypes::Int8Type>(
                     row_type,
@@ -1356,7 +1342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_column_with_scale_uses_decimal128() {
+    fn test_fixed_column_with_scale_narrows_to_int() {
         let rowset = vec![
             vec![Some("123.45".to_string())],
             vec![None],
@@ -1369,15 +1355,37 @@ mod tests {
             let col = batch
                 .column(0)
                 .as_any()
-                .downcast_ref::<arrow::array::Decimal128Array>()
+                .downcast_ref::<Int32Array>()
                 .unwrap();
-            assert_eq!(*col.data_type(), DataType::Decimal128(10, 2));
+            assert_eq!(*col.data_type(), DataType::Int32);
             assert_eq!(col.len(), 3);
             assert!(!col.is_null(0));
             assert_eq!(col.value(0), 12345);
             assert!(col.is_null(1));
             assert!(!col.is_null(2));
             assert_eq!(col.value(2), 67890);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
+    fn test_fixed_column_with_scale_falls_back_to_decimal128_for_large_values() {
+        let rowset = vec![vec![Some("99999999999999999.99".to_string())], vec![None]];
+        let row_types = vec![RowType::fixed("col_fixed", true, 38, 2)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Decimal128Array>()
+                .unwrap();
+            assert_eq!(*col.data_type(), DataType::Decimal128(38, 2));
+            assert_eq!(col.len(), 2);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 9999999999999999999i128);
+            assert!(col.is_null(1));
         } else {
             panic!("Expected one record batch");
         }

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -362,8 +362,10 @@ fn create_column_array(
                 .collect();
 
             let decimal_values = decimal_values?;
-            let non_null: Vec<i128> = decimal_values.iter().filter_map(|v| *v).collect();
-            if non_null.is_empty() {
+            let min_value = decimal_values.iter().filter_map(|v| *v).min();
+            let max_value = decimal_values.iter().filter_map(|v| *v).max();
+            if min_value.is_none() {
+                // All values are null — pick the appropriate null array type
                 if *scale > 0 {
                     return Ok((
                         create_field_with_type(
@@ -382,8 +384,8 @@ fn create_column_array(
                     Arc::new(Int64Array::new_null(len)),
                 ));
             }
-            let min_value: i128 = non_null.iter().min().copied().unwrap();
-            let max_value: i128 = non_null.iter().max().copied().unwrap();
+            let min_value: i128 = min_value.unwrap();
+            let max_value: i128 = max_value.unwrap();
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
                 let int8_values: Vec<Option<i8>> = decimal_values
@@ -534,6 +536,7 @@ fn create_column_array(
                 }
                 DataType::Struct(fields) => {
                     let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
+                    // Sentinel zeros for null rows — masked by the NullBuffer so never read.
                     let epoch_values: Vec<i64> =
                         all_values.iter().map(|v| v.map_or(0, |(e, _)| e)).collect();
                     let fraction_values: Vec<i32> =
@@ -763,9 +766,10 @@ fn create_column_array(
     }
 }
 
-/// Converts a string rowset with RowType metadata to Arrow format
-/// Supports TEXT and FIXED (with scale 0) types, converting strings to appropriate Arrow types
-/// Assumes rowset and row_types have been validated to have matching column counts
+/// Converts a string rowset with RowType metadata to Arrow format.
+/// Supports TEXT, FIXED, BOOLEAN, REAL, DATE, TIMESTAMP_NTZ, and TIMESTAMP_LTZ types.
+/// Null values in the rowset are preserved as Arrow nulls.
+/// Assumes rowset and row_types have been validated to have matching column counts.
 pub fn convert_string_rowset_to_arrow_reader(
     rowset: &[Vec<Option<String>>],
     row_types: &[RowType],

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -751,48 +751,62 @@ fn create_column_array(
             let field = create_field(row_type)?;
             match field.data_type() {
                 DataType::Int32 => {
-                    let normalized: Result<Vec<i32>, ArrowUtilsError> = values
+                    let normalized: Result<Vec<Option<i32>>, ArrowUtilsError> = values
                         .into_iter()
-                        .map(|v| {
-                            let (seconds_str, fraction_str) = v.split_once('.').unwrap_or((v, ""));
-                            let seconds: i32 =
-                                seconds_str.parse().context(IntegerParsingSnafu {
-                                    value: v.to_string(),
-                                })?;
-                            let fraction: i32 = if fraction_str.is_empty() {
-                                0
-                            } else {
-                                let filled =
-                                    format!("{:0<width$}", fraction_str, width = *scale as usize);
-                                filled.parse::<i32>().context(IntegerParsingSnafu {
-                                    value: v.to_string(),
-                                })?
-                            };
-                            Ok(seconds * 10i32.pow(*scale as u32) + fraction)
+                        .map(|v| match v {
+                            None => Ok(None),
+                            Some(v) => {
+                                let (seconds_str, fraction_str) =
+                                    v.split_once('.').unwrap_or((v, ""));
+                                let seconds: i32 =
+                                    seconds_str.parse().context(IntegerParsingSnafu {
+                                        value: v.to_string(),
+                                    })?;
+                                let fraction: i32 = if fraction_str.is_empty() {
+                                    0
+                                } else {
+                                    let filled = format!(
+                                        "{:0<width$}",
+                                        fraction_str,
+                                        width = *scale as usize
+                                    );
+                                    filled.parse::<i32>().context(IntegerParsingSnafu {
+                                        value: v.to_string(),
+                                    })?
+                                };
+                                Ok(Some(seconds * 10i32.pow(*scale as u32) + fraction))
+                            }
                         })
                         .collect();
                     Ok((field, Arc::new(Int32Array::from(normalized?))))
                 }
                 DataType::Int64 => {
-                    let normalized: Result<Vec<i64>, ArrowUtilsError> = values
+                    let normalized: Result<Vec<Option<i64>>, ArrowUtilsError> = values
                         .into_iter()
-                        .map(|v| {
-                            let scale1 = *scale;
-                            let (seconds_str, fraction_str) = v.split_once('.').unwrap_or((v, ""));
-                            let seconds: i64 =
-                                seconds_str.parse().context(IntegerParsingSnafu {
-                                    value: v.to_string(),
-                                })?;
-                            let fraction: i64 = if fraction_str.is_empty() {
-                                0
-                            } else {
-                                let filled =
-                                    format!("{:0<width$}", fraction_str, width = scale1 as usize);
-                                filled.parse::<i64>().context(IntegerParsingSnafu {
-                                    value: v.to_string(),
-                                })?
-                            };
-                            Ok(seconds * 10i64.pow(scale1 as u32) + fraction)
+                        .map(|v| match v {
+                            None => Ok(None),
+                            Some(v) => {
+                                let scale1 = *scale;
+                                let (seconds_str, fraction_str) =
+                                    v.split_once('.').unwrap_or((v, ""));
+                                let seconds: i64 =
+                                    seconds_str.parse().context(IntegerParsingSnafu {
+                                        value: v.to_string(),
+                                    })?;
+                                let fraction: i64 = if fraction_str.is_empty() {
+                                    0
+                                } else {
+                                    let filled = format!(
+                                        "{:0<width$}",
+                                        fraction_str,
+                                        width = scale1 as usize
+                                    );
+                                    filled.parse::<i64>().context(IntegerParsingSnafu {
+                                        value: v.to_string(),
+                                    })?
+                                };
+                                Ok(Some(seconds * 10i64.pow(scale1 as u32) + fraction))
+                            }
                         })
                         .collect();
                     Ok((field, Arc::new(Int64Array::from(normalized?))))
@@ -805,31 +819,52 @@ fn create_column_array(
             }
         }
         RowType::Binary { .. } => {
-            let binary_values: Result<Vec<Vec<u8>>, ArrowUtilsError> = values
+            let binary_values: Result<Vec<Option<Vec<u8>>>, ArrowUtilsError> = values
                 .into_iter()
-                .map(|v| hex::decode(v).context(BinaryParsingSnafu {}))
+                .map(|v| match v {
+                    None => Ok(None),
+                    Some(s) => Ok(Some(hex::decode(s).context(BinaryParsingSnafu {})?)),
+                })
                 .collect();
             let binary_values = binary_values?;
-            let refs: Vec<&[u8]> = binary_values.iter().map(|v| v.as_slice()).collect();
+            let refs: Vec<Option<&[u8]>> = binary_values.iter().map(|v| v.as_deref()).collect();
             Ok((create_field(row_type)?, Arc::new(BinaryArray::from(refs))))
         }
         RowType::Decfloat { .. } => {
-            let parsed: Result<Vec<(i16, Vec<u8>)>, ArrowUtilsError> =
-                values.into_iter().map(parse_decfloat_str).collect();
+            #[allow(clippy::type_complexity)]
+            let parsed: Result<Vec<Option<(i16, Vec<u8>)>>, ArrowUtilsError> = values
+                .into_iter()
+                .map(|v| match v {
+                    None => Ok(None),
+                    Some(s) => Ok(Some(parse_decfloat_str(s)?)),
+                })
+                .collect();
             let parsed = parsed?;
-            let (exponents, mantissas): (Vec<i16>, Vec<Vec<u8>>) = parsed.into_iter().unzip();
-            let mantissa_refs: Vec<&[u8]> = mantissas.iter().map(|v| v.as_slice()).collect();
+            let exponents: Vec<Option<i16>> =
+                parsed.iter().map(|v| v.as_ref().map(|(e, _)| *e)).collect();
+            let mantissas: Vec<Option<&[u8]>> = parsed
+                .iter()
+                .map(|v| v.as_ref().map(|(_, m)| m.as_slice()))
+                .collect();
+            let null_buffer = arrow::buffer::NullBuffer::from(
+                parsed.iter().map(|v| v.is_some()).collect::<Vec<bool>>(),
+            );
 
             let field = create_field(row_type)?;
             match field.data_type() {
                 DataType::Struct(fields) => {
                     let exponent_array: Arc<dyn Array> = Arc::new(Int16Array::from(exponents));
-                    let mantissa_array: Arc<dyn Array> = Arc::new(BinaryArray::from(mantissa_refs));
-                    let values = vec![
+                    let mantissa_array: Arc<dyn Array> = Arc::new(BinaryArray::from(mantissas));
+                    let struct_array = arrow::array::StructArray::from(vec![
                         (fields[0].clone(), exponent_array),
                         (fields[1].clone(), mantissa_array),
-                    ];
-                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                    ]);
+                    let nullable_struct = arrow::array::StructArray::new(
+                        struct_array.fields().clone(),
+                        struct_array.columns().to_vec(),
+                        Some(null_buffer),
+                    );
+                    Ok((field, Arc::new(nullable_struct)))
                 }
                 _ => UnsupportedDataTypeSnafu {
                     data_type: format!("{:?}", field.data_type()),

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -221,8 +221,9 @@ pub fn create_field_with_type(
 }
 
 /// Maps a FIXED column's precision to the narrowest integer Arrow type that can
-/// hold all possible values for that precision. Used for the all-null path so
-/// the schema stays consistent with what the non-null path would produce.
+/// hold all possible values for that precision. Used as a precision-based
+/// fallback for all-null columns (the non-null path instead infers the type
+/// from the observed min/max values, which may select a different width).
 fn integer_type_for_precision(precision: u64) -> DataType {
     if precision <= 2 {
         DataType::Int8
@@ -399,8 +400,8 @@ fn create_column_array(
                 .collect();
 
             let decimal_values = decimal_values?;
-            let min_value = decimal_values.iter().filter_map(|v| *v).min();
-            let max_value = decimal_values.iter().filter_map(|v| *v).max();
+            let min_value = decimal_values.iter().flatten().min().copied();
+            let max_value = decimal_values.iter().flatten().max().copied();
             if min_value.is_none() {
                 if *scale > 0 {
                     return Ok((
@@ -448,6 +449,20 @@ fn create_column_array(
             }
             let min_value = min_value.unwrap();
             let max_value = max_value.unwrap();
+
+            if *scale > 0 {
+                return Ok((
+                    create_field_with_type(
+                        row_type,
+                        Some(DataType::Decimal128(*precision as u8, *scale as i8)),
+                    )?,
+                    Arc::new(
+                        arrow::array::Decimal128Array::from(decimal_values)
+                            .with_precision_and_scale(*precision as u8, *scale as i8)
+                            .context(ArrowSnafu {})?,
+                    ),
+                ));
+            }
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
                 cast_fixed_to_arrow::<arrow::datatypes::Int8Type>(
@@ -844,7 +859,7 @@ fn create_column_array(
 }
 
 /// Converts a string rowset with RowType metadata to Arrow format.
-/// Supports TEXT, FIXED, BOOLEAN, REAL, DATE, TIMESTAMP_NTZ, and TIMESTAMP_LTZ types.
+/// Supports TEXT, FIXED, BOOLEAN, REAL, DATE, TIMESTAMP_NTZ, TIMESTAMP_LTZ, and TIMESTAMP_TZ types.
 /// Null values in the rowset are preserved as Arrow nulls.
 /// Assumes rowset and row_types have been validated to have matching column counts.
 pub fn convert_string_rowset_to_arrow_reader(
@@ -1294,6 +1309,75 @@ mod tests {
             assert!(col.is_null(1));
             assert!(!col.is_null(2));
             assert_eq!(col.value(2), 4_000_000_000);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
+    fn test_all_null_fixed_column_decimal128() {
+        let rowset = vec![vec![None], vec![None]];
+        let row_types = vec![RowType::fixed("col", true, 20, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column(0);
+        assert_eq!(col.null_count(), 2);
+        assert_eq!(*col.data_type(), DataType::Decimal128(20, 0));
+    }
+
+    #[test]
+    fn test_null_values_in_fixed_column_decimal128() {
+        let rowset = vec![
+            vec![Some("12345678901234567890".to_string())],
+            vec![None],
+            vec![Some("98765432109876543210".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 38, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Decimal128Array>()
+                .unwrap();
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 12_345_678_901_234_567_890);
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+            assert_eq!(col.value(2), 98_765_432_109_876_543_210);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
+    fn test_fixed_column_with_scale_uses_decimal128() {
+        let rowset = vec![
+            vec![Some("123.45".to_string())],
+            vec![None],
+            vec![Some("678.90".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 10, 2)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Decimal128Array>()
+                .unwrap();
+            assert_eq!(*col.data_type(), DataType::Decimal128(10, 2));
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 12345);
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+            assert_eq!(col.value(2), 67890);
         } else {
             panic!("Expected one record batch");
         }

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -220,6 +220,26 @@ pub fn create_field_with_type(
     }
 }
 
+fn cast_fixed_to_arrow<T>(
+    row_type: &RowType,
+    data_type: DataType,
+    parsed: Vec<Option<i128>>,
+) -> Result<(Field, Arc<dyn Array>), ArrowUtilsError>
+where
+    T: arrow::datatypes::ArrowPrimitiveType,
+    T::Native: TryFrom<i128>,
+    arrow::array::PrimitiveArray<T>: From<Vec<Option<T::Native>>>,
+{
+    let values: Vec<Option<T::Native>> = parsed
+        .into_iter()
+        .map(|v| v.and_then(|x| T::Native::try_from(x).ok()))
+        .collect();
+    Ok((
+        create_field_with_type(row_type, Some(data_type))?,
+        Arc::new(arrow::array::PrimitiveArray::<T>::from(values)),
+    ))
+}
+
 /// Parses a decimal string like "123.45" into the unscaled i128 representation
 /// that Arrow's Decimal128Array expects. For scale=2, "123.45" becomes 12345i128.
 fn parse_decimal_str(v: &str, scale: u32) -> Result<i128, ArrowUtilsError> {
@@ -365,7 +385,6 @@ fn create_column_array(
             let min_value = decimal_values.iter().filter_map(|v| *v).min();
             let max_value = decimal_values.iter().filter_map(|v| *v).max();
             if min_value.is_none() {
-                // All values are null — pick the appropriate null array type
                 if *scale > 0 {
                     return Ok((
                         create_field_with_type(
@@ -384,45 +403,33 @@ fn create_column_array(
                     Arc::new(Int64Array::new_null(len)),
                 ));
             }
-            let min_value: i128 = min_value.unwrap();
-            let max_value: i128 = max_value.unwrap();
+            let min_value = min_value.unwrap();
+            let max_value = max_value.unwrap();
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
-                let int8_values: Vec<Option<i8>> = decimal_values
-                    .into_iter()
-                    .map(|v| v.map(|x| x as i8))
-                    .collect();
-                Ok((
-                    create_field_with_type(row_type, Some(DataType::Int8))?,
-                    Arc::new(Int8Array::from(int8_values)),
-                ))
+                cast_fixed_to_arrow::<arrow::datatypes::Int8Type>(
+                    row_type,
+                    DataType::Int8,
+                    decimal_values,
+                )
             } else if min_value >= i16::MIN as i128 && max_value <= i16::MAX as i128 {
-                let int16_values: Vec<Option<i16>> = decimal_values
-                    .into_iter()
-                    .map(|v| v.map(|x| x as i16))
-                    .collect();
-                Ok((
-                    create_field_with_type(row_type, Some(DataType::Int16))?,
-                    Arc::new(arrow::array::Int16Array::from(int16_values)),
-                ))
+                cast_fixed_to_arrow::<arrow::datatypes::Int16Type>(
+                    row_type,
+                    DataType::Int16,
+                    decimal_values,
+                )
             } else if min_value >= i32::MIN as i128 && max_value <= i32::MAX as i128 {
-                let int32_values: Vec<Option<i32>> = decimal_values
-                    .into_iter()
-                    .map(|v| v.map(|x| x as i32))
-                    .collect();
-                Ok((
-                    create_field_with_type(row_type, Some(DataType::Int32))?,
-                    Arc::new(arrow::array::Int32Array::from(int32_values)),
-                ))
+                cast_fixed_to_arrow::<arrow::datatypes::Int32Type>(
+                    row_type,
+                    DataType::Int32,
+                    decimal_values,
+                )
             } else if min_value >= i64::MIN as i128 && max_value <= i64::MAX as i128 {
-                let int64_values: Vec<Option<i64>> = decimal_values
-                    .into_iter()
-                    .map(|v| v.map(|x| x as i64))
-                    .collect();
-                Ok((
-                    create_field_with_type(row_type, Some(DataType::Int64))?,
-                    Arc::new(Int64Array::from(int64_values)),
-                ))
+                cast_fixed_to_arrow::<arrow::datatypes::Int64Type>(
+                    row_type,
+                    DataType::Int64,
+                    decimal_values,
+                )
             } else {
                 Ok((
                     create_field_with_type(
@@ -442,8 +449,8 @@ fn create_column_array(
                 .into_iter()
                 .map(|v| match v {
                     None => Ok(None),
-                    Some("true") | Some("1") => Ok(Some(true)),
-                    Some("false") | Some("0") => Ok(Some(false)),
+                    Some(s) if s.eq_ignore_ascii_case("true") || s == "1" => Ok(Some(true)),
+                    Some(s) if s.eq_ignore_ascii_case("false") || s == "0" => Ok(Some(false)),
                     Some(other) => BooleanParsingSnafu {
                         value: other.to_string(),
                     }
@@ -536,7 +543,6 @@ fn create_column_array(
                 }
                 DataType::Struct(fields) => {
                     let null_mask: Vec<bool> = all_values.iter().map(|v| v.is_some()).collect();
-                    // Sentinel zeros for null rows — masked by the NullBuffer so never read.
                     let epoch_values: Vec<i64> =
                         all_values.iter().map(|v| v.map_or(0, |(e, _)| e)).collect();
                     let fraction_values: Vec<i32> =
@@ -872,7 +878,7 @@ pub enum ArrowUtilsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int16Array, Int64Array, StringArray};
+    use arrow::array::{Int8Array, Int16Array, Int64Array, StringArray};
     use arrow::record_batch::RecordBatchReader;
 
     #[test]
@@ -1101,6 +1107,87 @@ mod tests {
     }
 
     #[test]
+    fn test_null_values_in_fixed_column_int16() {
+        let rowset = vec![
+            vec![Some("1000".to_string())],
+            vec![None],
+            vec![Some("2000".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 5, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .unwrap();
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 1000);
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+            assert_eq!(col.value(2), 2000);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
+    fn test_null_values_in_fixed_column_int32() {
+        let rowset = vec![
+            vec![Some("100000".to_string())],
+            vec![None],
+            vec![Some("200000".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 10, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Int32Array>()
+                .unwrap();
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 100000);
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+            assert_eq!(col.value(2), 200000);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
+    fn test_null_values_in_fixed_column_int64() {
+        let rowset = vec![
+            vec![Some("3000000000".to_string())],
+            vec![None],
+            vec![Some("4000000000".to_string())],
+        ];
+        let row_types = vec![RowType::fixed("col_fixed", true, 19, 0)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert_eq!(col.value(0), 3_000_000_000);
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+            assert_eq!(col.value(2), 4_000_000_000);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
     fn test_null_values_in_boolean_column() {
         let rowset = vec![
             vec![Some("true".to_string())],
@@ -1194,13 +1281,41 @@ mod tests {
     }
 
     #[test]
+    fn test_null_values_in_timestamp_ntz_struct_column() {
+        let rowset = vec![
+            vec![Some("1609459200.123456789".to_string())],
+            vec![None],
+            vec![Some("1609545600.987654321".to_string())],
+        ];
+        let row_types = vec![RowType::timestamp_ntz("col_ts", true, 9)];
+
+        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
+        if let Some(Ok(batch)) = reader.next() {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .unwrap();
+            assert_eq!(col.len(), 3);
+            assert!(!col.is_null(0));
+            assert!(col.is_null(1));
+            assert!(!col.is_null(2));
+
+            let epoch_col = col.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+            assert_eq!(epoch_col.value(0), 1609459200);
+            assert_eq!(epoch_col.value(2), 1609545600);
+        } else {
+            panic!("Expected one record batch");
+        }
+    }
+
+    #[test]
     fn test_null_values_in_timestamp_ltz_struct() {
         let rowset = vec![
             vec![Some("1234567.890000000".to_string())],
             vec![None],
             vec![Some("9876543.210000000".to_string())],
         ];
-        // scale > 7 uses Struct representation
         let row_types = vec![RowType::timestamp_ltz("col", true, 9)];
 
         let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -836,7 +836,7 @@ mod tests {
     }
 
     #[test]
-    fn test_object_type_maps_to_text() {
+    fn test_object_type_maps_to_object() {
         let row_type = RowType {
             name: "obj_col".to_string(),
             type_: "OBJECT".to_string(),
@@ -851,17 +851,15 @@ mod tests {
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(
             converted,
-            crate::query_types::RowType::Text {
+            crate::query_types::RowType::Object {
                 ref name,
                 nullable: true,
-                length: 1024,
-                byte_length: 4096,
             } if name == "obj_col"
         ));
     }
 
     #[test]
-    fn test_variant_type_maps_to_text() {
+    fn test_variant_type_maps_to_variant() {
         let row_type = RowType {
             name: "var_col".to_string(),
             type_: "VARIANT".to_string(),
@@ -876,17 +874,15 @@ mod tests {
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(
             converted,
-            crate::query_types::RowType::Text {
+            crate::query_types::RowType::Variant {
                 ref name,
                 nullable: false,
-                length: 0,
-                byte_length: 0,
             } if name == "var_col"
         ));
     }
 
     #[test]
-    fn test_array_type_maps_to_text() {
+    fn test_array_type_maps_to_array() {
         let row_type = RowType {
             name: "arr_col".to_string(),
             type_: "ARRAY".to_string(),
@@ -901,11 +897,9 @@ mod tests {
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(
             converted,
-            crate::query_types::RowType::Text {
+            crate::query_types::RowType::Array {
                 ref name,
                 nullable: true,
-                length: 512,
-                byte_length: 2048,
             } if name == "arr_col"
         ));
     }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -20,7 +20,7 @@ pub struct Response {
 #[derive(Deserialize)]
 pub struct Data {
     #[serde(rename = "rowset")]
-    pub rowset: Option<Vec<Vec<String>>>,
+    pub rowset: Option<Vec<Vec<Option<String>>>>,
     #[serde(rename = "rowsetBase64")]
     pub rowset_base64: Option<String>,
     #[serde(rename = "rowtype")]
@@ -490,7 +490,8 @@ impl Data {
         if value.is_empty() { None } else { Some(value) }
     }
 
-    pub fn to_json_rowset(&self) -> Option<(&Vec<Vec<String>>, &Vec<RowType>)> {
+    #[allow(clippy::type_complexity)]
+    pub fn to_json_rowset(&self) -> Option<(&Vec<Vec<Option<String>>>, &Vec<RowType>)> {
         match (self.rowset.as_ref(), self.row_type.as_ref()) {
             (Some(rowset), Some(row_type)) => Some((rowset, row_type)),
             (Some(_), None) => {
@@ -519,7 +520,7 @@ pub enum RowsetData<'a> {
         chunk_base64: &'a str,
     },
     JsonRowset {
-        rowset: &'a Vec<Vec<String>>,
+        rowset: &'a Vec<Vec<Option<String>>>,
         rowtype: &'a Vec<RowType>,
     },
     NoData,
@@ -756,4 +757,179 @@ pub enum QueryResponseError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_rowset_with_null_values() {
+        let json = r#"{
+            "data": {
+                "rowset": [["val1", null, "val3"], [null, "val2", null]],
+                "queryResultFormat": "json",
+                "rowtype": [
+                    {"name": "c1", "type": "TEXT", "nullable": false, "scale": null, "byteLength": 64, "length": 16, "precision": null},
+                    {"name": "c2", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null},
+                    {"name": "c3", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null}
+                ]
+            },
+            "success": true
+        }"#;
+
+        let response: Response = serde_json::from_str(json).unwrap();
+        assert!(response.success);
+
+        let rowset = response.data.rowset.as_ref().unwrap();
+        assert_eq!(rowset.len(), 2);
+
+        // First row: "val1", null, "val3"
+        assert_eq!(rowset[0][0], Some("val1".to_string()));
+        assert_eq!(rowset[0][1], None);
+        assert_eq!(rowset[0][2], Some("val3".to_string()));
+
+        // Second row: null, "val2", null
+        assert_eq!(rowset[1][0], None);
+        assert_eq!(rowset[1][1], Some("val2".to_string()));
+        assert_eq!(rowset[1][2], None);
+    }
+
+    #[test]
+    fn test_deserialize_rowset_all_nulls() {
+        let json = r#"{
+            "data": {
+                "rowset": [[null, null]],
+                "queryResultFormat": "json",
+                "rowtype": [
+                    {"name": "c1", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null},
+                    {"name": "c2", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null}
+                ]
+            },
+            "success": true
+        }"#;
+
+        let response: Response = serde_json::from_str(json).unwrap();
+        let rowset = response.data.rowset.as_ref().unwrap();
+        assert_eq!(rowset[0][0], None);
+        assert_eq!(rowset[0][1], None);
+    }
+
+    #[test]
+    fn test_to_json_rowset_with_nulls() {
+        let json = r#"{
+            "data": {
+                "rowset": [["a", null], [null, "b"]],
+                "queryResultFormat": "json",
+                "rowtype": [
+                    {"name": "c1", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null},
+                    {"name": "c2", "type": "TEXT", "nullable": true, "scale": null, "byteLength": 64, "length": 16, "precision": null}
+                ]
+            },
+            "success": true
+        }"#;
+
+        let response: Response = serde_json::from_str(json).unwrap();
+        let (rowset, row_types) = response.data.to_json_rowset().unwrap();
+        assert_eq!(rowset.len(), 2);
+        assert_eq!(row_types.len(), 2);
+    }
+
+    #[test]
+    fn test_object_type_maps_to_text() {
+        let row_type = RowType {
+            name: "obj_col".to_string(),
+            type_: "OBJECT".to_string(),
+            nullable: true,
+            scale: None,
+            precision: None,
+            length: Some(1024),
+            byte_length: Some(4096),
+            _fields: None,
+        };
+
+        let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            converted,
+            crate::query_types::RowType::Text {
+                ref name,
+                nullable: true,
+                length: 1024,
+                byte_length: 4096,
+            } if name == "obj_col"
+        ));
+    }
+
+    #[test]
+    fn test_variant_type_maps_to_text() {
+        let row_type = RowType {
+            name: "var_col".to_string(),
+            type_: "VARIANT".to_string(),
+            nullable: false,
+            scale: None,
+            precision: None,
+            length: None,
+            byte_length: None,
+            _fields: None,
+        };
+
+        let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            converted,
+            crate::query_types::RowType::Text {
+                ref name,
+                nullable: false,
+                length: 0,
+                byte_length: 0,
+            } if name == "var_col"
+        ));
+    }
+
+    #[test]
+    fn test_array_type_maps_to_text() {
+        let row_type = RowType {
+            name: "arr_col".to_string(),
+            type_: "ARRAY".to_string(),
+            nullable: true,
+            scale: None,
+            precision: None,
+            length: Some(512),
+            byte_length: Some(2048),
+            _fields: None,
+        };
+
+        let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            converted,
+            crate::query_types::RowType::Text {
+                ref name,
+                nullable: true,
+                length: 512,
+                byte_length: 2048,
+            } if name == "arr_col"
+        ));
+    }
+
+    #[test]
+    fn test_unsupported_column_type_returns_error() {
+        let row_type = RowType {
+            name: "bad_col".to_string(),
+            type_: "GEOGRAPHY".to_string(),
+            nullable: false,
+            scale: None,
+            precision: None,
+            length: None,
+            byte_length: None,
+            _fields: None,
+        };
+
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        match result {
+            Err(err) => assert!(
+                err.to_string().contains("GEOGRAPHY"),
+                "Error should mention the unsupported type: {err}"
+            ),
+            Ok(_) => panic!("Expected error for unsupported column type GEOGRAPHY"),
+        }
+    }
 }

--- a/sf_core/tests/integration/query/json_result_set_nulls.rs
+++ b/sf_core/tests/integration/query/json_result_set_nulls.rs
@@ -1,0 +1,178 @@
+use crate::common::arrow_result_helper::ArrowResultHelper;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use arrow::array::Array;
+
+/// Forces the session to return JSON result format and executes the given query.
+fn execute_json_query(client: &SnowflakeTestClient, query: &str) -> ArrowResultHelper {
+    let stmt = client.new_statement();
+
+    client.set_sql_query(
+        &stmt,
+        "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
+    );
+    let result = client.execute_statement_query(&stmt);
+    assert_eq!(result.rows_affected(), 1, "Cannot force JSON result set");
+
+    client.set_sql_query(&stmt, query);
+    let result = client.execute_statement_query(&stmt);
+    let helper = ArrowResultHelper::from_result(result);
+    client.release_statement(&stmt);
+    helper
+}
+
+#[test]
+fn should_handle_null_values_in_json_result_set() {
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let stmt = client.new_statement();
+
+    // Create table with nullable columns of various types
+    client.set_sql_query(
+        &stmt,
+        "CREATE OR REPLACE TABLE json_null_test (
+            str_col STRING,
+            int_col INTEGER,
+            bool_col BOOLEAN,
+            real_col DOUBLE,
+            date_col DATE,
+            ntz_col TIMESTAMP_NTZ(3)
+        )",
+    );
+    client.execute_statement_query(&stmt);
+
+    // Insert rows with null values in different columns
+    client.set_sql_query(
+        &stmt,
+        "INSERT INTO json_null_test VALUES
+            ('hello', 42, true, 3.14, '2024-01-15', '2024-01-15 10:30:00.123'),
+            (null, null, null, null, null, null),
+            ('world', 7, false, 2.71, '2024-06-01', '2024-06-01 12:00:00.456')",
+    );
+    client.execute_statement_query(&stmt);
+    client.release_statement(&stmt);
+
+    // Query with JSON format
+    let mut helper = execute_json_query(
+        &client,
+        "SELECT * FROM json_null_test ORDER BY str_col NULLS FIRST",
+    );
+
+    let batch = helper.next_batch().expect("Expected a record batch");
+    assert_eq!(batch.num_rows(), 3);
+    assert_eq!(batch.num_columns(), 6);
+
+    // First row should be all nulls (NULLS FIRST ordering)
+    for col_idx in 0..batch.num_columns() {
+        assert!(
+            batch.column(col_idx).is_null(0),
+            "Column {} row 0 should be null",
+            batch.schema().field(col_idx).name()
+        );
+    }
+
+    // Second and third rows should have valid values
+    for col_idx in 0..batch.num_columns() {
+        assert!(
+            batch.column(col_idx).is_valid(1),
+            "Column {} row 1 should be valid",
+            batch.schema().field(col_idx).name()
+        );
+        assert!(
+            batch.column(col_idx).is_valid(2),
+            "Column {} row 2 should be valid",
+            batch.schema().field(col_idx).name()
+        );
+    }
+}
+
+#[test]
+fn should_handle_show_schemas_json_result_with_nulls() {
+    let client = SnowflakeTestClient::connect_with_default_auth();
+
+    // SHOW SCHEMAS returns JSON format with nullable columns like comment, options
+    let mut helper = execute_json_query(&client, "SHOW SCHEMAS");
+
+    let batch = helper.next_batch().expect("Expected a record batch");
+    assert!(batch.num_rows() > 0, "Expected at least one schema");
+    assert!(
+        batch.num_columns() > 0,
+        "Expected at least one column in SHOW SCHEMAS result"
+    );
+}
+
+#[test]
+fn should_match_null_positions_between_arrow_and_json_formats() {
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let stmt = client.new_statement();
+
+    // Create table with sparse nulls across different types
+    client.set_sql_query(
+        &stmt,
+        "CREATE OR REPLACE TABLE json_null_parity (
+            txt STRING,
+            num INTEGER,
+            ntz TIMESTAMP_NTZ
+        )",
+    );
+    client.execute_statement_query(&stmt);
+
+    client.set_sql_query(
+        &stmt,
+        "INSERT INTO json_null_parity VALUES
+            ('a', 1, '2024-01-01 00:00:00'),
+            (null, 2, '2024-01-02 00:00:00'),
+            ('c', null, '2024-01-03 00:00:00'),
+            ('d', 4, null)",
+    );
+    client.execute_statement_query(&stmt);
+
+    // Get Arrow result
+    client.set_sql_query(
+        &stmt,
+        "SELECT * FROM json_null_parity ORDER BY txt NULLS FIRST",
+    );
+    let arrow_result = client.execute_statement_query(&stmt);
+    let mut arrow_helper = ArrowResultHelper::from_result(arrow_result);
+    let arrow_batch = arrow_helper.next_batch().expect("Expected arrow batch");
+
+    // Get JSON result
+    client.set_sql_query(
+        &stmt,
+        "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
+    );
+    client.execute_statement_query(&stmt);
+
+    client.set_sql_query(
+        &stmt,
+        "SELECT * FROM json_null_parity ORDER BY txt NULLS FIRST",
+    );
+    let json_result = client.execute_statement_query(&stmt);
+    let mut json_helper = ArrowResultHelper::from_result(json_result);
+    let json_batch = json_helper.next_batch().expect("Expected json batch");
+
+    // Verify both have the same number of rows
+    assert_eq!(arrow_batch.num_rows(), json_batch.num_rows());
+    assert_eq!(arrow_batch.num_columns(), json_batch.num_columns());
+
+    // Verify null positions match between Arrow and JSON-converted-to-Arrow
+    for col_idx in 0..arrow_batch.num_columns() {
+        let arrow_col = arrow_batch.column(col_idx);
+        let json_col = json_batch.column(col_idx);
+        let field_name = arrow_batch.schema().field(col_idx).name().clone();
+
+        assert_eq!(
+            arrow_col.null_count(),
+            json_col.null_count(),
+            "Null count mismatch for column '{field_name}'"
+        );
+
+        for row_idx in 0..arrow_batch.num_rows() {
+            assert_eq!(
+                arrow_col.is_null(row_idx),
+                json_col.is_null(row_idx),
+                "Null mismatch at row {row_idx} for column '{field_name}'"
+            );
+        }
+    }
+
+    client.release_statement(&stmt);
+}

--- a/sf_core/tests/integration/query/mod.rs
+++ b/sf_core/tests/integration/query/mod.rs
@@ -1,1 +1,2 @@
 mod json_result_set;
+mod json_result_set_nulls;

--- a/tests/definitions/python/query/cuj.feature
+++ b/tests/definitions/python/query/cuj.feature
@@ -1,0 +1,12 @@
+@python
+Feature: Critical user journeys
+
+  @python_e2e
+  Scenario: desc command
+    When DESC SCHEMA command is executed
+    Then Schema properties are returned with correct types
+
+  @python_e2e
+  Scenario: show command
+    When SHOW SCHEMAS command is executed
+    Then Result contains INFORMATION_SCHEMA and PUBLIC schemas


### PR DESCRIPTION
The SHOW SCHEMAS command returns JSON results where some column values are null (e.g. comment, options). The Rust core deserialized the rowset field as Vec<Vec<String>>, which cannot represent nulls and caused serde to fail. Change the type to Vec<Vec<Option<String>>> and propagate through statement.rs and arrow_utils.rs so null cells produce proper Arrow null entries.

Also add support for OBJECT, VARIANT, and ARRAY column types by mapping them to Text, since their JSON rowset representation is just strings.