### PR TITLE
Implement APD/IPD descriptor integration for parameter binding

### DIFF
--- a/odbc/exports.def
+++ b/odbc/exports.def
@@ -30,7 +30,9 @@ EXPORTS
     SQLGetInfoW
     SQLGetStmtAttrW
     SQLMoreResults
+    SQLNumParams
     SQLNumResultCols
+    SQLDescribeParam
     SQLPrepareW
     SQLRowCount
     SQLSetConnectAttrW

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -458,95 +458,94 @@ fn get_apd_field(
     field: DescField,
     value_ptr: sql::Pointer,
 ) -> OdbcResult<()> {
-    if rec_number == 0 {
-        match field {
-            DescField::Count => {
-                let count = desc.desc_count();
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut sql::SmallInt,
-                        count as sql::SmallInt,
-                    );
-                }
-                Ok(())
+    // Per ODBC spec: "If the FieldIdentifier argument indicates a header field,
+    // RecNumber is ignored." Handle header fields first regardless of rec_number.
+    match field {
+        DescField::Count => {
+            let count = desc.desc_count();
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut sql::SmallInt, count as sql::SmallInt);
             }
-            DescField::ArraySize => {
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut sql::ULen,
-                        desc.array_size as sql::ULen,
-                    );
-                }
-                Ok(())
-            }
-            DescField::BindType => {
-                unsafe {
-                    std::ptr::write_unaligned(value_ptr as *mut sql::ULen, desc.bind_type);
-                }
-                Ok(())
-            }
-            DescField::BindOffsetPtr => {
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut *mut sql::Len,
-                        desc.bind_offset_ptr,
-                    );
-                }
-                Ok(())
-            }
-            _ => {
-                tracing::warn!("get_desc_field: unsupported APD header field {:?}", field);
-                crate::api::error::UnknownAttributeSnafu {
-                    attribute: field as i32,
-                }
-                .fail()
-            }
+            return Ok(());
         }
-    } else {
-        let param_number = rec_number as u16;
-        let record = match desc.records.get(&param_number) {
-            Some(r) => r,
-            None => return crate::api::error::NoMoreDataSnafu.fail(),
-        };
+        DescField::ArraySize => {
+            unsafe {
+                std::ptr::write_unaligned(
+                    value_ptr as *mut sql::ULen,
+                    desc.array_size as sql::ULen,
+                );
+            }
+            return Ok(());
+        }
+        DescField::BindType => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut sql::ULen, desc.bind_type);
+            }
+            return Ok(());
+        }
+        DescField::BindOffsetPtr => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut *mut sql::Len, desc.bind_offset_ptr);
+            }
+            return Ok(());
+        }
+        _ => {}
+    }
 
-        match field {
-            DescField::Type | DescField::ConciseType => {
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut sql::SmallInt,
-                        record.value_type as sql::SmallInt,
-                    );
-                }
-                Ok(())
+    if rec_number == 0 {
+        tracing::warn!(
+            "get_desc_field: unsupported APD field {:?} for record 0",
+            field
+        );
+        return crate::api::error::UnknownAttributeSnafu {
+            attribute: field as i32,
+        }
+        .fail();
+    }
+
+    let param_number = rec_number as u16;
+    let record = match desc.records.get(&param_number) {
+        Some(r) => r,
+        None => return crate::api::error::NoMoreDataSnafu.fail(),
+    };
+
+    match field {
+        DescField::Type | DescField::ConciseType => {
+            unsafe {
+                std::ptr::write_unaligned(
+                    value_ptr as *mut sql::SmallInt,
+                    record.value_type as sql::SmallInt,
+                );
             }
-            DescField::DataPtr => {
-                unsafe {
-                    std::ptr::write_unaligned(value_ptr as *mut sql::Pointer, record.data_ptr);
-                }
-                Ok(())
+            Ok(())
+        }
+        DescField::DataPtr => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut sql::Pointer, record.data_ptr);
             }
-            DescField::OctetLength => {
-                unsafe {
-                    std::ptr::write_unaligned(value_ptr as *mut sql::Len, record.buffer_length);
-                }
-                Ok(())
+            Ok(())
+        }
+        DescField::OctetLength => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut sql::Len, record.buffer_length);
             }
-            DescField::IndicatorPtr | DescField::OctetLengthPtr => {
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut *mut sql::Len,
-                        record.str_len_or_ind_ptr,
-                    );
-                }
-                Ok(())
+            Ok(())
+        }
+        DescField::IndicatorPtr | DescField::OctetLengthPtr => {
+            unsafe {
+                std::ptr::write_unaligned(
+                    value_ptr as *mut *mut sql::Len,
+                    record.str_len_or_ind_ptr,
+                );
             }
-            _ => {
-                tracing::warn!("get_desc_field: unsupported APD record field {:?}", field);
-                crate::api::error::UnknownAttributeSnafu {
-                    attribute: field as i32,
-                }
-                .fail()
+            Ok(())
+        }
+        _ => {
+            tracing::warn!("get_desc_field: unsupported APD record field {:?}", field);
+            crate::api::error::UnknownAttributeSnafu {
+                attribute: field as i32,
             }
+            .fail()
         }
     }
 }
@@ -644,42 +643,45 @@ fn get_ipd_field(
     field: DescField,
     value_ptr: sql::Pointer,
 ) -> OdbcResult<()> {
-    if rec_number == 0 {
-        match field {
-            DescField::Count => {
-                let count = desc.desc_count();
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut sql::SmallInt,
-                        count as sql::SmallInt,
-                    );
-                }
-                Ok(())
+    // Per ODBC spec: header fields ignore RecNumber.
+    match field {
+        DescField::Count => {
+            let count = desc.desc_count();
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut sql::SmallInt, count as sql::SmallInt);
             }
-            DescField::ArrayStatusPtr => {
-                unsafe {
-                    std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
-                }
-                Ok(())
-            }
-            DescField::RowsProcessedPtr => {
-                unsafe {
-                    std::ptr::write_unaligned(
-                        value_ptr as *mut *mut sql::ULen,
-                        desc.rows_processed_ptr,
-                    );
-                }
-                Ok(())
-            }
-            _ => {
-                tracing::warn!("get_desc_field: unsupported IPD header field {:?}", field);
-                crate::api::error::UnknownAttributeSnafu {
-                    attribute: field as i32,
-                }
-                .fail()
-            }
+            return Ok(());
         }
-    } else {
+        DescField::ArrayStatusPtr => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+            }
+            return Ok(());
+        }
+        DescField::RowsProcessedPtr => {
+            unsafe {
+                std::ptr::write_unaligned(
+                    value_ptr as *mut *mut sql::ULen,
+                    desc.rows_processed_ptr,
+                );
+            }
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    if rec_number == 0 {
+        tracing::warn!(
+            "get_desc_field: unsupported IPD field {:?} for record 0",
+            field
+        );
+        return crate::api::error::UnknownAttributeSnafu {
+            attribute: field as i32,
+        }
+        .fail();
+    }
+
+    {
         let param_number = rec_number as u16;
         let record = match desc.records.get(&param_number) {
             Some(r) => r,

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -35,6 +35,8 @@ pub fn get_desc_field(
     match desc_ref {
         DescriptorRef::Ard(desc) => get_ard_field(desc, rec_number, field, value_ptr),
         DescriptorRef::Ird(desc) => get_ird_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Apd(desc) => get_apd_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Ipd(desc) => get_ipd_field(desc, rec_number, field, value_ptr),
     }
 }
 
@@ -237,6 +239,8 @@ pub fn set_desc_field(
     match desc_ref {
         DescriptorRef::Ard(desc) => set_ard_field(desc, rec_number, field, value_ptr),
         DescriptorRef::Ird(desc) => set_ird_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Apd(desc) => set_apd_field(desc, rec_number, field, value_ptr),
+        DescriptorRef::Ipd(desc) => set_ipd_field(desc, rec_number, field, value_ptr),
     }
 }
 
@@ -441,5 +445,344 @@ fn set_ird_field(
             attribute: field as i32,
         }
         .fail()
+    }
+}
+
+// =============================================================================
+// APD — Application Parameter Descriptor
+// =============================================================================
+
+fn get_apd_field(
+    desc: &crate::api::ApdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::Count => {
+                let count = desc.desc_count();
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::SmallInt,
+                        count as sql::SmallInt,
+                    );
+                }
+                Ok(())
+            }
+            DescField::ArraySize => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::ULen,
+                        desc.array_size as sql::ULen,
+                    );
+                }
+                Ok(())
+            }
+            DescField::BindType => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::ULen, desc.bind_type);
+                }
+                Ok(())
+            }
+            DescField::BindOffsetPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::Len,
+                        desc.bind_offset_ptr,
+                    );
+                }
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("get_desc_field: unsupported APD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        let param_number = rec_number as u16;
+        let record = match desc.records.get(&param_number) {
+            Some(r) => r,
+            None => return crate::api::error::NoMoreDataSnafu.fail(),
+        };
+
+        match field {
+            DescField::Type | DescField::ConciseType => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::SmallInt,
+                        record.value_type as sql::SmallInt,
+                    );
+                }
+                Ok(())
+            }
+            DescField::DataPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::Pointer, record.data_ptr);
+                }
+                Ok(())
+            }
+            DescField::OctetLength => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::Len, record.buffer_length);
+                }
+                Ok(())
+            }
+            DescField::IndicatorPtr | DescField::OctetLengthPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::Len,
+                        record.str_len_or_ind_ptr,
+                    );
+                }
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("get_desc_field: unsupported APD record field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    }
+}
+
+fn set_apd_field(
+    desc: &mut crate::api::ApdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::ArraySize => {
+                let size = value_ptr as usize;
+                if size == 0 {
+                    return crate::api::error::InvalidDescriptorIndexSnafu { number: 0i16 }.fail();
+                }
+                desc.array_size = size;
+                Ok(())
+            }
+            DescField::BindType => {
+                desc.bind_type = value_ptr as usize;
+                Ok(())
+            }
+            DescField::BindOffsetPtr => {
+                desc.bind_offset_ptr = value_ptr as *mut sql::Len;
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("set_desc_field: unsupported APD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        let param_number = rec_number as u16;
+        let record = desc.records.entry(param_number).or_default();
+
+        match field {
+            DescField::Type | DescField::ConciseType => {
+                let raw = value_ptr as i16;
+                let c_type = CDataType::try_from(raw).map_err(|unknown| {
+                    tracing::error!("set_desc_field: unknown C data type discriminant {unknown}");
+                    crate::api::error::OdbcError::InvalidApplicationBufferType {
+                        location: snafu::location!(),
+                    }
+                })?;
+                record.value_type = c_type;
+                Ok(())
+            }
+            DescField::DataPtr => {
+                record.data_ptr = value_ptr;
+                Ok(())
+            }
+            DescField::OctetLength => {
+                record.buffer_length = value_ptr as sql::Len;
+                Ok(())
+            }
+            DescField::IndicatorPtr | DescField::OctetLengthPtr => {
+                record.str_len_or_ind_ptr = value_ptr as *mut sql::Len;
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("set_desc_field: unsupported APD record field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    }
+}
+
+// =============================================================================
+// IPD — Implementation Parameter Descriptor
+// =============================================================================
+
+fn get_ipd_field(
+    desc: &crate::api::IpdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::Count => {
+                let count = desc.desc_count();
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::SmallInt,
+                        count as sql::SmallInt,
+                    );
+                }
+                Ok(())
+            }
+            DescField::ArrayStatusPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+                }
+                Ok(())
+            }
+            DescField::RowsProcessedPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut *mut sql::ULen,
+                        desc.rows_processed_ptr,
+                    );
+                }
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("get_desc_field: unsupported IPD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        let param_number = rec_number as u16;
+        let record = match desc.records.get(&param_number) {
+            Some(r) => r,
+            None => return crate::api::error::NoMoreDataSnafu.fail(),
+        };
+
+        match field {
+            DescField::Type | DescField::ConciseType => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::SmallInt,
+                        record.parameter_type.0,
+                    );
+                }
+                Ok(())
+            }
+            DescField::Precision => {
+                let precision = if record.column_size <= i16::MAX as sql::ULen {
+                    record.column_size as sql::SmallInt
+                } else {
+                    i16::MAX
+                };
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::SmallInt, precision);
+                }
+                Ok(())
+            }
+            DescField::Scale => {
+                unsafe {
+                    std::ptr::write_unaligned(
+                        value_ptr as *mut sql::SmallInt,
+                        record.decimal_digits,
+                    );
+                }
+                Ok(())
+            }
+            DescField::ParameterType => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::SmallInt, record.direction);
+                }
+                Ok(())
+            }
+            DescField::Nullable => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut sql::SmallInt, record.nullable);
+                }
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("get_desc_field: unsupported IPD record field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    }
+}
+
+fn set_ipd_field(
+    desc: &mut crate::api::IpdDescriptor,
+    rec_number: sql::SmallInt,
+    field: DescField,
+    value_ptr: sql::Pointer,
+) -> OdbcResult<()> {
+    if rec_number == 0 {
+        match field {
+            DescField::ArrayStatusPtr => {
+                desc.array_status_ptr = value_ptr as *mut u16;
+                Ok(())
+            }
+            DescField::RowsProcessedPtr => {
+                desc.rows_processed_ptr = value_ptr as *mut sql::ULen;
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("set_desc_field: unsupported IPD header field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
+    } else {
+        let param_number = rec_number as u16;
+        let record = desc.records.entry(param_number).or_default();
+
+        match field {
+            DescField::Type | DescField::ConciseType => {
+                record.parameter_type = sql::SqlDataType(value_ptr as i16);
+                Ok(())
+            }
+            DescField::Precision => {
+                record.column_size = value_ptr as sql::ULen;
+                Ok(())
+            }
+            DescField::Scale => {
+                record.decimal_digits = value_ptr as sql::SmallInt;
+                Ok(())
+            }
+            DescField::ParameterType => {
+                record.direction = value_ptr as sql::SmallInt;
+                Ok(())
+            }
+            DescField::Nullable => {
+                record.nullable = value_ptr as sql::SmallInt;
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("set_desc_field: unsupported IPD record field {:?}", field);
+                crate::api::error::UnknownAttributeSnafu {
+                    attribute: field as i32,
+                }
+                .fail()
+            }
+        }
     }
 }

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -559,6 +559,18 @@ fn set_apd_field(
 ) -> OdbcResult<()> {
     if rec_number == 0 {
         match field {
+            DescField::Count => {
+                let count = value_ptr as sql::SmallInt;
+                if count < 0 {
+                    return crate::api::error::InvalidDescriptorIndexSnafu { number: count }.fail();
+                }
+                if count == 0 {
+                    desc.clear();
+                } else {
+                    desc.records.retain(|&k, _| k <= count as u16);
+                }
+                Ok(())
+            }
             DescField::ArraySize => {
                 let size = value_ptr as usize;
                 if size == 0 {
@@ -679,7 +691,7 @@ fn get_ipd_field(
                 unsafe {
                     std::ptr::write_unaligned(
                         value_ptr as *mut sql::SmallInt,
-                        record.parameter_type.0,
+                        record.sql_data_type.0,
                     );
                 }
                 Ok(())
@@ -757,7 +769,9 @@ fn set_ipd_field(
 
         match field {
             DescField::Type | DescField::ConciseType => {
-                record.parameter_type = sql::SqlDataType(value_ptr as i16);
+                let raw_type = value_ptr as i16;
+                crate::api::SqlType::try_from(raw_type)?;
+                record.sql_data_type = sql::SqlDataType(raw_type);
                 Ok(())
             }
             DescField::Precision => {

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -769,7 +769,9 @@ fn set_ipd_field(
                 Ok(())
             }
             DescField::ParameterType => {
-                record.direction = value_ptr as sql::SmallInt;
+                let direction = value_ptr as sql::SmallInt;
+                crate::api::ParamDirection::try_from(direction)?;
+                record.direction = direction;
                 Ok(())
             }
             DescField::Nullable => {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -1,7 +1,7 @@
 use crate::api::error::{DisconnectedSnafu, InvalidHandleSnafu, OdbcRuntimeSnafu, Required};
 use crate::api::{
-    ArdDescriptor, Connection, ConnectionState, Environment, IrdDescriptor, OdbcResult, Statement,
-    StatementState, conn_from_handle,
+    ApdDescriptor, ArdDescriptor, Connection, ConnectionState, Environment, IpdDescriptor,
+    IrdDescriptor, OdbcResult, Statement, StatementState, conn_from_handle,
     diagnostic::DiagnosticInfo,
     runtime::{env_allocated, env_freed, global},
 };
@@ -58,11 +58,10 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement<'
                 conn,
                 stmt_handle,
                 state: StatementState::Created.into(),
-                parameter_bindings: std::collections::HashMap::new(),
                 ard: ArdDescriptor::new(),
                 ird: IrdDescriptor::new(),
-                apd: ArdDescriptor::new_apd(),
-                ipd: IrdDescriptor::new_ipd(),
+                apd: ApdDescriptor::new(),
+                ipd: IpdDescriptor::new(),
                 diagnostic_info: DiagnosticInfo::default(),
                 get_data_state: None,
                 cursor_type: crate::api::CursorType::ForwardOnly,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -4,7 +4,7 @@ use crate::api::error::{
     ArrowArrayStreamReaderCreationSnafu, DisconnectedSnafu, InvalidBufferLengthSnafu,
     InvalidCursorStateSnafu, InvalidHandleSnafu, InvalidParameterNumberSnafu,
     InvalidPrecisionOrScaleSnafu, JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu,
-    OdbcRuntimeSnafu, Required,
+    OdbcRuntimeSnafu, Required, StatementNotExecutedSnafu,
 };
 use crate::api::runtime::global;
 use crate::api::{
@@ -513,21 +513,26 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
 }
 
 /// Return the number of parameters in the statement via the IPD descriptor.
+// TODO: Once auto-IPD is implemented (parsing ? markers during SQLPrepare),
+// this will also work for statements that haven't had SQLBindParameter called.
 pub fn num_params(
     statement_handle: sql::Handle,
     param_count_ptr: *mut sql::SmallInt,
 ) -> OdbcResult<()> {
     tracing::debug!("num_params: statement_handle={:?}", statement_handle);
 
-    if param_count_ptr.is_null() {
-        return NullPointerSnafu.fail();
+    let stmt = stmt_from_handle(statement_handle);
+
+    if matches!(stmt.state.as_ref(), StatementState::Created) {
+        return StatementNotExecutedSnafu.fail();
     }
 
-    let stmt = stmt_from_handle(statement_handle);
     let count = stmt.ipd.desc_count();
 
-    unsafe {
-        *param_count_ptr = count as sql::SmallInt;
+    if !param_count_ptr.is_null() {
+        unsafe {
+            *param_count_ptr = count as sql::SmallInt;
+        }
     }
 
     tracing::info!("num_params: {} parameters", count);
@@ -535,6 +540,8 @@ pub fn num_params(
 }
 
 /// Describe a bound parameter via the IPD descriptor.
+// TODO: Once auto-IPD is implemented, this will also work for parameters
+// that were not explicitly bound but inferred from ? markers in SQLPrepare.
 pub fn describe_param(
     statement_handle: sql::Handle,
     parameter_number: sql::USmallInt,
@@ -554,6 +561,10 @@ pub fn describe_param(
     }
 
     let stmt = stmt_from_handle(statement_handle);
+
+    if matches!(stmt.state.as_ref(), StatementState::Created) {
+        return StatementNotExecutedSnafu.fail();
+    }
     let ipd_rec = stmt.ipd.records.get(&parameter_number).ok_or_else(|| {
         tracing::error!(
             "describe_param: parameter #{} not found in IPD",

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -430,7 +430,7 @@ pub fn bind_parameter(
     stmt.ipd.records.insert(
         parameter_number,
         IpdRecord {
-            parameter_type,
+            sql_data_type: parameter_type,
             column_size,
             decimal_digits,
             direction: raw_input_output_type,
@@ -575,7 +575,7 @@ pub fn describe_param(
 
     if !data_type_ptr.is_null() {
         unsafe {
-            *data_type_ptr = ipd_rec.parameter_type.0;
+            *data_type_ptr = ipd_rec.sql_data_type.0;
         }
     }
     if !parameter_size_ptr.is_null() {
@@ -597,7 +597,7 @@ pub fn describe_param(
     tracing::info!(
         "describe_param: parameter {} type={:?} size={} digits={} nullable={}",
         parameter_number,
-        ipd_rec.parameter_type,
+        ipd_rec.sql_data_type,
         ipd_rec.column_size,
         ipd_rec.decimal_digits,
         ipd_rec.nullable,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -8,8 +8,8 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::{
-    ConnectionState, FreeStmtOption, OdbcResult, ParamDirection, ParameterBinding, SqlType,
-    Statement, StatementState, stmt_from_handle,
+    ApdRecord, ConnectionState, FreeStmtOption, IpdRecord, OdbcResult, ParamDirection,
+    ParameterBinding, SqlType, Statement, StatementState, stmt_from_handle,
 };
 use crate::conversion::Binding;
 use crate::conversion::param_binding::odbc_bindings_to_json;
@@ -43,7 +43,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd)?;
             let stmt_handle = stmt.stmt_handle;
 
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
@@ -214,7 +214,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.parameter_bindings)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd)?;
 
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                 c.statement_execute_query(StatementExecuteQueryRequest {
@@ -320,17 +320,18 @@ fn create_execute_state(
 /// until after the bindings have been consumed by `statement_execute_query`,
 /// because `BinaryDataPtr` holds a raw pointer into the owned `String`.
 fn apply_parameter_bindings(
-    parameter_bindings: &std::collections::HashMap<u16, ParameterBinding>,
+    apd: &crate::api::ApdDescriptor,
+    ipd: &crate::api::IpdDescriptor,
 ) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
-    if parameter_bindings.is_empty() {
+    if apd.records.is_empty() {
         return Ok((None, None));
     }
     tracing::info!(
         "apply_parameter_bindings: Found {} bound parameters",
-        parameter_bindings.len()
+        apd.records.len()
     );
 
-    let json_string = odbc_bindings_to_json(parameter_bindings).context(JsonBindingSnafu {})?;
+    let json_string = odbc_bindings_to_json(apd, ipd).context(JsonBindingSnafu {})?;
 
     let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
     let json_data_len = json_string.len();
@@ -357,7 +358,7 @@ pub fn bind_parameter(
     raw_input_output_type: sql::SmallInt,
     raw_value_type: sql::SmallInt,
     raw_parameter_type: sql::SmallInt,
-    _column_size: sql::ULen,
+    column_size: sql::ULen,
     decimal_digits: sql::SmallInt,
     parameter_value_ptr: sql::Pointer,
     buffer_length: sql::Len,
@@ -416,15 +417,26 @@ pub fn bind_parameter(
 
     let stmt = stmt_from_handle(statement_handle);
 
-    let binding = ParameterBinding {
-        parameter_type,
-        value_type,
-        parameter_value_ptr,
-        buffer_length,
-        str_len_or_ind_ptr,
-    };
+    stmt.apd.records.insert(
+        parameter_number,
+        ApdRecord {
+            value_type,
+            data_ptr: parameter_value_ptr,
+            buffer_length,
+            str_len_or_ind_ptr,
+        },
+    );
 
-    stmt.parameter_bindings.insert(parameter_number, binding);
+    stmt.ipd.records.insert(
+        parameter_number,
+        IpdRecord {
+            parameter_type,
+            column_size,
+            decimal_digits,
+            direction: raw_input_output_type,
+            ..IpdRecord::default()
+        },
+    );
 
     tracing::info!(
         "bind_parameter: Successfully bound parameter {}",
@@ -492,10 +504,93 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
         }
         FreeStmtOption::ResetParams => {
             tracing::info!("free_stmt: Resetting all parameters");
-            stmt.parameter_bindings.clear();
+            stmt.apd.clear();
+            stmt.ipd.clear();
         }
     }
 
+    Ok(())
+}
+
+/// Return the number of parameters in the statement via the IPD descriptor.
+pub fn num_params(
+    statement_handle: sql::Handle,
+    param_count_ptr: *mut sql::SmallInt,
+) -> OdbcResult<()> {
+    tracing::debug!("num_params: statement_handle={:?}", statement_handle);
+
+    if param_count_ptr.is_null() {
+        return NullPointerSnafu.fail();
+    }
+
+    let stmt = stmt_from_handle(statement_handle);
+    let count = stmt.ipd.desc_count();
+
+    unsafe {
+        *param_count_ptr = count as sql::SmallInt;
+    }
+
+    tracing::info!("num_params: {} parameters", count);
+    Ok(())
+}
+
+/// Describe a bound parameter via the IPD descriptor.
+pub fn describe_param(
+    statement_handle: sql::Handle,
+    parameter_number: sql::USmallInt,
+    data_type_ptr: *mut sql::SmallInt,
+    parameter_size_ptr: *mut sql::ULen,
+    decimal_digits_ptr: *mut sql::SmallInt,
+    nullable_ptr: *mut sql::SmallInt,
+) -> OdbcResult<()> {
+    tracing::debug!(
+        "describe_param: statement_handle={:?}, parameter_number={}",
+        statement_handle,
+        parameter_number
+    );
+
+    if parameter_number == 0 {
+        return InvalidParameterNumberSnafu.fail();
+    }
+
+    let stmt = stmt_from_handle(statement_handle);
+    let ipd_rec = stmt.ipd.records.get(&parameter_number).ok_or_else(|| {
+        tracing::error!(
+            "describe_param: parameter #{} not found in IPD",
+            parameter_number
+        );
+        InvalidParameterNumberSnafu.build()
+    })?;
+
+    if !data_type_ptr.is_null() {
+        unsafe {
+            *data_type_ptr = ipd_rec.parameter_type.0;
+        }
+    }
+    if !parameter_size_ptr.is_null() {
+        unsafe {
+            *parameter_size_ptr = ipd_rec.column_size;
+        }
+    }
+    if !decimal_digits_ptr.is_null() {
+        unsafe {
+            *decimal_digits_ptr = ipd_rec.decimal_digits;
+        }
+    }
+    if !nullable_ptr.is_null() {
+        unsafe {
+            *nullable_ptr = ipd_rec.nullable;
+        }
+    }
+
+    tracing::info!(
+        "describe_param: parameter {} type={:?} size={} digits={} nullable={}",
+        parameter_number,
+        ipd_rec.parameter_type,
+        ipd_rec.column_size,
+        ipd_rec.decimal_digits,
+        ipd_rec.nullable,
+    );
     Ok(())
 }
 
@@ -681,14 +776,14 @@ pub fn get_stmt_attr(
             Ok(())
         }
         StmtAttr::AppParamDesc => {
-            let apd_ptr = &mut stmt.apd as *mut crate::api::ArdDescriptor as sql::Handle;
+            let apd_ptr = &mut stmt.apd as *mut crate::api::ApdDescriptor as sql::Handle;
             unsafe {
                 *(value_ptr as *mut sql::Handle) = apd_ptr;
             }
             Ok(())
         }
         StmtAttr::ImpParamDesc => {
-            let ipd_ptr = &mut stmt.ipd as *mut crate::api::IrdDescriptor as sql::Handle;
+            let ipd_ptr = &mut stmt.ipd as *mut crate::api::IpdDescriptor as sql::Handle;
             unsafe {
                 *(value_ptr as *mut sql::Handle) = ipd_ptr;
             }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -8,8 +8,8 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::{
-    ApdRecord, ConnectionState, FreeStmtOption, IpdRecord, OdbcResult, ParamDirection,
-    ParameterBinding, SqlType, Statement, StatementState, stmt_from_handle,
+    ApdRecord, ConnectionState, FreeStmtOption, IpdRecord, OdbcResult, ParamDirection, SqlType,
+    Statement, StatementState, stmt_from_handle,
 };
 use crate::conversion::Binding;
 use crate::conversion::param_binding::odbc_bindings_to_json;

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -793,7 +793,7 @@ pub struct Connection {
 /// the pointer to the application's data buffer, its length, and the
 /// indicator/length pointer. Populated by `SQLBindParameter` or
 /// `SQLSetDescField` on the APD handle.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ApdRecord {
     pub value_type: CDataType,
     pub data_ptr: sql::Pointer,
@@ -817,7 +817,7 @@ impl Default for ApdRecord {
 /// Stores the implementation-side view of a bound parameter: the SQL data type,
 /// column size, decimal digits, and parameter direction. Populated by
 /// `SQLBindParameter` or `SQLSetDescField` on the IPD handle.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct IpdRecord {
     pub parameter_type: sql::SqlDataType,
     pub column_size: sql::ULen,

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -819,7 +819,7 @@ impl Default for ApdRecord {
 /// `SQLBindParameter` or `SQLSetDescField` on the IPD handle.
 #[derive(Debug)]
 pub struct IpdRecord {
-    pub parameter_type: sql::SqlDataType,
+    pub sql_data_type: sql::SqlDataType,
     pub column_size: sql::ULen,
     pub decimal_digits: sql::SmallInt,
     pub direction: sql::SmallInt,
@@ -829,7 +829,7 @@ pub struct IpdRecord {
 impl Default for IpdRecord {
     fn default() -> Self {
         Self {
-            parameter_type: sql::SqlDataType::VARCHAR,
+            sql_data_type: sql::SqlDataType::VARCHAR,
             column_size: 0,
             decimal_digits: 0,
             direction: sql::ParamType::Input as sql::SmallInt,
@@ -842,7 +842,7 @@ impl Default for IpdRecord {
 /// for consumption by the parameter conversion pipeline.
 #[derive(Debug, Clone)]
 pub struct ParameterBinding {
-    pub parameter_type: sql::SqlDataType,
+    pub sql_data_type: sql::SqlDataType,
     pub value_type: CDataType,
     pub parameter_value_ptr: sql::Pointer,
     pub buffer_length: sql::Len,
@@ -852,7 +852,7 @@ pub struct ParameterBinding {
 impl ParameterBinding {
     pub fn from_apd_ipd(apd: &ApdRecord, ipd: &IpdRecord) -> Self {
         Self {
-            parameter_type: ipd.parameter_type,
+            sql_data_type: ipd.sql_data_type,
             value_type: apd.value_type,
             parameter_value_ptr: apd.data_ptr,
             buffer_length: apd.buffer_length,

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -833,7 +833,7 @@ impl Default for IpdRecord {
             column_size: 0,
             decimal_digits: 0,
             direction: sql::ParamType::Input as sql::SmallInt,
-            nullable: 2, // SQL_NULLABLE_UNKNOWN
+            nullable: 1, // SQL_NULLABLE — per ODBC spec: "dynamic parameters are always nullable"
         }
     }
 }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -265,6 +265,10 @@ pub enum DescField {
     DataPtr = 1010,
     /// `SQL_DESC_OCTET_LENGTH` (1013) — length in bytes of the data buffer.
     OctetLength = 1013,
+    /// `SQL_DESC_PARAMETER_TYPE` (1015) — parameter direction (IPD only).
+    ParameterType = 1015,
+    /// `SQL_DESC_NULLABLE` (1008) — whether the parameter is nullable (IPD only).
+    Nullable = 1008,
 }
 
 impl TryFrom<i16> for DescField {
@@ -284,9 +288,11 @@ impl TryFrom<i16> for DescField {
             1004 => Ok(DescField::OctetLengthPtr),
             1005 => Ok(DescField::Precision),
             1006 => Ok(DescField::Scale),
+            1008 => Ok(DescField::Nullable),
             1009 => Ok(DescField::IndicatorPtr),
             1010 => Ok(DescField::DataPtr),
             1013 => Ok(DescField::OctetLength),
+            1015 => Ok(DescField::ParameterType),
             _ => {
                 tracing::warn!("Unknown descriptor field identifier: {}", value);
                 Err(OdbcError::UnknownAttribute {
@@ -539,16 +545,8 @@ impl Default for ArdDescriptor {
 
 impl ArdDescriptor {
     pub fn new() -> Self {
-        Self::with_kind(DescriptorKind::Ard)
-    }
-
-    pub fn new_apd() -> Self {
-        Self::with_kind(DescriptorKind::Apd)
-    }
-
-    fn with_kind(kind: DescriptorKind) -> Self {
         Self {
-            kind,
+            kind: DescriptorKind::Ard,
             bindings: HashMap::new(),
             array_size: 1,
             bind_type: 0,
@@ -571,6 +569,50 @@ impl ArdDescriptor {
         for col in 1..=count {
             self.bindings.entry(col as u16).or_default();
         }
+    }
+}
+
+/// Application Parameter Descriptor (APD).
+///
+/// Stores parameter binding information from the application's perspective:
+/// C data types, data buffer pointers, and indicator pointers.
+/// A pointer to this struct is returned as the descriptor handle via
+/// `SQLGetStmtAttr(SQL_ATTR_APP_PARAM_DESC)`.
+#[repr(C)]
+pub struct ApdDescriptor {
+    kind: DescriptorKind,
+    pub records: HashMap<u16, ApdRecord>,
+    /// `SQL_DESC_ARRAY_SIZE` — number of parameter sets (default 1).
+    pub array_size: usize,
+    /// `SQL_DESC_BIND_TYPE` — 0 = column-wise (default).
+    pub bind_type: sql::ULen,
+    /// `SQL_DESC_BIND_OFFSET_PTR` — default null.
+    pub bind_offset_ptr: *mut sql::Len,
+}
+
+impl Default for ApdDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ApdDescriptor {
+    pub fn new() -> Self {
+        Self {
+            kind: DescriptorKind::Apd,
+            records: HashMap::new(),
+            array_size: 1,
+            bind_type: 0,
+            bind_offset_ptr: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn desc_count(&self) -> u16 {
+        self.records.keys().copied().max().unwrap_or(0)
+    }
+
+    pub fn clear(&mut self) {
+        self.records.clear();
     }
 }
 
@@ -598,16 +640,8 @@ impl Default for IrdDescriptor {
 
 impl IrdDescriptor {
     pub fn new() -> Self {
-        Self::with_kind(DescriptorKind::Ird)
-    }
-
-    pub fn new_ipd() -> Self {
-        Self::with_kind(DescriptorKind::Ipd)
-    }
-
-    fn with_kind(kind: DescriptorKind) -> Self {
         Self {
-            kind,
+            kind: DescriptorKind::Ird,
             desc_count: 0,
             array_status_ptr: std::ptr::null_mut(),
             rows_processed_ptr: std::ptr::null_mut(),
@@ -615,10 +649,53 @@ impl IrdDescriptor {
     }
 }
 
+/// Implementation Parameter Descriptor (IPD).
+///
+/// Stores the implementation-side view of bound parameters: SQL data types,
+/// precision, scale, and parameter direction.
+/// A pointer to this struct is returned as the descriptor handle via
+/// `SQLGetStmtAttr(SQL_ATTR_IMP_PARAM_DESC)`.
+#[repr(C)]
+pub struct IpdDescriptor {
+    kind: DescriptorKind,
+    pub records: HashMap<u16, IpdRecord>,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` — default null.
+    pub array_status_ptr: *mut u16,
+    /// `SQL_DESC_ROWS_PROCESSED_PTR` — default null.
+    pub rows_processed_ptr: *mut sql::ULen,
+}
+
+impl Default for IpdDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IpdDescriptor {
+    pub fn new() -> Self {
+        Self {
+            kind: DescriptorKind::Ipd,
+            records: HashMap::new(),
+            array_status_ptr: std::ptr::null_mut(),
+            rows_processed_ptr: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn desc_count(&self) -> u16 {
+        self.records.keys().copied().max().unwrap_or(0)
+    }
+
+    pub fn clear(&mut self) {
+        self.records.clear();
+    }
+}
+
 /// A resolved descriptor reference returned by `desc_ref_from_handle`.
 pub enum DescriptorRef<'a> {
     Ard(&'a mut ArdDescriptor),
     Ird(&'a mut IrdDescriptor),
+    Apd(&'a mut ApdDescriptor),
+    Ipd(&'a mut IpdDescriptor),
 }
 
 /// Convert a descriptor handle (returned by `SQLGetStmtAttr`) back to a
@@ -629,18 +706,24 @@ pub fn desc_ref_from_handle<'a>(handle: sql::Handle) -> OdbcResult<DescriptorRef
             location: snafu::location!(),
         });
     }
-    // Read the raw discriminant byte at offset 0 and validate before
-    // interpreting it as a DescriptorKind enum to avoid UB on corrupt handles.
     let raw_kind = unsafe { *(handle as *const u8) };
     let kind = DescriptorKind::try_from(raw_kind)?;
     match kind {
-        DescriptorKind::Ard | DescriptorKind::Apd => {
+        DescriptorKind::Ard => {
             let desc = unsafe { &mut *(handle as *mut ArdDescriptor) };
             Ok(DescriptorRef::Ard(desc))
         }
-        DescriptorKind::Ird | DescriptorKind::Ipd => {
+        DescriptorKind::Ird => {
             let desc = unsafe { &mut *(handle as *mut IrdDescriptor) };
             Ok(DescriptorRef::Ird(desc))
+        }
+        DescriptorKind::Apd => {
+            let desc = unsafe { &mut *(handle as *mut ApdDescriptor) };
+            Ok(DescriptorRef::Apd(desc))
+        }
+        DescriptorKind::Ipd => {
+            let desc = unsafe { &mut *(handle as *mut IpdDescriptor) };
+            Ok(DescriptorRef::Ipd(desc))
         }
     }
 }
@@ -704,6 +787,59 @@ pub struct Connection {
     pub numeric_settings: NumericSettings,
 }
 
+/// Application Parameter Descriptor (APD) record.
+///
+/// Stores the application-side view of a bound parameter: the C data type,
+/// the pointer to the application's data buffer, its length, and the
+/// indicator/length pointer. Populated by `SQLBindParameter` or
+/// `SQLSetDescField` on the APD handle.
+#[derive(Debug, Clone)]
+pub struct ApdRecord {
+    pub value_type: CDataType,
+    pub data_ptr: sql::Pointer,
+    pub buffer_length: sql::Len,
+    pub str_len_or_ind_ptr: *mut sql::Len,
+}
+
+impl Default for ApdRecord {
+    fn default() -> Self {
+        Self {
+            value_type: CDataType::Default,
+            data_ptr: std::ptr::null_mut(),
+            buffer_length: 0,
+            str_len_or_ind_ptr: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// Implementation Parameter Descriptor (IPD) record.
+///
+/// Stores the implementation-side view of a bound parameter: the SQL data type,
+/// column size, decimal digits, and parameter direction. Populated by
+/// `SQLBindParameter` or `SQLSetDescField` on the IPD handle.
+#[derive(Debug, Clone)]
+pub struct IpdRecord {
+    pub parameter_type: sql::SqlDataType,
+    pub column_size: sql::ULen,
+    pub decimal_digits: sql::SmallInt,
+    pub direction: sql::SmallInt,
+    pub nullable: sql::SmallInt,
+}
+
+impl Default for IpdRecord {
+    fn default() -> Self {
+        Self {
+            parameter_type: sql::SqlDataType::VARCHAR,
+            column_size: 0,
+            decimal_digits: 0,
+            direction: sql::ParamType::Input as sql::SmallInt,
+            nullable: 2, // SQL_NULLABLE_UNKNOWN
+        }
+    }
+}
+
+/// Combined view of APD + IPD records, reconstructed at execution time
+/// for consumption by the parameter conversion pipeline.
 #[derive(Debug, Clone)]
 pub struct ParameterBinding {
     pub parameter_type: sql::SqlDataType,
@@ -711,6 +847,18 @@ pub struct ParameterBinding {
     pub parameter_value_ptr: sql::Pointer,
     pub buffer_length: sql::Len,
     pub str_len_or_ind_ptr: *mut sql::Len,
+}
+
+impl ParameterBinding {
+    pub fn from_apd_ipd(apd: &ApdRecord, ipd: &IpdRecord) -> Self {
+        Self {
+            parameter_type: ipd.parameter_type,
+            value_type: apd.value_type,
+            parameter_value_ptr: apd.data_ptr,
+            buffer_length: apd.buffer_length,
+            str_len_or_ind_ptr: apd.str_len_or_ind_ptr,
+        }
+    }
 }
 
 pub enum StatementState {
@@ -828,11 +976,10 @@ pub struct Statement<'a> {
     pub conn: &'a mut Connection,
     pub stmt_handle: StatementHandle,
     pub state: State<StatementState>,
-    pub parameter_bindings: HashMap<u16, ParameterBinding>,
     pub ard: ArdDescriptor,
     pub ird: IrdDescriptor,
-    pub apd: ArdDescriptor,
-    pub ipd: IrdDescriptor,
+    pub apd: ApdDescriptor,
+    pub ipd: IpdDescriptor,
     pub diagnostic_info: DiagnosticInfo,
     pub get_data_state: Option<GetDataState>,
     /// `SQL_ATTR_CURSOR_TYPE` — default `ForwardOnly`.

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -265,8 +265,8 @@ pub enum DescField {
     DataPtr = 1010,
     /// `SQL_DESC_OCTET_LENGTH` (1013) — length in bytes of the data buffer.
     OctetLength = 1013,
-    /// `SQL_DESC_PARAMETER_TYPE` (1015) — parameter direction (IPD only).
-    ParameterType = 1015,
+    /// `SQL_DESC_PARAMETER_TYPE` (33) — parameter direction (IPD only).
+    ParameterType = 33,
     /// `SQL_DESC_NULLABLE` (1008) — whether the parameter is nullable (IPD only).
     Nullable = 1008,
 }
@@ -292,7 +292,7 @@ impl TryFrom<i16> for DescField {
             1009 => Ok(DescField::IndicatorPtr),
             1010 => Ok(DescField::DataPtr),
             1013 => Ok(DescField::OctetLength),
-            1015 => Ok(DescField::ParameterType),
+            33 => Ok(DescField::ParameterType),
             _ => {
                 tracing::warn!("Unknown descriptor field identifier: {}", value);
                 Err(OdbcError::UnknownAttribute {

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -603,6 +603,43 @@ pub unsafe extern "C" fn SQLNumResultCols(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLNumParams(
+    statement_handle: sql::Handle,
+    param_count_ptr: *mut sql::SmallInt,
+) -> sql::RetCode {
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::statement::num_params(statement_handle, param_count_ptr);
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLDescribeParam(
+    statement_handle: sql::Handle,
+    parameter_number: sql::USmallInt,
+    data_type_ptr: *mut sql::SmallInt,
+    parameter_size_ptr: *mut sql::ULen,
+    decimal_digits_ptr: *mut sql::SmallInt,
+    nullable_ptr: *mut sql::SmallInt,
+) -> sql::RetCode {
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::statement::describe_param(
+        statement_handle,
+        parameter_number,
+        data_type_ptr,
+        parameter_size_ptr,
+        decimal_digits_ptr,
+        nullable_ptr,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLRowCount(
     statement_handle: sql::Handle,
     row_count_ptr: *mut sql::Len,

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     ffi::{CStr, c_char},
     mem, slice, str,
 };
@@ -8,7 +7,7 @@ use serde_json::{Map, Value};
 use snafu::ResultExt;
 
 use crate::api::CDataType;
-use crate::api::ParameterBinding;
+use crate::api::{ApdDescriptor, IpdDescriptor, ParameterBinding};
 use odbc_sys as sql;
 
 use super::binary::SnowflakeBinary;
@@ -168,14 +167,13 @@ fn make_converter(
 // Pipeline
 // =============================================================================
 
-/// Convert ODBC parameter bindings to JSON string format for server-side binding.
+/// Convert ODBC parameter bindings (from APD + IPD descriptors) to JSON
+/// string format for server-side binding.
 ///
 /// # Safety contract
-/// The `bindings` map must contain `ParameterBinding` instances whose
-/// `parameter_value_ptr` pointers remain valid for the duration of this call.
-/// If `str_len_or_ind_ptr` is non-null, it must also point to valid memory
-/// for reads, as it is dereferenced to check for null indicators and
-/// determine buffer data lengths.
+/// The APD records' `data_ptr` pointers must remain valid for the duration
+/// of this call. If `str_len_or_ind_ptr` is non-null, it must also point to
+/// valid memory for reads.
 ///
 /// Returns a JSON string in the format:
 /// ```json
@@ -185,29 +183,39 @@ fn make_converter(
 /// }
 /// ```
 pub fn odbc_bindings_to_json(
-    bindings: &HashMap<u16, ParameterBinding>,
+    apd: &ApdDescriptor,
+    ipd: &IpdDescriptor,
 ) -> Result<String, JsonBindingError> {
     let mut json_bindings = Map::new();
 
-    let max_key = bindings.keys().copied().max().unwrap_or(0);
+    let max_key = apd.desc_count().max(ipd.desc_count());
 
     for param_num in 1..=max_key {
-        let binding = bindings.get(&param_num).ok_or_else(|| {
+        let apd_rec = apd.records.get(&param_num).ok_or_else(|| {
             tracing::error!(
-                "odbc_bindings_to_json: parameter #{param_num} not found. \
+                "odbc_bindings_to_json: APD record #{param_num} not found. \
+                 Parameter bindings must be contiguous and start at 1.",
+            );
+            InvalidParameterIndicesSnafu.build()
+        })?;
+        let ipd_rec = ipd.records.get(&param_num).ok_or_else(|| {
+            tracing::error!(
+                "odbc_bindings_to_json: IPD record #{param_num} not found. \
                  Parameter bindings must be contiguous and start at 1.",
             );
             InvalidParameterIndicesSnafu.build()
         })?;
 
-        let (snowflake_type, json_value) = if is_null_indicator(binding) {
+        let binding = ParameterBinding::from_apd_ipd(apd_rec, ipd_rec);
+
+        let (snowflake_type, json_value) = if is_null_indicator(&binding) {
             (SnowflakeLogicalType::Any, Value::Null)
         } else {
             if binding.parameter_value_ptr.is_null() {
                 return NullPointerSnafu.fail();
             }
             let converter = make_converter(&binding.parameter_type)?;
-            converter.convert(binding)?
+            converter.convert(&binding)?
         };
 
         let mut binding_obj = Map::new();
@@ -367,6 +375,7 @@ pub(crate) fn read_wchar_str(binding: &ParameterBinding) -> Result<String, JsonB
 mod tests {
     use super::*;
     use crate::api::CDataType;
+    use crate::api::{ApdRecord, IpdRecord};
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -384,6 +393,39 @@ mod tests {
             buffer_length,
             str_len_or_ind_ptr: ind_ptr,
         }
+    }
+
+    fn make_descriptors(
+        params: Vec<(
+            u16,
+            CDataType,
+            sql::SqlDataType,
+            sql::Pointer,
+            sql::Len,
+            *mut sql::Len,
+        )>,
+    ) -> (ApdDescriptor, IpdDescriptor) {
+        let mut apd = ApdDescriptor::new();
+        let mut ipd = IpdDescriptor::new();
+        for (num, value_type, parameter_type, ptr, buf_len, ind_ptr) in params {
+            apd.records.insert(
+                num,
+                ApdRecord {
+                    value_type,
+                    data_ptr: ptr,
+                    buffer_length: buf_len,
+                    str_len_or_ind_ptr: ind_ptr,
+                },
+            );
+            ipd.records.insert(
+                num,
+                IpdRecord {
+                    parameter_type,
+                    ..IpdRecord::default()
+                },
+            );
+        }
+        (apd, ipd)
     }
 
     fn convert_binding(
@@ -640,18 +682,15 @@ mod tests {
     #[test]
     fn convert_null_data() -> TestResult {
         let mut ind: sql::Len = sql::NULL_DATA;
-        let mut bindings = HashMap::new();
-        bindings.insert(
-            1u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                std::ptr::null_mut(),
-                0,
-                &mut ind,
-            ),
-        );
-        let json = odbc_bindings_to_json(&bindings)?;
+        let (apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            std::ptr::null_mut(),
+            0,
+            &mut ind,
+        )]);
+        let json = odbc_bindings_to_json(&apd, &ipd)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -660,18 +699,15 @@ mod tests {
 
     #[test]
     fn convert_null_pointer_without_indicator_fails() {
-        let mut bindings = HashMap::new();
-        bindings.insert(
-            1u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                std::ptr::null_mut(),
-                0,
-                std::ptr::null_mut(),
-            ),
-        );
-        assert!(odbc_bindings_to_json(&bindings).is_err());
+        let (apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+        )]);
+        assert!(odbc_bindings_to_json(&apd, &ipd).is_err());
     }
 
     #[test]
@@ -708,18 +744,15 @@ mod tests {
     #[test]
     fn pipeline_full_json_output() -> TestResult {
         let val: i32 = 7;
-        let mut bindings = HashMap::new();
-        bindings.insert(
-            1u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                &val as *const i32 as sql::Pointer,
-                0,
-                std::ptr::null_mut(),
-            ),
-        );
-        let json = odbc_bindings_to_json(&bindings)?;
+        let (apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            &val as *const i32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        )]);
+        let json = odbc_bindings_to_json(&apd, &ipd)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "FIXED");
         assert_eq!(parsed["1"]["value"], "7");
@@ -729,18 +762,15 @@ mod tests {
     #[test]
     fn pipeline_null_json_output() -> TestResult {
         let mut ind: sql::Len = sql::NULL_DATA;
-        let mut bindings = HashMap::new();
-        bindings.insert(
-            1u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                std::ptr::null_mut(),
-                0,
-                &mut ind,
-            ),
-        );
-        let json = odbc_bindings_to_json(&bindings)?;
+        let (apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            std::ptr::null_mut(),
+            0,
+            &mut ind,
+        )]);
+        let json = odbc_bindings_to_json(&apd, &ipd)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -750,28 +780,31 @@ mod tests {
     #[test]
     fn pipeline_non_contiguous_params_error() {
         let val: i32 = 1;
-        let mut bindings = HashMap::new();
-        bindings.insert(
-            1u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                &val as *const i32 as sql::Pointer,
-                0,
-                std::ptr::null_mut(),
-            ),
+        let (mut apd, mut ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            &val as *const i32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        )]);
+        apd.records.insert(
+            3,
+            ApdRecord {
+                value_type: CDataType::Long,
+                data_ptr: &val as *const i32 as sql::Pointer,
+                buffer_length: 0,
+                str_len_or_ind_ptr: std::ptr::null_mut(),
+            },
         );
-        bindings.insert(
-            3u16,
-            make_binding(
-                CDataType::Long,
-                sql::SqlDataType::INTEGER,
-                &val as *const i32 as sql::Pointer,
-                0,
-                std::ptr::null_mut(),
-            ),
+        ipd.records.insert(
+            3,
+            IpdRecord {
+                parameter_type: sql::SqlDataType::INTEGER,
+                ..IpdRecord::default()
+            },
         );
-        assert!(odbc_bindings_to_json(&bindings).is_err());
+        assert!(odbc_bindings_to_json(&apd, &ipd).is_err());
     }
 
     #[test]

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -214,7 +214,7 @@ pub fn odbc_bindings_to_json(
             if binding.parameter_value_ptr.is_null() {
                 return NullPointerSnafu.fail();
             }
-            let converter = make_converter(&binding.parameter_type)?;
+            let converter = make_converter(&binding.sql_data_type)?;
             converter.convert(&binding)?
         };
 
@@ -387,7 +387,7 @@ mod tests {
         ind_ptr: *mut sql::Len,
     ) -> ParameterBinding {
         ParameterBinding {
-            parameter_type,
+            sql_data_type: parameter_type,
             value_type,
             parameter_value_ptr: ptr,
             buffer_length,
@@ -420,7 +420,7 @@ mod tests {
             ipd.records.insert(
                 num,
                 IpdRecord {
-                    parameter_type,
+                    sql_data_type: parameter_type,
                     ..IpdRecord::default()
                 },
             );
@@ -431,7 +431,7 @@ mod tests {
     fn convert_binding(
         binding: &ParameterBinding,
     ) -> Result<(SnowflakeLogicalType, Value), JsonBindingError> {
-        let converter = make_converter(&binding.parameter_type)?;
+        let converter = make_converter(&binding.sql_data_type)?;
         converter.convert(binding)
     }
 
@@ -720,7 +720,7 @@ mod tests {
             0,
             std::ptr::null_mut(),
         );
-        assert!(make_converter(&binding.parameter_type).is_err());
+        assert!(make_converter(&binding.sql_data_type).is_err());
     }
 
     // -- end-to-end pipeline tests -------------------------------------------
@@ -800,7 +800,7 @@ mod tests {
         ipd.records.insert(
             3,
             IpdRecord {
-                parameter_type: sql::SqlDataType::INTEGER,
+                sql_data_type: sql::SqlDataType::INTEGER,
                 ..IpdRecord::default()
             },
         );

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -312,3 +312,12 @@ behavior_differences:
       field incorrect), caught locally by the driver.
       NEW driver: Sends the query to the server, which returns SQL_ERROR with
       SQLSTATE 42000 (Syntax error: Bind variable ? not set).
+
+  30:
+    name: "SQLGetDescField on empty IPD returns SQL_ERROR instead of SQL_NO_DATA"
+    description: |
+      OLD driver: Querying a record field on an empty IPD (no parameters
+      bound, no prepare) returns SQL_ERROR.
+      NEW driver: Returns SQL_NO_DATA per the ODBC spec, which states
+      "SQL_NO_DATA is returned if RecNumber is greater than the current
+      number of descriptor records."

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -312,19 +312,3 @@ behavior_differences:
       field incorrect), caught locally by the driver.
       NEW driver: Sends the query to the server, which returns SQL_ERROR with
       SQLSTATE 42000 (Syntax error: Bind variable ? not set).
-
-  30:
-    name: "IPD SQL_DESC_NULLABLE defaults to SQL_NULLABLE instead of SQL_NULLABLE_UNKNOWN"
-    description: |
-      OLD driver: After SQLBindParameter, SQL_DESC_NULLABLE in the IPD
-      returns SQL_NULLABLE (1).
-      NEW driver: Returns SQL_NULLABLE_UNKNOWN (2), since the driver
-      has no column metadata to determine nullability at bind time.
-
-  31:
-    name: "SQLGetDescField accepts header-only fields on non-zero record number"
-    description: |
-      OLD driver: SQLGetDescField with a header field (e.g. SQL_DESC_ARRAY_SIZE)
-      on RecNumber > 0 returns SQL_SUCCESS and silently reads the header value.
-      NEW driver: Returns SQL_ERROR, since header fields are only valid on
-      RecNumber 0 per the ODBC specification.

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -312,3 +312,19 @@ behavior_differences:
       field incorrect), caught locally by the driver.
       NEW driver: Sends the query to the server, which returns SQL_ERROR with
       SQLSTATE 42000 (Syntax error: Bind variable ? not set).
+
+  30:
+    name: "IPD SQL_DESC_NULLABLE defaults to SQL_NULLABLE instead of SQL_NULLABLE_UNKNOWN"
+    description: |
+      OLD driver: After SQLBindParameter, SQL_DESC_NULLABLE in the IPD
+      returns SQL_NULLABLE (1).
+      NEW driver: Returns SQL_NULLABLE_UNKNOWN (2), since the driver
+      has no column metadata to determine nullability at bind time.
+
+  31:
+    name: "SQLGetDescField accepts header-only fields on non-zero record number"
+    description: |
+      OLD driver: SQLGetDescField with a header field (e.g. SQL_DESC_ARRAY_SIZE)
+      on RecNumber > 0 returns SQL_SUCCESS and silently reads the header value.
+      NEW driver: Returns SQL_ERROR, since header fields are only valid on
+      RecNumber 0 per the ODBC specification.

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -569,8 +569,8 @@ TEST_CASE("should return SQL_NO_DATA for unbound APD record.", "[query][bind_par
   SQLSMALLINT type = -1;
   ret = SQLGetDescField(apd, 1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
 
-  // Then SQL_NO_DATA or SQL_ERROR should be returned
-  CHECK(ret != SQL_SUCCESS);
+  // Then SQL_NO_DATA should be returned per ODBC spec
+  CHECK(ret == SQL_NO_DATA);
 }
 
 TEST_CASE("should return SQL_NO_DATA for unbound IPD record.", "[query][bind_parameter][descriptor]") {
@@ -586,8 +586,8 @@ TEST_CASE("should return SQL_NO_DATA for unbound IPD record.", "[query][bind_par
   SQLSMALLINT type = -1;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
 
-  // Then SQL_NO_DATA or SQL_ERROR should be returned
-  CHECK(ret != SQL_SUCCESS);
+  // Then SQL_NO_DATA should be returned per ODBC spec
+  CHECK(ret == SQL_NO_DATA);
 }
 
 TEST_CASE("should return error for negative descriptor record number.", "[query][bind_parameter][descriptor]") {

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -586,8 +586,9 @@ TEST_CASE("should return SQL_NO_DATA for unbound IPD record.", "[query][bind_par
   SQLSMALLINT type = -1;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
 
-  // Then SQL_NO_DATA should be returned per ODBC spec
-  CHECK(ret == SQL_NO_DATA);
+  // Then the record should not be found (SQL_NO_DATA per spec; old driver returns SQL_ERROR)
+  NEW_DRIVER_ONLY("BD#30") { CHECK(ret == SQL_NO_DATA); }
+  OLD_DRIVER_ONLY("BD#30") { CHECK(ret == SQL_ERROR); }
 }
 
 TEST_CASE("should return error for negative descriptor record number.", "[query][bind_parameter][descriptor]") {

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -428,12 +428,12 @@ TEST_CASE("should populate APD descriptor fields after SQLBindParameter.", "[que
 
   SQLSMALLINT concise_type = 0;
   ret = SQLGetDescField(apd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
-  REQUIRE_ODBC(ret, stmt);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
   CHECK(concise_type == SQL_C_SLONG);
 
   SQLPOINTER data_ptr = nullptr;
   ret = SQLGetDescField(apd, 1, SQL_DESC_DATA_PTR, &data_ptr, 0, nullptr);
-  REQUIRE_ODBC(ret, stmt);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
   CHECK(data_ptr == &param);
 }
 
@@ -456,12 +456,12 @@ TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[que
 
   SQLSMALLINT param_type = 0;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_PARAMETER_TYPE, &param_type, 0, nullptr);
-  REQUIRE_ODBC(ret, stmt);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
   CHECK(param_type == SQL_PARAM_INPUT);
 
   SQLSMALLINT concise_type = 0;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
-  REQUIRE_ODBC(ret, stmt);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
   CHECK(concise_type == SQL_INTEGER);
 }
 

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -498,8 +498,7 @@ TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[que
   SQLSMALLINT nullable = -1;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_NULLABLE, &nullable, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-  OLD_DRIVER_ONLY("BD#30") { CHECK(nullable == SQL_NULLABLE); }
-  NEW_DRIVER_ONLY("BD#30") { CHECK(nullable == SQL_NULLABLE_UNKNOWN); }
+  CHECK(nullable == SQL_NULLABLE);
 
   // And the IPD header should report the correct count
   SQLSMALLINT count = -1;
@@ -649,9 +648,9 @@ TEST_CASE("should return error for header-only field on record index greater tha
   SQLULEN array_size = 0;
   ret = SQLGetDescField(apd, 1, SQL_DESC_ARRAY_SIZE, &array_size, 0, nullptr);
 
-  // Then new driver rejects, old driver silently accepts
-  NEW_DRIVER_ONLY("BD#31") { CHECK(ret == SQL_ERROR); }
-  OLD_DRIVER_ONLY("BD#31") { CHECK(ret == SQL_SUCCESS); }
+  // Then SQL_SUCCESS — per ODBC spec, header fields ignore RecNumber
+  CHECK(ret == SQL_SUCCESS);
+  CHECK(array_size == 1);
 }
 
 TEST_CASE("should report correct APD and IPD count for multiple parameters.", "[query][bind_parameter][descriptor]") {

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -405,8 +405,107 @@ TEST_CASE("should allow rebinding after SQL_RESET_PARAMS.", "[query][bind_parame
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "rebound");
 }
 
-// TODO: Add APD/IPD descriptor integration tests in PR #566:
-// - APD fields populated after bind
-// - IPD fields populated after bind
-// - SQLNumParams after binding
-// - SQLDescribeParam after binding
+// =============================================================================
+// APD/IPD Descriptor Integration
+// =============================================================================
+
+TEST_CASE("should populate APD descriptor fields after SQLBindParameter.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When an integer parameter is bound
+  SQLINTEGER param = 42;
+  SQLLEN indicator = 0;
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then the APD should reflect the bound C type and data pointer
+  SQLHDESC apd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT concise_type = 0;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(concise_type == SQL_C_SLONG);
+
+  SQLPOINTER data_ptr = nullptr;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_DATA_PTR, &data_ptr, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(data_ptr == &param);
+}
+
+TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When an integer parameter is bound as SQL_PARAM_INPUT
+  SQLINTEGER param = 42;
+  SQLLEN indicator = 0;
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then the IPD should reflect the SQL type and parameter direction
+  SQLHDESC ipd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_PARAM_DESC, &ipd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT param_type = 0;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_PARAMETER_TYPE, &param_type, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(param_type == SQL_PARAM_INPUT);
+
+  SQLSMALLINT concise_type = 0;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(concise_type == SQL_INTEGER);
+}
+
+TEST_CASE("should report parameter count via SQLNumParams after binding.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a statement with two parameter markers is prepared and both are bound
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?, ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  SQLINTEGER p1 = 1, p2 = 2;
+  SQLLEN i1 = 0, i2 = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p1, 0, &i1);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p2, 0, &i2);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then SQLNumParams should return 2
+  SQLSMALLINT num_params = 0;
+  ret = SQLNumParams(stmt.getHandle(), &num_params);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(num_params == 2);
+}
+
+TEST_CASE("should describe bound parameter via SQLDescribeParam.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a parameterized SELECT is prepared and an integer parameter is bound
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  SQLINTEGER param = 42;
+  SQLLEN indicator = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then SQLDescribeParam should return the SQL type information
+  SQLSMALLINT data_type = 0;
+  SQLULEN param_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeParam(stmt.getHandle(), 1, &data_type, &param_size, &decimal_digits, &nullable);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(data_type == SQL_INTEGER);
+}

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -414,14 +414,14 @@ TEST_CASE("should populate APD descriptor fields after SQLBindParameter.", "[que
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When an integer parameter is bound
-  SQLINTEGER param = 42;
-  SQLLEN indicator = 0;
-  SQLRETURN ret =
-      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  // When a char parameter is bound with explicit buffer length and indicator
+  char param[] = "hello";
+  SQLLEN indicator = SQL_NTS;
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, strlen(param), 0,
+                                   param, sizeof(param), &indicator);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
 
-  // Then the APD should reflect the bound C type and data pointer
+  // Then the APD record should reflect all bound fields
   SQLHDESC apd = SQL_NULL_HDESC;
   ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
   REQUIRE_ODBC(ret, stmt);
@@ -429,12 +429,33 @@ TEST_CASE("should populate APD descriptor fields after SQLBindParameter.", "[que
   SQLSMALLINT concise_type = 0;
   ret = SQLGetDescField(apd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-  CHECK(concise_type == SQL_C_SLONG);
+  CHECK(concise_type == SQL_C_CHAR);
 
   SQLPOINTER data_ptr = nullptr;
   ret = SQLGetDescField(apd, 1, SQL_DESC_DATA_PTR, &data_ptr, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-  CHECK(data_ptr == &param);
+  CHECK(data_ptr == param);
+
+  SQLLEN octet_length = -1;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_OCTET_LENGTH, &octet_length, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(octet_length == sizeof(param));
+
+  SQLLEN* ind_ptr = nullptr;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_INDICATOR_PTR, &ind_ptr, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(ind_ptr == &indicator);
+
+  SQLLEN* octet_len_ptr = nullptr;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_OCTET_LENGTH_PTR, &octet_len_ptr, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(octet_len_ptr == &indicator);
+
+  // And the APD header should report the correct count
+  SQLSMALLINT count = -1;
+  ret = SQLGetDescField(apd, 0, SQL_DESC_COUNT, &count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(count == 1);
 }
 
 TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[query][bind_parameter][descriptor]") {
@@ -442,27 +463,48 @@ TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[que
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When an integer parameter is bound as SQL_PARAM_INPUT
-  SQLINTEGER param = 42;
-  SQLLEN indicator = 0;
-  SQLRETURN ret =
-      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  // When a decimal parameter is bound with precision and scale
+  char param[] = "123.45";
+  SQLLEN indicator = SQL_NTS;
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_DECIMAL, 10, 2, param,
+                                   sizeof(param), &indicator);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
 
-  // Then the IPD should reflect the SQL type and parameter direction
+  // Then the IPD record should reflect all bound fields
   SQLHDESC ipd = SQL_NULL_HDESC;
   ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_PARAM_DESC, &ipd, 0, nullptr);
   REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT concise_type = 0;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(concise_type == SQL_DECIMAL);
 
   SQLSMALLINT param_type = 0;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_PARAMETER_TYPE, &param_type, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
   CHECK(param_type == SQL_PARAM_INPUT);
 
-  SQLSMALLINT concise_type = 0;
-  ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &concise_type, 0, nullptr);
+  SQLSMALLINT precision = -1;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_PRECISION, &precision, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-  CHECK(concise_type == SQL_INTEGER);
+  CHECK(precision == 10);
+
+  SQLSMALLINT scale = -1;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_SCALE, &scale, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(scale == 2);
+
+  SQLSMALLINT nullable = -1;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_NULLABLE, &nullable, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(nullable == SQL_NULLABLE_UNKNOWN);
+
+  // And the IPD header should report the correct count
+  SQLSMALLINT count = -1;
+  ret = SQLGetDescField(ipd, 0, SQL_DESC_COUNT, &count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(count == 1);
 }
 
 TEST_CASE("should report parameter count via SQLNumParams after binding.", "[query][bind_parameter][descriptor]") {

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -551,3 +551,121 @@ TEST_CASE("should describe bound parameter via SQLDescribeParam.", "[query][bind
   REQUIRE_ODBC(ret, stmt);
   CHECK(data_type == SQL_INTEGER);
 }
+
+// =============================================================================
+// Descriptor Error Scenarios
+// =============================================================================
+
+TEST_CASE("should return SQL_NO_DATA for unbound APD record.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When no parameters are bound and APD record 1 is queried
+  SQLHDESC apd = SQL_NULL_HDESC;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT type = -1;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
+
+  // Then SQL_NO_DATA or SQL_ERROR should be returned
+  CHECK(ret != SQL_SUCCESS);
+}
+
+TEST_CASE("should return SQL_NO_DATA for unbound IPD record.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When no parameters are bound and IPD record 1 is queried
+  SQLHDESC ipd = SQL_NULL_HDESC;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_PARAM_DESC, &ipd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT type = -1;
+  ret = SQLGetDescField(ipd, 1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
+
+  // Then SQL_NO_DATA or SQL_ERROR should be returned
+  CHECK(ret != SQL_SUCCESS);
+}
+
+TEST_CASE("should return error for negative descriptor record number.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When APD is queried with negative record number
+  SQLHDESC apd = SQL_NULL_HDESC;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT type = -1;
+  ret = SQLGetDescField(apd, -1, SQL_DESC_CONCISE_TYPE, &type, 0, nullptr);
+
+  // Then SQL_ERROR should be returned
+  CHECK(ret == SQL_ERROR);
+}
+
+TEST_CASE("should return error for unknown descriptor field identifier.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in and a parameter is bound
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLINTEGER param = 1;
+  SQLLEN indicator = 0;
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When APD is queried with an unknown field identifier
+  SQLHDESC apd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER dummy = 0;
+  ret = SQLGetDescField(apd, 1, 9999, &dummy, 0, nullptr);
+
+  // Then SQL_ERROR should be returned
+  CHECK(ret == SQL_ERROR);
+}
+
+TEST_CASE("should return error for header-only field on record index greater than zero.",
+          "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in and a parameter is bound
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLINTEGER param = 1;
+  SQLLEN indicator = 0;
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When APD is queried with SQL_DESC_ARRAY_SIZE (header field) on record 1
+  SQLHDESC apd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLULEN array_size = 0;
+  ret = SQLGetDescField(apd, 1, SQL_DESC_ARRAY_SIZE, &array_size, 0, nullptr);
+
+  // Then SQL_ERROR should be returned (header fields require RecNumber 0)
+  CHECK(ret == SQL_ERROR);
+}
+
+TEST_CASE("should report APD count zero when no parameters are bound.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When APD header count is queried before any binding
+  SQLHDESC apd = SQL_NULL_HDESC;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLSMALLINT count = -1;
+  ret = SQLGetDescField(apd, 0, SQL_DESC_COUNT, &count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then count should be 0
+  CHECK(count == 0);
+}

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -498,7 +498,8 @@ TEST_CASE("should populate IPD descriptor fields after SQLBindParameter.", "[que
   SQLSMALLINT nullable = -1;
   ret = SQLGetDescField(ipd, 1, SQL_DESC_NULLABLE, &nullable, 0, nullptr);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-  CHECK(nullable == SQL_NULLABLE_UNKNOWN);
+  OLD_DRIVER_ONLY("BD#30") { CHECK(nullable == SQL_NULLABLE); }
+  NEW_DRIVER_ONLY("BD#30") { CHECK(nullable == SQL_NULLABLE_UNKNOWN); }
 
   // And the IPD header should report the correct count
   SQLSMALLINT count = -1;
@@ -648,8 +649,66 @@ TEST_CASE("should return error for header-only field on record index greater tha
   SQLULEN array_size = 0;
   ret = SQLGetDescField(apd, 1, SQL_DESC_ARRAY_SIZE, &array_size, 0, nullptr);
 
-  // Then SQL_ERROR should be returned (header fields require RecNumber 0)
-  CHECK(ret == SQL_ERROR);
+  // Then new driver rejects, old driver silently accepts
+  NEW_DRIVER_ONLY("BD#31") { CHECK(ret == SQL_ERROR); }
+  OLD_DRIVER_ONLY("BD#31") { CHECK(ret == SQL_SUCCESS); }
+}
+
+TEST_CASE("should report correct APD and IPD count for multiple parameters.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When three parameters are bound
+  SQLINTEGER p1 = 1, p2 = 2, p3 = 3;
+  SQLLEN i1 = 0, i2 = 0, i3 = 0;
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p1, 0, &i1);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p2, 0, &i2);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p3, 0, &i3);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then APD and IPD should both report count 3
+  SQLHDESC apd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  SQLSMALLINT apd_count = -1;
+  ret = SQLGetDescField(apd, 0, SQL_DESC_COUNT, &apd_count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(apd_count == 3);
+
+  SQLHDESC ipd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_PARAM_DESC, &ipd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  SQLSMALLINT ipd_count = -1;
+  ret = SQLGetDescField(ipd, 0, SQL_DESC_COUNT, &ipd_count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(ipd_count == 3);
+}
+
+TEST_CASE("should reset APD count to zero after SQL_RESET_PARAMS.", "[query][bind_parameter][descriptor]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a parameter is bound and then bindings are reset
+  SQLINTEGER param = 1;
+  SQLLEN indicator = 0;
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLFreeStmt(stmt.getHandle(), SQL_RESET_PARAMS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then APD count should be zero
+  SQLHDESC apd = SQL_NULL_HDESC;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_APP_PARAM_DESC, &apd, 0, nullptr);
+  REQUIRE_ODBC(ret, stmt);
+  SQLSMALLINT count = -1;
+  ret = SQLGetDescField(apd, 0, SQL_DESC_COUNT, &count, 0, nullptr);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  CHECK(count == 0);
 }
 
 TEST_CASE("should report APD count zero when no parameters are bound.", "[query][bind_parameter][descriptor]") {

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -135,14 +135,16 @@ Feature: ODBC SQLBindParameter spec compliance
   @odbc_e2e
   Scenario: should populate APD descriptor fields after SQLBindParameter.
     Given Snowflake client is logged in
-    When an integer parameter is bound
-    Then the APD should reflect the bound C type and data pointer
+    When a char parameter is bound with explicit buffer length and indicator
+    Then the APD record should reflect all bound fields
+    And the APD header should report the correct count
 
   @odbc_e2e
   Scenario: should populate IPD descriptor fields after SQLBindParameter.
     Given Snowflake client is logged in
-    When an integer parameter is bound as SQL_PARAM_INPUT
-    Then the IPD should reflect the SQL type and parameter direction
+    When a decimal parameter is bound with precision and scale
+    Then the IPD record should reflect all bound fields
+    And the IPD header should report the correct count
 
   @odbc_e2e
   Scenario: should report parameter count via SQLNumParams after binding.

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -190,7 +190,19 @@ Feature: ODBC SQLBindParameter spec compliance
   Scenario: should return error for header-only field on record index greater than zero.
     Given Snowflake client is logged in and a parameter is bound
     When APD is queried with SQL_DESC_ARRAY_SIZE (header field) on record 1
-    Then SQL_ERROR should be returned (header fields require RecNumber 0)
+    Then new driver rejects, old driver silently accepts
+
+  @odbc_e2e
+  Scenario: should report correct APD and IPD count for multiple parameters.
+    Given Snowflake client is logged in
+    When three parameters are bound
+    Then APD and IPD should both report count 3
+
+  @odbc_e2e
+  Scenario: should reset APD count to zero after SQL_RESET_PARAMS.
+    Given Snowflake client is logged in
+    When a parameter is bound and then bindings are reset
+    Then APD count should be zero
 
   @odbc_e2e
   Scenario: should report APD count zero when no parameters are bound.

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -129,10 +129,29 @@ Feature: ODBC SQLBindParameter spec compliance
     Then re-executing should return the new string value
 
   # ============================================================================
-  # APD/IPD Descriptor Integration — uncomment in PR #566
+  # APD/IPD Descriptor Integration
   # ============================================================================
 
-  # Scenario: should populate APD descriptor fields after SQLBindParameter.
-  # Scenario: should populate IPD descriptor fields after SQLBindParameter.
-  # Scenario: should report parameter count via SQLNumParams after binding.
-  # Scenario: should describe bound parameter via SQLDescribeParam.
+  @odbc_e2e
+  Scenario: should populate APD descriptor fields after SQLBindParameter.
+    Given Snowflake client is logged in
+    When an integer parameter is bound
+    Then the APD should reflect the bound C type and data pointer
+
+  @odbc_e2e
+  Scenario: should populate IPD descriptor fields after SQLBindParameter.
+    Given Snowflake client is logged in
+    When an integer parameter is bound as SQL_PARAM_INPUT
+    Then the IPD should reflect the SQL type and parameter direction
+
+  @odbc_e2e
+  Scenario: should report parameter count via SQLNumParams after binding.
+    Given Snowflake client is logged in
+    When a statement with two parameter markers is prepared and both are bound
+    Then SQLNumParams should return 2
+
+  @odbc_e2e
+  Scenario: should describe bound parameter via SQLDescribeParam.
+    Given Snowflake client is logged in
+    When a parameterized SELECT is prepared and an integer parameter is bound
+    Then SQLDescribeParam should return the SQL type information

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -172,7 +172,7 @@ Feature: ODBC SQLBindParameter spec compliance
   Scenario: should return SQL_NO_DATA for unbound IPD record.
     Given Snowflake client is logged in
     When no parameters are bound and IPD record 1 is queried
-    Then SQL_NO_DATA should be returned per ODBC spec
+    Then the record should not be found (SQL_NO_DATA per spec; old driver returns SQL_ERROR)
 
   @odbc_e2e
   Scenario: should return error for negative descriptor record number.

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -166,13 +166,13 @@ Feature: ODBC SQLBindParameter spec compliance
   Scenario: should return SQL_NO_DATA for unbound APD record.
     Given Snowflake client is logged in
     When no parameters are bound and APD record 1 is queried
-    Then SQL_NO_DATA or SQL_ERROR should be returned
+    Then SQL_NO_DATA should be returned per ODBC spec
 
   @odbc_e2e
   Scenario: should return SQL_NO_DATA for unbound IPD record.
     Given Snowflake client is logged in
     When no parameters are bound and IPD record 1 is queried
-    Then SQL_NO_DATA or SQL_ERROR should be returned
+    Then SQL_NO_DATA should be returned per ODBC spec
 
   @odbc_e2e
   Scenario: should return error for negative descriptor record number.

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -190,7 +190,7 @@ Feature: ODBC SQLBindParameter spec compliance
   Scenario: should return error for header-only field on record index greater than zero.
     Given Snowflake client is logged in and a parameter is bound
     When APD is queried with SQL_DESC_ARRAY_SIZE (header field) on record 1
-    Then new driver rejects, old driver silently accepts
+    Then SQL_SUCCESS — per ODBC spec, header fields ignore RecNumber
 
   @odbc_e2e
   Scenario: should report correct APD and IPD count for multiple parameters.

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -157,3 +157,43 @@ Feature: ODBC SQLBindParameter spec compliance
     Given Snowflake client is logged in
     When a parameterized SELECT is prepared and an integer parameter is bound
     Then SQLDescribeParam should return the SQL type information
+
+  # ============================================================================
+  # Descriptor Error Scenarios
+  # ============================================================================
+
+  @odbc_e2e
+  Scenario: should return SQL_NO_DATA for unbound APD record.
+    Given Snowflake client is logged in
+    When no parameters are bound and APD record 1 is queried
+    Then SQL_NO_DATA or SQL_ERROR should be returned
+
+  @odbc_e2e
+  Scenario: should return SQL_NO_DATA for unbound IPD record.
+    Given Snowflake client is logged in
+    When no parameters are bound and IPD record 1 is queried
+    Then SQL_NO_DATA or SQL_ERROR should be returned
+
+  @odbc_e2e
+  Scenario: should return error for negative descriptor record number.
+    Given Snowflake client is logged in
+    When APD is queried with negative record number
+    Then SQL_ERROR should be returned
+
+  @odbc_e2e
+  Scenario: should return error for unknown descriptor field identifier.
+    Given Snowflake client is logged in and a parameter is bound
+    When APD is queried with an unknown field identifier
+    Then SQL_ERROR should be returned
+
+  @odbc_e2e
+  Scenario: should return error for header-only field on record index greater than zero.
+    Given Snowflake client is logged in and a parameter is bound
+    When APD is queried with SQL_DESC_ARRAY_SIZE (header field) on record 1
+    Then SQL_ERROR should be returned (header fields require RecNumber 0)
+
+  @odbc_e2e
+  Scenario: should report APD count zero when no parameters are bound.
+    Given Snowflake client is logged in
+    When APD header count is queried before any binding
+    Then count should be 0


### PR DESCRIPTION
## Summary

Implement APD (Application Parameter Descriptor) and IPD (Implementation Parameter Descriptor) integration for ODBC parameter binding. This makes `SQLBindParameter` populate proper descriptor records instead of a flat `ParameterBinding` map, enabling `SQLGetDescField`, `SQLNumParams`, and `SQLDescribeParam` to work correctly.

### Driver changes

**New types:**
- `ApdDescriptor` / `ApdRecord` — stores application-side binding info (C type, data pointer, buffer length, indicator pointer)
- `IpdDescriptor` / `IpdRecord` — stores implementation-side binding info (SQL type, precision, scale, direction, nullable)
- `ParameterBinding::from_apd_ipd()` — reconstructs execution-time binding from APD + IPD

**SQLBindParameter refactored:**
- Now writes to both APD and IPD descriptors (previously used a flat `HashMap<u16, ParameterBinding>`)
- `SQL_RESET_PARAMS` clears APD only (per ODBC spec — IPD retains prepare metadata)

**New ODBC functions:**
- `SQLNumParams` — returns parameter count from IPD, with HY010 state check
- `SQLDescribeParam` — returns SQL type/precision/scale/nullable from IPD record
- `SQL_DESC_PARAMETER_TYPE` field corrected from 1015 to 33 (actual ODBC constant)

**Descriptor access:**
- `SQLGetDescField` / `SQLSetDescField` extended for APD and IPD handles
- `set_ipd_field` validates SQL type via `SqlType::try_from` and direction via `ParamDirection::try_from`
- `set_apd_field` supports `SQL_DESC_COUNT` header

**Naming cleanup:**
- `IpdRecord::parameter_type` renamed to `sql_data_type` to avoid confusion with `DescField::ParameterType` (direction)
- Removed unused `Clone` derive from `ApdRecord` and `IpdRecord` (contain raw pointers)

### E2E test coverage (20 tests)

**Error codes (8):** SQL_INVALID_HANDLE, 07009, HY003, HY004, HY009, HY090, HY104, HY105

**API behavior (9):** deferred binding via SQLExecDirect, rebinding replaces, re-execute with changed value, multiple parameters, rebind to different type, NULL via indicator, mixed NULL/non-NULL sequential, rebind after SQL_RESET_PARAMS

**APD/IPD descriptor fields (2):**
- APD: SQL_DESC_CONCISE_TYPE, SQL_DESC_DATA_PTR, SQL_DESC_OCTET_LENGTH, SQL_DESC_INDICATOR_PTR, SQL_DESC_OCTET_LENGTH_PTR, SQL_DESC_COUNT
- IPD: SQL_DESC_CONCISE_TYPE, SQL_DESC_PARAMETER_TYPE, SQL_DESC_PRECISION, SQL_DESC_SCALE, SQL_DESC_NULLABLE, SQL_DESC_COUNT

**Descriptor error scenarios (6):** unbound APD/IPD record, negative record number, unknown field identifier, header field on record > 0, count zero before binding

**SQLNumParams + SQLDescribeParam (2):** parameter count after binding, describe bound parameter type

### Behavior differences
- BD#28: New driver rejects negative DecimalDigits with HY104; old driver accepts
- BD#29: Unbound parameter marker returns 42000 (server) instead of 07002 (client)

## Test plan
- [x] Format validator passes
- [x] clang-format passes
- [x] Rust clippy passes
- [x] 598 unit tests pass
- [ ] ODBC E2E tests pass (CI)
- [ ] Old driver reference tests pass (CI)