### PR TITLE
Add cloud provider to testing matrix for Python and ODBC

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -194,14 +194,17 @@ jobs:
           - os: ubuntu-latest
             name: Linux x64
             driver_lib: libsfodbc.so
+            cloud_provider: aws
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
+            cloud_provider: gcp
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+            cloud_provider: aws
     runs-on: ${{ matrix.os }}
-    name: odbc_tests (${{ matrix.name }})
+    name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }})
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -271,7 +274,7 @@ jobs:
           echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\x64\MD" >> $env:GITHUB_ENV
 
       - name: Decode secrets
-        run: ./scripts/decode_secrets.sh
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -198,11 +198,23 @@ jobs:
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
-            cloud_provider: gcp
+            cloud_provider: aws
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
             cloud_provider: aws
+          - os: ubuntu-latest
+            name: Linux x64
+            driver_lib: libsfodbc.so
+            cloud_provider: gcp
+          - os: macos-latest
+            name: macOS ARM64
+            driver_lib: libsfodbc.dylib
+            cloud_provider: gcp
+          - os: windows-latest
+            name: Windows x64
+            driver_lib: sfodbc.dll
+            cloud_provider: gcp
     runs-on: ${{ matrix.os }}
     name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }})
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -118,7 +118,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     strategy:
       fail-fast: false
-      matrix:
+      matrix: &base_matrix
         os: [ubuntu-latest, windows-11-arm]
         py: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
@@ -293,38 +293,48 @@ jobs:
           - os: ubuntu-latest
             py: "3.9"
             hatch_env: "test"
+            cloud_provider: aws
           - os: ubuntu-latest
             py: "3.12"
             hatch_env: "test"
+            cloud_provider: gcp
           - os: ubuntu-latest
             py: "3.14"
             hatch_env: "test"
+            cloud_provider: aws
           - os: windows-11-arm
             py: "3.11"
             hatch_env: "test"
+            cloud_provider: gcp
           - os: windows-11-arm
             py: "3.12"
             hatch_env: "test"
+            cloud_provider: aws
           - os: windows-11-arm
             py: "3.13"
             hatch_env: "test"
+            cloud_provider: gcp
           - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
             py: "3.13"
             hatch_env: "test"
+            cloud_provider: aws
           # test integration with Pandas
           - os: ubuntu-latest
             py: "3.9"
             hatch_env: "test-pandas"
+            cloud_provider: gcp
           - os: ubuntu-latest # Reference combination for Pandas integration — keep in sync with REFERENCE_* env vars above
             py: "3.13"
             hatch_env: "test-pandas"
+            cloud_provider: aws
           - os: ubuntu-latest
             py: "3.14"
             hatch_env: "test-pandas"
+            cloud_provider: gcp
     runs-on: ${{ matrix.os }}
-    name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }})
+    name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:
-      MATRIX_KEY: ${{ matrix.os }}-${{ matrix.py }}-${{ matrix.hatch_env }}
+      MATRIX_KEY: ${{ matrix.os }}-${{ matrix.py }}-${{ matrix.hatch_env }}-${{ matrix.cloud_provider }}
     steps:
       - name: Set UV cache dir
         shell: bash
@@ -375,7 +385,7 @@ jobs:
           path: python/dist
 
       - name: Decode secrets
-        run: ./scripts/decode_secrets.sh
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
@@ -586,7 +596,7 @@ jobs:
       - name: Download universal test results
         uses: actions/download-artifact@v4
         with:
-          name: results-universal-${{ env.MATRIX_KEY }}
+          name: results-universal-${{ env.MATRIX_KEY }}-aws
           path: ${{ github.workspace }}/universal-results
 
       - name: Download reference test results
@@ -605,7 +615,7 @@ jobs:
           hatch run reference:compare \
             --py ${{ env.REFERENCE_PYTHON_VERSION }} \
             --os ${{ env.REFERENCE_OS_VERSION }} \
-            --universal ${{ github.workspace }}/universal-results/universal-${{ env.MATRIX_KEY }}.json \
+            --universal ${{ github.workspace }}/universal-results/universal-${{ env.MATRIX_KEY }}-aws.json \
             --reference ${{ github.workspace }}/reference-results/reference-${{ env.REF_MATRIX_KEY }}.json \
             --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -19,6 +19,7 @@ env:
   REFERENCE_PYTHON_VERSION: "3.13"
   # OS version for consistent naming across jobs
   REFERENCE_OS_VERSION: "ubuntu-latest"
+  REFERENCE_CLOUD_PROVIDER: "aws"
 
 jobs:
   detect-changes:
@@ -118,7 +119,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     strategy:
       fail-fast: false
-      matrix: &base_matrix
+      matrix:
         os: [ubuntu-latest, windows-11-arm]
         py: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
@@ -539,7 +540,7 @@ jobs:
           path: python/dist
 
       - name: Decode secrets
-        run: ./scripts/decode_secrets.sh
+        run: ./scripts/decode_secrets.sh ${{ env.REFERENCE_CLOUD_PROVIDER }}
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
 
@@ -596,7 +597,7 @@ jobs:
       - name: Download universal test results
         uses: actions/download-artifact@v4
         with:
-          name: results-universal-${{ env.MATRIX_KEY }}-aws
+          name: results-universal-${{ env.MATRIX_KEY }}-${{ env.REFERENCE_CLOUD_PROVIDER }}
           path: ${{ github.workspace }}/universal-results
 
       - name: Download reference test results
@@ -615,7 +616,7 @@ jobs:
           hatch run reference:compare \
             --py ${{ env.REFERENCE_PYTHON_VERSION }} \
             --os ${{ env.REFERENCE_OS_VERSION }} \
-            --universal ${{ github.workspace }}/universal-results/universal-${{ env.MATRIX_KEY }}-aws.json \
+            --universal ${{ github.workspace }}/universal-results/universal-${{ env.MATRIX_KEY }}-${{ env.REFERENCE_CLOUD_PROVIDER }}.json \
             --reference ${{ github.workspace }}/reference-results/reference-${{ env.REF_MATRIX_KEY }}.json \
             --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
 

--- a/odbc_tests/common/include/ReadOnlyDbFixture.hpp
+++ b/odbc_tests/common/include/ReadOnlyDbFixture.hpp
@@ -113,7 +113,14 @@ inline std::string get_readonly_db_connection_string() {
   const auto params = get_test_parameters("testconnection");
   std::stringstream ss;
   read_default_params(ss, params, {"DATABASE", "SCHEMA"});
-  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_PASSWORD", "PWD");
+  ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  ss << "PRIV_KEY_FILE=" << get_or_create_private_key_file(params) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_FILE_PWD");
+#else
+  ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(read_private_key(params)) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_PWD");
+#endif
   ss << "DATABASE=" << READONLY_DB_NAME << ";";
   ss << "SCHEMA=" << READONLY_SCHEMA_NAME << ";";
   return ss.str();


### PR DESCRIPTION
## Summary
- Add cloud provider (AWS/GCS) as a dimension in the CI testing matrix for Python and ODBC workflows

**Part 3 of 3** — builds on #585 (GCS transfer implementation). Stack: #584 → #585 → this PR.

## Test plan
- [ ] CI matrix runs against configured cloud providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)