### PR TITLE
SNOW-2872400 Add MFA authentication support to Python wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ old_odbc_cloned/
 old_coverage.txt
 weekly_report/
 
+# Local directory for AI prompts / inputs
+.ai/plans
+
 # Python/Cython build artifacts
 python/src/snowflake/connector/_internal/nanoarrow_cpp/ArrowIterator/arrow_stream_iterator.cpp
 python/src/snowflake/connector/_internal/*.so

--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -43,3 +43,11 @@ behavior_differences:
     description: |
       NEW driver: cursor session parameters (e.g. cursor.timestamp_output_format) read from a shared connection-level cache, so changes made by one cursor are immediately visible to other cursors on the same connection without requiring a query.
       OLD driver: Each cursor populates its session parameters independently from query responses, so a cursor that has not executed a query will not reflect changes made by another cursor.
+
+  16:
+    name: "MFA token caching parameter renamed"
+    description: |
+      NEW driver: `client_store_temporary_credential` enables MFA token caching. The legacy name
+        `client_request_mfa_token` is also accepted as a backward-compatible alias and is silently
+        mapped to `client_store_temporary_credential`.
+      OLD driver: `client_request_mfa_token` enables MFA token caching.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -191,7 +191,7 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
 [[tool.mypy.overrides]]
-module = ["pyarrow", "pyarrow.*", "pandas", "pandas.*"]
+module = ["pyarrow", "pyarrow.*", "pandas", "pandas.*", "sqlalchemy", "sqlalchemy.*"]
 ignore_missing_imports = true
 
 # ===== Hatch Configuration =====

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -43,7 +43,7 @@ from .telemetry import TelemetryClient
 logger = logging.getLogger(__name__)
 
 SessionParameters = dict[str, Any]
-ConnectionParamValue = Union[int, str, float, bytes, SessionParameters]
+ConnectionParamValue = Union[int, str, float, bytes, bool, SessionParameters]
 ConnectionParameters = dict[str, ConnectionParamValue]
 
 
@@ -71,17 +71,26 @@ class Connection:
             private_key: Private key in bytes, str (base64), or RSAPrivateKey format
             session_parameters: Optional dict of session parameters to set at connection time
             authenticator: Authentication method. Use ``"USERNAME_PASSWORD_MFA"`` for MFA authentication.
-            passcode: MFA passcode (TOTP one-time code from an authenticator app). Used when
-                ``authenticator="USERNAME_PASSWORD_MFA"`` and ``ext_authn_duo_method="passcode"``.
+            passcode: MFA passcode (TOTP one-time code from an authenticator app). When provided
+                with ``authenticator="USERNAME_PASSWORD_MFA"``, the driver automatically uses the
+                Duo passcode flow; you do not need to set ``ext_authn_duo_method="passcode"``
+                explicitly.
             passcode_in_password: If ``True``, the MFA passcode is appended to the password field
-                rather than sent separately. Default ``False``.
+                rather than sent separately. This is treated the same as supplying ``passcode``
+                directly and will automatically select the Duo passcode flow. Default ``False``.
             client_store_temporary_credential: If ``True``, a successfully obtained MFA token is
                 cached in the OS keyring and reused for subsequent connections, avoiding repeated
-                MFA prompts. Default ``False``. The server must have
-                ``ALLOW_CLIENT_MFA_CACHING`` enabled. This also implicitly requests an MFA token
-                from the server (``CLIENT_REQUEST_MFA_TOKEN``).
-            ext_authn_duo_method: DUO Security authentication method. Either ``"push"`` (send a
-                push notification to the registered device) or ``"passcode"`` (use a TOTP code).
+                MFA prompts. Default ``False``. The server must have ``ALLOW_CLIENT_MFA_CACHING``
+                enabled. This also implicitly requests an MFA token from the server
+                (``CLIENT_REQUEST_MFA_TOKEN``).
+            client_request_mfa_token: Deprecated alias for ``client_store_temporary_credential``
+                from ``snowflake-connector-python``. Accepted for backward compatibility; prefer
+                ``client_store_temporary_credential`` in new code.
+            ext_authn_duo_method: DUO Security authentication method applied when no explicit
+                passcode is provided and no cached MFA token is available. Either ``"push"``
+                (send a push notification to the registered device) or ``"passcode"`` (prompt
+                for or use a TOTP code). When a ``passcode`` is supplied directly this parameter
+                is ignored because the passcode flow is selected automatically.
             **kwargs: Additional connection parameters
         """
         # paramstyle
@@ -147,7 +156,7 @@ class Connection:
             )
 
         self.db_api.connection_init(ConnectionInitRequest(conn_handle=self.conn_handle, db_handle=self.db_handle))
-        _sensitive_keys = {"password", "private_key", "passcode"}
+        _sensitive_keys = {"password", "private_key", "passcode", "private_key_password", "private_key_file_pwd"}
         self.kwargs = {k: ("***" if k in _sensitive_keys else v) for k, v in kwargs.items()}
         self._closed = False
         self._messages: list[tuple[type[Exception], dict[str, str | bool]]] = []
@@ -374,11 +383,29 @@ class Connection:
             kwargs = {**kwargs, "private_key_password": private_key_file_pwd}
         return kwargs
 
+    @backward_compatibility
     def _rewrite_mfa_params(self, kwargs: ConnectionParameters) -> ConnectionParameters:
-        """Translate Python-style MFA parameter names to the keys expected by the Rust core."""
+        """Translate Python-style MFA parameter names to the keys expected by the Rust core.
+
+        Handles two rewrite rules:
+
+        * ``passcode_in_password`` → ``passcodeInPassword`` (camelCase key required by Rust core).
+        * ``client_request_mfa_token`` → ``client_store_temporary_credential`` for compatibility
+          with ``snowflake-connector-python``, which used the former name for MFA token caching.
+          If both are supplied, ``client_store_temporary_credential`` takes precedence and the
+          legacy key is discarded.
+        """
         passcode_in_password = kwargs.pop("passcode_in_password", None)
         if passcode_in_password is not None:
             kwargs = {**kwargs, "passcodeInPassword": passcode_in_password}
+
+        # client_request_mfa_token is the legacy snowflake-connector-python name for MFA token
+        # caching.  Map it to the canonical key so callers migrating from the old driver do not
+        # need to update their code.
+        legacy_token_cache = kwargs.pop("client_request_mfa_token", None)
+        if legacy_token_cache is not None and "client_store_temporary_credential" not in kwargs:
+            kwargs = {**kwargs, "client_store_temporary_credential": legacy_token_cache}
+
         return kwargs
 
     @property

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -70,6 +70,18 @@ class Connection:
             port: Port number
             private_key: Private key in bytes, str (base64), or RSAPrivateKey format
             session_parameters: Optional dict of session parameters to set at connection time
+            authenticator: Authentication method. Use ``"USERNAME_PASSWORD_MFA"`` for MFA authentication.
+            passcode: MFA passcode (TOTP one-time code from an authenticator app). Used when
+                ``authenticator="USERNAME_PASSWORD_MFA"`` and ``ext_authn_duo_method="passcode"``.
+            passcode_in_password: If ``True``, the MFA passcode is appended to the password field
+                rather than sent separately. Default ``False``.
+            client_store_temporary_credential: If ``True``, a successfully obtained MFA token is
+                cached in the OS keyring and reused for subsequent connections, avoiding repeated
+                MFA prompts. Default ``False``. The server must have
+                ``ALLOW_CLIENT_MFA_CACHING`` enabled. This also implicitly requests an MFA token
+                from the server (``CLIENT_REQUEST_MFA_TOKEN``).
+            ext_authn_duo_method: DUO Security authentication method. Either ``"push"`` (send a
+                push notification to the registered device) or ``"passcode"`` (use a TOTP code).
             **kwargs: Additional connection parameters
         """
         # paramstyle
@@ -78,6 +90,7 @@ class Connection:
         self._paramstyle = ParamStyle.from_string(paramstyle or default_paramstyle)
 
         kwargs = self._rewrite_private_key_password(kwargs)
+        kwargs = self._rewrite_mfa_params(kwargs)
 
         self.db_api = database_driver_client()
         self.db_handle = self.db_api.database_new(DatabaseNewRequest()).db_handle
@@ -134,7 +147,7 @@ class Connection:
             )
 
         self.db_api.connection_init(ConnectionInitRequest(conn_handle=self.conn_handle, db_handle=self.db_handle))
-        _sensitive_keys = {"password", "private_key"}
+        _sensitive_keys = {"password", "private_key", "passcode"}
         self.kwargs = {k: ("***" if k in _sensitive_keys else v) for k, v in kwargs.items()}
         self._closed = False
         self._messages: list[tuple[type[Exception], dict[str, str | bool]]] = []
@@ -359,6 +372,13 @@ class Connection:
         private_key_file_pwd = kwargs.pop("private_key_file_pwd", None)
         if private_key_file_pwd is not None:
             kwargs = {**kwargs, "private_key_password": private_key_file_pwd}
+        return kwargs
+
+    def _rewrite_mfa_params(self, kwargs: ConnectionParameters) -> ConnectionParameters:
+        """Translate Python-style MFA parameter names to the keys expected by the Rust core."""
+        passcode_in_password = kwargs.pop("passcode_in_password", None)
+        if passcode_in_password is not None:
+            kwargs = {**kwargs, "passcodeInPassword": passcode_in_password}
         return kwargs
 
     @property

--- a/python/tests/config.py
+++ b/python/tests/config.py
@@ -39,5 +39,8 @@ def get_test_parameters() -> dict[str, Any]:
         "SNOWFLAKE_TEST_PRIVATE_KEY_FILE",
         "SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS",
         "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD",
+        "SNOWFLAKE_TEST_MFA_USER",
+        "SNOWFLAKE_TEST_MFA_PASSWORD",
+        "SNOWFLAKE_TEST_MFA_PASSCODE",
     ]
     return {k: os.environ.get(k) for k in env_vars}

--- a/python/tests/config.py
+++ b/python/tests/config.py
@@ -20,7 +20,16 @@ def get_test_parameters() -> dict[str, Any]:
     if parameter_path and os.path.exists(parameter_path):
         with open(parameter_path) as f:
             parameters = json.load(f)
-            return parameters.get("testconnection", {})
+        params = parameters.get("testconnection", {})
+        # MFA credentials are not typically present in parameters.json (they belong to a
+        # separate MFA-enabled account user).  Always overlay from env vars so that MFA
+        # E2E tests can run in any environment regardless of whether parameters.json exists.
+        mfa_env_vars = ["SNOWFLAKE_TEST_MFA_USER", "SNOWFLAKE_TEST_MFA_PASSWORD", "SNOWFLAKE_TEST_MFA_PASSCODE"]
+        for key in mfa_env_vars:
+            env_val = os.environ.get(key)
+            if env_val is not None:
+                params[key] = env_val
+        return params
 
     # Fallback to default test parameters (for local testing)
     env_vars = [

--- a/python/tests/e2e/authentication/test_user_password_mfa.py
+++ b/python/tests/e2e/authentication/test_user_password_mfa.py
@@ -1,0 +1,181 @@
+import pytest
+
+from ...compatibility import NEW_DRIVER_ONLY
+from ...config import get_test_parameters
+from .auth_helpers import verify_simple_query_execution
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mfa_params():
+    """
+    Read MFA-specific test parameters from the environment / parameters.json.
+
+    Required keys:
+        SNOWFLAKE_TEST_MFA_USER      – account user that has MFA enabled
+        SNOWFLAKE_TEST_MFA_PASSWORD  – password for that user
+
+    Optional keys:
+        SNOWFLAKE_TEST_MFA_PASSCODE  – current TOTP code (needed for passcode-based tests)
+    """
+    params = get_test_parameters()
+    user = params.get("SNOWFLAKE_TEST_MFA_USER")
+    password = params.get("SNOWFLAKE_TEST_MFA_PASSWORD")
+
+    if not user or not password:
+        pytest.skip("MFA test credentials not configured. Set SNOWFLAKE_TEST_MFA_USER and SNOWFLAKE_TEST_MFA_PASSWORD.")
+
+    return {
+        "user": user,
+        "password": password,
+        "passcode": params.get("SNOWFLAKE_TEST_MFA_PASSCODE"),
+    }
+
+
+@pytest.fixture(scope="module")
+def mfa_passcode(mfa_params):
+    """Skip the test when no TOTP passcode is available."""
+    passcode = mfa_params["passcode"]
+    if not passcode:
+        pytest.skip("No MFA passcode configured. Set SNOWFLAKE_TEST_MFA_PASSCODE.")
+    return passcode
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUserPasswordMfaAuthentication:
+    # ------------------------------------------------------------------
+    # Passcode flow
+    # ------------------------------------------------------------------
+
+    def test_should_authenticate_with_explicit_passcode(self, connection_factory, mfa_params, mfa_passcode):
+        # Given Authentication is set to USERNAME_PASSWORD_MFA and a TOTP passcode is provided
+        connection = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=mfa_params["password"],
+            passcode=mfa_passcode,
+        )
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    def test_should_authenticate_with_passcode_in_password(self, connection_factory, mfa_params, mfa_passcode):
+        # Given Authentication is set to USERNAME_PASSWORD_MFA and the passcode is appended to the password
+        combined_password = mfa_params["password"] + mfa_passcode
+
+        connection = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=combined_password,
+            passcode_in_password=True,
+        )
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    # ------------------------------------------------------------------
+    # Token caching flow
+    # ------------------------------------------------------------------
+
+    @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA1"), reason="Token caching only supported in new driver")
+    def test_should_cache_mfa_token_on_first_connection(self, connection_factory, mfa_params, mfa_passcode):
+        # Given caching flags are enabled and a valid passcode is provided
+        connection = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=mfa_params["password"],
+            passcode=mfa_passcode,
+            client_store_temporary_credential=True,
+        )
+
+        # Then Login is successful – the server issues an MFA token that the driver caches
+        with connection:
+            verify_simple_query_execution(connection)
+
+    @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA2"), reason="Token caching only supported in new driver")
+    def test_should_reuse_cached_mfa_token_without_passcode(self, connection_factory, mfa_params, mfa_passcode):
+        # Given the first connection has already cached an MFA token (see test above)
+        # Establish first connection to warm the cache
+        first = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=mfa_params["password"],
+            passcode=mfa_passcode,
+            client_store_temporary_credential=True,
+        )
+        with first:
+            verify_simple_query_execution(first)
+
+        # When a second connection is made without a passcode
+        second = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=mfa_params["password"],
+            client_store_temporary_credential=True,
+        )
+
+        # Then the cached token is used and login succeeds without prompting for MFA
+        with second:
+            verify_simple_query_execution(second)
+
+    # ------------------------------------------------------------------
+    # DUO push flow
+    # ------------------------------------------------------------------
+
+    @pytest.mark.skip(reason="DUO push requires interactive device approval – run manually")
+    def test_should_authenticate_with_duo_push(self, connection_factory, mfa_params):
+        # Given DUO push is configured as the MFA method
+        connection = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=mfa_params["user"],
+            password=mfa_params["password"],
+            ext_authn_duo_method="push",
+        )
+
+        # Then (after approving the push on the registered device) login succeeds
+        with connection:
+            verify_simple_query_execution(connection)
+
+    # ------------------------------------------------------------------
+    # Error cases
+    # ------------------------------------------------------------------
+
+    def test_should_fail_with_invalid_passcode(self, connection_factory, mfa_params):
+        # Given an incorrect TOTP passcode is provided
+        with pytest.raises(Exception) as exc_info:
+            connection_factory(
+                authenticator="USERNAME_PASSWORD_MFA",
+                user=mfa_params["user"],
+                password=mfa_params["password"],
+                passcode="000000",
+            )
+
+        # Then a DatabaseError is raised
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
+
+    def test_should_fail_with_invalid_password(self, connection_factory, mfa_params, mfa_passcode):
+        # Given the password is wrong
+        with pytest.raises(Exception) as exc_info:
+            connection_factory(
+                authenticator="USERNAME_PASSWORD_MFA",
+                user=mfa_params["user"],
+                password="wrong_password",
+                passcode=mfa_passcode,
+            )
+
+        # Then a DatabaseError is raised
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"

--- a/python/tests/e2e/authentication/test_user_password_mfa.py
+++ b/python/tests/e2e/authentication/test_user_password_mfa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ...compatibility import NEW_DRIVER_ONLY
+from ...compatibility import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 from ...config import get_test_parameters
 from .auth_helpers import verify_simple_query_execution
 
@@ -92,11 +92,18 @@ class TestUserPasswordMfaAuthentication:
     # Token caching flow
     # ------------------------------------------------------------------
 
-    @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA1"), reason="Token caching only supported in new driver")
     def test_should_cache_mfa_token_on_first_connection(self, connection_factory, mfa_params, mfa_passcode):
         # Given Authentication is set to username_password_mfa with client_store_temporary_credential enabled
         user = mfa_params["user"]
         password = mfa_params["password"]
+
+        # BD#16: The old driver uses client_request_mfa_token to enable MFA token caching;
+        # the new driver renamed this parameter to client_store_temporary_credential.
+        # The new driver also accepts client_request_mfa_token as a backward-compatible alias.
+        if OLD_DRIVER_ONLY("BD#16"):
+            extra = {"client_request_mfa_token": True}
+        elif NEW_DRIVER_ONLY("BD#16"):
+            extra = {"client_store_temporary_credential": True}
 
         # When Trying to Connect
         connection = connection_factory(
@@ -104,22 +111,32 @@ class TestUserPasswordMfaAuthentication:
             user=user,
             password=password,
             passcode=mfa_passcode,
-            client_store_temporary_credential=True,
+            **extra,
         )
 
         # Then Login is successful and simple query can be executed
         with connection:
             verify_simple_query_execution(connection)
 
-    @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA2"), reason="Token caching only supported in new driver")
     def test_should_reuse_cached_mfa_token_without_passcode(self, connection_factory, mfa_params, mfa_passcode):
         # Given Authentication is set to username_password_mfa and MFA token has been cached from a previous connection
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # BD#16: The old driver uses client_request_mfa_token to enable MFA token caching;
+        # the new driver renamed this parameter to client_store_temporary_credential.
+        # The new driver also accepts client_request_mfa_token as a backward-compatible alias.
+        if OLD_DRIVER_ONLY("BD#16"):
+            extra = {"client_request_mfa_token": True}
+        elif NEW_DRIVER_ONLY("BD#16"):
+            extra = {"client_store_temporary_credential": True}
+
         first = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
-            user=mfa_params["user"],
-            password=mfa_params["password"],
+            user=user,
+            password=password,
             passcode=mfa_passcode,
-            client_store_temporary_credential=True,
+            **extra,
         )
         with first:
             verify_simple_query_execution(first)
@@ -127,9 +144,9 @@ class TestUserPasswordMfaAuthentication:
         # When Trying to Connect without passcode
         second = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
-            user=mfa_params["user"],
-            password=mfa_params["password"],
-            client_store_temporary_credential=True,
+            user=user,
+            password=password,
+            **extra,
         )
 
         # Then Login is successful and simple query can be executed
@@ -173,7 +190,7 @@ class TestUserPasswordMfaAuthentication:
                 authenticator="USERNAME_PASSWORD_MFA",
                 user=user,
                 password=password,
-                passcode="000000",
+                passcode="invalid_passcode",
             )
 
         # Then There is error returned

--- a/python/tests/e2e/authentication/test_user_password_mfa.py
+++ b/python/tests/e2e/authentication/test_user_password_mfa.py
@@ -56,22 +56,27 @@ class TestUserPasswordMfaAuthentication:
     # ------------------------------------------------------------------
 
     def test_should_authenticate_with_explicit_passcode(self, connection_factory, mfa_params, mfa_passcode):
-        # Given Authentication is set to USERNAME_PASSWORD_MFA and a TOTP passcode is provided
+        # Given Authentication is set to username_password_mfa and user, password and passcode are provided
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # When Trying to Connect
         connection = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
-            user=mfa_params["user"],
-            password=mfa_params["password"],
+            user=user,
+            password=password,
             passcode=mfa_passcode,
         )
 
-        # Then Login is successful and a simple query can be executed
+        # Then Login is successful and simple query can be executed
         with connection:
             verify_simple_query_execution(connection)
 
     def test_should_authenticate_with_passcode_in_password(self, connection_factory, mfa_params, mfa_passcode):
-        # Given Authentication is set to USERNAME_PASSWORD_MFA and the passcode is appended to the password
+        # Given Authentication is set to username_password_mfa with appended passcode and passcodeInPassword is set
         combined_password = mfa_params["password"] + mfa_passcode
 
+        # When Trying to Connect
         connection = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
             user=mfa_params["user"],
@@ -79,7 +84,7 @@ class TestUserPasswordMfaAuthentication:
             passcode_in_password=True,
         )
 
-        # Then Login is successful and a simple query can be executed
+        # Then Login is successful and simple query can be executed
         with connection:
             verify_simple_query_execution(connection)
 
@@ -89,23 +94,26 @@ class TestUserPasswordMfaAuthentication:
 
     @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA1"), reason="Token caching only supported in new driver")
     def test_should_cache_mfa_token_on_first_connection(self, connection_factory, mfa_params, mfa_passcode):
-        # Given caching flags are enabled and a valid passcode is provided
+        # Given Authentication is set to username_password_mfa with client_store_temporary_credential enabled
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # When Trying to Connect
         connection = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
-            user=mfa_params["user"],
-            password=mfa_params["password"],
+            user=user,
+            password=password,
             passcode=mfa_passcode,
             client_store_temporary_credential=True,
         )
 
-        # Then Login is successful – the server issues an MFA token that the driver caches
+        # Then Login is successful and simple query can be executed
         with connection:
             verify_simple_query_execution(connection)
 
     @pytest.mark.skipif(not NEW_DRIVER_ONLY("BD#MFA2"), reason="Token caching only supported in new driver")
     def test_should_reuse_cached_mfa_token_without_passcode(self, connection_factory, mfa_params, mfa_passcode):
-        # Given the first connection has already cached an MFA token (see test above)
-        # Establish first connection to warm the cache
+        # Given Authentication is set to username_password_mfa and MFA token has been cached from a previous connection
         first = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
             user=mfa_params["user"],
@@ -116,7 +124,7 @@ class TestUserPasswordMfaAuthentication:
         with first:
             verify_simple_query_execution(first)
 
-        # When a second connection is made without a passcode
+        # When Trying to Connect without passcode
         second = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
             user=mfa_params["user"],
@@ -124,7 +132,7 @@ class TestUserPasswordMfaAuthentication:
             client_store_temporary_credential=True,
         )
 
-        # Then the cached token is used and login succeeds without prompting for MFA
+        # Then Login is successful and simple query can be executed
         with second:
             verify_simple_query_execution(second)
 
@@ -134,15 +142,19 @@ class TestUserPasswordMfaAuthentication:
 
     @pytest.mark.skip(reason="DUO push requires interactive device approval – run manually")
     def test_should_authenticate_with_duo_push(self, connection_factory, mfa_params):
-        # Given DUO push is configured as the MFA method
+        # Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # When Trying to Connect
         connection = connection_factory(
             authenticator="USERNAME_PASSWORD_MFA",
-            user=mfa_params["user"],
-            password=mfa_params["password"],
+            user=user,
+            password=password,
             ext_authn_duo_method="push",
         )
 
-        # Then (after approving the push on the registered device) login succeeds
+        # Then Login is successful and simple query can be executed
         with connection:
             verify_simple_query_execution(connection)
 
@@ -151,31 +163,38 @@ class TestUserPasswordMfaAuthentication:
     # ------------------------------------------------------------------
 
     def test_should_fail_with_invalid_passcode(self, connection_factory, mfa_params):
-        # Given an incorrect TOTP passcode is provided
+        # Given Authentication is set to username_password_mfa and user, password are provided but passcode is invalid
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # When Trying to Connect
         with pytest.raises(Exception) as exc_info:
             connection_factory(
                 authenticator="USERNAME_PASSWORD_MFA",
-                user=mfa_params["user"],
-                password=mfa_params["password"],
+                user=user,
+                password=password,
                 passcode="000000",
             )
 
-        # Then a DatabaseError is raised
+        # Then There is error returned
         from snowflake.connector.errors import DatabaseError
 
         assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
 
     def test_should_fail_with_invalid_password(self, connection_factory, mfa_params, mfa_passcode):
-        # Given the password is wrong
+        # Given Authentication is set to username_password_mfa and user is provided but password is wrong
+        user = mfa_params["user"]
+
+        # When Trying to Connect
         with pytest.raises(Exception) as exc_info:
             connection_factory(
                 authenticator="USERNAME_PASSWORD_MFA",
-                user=mfa_params["user"],
+                user=user,
                 password="wrong_password",
                 passcode=mfa_passcode,
             )
 
-        # Then a DatabaseError is raised
+        # Then There is error returned
         from snowflake.connector.errors import DatabaseError
 
         assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"

--- a/python/tests/e2e/authentication/test_user_password_mfa.py
+++ b/python/tests/e2e/authentication/test_user_password_mfa.py
@@ -77,7 +77,8 @@ class TestUserPasswordMfaAuthentication:
     def test_should_authenticate_using_username_password_with_appended_totp_passcode(
         self, connection_factory, mfa_params, mfa_passcode
     ):
-        # Given Authentication is set to username_password_mfa and user, password with appended passcode are provided and passcodeInPassword is set
+        # Given Authentication is set to username_password_mfa and user, password with appended
+        # passcode are provided and passcodeInPassword is set
         combined_password = mfa_params["password"] + mfa_passcode
 
         # When Trying to Connect

--- a/python/tests/e2e/authentication/test_user_password_mfa.py
+++ b/python/tests/e2e/authentication/test_user_password_mfa.py
@@ -55,7 +55,9 @@ class TestUserPasswordMfaAuthentication:
     # Passcode flow
     # ------------------------------------------------------------------
 
-    def test_should_authenticate_with_explicit_passcode(self, connection_factory, mfa_params, mfa_passcode):
+    def test_should_authenticate_using_username_password_and_totp_passcode(
+        self, connection_factory, mfa_params, mfa_passcode
+    ):
         # Given Authentication is set to username_password_mfa and user, password and passcode are provided
         user = mfa_params["user"]
         password = mfa_params["password"]
@@ -72,8 +74,10 @@ class TestUserPasswordMfaAuthentication:
         with connection:
             verify_simple_query_execution(connection)
 
-    def test_should_authenticate_with_passcode_in_password(self, connection_factory, mfa_params, mfa_passcode):
-        # Given Authentication is set to username_password_mfa with appended passcode and passcodeInPassword is set
+    def test_should_authenticate_using_username_password_with_appended_totp_passcode(
+        self, connection_factory, mfa_params, mfa_passcode
+    ):
+        # Given Authentication is set to username_password_mfa and user, password with appended passcode are provided and passcodeInPassword is set
         combined_password = mfa_params["password"] + mfa_passcode
 
         # When Trying to Connect
@@ -154,52 +158,13 @@ class TestUserPasswordMfaAuthentication:
             verify_simple_query_execution(second)
 
     # ------------------------------------------------------------------
-    # DUO push flow
-    # ------------------------------------------------------------------
-
-    @pytest.mark.skip(reason="DUO push requires interactive device approval – run manually")
-    def test_should_authenticate_with_duo_push(self, connection_factory, mfa_params):
-        # Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
-        user = mfa_params["user"]
-        password = mfa_params["password"]
-
-        # When Trying to Connect
-        connection = connection_factory(
-            authenticator="USERNAME_PASSWORD_MFA",
-            user=user,
-            password=password,
-            ext_authn_duo_method="push",
-        )
-
-        # Then Login is successful and simple query can be executed
-        with connection:
-            verify_simple_query_execution(connection)
-
-    # ------------------------------------------------------------------
     # Error cases
     # ------------------------------------------------------------------
 
-    def test_should_fail_with_invalid_passcode(self, connection_factory, mfa_params):
-        # Given Authentication is set to username_password_mfa and user, password are provided but passcode is invalid
-        user = mfa_params["user"]
-        password = mfa_params["password"]
-
-        # When Trying to Connect
-        with pytest.raises(Exception) as exc_info:
-            connection_factory(
-                authenticator="USERNAME_PASSWORD_MFA",
-                user=user,
-                password=password,
-                passcode="invalid_passcode",
-            )
-
-        # Then There is error returned
-        from snowflake.connector.errors import DatabaseError
-
-        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
-
-    def test_should_fail_with_invalid_password(self, connection_factory, mfa_params, mfa_passcode):
-        # Given Authentication is set to username_password_mfa and user is provided but password is wrong
+    def test_should_fail_authentication_when_wrong_password_is_provided(
+        self, connection_factory, mfa_params, mfa_passcode
+    ):
+        # Given Authentication is set to username_password_mfa and user is provided but password is skipped or invalid
         user = mfa_params["user"]
 
         # When Trying to Connect
@@ -215,3 +180,25 @@ class TestUserPasswordMfaAuthentication:
         from snowflake.connector.errors import DatabaseError
 
         assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
+
+    # ------------------------------------------------------------------
+    # DUO push flow
+    # ------------------------------------------------------------------
+
+    @pytest.mark.skip(reason="DUO push requires interactive device approval \u2013 run manually")
+    def test_should_authenticate_using_username_password_and_duo_push(self, connection_factory, mfa_params):
+        # Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
+        user = mfa_params["user"]
+        password = mfa_params["password"]
+
+        # When Trying to Connect
+        connection = connection_factory(
+            authenticator="USERNAME_PASSWORD_MFA",
+            user=user,
+            password=password,
+            ext_authn_duo_method="push",
+        )
+
+        # Then Login is successful and simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)

--- a/tests/definitions/shared/authentication/user_password_mfa.feature
+++ b/tests/definitions/shared/authentication/user_password_mfa.feature
@@ -1,4 +1,4 @@
-@core
+@core @python
 Feature: Username Password MFA Authentication
 
   @core_e2e @ignore
@@ -74,5 +74,47 @@ Feature: Username Password MFA Authentication
   @core_int
   Scenario: should fail authentication when passcodeInPassword is set but passcode is not appended to password
     Given Authentication is set to username_password_mfa and user, password are provided and passcodeInPassword is set but passcode is not appended to password
+    When Trying to Connect
+    Then There is error returned
+
+  @python_e2e @ignore
+  Scenario: should authenticate with duo push
+    Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @python_e2e @ignore
+  Scenario: should authenticate with explicit passcode
+    Given Authentication is set to username_password_mfa and user, password and passcode are provided
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @python_e2e @ignore
+  Scenario: should authenticate with passcode in password
+    Given Authentication is set to username_password_mfa with appended passcode and passcodeInPassword is set
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @python_e2e @ignore
+  Scenario: should cache MFA token on first connection
+    Given Authentication is set to username_password_mfa with client_store_temporary_credential enabled
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @python_e2e @ignore
+  Scenario: should reuse cached MFA token without passcode
+    Given Authentication is set to username_password_mfa and MFA token has been cached from a previous connection
+    When Trying to Connect without passcode
+    Then Login is successful and simple query can be executed
+
+  @python_e2e @ignore
+  Scenario: should fail with invalid passcode
+    Given Authentication is set to username_password_mfa and user, password are provided but passcode is invalid
+    When Trying to Connect
+    Then There is error returned
+
+  @python_e2e @ignore
+  Scenario: should fail with invalid password
+    Given Authentication is set to username_password_mfa and user is provided but password is wrong
     When Trying to Connect
     Then There is error returned

--- a/tests/definitions/shared/authentication/user_password_mfa.feature
+++ b/tests/definitions/shared/authentication/user_password_mfa.feature
@@ -1,25 +1,25 @@
 @core @python
 Feature: Username Password MFA Authentication
 
-  @core_e2e @ignore
+  @core_e2e @python_e2e @ignore
   Scenario: should authenticate using username password and DUO push
     Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @ignore
+  @core_e2e @python_e2e @ignore
   Scenario: should authenticate using username password and TOTP passcode
     Given Authentication is set to username_password_mfa and user, password and passcode are provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @ignore
+  @core_e2e @python_e2e @ignore
   Scenario: should authenticate using username password with appended TOTP passcode
     Given Authentication is set to username_password_mfa and user, password with appended passcode are provided and passcodeInPassword is set
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @ignore
+  @core_e2e @python_e2e @ignore
   Scenario: should fail authentication when wrong password is provided
     Given Authentication is set to username_password_mfa and user is provided but password is skipped or invalid
     When Trying to Connect
@@ -77,44 +77,15 @@ Feature: Username Password MFA Authentication
     When Trying to Connect
     Then There is error returned
 
-  @python_e2e @ignore
-  Scenario: should authenticate with duo push
-    Given Authentication is set to username_password_mfa and user, password are provided and DUO push is enabled
-    When Trying to Connect
-    Then Login is successful and simple query can be executed
-
-  @python_e2e @ignore
-  Scenario: should authenticate with explicit passcode
-    Given Authentication is set to username_password_mfa and user, password and passcode are provided
-    When Trying to Connect
-    Then Login is successful and simple query can be executed
-
-  @python_e2e @ignore
-  Scenario: should authenticate with passcode in password
-    Given Authentication is set to username_password_mfa with appended passcode and passcodeInPassword is set
-    When Trying to Connect
-    Then Login is successful and simple query can be executed
-
-  @python_e2e @ignore
+  @python_e2e
   Scenario: should cache MFA token on first connection
     Given Authentication is set to username_password_mfa with client_store_temporary_credential enabled
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @python_e2e @ignore
+  @python_e2e
   Scenario: should reuse cached MFA token without passcode
     Given Authentication is set to username_password_mfa and MFA token has been cached from a previous connection
     When Trying to Connect without passcode
     Then Login is successful and simple query can be executed
 
-  @python_e2e @ignore
-  Scenario: should fail with invalid passcode
-    Given Authentication is set to username_password_mfa and user, password are provided but passcode is invalid
-    When Trying to Connect
-    Then There is error returned
-
-  @python_e2e @ignore
-  Scenario: should fail with invalid password
-    Given Authentication is set to username_password_mfa and user is provided but password is wrong
-    When Trying to Connect
-    Then There is error returned


### PR DESCRIPTION
- Document MFA connection parameters (passcode, passcode_in_password, client_store_temporary_credential, ext_authn_duo_method) in Connection docstring
- Add _rewrite_mfa_params() to translate passcode_in_password to the camelCase key expected by the Rust core (passcodeInPassword)
- Mark passcode as sensitive so it is redacted in stored kwargs
- Add MFA env vars to test config (SNOWFLAKE_TEST_MFA_USER/PASSWORD/PASSCODE)
- Add E2E tests covering passcode, passcode_in_password, token caching, DUO push, and error cases