### PR TITLE
support skip driver  annotations in validator/test coverage report

### DIFF
--- a/tests/test_coverage_report/behavior_differences_handler.py
+++ b/tests/test_coverage_report/behavior_differences_handler.py
@@ -81,6 +81,11 @@ class BehaviorDifferencesHandler:
                             converted_impl['old_behaviour_file'] = impl['old_behaviour_file']
                             converted_impl['old_behaviour_line'] = impl['old_behaviour_line']
                         
+                        if impl.get('old_driver_skipped'):
+                            converted_impl['old_driver_skipped'] = True
+                        if impl.get('new_driver_skipped'):
+                            converted_impl['new_driver_skipped'] = True
+                        
                         result[lang][behavior_difference_id].append(converted_impl)
         
         return result

--- a/tests/test_coverage_report/coverage_report.py
+++ b/tests/test_coverage_report/coverage_report.py
@@ -2212,7 +2212,13 @@ class CoverageReportGenerator:
             # Generate Behavior Difference sections
             behavior_difference_sections = []
             
-            for behavior_difference_id in sorted(all_behavior_differences):
+            def _bd_sort_key(bd_id):
+                """Sort BD#N numerically so BD#2 comes before BD#11."""
+                import re
+                m = re.search(r'(\d+)', bd_id)
+                return int(m.group(1)) if m else 0
+
+            for behavior_difference_id in sorted(all_behavior_differences, key=_bd_sort_key):
                 description = behavior_difference_descriptions.get(behavior_difference_id, 'No description available')
                 
                 # Create title with driver prefix (without full description in title)
@@ -2245,7 +2251,7 @@ class CoverageReportGenerator:
                 # Get test implementations for this Behavior Difference
                 test_implementations = behavior_difference_test_mapping.get(driver, {}).get(behavior_difference_id, [])
                 
-                                # Build test implementation list
+                # Build test implementation list
                 impl_items = []
                 for impl in test_implementations:
                     test_line_info = f"{impl['test_line']}" if impl.get('test_line') else "unknown"
@@ -2253,17 +2259,21 @@ class CoverageReportGenerator:
                     # Build behaviour lines
                     behaviour_lines = []
                     
-                    # New behaviour (NEW_DRIVER_ONLY)
+                    # New behaviour (NEW_DRIVER_ONLY or SKIP_OLD_DRIVER)
                     if impl.get('new_behaviour_file') and impl.get('new_behaviour_line'):
                         new_file = impl['new_behaviour_file']
                         new_line = impl['new_behaviour_line']
                         behaviour_lines.append(f"<strong>New Behavior:</strong> <code>{new_file}:{new_line}</code>")
+                    elif impl.get('new_driver_skipped'):
+                        behaviour_lines.append('<strong>New Behavior:</strong> <span style="color:#e67e22;font-style:italic">Test skipped for new driver</span>')
                     
-                    # Old behaviour (OLD_DRIVER_ONLY)
+                    # Old behaviour (OLD_DRIVER_ONLY or SKIP_NEW_DRIVER)
                     if impl.get('old_behaviour_file') and impl.get('old_behaviour_line'):
                         old_file = impl['old_behaviour_file']
                         old_line = impl['old_behaviour_line']
                         behaviour_lines.append(f"<strong>Old Behavior:</strong> <code>{old_file}:{old_line}</code>")
+                    elif impl.get('old_driver_skipped'):
+                        behaviour_lines.append('<strong>Old Behavior:</strong> <span style="color:#e67e22;font-style:italic">Test skipped for old driver</span>')
                     
                     # If no new/old behaviour found, fall back to legacy assertion field
                     if not behaviour_lines:

--- a/tests/tests_format_validator/src/behavior_differences_processor.rs
+++ b/tests/tests_format_validator/src/behavior_differences_processor.rs
@@ -169,6 +169,10 @@ impl BehaviorDifferencesProcessor {
                                             .old_behaviour_file,
                                         old_behaviour_line: behavior_difference_location
                                             .old_behaviour_line,
+                                        old_driver_skipped: behavior_difference_location
+                                            .old_driver_skipped,
+                                        new_driver_skipped: behavior_difference_location
+                                            .new_driver_skipped,
                                     },
                                 );
                             }
@@ -273,6 +277,10 @@ impl BehaviorDifferencesProcessor {
                                             .old_behaviour_file,
                                         old_behaviour_line: behavior_difference_location
                                             .old_behaviour_line,
+                                        old_driver_skipped: behavior_difference_location
+                                            .old_driver_skipped,
+                                        new_driver_skipped: behavior_difference_location
+                                            .new_driver_skipped,
                                     },
                                 );
                             }

--- a/tests/tests_format_validator/src/driver_handlers/base_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/base_handler.rs
@@ -80,4 +80,6 @@ pub struct BehaviorDifferenceLocation {
     pub new_behaviour_line: Option<usize>,
     pub old_behaviour_file: Option<String>,
     pub old_behaviour_line: Option<usize>,
+    pub old_driver_skipped: bool,
+    pub new_driver_skipped: bool,
 }

--- a/tests/tests_format_validator/src/driver_handlers/jdbc_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/jdbc_handler.rs
@@ -205,17 +205,36 @@ impl JdbcHandler {
         let lines: Vec<&str> = content.lines().collect();
         let mut in_method = false;
         let mut brace_count = 0;
+        let mut method_start_line: usize = 0;
+
+        let new_driver_re = Regex::new(r#"//\s*NEW_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+        let old_driver_re = Regex::new(r#"//\s*OLD_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+        let skip_old_re = Regex::new(r#"//\s*SKIP_OLD_DRIVER\s*\(\s*"(BD#\d+)""#).unwrap();
+        let skip_new_re = Regex::new(r#"//\s*SKIP_NEW_DRIVER\s*\(\s*"(BD#\d+)""#).unwrap();
+        let assume_new_re =
+            Regex::new(r#"assumeTrue\s*\(\s*isNewDriver\s*\(\s*\).*?(BD#\d+)"#).unwrap();
+        let assume_old_re =
+            Regex::new(r#"assumeTrue\s*\(\s*isOldDriver\s*\(\s*\).*?(BD#\d+)"#).unwrap();
+
+        let default_loc = || BehaviorDifferenceLocation {
+            new_behaviour_file: None,
+            new_behaviour_line: None,
+            old_behaviour_file: None,
+            old_behaviour_line: None,
+            old_driver_skipped: false,
+            new_driver_skipped: false,
+        };
 
         for (line_num, line) in lines.iter().enumerate() {
             let line = line.trim();
 
-            // Check for method start
             let is_method = line.contains(&format!("void {method_name}("))
                 || line.contains(&format!("{method_name}("))
                 || line.contains(&format!("static void {method_name}("));
 
             if !line.starts_with("//") && is_method && !in_method {
                 in_method = true;
+                method_start_line = line_num + 1;
                 brace_count += line.matches('{').count() as i32 - line.matches('}').count() as i32;
                 continue;
             }
@@ -227,61 +246,46 @@ impl JdbcHandler {
                     break;
                 }
 
-                // Look for Behavior Difference annotations in Java comments
-                let new_driver_re =
-                    Regex::new(r#"//\s*NEW_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
-                let old_driver_re =
-                    Regex::new(r#"//\s*OLD_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+                let rel_path = file_path
+                    .strip_prefix(&self.workspace_root)
+                    .unwrap_or(file_path)
+                    .to_string_lossy()
+                    .to_string();
 
-                if let Some(captures) = new_driver_re.captures(line) {
-                    if let Some(breaking_change_reference) = captures.get(1) {
-                        let breaking_change_reference = breaking_change_reference.as_str();
-                        let breaking_change_id =
-                            self.extract_breaking_change_id(breaking_change_reference);
+                // (regex, sets_new_behaviour, use_method_start_line, sets_old_skipped, sets_new_skipped)
+                let matchers: &[(&Regex, bool, bool, bool, bool)] = &[
+                    (&new_driver_re, true, false, false, false),
+                    (&old_driver_re, false, false, false, false),
+                    (&skip_old_re, true, true, true, false),
+                    (&skip_new_re, false, true, false, true),
+                    (&assume_new_re, true, true, true, false),
+                    (&assume_old_re, false, true, false, true),
+                ];
 
-                        let breaking_change_location = breaking_changes
-                            .entry(breaking_change_id)
-                            .or_insert_with(|| BehaviorDifferenceLocation {
-                                new_behaviour_file: None,
-                                new_behaviour_line: None,
-                                old_behaviour_file: None,
-                                old_behaviour_line: None,
-                            });
-
-                        breaking_change_location.new_behaviour_file = Some(
-                            file_path
-                                .strip_prefix(&self.workspace_root)
-                                .unwrap_or(file_path)
-                                .to_string_lossy()
-                                .to_string(),
-                        );
-                        breaking_change_location.new_behaviour_line = Some(line_num + 1);
-                    }
-                }
-
-                if let Some(captures) = old_driver_re.captures(line) {
-                    if let Some(breaking_change_reference) = captures.get(1) {
-                        let breaking_change_reference = breaking_change_reference.as_str();
-                        let breaking_change_id =
-                            self.extract_breaking_change_id(breaking_change_reference);
-
-                        let breaking_change_location = breaking_changes
-                            .entry(breaking_change_id)
-                            .or_insert_with(|| BehaviorDifferenceLocation {
-                                new_behaviour_file: None,
-                                new_behaviour_line: None,
-                                old_behaviour_file: None,
-                                old_behaviour_line: None,
-                            });
-
-                        breaking_change_location.old_behaviour_file = Some(
-                            file_path
-                                .strip_prefix(&self.workspace_root)
-                                .unwrap_or(file_path)
-                                .to_string_lossy()
-                                .to_string(),
-                        );
-                        breaking_change_location.old_behaviour_line = Some(line_num + 1);
+                for &(re, is_new, use_method_start, skip_old, skip_new) in matchers {
+                    if let Some(captures) = re.captures(line) {
+                        if let Some(id_match) = captures.get(1) {
+                            let bd_id = self.extract_breaking_change_id(id_match.as_str());
+                            let loc = breaking_changes.entry(bd_id).or_insert_with(default_loc);
+                            let line_no = if use_method_start {
+                                method_start_line
+                            } else {
+                                line_num + 1
+                            };
+                            if is_new {
+                                loc.new_behaviour_file = Some(rel_path.clone());
+                                loc.new_behaviour_line = Some(line_no);
+                            } else {
+                                loc.old_behaviour_file = Some(rel_path.clone());
+                                loc.old_behaviour_line = Some(line_no);
+                            }
+                            if skip_old {
+                                loc.old_driver_skipped = true;
+                            }
+                            if skip_new {
+                                loc.new_driver_skipped = true;
+                            }
+                        }
                     }
                 }
             }

--- a/tests/tests_format_validator/src/driver_handlers/odbc_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/odbc_handler.rs
@@ -171,12 +171,36 @@ impl BaseDriverHandler for OdbcHandler {
         method_name: &str,
         file_path: &Path,
     ) -> Result<HashMap<String, BehaviorDifferenceLocation>> {
+        enum SkipKind {
+            SkipOld,
+            SkipNew,
+        }
+
         let mut breaking_changes = HashMap::new();
         let lines: Vec<&str> = content.lines().collect();
 
         let mut in_method = false;
         let mut brace_count = 0;
         let mut in_test_case_declaration = false;
+        let mut pending_skip_kind: Option<SkipKind> = None;
+        let mut method_start_line: usize = 0;
+
+        let new_driver_re = Regex::new(r#"NEW_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+        let old_driver_re = Regex::new(r#"OLD_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+        let skip_old_re = Regex::new(r#"SKIP_OLD_DRIVER\s*\(\s*"(BD#\d+)""#).unwrap();
+        let skip_new_re = Regex::new(r#"SKIP_NEW_DRIVER\s*\(\s*"(BD#\d+)""#).unwrap();
+        let skip_old_multiline_re = Regex::new(r#"SKIP_OLD_DRIVER\s*\(\s*$"#).unwrap();
+        let skip_new_multiline_re = Regex::new(r#"SKIP_NEW_DRIVER\s*\(\s*$"#).unwrap();
+        let bd_id_re = Regex::new(r#""(BD#\d+)""#).unwrap();
+
+        let default_loc = || BehaviorDifferenceLocation {
+            new_behaviour_file: None,
+            new_behaviour_line: None,
+            old_behaviour_file: None,
+            old_behaviour_line: None,
+            old_driver_skipped: false,
+            new_driver_skipped: false,
+        };
 
         for (line_num, line) in lines.iter().enumerate() {
             let line = line.trim();
@@ -184,13 +208,16 @@ impl BaseDriverHandler for OdbcHandler {
             // Check for TEST_CASE start (might be multi-line)
             if line.starts_with("TEST_CASE(") {
                 if line.contains(&format!("\"{method_name}\"")) {
-                    // Method name is on the same line
                     in_method = true;
+                    method_start_line = line_num + 1;
+                    brace_count +=
+                        line.matches('{').count() as i32 - line.matches('}').count() as i32;
+                } else if line.contains('{') {
+                    // Declaration complete on one line but not our method — skip it
                 } else {
-                    // Method name might be on next line
                     in_test_case_declaration = true;
+                    method_start_line = line_num + 1;
                 }
-                brace_count += line.matches('{').count() as i32 - line.matches('}').count() as i32;
                 continue;
             }
 
@@ -202,6 +229,9 @@ impl BaseDriverHandler for OdbcHandler {
                 brace_count += line.matches('{').count() as i32 - line.matches('}').count() as i32;
                 if line.contains('{') {
                     in_test_case_declaration = false;
+                    if !in_method {
+                        brace_count = 0;
+                    }
                 }
                 continue;
             }
@@ -212,6 +242,7 @@ impl BaseDriverHandler for OdbcHandler {
 
             if !line.starts_with("//") && is_void_method && !in_method {
                 in_method = true;
+                method_start_line = line_num + 1;
                 brace_count += line.matches('{').count() as i32 - line.matches('}').count() as i32;
                 continue;
             }
@@ -223,60 +254,77 @@ impl BaseDriverHandler for OdbcHandler {
                     break;
                 }
 
-                // Look for Behavior Difference annotations
-                let new_driver_re = Regex::new(r#"NEW_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
-                let old_driver_re = Regex::new(r#"OLD_DRIVER_ONLY\s*\(\s*"([^"]+)"\s*\)"#).unwrap();
+                let rel_path = file_path
+                    .strip_prefix(&self.workspace_root)
+                    .unwrap_or(file_path)
+                    .to_string_lossy()
+                    .to_string();
 
+                // Handle continuation of a multi-line SKIP macro from the previous line
+                if let Some(pending) = pending_skip_kind.take() {
+                    if let Some(captures) = bd_id_re.captures(line) {
+                        let bd_id = captures[1].to_string();
+                        let loc = breaking_changes.entry(bd_id).or_insert_with(default_loc);
+                        match pending {
+                            SkipKind::SkipOld => {
+                                loc.new_behaviour_file = Some(rel_path.clone());
+                                loc.new_behaviour_line = Some(method_start_line);
+                                loc.old_driver_skipped = true;
+                            }
+                            SkipKind::SkipNew => {
+                                loc.old_behaviour_file = Some(rel_path.clone());
+                                loc.old_behaviour_line = Some(method_start_line);
+                                loc.new_driver_skipped = true;
+                            }
+                        }
+                    }
+                }
+
+                // NEW_DRIVER_ONLY / OLD_DRIVER_ONLY — point to the annotation line
                 if let Some(captures) = new_driver_re.captures(line) {
                     if let Some(breaking_change_reference) = captures.get(1) {
-                        let breaking_change_reference = breaking_change_reference.as_str();
                         let breaking_change_id =
-                            self.extract_breaking_change_id(breaking_change_reference);
-
-                        let breaking_change_location = breaking_changes
+                            self.extract_breaking_change_id(breaking_change_reference.as_str());
+                        let loc = breaking_changes
                             .entry(breaking_change_id)
-                            .or_insert_with(|| BehaviorDifferenceLocation {
-                                new_behaviour_file: None,
-                                new_behaviour_line: None,
-                                old_behaviour_file: None,
-                                old_behaviour_line: None,
-                            });
-
-                        breaking_change_location.new_behaviour_file = Some(
-                            file_path
-                                .strip_prefix(&self.workspace_root)
-                                .unwrap_or(file_path)
-                                .to_string_lossy()
-                                .to_string(),
-                        );
-                        breaking_change_location.new_behaviour_line = Some(line_num + 1);
+                            .or_insert_with(default_loc);
+                        loc.new_behaviour_file = Some(rel_path.clone());
+                        loc.new_behaviour_line = Some(line_num + 1);
                     }
                 }
 
                 if let Some(captures) = old_driver_re.captures(line) {
                     if let Some(breaking_change_reference) = captures.get(1) {
-                        let breaking_change_reference = breaking_change_reference.as_str();
                         let breaking_change_id =
-                            self.extract_breaking_change_id(breaking_change_reference);
-
-                        let breaking_change_location = breaking_changes
+                            self.extract_breaking_change_id(breaking_change_reference.as_str());
+                        let loc = breaking_changes
                             .entry(breaking_change_id)
-                            .or_insert_with(|| BehaviorDifferenceLocation {
-                                new_behaviour_file: None,
-                                new_behaviour_line: None,
-                                old_behaviour_file: None,
-                                old_behaviour_line: None,
-                            });
-
-                        breaking_change_location.old_behaviour_file = Some(
-                            file_path
-                                .strip_prefix(&self.workspace_root)
-                                .unwrap_or(file_path)
-                                .to_string_lossy()
-                                .to_string(),
-                        );
-                        breaking_change_location.old_behaviour_line = Some(line_num + 1);
+                            .or_insert_with(default_loc);
+                        loc.old_behaviour_file = Some(rel_path.clone());
+                        loc.old_behaviour_line = Some(line_num + 1);
                     }
+                }
+
+                // SKIP_OLD_DRIVER — test only runs on new driver; point to method start
+                if let Some(captures) = skip_old_re.captures(line) {
+                    let bd_id = captures[1].to_string();
+                    let loc = breaking_changes.entry(bd_id).or_insert_with(default_loc);
+                    loc.new_behaviour_file = Some(rel_path.clone());
+                    loc.new_behaviour_line = Some(method_start_line);
+                    loc.old_driver_skipped = true;
+                } else if skip_old_multiline_re.is_match(line) {
+                    pending_skip_kind = Some(SkipKind::SkipOld);
+                }
+
+                // SKIP_NEW_DRIVER — test only runs on old driver; point to method start
+                if let Some(captures) = skip_new_re.captures(line) {
+                    let bd_id = captures[1].to_string();
+                    let loc = breaking_changes.entry(bd_id).or_insert_with(default_loc);
+                    loc.old_behaviour_file = Some(rel_path.clone());
+                    loc.old_behaviour_line = Some(method_start_line);
+                    loc.new_driver_skipped = true;
+                } else if skip_new_multiline_re.is_match(line) {
+                    pending_skip_kind = Some(SkipKind::SkipNew);
                 }
             }
         }

--- a/tests/tests_format_validator/src/driver_handlers/python_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/python_handler.rs
@@ -120,8 +120,68 @@ impl BaseDriverHandler for PythonHandler {
         let mut breaking_changes: HashMap<String, BehaviorDifferenceLocation> = HashMap::new();
         let lines: Vec<&str> = content.lines().collect();
         let mut in_method = false;
+        let skip_ref_re = Regex::new(r#"@pytest\.mark\.skip_reference\(.*?(BD#\d+)"#).unwrap();
+        let skip_uni_re = Regex::new(r#"@pytest\.mark\.skip_universal\(.*?(BD#\d+)"#).unwrap();
 
-        // Find the method start
+        // Pre-scan: collect skip decorators that appear immediately before this method
+        for (line_num, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with(&format!("def {}(", method_name)) {
+                let method_start_line = line_num + 1;
+                // Look backwards for skip decorators
+                let mut j = line_num;
+                while j > 0 {
+                    j -= 1;
+                    let prev = lines[j].trim();
+                    if prev.starts_with('@') {
+                        let rel_path = file_path
+                            .strip_prefix(&self.workspace_root)
+                            .unwrap_or(file_path)
+                            .to_string_lossy()
+                            .to_string();
+                        // skip_reference = skip old/reference → new-driver behaviour
+                        if let Some(caps) = skip_ref_re.captures(prev) {
+                            let bd_id = caps[1].to_string();
+                            let loc = breaking_changes.entry(bd_id).or_insert_with(|| {
+                                BehaviorDifferenceLocation {
+                                    new_behaviour_file: None,
+                                    new_behaviour_line: None,
+                                    old_behaviour_file: None,
+                                    old_behaviour_line: None,
+                                    old_driver_skipped: false,
+                                    new_driver_skipped: false,
+                                }
+                            });
+                            loc.new_behaviour_file = Some(rel_path.clone());
+                            loc.new_behaviour_line = Some(method_start_line);
+                            loc.old_driver_skipped = true;
+                        }
+                        // skip_universal = skip new/universal → old-driver behaviour
+                        if let Some(caps) = skip_uni_re.captures(prev) {
+                            let bd_id = caps[1].to_string();
+                            let loc = breaking_changes.entry(bd_id).or_insert_with(|| {
+                                BehaviorDifferenceLocation {
+                                    new_behaviour_file: None,
+                                    new_behaviour_line: None,
+                                    old_behaviour_file: None,
+                                    old_behaviour_line: None,
+                                    old_driver_skipped: false,
+                                    new_driver_skipped: false,
+                                }
+                            });
+                            loc.old_behaviour_file = Some(rel_path.clone());
+                            loc.old_behaviour_line = Some(method_start_line);
+                            loc.new_driver_skipped = true;
+                        }
+                    } else if !prev.is_empty() && !prev.starts_with('#') {
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+
+        // Main scan: find NEW_DRIVER_ONLY / OLD_DRIVER_ONLY inside the method body
         for (line_num, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
             if trimmed.starts_with(&format!("def {}(", method_name)) {
@@ -132,7 +192,6 @@ impl BaseDriverHandler for PythonHandler {
             if in_method {
                 let indent_level = line.len() - line.trim_start().len();
 
-                // If we hit a line with same or less indentation that starts with def/class, we're out of the method
                 if indent_level <= 4
                     && (trimmed.starts_with("def ") || trimmed.starts_with("class "))
                     && !trimmed.starts_with(&format!("def {}(", method_name))
@@ -140,49 +199,43 @@ impl BaseDriverHandler for PythonHandler {
                     break;
                 }
 
-                // Look for Behavior Difference patterns in Python: NEW_DRIVER_ONLY("BD#X") or OLD_DRIVER_ONLY("BD#X")
                 if let Some(breaking_change_id) = self.extract_breaking_change_from_line(trimmed) {
-                    // Determine if this is NEW or OLD driver behavior
                     let is_new_driver = trimmed.contains("NEW_DRIVER_ONLY");
 
-                    let location = if is_new_driver {
-                        BehaviorDifferenceLocation {
-                            new_behaviour_file: Some(
-                                file_path
-                                    .strip_prefix(&self.workspace_root)
-                                    .unwrap_or(file_path)
-                                    .to_string_lossy()
-                                    .to_string(),
-                            ),
-                            new_behaviour_line: Some(line_num + 1),
-                            old_behaviour_file: None,
-                            old_behaviour_line: None,
-                        }
-                    } else {
-                        BehaviorDifferenceLocation {
-                            new_behaviour_file: None,
-                            new_behaviour_line: None,
-                            old_behaviour_file: Some(
-                                file_path
-                                    .strip_prefix(&self.workspace_root)
-                                    .unwrap_or(file_path)
-                                    .to_string_lossy()
-                                    .to_string(),
-                            ),
-                            old_behaviour_line: Some(line_num + 1),
-                        }
-                    };
+                    let rel_path = file_path
+                        .strip_prefix(&self.workspace_root)
+                        .unwrap_or(file_path)
+                        .to_string_lossy()
+                        .to_string();
 
-                    // If we already have this Behavior Difference, merge the locations
                     if let Some(existing) = breaking_changes.get_mut(&breaking_change_id) {
                         if is_new_driver {
-                            existing.new_behaviour_file = location.new_behaviour_file;
-                            existing.new_behaviour_line = location.new_behaviour_line;
+                            existing.new_behaviour_file = Some(rel_path);
+                            existing.new_behaviour_line = Some(line_num + 1);
                         } else {
-                            existing.old_behaviour_file = location.old_behaviour_file;
-                            existing.old_behaviour_line = location.old_behaviour_line;
+                            existing.old_behaviour_file = Some(rel_path);
+                            existing.old_behaviour_line = Some(line_num + 1);
                         }
                     } else {
+                        let location = if is_new_driver {
+                            BehaviorDifferenceLocation {
+                                new_behaviour_file: Some(rel_path),
+                                new_behaviour_line: Some(line_num + 1),
+                                old_behaviour_file: None,
+                                old_behaviour_line: None,
+                                old_driver_skipped: false,
+                                new_driver_skipped: false,
+                            }
+                        } else {
+                            BehaviorDifferenceLocation {
+                                new_behaviour_file: None,
+                                new_behaviour_line: None,
+                                old_behaviour_file: Some(rel_path),
+                                old_behaviour_line: Some(line_num + 1),
+                                old_driver_skipped: false,
+                                new_driver_skipped: false,
+                            }
+                        };
                         breaking_changes.insert(breaking_change_id, location);
                     }
                 }
@@ -265,34 +318,31 @@ impl PythonHandler {
 
                 // Look for Behavior Difference patterns in Python: NEW_DRIVER_ONLY("BD#X") or OLD_DRIVER_ONLY("BD#X")
                 if let Some(breaking_change_id) = self.extract_breaking_change_from_line(trimmed) {
-                    // Determine if this is NEW or OLD driver behavior
                     let is_new_driver = trimmed.contains("NEW_DRIVER_ONLY");
+
+                    let rel_path = file_path
+                        .strip_prefix(&self.workspace_root)
+                        .unwrap_or(file_path)
+                        .to_string_lossy()
+                        .to_string();
 
                     let location = if is_new_driver {
                         BehaviorDifferenceLocation {
-                            new_behaviour_file: Some(
-                                file_path
-                                    .strip_prefix(&self.workspace_root)
-                                    .unwrap_or(file_path)
-                                    .to_string_lossy()
-                                    .to_string(),
-                            ),
+                            new_behaviour_file: Some(rel_path),
                             new_behaviour_line: Some(line_num + 1),
                             old_behaviour_file: None,
                             old_behaviour_line: None,
+                            old_driver_skipped: false,
+                            new_driver_skipped: false,
                         }
                     } else {
                         BehaviorDifferenceLocation {
                             new_behaviour_file: None,
                             new_behaviour_line: None,
-                            old_behaviour_file: Some(
-                                file_path
-                                    .strip_prefix(&self.workspace_root)
-                                    .unwrap_or(file_path)
-                                    .to_string_lossy()
-                                    .to_string(),
-                            ),
+                            old_behaviour_file: Some(rel_path),
                             old_behaviour_line: Some(line_num + 1),
+                            old_driver_skipped: false,
+                            new_driver_skipped: false,
                         }
                     };
 

--- a/tests/tests_format_validator/src/validator.rs
+++ b/tests/tests_format_validator/src/validator.rs
@@ -82,6 +82,10 @@ pub struct BehaviorDifferenceImplementation {
     pub new_behaviour_line: Option<usize>,
     pub old_behaviour_file: Option<String>,
     pub old_behaviour_line: Option<usize>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub old_driver_skipped: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub new_driver_skipped: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1177,7 +1181,7 @@ impl GherkinValidator {
                 // Extract Behavior Difference scenarios (scenarios with @{driver}_behavior_difference annotations)
                 // Include scenarios with driver tags that might have Behavior Difference implementations
                 // We'll check for actual Behavior Difference implementations during processing
-                let behavior_difference_scenarios = feature
+                let behavior_difference_scenarios: Vec<String> = feature
                     .scenarios
                     .iter()
                     .filter(|scenario| {
@@ -1209,12 +1213,14 @@ impl GherkinValidator {
                     .map(|s| s.name.clone())
                     .collect();
 
-                features.insert(
-                    feature.name.clone(),
-                    crate::behavior_differences_processor::FeatureInfo {
-                        behavior_difference_scenarios,
-                    },
-                );
+                let feature_id = self.get_feature_id(entry.path());
+                features
+                    .entry(feature_id)
+                    .or_insert_with(|| crate::behavior_differences_processor::FeatureInfo {
+                        behavior_difference_scenarios: Vec::new(),
+                    })
+                    .behavior_difference_scenarios
+                    .extend(behavior_difference_scenarios);
             }
         }
 

--- a/tests/tests_format_validator/tests/validator_tests.rs
+++ b/tests/tests_format_validator/tests/validator_tests.rs
@@ -1089,6 +1089,587 @@ fn should_handle_multiple_breaking_changes_in_single_test_method() -> Result<()>
     Ok(())
 }
 
+// ===== Regression Tests for SKIP_OLD_DRIVER / SKIP_NEW_DRIVER =====
+
+#[test]
+fn should_detect_skip_old_driver_annotations_in_cpp() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_feature_file(
+        "auth",
+        "skip_annotations",
+        TestImplementations::create_skip_annotation_feature(),
+    )?;
+
+    workspace.create_cpp_test(
+        "auth",
+        "skip_annotations",
+        TestImplementations::create_cpp_test_with_skip_annotations(),
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let enhanced_results = validator.validate_all_with_breaking_changes()?;
+
+    let report = &enhanced_results.behavior_differences_report;
+    let odbc_bds = report
+        .behavior_differences_by_language
+        .get("odbc")
+        .expect("Should find ODBC behavior differences");
+
+    let bd_ids: Vec<&str> = odbc_bds
+        .iter()
+        .map(|b| b.behavior_difference_id.as_str())
+        .collect();
+
+    // Single-line SKIP_OLD_DRIVER
+    assert!(
+        bd_ids.contains(&"BD#11"),
+        "Should detect single-line SKIP_OLD_DRIVER BD#11"
+    );
+    // Multi-line SKIP_OLD_DRIVER (BD# on next line)
+    assert!(
+        bd_ids.contains(&"BD#15"),
+        "Should detect multi-line SKIP_OLD_DRIVER BD#15"
+    );
+    // SKIP_NEW_DRIVER
+    assert!(
+        bd_ids.contains(&"BD#20"),
+        "Should detect SKIP_NEW_DRIVER BD#20"
+    );
+
+    // SKIP_OLD_DRIVER → new-driver behaviour points to method start, old side is "skipped"
+    let bd11 = odbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#11")
+        .unwrap();
+    let impl11 = &bd11.implementations[0];
+    assert!(
+        impl11.new_behaviour_file.is_some(),
+        "SKIP_OLD_DRIVER should record new_behaviour_file"
+    );
+    assert!(
+        impl11.new_behaviour_line.is_some(),
+        "SKIP_OLD_DRIVER should record new_behaviour_line"
+    );
+    assert_eq!(
+        impl11.new_behaviour_line.unwrap(),
+        impl11.test_line,
+        "SKIP_OLD_DRIVER new_behaviour_line should point to the test method start"
+    );
+    assert!(
+        impl11.old_driver_skipped,
+        "SKIP_OLD_DRIVER should set old_driver_skipped = true"
+    );
+    assert!(
+        !impl11.new_driver_skipped,
+        "SKIP_OLD_DRIVER should NOT set new_driver_skipped"
+    );
+
+    // SKIP_NEW_DRIVER → old-driver behaviour points to method start, new side is "skipped"
+    let bd20 = odbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#20")
+        .unwrap();
+    let impl20 = &bd20.implementations[0];
+    assert!(
+        impl20.old_behaviour_file.is_some(),
+        "SKIP_NEW_DRIVER should record old_behaviour_file"
+    );
+    assert!(
+        impl20.old_behaviour_line.is_some(),
+        "SKIP_NEW_DRIVER should record old_behaviour_line"
+    );
+    assert_eq!(
+        impl20.old_behaviour_line.unwrap(),
+        impl20.test_line,
+        "SKIP_NEW_DRIVER old_behaviour_line should point to the test method start"
+    );
+    assert!(
+        impl20.new_driver_skipped,
+        "SKIP_NEW_DRIVER should set new_driver_skipped = true"
+    );
+    assert!(
+        !impl20.old_driver_skipped,
+        "SKIP_NEW_DRIVER should NOT set old_driver_skipped"
+    );
+
+    // Multi-line SKIP_OLD_DRIVER should also point to method start
+    let bd15 = odbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#15")
+        .unwrap();
+    let impl15 = &bd15.implementations[0];
+    assert_eq!(
+        impl15.new_behaviour_line.unwrap(),
+        impl15.test_line,
+        "Multi-line SKIP_OLD_DRIVER should also point to test method start"
+    );
+    assert!(
+        impl15.old_driver_skipped,
+        "Multi-line SKIP_OLD_DRIVER should set old_driver_skipped"
+    );
+
+    Ok(())
+}
+
+// ===== Python skip_reference / skip_universal BD Tests =====
+
+#[test]
+fn should_detect_skip_reference_annotations_in_python() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_bd_yaml(
+        "python",
+        r#"behavior_differences:
+  11:
+    name: "Numeric conversion returns 22003 instead of SQL_SUCCESS"
+  20:
+    name: "Interval leading field precision enforcement"
+"#,
+    )?;
+
+    workspace.create_feature_file(
+        "auth",
+        "skip_annotations_python",
+        r#"@python
+Feature: Python Skip Annotation Test
+
+  @python_e2e
+  Scenario: should handle numeric conversion correctly
+    Given I have a numeric column
+    When I fetch with small buffer
+    Then correct error is returned
+
+  @python_e2e
+  Scenario: should handle interval precision
+    Given I have a number column
+    When I convert to interval type
+    Then interval precision is enforced
+"#,
+    )?;
+
+    workspace.create_python_test(
+        "auth",
+        "skip_annotations_python",
+        r#"import pytest
+
+@pytest.mark.skip_reference(reason="BD#11: Old driver returns SQL_SUCCESS instead of 22003")
+def test_should_handle_numeric_conversion_correctly():
+    # Given I have a numeric column
+    stmt = setup_numeric_column()
+
+    # When I fetch with small buffer
+    ret = fetch_with_small_buffer(stmt)
+
+    # Then correct error is returned
+    assert ret == "22003"
+
+@pytest.mark.skip_universal(reason="BD#20: New driver enforces interval leading precision")
+def test_should_handle_interval_precision():
+    # Given I have a number column
+    stmt = setup_number_column()
+
+    # When I convert to interval type
+    ret = convert_to_interval(stmt, 999)
+
+    # Then interval precision is enforced
+    assert ret == "SQL_SUCCESS"
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let enhanced_results = validator.validate_all_with_breaking_changes()?;
+
+    let report = &enhanced_results.behavior_differences_report;
+    let python_bds = report
+        .behavior_differences_by_language
+        .get("python")
+        .expect("Should find Python behavior differences");
+
+    let bd_ids: Vec<&str> = python_bds
+        .iter()
+        .map(|b| b.behavior_difference_id.as_str())
+        .collect();
+
+    assert!(
+        bd_ids.contains(&"BD#11"),
+        "Should detect skip_reference BD#11, found: {:?}",
+        bd_ids
+    );
+    assert!(
+        bd_ids.contains(&"BD#20"),
+        "Should detect skip_universal BD#20, found: {:?}",
+        bd_ids
+    );
+
+    // skip_reference → old driver is skipped, new-driver behaviour points to method start
+    let bd11 = python_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#11")
+        .unwrap();
+    let impl11 = &bd11.implementations[0];
+    assert!(
+        impl11.new_behaviour_file.is_some(),
+        "skip_reference should record new_behaviour_file"
+    );
+    assert!(
+        impl11.old_driver_skipped,
+        "skip_reference should set old_driver_skipped = true"
+    );
+    assert!(
+        !impl11.new_driver_skipped,
+        "skip_reference should NOT set new_driver_skipped"
+    );
+
+    // skip_universal → new driver is skipped, old-driver behaviour points to method start
+    let bd20 = python_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#20")
+        .unwrap();
+    let impl20 = &bd20.implementations[0];
+    assert!(
+        impl20.old_behaviour_file.is_some(),
+        "skip_universal should record old_behaviour_file"
+    );
+    assert!(
+        impl20.new_driver_skipped,
+        "skip_universal should set new_driver_skipped = true"
+    );
+    assert!(
+        !impl20.old_driver_skipped,
+        "skip_universal should NOT set old_driver_skipped"
+    );
+
+    Ok(())
+}
+
+// ===== JDBC SKIP_OLD_DRIVER / SKIP_NEW_DRIVER BD Tests =====
+
+#[test]
+fn should_detect_skip_driver_annotations_in_jdbc() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_bd_yaml(
+        "jdbc",
+        r#"behavior_differences:
+  11:
+    name: "Numeric conversion returns 22003 instead of SQL_SUCCESS"
+  20:
+    name: "Interval leading field precision enforcement"
+"#,
+    )?;
+
+    workspace.create_feature_file(
+        "auth",
+        "skip_annotations_jdbc",
+        r#"@jdbc
+Feature: JDBC Skip Annotation Test
+
+  @jdbc_int
+  Scenario: should handle numeric conversion correctly
+    Given I have a numeric column
+    When I fetch with small buffer
+    Then correct error is returned
+
+  @jdbc_int
+  Scenario: should handle interval precision
+    Given I have a number column
+    When I convert to interval type
+    Then interval precision is enforced
+"#,
+    )?;
+
+    workspace.create_java_test(
+        "auth",
+        "SkipAnnotationsJdbc",
+        r#"
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SkipAnnotationsJdbcTest {
+    @Test
+    public void shouldHandleNumericConversionCorrectly() throws Exception {
+        // Given I have a numeric column
+        Statement stmt = setupNumericColumn();
+
+        // When I fetch with small buffer
+        // SKIP_OLD_DRIVER("BD#11", "Old driver returns SQL_SUCCESS instead of 22003")
+        ResultSet rs = fetchWithSmallBuffer(stmt);
+
+        // Then correct error is returned
+        assertEquals("22003", getErrorCode(rs));
+    }
+
+    @Test
+    public void shouldHandleIntervalPrecision() throws Exception {
+        // Given I have a number column
+        Statement stmt = setupNumberColumn();
+
+        // When I convert to interval type
+        // SKIP_NEW_DRIVER("BD#20", "New driver enforces interval leading precision")
+        ResultSet rs = convertToInterval(stmt, 999);
+
+        // Then interval precision is enforced
+        assertEquals("SQL_SUCCESS", getResult(rs));
+    }
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let enhanced_results = validator.validate_all_with_breaking_changes()?;
+
+    let report = &enhanced_results.behavior_differences_report;
+    let jdbc_bds = report
+        .behavior_differences_by_language
+        .get("jdbc")
+        .expect("Should find JDBC behavior differences");
+
+    let bd_ids: Vec<&str> = jdbc_bds
+        .iter()
+        .map(|b| b.behavior_difference_id.as_str())
+        .collect();
+
+    assert!(
+        bd_ids.contains(&"BD#11"),
+        "Should detect SKIP_OLD_DRIVER BD#11, found: {:?}",
+        bd_ids
+    );
+    assert!(
+        bd_ids.contains(&"BD#20"),
+        "Should detect SKIP_NEW_DRIVER BD#20, found: {:?}",
+        bd_ids
+    );
+
+    // SKIP_OLD_DRIVER → old driver is skipped, new-driver behaviour points to method start
+    let bd11 = jdbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#11")
+        .unwrap();
+    let impl11 = &bd11.implementations[0];
+    assert!(
+        impl11.new_behaviour_file.is_some(),
+        "SKIP_OLD_DRIVER should record new_behaviour_file"
+    );
+    assert_eq!(
+        impl11.new_behaviour_line.unwrap(),
+        impl11.test_line,
+        "SKIP_OLD_DRIVER new_behaviour_line should point to method start"
+    );
+    assert!(
+        impl11.old_driver_skipped,
+        "SKIP_OLD_DRIVER should set old_driver_skipped = true"
+    );
+    assert!(
+        !impl11.new_driver_skipped,
+        "SKIP_OLD_DRIVER should NOT set new_driver_skipped"
+    );
+
+    // SKIP_NEW_DRIVER → new driver is skipped, old-driver behaviour points to method start
+    let bd20 = jdbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#20")
+        .unwrap();
+    let impl20 = &bd20.implementations[0];
+    assert!(
+        impl20.old_behaviour_file.is_some(),
+        "SKIP_NEW_DRIVER should record old_behaviour_file"
+    );
+    assert_eq!(
+        impl20.old_behaviour_line.unwrap(),
+        impl20.test_line,
+        "SKIP_NEW_DRIVER old_behaviour_line should point to method start"
+    );
+    assert!(
+        impl20.new_driver_skipped,
+        "SKIP_NEW_DRIVER should set new_driver_skipped = true"
+    );
+    assert!(
+        !impl20.old_driver_skipped,
+        "SKIP_NEW_DRIVER should NOT set old_driver_skipped"
+    );
+
+    Ok(())
+}
+
+// ===== JDBC assumeTrue BD Tests =====
+
+#[test]
+fn should_detect_assume_true_annotations_in_jdbc() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    workspace.create_bd_yaml(
+        "jdbc",
+        r#"behavior_differences:
+  15:
+    name: "Float buffer truncation returns 01004 instead of SQL_ERROR"
+"#,
+    )?;
+
+    workspace.create_feature_file(
+        "auth",
+        "assume_true_jdbc",
+        r#"@jdbc
+Feature: JDBC Assume True Test
+
+  @jdbc_int
+  Scenario: should skip old driver via assumption
+    Given I have a float column
+    When I fetch with small char buffer
+    Then truncation warning is returned
+"#,
+    )?;
+
+    workspace.create_java_test(
+        "auth",
+        "AssumeTrueJdbc",
+        r#"
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AssumeTrueJdbcTest {
+    @Test
+    public void shouldSkipOldDriverViaAssumption() throws Exception {
+        // Given I have a float column
+        Statement stmt = setupFloatColumn();
+        Assumptions.assumeTrue(isNewDriver(), "BD#15: Old driver returns SQL_ERROR");
+
+        // When I fetch with small char buffer
+        ResultSet rs = fetchFloatSmallBuffer(stmt);
+
+        // Then truncation warning is returned
+        assertEquals("01004", getSqlState(rs));
+    }
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let enhanced_results = validator.validate_all_with_breaking_changes()?;
+
+    let report = &enhanced_results.behavior_differences_report;
+    let jdbc_bds = report
+        .behavior_differences_by_language
+        .get("jdbc")
+        .expect("Should find JDBC behavior differences");
+
+    let bd_ids: Vec<&str> = jdbc_bds
+        .iter()
+        .map(|b| b.behavior_difference_id.as_str())
+        .collect();
+
+    assert!(
+        bd_ids.contains(&"BD#15"),
+        "Should detect assumeTrue(isNewDriver()) BD#15, found: {:?}",
+        bd_ids
+    );
+
+    let bd15 = jdbc_bds
+        .iter()
+        .find(|b| b.behavior_difference_id == "BD#15")
+        .unwrap();
+    let impl15 = &bd15.implementations[0];
+    assert!(
+        impl15.new_behaviour_file.is_some(),
+        "assumeTrue(isNewDriver) should record new_behaviour_file"
+    );
+    assert!(
+        impl15.old_driver_skipped,
+        "assumeTrue(isNewDriver) should set old_driver_skipped = true"
+    );
+
+    Ok(())
+}
+
+// ===== Regression Tests for Feature Name Collision in BD Processing =====
+
+/// Test that behaviour differences are found even when two feature files share the same
+/// file stem (e.g. shared/auth/auth.feature and odbc/auth/auth.feature).
+#[test]
+fn should_find_behavior_differences_when_feature_names_collide() -> Result<()> {
+    let workspace = TestWorkspace::new()?;
+
+    // shared/auth/key_auth.feature — contains the scenario whose test has BD annotations
+    workspace.create_feature_file_in_folder(
+        "shared",
+        "auth",
+        "key_auth",
+        r#"@core @odbc @python
+Feature: Key Auth (shared)
+
+  @core_int @odbc_int @python_int
+  Scenario: should fail when no key provided
+    Given Authentication is set to JWT
+    When Trying to Connect with no key provided
+    Then There is error returned
+"#,
+    )?;
+
+    // odbc/auth/key_auth.feature — same file stem, different scenarios
+    workspace.create_feature_file_in_folder(
+        "odbc",
+        "auth",
+        "key_auth",
+        r#"@odbc
+Feature: Key Auth (ODBC-specific)
+
+  @odbc_int
+  Scenario: should forward key content via SQLSetConnectAttr
+    Given A connection handle is allocated with key content
+    When Trying to Connect
+    Then The key is forwarded to core
+"#,
+    )?;
+
+    // C++ test matching the *shared* scenario, with BD annotation
+    workspace.create_cpp_test(
+        "auth",
+        "key_auth",
+        r#"#include <catch2/catch.hpp>
+
+TEST_CASE("should fail when no key provided") {
+    // Given Authentication is set to JWT
+    auto conn = setup_jwt_connection();
+
+    // When Trying to Connect with no key provided
+    auto ret = connect(conn);
+
+    // Then There is error returned
+    OLD_DRIVER_ONLY("BD#1") {
+        CHECK(get_error_code(conn) == 20032);
+    }
+
+    NEW_DRIVER_ONLY("BD#1") {
+        CHECK(get_error_code(conn) == 0);
+    }
+}
+"#,
+    )?;
+
+    let validator = workspace.get_validator()?;
+    let enhanced_results = validator.validate_all_with_breaking_changes()?;
+    let report = &enhanced_results.behavior_differences_report;
+
+    let odbc_bds = report
+        .behavior_differences_by_language
+        .get("odbc")
+        .expect("Should find ODBC behaviour differences even with colliding feature names");
+
+    let bd_ids: Vec<&str> = odbc_bds
+        .iter()
+        .map(|b| b.behavior_difference_id.as_str())
+        .collect();
+
+    assert!(
+        bd_ids.contains(&"BD#1"),
+        "BD#1 must be found from shared feature despite name collision with odbc feature. Found: {:?}",
+        bd_ids
+    );
+
+    Ok(())
+}
+
 // ===== Regression Tests for Path-Based Feature IDs =====
 
 /// Test that features with the same name in different folders are treated as separate.
@@ -2113,6 +2694,16 @@ impl TestWorkspace {
         Ok(())
     }
 
+    fn create_bd_yaml(&self, lang_dir: &str, content: &str) -> Result<()> {
+        let bd_path = self
+            .workspace_root
+            .join(lang_dir)
+            .join("BehaviorDifferences.yaml");
+        fs::create_dir_all(bd_path.parent().unwrap())?;
+        fs::write(bd_path, content)?;
+        Ok(())
+    }
+
     fn create_cpp_common_file(&self, name: &str, content: &str) -> Result<()> {
         let common_dir = self.workspace_root.join("odbc_tests/common/src");
         fs::create_dir_all(&common_dir)?;
@@ -2165,6 +2756,15 @@ impl TestWorkspace {
   
   10:
     name: "Third multiple Breaking Change for testing multiple Breaking Changes in single method"
+  
+  11:
+    name: "Numeric conversion returns 22003 instead of SQL_SUCCESS"
+  
+  15:
+    name: "Float buffer truncation returns 01004 instead of SQL_ERROR"
+  
+  20:
+    name: "Interval leading field precision enforcement"
 "#
     }
 }
@@ -2878,6 +3478,73 @@ TEST_CASE("should test specific line numbers") {
     
     // Then line numbers should be accurate
     REQUIRE(line_numbers_are_correct());
+}
+"#
+    }
+
+    fn create_skip_annotation_feature() -> &'static str {
+        r#"@core @jdbc
+Feature: Skip Annotation Test
+
+  @odbc
+  Scenario: should handle numeric conversion correctly
+    Given I have a numeric column
+    When I fetch with small buffer
+    Then correct error is returned
+
+  @odbc
+  Scenario: should handle float buffer truncation
+    Given I have a float column
+    When I fetch with small char buffer
+    Then truncation warning is returned
+
+  @odbc
+  Scenario: should handle interval precision
+    Given I have a number column
+    When I convert to interval type
+    Then interval precision is enforced
+"#
+    }
+
+    fn create_cpp_test_with_skip_annotations() -> &'static str {
+        r#"#include <catch2/catch.hpp>
+
+TEST_CASE("should handle numeric conversion correctly") {
+    // Given I have a numeric column
+    auto stmt = setup_numeric_column();
+
+    // When I fetch with small buffer
+    SKIP_OLD_DRIVER("BD#11", "Old driver returns SQL_SUCCESS instead of 22003");
+    auto ret = fetch_with_small_buffer(stmt);
+
+    // Then correct error is returned
+    CHECK(ret == SQL_ERROR);
+}
+
+TEST_CASE("should handle float buffer truncation") {
+    // Given I have a float column
+    auto stmt = setup_float_column();
+
+    // When I fetch with small char buffer
+    SKIP_OLD_DRIVER(
+        "BD#15",
+        "Old driver returns SQL_ERROR instead of SQL_SUCCESS_WITH_INFO");
+    auto ret = fetch_float_small_buffer(stmt);
+
+    // Then truncation warning is returned
+    CHECK(ret == SQL_SUCCESS_WITH_INFO);
+}
+
+TEST_CASE("should handle interval precision") {
+    // Given I have a number column
+    auto stmt = setup_number_column();
+
+    // When I convert to interval type
+    SKIP_NEW_DRIVER("BD#20", "New driver enforces interval leading precision");
+    auto ret = convert_to_interval(stmt, 999);
+
+    // Then interval precision is enforced
+    CHECK(ret == SQL_SUCCESS);
 }
 "#
     }


### PR DESCRIPTION
Behavior differences for some tests in ODBC are used with the SKIP_OLD_DRIVER annotation:   
SKIP_OLD_DRIVER("BD#17", "Old driver produces negative zero for interval types");
Adding support to the validator and test coverage reporter to display those behavior differences in the report