### PR TITLE
SNOW-2433865 add perf tests with ORDER BY

### DIFF
--- a/tests/performance/tests/test_select_1M.py
+++ b/tests/performance/tests/test_select_1M.py
@@ -63,3 +63,47 @@ def test_select_15columns_1M_arrow(perf_test):
         """
     )
 
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_string_1M_ordered_arrow(perf_test):
+    perf_test(
+        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000"
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_number_1M_ordered_arrow(perf_test):
+    perf_test(
+        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000"
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_15columns_1M_ordered_arrow(perf_test):
+    perf_test(
+        sql_command="""
+            SELECT 
+                L_ORDERKEY,
+                L_PARTKEY,
+                L_SUPPKEY,
+                L_LINENUMBER,
+                L_QUANTITY,
+                L_EXTENDEDPRICE,
+                L_DISCOUNT,
+                L_TAX,
+                L_RETURNFLAG,
+                L_LINESTATUS,
+                L_SHIPDATE,
+                L_COMMITDATE,
+                L_RECEIPTDATE,
+                L_SHIPINSTRUCT,
+                L_COMMENT
+            FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM 
+            ORDER BY L_ORDERKEY
+            LIMIT 1000000
+        """
+    )
+

--- a/tests/performance/tests/test_select_1M_recorded_http.py
+++ b/tests/performance/tests/test_select_1M_recorded_http.py
@@ -68,3 +68,50 @@ def test_select_15columns_1M_arrow_recorded_http(perf_test):
             LIMIT 1000000
         """,
     )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_string_1M_ordered_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=TestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_number_1M_ordered_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=TestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_15columns_1M_ordered_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=TestType.SELECT_RECORDED_HTTP,
+        sql_command="""
+            SELECT 
+                L_ORDERKEY,
+                L_PARTKEY,
+                L_SUPPKEY,
+                L_LINENUMBER,
+                L_QUANTITY,
+                L_EXTENDEDPRICE,
+                L_DISCOUNT,
+                L_TAX,
+                L_RETURNFLAG,
+                L_LINESTATUS,
+                L_SHIPDATE,
+                L_COMMITDATE,
+                L_RECEIPTDATE,
+                L_SHIPINSTRUCT,
+                L_COMMENT
+            FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM 
+            ORDER BY L_ORDERKEY
+            LIMIT 1000000
+        """,
+    )

--- a/tests/performance/tests/test_select_50M.py
+++ b/tests/performance/tests/test_select_50M.py
@@ -62,3 +62,19 @@ def test_select_15columns_50M_arrow(perf_test):
         """
     )
 
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_string_50M_ordered_arrow(perf_test):
+    perf_test(
+        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000"
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_number_50M_ordered_arrow(perf_test):
+    perf_test(
+        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000"
+    )
+

--- a/tests/performance/tests/test_select_50M_recorded_http.py
+++ b/tests/performance/tests/test_select_50M_recorded_http.py
@@ -67,3 +67,21 @@ def test_select_15columns_50M_arrow_recorded_http(perf_test):
             LIMIT 50000000
         """,
     )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_string_50M_ordered_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=TestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_number_50M_ordered_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=TestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
+    )


### PR DESCRIPTION
Add ORDER BY L_ORDERKEY variants to 1M and 50M performance tests to measure the impact of server-side sorting on client-side fetch times