### PR TITLE
SNOW-3243342 Implement JSON to Arrow conversion for binary, time and decfloat

### DIFF
--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1,10 +1,12 @@
 use crate::query_types::RowType;
 use arrow::array::{
-    Array, BooleanArray, Float64Array, Int8Array, Int32Array, Int64Array, StringArray,
+    Array, BinaryArray, BooleanArray, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    StringArray,
 };
 use arrow::datatypes::{DataType, Date32Type, Field, Int32Type, Int64Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
+use hex::FromHexError;
 use snafu::{Location, ResultExt, Snafu};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -145,6 +147,52 @@ pub fn create_field_with_type(
             };
             Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
         }
+        RowType::Time {
+            name,
+            nullable,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "TIME".to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            let data_type = if scale <= &4 {
+                data_type.unwrap_or(DataType::Int32)
+            } else {
+                data_type.unwrap_or(DataType::Int64)
+            };
+            Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
+        }
+        RowType::Binary {
+            name,
+            nullable,
+            length,
+            byte_length,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "BINARY".to_string());
+            metadata.insert("byteLength".to_string(), byte_length.to_string());
+            metadata.insert("charLength".to_string(), length.to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Binary), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
+        RowType::Decfloat { name, nullable } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "DECFLOAT".to_string());
+            let data_type = data_type.unwrap_or_else(|| {
+                DataType::Struct(
+                    vec![
+                        Field::new("exponent", DataType::Int16, false)
+                            .with_metadata(metadata.clone()),
+                        Field::new("significand", DataType::Binary, false)
+                            .with_metadata(metadata.clone()),
+                    ]
+                    .into(),
+                )
+            });
+            Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
+        }
     }
 }
 
@@ -187,6 +235,87 @@ fn parse_decimal_str(v: &str, scale: u32) -> Result<i128, ArrowUtilsError> {
 
     let unscaled = abs_int * 10i128.pow(scale) + frac_scaled;
     Ok(if negative { -unscaled } else { unscaled })
+}
+
+/// Parses a DECFLOAT string (decimal or scientific notation) into (exponent, mantissa_bytes).
+/// The mantissa is normalized by stripping trailing zeros, and the mantissa bytes are
+/// minimal big-endian two's complement.
+fn parse_decfloat_str(v: &str) -> Result<(i16, Vec<u8>), ArrowUtilsError> {
+    if v == "0" || v == "0.0" || v == "-0" || v == "-0.0" {
+        return Ok((0_i16, vec![0]));
+    }
+
+    // Parse into integer mantissa (i128) and exponent (i16).
+    // Handle scientific notation: "1.23e5" or "1.23E-5"
+    let lowered = v.to_lowercase();
+    let (coeff_str, exp_offset) = match lowered.split_once('e') {
+        Some((c, e)) => {
+            let exp: i16 = e.parse().context(DecfloatParsingSnafu {
+                value: v.to_string(),
+            })?;
+            (c, exp)
+        }
+        None => (v, 0_i16),
+    };
+
+    let negative = coeff_str.starts_with('-');
+    let abs_coeff = coeff_str.trim_start_matches('-');
+
+    // Split on decimal point
+    let (int_part, frac_part) = match abs_coeff.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (abs_coeff, ""),
+    };
+
+    // Combine into integer mantissa: "123.456" -> 123456, with implicit exponent = -3
+    let digits = format!("{int_part}{frac_part}");
+    let frac_len = frac_part.len() as i16;
+
+    let mut mantissa: i128 = digits.parse().context(DecfloatParsingSnafu {
+        value: v.to_string(),
+    })?;
+    let mut exponent: i16 = exp_offset - frac_len;
+
+    if negative {
+        mantissa = -mantissa;
+    }
+
+    // Strip trailing zeros from mantissa, adjust exponent (Snowflake normalization)
+    if mantissa != 0 {
+        while mantissa % 10 == 0 {
+            mantissa /= 10;
+            exponent += 1;
+        }
+    }
+
+    // Convert mantissa i128 to minimal big-endian two's complement bytes
+    let bytes = i128::to_be_bytes(mantissa);
+    let mantissa_bytes = minimal_twos_complement(&bytes);
+
+    Ok((exponent, mantissa_bytes))
+}
+
+/// Strips leading redundant bytes from a big-endian two's complement representation,
+/// keeping the sign bit intact.
+fn minimal_twos_complement(bytes: &[u8]) -> Vec<u8> {
+    if bytes.is_empty() {
+        return vec![0];
+    }
+
+    let is_negative = bytes[0] & 0x80 != 0;
+    let pad_byte: u8 = if is_negative { 0xFF } else { 0x00 };
+
+    let mut start = 0;
+    while start < bytes.len() - 1 && bytes[start] == pad_byte {
+        // Keep this byte if removing it would change the sign
+        let next_sign = bytes[start + 1] & 0x80 != 0;
+        if next_sign != is_negative {
+            break;
+        }
+        start += 1;
+    }
+
+    bytes[start..].to_vec()
 }
 
 /// Creates an Arrow array from column values and data type
@@ -466,6 +595,97 @@ fn create_column_array(
                 .fail(),
             }
         }
+        RowType::Time { scale, .. } => {
+            let field = create_field(row_type)?;
+            match field.data_type() {
+                DataType::Int32 => {
+                    let normalized: Result<Vec<i32>, ArrowUtilsError> = values
+                        .into_iter()
+                        .map(|v| {
+                            let (seconds_str, fraction_str) = v.split_once('.').unwrap_or((v, ""));
+                            let seconds: i32 =
+                                seconds_str.parse().context(IntegerParsingSnafu {
+                                    value: v.to_string(),
+                                })?;
+                            let fraction: i32 = if fraction_str.is_empty() {
+                                0
+                            } else {
+                                let filled =
+                                    format!("{:0<width$}", fraction_str, width = *scale as usize);
+                                filled.parse::<i32>().context(IntegerParsingSnafu {
+                                    value: v.to_string(),
+                                })?
+                            };
+                            Ok(seconds * 10i32.pow(*scale as u32) + fraction)
+                        })
+                        .collect();
+                    Ok((field, Arc::new(Int32Array::from(normalized?))))
+                }
+                DataType::Int64 => {
+                    let normalized: Result<Vec<i64>, ArrowUtilsError> = values
+                        .into_iter()
+                        .map(|v| {
+                            let scale1 = *scale;
+                            let (seconds_str, fraction_str) = v.split_once('.').unwrap_or((v, ""));
+                            let seconds: i64 =
+                                seconds_str.parse().context(IntegerParsingSnafu {
+                                    value: v.to_string(),
+                                })?;
+                            let fraction: i64 = if fraction_str.is_empty() {
+                                0
+                            } else {
+                                let filled =
+                                    format!("{:0<width$}", fraction_str, width = scale1 as usize);
+                                filled.parse::<i64>().context(IntegerParsingSnafu {
+                                    value: v.to_string(),
+                                })?
+                            };
+                            Ok(seconds * 10i64.pow(scale1 as u32) + fraction)
+                        })
+                        .collect();
+                    Ok((field, Arc::new(Int64Array::from(normalized?))))
+                }
+                _ => UnsupportedDataTypeSnafu {
+                    data_type: format!("{:?}", field.data_type()),
+                    row_type: "TIME".to_string(),
+                }
+                .fail(),
+            }
+        }
+        RowType::Binary { .. } => {
+            let binary_values: Result<Vec<Vec<u8>>, ArrowUtilsError> = values
+                .into_iter()
+                .map(|v| hex::decode(v).context(BinaryParsingSnafu {}))
+                .collect();
+            let binary_values = binary_values?;
+            let refs: Vec<&[u8]> = binary_values.iter().map(|v| v.as_slice()).collect();
+            Ok((create_field(row_type)?, Arc::new(BinaryArray::from(refs))))
+        }
+        RowType::Decfloat { .. } => {
+            let parsed: Result<Vec<(i16, Vec<u8>)>, ArrowUtilsError> =
+                values.into_iter().map(parse_decfloat_str).collect();
+            let parsed = parsed?;
+            let (exponents, mantissas): (Vec<i16>, Vec<Vec<u8>>) = parsed.into_iter().unzip();
+            let mantissa_refs: Vec<&[u8]> = mantissas.iter().map(|v| v.as_slice()).collect();
+
+            let field = create_field(row_type)?;
+            match field.data_type() {
+                DataType::Struct(fields) => {
+                    let exponent_array: Arc<dyn Array> = Arc::new(Int16Array::from(exponents));
+                    let mantissa_array: Arc<dyn Array> = Arc::new(BinaryArray::from(mantissa_refs));
+                    let values = vec![
+                        (fields[0].clone(), exponent_array),
+                        (fields[1].clone(), mantissa_array),
+                    ];
+                    Ok((field, Arc::new(arrow::array::StructArray::from(values))))
+                }
+                _ => UnsupportedDataTypeSnafu {
+                    data_type: format!("{:?}", field.data_type()),
+                    row_type: "DECFLOAT".to_string(),
+                }
+                .fail(),
+            }
+        }
     }
 }
 
@@ -536,9 +756,22 @@ pub enum ArrowUtilsError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Failed to parse decfloat value: {value}"))]
+    DecfloatParsing {
+        value: String,
+        source: std::num::ParseIntError,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Failed to parse boolean value: {value}"))]
     BooleanParsing {
         value: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse binary value"))]
+    BinaryParsing {
+        source: FromHexError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -38,6 +38,21 @@ pub enum RowType {
         nullable: bool,
         scale: u64,
     },
+    Time {
+        name: String,
+        nullable: bool,
+        scale: u64,
+    },
+    Binary {
+        name: String,
+        nullable: bool,
+        length: u64,
+        byte_length: u64,
+    },
+    Decfloat {
+        name: String,
+        nullable: bool,
+    },
 }
 
 impl RowType {
@@ -110,6 +125,30 @@ impl RowType {
             name: name.to_string(),
             nullable,
             scale,
+        }
+    }
+
+    pub fn time(name: &str, nullable: bool, scale: u64) -> Self {
+        RowType::Time {
+            name: name.to_string(),
+            nullable,
+            scale,
+        }
+    }
+
+    pub fn binary(name: &str, nullable: bool, length: u64, byte_length: u64) -> Self {
+        RowType::Binary {
+            name: name.to_string(),
+            nullable,
+            length,
+            byte_length,
+        }
+    }
+
+    pub fn decfloat(name: &str, nullable: bool) -> Self {
+        RowType::Decfloat {
+            name: name.to_string(),
+            nullable,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -585,6 +585,27 @@ impl TryFrom<&RowType> for query_types::RowType {
                 Ok(query_types::RowType::timestamp_tz(&name, nullable, scale))
             }
             "BOOLEAN" => Ok(query_types::RowType::boolean(&name, nullable)),
+            "TIME" => {
+                let scale = value.scale.unwrap_or(9);
+                Ok(query_types::RowType::time(&name, nullable, scale))
+            }
+            "BINARY" => {
+                let length = value.length.context(MissingParameterSnafu {
+                    parameter: format!("row type -> length for BINARY column '{name}'"),
+                })?;
+
+                let byte_length = value.byte_length.context(MissingParameterSnafu {
+                    parameter: format!("row type -> byte length for BINARY column '{name}'"),
+                })?;
+
+                Ok(query_types::RowType::binary(
+                    &name,
+                    nullable,
+                    length,
+                    byte_length,
+                ))
+            }
+            "DECFLOAT" => Ok(query_types::RowType::decfloat(&name, nullable)),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
             }

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -132,6 +132,15 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
             "precision",
             "physicalType",
         ],
+        "TIME" => &[
+            "finalType",
+            "charLength",
+            "byteLength",
+            "precision",
+            "physicalType",
+        ],
+        "BINARY" => &["finalType", "precision", "scale", "physicalType"],
+        "DECFLOAT" => &["finalType", "precision", "scale", "physicalType"],
         _ => &[],
     }
 }
@@ -183,27 +192,27 @@ fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
             .collect()
     };
 
-    let arrow_meta: BTreeMap<String, String> = left
+    let left_meta: BTreeMap<String, String> = left
         .metadata()
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    let json_meta: BTreeMap<String, String> = right
+    let right_meta: BTreeMap<String, String> = right
         .metadata()
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
 
-    let filtered_arrow = filter_metadata(&arrow_meta);
-    let filtered_json = filter_metadata(&json_meta);
+    let filtered_left_meta = filter_metadata(&left_meta);
+    let filtered_right_meta = filter_metadata(&right_meta);
 
     assert_eq!(
-        filtered_arrow,
-        filtered_json,
+        filtered_left_meta,
+        filtered_right_meta,
         "Metadata mismatch for field '{}'\n  left: {:?}\n  right:  {:?}",
         left.name(),
-        filtered_arrow,
-        filtered_json
+        filtered_left_meta,
+        filtered_right_meta
     );
     match (left.data_type(), right.data_type()) {
         (DataType::Struct(left_fields), DataType::Struct(right_fields)) => {

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -57,6 +57,72 @@ fn should_return_timestamp_tz_as_arrow_even_if_json_result_set_is_returned() {
     )
 }
 
+#[test]
+fn should_return_time_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_time (t0 TIME(0),\
+            t1 TIME(1), t2 TIME(2), t3 TIME(3), t4 TIME(4), t5 TIME(5), t6 TIME(6), t7 TIME(7), t8 TIME(8), t9 TIME(9),\
+            t1a TIME(1), t2a TIME(2), t3a TIME(3), t4a TIME(4), t5a TIME(5), t6a TIME(6), t7a TIME(7), t8a TIME(8), t9a TIME(9))",
+        "INSERT INTO json_result_set_time VALUES ('10:10:10',\
+            '11:11:11.1', '12:12:12.12', '13:13:13.123', '14:14:14.1234', '15:15:15.12345', '16:16:16.123456', '17:17:17.1234567', '18:18:18.12345678', '19:19:19.123456789',\
+            '11:11:11', '12:12:12', '13:13:13', '14:14:14', '15:15:15', '16:16:16', '17:17:17', '18:18:18', '19:19:19')",
+        "SELECT * FROM json_result_set_time",
+    )
+}
+
+#[test]
+fn should_return_binary_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_binary (b BINARY)",
+        "INSERT INTO json_result_set_binary VALUES (TO_BINARY('hello', 'UTF-8'))",
+        "SELECT * FROM json_result_set_binary",
+    )
+}
+
+#[test]
+fn should_return_decfloat_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_decfloat (\
+            d_zero DECFLOAT,\
+            d_pos DECFLOAT,\
+            d_neg DECFLOAT,\
+            d_pos_frac DECFLOAT,\
+            d_neg_frac DECFLOAT,\
+            d_large_pos_exp DECFLOAT,\
+            d_large_neg_exp DECFLOAT,\
+            d_tiny_pos DECFLOAT,\
+            d_tiny_neg DECFLOAT,\
+            d_max_precision DECFLOAT, d_neg_max_precision DECFLOAT,\
+            d_max_exp DECFLOAT,\
+            d_min_exp DECFLOAT,\
+            d_neg_large_exp DECFLOAT,\
+            d_pos_large_exp DECFLOAT,\
+            d_one DECFLOAT,\
+            d_neg_one DECFLOAT,\
+            d_integer DECFLOAT)",
+        "INSERT INTO json_result_set_decfloat SELECT \
+            0::DECFLOAT, \
+            123.456::DECFLOAT, \
+            '-789.012'::DECFLOAT, \
+            1.5::DECFLOAT, \
+            '-1.5'::DECFLOAT, \
+            1.23E+20::DECFLOAT, \
+            '-9.87E-15'::DECFLOAT, \
+            1E-16383::DECFLOAT, \
+            '-1E-16383'::DECFLOAT,
+            12345678901234567890123456789012345678::DECFLOAT, \
+            '-12345678901234567890123456789012345678'::DECFLOAT, \
+            '1E+16384'::DECFLOAT, \
+            '1E-16383'::DECFLOAT, \
+            '-1.234E+8000'::DECFLOAT, \
+            '9.876E-8000'::DECFLOAT, \
+            1::DECFLOAT, \
+            (-1)::DECFLOAT, \
+            42::DECFLOAT",
+        "SELECT * FROM json_result_set_decfloat",
+    )
+}
+
 fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, select_query: &str) {
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();


### PR DESCRIPTION
### TL;DR

Added support for TIME, BINARY, and DECFLOAT data types in Arrow conversion utilities.

### What changed?

- Added three new data types to the `RowType` enum: `Time`, `Binary`, and `Decfloat`
- Implemented Arrow field creation logic for these new types with appropriate metadata
- Added parsing functions for TIME values (handling fractional seconds based on scale), BINARY values (hex decoding), and DECFLOAT values (parsing decimal/scientific notation into exponent and mantissa components)
- Created array conversion logic that maps TIME to Int32/Int64 arrays based on scale, BINARY to BinaryArray, and DECFLOAT to StructArray with exponent and significand fields
- Added corresponding constructor methods and error handling for binary parsing
- Updated test helpers to handle metadata filtering for the new data types
- Added integration tests verifying Arrow and JSON result set compatibility for all three new types