### PR TITLE
Improve Catch2 assertion and add local review rules

### DIFF
--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -1,0 +1,27 @@
+---
+description: Review changes in the PR
+---
+
+# Review 
+
+## Run Arctic owl review
+
+```
+sf ai review run
+```
+
+## As @odbc-test-reviewer review odbc-tests
+
+For each file, systematically check all categories (RAII, test structure, ODBC call validation, assertions, data retrieval, behavior differences, code style, abstraction levels, ODBC spec compliance, and coverage gaps).
+
+Fetch the relevant ODBC function spec from Microsoft docs before checking spec compliance.
+
+Output findings grouped by severity (High / Medium / Low) using the review output format defined in the rule.
+
+## Combine review reports and present to the user
+
+- Merge findings from the Arctic Owl review and the ODBC test review into a single report.
+- Deduplicate overlapping issues, keeping the more detailed description.
+- Group all findings by severity (High / Medium / Low), then by file.
+- Append the ODBC Spec Compliance and Missing Test Coverage sections from the test review.
+- End with the consolidated checklist below.

--- a/.cursor/rules/odbc-test-generation.mdc
+++ b/.cursor/rules/odbc-test-generation.mdc
@@ -11,6 +11,18 @@ alwaysApply: false
 2. **Run format validator** with `tests/tests_format_validator/run_validator.sh`
 3. **Run precommit** to ensure linter compliance
 
+## ODBC Reference Documentation
+
+When writing or reviewing ODBC tests, fetch the relevant Microsoft ODBC API reference pages for context. Use these URLs as needed:
+- Function reference index: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/odbc-api-reference
+- Individual function (replace `sqlfunctionname` with lowercase function name, e.g. `sqlgetdata`, `sqlexecdirect`, `sqlfetch`): `https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlfunctionname-function`
+- Data types: https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/sql-data-types
+- Return codes: https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/return-codes-odbc
+- Diagnostics / SQLGetDiagRec: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function
+- SQLSTATE reference: https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes
+
+Before writing or modifying a test for a specific ODBC function, use the WebFetch tool to retrieve that function's documentation page. For example, when working on a `SQLGetData` test, fetch `https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function`. Use the fetched content to verify correct parameter types, buffer sizes, expected return codes, SQLSTATE values, and documented edge cases.
+
 ## C++ Test Structure
 
 ### Framework & Includes
@@ -24,23 +36,46 @@ alwaysApply: false
   #include "test_setup.hpp"
   ```
 
-### Test Case Naming
-- Use descriptive names starting with "should": `TEST_CASE("should select hardcoded string literals", "[tag1][tag2]")`
+### Test Case Naming & Structure
+- Use `TEST_CASE` + `Connection` RAII. Names start with `"should ..."`.
+- Use `TEST_CASE_METHOD(Fixture, ...)` with the appropriate fixture (`EnvFixture`, `DbcFixture`, `StmtFixture`).
 - Tags should match category: `[datatype][string]`, `[put_get]`, `[auth]`, `[query]`
 
 ### Given-When-Then Comments
-Always structure tests with Gherkin comments:
+Always structure tests with Gherkin comments. Each comment must be followed by relevant code (no empty stubs).
+
+**E2E example:**
 ```cpp
 TEST_CASE("should select data from file uploaded to stage", "[put_get]") {
   // Given File is uploaded to stage
   Connection conn;
-  // setup code...
+  // setup code using high-level abstractions...
 
   // When File data is queried using Select command
-  auto stmt = conn.execute_fetch(select_sql);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ..."), SQL_NTS);
 
   // Then File data should be correctly returned
   CHECK(result == expected);
+}
+```
+
+**API test example:**
+```cpp
+TEST_CASE_METHOD(StmtFixture, "SQLGetData: should return correct integer value", "[sqlgetdata]") {
+  // Given A query returning an integer is executed
+  SQLRETURN ret = SQLExecDirect(stmt, sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When Data is retrieved via SQLGetData
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLGetData(stmt, 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+
+  // Then The call should succeed and return the correct value
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(value == 42);
 }
 ```
 
@@ -57,18 +92,27 @@ auto stmt = conn.execute("SQL QUERY");
 auto stmt = conn.execute_fetch("SQL QUERY");  // execute + fetch first row
 ```
 
-### ODBC Error Handling
-- Use `CHECK_ODBC(ret, handle)` macro after every ODBC call:
+### ODBC Return Value Checking
+Every ODBC call return value **must** be checked. Use different macros depending on context:
+- **Setup (Given)**: use `REQUIRE_ODBC(ret, handle)` or `REQUIRE_ODBC_SUCCESS(ret, handle)` — failure is fatal, subsequent code is meaningless.
+- **Behaviour assertions (Then)**: use `REQUIRE_THAT` / `CHECK_THAT` with `OdbcMatchers` (see below).
+
 ```cpp
-SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT...", SQL_NTS);
-CHECK_ODBC(ret, stmt);
+// Setup — fatal on failure
+SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+REQUIRE_ODBC(ret, stmt);
+
+// Behaviour assertion — the return code itself is what we're testing
+ret = SQLExecDirect(stmt.getHandle(), sqlchar("INVALID SQL"), SQL_NTS);
+REQUIRE_THAT(OdbcResult(ret, stmt),
+             OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("42000"));
 ```
 
 ### Schema & Table Management
+Use `Schema::use_random_schema(conn)` when the test creates tables. The schema destructor drops CASCADE, so `DROP TABLE IF EXISTS` is redundant inside a random schema.
 ```cpp
 auto random_schema = Schema::use_random_schema(conn);
-conn.execute("DROP TABLE IF EXISTS test_table");
-conn.execute("CREATE TABLE test_table (col VARCHAR(1000))");
+conn.execute("CREATE OR REPLACE TABLE test_table (col VARCHAR(1000))");
 ```
 
 ### Data Retrieval
@@ -76,15 +120,60 @@ conn.execute("CREATE TABLE test_table (col VARCHAR(1000))");
 #include "get_data.hpp"
 auto value = get_data<SQL_C_CHAR>(stmt, column_index);
 auto num = get_data<SQL_C_LONG>(stmt, column_index);
+
+// When NULLs are expected:
+auto maybe_value = get_data_optional<SQL_C_CHAR>(stmt, column_index);
+```
+- For type conversion tests, use `conversion_checks.hpp` helpers (`check_fractional_truncation`, `check_no_truncation`, `check_numeric_out_of_range`):
+```cpp
+#include "conversion_checks.hpp"
+
+// Fetch succeeds, value returned without truncation
+auto value = check_no_truncation<SQL_C_SLONG>(stmt, 1);
+CHECK(value == 42);
+
+// Fetch succeeds with SQL_SUCCESS_WITH_INFO + SQLSTATE 01S07 (fractional truncation)
+auto truncated = check_fractional_truncation<SQL_C_SLONG>(stmt, 2);
+CHECK(truncated == 3);  // e.g. 3.14 → 3
+
+// Fetch fails with SQL_ERROR + SQLSTATE 22003 (numeric out of range)
+check_numeric_out_of_range<SQL_C_STINYINT>(stmt, 3);  // e.g. 999 doesn't fit in TINYINT
+
+// Fetch fails with SQL_ERROR + SQLSTATE 22018 (invalid character value for cast)
+check_invalid_string<SQL_C_SLONG>(stmt, 4);  // e.g. "abc" → integer
+
+// Check that a column is NULL
+check_null_via_get_data(stmt, 5, SQL_C_CHAR);
 ```
 
-### Assertions
-- Use `CHECK()` for non-fatal assertions
-- Use `REQUIRE()` for fatal assertions (test stops on failure)
+### Assertions — CHECK vs REQUIRE
+- `CHECK` for value assertions (non-fatal — all failures are reported).
+- `REQUIRE` only for preconditions whose failure makes subsequent code meaningless.
+- **Do not use `REQUIRE` inside loops or multi-column checks** — the first failure hides the rest.
+- Pattern: `REQUIRE_ODBC` on fetch, then `CHECK(value == expected)` per column.
+
+### OdbcMatchers (Behaviour Assertions)
+Use `OdbcMatchers` with `REQUIRE_THAT` / `CHECK_THAT` for asserting ODBC return codes and diagnostics in Then blocks:
 ```cpp
-CHECK(actual == expected);
-REQUIRE(indicator > 0);
+#include "odbc_matchers.hpp"
+
+// Assert error with SQLSTATE
+REQUIRE_THAT(OdbcResult(ret, stmt),
+             OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("42000"));
+
+// Assert error with diagnostic message
+REQUIRE_THAT(OdbcResult(ret, stmt),
+             OdbcMatchers::IsError() && OdbcMatchers::HasDiagMessage("syntax error"));
+
+// Assert success
+REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 ```
+Available matchers: `Succeeded()`, `IsSuccess()`, `IsSuccessWithInfo()`, `IsError()`, `HasSqlState(code)`, `HasDiagMessage(substring)`. Compose with `&&` / `||`.
+
+### Abstraction Levels
+- **Given (setup)**: use high-level abstractions — `Connection`, `Schema::use_random_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
+- **When/Then (test)**: use raw ODBC calls (`SQLExecDirect`, `SQLFetch`, `SQLGetData`) or purpose-built helpers to make the tested code path explicit and auditable.
+- Do not use raw ODBC for setup or high-level wrappers for the behaviour under test.
 
 ## Behavior Differences (BD)
 
@@ -134,14 +223,24 @@ odbc_tests/tests/
 
 ### Available Headers (in `odbc_tests/common/include/`)
 - `Connection.hpp` - Connection management wrapper
-- `HandleWrapper.hpp` - ODBC handle wrappers (Env, Conn, Stmt)
-- `macros.hpp` - `CHECK_ODBC` and error handling macros
+- `HandleWrapper.hpp` - ODBC handle wrappers (Env, Conn, Stmt) and test fixtures (`EnvFixture`, `DbcFixture`, `StmtFixture`)
+- `macros.hpp` - `REQUIRE_ODBC`, `REQUIRE_ODBC_SUCCESS` and error handling macros
+- `odbc_matchers.hpp` - `OdbcMatchers` for Catch2 `REQUIRE_THAT` / `CHECK_THAT` assertions
+- `odbc_cast.hpp` - `sqlchar()` helper (replaces C-style `(SQLCHAR*)` casts)
 - `test_setup.hpp` - Test parameters and connection strings
 - `utils.hpp` - File paths, repo root utilities
-- `get_data.hpp` - Typed data retrieval helpers
+- `get_data.hpp` - `get_data<>()` and `get_data_optional<>()` typed data retrieval helpers
+- `conversion_checks.hpp` - Helpers for type conversion tests
 - `Schema.hpp` - Schema management
 - `put_get_utils.hpp` - PUT/GET operation utilities
 - `compatibility.hpp` - `OLD_DRIVER_ONLY`, `NEW_DRIVER_ONLY` macros
+
+### Code Style
+- No hardcoded SQL type integers (e.g. `3`) — use ODBC constants (`SQL_DECIMAL`).
+- No C-style casts `(SQLCHAR*)` — use `sqlchar()` from `odbc_cast.hpp`.
+- File-local helpers must be `static` or in an anonymous namespace.
+- Avoid verbose table names — use short names within a random schema.
+- Extract duplicated fetch/validation loops into helpers.
 
 ### Creating Helper Functions
 - Put reusable helpers in common headers
@@ -154,15 +253,33 @@ static std::string to_lower_copy(const std::string& s) {
 }
 ```
 
-## Skipping Tests
+## Skipping Tests & Behavior Differences
 
-When a test cannot be run (missing feature, known issue):
+- Prefer `OLD_DRIVER_ONLY("BD#N")` / `NEW_DRIVER_ONLY("BD#N")` over `SKIP` for behavior differences between drivers.
+- `SKIP("SNOW-XXXXXX: reason")` is only acceptable when the test truly cannot execute (missing feature/infra).
 ```cpp
-TEST_CASE("should return correct column metadata", "[put_get]") {
-  SKIP("SNOW-1234567: Reason for skipping");
-  // Given...
-  // When...
-  // Then...
+#include "compatibility.hpp"
+
+TEST_CASE_METHOD(StmtFixture, "SQLGetData: should return trimmed string", "[sqlgetdata]") {
+  // Given A query returning a padded string is executed
+  SQLRETURN ret = SQLExecDirect(stmt, sqlchar("SELECT '  hello  '"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When Data is retrieved via SQLGetData
+  char buffer[256] = {};
+  SQLLEN indicator = 0;
+  ret = SQLGetData(stmt, 1, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
+
+  // Then The old driver returns the string as-is, the new driver trims it
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+  OLD_DRIVER_ONLY("BD#3") {
+    CHECK(std::string(buffer, indicator) == "  hello  ");
+  }
+  NEW_DRIVER_ONLY("BD#3") {
+    CHECK(std::string(buffer, indicator) == "hello");
+  }
 }
 ```
 
@@ -190,5 +307,3 @@ TEST_CASE("should return correct column metadata", "[put_get]") {
 - [ ] Tests pass against OLD driver (`run_reference.sh`)
 - [ ] Format validator passes (`tests/tests_format_validator/run_validator.sh`)
 - [ ] Precommit hooks pass
-- [ ] Test follows Given-When-Then comment structure
-- [ ] Appropriate tags added to TEST_CASE

--- a/.cursor/rules/odbc-test-reviewer.mdc
+++ b/.cursor/rules/odbc-test-reviewer.mdc
@@ -1,0 +1,222 @@
+---
+description: ODBC test reviewer agent — reviews test code for best practices, anti-patterns, and correctness
+globs: odbc_tests/**/*.cpp,odbc_tests/**/*.hpp
+alwaysApply: false
+---
+
+# ODBC Test Reviewer Agent
+
+When asked to review ODBC test code, systematically check each category below. Report findings grouped by severity (High / Medium / Low). For each finding, cite the exact line(s), explain the issue, and show the corrected code.
+
+## 1. RAII Resource Management
+
+- All ODBC handles must use RAII wrappers (`Connection`, `Schema`, `TestTable`, `HandleWrapper` variants).
+- Flag manual `SQLAllocHandle` / `SQLDisconnect` / `SQLFreeHandle` — these leak on test failure.
+- `Schema::use_random_schema(conn)` is required when the test creates tables. Do NOT flag its absence for literal-only queries.
+- Flag `DROP TABLE IF EXISTS` inside a random schema — the schema destructor drops CASCADE, making it redundant. Suggest `CREATE OR REPLACE TABLE` or plain `CREATE TABLE`.
+
+## 2. Test Structure
+
+- E2E tests (`odbc_tests/tests/e2e/`): require `TEST_CASE` + `Connection` RAII. Must have Given-When-Then comments, each followed by code (no empty Gherkin stubs).
+- API tests (`odbc_tests/tests/basic_tests/`, `odbc_tests/tests/datatype_tests/`): require `TEST_CASE_METHOD(Fixture, ...)` with the appropriate fixture (`EnvFixture`, `DbcFixture`, `StmtFixture`).
+- Test names: E2E should start with "should …"; API tests use `SQLFunctionName: description`.
+- Flag leftover debug sections named "TEST".
+
+## 3. ODBC Call Validation
+
+- Every ODBC call return value **must** be checked. Flag unchecked `SQLGetData`, `SQLFetch`, `SQLExecDirect`, etc.
+- Setup steps (Given): use `REQUIRE_ODBC(ret, handle)` or `REQUIRE_ODBC_SUCCESS(ret, handle)`.
+- Behaviour assertions (Then): use `REQUIRE_THAT` / `CHECK_THAT` with `OdbcMatchers`:
+
+```cpp
+// Correct: assert error with SQLSTATE
+REQUIRE_THAT(OdbcResult(ret, stmt),
+             OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("42000"));
+
+// Correct: assert error with diagnostic message
+REQUIRE_THAT(OdbcResult(ret, stmt),
+             OdbcMatchers::IsError() && OdbcMatchers::HasDiagMessage("syntax error"));
+```
+
+Available matchers: `Succeeded()`, `IsSuccess()`, `IsSuccessWithInfo()`, `IsError()`, `HasSqlState(code)`, `HasDiagMessage(substring)`. Compose with `&&` / `||`.
+
+## 4. Assertions — CHECK vs REQUIRE
+
+- `CHECK` for value assertions (non-fatal — all failures are reported).
+- `REQUIRE` only for preconditions whose failure makes subsequent code meaningless.
+- **Flag `REQUIRE` inside loops or multi-column checks** — first failure hides the rest.
+- Pattern: `REQUIRE_ODBC` on fetch, then `CHECK(value == expected)` per column.
+
+## 5. Data Retrieval
+
+- Prefer `get_data<SQL_C_TYPE>(stmt, col)` (auto-checks return).
+- Use `get_data_optional<SQL_C_TYPE>(stmt, col)` when NULLs are expected.
+- For type conversion tests, use `conversion_checks.hpp` helpers (`check_fractional_truncation`, `check_no_truncation`, `check_numeric_out_of_range`).
+
+## 6. Behavior Differences
+
+- Prefer `OLD_DRIVER_ONLY("BD#N")` / `NEW_DRIVER_ONLY("BD#N")` over `SKIP` for behavior differences.
+- Each BD must be documented in `BehaviorDifferences.yaml` with sequential ID, name, and type.
+- `SKIP("SNOW-XXXXXX: reason")` is only acceptable when the test truly cannot execute (missing feature/infra).
+
+## 7. Code Style
+
+- No hardcoded SQL type integers (e.g. `3`) — use ODBC constants (`SQL_DECIMAL`).
+- No C-style casts `(SQLCHAR*)` — use `sqlchar()` from `odbc_cast.hpp` or `reinterpret_cast`.
+- File-local helpers must be `static` or in an anonymous namespace (flag bare file-scope functions).
+- Avoid verbose table names like `universal_driver_odbc_small_binding_integer_test_table` — use short names within a random schema.
+- Flag duplicated fetch/validation loops — suggest extracting a helper.
+
+## 8. Abstraction Levels
+
+- **Given (setup)**: high-level abstractions — `Connection`, `Schema::use_random_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
+- **When/Then (test)**: raw ODBC calls (`SQLExecDirect`, `SQLFetch`, `SQLGetData`) or purpose-built helpers to make the tested code path explicit and auditable.
+- Flag tests that use raw ODBC for setup or high-level wrappers for the behaviour under test.
+
+## 9. ODBC Spec Compliance
+
+Before reviewing a test file for a specific ODBC function, fetch the function's Microsoft documentation page using `https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/<function-lowercase>-function` (e.g. `sqlgetdata-function`). Cross-reference the test against the spec:
+
+### Return Codes
+- Every function documents a set of possible return codes (`SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, `SQL_NO_DATA`, `SQL_NEED_DATA`, `SQL_STILL_EXECUTING`). Flag return codes listed in the spec that have no test coverage.
+- Verify that tests for `SQL_SUCCESS_WITH_INFO` also check the accompanying SQLSTATE (e.g. `01004` for truncation, `01S02` for option value changed).
+
+### SQLSTATEs
+- The spec lists all possible SQLSTATEs for each function. Flag any documented SQLSTATE with no corresponding test case.
+- Prioritize coverage for these common classes:
+  - **HY009** — null pointer arguments
+  - **HY010** — function sequence errors (calling in wrong state)
+  - **HY090** — invalid string or buffer length
+  - **HY024** — invalid attribute value
+  - **HY092** — invalid attribute/option identifier
+  - **08003** — connection not open
+  - **24000** — invalid cursor state
+  - **01004** — string data, right truncated
+  - **22003** — numeric value out of range
+  - **07009** — invalid descriptor index
+
+### State Transitions
+- ODBC defines a state machine for each handle type (Environment, Connection, Statement, Descriptor). Verify:
+  - Calling functions on unallocated or freed handles returns `SQL_INVALID_HANDLE`.
+  - Calling functions out of sequence returns `HY010` (Function sequence error).
+  - Calling statement functions while in a `SQL_NEED_DATA` state returns `HY010`.
+  - Closing a cursor or freeing a statement resets state correctly for reuse.
+
+### Parameter Validation
+- Check that tests exercise each documented invalid-parameter scenario:
+  - Null pointer for required output parameters → `HY009`.
+  - Invalid `BufferLength` (negative, zero when disallowed) → `HY090`.
+  - Invalid `ColumnNumber` / `ParameterNumber` beyond result set → `07009`.
+  - Invalid `HandleType` → `SQL_INVALID_HANDLE` or `HY092`.
+
+### Buffer & Truncation Behavior
+- For functions that return string/binary data (`SQLGetData`, `SQLDescribeCol`, `SQLGetInfo`, `SQLGetDiagRec`, etc.), verify:
+  - Truncation returns `SQL_SUCCESS_WITH_INFO` with SQLSTATE `01004`.
+  - `StrLen_or_IndPtr` contains the full (untruncated) length.
+  - Zero-length buffer returns `01004` with full length in indicator.
+  - Output is null-terminated even when truncated.
+  - `SQL_NULL_DATA` indicator when column value is NULL.
+
+### Conformance Level
+- Flag tests that exercise Level 1 or Level 2 functions without a `[level1]` or `[level2]` tag. Core functions need no extra tag.
+- The ODBC spec classifies each function into Core, Level 1, or Level 2. Ensure the test file header or naming reflects this when relevant.
+
+## 10. Test Coverage Gap Analysis
+
+When reviewing a test file (or an `odbc-api/` subdirectory), assess coverage completeness:
+
+### Per-Function Checklist
+For each ODBC function under test, verify test cases exist for:
+1. **Happy path** — basic successful usage.
+2. **SQL_INVALID_HANDLE** — null or wrong-type handle.
+3. **HY009** — null pointer for required output argument.
+4. **HY010** — function sequence error (at least one scenario).
+5. **Function-specific errors** — every SQLSTATE documented in the spec's "Diagnostics" table.
+6. **SQL_NO_DATA** — where the spec documents it (e.g. `SQLFetch` after last row, `SQLExecDirect` with zero-row DML).
+7. **SQL_SUCCESS_WITH_INFO** — truncation, option value changed, etc.
+8. **Edge cases from "Comments" section** — the spec's Comments often describe boundary behaviors (e.g. calling `SQLGetData` on a bound column, multiple `SQLGetData` calls for chunked retrieval).
+
+### Missing Function Coverage
+Flag ODBC API functions that have **no test file** in `odbc_tests/tests/odbc-api/`. The full ODBC 3.x function list for reference:
+
+**Attribute get/set (currently missing dedicated test files):**
+- `SQLSetEnvAttr` / `SQLGetEnvAttr`
+- `SQLSetConnectAttr` / `SQLGetConnectAttr`
+- `SQLSetStmtAttr` / `SQLGetStmtAttr`
+
+**Result set retrieval (E2E-only — no API-level tests):**
+- `SQLFetch` / `SQLFetchScroll`
+- `SQLGetData`
+- `SQLBindCol`
+- `SQLDescribeCol` / `SQLColAttribute`
+- `SQLNumResultCols`
+- `SQLRowCount`
+- `SQLMoreResults`
+
+**Diagnostics:**
+- `SQLGetDiagRec` / `SQLGetDiagField`
+
+**Positioned operations:**
+- `SQLSetPos`
+- `SQLBulkOperations`
+
+**Driver/data-source enumeration:**
+- `SQLDataSources`
+- `SQLDrivers`
+
+When identifying gaps, output them as:
+
+```
+### Missing Test Coverage
+| Function | Gap | Priority |
+|----------|-----|----------|
+| SQLGetData | No test for 01004 truncation | High |
+| SQLSetConnectAttr | No test file exists | Medium |
+| SQLFetchScroll | No API-level tests (E2E only) | Medium |
+```
+
+Priority levels:
+- **High**: Core function with untested error paths or missing spec-mandated behaviors.
+- **Medium**: Level 1/2 function or non-critical SQLSTATE missing.
+- **Low**: Edge case from spec "Comments" that is unlikely to surface in practice.
+
+## Review Output Format
+
+```
+## Review: <filename>
+
+### High Severity
+- **Line N**: <issue>. Fix: <corrected code or guidance>.
+
+### Medium Severity
+- **Line N**: <issue>. Fix: <corrected code or guidance>.
+
+### Low Severity
+- **Line N**: <issue>. Fix: <corrected code or guidance>.
+
+### ODBC Spec Compliance
+- **<Function>**: <SQLSTATE or return code> documented in spec but not tested.
+- **<Function>**: <Edge case from Comments section> not covered.
+
+### Missing Test Coverage
+| Function | Gap | Priority |
+|----------|-----|----------|
+| ... | ... | ... |
+
+### Checklist
+- [ ] RAII for all resources
+- [ ] Every ODBC return value checked
+- [ ] CHECK for values, REQUIRE for preconditions
+- [ ] Given-When-Then comments (E2E)
+- [ ] Descriptive test name with tags
+- [ ] No hardcoded SQL type integers
+- [ ] No C-style casts
+- [ ] File-local helpers are static / anonymous namespace
+- [ ] No redundant cleanup
+- [ ] Behavior differences documented & guarded
+- [ ] All spec-documented return codes tested
+- [ ] All spec-documented SQLSTATEs tested (or explicitly noted as out-of-scope)
+- [ ] State transition errors tested (HY010)
+- [ ] Buffer truncation behavior tested where applicable (01004)
+- [ ] Null-pointer parameter validation tested (HY009)
+```

--- a/odbc_tests/common/include/HandleWrapper.hpp
+++ b/odbc_tests/common/include/HandleWrapper.hpp
@@ -6,10 +6,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "odbc_return_code.hpp"
+
 class HandleWrapper {
  public:
   HandleWrapper(SQLHANDLE parent_handle, SQLSMALLINT type) : handle(SQL_NULL_HANDLE), type(type) {
     SQLRETURN ret = SQLAllocHandle(type, parent_handle, &this->handle);
+    INFO("SQLAllocHandle returned " << return_code_to_string(ret));
     REQUIRE(ret == SQL_SUCCESS);
   }
 

--- a/odbc_tests/common/include/HandleWrapper.hpp
+++ b/odbc_tests/common/include/HandleWrapper.hpp
@@ -4,13 +4,13 @@
 #include <sql.h>
 #include <sqltypes.h>
 
-#include "macros.hpp"
+#include <catch2/catch_test_macros.hpp>
 
 class HandleWrapper {
  public:
   HandleWrapper(SQLHANDLE parent_handle, SQLSMALLINT type) : handle(SQL_NULL_HANDLE), type(type) {
     SQLRETURN ret = SQLAllocHandle(type, parent_handle, &this->handle);
-    CHECK_ODBC_ERROR(ret, handle, type);
+    REQUIRE(ret == SQL_SUCCESS);
   }
 
   HandleWrapper(const HandleWrapper& other) = delete;

--- a/odbc_tests/common/include/get_data.hpp
+++ b/odbc_tests/common/include/get_data.hpp
@@ -9,7 +9,7 @@
 
 #include "HandleWrapper.hpp"
 #include "MetaOfSqlCTypes.hpp"
-#include "macros.hpp"
+#include "odbc_matchers.hpp"
 
 template <int SQL_C_TYPE>
 inline std::optional<typename MetaOfSqlCType<SQL_C_TYPE>::type> get_data_optional(const StatementHandleWrapper& stmt,
@@ -17,7 +17,7 @@ inline std::optional<typename MetaOfSqlCType<SQL_C_TYPE>::type> get_data_optiona
   typename MetaOfSqlCType<SQL_C_TYPE>::type value;
   SQLLEN indicator;
   SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_TYPE, &value, sizeof(value), &indicator);
-  CHECK_ODBC(ret, stmt);
+  REQUIRE_ODBC(ret, stmt);
   if (indicator == SQL_NULL_DATA) {
     return std::nullopt;
   }
@@ -30,7 +30,7 @@ inline std::optional<std::string> get_data_optional<SQL_C_CHAR>(const StatementH
   char buffer[8192];
   SQLLEN indicator;
   SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_CHAR, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
+  REQUIRE_ODBC(ret, stmt);
   if (indicator == SQL_NULL_DATA) {
     return std::nullopt;
   }
@@ -43,7 +43,7 @@ inline std::optional<std::u16string> get_data_optional<SQL_C_WCHAR>(const Statem
   char16_t buffer[8192];
   SQLLEN indicator;
   SQLRETURN ret = SQLGetData(stmt.getHandle(), col, SQL_C_WCHAR, buffer, sizeof(buffer), &indicator);
-  CHECK_ODBC(ret, stmt);
+  REQUIRE_ODBC(ret, stmt);
   if (indicator == SQL_NULL_DATA) {
     return std::nullopt;
   }

--- a/odbc_tests/common/include/get_data.hpp
+++ b/odbc_tests/common/include/get_data.hpp
@@ -9,6 +9,7 @@
 
 #include "HandleWrapper.hpp"
 #include "MetaOfSqlCTypes.hpp"
+#include "macros.hpp"
 
 template <int SQL_C_TYPE>
 inline std::optional<typename MetaOfSqlCType<SQL_C_TYPE>::type> get_data_optional(const StatementHandleWrapper& stmt,

--- a/odbc_tests/common/include/macros.hpp
+++ b/odbc_tests/common/include/macros.hpp
@@ -1,50 +1,25 @@
 #ifndef ODBC_TESTS_MACROS_HPP
 #define ODBC_TESTS_MACROS_HPP
 
-#include <sql.h>
-#include <sqlext.h>
-#include <sqltypes.h>
+#include "odbc_matchers.hpp"
 
-#include <catch2/catch_test_macros.hpp>
-
-inline std::string return_code_to_string(SQLRETURN ret) {
-  switch (ret) {
-    case SQL_SUCCESS:
-      return "SQL_SUCCESS";
-    case SQL_SUCCESS_WITH_INFO:
-      return "SQL_SUCCESS_WITH_INFO";
-    case SQL_ERROR:
-      return "SQL_ERROR";
-    case SQL_INVALID_HANDLE:
-      return "SQL_INVALID_HANDLE";
-    default:
-      return "UNKNOWN_RETURN_CODE(" + std::to_string(ret) + ")";
-  }
-}
-
-#define CHECK_ODBC(ret, handle) CHECK_ODBC_ERROR(ret, handle.getHandle(), handle.getType())
-
-#define CHECK_ODBC_ERROR(ret, handle, handleType)                                                                   \
-  if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) {                                                         \
-    if (ret == SQL_INVALID_HANDLE) {                                                                                \
-      FAIL("ODBC Error Status:" << return_code_to_string(ret) << " (SQL_INVALID_HANDLE).\n "                        \
-                                << "HandleType=" << handleType << " Handle=" << handle);                            \
-    }                                                                                                               \
-    SQLINTEGER nativeError = 0;                                                                                     \
-    SQLCHAR state[1024] = {0};                                                                                      \
-    SQLCHAR message[1024] = {0};                                                                                    \
-    SQLRETURN diag_ret = SQLGetDiagRec(handleType, handle, 1, state, &nativeError, message, sizeof(message), NULL); \
-    if (diag_ret == SQL_SUCCESS || diag_ret == SQL_SUCCESS_WITH_INFO) {                                             \
-      FAIL("ODBC Error Status:" << ret << '\n'                                                                      \
-                                << "Error: " << message << '\n'                                                     \
-                                << "State: " << state << '\n'                                                       \
-                                << "NativeError: " << nativeError);                                                 \
-    } else {                                                                                                        \
-      FAIL("ODBC Error Status:" << ret << '\n'                                                                      \
-                                << "No diagnostics; SQLGetDiagRec ret=" << diag_ret << '\n'                         \
-                                << "HandleType=" << handleType << '\n'                                              \
-                                << "Handle=" << handle);                                                            \
-    }                                                                                                               \
-  }
+// Deprecated – use REQUIRE_ODBC(ret, handle) from odbc_matchers.hpp.
+#ifdef __GNUC__
+#define CHECK_ODBC(ret, handle) \
+  _Pragma("GCC warning \"CHECK_ODBC is deprecated, use REQUIRE_ODBC from odbc_matchers.hpp\"") REQUIRE_ODBC(ret, handle)
+#define CHECK_ODBC_ERROR(ret, handle, handleType)                                   \
+  _Pragma("GCC warning \"CHECK_ODBC_ERROR is deprecated – see odbc_matchers.hpp\"") \
+      REQUIRE_THAT(OdbcResult(ret, handleType, handle), OdbcMatchers::Succeeded())
+#elif defined(_MSC_VER)
+#define CHECK_ODBC(ret, handle) \
+  __pragma(message("CHECK_ODBC is deprecated, use REQUIRE_ODBC from odbc_matchers.hpp")) REQUIRE_ODBC(ret, handle)
+#define CHECK_ODBC_ERROR(ret, handle, handleType)                             \
+  __pragma(message("CHECK_ODBC_ERROR is deprecated – see odbc_matchers.hpp")) \
+      REQUIRE_THAT(OdbcResult(ret, handleType, handle), OdbcMatchers::Succeeded())
+#else
+#define CHECK_ODBC(ret, handle) REQUIRE_ODBC(ret, handle)
+#define CHECK_ODBC_ERROR(ret, handle, handleType) \
+  REQUIRE_THAT(OdbcResult(ret, handleType, handle), OdbcMatchers::Succeeded())
+#endif
 
 #endif  // ODBC_TESTS_MACROS_HPP

--- a/odbc_tests/common/include/odbc_matchers.hpp
+++ b/odbc_tests/common/include/odbc_matchers.hpp
@@ -76,6 +76,20 @@ class IsError : public Catch::Matchers::MatcherBase<OdbcResult> {
   std::string describe() const override { return "is SQL_ERROR"; }
 };
 
+// Matches SQL_NO_DATA.
+class IsNoData : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override { return result.returnCode == SQL_NO_DATA; }
+  std::string describe() const override { return "is SQL_NO_DATA"; }
+};
+
+// Matches SQL_INVALID_HANDLE.
+class IsInvalidHandle : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override { return result.returnCode == SQL_INVALID_HANDLE; }
+  std::string describe() const override { return "is SQL_INVALID_HANDLE"; }
+};
+
 // Matches when any diagnostic record has the given SQLSTATE.
 class HasSqlState : public Catch::Matchers::MatcherBase<OdbcResult> {
   std::string expectedState_;
@@ -127,6 +141,12 @@ class HasDiagMessage : public Catch::Matchers::MatcherBase<OdbcResult> {
 
 // Requires SQL_ERROR.
 #define REQUIRE_ODBC_ERROR(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsError())
+
+// Requires SQL_NO_DATA.
+#define REQUIRE_ODBC_NO_DATA(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsNoData())
+
+// Requires SQL_INVALID_HANDLE.
+#define REQUIRE_ODBC_INVALID_HANDLE(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsInvalidHandle())
 
 // Requires SQL_ERROR with the given SQLSTATE.
 #define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType) \

--- a/odbc_tests/common/include/odbc_matchers.hpp
+++ b/odbc_tests/common/include/odbc_matchers.hpp
@@ -1,0 +1,140 @@
+#ifndef ODBC_MATCHERS_HPP
+#define ODBC_MATCHERS_HPP
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include "get_diag_rec.hpp"
+#include "odbc_return_code.hpp"
+
+// Bundles an ODBC return code with diagnostic records extracted from the handle.
+// Construct this and pass it to REQUIRE_THAT / CHECK_THAT with OdbcMatchers.
+struct OdbcResult {
+  SQLRETURN returnCode;
+  std::vector<DiagRec> diagRecords;
+
+  OdbcResult(SQLRETURN ret, SQLSMALLINT handleType, SQLHANDLE handle) : returnCode(ret) {
+    if (ret != SQL_SUCCESS && ret != SQL_INVALID_HANDLE) {
+      diagRecords = get_diag_rec(handleType, handle);
+    }
+  }
+
+  OdbcResult(SQLRETURN ret, const HandleWrapper& handle) : OdbcResult(ret, handle.getType(), handle.getHandle()) {}
+};
+
+namespace Catch {
+template <>
+struct StringMaker<OdbcResult> {
+  static std::string convert(const OdbcResult& result) {
+    std::string out = return_code_to_string(result.returnCode);
+    for (size_t i = 0; i < result.diagRecords.size(); ++i) {
+      const auto& rec = result.diagRecords[i];
+      out += "\n  [" + std::to_string(i) + "] SQLSTATE=" + rec.sqlState +
+             " NativeError=" + std::to_string(rec.nativeError) + "\n      " + rec.messageText;
+    }
+    return out;
+  }
+};
+}  // namespace Catch
+
+namespace OdbcMatchers {
+
+// Matches SQL_SUCCESS or SQL_SUCCESS_WITH_INFO.
+class Succeeded : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override {
+    return result.returnCode == SQL_SUCCESS || result.returnCode == SQL_SUCCESS_WITH_INFO;
+  }
+  std::string describe() const override { return "is SQL_SUCCESS or SQL_SUCCESS_WITH_INFO"; }
+};
+
+// Matches exactly SQL_SUCCESS (no info).
+class IsSuccess : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override { return result.returnCode == SQL_SUCCESS; }
+  std::string describe() const override { return "is SQL_SUCCESS"; }
+};
+
+// Matches exactly SQL_SUCCESS_WITH_INFO.
+class IsSuccessWithInfo : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override { return result.returnCode == SQL_SUCCESS_WITH_INFO; }
+  std::string describe() const override { return "is SQL_SUCCESS_WITH_INFO"; }
+};
+
+// Matches SQL_ERROR.
+class IsError : public Catch::Matchers::MatcherBase<OdbcResult> {
+ public:
+  bool match(const OdbcResult& result) const override { return result.returnCode == SQL_ERROR; }
+  std::string describe() const override { return "is SQL_ERROR"; }
+};
+
+// Matches when any diagnostic record has the given SQLSTATE.
+class HasSqlState : public Catch::Matchers::MatcherBase<OdbcResult> {
+  std::string expectedState_;
+
+ public:
+  explicit HasSqlState(std::string state) : expectedState_(std::move(state)) {}
+
+  bool match(const OdbcResult& result) const override {
+    for (const auto& rec : result.diagRecords) {
+      if (rec.sqlState == expectedState_) return true;
+    }
+    return false;
+  }
+  std::string describe() const override { return "has SQLSTATE " + expectedState_; }
+};
+
+// Matches when any diagnostic message contains the given substring.
+class HasDiagMessage : public Catch::Matchers::MatcherBase<OdbcResult> {
+  std::string substring_;
+
+ public:
+  explicit HasDiagMessage(std::string substr) : substring_(std::move(substr)) {}
+
+  bool match(const OdbcResult& result) const override {
+    for (const auto& rec : result.diagRecords) {
+      if (rec.messageText.find(substring_) != std::string::npos) return true;
+    }
+    return false;
+  }
+  std::string describe() const override { return "has diagnostic message containing \"" + substring_ + "\""; }
+};
+
+}  // namespace OdbcMatchers
+
+// ---------------------------------------------------------------------------
+// Convenience macros — thin wrappers around REQUIRE_THAT with OdbcMatchers.
+// On failure Catch2 prints the ODBC return code and all diagnostic records.
+// ---------------------------------------------------------------------------
+
+// Requires SQL_SUCCESS or SQL_SUCCESS_WITH_INFO (replaces CHECK_ODBC).
+#define REQUIRE_ODBC(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::Succeeded())
+
+// Requires exactly SQL_SUCCESS.
+#define REQUIRE_ODBC_SUCCESS(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsSuccess())
+
+// Requires exactly SQL_SUCCESS_WITH_INFO.
+#define REQUIRE_ODBC_SUCCESS_WITH_INFO(ret, handle) \
+  REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsSuccessWithInfo())
+
+// Requires SQL_ERROR.
+#define REQUIRE_ODBC_ERROR(ret, handle) REQUIRE_THAT(OdbcResult(ret, handle), OdbcMatchers::IsError())
+
+// Requires SQL_ERROR with the given SQLSTATE.
+#define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType) \
+  REQUIRE_THAT(OdbcResult(ret, handleType, handle), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState(expectedState))
+
+// Requires SQL_SUCCESS_WITH_INFO with the given SQLSTATE.
+#define REQUIRE_EXPECTED_WARNING(ret, expectedState, handle, handleType) \
+  REQUIRE_THAT(OdbcResult(ret, handleType, handle),                      \
+               OdbcMatchers::IsSuccessWithInfo() && OdbcMatchers::HasSqlState(expectedState))
+
+#endif  // ODBC_MATCHERS_HPP

--- a/odbc_tests/common/include/odbc_return_code.hpp
+++ b/odbc_tests/common/include/odbc_return_code.hpp
@@ -15,6 +15,12 @@ inline std::string return_code_to_string(SQLRETURN ret) {
       return "SQL_ERROR";
     case SQL_INVALID_HANDLE:
       return "SQL_INVALID_HANDLE";
+    case SQL_NO_DATA:
+      return "SQL_NO_DATA";
+    case SQL_NEED_DATA:
+      return "SQL_NEED_DATA";
+    case SQL_STILL_EXECUTING:
+      return "SQL_STILL_EXECUTING";
     default:
       return "UNKNOWN_RETURN_CODE(" + std::to_string(ret) + ")";
   }

--- a/odbc_tests/common/include/odbc_return_code.hpp
+++ b/odbc_tests/common/include/odbc_return_code.hpp
@@ -1,0 +1,23 @@
+#ifndef ODBC_RETURN_CODE_HPP
+#define ODBC_RETURN_CODE_HPP
+
+#include <sql.h>
+
+#include <string>
+
+inline std::string return_code_to_string(SQLRETURN ret) {
+  switch (ret) {
+    case SQL_SUCCESS:
+      return "SQL_SUCCESS";
+    case SQL_SUCCESS_WITH_INFO:
+      return "SQL_SUCCESS_WITH_INFO";
+    case SQL_ERROR:
+      return "SQL_ERROR";
+    case SQL_INVALID_HANDLE:
+      return "SQL_INVALID_HANDLE";
+    default:
+      return "UNKNOWN_RETURN_CODE(" + std::to_string(ret) + ")";
+  }
+}
+
+#endif  // ODBC_RETURN_CODE_HPP

--- a/odbc_tests/common/include/require.hpp
+++ b/odbc_tests/common/include/require.hpp
@@ -1,3 +1,6 @@
+#ifndef REQUIRE_HPP
+#define REQUIRE_HPP
+
 #include "HandleWrapper.hpp"
 #include "get_diag_rec.hpp"
 #include "macros.hpp"
@@ -13,3 +16,5 @@ inline std::vector<DiagRec> require_connection_failed(const std::string& connect
   REQUIRE(ret == SQL_ERROR);
   return get_diag_rec(dbc);
 }
+
+#endif  // REQUIRE_HPP

--- a/odbc_tests/common/include/require.hpp
+++ b/odbc_tests/common/include/require.hpp
@@ -1,10 +1,11 @@
 #include "HandleWrapper.hpp"
 #include "get_diag_rec.hpp"
+#include "macros.hpp"
 
 inline std::vector<DiagRec> require_connection_failed(const std::string& connection_string) {
   auto env = EnvironmentHandleWrapper();
   SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
-  CHECK_ODBC(ret, env);
+  REQUIRE_ODBC(ret, env);
 
   auto dbc = env.createConnectionHandle();
   ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,

--- a/odbc_tests/common/include/test_macros.hpp
+++ b/odbc_tests/common/include/test_macros.hpp
@@ -1,33 +1,8 @@
 #ifndef TEST_MACROS_HPP
 #define TEST_MACROS_HPP
 
-#include <sql.h>
-#include <sqlext.h>
+// Deprecated header file, include odbc_matchers.hpp instead
+// Will be removed in a future version.
+#include "odbc_matchers.hpp"
 
-#include <string>
-
-#include <catch2/catch_test_macros.hpp>
-
-// Helper macro to check for expected ODBC error with specific SQLSTATE
-#define REQUIRE_EXPECTED_ERROR(ret, expectedState, handle, handleType)                \
-  do {                                                                                \
-    REQUIRE(ret == SQL_ERROR);                                                        \
-    const auto __odbc_test_diag_records__ = get_diag_rec(handleType, handle);         \
-    REQUIRE(!__odbc_test_diag_records__.empty());                                     \
-    INFO("SQLSTATE: " << __odbc_test_diag_records__[0].sqlState                       \
-                      << ", Message: " << __odbc_test_diag_records__[0].messageText); \
-    REQUIRE(__odbc_test_diag_records__[0].sqlState == expectedState);                 \
-  } while (0)
-
-// Helper macro to check for expected ODBC warning (SQL_SUCCESS_WITH_INFO) with specific SQLSTATE
-#define REQUIRE_EXPECTED_WARNING(ret, expectedState, handle, handleType)              \
-  do {                                                                                \
-    REQUIRE(ret == SQL_SUCCESS_WITH_INFO);                                            \
-    const auto __odbc_test_diag_records__ = get_diag_rec(handleType, handle);         \
-    REQUIRE(!__odbc_test_diag_records__.empty());                                     \
-    INFO("SQLSTATE: " << __odbc_test_diag_records__[0].sqlState                       \
-                      << ", Message: " << __odbc_test_diag_records__[0].messageText); \
-    REQUIRE(__odbc_test_diag_records__[0].sqlState == expectedState);                 \
-  } while (0)
-
-#endif
+#endif  // TEST_MACROS_HPP

--- a/odbc_tests/tests/basic_tests/test.cpp
+++ b/odbc_tests/tests/basic_tests/test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Test SELECT 1", "[odbc]") {
   EnvironmentHandleWrapper env;
 
   SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
-  CHECK_ODBC(ret, env)
+  CHECK_ODBC(ret, env);
 
   // Get driver path from environment variable
   ConnectionHandleWrapper dbc = env.createConnectionHandle();

--- a/odbc_tests/tests/basic_tests/test.cpp
+++ b/odbc_tests/tests/basic_tests/test.cpp
@@ -42,5 +42,6 @@ TEST_CASE("Test SELECT 1", "[odbc]") {
     ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &result, sizeof(result), NULL);
     REQUIRE_ODBC(ret, stmt);
   }
-  SQLDisconnect(dbc.getHandle());
+  ret = SQLDisconnect(dbc.getHandle());
+  REQUIRE_ODBC(ret, dbc);
 }

--- a/odbc_tests/tests/basic_tests/test.cpp
+++ b/odbc_tests/tests/basic_tests/test.cpp
@@ -10,7 +10,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "HandleWrapper.hpp"
-#include "macros.hpp"
+#include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
 TEST_CASE("Test SELECT 1", "[odbc]") {
@@ -18,28 +19,28 @@ TEST_CASE("Test SELECT 1", "[odbc]") {
   EnvironmentHandleWrapper env;
 
   SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
-  CHECK_ODBC(ret, env);
+  REQUIRE_ODBC(ret, env);
 
   // Get driver path from environment variable
   ConnectionHandleWrapper dbc = env.createConnectionHandle();
-  ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,
+  ret = SQLDriverConnect(dbc.getHandle(), NULL, sqlchar(connection_string.c_str()), SQL_NTS, NULL, 0, NULL,
                          SQL_DRIVER_NOPROMPT);
-  CHECK_ODBC(ret, dbc);
+  REQUIRE_ODBC(ret, dbc);
   {
     StatementHandleWrapper stmt = dbc.createStatementHandle();
-    ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
-    CHECK_ODBC(ret, stmt);
+    ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+    REQUIRE_ODBC(ret, stmt);
 
     SQLSMALLINT num_cols;
     ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
-    CHECK_ODBC(ret, stmt);
+    REQUIRE_ODBC(ret, stmt);
 
     ret = SQLFetch(stmt.getHandle());
-    CHECK_ODBC(ret, stmt);
+    REQUIRE_ODBC(ret, stmt);
 
     SQLINTEGER result = 0;
     ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &result, sizeof(result), NULL);
-    CHECK_ODBC(ret, stmt);
+    REQUIRE_ODBC(ret, stmt);
   }
   SQLDisconnect(dbc.getHandle());
 }


### PR DESCRIPTION
Improves ODBC test assertions with Catch2-idiomatic matchers and adds Cursor IDE review rules.

**Changes:**

- New `odbc_matchers.hpp` with composable matchers (`Succeeded()`, `IsError()`, `HasSqlState()`)
- Replaces `CHECK_ODBC` → `REQUIRE_ODBC` (Catch2-idiomatic, better diagnostics with SQLSTATE/messages)
- Adds `.cursor/rules/` for automated ODBC test review and generation guidelines

**Benefits:**

- Composable assertions: `IsError() && HasSqlState("42000")`
- Systematic review checklist for ODBC spec compliance