### PR TITLE
Refactor credential types to support multiple cloud storage backends

### DIFF
--- a/sf_core/src/file_manager/file_transfer.rs
+++ b/sf_core/src/file_manager/file_transfer.rs
@@ -164,10 +164,19 @@ pub async fn download_from_s3(
 }
 
 async fn create_s3_client(stage_info: &StageInfo, provider_name: &'static str) -> S3Client {
+    let super::types::CloudCredentials::S3 {
+        ref aws_key_id,
+        ref aws_secret_key,
+        ref aws_token,
+    } = stage_info.creds
+    else {
+        panic!("S3 client requires S3 credentials");
+    };
+
     let credentials = Credentials::new(
-        &stage_info.creds.aws_key_id,
-        stage_info.creds.aws_secret_key.reveal(),
-        Some(stage_info.creds.aws_token.reveal().to_string()),
+        aws_key_id,
+        aws_secret_key.reveal(),
+        Some(aws_token.reveal().to_string()),
         None,
         provider_name,
     );

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -49,14 +49,28 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
 
     let (encryption_result, file_metadata) = preprocess_file_before_upload(file_buffer, &data)?;
 
-    let status = upload_to_s3_or_skip(
-        encryption_result,
-        &data.stage_info,
-        file_metadata.target.as_str(),
-        data.overwrite,
-    )
-    .await
-    .context(S3UploadSnafu)?;
+    let status = match data.stage_info.location_type {
+        LocationType::S3 => upload_to_s3_or_skip(
+            encryption_result,
+            &data.stage_info,
+            file_metadata.target.as_str(),
+            data.overwrite,
+        )
+        .await
+        .context(S3UploadSnafu)?,
+        LocationType::Gcs => {
+            return UnsupportedStorageTypeSnafu {
+                storage_type: "GCS",
+            }
+            .fail();
+        }
+        LocationType::Azure => {
+            return UnsupportedStorageTypeSnafu {
+                storage_type: "Azure",
+            }
+            .fail();
+        }
+    };
 
     // TODO: Right now empty message is hardcoded, because any error in the upload process will
     // result in an error before this point and an ERROR status is never returned.
@@ -169,11 +183,24 @@ pub async fn download_files(
 pub async fn download_single_file(
     data: SingleDownloadData,
 ) -> Result<DownloadResult, FileManagerError> {
-    // Download encrypted data and metadata from S3
-    let (encrypted_data, file_metadata) =
-        download_from_s3(&data.stage_info, data.src_location.as_str())
+    // Download encrypted data and metadata from cloud storage
+    let (encrypted_data, file_metadata) = match data.stage_info.location_type {
+        LocationType::S3 => download_from_s3(&data.stage_info, data.src_location.as_str())
             .await
-            .context(S3DownloadSnafu)?;
+            .context(S3DownloadSnafu)?,
+        LocationType::Gcs => {
+            return UnsupportedStorageTypeSnafu {
+                storage_type: "GCS",
+            }
+            .fail();
+        }
+        LocationType::Azure => {
+            return UnsupportedStorageTypeSnafu {
+                storage_type: "Azure",
+            }
+            .fail();
+        }
+    };
 
     // Decrypt the data (this gives us the compressed data)
     let compressed_data =
@@ -243,6 +270,12 @@ pub enum FileManagerError {
     #[snafu(display("Failed to download file from S3"))]
     S3Download {
         source: DownloadFileError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Unsupported storage type: {storage_type}"))]
+    UnsupportedStorageType {
+        storage_type: &'static str,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -82,23 +82,39 @@ pub enum SourceCompressionParam {
     AutoDetect,
 }
 
+/// Cloud storage location type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocationType {
+    S3,
+    Gcs,
+    Azure,
+}
+
 #[derive(Debug, Clone)]
 pub struct StageInfo {
+    pub location_type: LocationType,
     pub bucket: String,
     pub key_prefix: String,
     pub region: String,
-    pub creds: Credentials,
-    /// S3 endpoint provided by Snowflake (e.g. for FIPS or regional routing).
-    /// When present, the S3 client uses this instead of the SDK default.
+    pub creds: CloudCredentials,
+    /// Cloud endpoint provided by Snowflake (e.g. for FIPS or regional routing).
+    /// When present, the storage client uses this instead of the default.
     pub end_point: Option<String>,
+    /// Presigned URL for GCS operations (when access tokens are not available).
+    pub presigned_url: Option<String>,
 }
 
-/// AWS credentials for S3 stage access.
+/// Cloud storage credentials.
 #[derive(Debug, Clone)]
-pub struct Credentials {
-    pub aws_key_id: String,
-    pub aws_secret_key: SensitiveString,
-    pub aws_token: SensitiveString,
+pub enum CloudCredentials {
+    /// AWS S3 credentials (access key + secret + session token).
+    S3 {
+        aws_key_id: String,
+        aws_secret_key: SensitiveString,
+        aws_token: SensitiveString,
+    },
+    /// Google Cloud Storage credentials (OAuth2 Bearer token).
+    Gcs { gcs_access_token: SensitiveString },
 }
 
 /// Encryption material for file transfer.

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -227,17 +227,18 @@ pub struct StageInfo {
     #[serde(rename = "endPoint")]
     end_point: Option<String>,
 
-    // unused fields
     #[serde(rename = "locationType")]
-    _location_type: Option<String>,
+    location_type: Option<String>,
+    #[serde(rename = "presignedUrl")]
+    presigned_url: Option<String>,
+
+    // unused fields
     #[serde(rename = "path")]
     _path: Option<String>,
     #[serde(rename = "storageAccount")]
     _storage_account: Option<String>,
     #[serde(rename = "isClientSideEncrypted")]
     _is_client_side_encrypted: Option<bool>,
-    #[serde(rename = "presignedUrl")]
-    _presigned_url: Option<String>,
     #[serde(rename = "useS3RegionalUrl")]
     _use_s3_regional_url: Option<bool>,
     #[serde(rename = "useRegionalUrl")]
@@ -255,6 +256,9 @@ pub struct Credentials {
     #[serde(rename = "AWS_TOKEN")]
     aws_token: Option<String>,
 
+    #[serde(rename = "GCS_ACCESS_TOKEN")]
+    gcs_access_token: Option<String>,
+
     // unused fields
     #[serde(rename = "AWS_ID")]
     _aws_id: Option<String>,
@@ -262,8 +266,6 @@ pub struct Credentials {
     _aws_key: Option<String>,
     #[serde(rename = "AZURE_SAS_TOKEN")]
     _azure_sas_token: Option<String>,
-    #[serde(rename = "GCS_ACCESS_TOKEN")]
-    _gcs_access_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -622,6 +624,24 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
     type Error = QueryResponseError;
 
     fn try_from(value: &StageInfo) -> Result<Self, Self::Error> {
+        // Determine location type (default to S3 for backward compatibility)
+        let location_type = match value.location_type.as_deref() {
+            Some("GCS") => file_manager::LocationType::Gcs,
+            Some("AZURE") => {
+                return InvalidFormatSnafu {
+                    message: "Azure storage is not yet supported".to_string(),
+                }
+                .fail();
+            }
+            Some("S3") | None => file_manager::LocationType::S3,
+            Some(other) => {
+                return InvalidFormatSnafu {
+                    message: format!("Unknown location type: {other}"),
+                }
+                .fail();
+            }
+        };
+
         let location = value
             .location
             .as_ref()
@@ -631,7 +651,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             .clone();
 
         let bucket_separator = location.find('/').context(InvalidFormatSnafu {
-            message: format!("Invalid S3 location format: {location}"),
+            message: format!("Invalid location format: {location}"),
         })?;
 
         let bucket = location[..bucket_separator].to_string();
@@ -648,13 +668,49 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             })?
             .clone();
 
-        let creds: file_manager::Credentials = value
-            .creds
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "stage info -> credentials",
-            })?
-            .try_into()?;
+        // Build credentials based on location type
+        let creds_data = value.creds.as_ref().context(MissingParameterSnafu {
+            parameter: "stage info -> credentials",
+        })?;
+
+        let creds = match location_type {
+            file_manager::LocationType::S3 => file_manager::CloudCredentials::S3 {
+                aws_key_id: creds_data
+                    .aws_key_id
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> aws key id",
+                    })?
+                    .clone(),
+                aws_secret_key: creds_data
+                    .aws_secret_key
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> aws secret key",
+                    })?
+                    .clone()
+                    .into(),
+                aws_token: creds_data
+                    .aws_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> aws token",
+                    })?
+                    .clone()
+                    .into(),
+            },
+            file_manager::LocationType::Gcs => file_manager::CloudCredentials::Gcs {
+                gcs_access_token: creds_data
+                    .gcs_access_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> gcs access token",
+                    })?
+                    .clone()
+                    .into(),
+            },
+            file_manager::LocationType::Azure => unreachable!("Azure rejected above"),
+        };
 
         let end_point = value
             .end_point
@@ -662,48 +718,20 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             .filter(|ep| !ep.is_empty())
             .cloned();
 
+        let presigned_url = value
+            .presigned_url
+            .as_ref()
+            .filter(|url| !url.is_empty())
+            .cloned();
+
         Ok(file_manager::StageInfo {
+            location_type,
             bucket,
             key_prefix,
             region,
             creds,
             end_point,
-        })
-    }
-}
-
-impl TryFrom<&Credentials> for file_manager::Credentials {
-    type Error = QueryResponseError;
-
-    fn try_from(value: &Credentials) -> Result<Self, Self::Error> {
-        let aws_key_id = value
-            .aws_key_id
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws key id",
-            })?
-            .clone();
-
-        let aws_secret_key = value
-            .aws_secret_key
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws secret key",
-            })?
-            .clone();
-
-        let aws_token = value
-            .aws_token
-            .as_ref()
-            .context(MissingParameterSnafu {
-                parameter: "credentials -> aws token",
-            })?
-            .clone();
-
-        Ok(file_manager::Credentials {
-            aws_key_id,
-            aws_secret_key: aws_secret_key.into(),
-            aws_token: aws_token.into(),
+            presigned_url,
         })
     }
 }


### PR DESCRIPTION
## Summary
- Replace S3-only `Credentials` struct with `CloudCredentials` enum supporting S3 and GCS at the type level
- Add `LocationType` enum and extend `StageInfo` with `presigned_url` field
- Update query response parsing to build credentials based on `locationType` from server
- GCS and Azure operations return `UnsupportedStorageType` error (implementation in follow-up PR)

**Part 1 of 2** — type system refactoring only, no new cloud backend functionality.

## Test plan
- [x] All 251 sf_core unit tests pass
- [x] All 32 Python e2e put/get tests pass (S3 regression)
- [x] Pre-commit hooks pass (rustfmt, clippy, cargo check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)