### PR TITLE
SNOW-3243342 Add JSON to Arrow conversion for variant, semistructured object and semistructured array

### DIFF
--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -193,6 +193,30 @@ pub fn create_field_with_type(
             });
             Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
         }
+        RowType::Variant { name, nullable } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "VARIANT".to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
+        RowType::Object { name, nullable } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "OBJECT".to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
+        RowType::Array { name, nullable } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "ARRAY".to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
     }
 }
 
@@ -685,6 +709,9 @@ fn create_column_array(
                 }
                 .fail(),
             }
+        }
+        RowType::Variant { .. } | RowType::Object { .. } | RowType::Array { .. } => {
+            Ok((create_field(row_type)?, Arc::new(StringArray::from(values))))
         }
     }
 }

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -53,6 +53,18 @@ pub enum RowType {
         name: String,
         nullable: bool,
     },
+    Variant {
+        name: String,
+        nullable: bool,
+    },
+    Object {
+        name: String,
+        nullable: bool,
+    },
+    Array {
+        name: String,
+        nullable: bool,
+    },
 }
 
 impl RowType {
@@ -147,6 +159,27 @@ impl RowType {
 
     pub fn decfloat(name: &str, nullable: bool) -> Self {
         RowType::Decfloat {
+            name: name.to_string(),
+            nullable,
+        }
+    }
+
+    pub fn variant(name: &str, nullable: bool) -> Self {
+        RowType::Variant {
+            name: name.to_string(),
+            nullable,
+        }
+    }
+
+    pub fn object(name: &str, nullable: bool) -> Self {
+        RowType::Object {
+            name: name.to_string(),
+            nullable,
+        }
+    }
+
+    pub fn array(name: &str, nullable: bool) -> Self {
+        RowType::Array {
             name: name.to_string(),
             nullable,
         }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -606,6 +606,9 @@ impl TryFrom<&RowType> for query_types::RowType {
                 ))
             }
             "DECFLOAT" => Ok(query_types::RowType::decfloat(&name, nullable)),
+            "OBJECT" => Ok(query_types::RowType::object(&name, nullable)),
+            "ARRAY" => Ok(query_types::RowType::array(&name, nullable)),
+            "VARIANT" => Ok(query_types::RowType::variant(&name, nullable)),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
             }

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -141,6 +141,14 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
         ],
         "BINARY" => &["finalType", "precision", "scale", "physicalType"],
         "DECFLOAT" => &["finalType", "precision", "scale", "physicalType"],
+        "ARRAY" | "OBJECT" | "VARIANT" => &[
+            "finalType",
+            "byteLength",
+            "charLength",
+            "precision",
+            "scale",
+            "physicalType",
+        ],
         _ => &[],
     }
 }

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -123,6 +123,40 @@ fn should_return_decfloat_as_arrow_even_if_json_result_set_is_returned() {
     )
 }
 
+#[test]
+fn should_return_variant_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_variant (\
+            v_string VARIANT, v_number VARIANT, v_bool VARIANT, \
+            v_array VARIANT, v_object VARIANT)",
+        "INSERT INTO json_result_set_variant SELECT \
+            TO_VARIANT('hello'), \
+            TO_VARIANT(123.456), \
+            TO_VARIANT(TRUE), \
+            TO_VARIANT(PARSE_JSON('[1, 2, 3]')), \
+            TO_VARIANT(PARSE_JSON('{\"key\": \"value\"}'))",
+        "SELECT * FROM json_result_set_variant",
+    )
+}
+
+#[test]
+fn should_return_object_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_object (o OBJECT)",
+        "INSERT INTO json_result_set_object SELECT PARSE_JSON('{\"a\": 1, \"b\": \"two\"}')",
+        "SELECT * FROM json_result_set_object",
+    )
+}
+
+#[test]
+fn should_return_array_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_array (a ARRAY)",
+        "INSERT INTO json_result_set_array SELECT PARSE_JSON('[1, \"two\", 3.0, null]')",
+        "SELECT * FROM json_result_set_array",
+    )
+}
+
 fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, select_query: &str) {
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();


### PR DESCRIPTION
### TL;DR

Added support for Snowflake's VARIANT, semistructured OBJECT, and semistructured ARRAY data types in the Arrow conversion layer.

### What changed?

- Added three new variants (`Variant`, `Object`, `Array`) to the `RowType` enum with corresponding constructor methods
- Extended `create_field_with_type` function to handle the new data types by setting appropriate logical type metadata and defaulting to `DataType::Utf8`
- Updated `create_column_array` to process these types as string arrays
- Added type mapping in the Snowflake query response parser to convert "OBJECT", "ARRAY", and "VARIANT" strings to their respective `RowType` variants
- Updated test helpers to exclude additional metadata keys for these new logical types
