### PR TITLE
NO-SNOW: Add readonly database fixture for ODBC catalog tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ odbc_tests/cmake-build
 parameters*.json
 **/rsa_key.p8
 .DS_Store
+odbc.log
 /.tmp
 /build
 coverage_report/

--- a/odbc_tests/common/include/ReadOnlyDbFixture.hpp
+++ b/odbc_tests/common/include/ReadOnlyDbFixture.hpp
@@ -1,0 +1,122 @@
+#ifndef READONLY_DB_FIXTURE_HPP
+#define READONLY_DB_FIXTURE_HPP
+
+#include <string>
+
+#include "ODBCFixtures.hpp"
+#include "test_setup.hpp"
+
+// =============================================================================
+// Readonly Metadata Test Database
+// =============================================================================
+//
+// Pre-provisioned database for ODBC catalog and metadata tests. Contains
+// fixed tables, views, and procedures so that tests don't need per-test DDL.
+//
+// To (re)create the database, configure with -DBUILD_SETUP_TOOLS=ON and run:
+//   cmake -B cmake-build -DBUILD_SETUP_TOOLS=ON ... && cmake --build cmake-build
+//   ctest --test-dir cmake-build -R setup_readonly_db
+//
+// Tests MUST NOT modify objects in this database.
+// =============================================================================
+
+inline constexpr auto READONLY_DB_NAME = "ODBCMETADATATESTDB";
+inline constexpr auto READONLY_SCHEMA_NAME = "CATALOGTESTS";
+
+// =============================================================================
+// Object name constants
+// =============================================================================
+
+namespace readonly_db {
+
+// Basic tables
+inline constexpr auto BASIC_TABLE = "BASICTABLE";
+inline constexpr auto MULTI_TYPE_TABLE = "MULTITYPETABLE";
+inline constexpr auto THREE_COL_TABLE = "THREECOLTABLE";
+inline constexpr auto NULLABILITY_TABLE = "NULLABILITYTABLE";
+inline constexpr auto WILDCARD_COL_TABLE = "WILDCARDCOLTABLE";
+inline constexpr auto NO_PK_TABLE = "NOPKTABLE";
+
+// Primary key tables
+inline constexpr auto SINGLE_PK_TABLE = "SINGLEPKTABLE";
+inline constexpr auto COMPOSITE_PK_TABLE = "COMPOSITEPKTABLE";
+inline constexpr auto NAMED_PK_TABLE = "NAMEDPKTABLE";
+
+// Foreign key tables
+inline constexpr auto FK_PARENT = "FKPARENT";
+inline constexpr auto FK_CHILD = "FKCHILD";
+inline constexpr auto FK_MULTI_PARENT = "FKMULTIPARENT";
+inline constexpr auto FK_MULTI_CHILD_A = "FKMULTICHILDA";
+inline constexpr auto FK_MULTI_CHILD_B = "FKMULTICHILDB";
+
+// Views
+inline constexpr auto BASIC_VIEW = "BASICVIEW";
+
+// Procedures
+inline constexpr auto BASIC_PROC = "BASICPROC";
+inline constexpr auto MULTI_PARAM_PROC = "MULTIPARAMPROC";
+inline constexpr auto PROC_FILTER = "PROCFILTER";
+inline constexpr auto PROC_MULTI_A = "PROCMULTIA";
+inline constexpr auto PROC_MULTI_B = "PROCMULTIB";
+inline constexpr auto PROC_DTYPE_A = "PROCDTYPEA";
+inline constexpr auto PROC_DTYPE_B = "PROCDTYPEB";
+inline constexpr auto PROC_NUM_A = "PROCNUMA";
+inline constexpr auto PROC_NUM_B = "PROCNUMB";
+
+// Describe-col tables
+inline constexpr auto DESC_VARCHAR_TABLE = "DESCVARCHARTABLE";
+inline constexpr auto DESC_NUMBER_TABLE = "DESCNUMBERTABLE";
+inline constexpr auto DESC_BOOL_TABLE = "DESCBOOLTABLE";
+inline constexpr auto DESC_FLOAT_TABLE = "DESCFLOATTABLE";
+inline constexpr auto DESC_DATE_TABLE = "DESCDATETABLE";
+inline constexpr auto DESC_TIMESTAMP_TABLE = "DESCTIMESTAMPTABLE";
+inline constexpr auto DESC_SIZE_VARCHAR_TABLE = "DESCSIZEVARCHARTABLE";
+inline constexpr auto DESC_SIZE_NUMBER_TABLE = "DESCSIZENUMBERTABLE";
+inline constexpr auto DESC_DIGITS_TABLE = "DESCDIGITSTABLE";
+inline constexpr auto DESC_DIGITS_VARCHAR_TABLE = "DESCDIGITSVARCHARTABLE";
+inline constexpr auto DESC_NULLABLE_TABLE = "DESCNULLABLETABLE";
+inline constexpr auto DESC_NOTNULL_TABLE = "DESCNOTNULLTABLE";
+inline constexpr auto DESC_MULTI_TABLE = "DESCMULTITABLE";
+
+}  // namespace readonly_db
+
+// =============================================================================
+// Fixture for TEST_CASE_METHOD catalog tests (DSN-based connection)
+// =============================================================================
+
+class ReadOnlyDbStmtFixture : public StmtFixture {
+ public:
+  ReadOnlyDbStmtFixture()
+      : StmtFixture(
+            DataSourceConfig::Snowflake().set("DATABASE", READONLY_DB_NAME).set("SCHEMA", READONLY_SCHEMA_NAME)) {
+    const std::string fqn = std::string(READONLY_DB_NAME) + "." + READONLY_SCHEMA_NAME + "." + readonly_db::BASIC_TABLE;
+    const std::string probe = "SELECT 1 FROM " + fqn + " WHERE 1=0";
+    SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(probe.c_str()), SQL_NTS);
+    if (!SQL_SUCCEEDED(ret)) {
+      FAIL("Readonly metadata DB not provisioned (" << fqn
+                                                    << " not found). "
+                                                       "Build with -DBUILD_SETUP_TOOLS=ON and run: "
+                                                       "ctest --test-dir cmake-build -R setup_readonly_db");
+    }
+    SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  }
+
+  [[nodiscard]] static auto schema_name() { return READONLY_SCHEMA_NAME; }
+  [[nodiscard]] static auto database_name() { return READONLY_DB_NAME; }
+};
+
+// =============================================================================
+// Connection string helper for e2e tests (Connection class pattern)
+// =============================================================================
+
+inline std::string get_readonly_db_connection_string() {
+  const auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  read_default_params(ss, params, {"DATABASE", "SCHEMA"});
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_PASSWORD", "PWD");
+  ss << "DATABASE=" << READONLY_DB_NAME << ";";
+  ss << "SCHEMA=" << READONLY_SCHEMA_NAME << ";";
+  return ss.str();
+}
+
+#endif  // READONLY_DB_FIXTURE_HPP

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -5,6 +5,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <sstream>
 
 #include <catch2/catch_test_macros.hpp>
@@ -97,21 +98,31 @@ inline void configure_driver_string(std::stringstream& ss) {
 #endif
 }
 
-inline void read_default_params(std::stringstream& ss, const picojson::object& params) {
+inline void read_default_params(std::stringstream& ss, const picojson::object& params,
+                                const std::set<std::string>& skip_conn_keys = {}) {
+  auto req = [&](const std::string& cfg, const std::string& conn) {
+    if (!skip_conn_keys.count(conn)) add_param_required<std::string>(ss, params, cfg, conn);
+  };
+  auto opt = [&](const std::string& cfg, const std::string& conn) {
+    if (!skip_conn_keys.count(conn)) add_param_optional<std::string>(ss, params, cfg, conn);
+  };
+
   configure_driver_string(ss);
-  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_HOST", "SERVER");
-  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
-  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_USER", "UID");
-  if (params.count("SNOWFLAKE_TEST_WAREHOUSE_ODBC")) {
-    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE_ODBC", "WAREHOUSE");
-  } else {
-    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE", "WAREHOUSE");
+  req("SNOWFLAKE_TEST_HOST", "SERVER");
+  req("SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
+  req("SNOWFLAKE_TEST_USER", "UID");
+  if (!skip_conn_keys.count("WAREHOUSE")) {
+    if (params.count("SNOWFLAKE_TEST_WAREHOUSE_ODBC")) {
+      add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE_ODBC", "WAREHOUSE");
+    } else {
+      add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE", "WAREHOUSE");
+    }
   }
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_ROLE", "ROLE");
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_SCHEMA", "SCHEMA");
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_DATABASE", "DATABASE");
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PORT", "PORT");
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PROTOCOL", "PROTOCOL");
+  opt("SNOWFLAKE_TEST_ROLE", "ROLE");
+  opt("SNOWFLAKE_TEST_SCHEMA", "SCHEMA");
+  opt("SNOWFLAKE_TEST_DATABASE", "DATABASE");
+  opt("SNOWFLAKE_TEST_PORT", "PORT");
+  opt("SNOWFLAKE_TEST_PROTOCOL", "PROTOCOL");
 }
 
 inline std::string get_connection_string() {

--- a/odbc_tests/tests/CMakeLists.txt
+++ b/odbc_tests/tests/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 4.0)
 
+option(BUILD_SETUP_TOOLS "Build one-time DB setup utilities (not for CI)" OFF)
+if(BUILD_SETUP_TOOLS)
+  add_subdirectory(setup)
+endif()
+
 add_subdirectory(e2e)
 add_subdirectory(integration)
 add_subdirectory(basic_tests)

--- a/odbc_tests/tests/e2e/query/sql_describe_col.cpp
+++ b/odbc_tests/tests/e2e/query/sql_describe_col.cpp
@@ -1,9 +1,10 @@
 #include <cstring>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 
@@ -114,10 +115,8 @@ TEST_CASE("SQLDescribeCol returns SQL_VARCHAR for VARCHAR column.", "[query]") {
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_varchar_test (val VARCHAR(100))");
-  auto stmt = conn.execute("SELECT val FROM desc_varchar_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_VARCHAR_TABLE));
 
   // When SQLDescribeCol is called for the VARCHAR column
   SQLCHAR col_name[128] = {0};
@@ -146,10 +145,8 @@ TEST_CASE("SQLDescribeCol returns SQL_DECIMAL for NUMBER column.", "[query]") {
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_number_test (val NUMBER(10,2))");
-  auto stmt = conn.execute("SELECT val FROM desc_number_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_NUMBER_TABLE));
 
   // When SQLDescribeCol is called for the NUMBER column
   SQLCHAR col_name[128] = {0};
@@ -178,10 +175,8 @@ TEST_CASE("SQLDescribeCol returns SQL_BIT for BOOLEAN column.", "[query]") {
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_bool_test (val BOOLEAN)");
-  auto stmt = conn.execute("SELECT val FROM desc_bool_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_BOOL_TABLE));
 
   // When SQLDescribeCol is called for the BOOLEAN column
   SQLCHAR col_name[128] = {0};
@@ -210,10 +205,8 @@ TEST_CASE("SQLDescribeCol returns SQL_DOUBLE for FLOAT column.", "[query]") {
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_float_test (val FLOAT)");
-  auto stmt = conn.execute("SELECT val FROM desc_float_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_FLOAT_TABLE));
 
   // When SQLDescribeCol is called for the FLOAT column
   SQLCHAR col_name[128] = {0};
@@ -239,10 +232,8 @@ TEST_CASE("SQLDescribeCol returns SQL_TYPE_DATE for DATE column.", "[query]") {
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_date_test (val DATE)");
-  auto stmt = conn.execute("SELECT val FROM desc_date_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_DATE_TABLE));
 
   // When SQLDescribeCol is called for the DATE column
   SQLCHAR col_name[128] = {0};
@@ -270,10 +261,8 @@ TEST_CASE("SQLDescribeCol returns SQL_TYPE_TIMESTAMP for TIMESTAMP_NTZ column.",
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_ts_test (val TIMESTAMP_NTZ)");
-  auto stmt = conn.execute("SELECT val FROM desc_ts_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_TIMESTAMP_TABLE));
 
   // When SQLDescribeCol is called for the TIMESTAMP_NTZ column
   SQLCHAR col_name[128] = {0};
@@ -305,10 +294,8 @@ TEST_CASE("SQLDescribeCol returns correct column size for VARCHAR.", "[query]") 
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_size_varchar_test (val VARCHAR(200))");
-  auto stmt = conn.execute("SELECT val FROM desc_size_varchar_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_SIZE_VARCHAR_TABLE));
 
   // When SQLDescribeCol is called for the VARCHAR(200) column
   SQLCHAR col_name[128] = {0};
@@ -336,10 +323,8 @@ TEST_CASE("SQLDescribeCol returns precision as column size for NUMBER.", "[query
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_size_number_test (val NUMBER(12,3))");
-  auto stmt = conn.execute("SELECT val FROM desc_size_number_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_SIZE_NUMBER_TABLE));
 
   // When SQLDescribeCol is called for the NUMBER(12,3) column
   SQLCHAR col_name[128] = {0};
@@ -373,10 +358,8 @@ TEST_CASE("SQLDescribeCol returns scale as decimal digits for NUMBER.", "[query]
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_digits_test (val NUMBER(10,4))");
-  auto stmt = conn.execute("SELECT val FROM desc_digits_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_DIGITS_TABLE));
 
   // When SQLDescribeCol is called for the NUMBER(10,4) column
   SQLCHAR col_name[128] = {0};
@@ -404,10 +387,8 @@ TEST_CASE("SQLDescribeCol returns 0 decimal digits for non-numeric types.", "[qu
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_digits_varchar_test (val VARCHAR(50))");
-  auto stmt = conn.execute("SELECT val FROM desc_digits_varchar_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_DIGITS_VARCHAR_TABLE));
 
   // When SQLDescribeCol is called for the VARCHAR column
   SQLCHAR col_name[128] = {0};
@@ -440,10 +421,8 @@ TEST_CASE("SQLDescribeCol returns SQL_NULLABLE for nullable column.", "[query]")
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_nullable_test (val VARCHAR(50))");
-  auto stmt = conn.execute("SELECT val FROM desc_nullable_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_NULLABLE_TABLE));
 
   // When SQLDescribeCol is called for a nullable column
   SQLCHAR col_name[128] = {0};
@@ -470,10 +449,8 @@ TEST_CASE("SQLDescribeCol returns SQL_NO_NULLS for NOT NULL column.", "[query]")
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE desc_notnull_test (val VARCHAR(50) NOT NULL)");
-  auto stmt = conn.execute("SELECT val FROM desc_notnull_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT val FROM " + std::string(readonly_db::DESC_NOTNULL_TABLE));
 
   // When SQLDescribeCol is called for a NOT NULL column
   SQLCHAR col_name[128] = {0};
@@ -698,15 +675,8 @@ TEST_CASE("SQLDescribeCol returns correct metadata for each column in a multi-co
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute(
-      "CREATE TABLE desc_multi_test ("
-      "  str_col VARCHAR(50),"
-      "  num_col NUMBER(8,2),"
-      "  bool_col BOOLEAN"
-      ")");
-  auto stmt = conn.execute("SELECT str_col, num_col, bool_col FROM desc_multi_test");
+  Connection conn(get_readonly_db_connection_string());
+  auto stmt = conn.execute("SELECT strcol, numcol, boolcol FROM " + std::string(readonly_db::DESC_MULTI_TABLE));
 
   SQLCHAR col_name[128] = {0};
   SQLSMALLINT name_length = 0;
@@ -721,8 +691,8 @@ TEST_CASE("SQLDescribeCol returns correct metadata for each column in a multi-co
   CHECK_ODBC(ret, stmt);
 
   // Then column 1 should be VARCHAR with size 50
-  CHECK(std::string((char*)col_name) == "STR_COL");
-  CHECK(name_length == 7);
+  CHECK(std::string((char*)col_name) == "STRCOL");
+  CHECK(name_length == 6);
   CHECK(data_type == SQL_VARCHAR);
   CHECK(col_size == 50);
   CHECK(decimal_digits == 0);
@@ -734,8 +704,8 @@ TEST_CASE("SQLDescribeCol returns correct metadata for each column in a multi-co
   CHECK_ODBC(ret, stmt);
 
   // Then column 2 should be DECIMAL with precision 8 and scale 2
-  CHECK(std::string((char*)col_name) == "NUM_COL");
-  CHECK(name_length == 7);
+  CHECK(std::string((char*)col_name) == "NUMCOL");
+  CHECK(name_length == 6);
   CHECK(data_type == SQL_DECIMAL);
   CHECK(col_size == 8);
   CHECK(decimal_digits == 2);
@@ -747,8 +717,8 @@ TEST_CASE("SQLDescribeCol returns correct metadata for each column in a multi-co
   CHECK_ODBC(ret, stmt);
 
   // Then column 3 should be BIT
-  CHECK(std::string((char*)col_name) == "BOOL_COL");
-  CHECK(name_length == 8);
+  CHECK(std::string((char*)col_name) == "BOOLCOL");
+  CHECK(name_length == 7);
   CHECK(data_type == SQL_BIT);
   CHECK(col_size == 1);
   CHECK(decimal_digits == 0);

--- a/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
@@ -2,17 +2,16 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
+#include <cstring>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -24,19 +23,10 @@
 // SQLColumnPrivileges - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Result set has correct number of columns",
                  "[odbc-api][catalog][columnprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_NUMCOLS"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -45,18 +35,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has cor
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][columnprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_colnames (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_COLNAMES"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME",
@@ -81,83 +63,59 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column 
 // SQLColumnPrivileges - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty result set for existing table",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Returns empty result set for existing table",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Snowflake does NOT support traditional SQL column-level GRANT privileges
   // (e.g., GRANT SELECT(col)). SQLColumnPrivileges always returns an empty result set.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_empty (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_EMPTY"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter combinations return empty",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Various parameter combinations return empty",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Cannot verify actual search pattern/parameter behavior since Snowflake doesn't
   // support column privileges. These tests only verify that various parameter combinations
   // are accepted without error and return empty result sets.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_params (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
-
   // Wildcard % for ColumnName
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_PARAMS"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
   // NULL ColumnName (treated as wildcard)
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_PARAMS"), SQL_NTS, nullptr, 0);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
   // Explicit string lengths instead of SQL_NTS
-  const std::string tbl = "TEST_CP_PARAMS";
-  const std::string col = "%";
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                            sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
-                            sqlchar(tbl.c_str()), static_cast<SQLSMALLINT>(tbl.length()), sqlchar(col.c_str()),
-                            static_cast<SQLSMALLINT>(col.length()));
+  const char* tbl = readonly_db::BASIC_TABLE;
+  const char* col = "%";
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), static_cast<SQLSMALLINT>(strlen(database_name())),
+                            sqlchar(schema_name()), static_cast<SQLSMALLINT>(strlen(schema_name())), sqlchar(tbl),
+                            static_cast<SQLSMALLINT>(strlen(tbl)), sqlchar(col), static_cast<SQLSMALLINT>(strlen(col)));
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Non-existent table returns empty result set",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Cannot distinguish between "table doesn't exist" and "no privileges exist"
   // since Snowflake doesn't support column privileges - both return empty result sets.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret =
-      SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                          sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar("NONEXISTENTTABLEXYZ99999"), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -168,42 +126,26 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table
 // SQLColumnPrivileges - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple times after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: Can call multiple times after close cursor",
                  "[odbc-api][catalog][columnprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_reuse (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_REUSE"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_REUSE"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount returns -1",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: SQLRowCount returns -1",
                  "[odbc-api][catalog][columnprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_rowcount (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_ROWCOUNT"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -256,23 +198,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative C
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumnPrivileges: 24000 - Cursor already open",
                  "[odbc-api][catalog][columnprivileges][error]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_cp_cursor (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_CURSOR"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_CP_CURSOR"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  ret = SQLColumnPrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
@@ -9,11 +9,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -72,23 +71,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set column names mat
 // SQLColumns - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column metadata for known table",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Returns correct column metadata for known table",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE TABLE test_sqlcolumns_meta (id INTEGER, name VARCHAR(100), price FLOAT, active BOOLEAN)"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_META"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::MULTI_TYPE_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   std::vector<std::string> columnNames;
@@ -107,9 +95,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column meta
     SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
     SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
 
-    REQUIRE(std::string(tableCat) == currentDb);
-    REQUIRE(std::string(tableSchem) == schema.name());
-    REQUIRE(std::string(tableName) == "TEST_SQLCOLUMNS_META");
+    REQUIRE(std::string(tableCat) == database_name());
+    REQUIRE(std::string(tableSchem) == schema_name());
+    REQUIRE(std::string(tableName) == readonly_db::MULTI_TYPE_TABLE);
 
     columnNames.emplace_back(columnName);
   }
@@ -121,21 +109,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column meta
   REQUIRE(columnNames[3] == "ACTIVE");
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types for known columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Returns correct data types for known columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE TABLE test_sqlcolumns_types (id INTEGER, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_TYPES"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -169,21 +148,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types 
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequential starting from 1",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: ORDINAL_POSITION is sequential starting from 1",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_ord (col_a INT, col_b VARCHAR(50), col_c FLOAT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_ORD"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::THREE_COL_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   for (int i = 1; i <= 3; i++) {
@@ -199,21 +169,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequent
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports correct nullability",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: NULLABLE column reports correct nullability",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_null (id INTEGER NOT NULL, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_NULL"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::NULLABILITY_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // id INTEGER NOT NULL
@@ -238,21 +199,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports cor
 // SQLColumns - Search Patterns
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % returns all columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: ColumnName wildcard % returns all columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_wild (col_x INT, col_y VARCHAR(50), col_z FLOAT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_WILD"), SQL_NTS, sqlchar("%"), SQL_NTS);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::THREE_COL_TABLE), SQL_NTS, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -262,21 +214,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % retur
   REQUIRE(rowCount == 3);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: NULL ColumnName returns all columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_nullcol (col_a INT, col_b VARCHAR(50))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_NULLCOL"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -286,21 +229,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters results",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Specific ColumnName filters results",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_specific (id INT, name VARCHAR(50), age INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_SPECIFIC"), SQL_NTS, sqlchar("NAME"), SQL_NTS);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::MULTI_TYPE_TABLE), SQL_NTS, sqlchar("NAME"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -314,21 +248,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard matches single character",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Underscore _ wildcard matches single character",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_uscore (ca INT, cb INT, ddd INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_USCORE"), SQL_NTS, sqlchar("C_"), SQL_NTS);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::WILDCARD_COL_TABLE), SQL_NTS, sqlchar("C_"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // C_ matches CA and CB but not DDD
@@ -348,16 +273,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard match
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Non-existent table returns empty result set",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
-                             SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_12345"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar("NONEXISTENTTABLEXYZ12345"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -368,23 +289,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns 
 // SQLColumns - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinations are accepted",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Various parameter combinations are accepted",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_params (id INT, name VARCHAR(50))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
+  const char* db = database_name();
+  const char* schema = schema_name();
+  const char* table = readonly_db::BASIC_TABLE;
 
   // Explicit catalog and schema with SQL_NTS
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_PARAMS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret =
+      SQLColumns(stmt_handle(), sqlchar(db), SQL_NTS, sqlchar(schema), SQL_NTS, sqlchar(table), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -394,10 +309,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
   REQUIRE(ret == SQL_SUCCESS);
 
   // Explicit string lengths instead of SQL_NTS
-  const std::string table = "TEST_SQLCOLUMNS_PARAMS";
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                   sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(table.c_str()),
-                   static_cast<SQLSMALLINT>(table.length()), nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(db), static_cast<SQLSMALLINT>(std::strlen(db)), sqlchar(schema),
+                   static_cast<SQLSMALLINT>(std::strlen(schema)), sqlchar(table),
+                   static_cast<SQLSMALLINT>(std::strlen(table)), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -409,20 +323,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
 // SQLColumns - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLColumns: Can call multiple times on same statement after close cursor",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sqlcolumns_reuse (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_REUSE"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                             sqlchar(readonly_db::NAMED_PK_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int count1 = 0;
@@ -433,8 +339,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                   sqlchar("TEST_SQLCOLUMNS_REUSE"), SQL_NTS, nullptr, 0);
+  ret = SQLColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                   sqlchar(readonly_db::NAMED_PK_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int count2 = 0;

--- a/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
@@ -7,13 +7,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -21,29 +19,13 @@
 // SQLForeignKeys - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Result set has correct number of columns",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_parent (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(
-          "CREATE TABLE test_fk_child (id INT, parent_id INT, FOREIGN KEY (parent_id) REFERENCES test_fk_parent(id))"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
   // Query FK table to get foreign keys
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_CHILD"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC 3.x spec defines 14 columns for SQLForeignKeys
@@ -53,27 +35,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct 
   REQUIRE(numCols == 14);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Result set column names match ODBC 3.x spec",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_p_names (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE TABLE test_fk_c_names (id INT, pid INT, FOREIGN KEY (pid) REFERENCES test_fk_p_names(id))"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_C_NAMES"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"PKTABLE_CAT",   "PKTABLE_SCHEM", "PKTABLE_NAME",  "PKCOLUMN_NAME", "FKTABLE_CAT",
@@ -103,29 +70,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names
 // SQLForeignKeys - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreign key referencing PK table",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: FK table returns foreign key referencing PK table",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_orders_parent (order_id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE TABLE test_fk_lines (line_id INT, order_id INT, FOREIGN KEY "
-                              "(order_id) REFERENCES test_fk_orders_parent(order_id))"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  // Query by FK table: what foreign keys does test_fk_lines have?
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_LINES"), SQL_NTS);
+  // Query by FK table: what foreign keys does FK_CHILD have?
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -143,38 +94,23 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreig
   SQLGetData(stmt_handle(), 8, SQL_C_CHAR, fkColumnName, sizeof(fkColumnName), nullptr);
   SQLGetData(stmt_handle(), 9, SQL_C_SSHORT, &keySeq, 0, nullptr);
 
-  REQUIRE(std::string(pkTableName) == "TEST_FK_ORDERS_PARENT");
-  REQUIRE(std::string(pkColumnName) == "ORDER_ID");
-  REQUIRE(std::string(fkTableName) == "TEST_FK_LINES");
-  REQUIRE(std::string(fkColumnName) == "ORDER_ID");
+  REQUIRE(std::string(pkTableName) == readonly_db::FK_PARENT);
+  REQUIRE(std::string(pkColumnName) == "ID");
+  REQUIRE(std::string(fkTableName) == readonly_db::FK_CHILD);
+  REQUIRE(std::string(fkColumnName) == "PARENTID");
   REQUIRE(keySeq == 1);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreign keys referencing it",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: PK table returns foreign keys referencing it",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_pk_parent (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE TABLE test_fk_pk_child (id INT, parent_id INT, FOREIGN KEY "
-                              "(parent_id) REFERENCES test_fk_pk_parent(id))"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  // Query by PK table: what tables reference test_fk_pk_parent's primary key?
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_PK_PARENT"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
+  // Query by PK table: what tables reference FK_PARENT's primary key?
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::FK_PARENT), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -190,37 +126,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreig
   SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTableName, sizeof(fkTableName), nullptr);
   SQLGetData(stmt_handle(), 8, SQL_C_CHAR, fkColumnName, sizeof(fkColumnName), nullptr);
 
-  REQUIRE(std::string(pkTableName) == "TEST_FK_PK_PARENT");
+  REQUIRE(std::string(pkTableName) == readonly_db::FK_PARENT);
   REQUIRE(std::string(pkColumnName) == "ID");
-  REQUIRE(std::string(fkTableName) == "TEST_FK_PK_CHILD");
-  REQUIRE(std::string(fkColumnName) == "PARENT_ID");
+  REQUIRE(std::string(fkTableName) == readonly_db::FK_CHILD);
+  REQUIRE(std::string(fkColumnName) == "PARENTID");
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table specified returns matching relationship",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Both PK and FK table specified returns matching relationship",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_both_pk (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE TABLE test_fk_both_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_both_pk(id))"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_BOTH_PK"), SQL_NTS, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_BOTH_FK"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::FK_PARENT), SQL_NTS, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -231,44 +152,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table sp
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, pkTableName, sizeof(pkTableName), nullptr);
   SQLGetData(stmt_handle(), 7, SQL_C_CHAR, fkTableName, sizeof(fkTableName), nullptr);
 
-  REQUIRE(std::string(pkTableName) == "TEST_FK_BOTH_PK");
-  REQUIRE(std::string(fkTableName) == "TEST_FK_BOTH_FK");
+  REQUIRE(std::string(pkTableName) == readonly_db::FK_PARENT);
+  REQUIRE(std::string(fkTableName) == readonly_db::FK_CHILD);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture,
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture,
                  "SQLForeignKeys: PK table referenced by multiple children returns all relationships",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_multi_parent (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE TABLE test_fk_multi_child_a (id INT, parent_id INT, "
-                              "FOREIGN KEY (parent_id) REFERENCES test_fk_multi_parent(id))"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE TABLE test_fk_multi_child_b (id INT, ref_id INT, "
-                              "FOREIGN KEY (ref_id) REFERENCES test_fk_multi_parent(id))"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
   // Query by PK table: both children should appear
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_MULTI_PARENT"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::FK_MULTI_PARENT), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -280,38 +178,24 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign keys returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Table without foreign keys returns empty result set",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_nofk (id INT, name VARCHAR(50))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_NOFK"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::NO_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Non-existent table returns empty result set",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret =
-      SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                     sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar("NONEXISTENTTABLEXYZ99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -322,28 +206,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table retu
 // SQLForeignKeys - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: Can call multiple times on same statement after close cursor",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_reuse_pk (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(
-          "CREATE TABLE test_fk_reuse_fk (id INT, ref_id INT, FOREIGN KEY (ref_id) REFERENCES test_fk_reuse_pk(id))"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_REUSE_FK"), SQL_NTS);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                                 sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -353,8 +221,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(currentDb.c_str()), SQL_NTS,
-                       sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_FK_REUSE_FK"), SQL_NTS);
+  ret = SQLForeignKeys(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, 0, sqlchar(database_name()), SQL_NTS,
+                       sqlchar(schema_name()), SQL_NTS, sqlchar(readonly_db::FK_CHILD), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -362,20 +230,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: SQLRowCount after catalog function call",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_rc_pk (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_RC_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::FK_PARENT), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -420,25 +280,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTabl
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLForeignKeys: 24000 - Cursor already open",
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_fk_cursor_pk (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_CURSOR_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
+  SQLRETURN ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::FK_PARENT), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLForeignKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_FK_CURSOR_PK"), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
+  ret = SQLForeignKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                       sqlchar(readonly_db::FK_PARENT), SQL_NTS, nullptr, 0, nullptr, 0, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
@@ -7,13 +7,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -21,20 +19,12 @@
 // SQLPrimaryKeys - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Result set has correct number of columns",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_numcols (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_NUMCOLS"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -44,20 +34,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct 
   REQUIRE(numCols == 6);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Result set column names match ODBC 3.x spec",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_colnames (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_COLNAMES"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"};
@@ -85,21 +67,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names
 // SQLPrimaryKeys - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for single-column PK",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Returns primary key for single-column PK",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE TABLE test_pk_single (id INT PRIMARY KEY, name VARCHAR(50))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_SINGLE"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -117,9 +90,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
   SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
 
-  REQUIRE(std::string(tableCat) == currentDb);
-  REQUIRE(std::string(tableSchem) == schema.name());
-  REQUIRE(std::string(tableName) == "TEST_PK_SINGLE");
+  REQUIRE(std::string(tableCat) == database_name());
+  REQUIRE(std::string(tableSchem) == schema_name());
+  REQUIRE(std::string(tableName) == readonly_db::SINGLE_PK_TABLE);
   REQUIRE(std::string(columnName) == "ID");
   REQUIRE(keySeq == 1);
 
@@ -127,23 +100,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite primary key with correct KEY_SEQ",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Returns composite primary key with correct KEY_SEQ",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE TABLE test_pk_composite (region_id INT, store_id INT, name "
-                                        "VARCHAR(50), PRIMARY KEY (region_id, store_id))"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_COMPOSITE"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::COMPOSITE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   char columnName[256] = {};
@@ -153,51 +115,38 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite prima
   REQUIRE(ret == SQL_SUCCESS);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
   SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
-  REQUIRE(std::string(columnName) == "REGION_ID");
+  REQUIRE(std::string(columnName) == "REGIONID");
   REQUIRE(keySeq == 1);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, columnName, sizeof(columnName), nullptr);
   SQLGetData(stmt_handle(), 5, SQL_C_SSHORT, &keySeq, 0, nullptr);
-  REQUIRE(std::string(columnName) == "STORE_ID");
+  REQUIRE(std::string(columnName) == "STOREID");
   REQUIRE(keySeq == 2);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary key returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Table without primary key returns empty result set",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_none (id INT, name VARCHAR(50))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_NONE"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::NO_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Non-existent table returns empty result set",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
-                                 SQL_NTS, sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar("NONEXISTENTTABLEXYZ99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -208,22 +157,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table retu
 // SQLPrimaryKeys - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combinations are accepted",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Various parameter combinations are accepted",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_params (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
-
   // Explicit catalog, schema, table with SQL_NTS
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_PARAMS"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -233,10 +173,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
   REQUIRE(ret == SQL_SUCCESS);
 
   // Explicit string lengths instead of SQL_NTS
-  const std::string table = "TEST_PK_PARAMS";
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                       sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
-                       sqlchar(table.c_str()), static_cast<SQLSMALLINT>(table.length()));
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), static_cast<SQLSMALLINT>(std::strlen(database_name())),
+                       sqlchar(schema_name()), static_cast<SQLSMALLINT>(std::strlen(schema_name())),
+                       sqlchar(readonly_db::SINGLE_PK_TABLE),
+                       static_cast<SQLSMALLINT>(std::strlen(readonly_db::SINGLE_PK_TABLE)));
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -248,20 +188,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
 // SQLPrimaryKeys - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: Can call multiple times on same statement after close cursor",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_reuse (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_REUSE"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -271,8 +203,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_REUSE"), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                       sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -280,20 +212,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: SQLRowCount after catalog function call",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_ROWCOUNT"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -335,25 +259,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableN
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLPrimaryKeys: 24000 - Cursor already open",
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_pk_cursor (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_CURSOR"), SQL_NTS);
+  SQLRETURN ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                 sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                       sqlchar("TEST_PK_CURSOR"), SQL_NTS);
+  ret = SQLPrimaryKeys(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                       sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
@@ -7,13 +7,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -21,23 +19,12 @@
 // SQLProcedureColumns - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Result set has correct number of columns",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_pc_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_NUMCOLS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 21 columns (ODBC 3.x spec defines 19, driver adds 2 extra)
@@ -47,23 +34,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has cor
   REQUIRE(numCols == 21);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Result set column names match ODBC 3.x spec",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_pc_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_COLNAMES"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: Reference driver returns 21 columns (19 spec + 2 driver-specific)
@@ -97,23 +73,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column 
 // SQLProcedureColumns - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters for known procedure",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Returns parameters for known procedure",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_params(p_name VARCHAR, p_age FLOAT)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_PARAMS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::MULTI_PARAM_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   char procCat[256] = {};
@@ -128,61 +93,45 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters
   SQLGetData(stmt_handle(), 2, SQL_C_CHAR, procSchem, sizeof(procSchem), nullptr);
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, procName, sizeof(procName), nullptr);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
-  REQUIRE(std::string(procCat) == currentDb);
-  REQUIRE(std::string(procSchem) == schema.name());
-  REQUIRE(std::string(procName) == "TEST_PC_PARAMS");
+  REQUIRE(std::string(procCat) == database_name());
+  REQUIRE(std::string(procSchem) == schema_name());
+  REQUIRE(std::string(procName) == readonly_db::MULTI_PARAM_PROC);
   REQUIRE(std::string(colName).empty());
 
-  // Input parameter P_NAME
+  // Input parameter PNAME
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
-  REQUIRE(std::string(colName) == "P_NAME");
+  REQUIRE(std::string(colName) == "PNAME");
 
-  // Input parameter P_AGE
+  // Input parameter PAGE
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
-  REQUIRE(std::string(colName) == "P_AGE");
+  REQUIRE(std::string(colName) == "PAGE");
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent procedure returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Non-existent procedure returns empty result set",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret =
-      SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                          sqlchar("NONEXISTENT_PROC_XYZ_99999"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar("NONEXISTENTPROCXYZ99999"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnName filters results",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Specific ColumnName filters results",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_filter(p_id INTEGER, p_name VARCHAR)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p_name; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_FILTER"), SQL_NTS, sqlchar("P_NAME"), SQL_NTS);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::PROC_FILTER), SQL_NTS, sqlchar("PNAME"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -190,7 +139,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnNam
 
   char colName[256] = {};
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, colName, sizeof(colName), nullptr);
-  REQUIRE(std::string(colName) == "P_NAME");
+  REQUIRE(std::string(colName) == "PNAME");
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -200,27 +149,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnNam
 // SQLProcedureColumns - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_variations(p1 VARCHAR)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
-
   // Return value + 1 input parameter = 2 rows
   // Explicit catalog, schema, proc with SQL_NTS
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_VARIATIONS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -230,10 +167,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
   REQUIRE(ret == SQL_SUCCESS);
 
   // Explicit string lengths instead of SQL_NTS
-  const std::string proc = "TEST_PC_VARIATIONS";
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                            sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()),
-                            sqlchar(proc.c_str()), static_cast<SQLSMALLINT>(proc.length()), nullptr, 0);
+  const std::string proc = readonly_db::BASIC_PROC;
+  const std::string db = database_name();
+  const std::string schema = schema_name();
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(db.c_str()), static_cast<SQLSMALLINT>(db.length()),
+                            sqlchar(schema.c_str()), static_cast<SQLSMALLINT>(schema.length()), sqlchar(proc.c_str()),
+                            static_cast<SQLSMALLINT>(proc.length()), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -245,25 +184,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 // SQLProcedureColumns - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture,
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture,
                  "SQLProcedureColumns: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_reuse(p1 VARCHAR)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_REUSE"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   // Return value + 1 input parameter = 2 rows
   int count1 = 0;
@@ -274,8 +202,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_REUSE"), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -283,23 +211,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   REQUIRE(count2 == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: SQLRowCount after catalog function call",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_rowcount(p1 VARCHAR)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_ROWCOUNT"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -354,28 +271,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative C
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedureColumns: 24000 - Cursor already open",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_pc_cursor(p1 VARCHAR)"
-                                        " RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_CURSOR"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLProcedureColumns(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("TEST_PC_CURSOR"), SQL_NTS, nullptr, 0);
+  ret = SQLProcedureColumns(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_PROC), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
@@ -6,13 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -20,23 +18,12 @@
 // SQLProcedures - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Result set has correct number of columns",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_procs_numcols(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_NUMCOLS"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC 3.x spec defines 8 columns
@@ -46,24 +33,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct n
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Result set column names match ODBC 3.x spec",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(
-          "CREATE PROCEDURE test_procs_colnames(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_COLNAMES"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"PROCEDURE_CAT",     "PROCEDURE_SCHEM", "PROCEDURE_NAME", "NUM_INPUT_PARAMS",
@@ -92,23 +67,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names 
 // SQLProcedures - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure with correct metadata",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Returns known procedure with correct metadata",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_procs_meta(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_META"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -124,9 +88,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure 
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, procName, sizeof(procName), nullptr);
   SQLGetData(stmt_handle(), 8, SQL_C_SSHORT, &procType, 0, nullptr);
 
-  REQUIRE(std::string(procCat) == currentDb);
-  REQUIRE(std::string(procSchem) == schema.name());
-  REQUIRE(std::string(procName) == "TEST_PROCS_META");
+  REQUIRE(std::string(procCat) == database_name());
+  REQUIRE(std::string(procSchem) == schema_name());
+  REQUIRE(std::string(procName) == readonly_db::BASIC_PROC);
   // SQL_PT_FUNCTION since it has RETURNS
   REQUIRE(procType == SQL_PT_FUNCTION);
 
@@ -134,24 +98,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds procedure",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Wildcard search finds procedure",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(
-          "CREATE PROCEDURE test_procs_wildcard(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_WILD%"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar("BASICPR%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -159,33 +111,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds pr
 
   char name[256] = {};
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name, sizeof(name), nullptr);
-  REQUIRE(std::string(name) == "TEST_PROCS_WILDCARD");
+  REQUIRE(std::string(name) == readonly_db::BASIC_PROC);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returning procs are all returned",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Multiple VARCHAR-returning procs are all returned",
                  "[odbc-api][procedures][catalog][known-bug]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_procs_multi_a(p1 VARCHAR) RETURNS VARCHAR "
-                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE PROCEDURE test_procs_multi_b(p1 VARCHAR) RETURNS VARCHAR "
-                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_MULTI%"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar("PROCMULTI%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -199,30 +133,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returni
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is returned alongside VARCHAR proc",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: NUMBER-returning proc is returned alongside VARCHAR proc",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_procs_dtype_a(p1 VARCHAR) RETURNS VARCHAR "
-                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE PROCEDURE test_procs_dtype_b(p1 INT) RETURNS INT "
-                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_DTYPE%"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar("PROCDTYPE%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -235,30 +151,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returning procs are all returned",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Multiple NUMBER-returning procs are all returned",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE PROCEDURE test_procs_num_a(p1 INT) RETURNS INT "
-                                        "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                                SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(),
-                      sqlchar("CREATE PROCEDURE test_procs_num_b(p1 INT) RETURNS INT "
-                              "LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_NUM%"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar("PROCNUM%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   int rowCount = 0;
@@ -271,16 +169,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returnin
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Non-existent procedure returns empty result set",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
-                                SQL_NTS, sqlchar("NONEXISTENT_PROC_XYZ_99999"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar("NONEXISTENTPROCXYZ99999"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -291,26 +185,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure r
 // SQLProcedures - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combinations are accepted",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Various parameter combinations are accepted",
                  "[odbc-api][procedures][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_procs_params(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
-
   // Explicit catalog, schema, proc with SQL_NTS
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_PARAMS"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -320,9 +202,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
   REQUIRE(ret == SQL_SUCCESS);
 
   // Explicit string lengths instead of SQL_NTS
-  const std::string proc = "TEST_PROCS_PARAMS";
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                      sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(proc.c_str()),
+  const std::string proc = readonly_db::BASIC_PROC;
+  const std::string db = database_name();
+  const std::string schema = schema_name();
+  ret = SQLProcedures(stmt_handle(), sqlchar(db.c_str()), static_cast<SQLSMALLINT>(db.length()),
+                      sqlchar(schema.c_str()), static_cast<SQLSMALLINT>(schema.length()), sqlchar(proc.c_str()),
                       static_cast<SQLSMALLINT>(proc.length()));
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
@@ -335,24 +219,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
 // SQLProcedures - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedures][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_procs_reuse(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_REUSE"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -362,8 +235,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_REUSE"), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -371,24 +244,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times 
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: SQLRowCount after catalog function call",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(
-          "CREATE PROCEDURE test_procs_rowcount(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_ROWCOUNT"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -430,28 +291,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcNam
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLProcedures: 24000 - Cursor already open",
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar("CREATE PROCEDURE test_procs_cursor(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'"),
-      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_CURSOR"), SQL_NTS);
+  SQLRETURN ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLProcedures(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_PROCS_CURSOR"), SQL_NTS);
+  ret = SQLProcedures(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                      sqlchar(readonly_db::BASIC_PROC), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
@@ -6,13 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -24,20 +22,11 @@
 // SQLSpecialColumns - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: Result set has correct number of columns",
                  "[odbc-api][catalog][specialcolumns]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sc_numcols (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_NUMCOLS"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -46,19 +35,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has corre
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][specialcolumns]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_colnames (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COLNAMES"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"SCOPE",       "COLUMN_NAME",   "DATA_TYPE",      "TYPE_NAME",
@@ -83,75 +64,48 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column na
 // SQLSpecialColumns - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: SQL_BEST_ROWID returns empty result set",
                  "[odbc-api][catalog][specialcolumns]") {
   // Note: Snowflake does not support row identifiers, so SQLSpecialColumns
   // always returns an empty result set for SQL_BEST_ROWID.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sc_bestrowid (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_BESTROWID"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: SQL_ROWVER returns empty result set",
                  "[odbc-api][catalog][specialcolumns]") {
   // Note: Snowflake does not have auto-updated version columns, so
   // SQLSpecialColumns always returns an empty result set for SQL_ROWVER.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_sc_rowver (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret =
-      SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
-                        SQL_NTS, sqlchar("TEST_SC_ROWVER"), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                        sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nullable combinations return empty",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: Various scope and nullable combinations return empty",
                  "[odbc-api][catalog][specialcolumns]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_combos (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
   // SQL_SCOPE_CURROW + SQL_NO_NULLS
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COMBOS"), SQL_NTS, SQL_SCOPE_CURROW,
-                          SQL_NO_NULLS);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_CURROW, SQL_NO_NULLS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
   // SQL_SCOPE_TRANSACTION + SQL_NULLABLE
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_COMBOS"), SQL_NTS,
-                          SQL_SCOPE_TRANSACTION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                          SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_TRANSACTION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -161,45 +115,28 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nu
 // SQLSpecialColumns - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple times after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: Can call multiple times after close cursor",
                  "[odbc-api][catalog][specialcolumns]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_reuse (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_REUSE"), SQL_NTS, SQL_SCOPE_SESSION,
-                          SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret =
-      SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()),
-                        SQL_NTS, sqlchar("TEST_SC_REUSE"), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_ROWVER, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                          sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns -1",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: SQLRowCount returns -1",
                  "[odbc-api][catalog][specialcolumns]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_ROWCOUNT"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -226,25 +163,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: HY090 - Negative Tab
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLSpecialColumns: 24000 - Cursor already open",
                  "[odbc-api][catalog][specialcolumns][error]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_sc_cursor (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_CURSOR"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  SQLRETURN ret =
+      SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                        SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(currentDb.c_str()), SQL_NTS,
-                          sqlchar(schema.name().c_str()), SQL_NTS, sqlchar("TEST_SC_CURSOR"), SQL_NTS,
-                          SQL_SCOPE_SESSION, SQL_NULLABLE);
+  ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()),
+                          SQL_NTS, sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
@@ -6,13 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -24,19 +22,10 @@
 // SQLStatistics - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: Result set has correct number of columns",
                  "[odbc-api][catalog][statistics]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(
-      stmt_handle(), sqlchar("CREATE TABLE test_stat_numcols (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_NUMCOLS"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -45,19 +34,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct n
   REQUIRE(numCols == 13);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][statistics]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_colnames (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_COLNAMES"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT",   "TABLE_SCHEM", "TABLE_NAME",       "NON_UNIQUE",  "INDEX_QUALIFIER",
@@ -83,40 +63,23 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names 
 // SQLStatistics - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Returns empty result set for table with primary key",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: Returns empty result set for table with primary key",
                  "[odbc-api][catalog][statistics]") {
   // Note: Snowflake does not expose index/statistics metadata through ODBC.
   // SQLStatistics always returns an empty result set.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(),
-                                sqlchar("CREATE TABLE test_stat_pk (id INT PRIMARY KEY, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_PK"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns empty",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns empty",
                  "[odbc-api][catalog][statistics]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_unique (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_UNIQUE"), SQL_NTS, SQL_INDEX_UNIQUE, SQL_ENSURE);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_UNIQUE, SQL_ENSURE);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -127,42 +90,25 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns
 // SQLStatistics - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: Can call multiple times after close cursor",
                  "[odbc-api][catalog][statistics]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_reuse (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_REUSE"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_REUSE"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                      sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1", "[odbc-api][catalog][statistics]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_rowcount (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_ROWCOUNT"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: SQLRowCount returns -1", "[odbc-api][catalog][statistics]") {
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -188,23 +134,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: HY090 - Negative TableNa
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLStatistics: 24000 - Cursor already open",
                  "[odbc-api][catalog][statistics][error]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_stat_cursor (id INT PRIMARY KEY)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_CURSOR"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  SQLRETURN ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLStatistics(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                      sqlchar("TEST_STAT_CURSOR"), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
+  ret = SQLStatistics(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                      sqlchar(readonly_db::SINGLE_PK_TABLE), SQL_NTS, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
@@ -6,13 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -24,19 +22,10 @@
 // SQLTablePrivileges - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTablePrivileges: Result set has correct number of columns",
                  "[odbc-api][catalog][tableprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                           sqlchar("TEST_TP_NUMCOLS"), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                     sqlchar(readonly_db::BASIC_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT numCols = 0;
@@ -45,18 +34,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has corr
   REQUIRE(numCols == 7);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTablePrivileges: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][tableprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_colnames (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                           sqlchar("TEST_TP_COLNAMES"), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                     sqlchar(readonly_db::BASIC_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",  "GRANTOR",
@@ -81,22 +62,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column n
 // SQLTablePrivileges - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty result set for existing table",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTablePrivileges: Returns empty result set for existing table",
                  "[odbc-api][catalog][tableprivileges]") {
   // Note: Snowflake does not expose table-level privilege metadata through ODBC.
   // SQLTablePrivileges always returns an empty result set.
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_empty (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                           sqlchar("TEST_TP_EMPTY"), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                     sqlchar(readonly_db::BASIC_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -116,25 +88,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL p
 // SQLTablePrivileges - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple times after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTablePrivileges: Can call multiple times after close cursor",
                  "[odbc-api][catalog][tableprivileges]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tp_reuse (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                           sqlchar("TEST_TP_REUSE"), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                                     sqlchar(readonly_db::BASIC_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLTablePrivileges(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                           sqlchar("TEST_TP_REUSE"), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                           sqlchar(readonly_db::BASIC_TABLE), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
@@ -142,7 +106,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple t
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns -1",
                  "[odbc-api][catalog][tableprivileges]") {
-  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
+  const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANYTABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -176,11 +140,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative Sc
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: 24000 - Cursor already open",
                  "[odbc-api][catalog][tableprivileges][error]") {
-  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
+  SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANYTABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
+  ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANYTABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
@@ -2,17 +2,16 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
+#include <cstring>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
+#include "ReadOnlyDbFixture.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "query_helpers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -20,19 +19,10 @@
 // SQLTables - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct number of columns",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Result set has correct number of columns",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_numcols (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_NUMCOLS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // ODBC spec defines 5 columns
@@ -42,18 +32,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct numbe
   REQUIRE(numCols == 5);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_colnames (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_COLNAMES"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   const char* expectedColNames[] = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS"};
@@ -77,19 +59,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names matc
 // SQLTables - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with correct metadata",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Returns known table with correct metadata",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret =
-      SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_meta (id INT, name VARCHAR(100))"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_META"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -105,30 +78,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with cor
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, tableType, sizeof(tableType), nullptr);
 
-  REQUIRE(std::string(tableCat) == currentDb);
-  REQUIRE(std::string(tableSchem) == schema.name());
-  REQUIRE(std::string(tableName) == "TEST_TBL_META");
+  REQUIRE(std::string(tableCat) == database_name());
+  REQUIRE(std::string(tableSchem) == schema_name());
+  REQUIRE(std::string(tableName) == readonly_db::BASIC_TABLE);
   REQUIRE(std::string(tableType) == "TABLE");
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE VIEW", "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_base (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE VIEW test_tbl_view AS SELECT * FROM test_tbl_base"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_VIEW"), SQL_NTS, nullptr, 0);
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Returns view with TABLE_TYPE VIEW", "[odbc-api][catalog][tables]") {
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_VIEW), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -142,38 +103,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Non-existent table returns empty result set",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Non-existent table returns empty result set",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                            sqlchar("NONEXISTENT_TABLE_XYZ_99999"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar("NONEXISTENTTABLEXYZ99999"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts results",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: TABLE_TYPE filter restricts results",
                  "[odbc-api][catalog][tables]") {
-  auto schema = Schema::use_random_schema(dbc_handle());
-
-  // Create a table and a view with a similar naming pattern
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_filter_t (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE VIEW test_tbl_filter_v AS SELECT * FROM test_tbl_filter_t"),
-                      SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  // No filter - wildcard matches both table and view
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, nullptr, 0);
+  // No filter - wildcard BASIC% matches both BASIC_TABLE and BASIC_VIEW
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar("BASIC%"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int totalCount = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -181,9 +125,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   REQUIRE(totalCount == 2);
   SQLCloseCursor(stmt_handle());
 
-  // Filter for TABLE - should return only the table
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, sqlchar("TABLE"), SQL_NTS);
+  // Filter for TABLE - should return only BASIC_TABLE
+  ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                  sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, sqlchar("TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -192,15 +136,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   char type1[256] = {};
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name1, sizeof(name1), nullptr);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, type1, sizeof(type1), nullptr);
-  REQUIRE(std::string(name1) == "TEST_TBL_FILTER_T");
+  REQUIRE(std::string(name1) == readonly_db::BASIC_TABLE);
   REQUIRE(std::string(type1) == "TABLE");
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
   SQLCloseCursor(stmt_handle());
 
-  // Filter for VIEW - should return only the view
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_FILTER%"), SQL_NTS, sqlchar("VIEW"), SQL_NTS);
+  // Filter for VIEW - should return only BASIC_VIEW
+  ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                  sqlchar(readonly_db::BASIC_VIEW), SQL_NTS, sqlchar("VIEW"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -209,23 +153,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   char type2[256] = {};
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, name2, sizeof(name2), nullptr);
   SQLGetData(stmt_handle(), 4, SQL_C_CHAR, type2, sizeof(type2), nullptr);
-  REQUIRE(std::string(name2) == "TEST_TBL_FILTER_V");
+  REQUIRE(std::string(name2) == readonly_db::BASIC_VIEW);
   REQUIRE(std::string(type2) == "VIEW");
   ret = SQLFetch(stmt_handle());
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table", "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_wild (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_WIL%"), SQL_NTS, nullptr, 0);
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Wildcard search finds table", "[odbc-api][catalog][tables]") {
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar("BASICTAB%"), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFetch(stmt_handle());
@@ -233,27 +169,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table"
 
   char tableName[256] = {};
   SQLGetData(stmt_handle(), 3, SQL_C_CHAR, tableName, sizeof(tableName), nullptr);
-  REQUIRE(std::string(tableName) == "TEST_TBL_WILD");
+  REQUIRE(std::string(tableName) == readonly_db::BASIC_TABLE);
 }
 
 // ============================================================================
 // SQLTables - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinations are accepted",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Various parameter combinations are accepted",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_params (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-  const std::string& schemaName = schema.name();
+  const char* db = database_name();
+  const char* schema = schema_name();
+  const char* tbl = readonly_db::BASIC_TABLE;
 
   // SQL_NTS lengths
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schemaName.c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_PARAMS"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret =
+      SQLTables(stmt_handle(), sqlchar(db), SQL_NTS, sqlchar(schema), SQL_NTS, sqlchar(tbl), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -262,10 +193,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
   SQLCloseCursor(stmt_handle());
 
   // Explicit string lengths
-  const std::string tbl = "TEST_TBL_PARAMS";
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), static_cast<SQLSMALLINT>(currentDb.length()),
-                  sqlchar(schemaName.c_str()), static_cast<SQLSMALLINT>(schemaName.length()), sqlchar(tbl.c_str()),
-                  static_cast<SQLSMALLINT>(tbl.length()), nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(db), static_cast<SQLSMALLINT>(std::strlen(db)), sqlchar(schema),
+                  static_cast<SQLSMALLINT>(std::strlen(schema)), sqlchar(tbl),
+                  static_cast<SQLSMALLINT>(std::strlen(tbl)), nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -277,18 +207,10 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
 // SQLTables - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times after close cursor",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: Can call multiple times after close cursor",
                  "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_reuse (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_REUSE"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count1 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -296,8 +218,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
   REQUIRE(count1 == 1);
   SQLCloseCursor(stmt_handle());
 
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_REUSE"), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                  sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
   int count2 = 0;
   while (SQLFetch(stmt_handle()) == SQL_SUCCESS)
@@ -305,17 +227,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_rowcount (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_ROWCOUNT"), SQL_NTS, nullptr, 0);
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN rowCount = 0;
@@ -351,23 +265,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative TableName l
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: 24000 - Cursor already open",
+TEST_CASE_METHOD(ReadOnlyDbStmtFixture, "SQLTables: 24000 - Cursor already open",
                  "[odbc-api][catalog][tables][error]") {
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_cursor (id INT)"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
-  SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-
-  const std::string currentDb = get_current_database(dbc_handle());
-
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_CURSOR"), SQL_NTS, nullptr, 0);
+  SQLRETURN ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                            sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Second call without closing cursor
-  ret = SQLTables(stmt_handle(), sqlchar(currentDb.c_str()), SQL_NTS, sqlchar(schema.name().c_str()), SQL_NTS,
-                  sqlchar("TEST_TBL_CURSOR"), SQL_NTS, nullptr, 0);
+  ret = SQLTables(stmt_handle(), sqlchar(database_name()), SQL_NTS, sqlchar(schema_name()), SQL_NTS,
+                  sqlchar(readonly_db::BASIC_TABLE), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/setup/CMakeLists.txt
+++ b/odbc_tests/tests/setup/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(setup_readonly_db setup_readonly_db.cpp)
+target_link_libraries(setup_readonly_db PRIVATE common Threads::Threads)
+catch_discover_tests(setup_readonly_db TEST_PREFIX "setup_readonly_db: ")

--- a/odbc_tests/tests/setup/setup_readonly_db.cpp
+++ b/odbc_tests/tests/setup/setup_readonly_db.cpp
@@ -1,0 +1,135 @@
+#include <sql.h>
+#include <sqlext.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "HandleWrapper.hpp"
+#include "test_setup.hpp"
+#include "utils.hpp"
+
+static std::string strip_comments_and_trim(const std::string& raw) {
+  std::istringstream stream(raw);
+  std::string line;
+  std::string result;
+
+  while (std::getline(stream, line)) {
+    size_t start = line.find_first_not_of(" \t\r");
+    if (start == std::string::npos) continue;
+    if (line.size() >= start + 2 && line[start] == '-' && line[start + 1] == '-') continue;
+    if (!result.empty()) result += ' ';
+    result += line.substr(start);
+  }
+
+  while (!result.empty() && (result.back() == ' ' || result.back() == '\t' || result.back() == '\r')) {
+    result.pop_back();
+  }
+  return result;
+}
+
+static std::vector<std::string> parse_sql_statements(const std::string& sql) {
+  std::vector<std::string> statements;
+  std::string current;
+  bool in_single_quote = false;
+
+  for (size_t i = 0; i < sql.size(); ++i) {
+    char c = sql[i];
+
+    if (c == '\'' && (i == 0 || sql[i - 1] != '\\')) {
+      in_single_quote = !in_single_quote;
+    }
+
+    if (c == ';' && !in_single_quote) {
+      std::string cleaned = strip_comments_and_trim(current);
+      if (!cleaned.empty()) {
+        statements.push_back(cleaned);
+      }
+      current.clear();
+    } else {
+      current += c;
+    }
+  }
+
+  std::string trailing = strip_comments_and_trim(current);
+  if (!trailing.empty()) {
+    statements.push_back(trailing);
+  }
+
+  return statements;
+}
+
+static std::string get_odbc_diagnostics(SQLSMALLINT handle_type, SQLHANDLE handle) {
+  std::string diag;
+  SQLCHAR state[8];
+  SQLINTEGER native_error;
+  SQLCHAR message[1024];
+  SQLSMALLINT msg_len;
+
+  for (SQLSMALLINT rec = 1;; ++rec) {
+    SQLRETURN dr = SQLGetDiagRec(handle_type, handle, rec, state, &native_error, message, sizeof(message), &msg_len);
+    if (dr == SQL_NO_DATA) break;
+    if (!diag.empty()) diag += " | ";
+    diag += "SQLSTATE=" + std::string(reinterpret_cast<char*>(state)) + " NativeError=" + std::to_string(native_error) +
+            " " + std::string(reinterpret_cast<char*>(message), msg_len);
+  }
+  return diag;
+}
+
+TEST_CASE("Setup readonly metadata test database", "[setup]") {
+  const auto sql_path = test_utils::repo_root() / "scripts" / "odbc" / "setup_readonly_metadata_db.sql";
+
+  REQUIRE(std::filesystem::exists(sql_path));
+
+  std::ifstream file(sql_path);
+  REQUIRE(file.good());
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  const std::string sql_contents = buffer.str();
+
+  auto statements = parse_sql_statements(sql_contents);
+  REQUIRE(!statements.empty());
+
+  // Build the connection string first — this triggers driver registration
+  // and sets ODBCSYSINI before any ODBC handles are allocated.
+  std::string conn_str = get_connection_string();
+
+  EnvironmentHandleWrapper env;
+  SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+  if (!SQL_SUCCEEDED(ret)) {
+    FAIL("SQLSetEnvAttr failed: " << get_odbc_diagnostics(SQL_HANDLE_ENV, env.getHandle()));
+  }
+  ConnectionHandleWrapper dbc = env.createConnectionHandle();
+  ret = SQLDriverConnect(dbc.getHandle(), nullptr, (SQLCHAR*)conn_str.c_str(), SQL_NTS, nullptr, 0, nullptr,
+                         SQL_DRIVER_NOPROMPT);
+  if (!SQL_SUCCEEDED(ret)) {
+    FAIL("SQLDriverConnect failed: " << get_odbc_diagnostics(SQL_HANDLE_DBC, dbc.getHandle()));
+  }
+
+  int success_count = 0;
+  int total = static_cast<int>(statements.size());
+
+  for (int i = 0; i < total; ++i) {
+    const auto& stmt_sql = statements[i];
+
+    StatementHandleWrapper stmt = dbc.createStatementHandle();
+    ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)stmt_sql.c_str(), SQL_NTS);
+
+    if (!SQL_SUCCEEDED(ret)) {
+      std::string diag = get_odbc_diagnostics(SQL_HANDLE_STMT, stmt.getHandle());
+      FAIL("Statement " << (i + 1) << "/" << total << " failed: " << stmt_sql << "\n  " << diag);
+    }
+
+    success_count++;
+    std::cout << "[OK] (" << (i + 1) << "/" << total << ") " << stmt_sql << "\n";
+  }
+
+  SQLDisconnect(dbc.getHandle());
+  std::cout << "\n=== Setup complete: " << success_count << "/" << total << " statements executed successfully ===\n";
+}

--- a/scripts/odbc/setup_readonly_metadata_db.sql
+++ b/scripts/odbc/setup_readonly_metadata_db.sql
@@ -1,0 +1,103 @@
+-- =============================================================================
+-- Readonly Metadata Test Database Setup
+-- =============================================================================
+--
+-- This script creates a dedicated Snowflake database with pre-provisioned
+-- tables, views, and procedures used by ODBC catalog and metadata tests.
+--
+-- Purpose: Eliminate per-test DDL that causes flaky test failures. Tests query
+-- this pre-existing schema instead of creating their own objects.
+--
+-- IMPORTANT: Object names MUST NOT contain underscores. ODBC catalog functions
+-- treat '_' as a single-character wildcard in pattern arguments, which causes
+-- painfully slow metadata queries when identifiers contain them.
+--
+-- Usage:
+--   Via the C++ runner (recommended):
+--     cd odbc_tests
+--     cmake -B cmake-build -DBUILD_SETUP_TOOLS=ON [other flags...]
+--     cmake --build cmake-build
+--     ctest --test-dir cmake-build -R setup_readonly_db
+--
+--   Via SnowSQL:
+--     snowsql -f scripts/odbc/setup_readonly_metadata_db.sql
+--
+-- This script is idempotent: it drops and recreates the schema (CASCADE),
+-- so it can be safely re-run to reset the database.
+-- =============================================================================
+
+CREATE DATABASE IF NOT EXISTS ODBCMETADATATESTDB;
+USE DATABASE ODBCMETADATATESTDB;
+DROP SCHEMA IF EXISTS CATALOGTESTS CASCADE;
+CREATE SCHEMA CATALOGTESTS;
+USE SCHEMA CATALOGTESTS;
+
+-- =============================================================================
+-- Basic tables (used by SQLTables, SQLColumns, SQLTablePrivileges,
+-- SQLColumnPrivileges, and SQLDescribeCol tests)
+-- =============================================================================
+
+CREATE TABLE BASICTABLE (id INT, name VARCHAR(100));
+CREATE TABLE MULTITYPETABLE (id INTEGER, name VARCHAR(100), price FLOAT, active BOOLEAN);
+CREATE TABLE THREECOLTABLE (cola INT, colb VARCHAR(50), colc FLOAT);
+CREATE TABLE NULLABILITYTABLE (id INTEGER NOT NULL, name VARCHAR(100));
+CREATE TABLE WILDCARDCOLTABLE (ca INT, cb INT, ddd INT);
+CREATE TABLE NOPKTABLE (id INT, name VARCHAR(50));
+
+-- =============================================================================
+-- Primary key tables (used by SQLPrimaryKeys, SQLStatistics,
+-- SQLSpecialColumns tests)
+-- =============================================================================
+
+CREATE TABLE SINGLEPKTABLE (id INT PRIMARY KEY, name VARCHAR(50));
+CREATE TABLE COMPOSITEPKTABLE (regionid INT, storeid INT, name VARCHAR(50), PRIMARY KEY (regionid, storeid));
+CREATE TABLE NAMEDPKTABLE (id INT, CONSTRAINT PKNAMED PRIMARY KEY (id));
+
+-- =============================================================================
+-- Foreign key tables (used by SQLForeignKeys tests)
+-- Parent tables must be created before children.
+-- =============================================================================
+
+CREATE TABLE FKPARENT (id INT PRIMARY KEY);
+CREATE TABLE FKCHILD (id INT, parentid INT, FOREIGN KEY (parentid) REFERENCES FKPARENT(id));
+CREATE TABLE FKMULTIPARENT (id INT PRIMARY KEY);
+CREATE TABLE FKMULTICHILDA (id INT, parentid INT, FOREIGN KEY (parentid) REFERENCES FKMULTIPARENT(id));
+CREATE TABLE FKMULTICHILDB (id INT, refid INT, FOREIGN KEY (refid) REFERENCES FKMULTIPARENT(id));
+
+-- =============================================================================
+-- Views (used by SQLTables VIEW type tests)
+-- =============================================================================
+
+CREATE VIEW BASICVIEW AS SELECT * FROM BASICTABLE;
+
+-- =============================================================================
+-- Procedures (used by SQLProcedures and SQLProcedureColumns tests)
+-- =============================================================================
+
+CREATE PROCEDURE BASICPROC(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE MULTIPARAMPROC(pname VARCHAR, page FLOAT) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN pname; END';
+CREATE PROCEDURE PROCFILTER(pid INTEGER, pname VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN pname; END';
+CREATE PROCEDURE PROCMULTIA(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE PROCMULTIB(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE PROCDTYPEA(p1 VARCHAR) RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE PROCDTYPEB(p1 INT) RETURNS INT LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE PROCNUMA(p1 INT) RETURNS INT LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+CREATE PROCEDURE PROCNUMB(p1 INT) RETURNS INT LANGUAGE SQL AS 'BEGIN RETURN p1; END';
+
+-- =============================================================================
+-- SQLDescribeCol tables (used by e2e/query/sql_describe_col.cpp)
+-- =============================================================================
+
+CREATE TABLE DESCVARCHARTABLE (val VARCHAR(100));
+CREATE TABLE DESCNUMBERTABLE (val NUMBER(10,2));
+CREATE TABLE DESCBOOLTABLE (val BOOLEAN);
+CREATE TABLE DESCFLOATTABLE (val FLOAT);
+CREATE TABLE DESCDATETABLE (val DATE);
+CREATE TABLE DESCTIMESTAMPTABLE (val TIMESTAMP_NTZ);
+CREATE TABLE DESCSIZEVARCHARTABLE (val VARCHAR(200));
+CREATE TABLE DESCSIZENUMBERTABLE (val NUMBER(12,3));
+CREATE TABLE DESCDIGITSTABLE (val NUMBER(10,4));
+CREATE TABLE DESCDIGITSVARCHARTABLE (val VARCHAR(50));
+CREATE TABLE DESCNULLABLETABLE (val VARCHAR(50));
+CREATE TABLE DESCNOTNULLTABLE (val VARCHAR(50) NOT NULL);
+CREATE TABLE DESCMULTITABLE (strcol VARCHAR(50), numcol NUMBER(8,2), boolcol BOOLEAN);


### PR DESCRIPTION
### TL;DR

Introduces a pre-provisioned readonly database for ODBC catalog tests to eliminate flaky test failures caused by per-test DDL operations.

### What changed?

- Added `ReadOnlyDbFixture.hpp` with constants and fixtures for accessing a pre-provisioned test database
- Created `setup_readonly_db.cpp` tool to provision the readonly database from SQL scripts
- Added `setup_readonly_metadata_db.sql` script defining all test tables, views, and procedures
- Updated `test_setup.hpp` to support skipping specific connection parameters
- Converted all ODBC catalog tests to use the readonly database instead of creating temporary objects
- Added `odbc.log` to `.gitignore`
- Added `BUILD_SETUP_TOOLS` CMake option to build the database setup utility

### How to test?

1. Build with setup tools: `cmake -B cmake-build -DBUILD_SETUP_TOOLS=ON`
2. Provision the database: `ctest --test-dir cmake-build -R setup_readonly_db`
3. Run catalog tests normally - they will automatically use the readonly database

### Why make this change?

Per-test DDL operations in catalog tests were causing flaky failures due to Snowflake's eventual consistency and metadata propagation delays. Using a pre-provisioned readonly database eliminates these timing issues while making tests faster and more reliable. The approach also avoids ODBC wildcard performance issues by ensuring object names don't contain underscores.