### PR TITLE
Add TIME fetch support in conversion module

### DIFF
--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -15,6 +15,13 @@ pub enum ReadArrowError {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Invalid Arrow value: {reason}"))]
+    InvalidArrowValue {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 #[derive(Snafu, Debug, ErrorTrace)]

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -20,6 +20,8 @@ mod real_tests;
 #[cfg(test)]
 mod test_utils;
 mod time;
+#[cfg(test)]
+mod time_tests;
 mod timestamp;
 mod varchar;
 

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -142,6 +142,7 @@ enum SnowflakeFieldType {
     Varchar(varchar::SnowflakeVarchar),
     Number(number::SnowflakeNumber),
     Date(date::SnowflakeDate),
+    Time(time::SnowflakeTime),
     TimestampNtz(timestamp::SnowflakeTimestampNtz),
     Boolean(boolean::SnowflakeBoolean),
     Binary(binary::SnowflakeBinary),
@@ -178,6 +179,7 @@ impl SnowflakeFieldType {
                 }))
             }
             "DATE" => Ok(Self::Date(date::SnowflakeDate)),
+            "TIME" => Ok(Self::Time(time::SnowflakeTime)),
             "TIMESTAMP_NTZ" => Ok(Self::TimestampNtz(timestamp::SnowflakeTimestampNtz)),
             "BOOLEAN" => Ok(Self::Boolean(boolean::SnowflakeBoolean)),
             "BINARY" => Ok(Self::Binary(binary::SnowflakeBinary)),
@@ -195,6 +197,7 @@ impl SnowflakeFieldType {
             Self::Varchar(t) => t.sql_type(),
             Self::Number(t) => t.sql_type(),
             Self::Date(t) => t.sql_type(),
+            Self::Time(t) => t.sql_type(),
             Self::TimestampNtz(t) => t.sql_type(),
             Self::Boolean(t) => t.sql_type(),
             Self::Binary(t) => t.sql_type(),
@@ -207,6 +210,7 @@ impl SnowflakeFieldType {
             Self::Varchar(t) => t.column_size(),
             Self::Number(t) => t.column_size(),
             Self::Date(t) => t.column_size(),
+            Self::Time(t) => t.column_size(),
             Self::TimestampNtz(t) => t.column_size(),
             Self::Boolean(t) => t.column_size(),
             Self::Binary(t) => t.column_size(),
@@ -219,6 +223,7 @@ impl SnowflakeFieldType {
             Self::Varchar(t) => t.decimal_digits(),
             Self::Number(t) => t.decimal_digits(),
             Self::Date(t) => t.decimal_digits(),
+            Self::Time(t) => t.decimal_digits(),
             Self::TimestampNtz(t) => t.decimal_digits(),
             Self::Boolean(t) => t.decimal_digits(),
             Self::Binary(t) => t.decimal_digits(),
@@ -271,6 +276,9 @@ pub fn make_converter<'a>(
         },
         SnowflakeFieldType::Date(snowflake_type) => {
             make_primitive_data_converter!(Date32Type, snowflake_type, arrow_array, nullable)
+        }
+        SnowflakeFieldType::Time(snowflake_type) => {
+            make_primitive_data_converter!(Int64Type, snowflake_type, arrow_array, nullable)
         }
         SnowflakeFieldType::TimestampNtz(snowflake_type) => {
             make_converter!(

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -179,7 +179,10 @@ impl SnowflakeFieldType {
                 }))
             }
             "DATE" => Ok(Self::Date(date::SnowflakeDate)),
-            "TIME" => Ok(Self::Time(time::SnowflakeTime)),
+            "TIME" => {
+                let scale = get_field_metadata(field, "scale")?;
+                Ok(Self::Time(time::SnowflakeTime { scale }))
+            }
             "TIMESTAMP_NTZ" => Ok(Self::TimestampNtz(timestamp::SnowflakeTimestampNtz)),
             "BOOLEAN" => Ok(Self::Boolean(boolean::SnowflakeBoolean)),
             "BINARY" => Ok(Self::Binary(binary::SnowflakeBinary)),

--- a/odbc/src/conversion/nullable.rs
+++ b/odbc/src/conversion/nullable.rs
@@ -25,6 +25,7 @@ impl<R, T: SnowflakeType + ReadArrowType<R>> ReadArrowType<R> for Nullable<T> {
             .map(Some)
             .or_else(|e| match e {
                 ReadArrowError::NullValue { .. } => Ok(None),
+                other => Err(other),
             })
     }
 }

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -145,7 +145,7 @@ fn make_converter(
         })),
 
         sql::SqlDataType::TIME => Ok(Box::new(JsonParamConverter {
-            snowflake_type: SnowflakeTime,
+            snowflake_type: SnowflakeTime { scale: 9 },
         })),
 
         sql::SqlDataType::TIMESTAMP | sql::SqlDataType::EXT_TIMESTAMP => {

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -15,7 +15,9 @@ use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::Warnings;
 use crate::conversion::{ReadArrowType, WriteODBCType};
 
-pub(crate) struct SnowflakeTime;
+pub(crate) struct SnowflakeTime {
+    pub(crate) scale: u32,
+}
 
 impl SnowflakeType for SnowflakeTime {
     type Representation<'a> = NaiveTime;
@@ -32,9 +34,14 @@ impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
                 location: snafu::location!(),
             });
         }
-        let nanos_since_midnight = array.value(row_idx);
-        let secs = (nanos_since_midnight / 1_000_000_000) as u32;
-        let nanos = (nanos_since_midnight % 1_000_000_000) as u32;
+        let raw = array.value(row_idx);
+        let divisor = 10i64.pow(self.scale);
+        let secs = (raw / divisor) as u32;
+        // TODO: when scale < 9, the fractional part has fewer digits than nanoseconds;
+        // we multiply up to nano-precision here. When scale > 9 is ever encountered
+        // (shouldn't happen for Snowflake TIME), this would need clamping.
+        let frac = (raw % divisor) as u32;
+        let nanos = frac * 10u32.pow(9 - self.scale);
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or(
             ReadArrowError::NullValue {
                 location: snafu::location!(),
@@ -49,11 +56,15 @@ impl WriteODBCType for SnowflakeTime {
     }
 
     fn column_size(&self) -> sql::ULen {
-        8
+        if self.scale == 0 {
+            8
+        } else {
+            9 + self.scale as sql::ULen
+        }
     }
 
     fn decimal_digits(&self) -> sql::SmallInt {
-        9
+        self.scale as sql::SmallInt
     }
 
     fn write_odbc_type(
@@ -63,6 +74,9 @@ impl WriteODBCType for SnowflakeTime {
         get_data_offset: &mut Option<usize>,
     ) -> Result<Warnings, WriteOdbcError> {
         match binding.target_type {
+            // TODO: SQL_C_TYPE_TIME has no fractional-seconds field — sub-second
+            // precision is silently truncated. Consider emitting a truncation
+            // warning (SQLSTATE 01S07) when scale > 0.
             CDataType::Default | CDataType::Time | CDataType::TypeTime => {
                 let time = sql::Time {
                     hour: snowflake_value.hour() as u16,
@@ -72,6 +86,9 @@ impl WriteODBCType for SnowflakeTime {
                 binding.write_fixed(time);
                 Ok(vec![])
             }
+            // TODO: include fractional seconds in the formatted string when
+            // scale > 0 (e.g. "%H:%M:%S%.f" or a custom formatter that
+            // respects the column's scale).
             CDataType::Char => {
                 let formatted = snowflake_value.format("%H:%M:%S").to_string();
                 Ok(binding.write_char_string(&formatted, get_data_offset))

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -6,14 +6,14 @@ use serde_json::Value;
 
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
-use crate::conversion::error::{JsonBindingError, UnsupportedCDataTypeSnafu};
-use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
+use crate::conversion::error::{
+    JsonBindingError, ReadArrowError, UnsupportedCDataTypeSnafu, UnsupportedOdbcTypeSnafu,
+    WriteOdbcError,
+};
 use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
-use crate::conversion::traits::Binding;
-use crate::conversion::traits::SnowflakeType;
-use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
+use crate::conversion::traits::{Binding, ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::Warnings;
-use crate::conversion::{ReadArrowType, WriteODBCType};
+use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
 
 pub(crate) struct SnowflakeTime {
     pub(crate) scale: u32,

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -48,7 +48,14 @@ impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
             .fail();
         }
         let divisor = 10i64.pow(self.scale);
-        let secs = (raw / divisor) as u32;
+        let secs_i64 = raw / divisor;
+        if !(0..86_400).contains(&secs_i64) {
+            return InvalidArrowValueSnafu {
+                reason: format!("TIME seconds {secs_i64} out of range 0..86399"),
+            }
+            .fail();
+        }
+        let secs = secs_i64 as u32;
         let frac = (raw % divisor) as u32;
         let nanos = frac * 10u32.pow(9 - self.scale);
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or_else(|| {

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -1,3 +1,5 @@
+use arrow::array::{Array, PrimitiveArray};
+use arrow::datatypes::Int64Type;
 use chrono::{NaiveTime, Timelike};
 use odbc_sys as sql;
 use serde_json::Value;
@@ -5,14 +7,85 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::{JsonBindingError, UnsupportedCDataTypeSnafu};
+use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
 use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
+use crate::conversion::traits::Binding;
 use crate::conversion::traits::SnowflakeType;
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
+use crate::conversion::warning::Warnings;
+use crate::conversion::{ReadArrowType, WriteODBCType};
 
 pub(crate) struct SnowflakeTime;
 
 impl SnowflakeType for SnowflakeTime {
     type Representation<'a> = NaiveTime;
+}
+
+impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
+    fn read_arrow_type<'a>(
+        &self,
+        array: &'a PrimitiveArray<Int64Type>,
+        row_idx: usize,
+    ) -> Result<Self::Representation<'a>, ReadArrowError> {
+        if array.is_null(row_idx) {
+            return Err(ReadArrowError::NullValue {
+                location: snafu::location!(),
+            });
+        }
+        let nanos_since_midnight = array.value(row_idx);
+        let secs = (nanos_since_midnight / 1_000_000_000) as u32;
+        let nanos = (nanos_since_midnight % 1_000_000_000) as u32;
+        NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or(
+            ReadArrowError::NullValue {
+                location: snafu::location!(),
+            },
+        )
+    }
+}
+
+impl WriteODBCType for SnowflakeTime {
+    fn sql_type(&self) -> sql::SqlDataType {
+        sql::SqlDataType::TIME
+    }
+
+    fn column_size(&self) -> sql::ULen {
+        8
+    }
+
+    fn decimal_digits(&self) -> sql::SmallInt {
+        9
+    }
+
+    fn write_odbc_type(
+        &self,
+        snowflake_value: Self::Representation<'_>,
+        binding: &Binding,
+        get_data_offset: &mut Option<usize>,
+    ) -> Result<Warnings, WriteOdbcError> {
+        match binding.target_type {
+            CDataType::Default | CDataType::Time | CDataType::TypeTime => {
+                let time = sql::Time {
+                    hour: snowflake_value.hour() as u16,
+                    minute: snowflake_value.minute() as u16,
+                    second: snowflake_value.second() as u16,
+                };
+                binding.write_fixed(time);
+                Ok(vec![])
+            }
+            CDataType::Char => {
+                let formatted = snowflake_value.format("%H:%M:%S").to_string();
+                Ok(binding.write_char_string(&formatted, get_data_offset))
+            }
+            CDataType::WChar => {
+                let formatted = snowflake_value.format("%H:%M:%S").to_string();
+                Ok(binding.write_wchar_string(&formatted, get_data_offset))
+            }
+            _ => UnsupportedOdbcTypeSnafu {
+                target_type: binding.target_type,
+            }
+            .fail(),
+        }
+    }
 }
 
 impl ReadODBC for SnowflakeTime {

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::{
-    JsonBindingError, ReadArrowError, UnsupportedCDataTypeSnafu, UnsupportedOdbcTypeSnafu,
-    WriteOdbcError,
+    InvalidArrowValueSnafu, JsonBindingError, ReadArrowError, UnsupportedCDataTypeSnafu,
+    UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
 use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
 use crate::conversion::traits::{Binding, ReadODBC, SnowflakeLogicalType, WriteJson};
@@ -34,19 +34,29 @@ impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
                 location: snafu::location!(),
             });
         }
+        if self.scale > 9 {
+            return InvalidArrowValueSnafu {
+                reason: format!("TIME scale {} exceeds maximum of 9", self.scale),
+            }
+            .fail();
+        }
         let raw = array.value(row_idx);
+        if raw < 0 {
+            return InvalidArrowValueSnafu {
+                reason: format!("negative TIME value: {raw}"),
+            }
+            .fail();
+        }
         let divisor = 10i64.pow(self.scale);
         let secs = (raw / divisor) as u32;
-        // TODO: when scale < 9, the fractional part has fewer digits than nanoseconds;
-        // we multiply up to nano-precision here. When scale > 9 is ever encountered
-        // (shouldn't happen for Snowflake TIME), this would need clamping.
         let frac = (raw % divisor) as u32;
         let nanos = frac * 10u32.pow(9 - self.scale);
-        NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or(
-            ReadArrowError::NullValue {
-                location: snafu::location!(),
-            },
-        )
+        NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or_else(|| {
+            InvalidArrowValueSnafu {
+                reason: format!("out-of-range TIME: secs={secs}, nanos={nanos}"),
+            }
+            .build()
+        })
     }
 }
 

--- a/odbc/src/conversion/time_tests.rs
+++ b/odbc/src/conversion/time_tests.rs
@@ -1,0 +1,236 @@
+#[cfg(test)]
+mod tests {
+    use crate::cdata_types::CDataType;
+    use crate::conversion::ReadArrowType;
+    use crate::conversion::WriteODBCType;
+    use crate::conversion::error::ReadArrowError;
+    use crate::conversion::test_utils::helpers::{
+        binding_for_char_buffer, binding_for_value, binding_for_wchar_buffer,
+    };
+    use crate::conversion::time::SnowflakeTime;
+    use arrow::array::PrimitiveArray;
+    use arrow::datatypes::Int64Type;
+    use chrono::NaiveTime;
+    use odbc_sys as sql;
+
+    fn time(scale: u32) -> SnowflakeTime {
+        SnowflakeTime { scale }
+    }
+
+    // ========================================================================
+    // ReadArrowType — scale handling
+    // ========================================================================
+
+    #[test]
+    fn read_arrow_scale_0_whole_seconds() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(45296)]); // 12:34:56
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value, NaiveTime::from_hms_opt(12, 34, 56).unwrap());
+    }
+
+    #[test]
+    fn read_arrow_scale_3_milliseconds() {
+        let sn = time(3);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(45_296_789)]); // 12:34:56.789
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(
+            value,
+            NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap()
+        );
+    }
+
+    #[test]
+    fn read_arrow_scale_9_nanoseconds() {
+        let sn = time(9);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(45_296_123_456_789)]); // 12:34:56.123456789
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(
+            value,
+            NaiveTime::from_hms_nano_opt(12, 34, 56, 123_456_789).unwrap()
+        );
+    }
+
+    #[test]
+    fn read_arrow_midnight() {
+        let sn = time(9);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(0)]);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+    }
+
+    // ========================================================================
+    // ReadArrowType — null and error handling
+    // ========================================================================
+
+    #[test]
+    fn read_arrow_null_returns_null_error() {
+        let sn = time(9);
+        let array = PrimitiveArray::<Int64Type>::from(vec![None::<i64>]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(result, Err(ReadArrowError::NullValue { .. })));
+    }
+
+    #[test]
+    fn read_arrow_negative_value_returns_invalid() {
+        let sn = time(9);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(-1)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
+    #[test]
+    fn read_arrow_scale_over_9_returns_invalid() {
+        let sn = time(10);
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(0)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
+    // ========================================================================
+    // WriteODBCType — SQL_C_TYPE_TIME struct
+    // ========================================================================
+
+    #[test]
+    fn write_time_struct() {
+        let sn = time(9);
+        let mut value = sql::Time {
+            hour: 0,
+            minute: 0,
+            second: 0,
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::TypeTime, &mut value, &mut str_len);
+        let input = NaiveTime::from_hms_opt(12, 34, 56).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(value.hour, 12);
+        assert_eq!(value.minute, 34);
+        assert_eq!(value.second, 56);
+    }
+
+    #[test]
+    fn write_time_struct_default_type() {
+        let sn = time(0);
+        let mut value = sql::Time {
+            hour: 0,
+            minute: 0,
+            second: 0,
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::Default, &mut value, &mut str_len);
+        let input = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(value.hour, 23);
+        assert_eq!(value.minute, 59);
+        assert_eq!(value.second, 59);
+    }
+
+    // ========================================================================
+    // WriteODBCType — SQL_C_CHAR
+    // ========================================================================
+
+    #[test]
+    fn write_char() {
+        let sn = time(0);
+        let mut buffer = vec![0u8; 16];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let input = NaiveTime::from_hms_opt(9, 5, 3).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, 8);
+        assert_eq!(&buffer[..8], b"09:05:03");
+    }
+
+    #[test]
+    fn write_char_buffer_too_small_truncates() {
+        use crate::conversion::warning::Warning;
+        let sn = time(0);
+        let mut buffer = vec![0u8; 4];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let input = NaiveTime::from_hms_opt(12, 34, 56).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+        );
+    }
+
+    // ========================================================================
+    // WriteODBCType — SQL_C_WCHAR
+    // ========================================================================
+
+    #[test]
+    fn write_wchar() {
+        let sn = time(0);
+        let mut buffer = vec![0u16; 16];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(&mut buffer, &mut str_len);
+        let input = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, 16); // 8 UTF-16 code units * 2 bytes
+        let expected: Vec<u16> = "12:00:00".encode_utf16().collect();
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
+    }
+
+    // ========================================================================
+    // WriteODBCType — unsupported type
+    // ========================================================================
+
+    #[test]
+    fn unsupported_type_returns_error() {
+        let sn = time(0);
+        let mut value: u8 = 0;
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::TypeDate, &mut value, &mut str_len);
+        let input = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
+        assert!(sn.write_odbc_type(input, &binding, &mut None).is_err());
+    }
+
+    // ========================================================================
+    // Metadata
+    // ========================================================================
+
+    #[test]
+    fn sql_type_is_time() {
+        let sn = time(0);
+        assert_eq!(sn.sql_type(), sql::SqlDataType::TIME);
+    }
+
+    #[test]
+    fn column_size_scale_0() {
+        let sn = time(0);
+        assert_eq!(sn.column_size(), 8);
+    }
+
+    #[test]
+    fn column_size_scale_3() {
+        let sn = time(3);
+        assert_eq!(sn.column_size(), 12); // 9 + 3
+    }
+
+    #[test]
+    fn column_size_scale_9() {
+        let sn = time(9);
+        assert_eq!(sn.column_size(), 18); // 9 + 9
+    }
+
+    #[test]
+    fn decimal_digits_matches_scale() {
+        for scale in 0..=9 {
+            let sn = time(scale);
+            assert_eq!(sn.decimal_digits(), scale as sql::SmallInt);
+        }
+    }
+}

--- a/odbc/src/conversion/time_tests.rs
+++ b/odbc/src/conversion/time_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::cdata_types::CDataType;
+    use crate::api::CDataType;
     use crate::conversion::ReadArrowType;
     use crate::conversion::WriteODBCType;
     use crate::conversion::error::ReadArrowError;

--- a/odbc/src/conversion/time_tests.rs
+++ b/odbc/src/conversion/time_tests.rs
@@ -93,6 +93,30 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn read_arrow_overflow_secs_returns_invalid() {
+        let sn = time(0);
+        // 86400 seconds = 24:00:00, out of valid range 0..86399
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(86_400)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
+    #[test]
+    fn read_arrow_huge_value_returns_invalid() {
+        let sn = time(9);
+        // Value exceeding 24 hours in nanos — would wrap u32 without validation
+        let array = PrimitiveArray::<Int64Type>::from(vec![Some(100_000_000_000_000_000)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
     // ========================================================================
     // WriteODBCType — SQL_C_TYPE_TIME struct
     // ========================================================================
@@ -164,6 +188,35 @@ mod tests {
                 .iter()
                 .any(|w| matches!(w, Warning::StringDataTruncated))
         );
+    }
+
+    // TODO: these tests document current behavior where fractional seconds
+    // are dropped in string output. Once fractional-second formatting is
+    // implemented, update these to verify the fractional part is included.
+    #[test]
+    fn write_char_scale_3_drops_fractional() {
+        let sn = time(3);
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let input = NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(str_len, 8);
+        assert_eq!(&buffer[..8], b"12:34:56");
+    }
+
+    #[test]
+    fn write_wchar_scale_9_drops_fractional() {
+        let sn = time(9);
+        let mut buffer = vec![0u16; 32];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_wchar_buffer(&mut buffer, &mut str_len);
+        let input = NaiveTime::from_hms_nano_opt(12, 34, 56, 123_456_789).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        let expected: Vec<u16> = "12:34:56".encode_utf16().collect();
+        assert_eq!(&buffer[..expected.len()], &expected[..]);
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- Add TIME fetch support (server → ODBC application) in the conversion module
- `SnowflakeTime` now carries a `scale` field (read from Arrow field metadata), consistent with how `SnowflakeNumber` stores scale/precision
- `ReadArrowType<PrimitiveArray<Int64Type>>` converts Snowflake's scaled Int64 Arrow values to `NaiveTime`, correctly handling all TIME precisions (scale 0–9)
- `WriteODBCType` writes TIME values to ODBC buffers (`SQL_C_TYPE_TIME` struct, `SQL_C_CHAR`, `SQL_C_WCHAR`)
- `column_size` and `decimal_digits` are derived from scale per ODBC spec
- Input validation guards against scale > 9 and negative raw values
- Add `InvalidArrowValue` variant to `ReadArrowError` so out-of-range values are distinguishable from actual nulls
- Add `time_tests.rs` with 18 unit tests covering scale handling, null/error behavior, struct/char/wchar output, truncation, and metadata

This enables SELECT on TIME columns, which was previously unsupported and caused "TIME incompatible with Int64" errors.

### Known TODOs
- Fractional-second string formatting for CHAR/WCHAR output (currently always `%H:%M:%S`)
- Truncation warning (SQLSTATE 01S07) when writing to `SQL_C_TYPE_TIME` with scale > 0

Made with [Cursor](https://cursor.com)