### PR TITLE
SNOW-3235552 Implement remaining statement attributes for query execution

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -756,11 +756,20 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::TxnIsolation => {
-            // Snowflake supports only READ_COMMITTED. Accept it silently; substitute any
-            // other requested level with READ_COMMITTED and return 01S02 per ODBC spec.
-            // NOTE: HY011 when a transaction is open is deferred to SNOW-3240589.
-            if value_ptr as sql::UInteger != SQL_TXN_READ_COMMITTED {
+            // Snowflake always runs at READ COMMITTED. Full isolation-level support
+            // (HY011 when a transaction is open) is deferred to SNOW-3240589.
+            // Per ODBC spec §SQLSetConnectAttr: emit 01S02 whenever the driver
+            // substitutes the requested value.  READ_COMMITTED is accepted as-is;
+            // every other level is silently substituted so pools / ORMs that
+            // read-then-restore the isolation level see the expected warning.
+            let requested = value_ptr as sql::UInteger;
+            if requested != SQL_TXN_READ_COMMITTED {
+                tracing::debug!(
+                    "set_connect_attr: TxnIsolation={requested} substituted with READ_COMMITTED"
+                );
                 warnings.push(Warning::OptionValueChanged);
+            } else {
+                tracing::debug!("set_connect_attr: TxnIsolation=READ_COMMITTED accepted");
             }
             Ok(())
         }

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -305,6 +305,18 @@ fn fetch_impl(
     } else {
         0
     };
+    let max_rows = inner.max_rows;
+
+    // Enforce SQL_ATTR_MAX_ROWS: if the limit has already been reached, stop.
+    if max_rows > 0 && inner.rows_returned >= max_rows {
+        if !rows_fetched_ptr.is_null() {
+            unsafe { *rows_fetched_ptr = 0 };
+        }
+        for row_index in 0..array_size {
+            write_row_status(row_status_ptr, row_index, RowStatus::NoRow);
+        }
+        return NoMoreDataSnafu.fail();
+    }
 
     let mut cache = FetchConverterCache::new();
     // Fast path: a single-row fetch propagates the conversion error to
@@ -328,6 +340,7 @@ fn fetch_impl(
         let outputs = execute_bindings_for_segment(&inner, &cache, arrow_start, 1, 0, 0, 0);
         match outputs.into_iter().next().unwrap_or_else(|| Ok(Vec::new())) {
             Ok(row_warnings) => {
+                inner.rows_returned += 1;
                 let status = if row_warnings.is_empty() {
                     RowStatus::Success
                 } else {
@@ -348,6 +361,13 @@ fn fetch_impl(
     let mut has_error = false;
 
     while rows_fetched < array_size {
+        // Stop if max_rows limit reached mid-rowset.
+        if max_rows > 0 && inner.rows_returned + rows_fetched as sql::ULen >= max_rows {
+            for remaining in rows_fetched..array_size {
+                write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
+            }
+            break;
+        }
         match advance_cursor(&mut inner.state) {
             Ok(()) => {}
             Err(crate::api::OdbcError::NoMoreData { .. }) => {
@@ -417,8 +437,16 @@ fn fetch_impl(
                 }
                 .fail();
             }
-            let wanted = array_size - rows_fetched;
-            (*batch_idx, in_batch_remaining.min(wanted))
+            let mut wanted = array_size - rows_fetched;
+            if max_rows > 0 {
+                let remaining_quota = max_rows
+                    .saturating_sub(inner.rows_returned)
+                    .saturating_sub(rows_fetched as sql::ULen);
+                if (wanted as sql::ULen) > remaining_quota {
+                    wanted = remaining_quota;
+                }
+            }
+            (*batch_idx, in_batch_remaining.min(wanted).max(1))
         };
 
         let outputs = execute_bindings_for_segment(
@@ -457,6 +485,8 @@ fn fetch_impl(
             bump_batch_idx(&mut inner.state, segment_len - 1)?;
         }
     }
+
+    inner.rows_returned += rows_fetched as sql::ULen;
 
     if !rows_fetched_ptr.is_null() {
         unsafe { *rows_fetched_ptr = rows_fetched as sql::ULen };

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -1,18 +1,22 @@
 use crate::api::CDataType;
 use crate::api::TimestampSubtype;
-use crate::api::encoding::{OdbcEncoding, write_string_bytes_i32};
+use crate::api::encoding::OdbcEncoding;
 use crate::api::error::{
     ArrowArrayStreamReaderCreationSnafu, CursorAlreadyOpenSnafu, DaeRequiredSnafu,
-    DisconnectedSnafu, InvalidBufferLengthSnafu, InvalidCursorStateSnafu, InvalidDuringDaeSnafu,
-    InvalidHandleSnafu, InvalidParameterNumberSnafu, InvalidPrecisionOrScaleSnafu,
-    JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcRuntimeSnafu, OperationCanceledSnafu,
-    ReadOnlyAttributeSnafu, Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
+    DisconnectedSnafu, InvalidAttributeValueSnafu, InvalidBufferLengthSnafu,
+    InvalidCursorStateSnafu, InvalidDuringDaeSnafu, InvalidHandleSnafu,
+    InvalidParameterNumberSnafu, InvalidPrecisionOrScaleSnafu, JsonBindingSnafu, NoMoreDataSnafu,
+    NullPointerSnafu, OdbcRuntimeSnafu, OperationCanceledSnafu, ReadOnlyAttributeSnafu, Required,
+    StatementNotExecutedSnafu, UnsupportedAttributeSnafu, UnsupportedFeatureSnafu,
 };
 use crate::api::query_type::{QueryType, ResultKind};
 use crate::api::runtime::global;
 use crate::api::{
     ApdRecord, ConnectionState, DaeContext, ExecutionOrigin, FreeStmtOption, IpdRecord, OdbcResult,
-    ParamDirection, ParamValue, SqlType, StatementInner, StatementState, stmt_from_handle,
+    ParamDirection, ParamValue, SQL_CONCUR_LOCK, SQL_CONCUR_READ_ONLY, SQL_CONCUR_VALUES,
+    SQL_INSENSITIVE, SQL_NONSCROLLABLE, SQL_NOSCAN_OFF, SQL_NOSCAN_ON, SQL_RD_OFF, SQL_RD_ON,
+    SQL_SCROLLABLE, SQL_SENSITIVE, SQL_UNSPECIFIED, SqlType, StatementInner, StatementState,
+    stmt_from_handle,
 };
 use crate::conversion::Binding;
 use crate::conversion::param_binding::odbc_bindings_to_json;
@@ -110,6 +114,11 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
 
     let (bindings, _json_owner) = apply_parameter_bindings(&inner.apd, &inner.ipd, false, None)?;
     let stmt_handle = guard.stmt_handle;
+    let query_timeout = inner.query_timeout;
+    let max_rows = inner.max_rows;
+    let effective_query =
+        apply_limit(statement_text, max_rows).unwrap_or_else(|| statement_text.to_string());
+    let multi_statement_count = inner.multi_statement_count;
 
     let token = CancellationToken::new();
     *guard.active_cancel.lock() = Some(token.clone());
@@ -119,15 +128,37 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             biased;
             _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
             result = async {
+                if multi_statement_count >= 0 {
+                    let mut options = std::collections::HashMap::new();
+                    options.insert(
+                        "multi_statement_count".to_string(),
+                        ConfigSetting {
+                            value: Some(config_setting::Value::IntValue(
+                                multi_statement_count as i64,
+                            )),
+                        },
+                    );
+                    c.statement_set_options(StatementSetOptionsRequest {
+                        stmt_handle: Some(stmt_handle),
+                        options,
+                    })
+                    .await?;
+                }
+
                 c.statement_set_sql_query(StatementSetSqlQueryRequest {
                     stmt_handle: Some(stmt_handle),
-                    query: statement_text.to_string(),
+                    query: effective_query,
                 })
                 .await?;
 
                 c.statement_execute_query(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     bindings,
+                    timeout_seconds: if query_timeout > 0 {
+                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                    } else {
+                        None
+                    },
                 })
                 .await
             } => result.map_err(Into::into),
@@ -141,6 +172,10 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
 
     update_numeric_settings(&conn_handle, &mut conn.numeric_settings)?;
     apply_execute_response(&mut inner, stmt_handle, response, ExecutionOrigin::Direct)?;
+    inner.rows_returned = 0;
+    // Clear any SQL text cached by a prior SQLPrepare so a subsequent
+    // SQLExecute cannot inject LIMIT into stale prepared SQL.
+    inner.sql_text = None;
     Ok(())
 }
 
@@ -438,6 +473,7 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
     }
     tracing::info!("prepare: auto-IPD populated {param_count} parameter markers (from server)");
 
+    inner.sql_text = Some(query.to_string());
     inner.state.set(StatementState::Prepared { schema });
     tracing::info!("prepare: Successfully prepared statement");
     Ok(())
@@ -512,6 +548,24 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     )?;
 
     let stmt_handle = guard.stmt_handle;
+    let query_timeout = inner.query_timeout;
+    let max_rows = inner.max_rows;
+    let last_sent_max_rows = inner.last_sent_max_rows;
+    let sql_text = inner.sql_text.clone();
+    let multi_statement_count = inner.multi_statement_count;
+
+    // Determine the query to send. We must resend whenever max_rows changed
+    // since the last execution: to add/change a LIMIT, or to restore the
+    // original query when a previous LIMIT is cleared.
+    let query_to_send: Option<String> = sql_text.as_deref().and_then(|sql| {
+        let modified = apply_limit(sql, max_rows);
+        let max_rows_changed = last_sent_max_rows != Some(max_rows);
+        match (modified, max_rows_changed) {
+            (Some(q), _) => Some(q),
+            (None, true) => Some(sql.to_string()),
+            (None, false) => None,
+        }
+    });
 
     let token = CancellationToken::new();
     *guard.active_cancel.lock() = Some(token.clone());
@@ -521,9 +575,37 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             biased;
             _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
             result = async {
+                if multi_statement_count >= 0 {
+                    let mut options = std::collections::HashMap::new();
+                    options.insert(
+                        "multi_statement_count".to_string(),
+                        ConfigSetting {
+                            value: Some(config_setting::Value::IntValue(
+                                multi_statement_count as i64,
+                            )),
+                        },
+                    );
+                    c.statement_set_options(StatementSetOptionsRequest {
+                        stmt_handle: Some(stmt_handle),
+                        options,
+                    })
+                    .await?;
+                }
+                if let Some(query) = query_to_send {
+                    c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        query,
+                    })
+                    .await?;
+                }
                 c.statement_execute_query(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     bindings,
+                    timeout_seconds: if query_timeout > 0 {
+                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                    } else {
+                        None
+                    },
                 })
                 .await
             } => result.map_err(Into::into),
@@ -538,6 +620,8 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     update_numeric_settings(&conn_handle, &mut settings)?;
     dbc.connection.lock().numeric_settings = settings;
     apply_execute_response(&mut inner, stmt_handle, response, origin)?;
+    inner.rows_returned = 0;
+    inner.last_sent_max_rows = Some(max_rows);
     Ok(())
 }
 
@@ -754,6 +838,230 @@ fn apply_parameter_bindings(
     tracing::info!("apply_parameter_bindings: Successfully bound parameters");
 
     Ok((Some(bindings), Some(json_string)))
+}
+
+/// Skip leading SQL noise (whitespace, line comments `-- …`, block comments `/* … */`)
+/// and return the remaining slice.
+fn skip_sql_noise(sql: &str) -> &str {
+    let b = sql.as_bytes();
+    let mut i = 0;
+    loop {
+        // Skip whitespace.
+        while i < b.len() && b[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i + 1 < b.len() && b[i] == b'-' && b[i + 1] == b'-' {
+            // Line comment: skip until newline.
+            i += 2;
+            while i < b.len() && b[i] != b'\n' {
+                i += 1;
+            }
+        } else if i + 1 < b.len() && b[i] == b'/' && b[i + 1] == b'*' {
+            // Block comment: skip until `*/`.
+            i += 2;
+            while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < b.len() {
+                i += 2; // consume `*/`
+            } else {
+                i = b.len(); // unterminated block comment — treat rest as noise
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    &sql[i..]
+}
+
+/// Returns true if `sql` is a SELECT (or WITH…SELECT) query.
+/// Used to decide whether to inject LIMIT N for `SQL_ATTR_MAX_ROWS`.
+///
+/// For `WITH` queries, scans past CTE definitions (depth > 0) to find the
+/// terminal statement keyword at depth 0, so `WITH cte AS (...) INSERT ...`
+/// is correctly identified as non-SELECT and LIMIT is not injected.
+fn is_select_query(sql: &str) -> bool {
+    let t = skip_sql_noise(sql);
+    if t.get(..6).is_some_and(|s| s.eq_ignore_ascii_case("select")) {
+        return true;
+    }
+    if !t.get(..4).is_some_and(|s| s.eq_ignore_ascii_case("with")) {
+        return false;
+    }
+    // WITH query: scan past CTE bodies (enclosed in parentheses) to find the
+    // terminal statement keyword at depth 0.
+    let b = t.as_bytes();
+    let mut i = 4; // skip "WITH"
+    let mut depth: usize = 0;
+    while i < b.len() {
+        match b[i] {
+            b'\'' => {
+                i += 1;
+                while i < b.len() {
+                    if b[i] == b'\'' {
+                        i += 1;
+                        if i < b.len() && b[i] == b'\'' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < b.len() {
+                    if b[i] == b'"' {
+                        i += 1;
+                        if i < b.len() && b[i] == b'"' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'-' if i + 1 < b.len() && b[i + 1] == b'-' => {
+                while i < b.len() && b[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < b.len() && b[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < b.len() {
+                    i += 2; // consume `*/`
+                } else {
+                    break; // unterminated block comment — treat rest as noise
+                }
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            c if depth == 0 && c.is_ascii_alphabetic() => {
+                let start = i;
+                while i < b.len() && (b[i].is_ascii_alphanumeric() || b[i] == b'_') {
+                    i += 1;
+                }
+                let word = &b[start..i];
+                if word.eq_ignore_ascii_case(b"SELECT") {
+                    return true;
+                }
+                if word.eq_ignore_ascii_case(b"INSERT")
+                    || word.eq_ignore_ascii_case(b"UPDATE")
+                    || word.eq_ignore_ascii_case(b"DELETE")
+                    || word.eq_ignore_ascii_case(b"MERGE")
+                {
+                    return false;
+                }
+                // Other identifiers (cte name, AS, RECURSIVE, etc.) — keep scanning
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if `sql` already contains a LIMIT keyword as a standalone word,
+/// ignoring LIMIT inside string literals and comments.
+fn has_limit_clause(sql: &str) -> bool {
+    let b = sql.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        match b[i] {
+            // Skip single-quoted strings: '...' ('' is an escaped quote)
+            b'\'' => {
+                i += 1;
+                while i < b.len() {
+                    if b[i] == b'\'' {
+                        i += 1;
+                        if i < b.len() && b[i] == b'\'' {
+                            i += 1; // escaped ''
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            // Skip double-quoted identifiers: "..."
+            b'"' => {
+                i += 1;
+                while i < b.len() {
+                    if b[i] == b'"' {
+                        i += 1;
+                        if i < b.len() && b[i] == b'"' {
+                            i += 1; // escaped ""
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            // Skip line comments
+            b'-' if i + 1 < b.len() && b[i + 1] == b'-' => {
+                while i < b.len() && b[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            // Skip block comments
+            b'/' if i + 1 < b.len() && b[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2;
+            }
+            _ => {
+                // Check for standalone LIMIT keyword (case-insensitive)
+                if i + 5 <= b.len() {
+                    let word = &b[i..i + 5];
+                    let before_ok = i == 0 || !b[i - 1].is_ascii_alphanumeric() && b[i - 1] != b'_';
+                    let after_ok =
+                        i + 5 >= b.len() || !b[i + 5].is_ascii_alphanumeric() && b[i + 5] != b'_';
+                    if before_ok && after_ok && word.eq_ignore_ascii_case(b"LIMIT") {
+                        return true;
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+    false
+}
+
+/// Returns a SQL string with `LIMIT max_rows` appended if:
+/// - `max_rows > 0`
+/// - the query is a SELECT/WITH query
+/// - no LIMIT clause is already present
+///
+/// Returns `None` when no injection is needed.
+fn apply_limit(sql: &str, max_rows: sql::ULen) -> Option<String> {
+    if max_rows == 0 || !is_select_query(sql) || has_limit_clause(sql) {
+        return None;
+    }
+    // Strip trailing whitespace and semicolons to avoid `SELECT 1; LIMIT 5`.
+    // Use a newline before LIMIT so trailing line comments (`-- …`) don't
+    // swallow the clause: `SELECT 1 -- note LIMIT 5` would be ignored.
+    let trimmed = sql.trim_end().trim_end_matches(';').trim_end();
+    Some(format!("{}\nLIMIT {}", trimmed, max_rows))
 }
 
 /// Bind a parameter to a prepared statement
@@ -1211,24 +1519,186 @@ pub fn set_stmt_attr(
             tracing::warn!("set_stmt_attr: {:?} is read-only", attr);
             ReadOnlyAttributeSnafu { attribute }.fail()
         }
-        StmtAttr::MultiStatementCount => {
-            let count = value_ptr as i64;
-            tracing::debug!("set_stmt_attr: MultiStatementCount = {}", count);
-            let stmt_handle = guard.stmt_handle;
-            let mut options = std::collections::HashMap::new();
-            options.insert(
-                "multi_statement_count".to_string(),
-                ConfigSetting {
-                    value: Some(config_setting::Value::IntValue(count)),
-                },
-            );
-            global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_set_options(StatementSetOptionsRequest {
-                    stmt_handle: Some(stmt_handle),
-                    options,
-                })
-                .await
-            })?;
+        StmtAttr::QueryTimeout => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: QueryTimeout = {}", val);
+            if val > u32::MAX as sql::ULen {
+                return InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail();
+            }
+            inner.query_timeout = val;
+            Ok(())
+        }
+        StmtAttr::MaxRows => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: MaxRows = {}", val);
+            inner.max_rows = val;
+            Ok(())
+        }
+        StmtAttr::Noscan => {
+            let val = value_ptr as sql::ULen;
+            match val {
+                SQL_NOSCAN_OFF | SQL_NOSCAN_ON => {
+                    inner.noscan = val;
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::Concurrency => {
+            // 24000 if a cursor is open (includes Done — all rows fetched but not yet closed)
+            if inner.state.as_ref().has_open_cursor() {
+                tracing::error!("set_stmt_attr: Concurrency cannot be set while cursor is open");
+                return InvalidCursorStateSnafu.fail();
+            }
+            let val = value_ptr as sql::ULen;
+            match val {
+                SQL_CONCUR_READ_ONLY => {
+                    inner.concurrency = val;
+                    Ok(())
+                }
+                SQL_CONCUR_LOCK..=SQL_CONCUR_VALUES => {
+                    // SQL_CONCUR_LOCK / SQL_CONCUR_ROWVER / SQL_CONCUR_VALUES
+                    // Snowflake cursors are always read-only; substitute and warn
+                    inner.concurrency = SQL_CONCUR_READ_ONLY;
+                    warnings.push(Warning::OptionValueChanged);
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::CursorScrollable => {
+            if inner.state.as_ref().has_open_cursor() {
+                return InvalidCursorStateSnafu.fail();
+            }
+            let val = value_ptr as sql::ULen;
+            match val {
+                SQL_NONSCROLLABLE => {
+                    inner.cursor_scrollable = val;
+                    Ok(())
+                }
+                SQL_SCROLLABLE => {
+                    // Substitute with SQL_NONSCROLLABLE + 01S02
+                    inner.cursor_scrollable = SQL_NONSCROLLABLE;
+                    warnings.push(Warning::OptionValueChanged);
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::CursorSensitivity => {
+            if inner.state.as_ref().has_open_cursor() {
+                return InvalidCursorStateSnafu.fail();
+            }
+            let val = value_ptr as sql::ULen;
+            match val {
+                SQL_UNSPECIFIED => {
+                    inner.cursor_sensitivity = val;
+                    Ok(())
+                }
+                SQL_INSENSITIVE | SQL_SENSITIVE => {
+                    // Substitute with SQL_UNSPECIFIED + 01S02
+                    inner.cursor_sensitivity = SQL_UNSPECIFIED;
+                    warnings.push(Warning::OptionValueChanged);
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::EnableAutoIpd => {
+            let val = value_ptr as sql::ULen;
+            match val {
+                0 => {
+                    // SQL_FALSE — accepted (no-op)
+                    tracing::debug!("set_stmt_attr: EnableAutoIpd = SQL_FALSE (no-op)");
+                    Ok(())
+                }
+                1 => {
+                    // SQL_TRUE — valid value, but optional feature not implemented
+                    tracing::debug!("set_stmt_attr: EnableAutoIpd = SQL_TRUE is not supported");
+                    UnsupportedFeatureSnafu.fail()
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::KeysetSize => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: KeysetSize = {}", val);
+            inner.keyset_size = val;
+            Ok(())
+        }
+        StmtAttr::SimulateCursor => {
+            if inner.state.as_ref().has_open_cursor() {
+                return InvalidCursorStateSnafu.fail();
+            }
+            let val = value_ptr as sql::ULen;
+            match val {
+                0 => {
+                    // SQL_SC_NON_UNIQUE — accepted
+                    inner.simulate_cursor = val;
+                    Ok(())
+                }
+                1 | 2 => {
+                    // SQL_SC_TRY_UNIQUE / SQL_SC_UNIQUE — substitute with SQL_SC_NON_UNIQUE + 01S02
+                    inner.simulate_cursor = 0;
+                    warnings.push(Warning::OptionValueChanged);
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::RetrieveData => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: RetrieveData = {}", val);
+            match val {
+                SQL_RD_OFF | SQL_RD_ON => {
+                    inner.retrieve_data = val;
+                    Ok(())
+                }
+                _ => InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val as i64,
+                }
+                .fail(),
+            }
+        }
+        StmtAttr::SnowflakeMultiStatementCount => {
+            let val = value_ptr as i64;
+            if val < -1 || val > i16::MAX as i64 {
+                return InvalidAttributeValueSnafu {
+                    attribute,
+                    value: val,
+                }
+                .fail();
+            }
+            inner.multi_statement_count = val as i16;
             Ok(())
         }
         _ => {
@@ -1248,6 +1718,7 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
     warnings: &mut crate::conversion::warning::Warnings,
 ) -> OdbcResult<()> {
     use crate::api::StmtAttr;
+    use crate::api::encoding::write_string_bytes_i32;
 
     tracing::debug!("get_stmt_attr: attribute={}", attribute);
 
@@ -1378,9 +1849,108 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
             );
             Ok(())
         }
-        StmtAttr::MultiStatementCount => {
-            tracing::warn!("get_stmt_attr: MultiStatementCount is write-only");
-            crate::api::error::UnsupportedAttributeSnafu { attribute }.fail()
+        StmtAttr::QueryTimeout => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.query_timeout };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::MaxRows => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.max_rows };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::Noscan => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.noscan };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::Concurrency => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.concurrency };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::CursorScrollable => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.cursor_scrollable };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::CursorSensitivity => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.cursor_sensitivity };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::EnableAutoIpd => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = 0 }; // Always SQL_FALSE
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::KeysetSize => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.keyset_size };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::SimulateCursor => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.simulate_cursor };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::RetrieveData => {
+            if !value_ptr.is_null() {
+                unsafe { *(value_ptr as *mut sql::ULen) = inner.retrieve_data };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
+            }
+            Ok(())
+        }
+        StmtAttr::SnowflakeMultiStatementCount => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut sql::Integer) = inner.multi_statement_count as sql::Integer;
+                }
+            }
+            if !string_length_ptr.is_null() {
+                unsafe {
+                    *string_length_ptr = size_of::<sql::Integer>() as sql::Integer;
+                }
+            }
+            Ok(())
         }
         _ => {
             tracing::warn!("get_stmt_attr: unsupported attribute {:?}", attr);
@@ -1500,5 +2070,111 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.to_sql_state(), SqlState::CountFieldIncorrect);
+    }
+}
+
+#[cfg(test)]
+mod limit_injection_tests {
+    use super::*;
+
+    #[test]
+    fn select_is_detected() {
+        assert!(is_select_query("SELECT 1"));
+        assert!(is_select_query("  select * from t"));
+        assert!(is_select_query("WITH cte AS (SELECT 1) SELECT * FROM cte"));
+        assert!(!is_select_query("INSERT INTO t VALUES (1)"));
+        assert!(!is_select_query("UPDATE t SET x = 1"));
+        assert!(!is_select_query("DELETE FROM t"));
+    }
+
+    #[test]
+    fn with_dml_is_not_select() {
+        // CTE-prefixed DML must not be treated as SELECT; LIMIT injection would produce invalid SQL.
+        assert!(!is_select_query(
+            "WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte"
+        ));
+        assert!(!is_select_query(
+            "WITH cte AS (SELECT 1) UPDATE t SET x = 1"
+        ));
+        assert!(!is_select_query(
+            "WITH cte AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM cte)"
+        ));
+        // CTE followed by SELECT is still SELECT
+        assert!(is_select_query("WITH cte AS (SELECT 1) SELECT * FROM cte"));
+    }
+
+    #[test]
+    fn select_is_detected_with_leading_comments() {
+        assert!(is_select_query("/* hint */ SELECT 1"));
+        assert!(is_select_query("-- comment\nSELECT * FROM t"));
+        assert!(is_select_query("/* a */ /* b */ SELECT 1"));
+        assert!(!is_select_query("/* hint */ INSERT INTO t VALUES (1)"));
+    }
+
+    #[test]
+    fn limit_detection() {
+        assert!(has_limit_clause("SELECT 1 LIMIT 10"));
+        assert!(has_limit_clause("select * from t limit 5"));
+        assert!(!has_limit_clause("SELECT 1"));
+        assert!(!has_limit_clause("SELECT col_limit FROM t"));
+        assert!(!has_limit_clause("SELECT NOLIMIT FROM t"));
+    }
+
+    #[test]
+    fn limit_detection_ignores_string_literals() {
+        // LIMIT inside a string literal must not be detected
+        assert!(!has_limit_clause("SELECT * FROM t WHERE x = 'LIMIT'"));
+        assert!(!has_limit_clause("SELECT * FROM t WHERE x = 'NO LIMIT'"));
+        // LIMIT inside a line comment
+        assert!(!has_limit_clause("SELECT 1 -- LIMIT workaround"));
+        // LIMIT inside a block comment
+        assert!(!has_limit_clause("SELECT 1 /* LIMIT 5 */"));
+        // Real LIMIT after a string that contains the word
+        assert!(has_limit_clause(
+            "SELECT * FROM t WHERE x = 'LIMIT' LIMIT 5"
+        ));
+    }
+
+    #[test]
+    fn apply_limit_injects_when_needed() {
+        assert_eq!(
+            apply_limit("SELECT 1", 10),
+            Some("SELECT 1\nLIMIT 10".to_string())
+        );
+        assert_eq!(
+            apply_limit("  SELECT * FROM t  ", 5),
+            Some("  SELECT * FROM t\nLIMIT 5".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_limit_strips_trailing_semicolons() {
+        assert_eq!(
+            apply_limit("SELECT 1;", 5),
+            Some("SELECT 1\nLIMIT 5".to_string())
+        );
+        assert_eq!(
+            apply_limit("SELECT 1 ;  ", 5),
+            Some("SELECT 1\nLIMIT 5".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_limit_trailing_line_comment() {
+        // LIMIT must appear on a new line so a trailing `-- comment` does not swallow it.
+        assert_eq!(
+            apply_limit("SELECT 1 -- trailing comment", 5),
+            Some("SELECT 1 -- trailing comment\nLIMIT 5".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_limit_skips_when_not_needed() {
+        // max_rows = 0 → no limit
+        assert_eq!(apply_limit("SELECT 1", 0), None);
+        // already has LIMIT
+        assert_eq!(apply_limit("SELECT 1 LIMIT 100", 10), None);
+        // non-SELECT
+        assert_eq!(apply_limit("INSERT INTO t VALUES (1)", 10), None);
     }
 }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -259,19 +259,70 @@ impl TryFrom<sql::ULen> for CursorType {
     }
 }
 
+/// ODBC statement attribute value constants.
+/// `SQL_CONCUR_READ_ONLY` (1) — read-only cursor concurrency (default).
+pub const SQL_CONCUR_READ_ONLY: sql::ULen = 1;
+/// `SQL_CONCUR_LOCK` (2) — cursor concurrency with locking.
+pub const SQL_CONCUR_LOCK: sql::ULen = 2;
+/// `SQL_CONCUR_ROWVER` (3) — cursor concurrency with row versioning.
+#[allow(dead_code)] // Covered by SQL_CONCUR_LOCK..=SQL_CONCUR_VALUES range pattern
+pub const SQL_CONCUR_ROWVER: sql::ULen = 3;
+/// `SQL_CONCUR_VALUES` (4) — cursor concurrency with optimistic values.
+pub const SQL_CONCUR_VALUES: sql::ULen = 4;
+/// `SQL_NONSCROLLABLE` (0) — non-scrollable cursor (default).
+pub const SQL_NONSCROLLABLE: sql::ULen = 0;
+/// `SQL_SCROLLABLE` (1) — scrollable cursor.
+pub const SQL_SCROLLABLE: sql::ULen = 1;
+/// `SQL_UNSPECIFIED` (0) — unspecified cursor sensitivity (default).
+pub const SQL_UNSPECIFIED: sql::ULen = 0;
+/// `SQL_INSENSITIVE` (1) — insensitive cursor.
+pub const SQL_INSENSITIVE: sql::ULen = 1;
+/// `SQL_SENSITIVE` (2) — sensitive cursor.
+pub const SQL_SENSITIVE: sql::ULen = 2;
+/// `SQL_NOSCAN_OFF` (0) — scan for escape sequences (default).
+pub const SQL_NOSCAN_OFF: sql::ULen = 0;
+/// `SQL_NOSCAN_ON` (1) — do not scan for escape sequences.
+pub const SQL_NOSCAN_ON: sql::ULen = 1;
+/// `SQL_SC_NON_UNIQUE` (0) — simulate non-unique cursors (default).
+pub const SQL_SC_NON_UNIQUE: sql::ULen = 0;
+/// `SQL_RD_OFF` (0) — do not retrieve data after positioned update.
+pub const SQL_RD_OFF: sql::ULen = 0;
+/// `SQL_RD_ON` (1) — retrieve data after positioned update (default).
+pub const SQL_RD_ON: sql::ULen = 1;
+
 /// ODBC statement attribute identifiers (matching `SQL_ATTR_*` constants from `sql.h`).
 #[repr(i32)]
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StmtAttr {
+    /// `SQL_ATTR_CURSOR_SCROLLABLE` (-1) — whether the cursor is scrollable.
+    CursorScrollable = -1,
+    /// `SQL_ATTR_CURSOR_SENSITIVITY` (-2) — cursor sensitivity to changes.
+    CursorSensitivity = -2,
+    /// `SQL_ATTR_QUERY_TIMEOUT` (0) — query timeout in seconds (0 = no timeout).
+    QueryTimeout = 0,
+    /// `SQL_ATTR_MAX_ROWS` (1) — maximum rows returned (0 = no limit).
+    MaxRows = 1,
+    /// `SQL_ATTR_NOSCAN` (2) — whether to scan for ODBC escape sequences.
+    Noscan = 2,
     /// `SQL_ATTR_MAX_LENGTH` (3) — maximum amount of data returned from character/binary columns.
     MaxLength = 3,
     /// `SQL_ATTR_ROW_BIND_TYPE` (5) — row-wise vs column-wise binding.
     RowBindType = 5,
     /// `SQL_ATTR_CURSOR_TYPE` (6) — type of cursor.
     CursorType = 6,
+    /// `SQL_ATTR_CONCURRENCY` (7) — cursor concurrency.
+    Concurrency = 7,
+    /// `SQL_ATTR_KEYSET_SIZE` (8) — keyset size for keyset-driven cursors.
+    KeysetSize = 8,
+    /// `SQL_ATTR_SIMULATE_CURSOR` (10) — how to simulate positioned update/delete statements.
+    SimulateCursor = 10,
+    /// `SQL_ATTR_RETRIEVE_DATA` (11) — whether to retrieve data after a positioned update.
+    RetrieveData = 11,
     /// `SQL_ATTR_USE_BOOKMARKS` (12) — whether bookmarks are used.
     UseBookmarks = 12,
+    /// `SQL_ATTR_ENABLE_AUTO_IPD` (15) — automatic population of the IPD.
+    EnableAutoIpd = 15,
     /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
     RowBindOffsetPtr = 23,
     /// `SQL_ATTR_ROW_STATUS_PTR` (25) — pointer to per-row status array.
@@ -293,9 +344,8 @@ pub enum StmtAttr {
     /// `SQL_SF_STMT_ATTR_LAST_QUERY_ID` — last query ID (read-only string).
     /// Platform-dependent: 1263 (Windows/MDAC) or 16647 (Unix/iODBC).
     SnowflakeLastQueryId = 16647,
-    /// `SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT` — number of statements in multi-statement query.
-    /// Platform-dependent: 1264 (Windows/MDAC) or 16648 (Unix/iODBC).
-    MultiStatementCount = 16648,
+    /// `SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT` (0x4108 = 16648) — multi-statement count.
+    SnowflakeMultiStatementCount = 16648,
 }
 
 impl TryFrom<i32> for StmtAttr {
@@ -303,10 +353,20 @@ impl TryFrom<i32> for StmtAttr {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
+            -2 => Ok(StmtAttr::CursorSensitivity),
+            -1 => Ok(StmtAttr::CursorScrollable),
+            0 => Ok(StmtAttr::QueryTimeout),
+            1 => Ok(StmtAttr::MaxRows),
+            2 => Ok(StmtAttr::Noscan),
             3 => Ok(StmtAttr::MaxLength),
             5 => Ok(StmtAttr::RowBindType),
             6 => Ok(StmtAttr::CursorType),
+            7 => Ok(StmtAttr::Concurrency),
+            8 => Ok(StmtAttr::KeysetSize),
+            10 => Ok(StmtAttr::SimulateCursor),
+            11 => Ok(StmtAttr::RetrieveData),
             12 => Ok(StmtAttr::UseBookmarks),
+            15 => Ok(StmtAttr::EnableAutoIpd),
             23 => Ok(StmtAttr::RowBindOffsetPtr),
             25 => Ok(StmtAttr::RowStatusPtr),
             26 => Ok(StmtAttr::RowsFetchedPtr),
@@ -318,10 +378,10 @@ impl TryFrom<i32> for StmtAttr {
             10014 => Ok(StmtAttr::MetadataId),
             // Windows/Microsoft ODBC (SQL_DRIVER_STMT_ATTR_BASE = 1000)
             1263 => Ok(StmtAttr::SnowflakeLastQueryId),
-            1264 => Ok(StmtAttr::MultiStatementCount),
+            1264 => Ok(StmtAttr::SnowflakeMultiStatementCount),
             // Mac/iODBC (SQL_DRIVER_STMT_ATTR_BASE = 16384)
             16647 => Ok(StmtAttr::SnowflakeLastQueryId),
-            16648 => Ok(StmtAttr::MultiStatementCount),
+            16648 => Ok(StmtAttr::SnowflakeMultiStatementCount),
             _ => {
                 tracing::warn!("Unknown statement attribute: {}", value);
                 Err(OdbcError::UnknownAttribute {
@@ -1356,12 +1416,43 @@ pub struct StatementInner {
     /// parameters (e.g. DAE detection for "SELECT 1" with a bound param).
     /// `None` before the first prepare or after exec-direct.
     pub prepared_param_count: Option<u16>,
+    /// `SQL_ATTR_QUERY_TIMEOUT` — query timeout in seconds (default 0 = no timeout).
+    pub query_timeout: sql::ULen,
+    /// `SQL_ATTR_NOSCAN` — whether to scan for ODBC escape sequences (default SQL_NOSCAN_OFF = 0).
+    pub noscan: sql::ULen,
+    /// `SQL_ATTR_MAX_ROWS` — maximum rows returned (default 0 = no limit).
+    pub max_rows: sql::ULen,
+    /// Rows returned to the application so far in the current result set.
+    /// Reset to 0 on each execution. Used to enforce `max_rows`.
+    pub rows_returned: sql::ULen,
+    /// SQL text stored at `SQLPrepare` time. Used in `SQLExecute` to inject
+    /// `LIMIT N` for SELECT queries when `SQL_ATTR_MAX_ROWS` is set.
+    pub sql_text: Option<String>,
+    /// `SQL_ATTR_CONCURRENCY` — cursor concurrency (default SQL_CONCUR_READ_ONLY = 1).
+    pub concurrency: sql::ULen,
+    /// `SQL_ATTR_CURSOR_SCROLLABLE` — cursor scrollability (default SQL_NONSCROLLABLE = 0).
+    pub cursor_scrollable: sql::ULen,
+    /// `SQL_ATTR_CURSOR_SENSITIVITY` — cursor sensitivity (default SQL_UNSPECIFIED = 0).
+    pub cursor_sensitivity: sql::ULen,
+    /// `SQL_ATTR_KEYSET_SIZE` — keyset size for keyset-driven cursors (default 0).
+    pub keyset_size: sql::ULen,
+    /// `SQL_ATTR_SIMULATE_CURSOR` — simulate positioned update/delete (default SQL_SC_NON_UNIQUE = 0).
+    pub simulate_cursor: sql::ULen,
+    /// `SQL_ATTR_RETRIEVE_DATA` — whether to retrieve data after positioned update (default SQL_RD_ON = 1).
+    pub retrieve_data: sql::ULen,
+    /// The `max_rows` value last sent to the server via `statement_set_sql_query`.
+    /// `None` = never sent. Used to detect when a LIMIT must be added, removed,
+    /// or changed on re-execution of a prepared statement.
+    pub last_sent_max_rows: Option<sql::ULen>,
     /// Query ID of the last executed query (`SQL_SF_STMT_ATTR_LAST_QUERY_ID`).
     pub last_query_id: Option<String>,
     /// Child query IDs for multi-statement execution (consumed by SQLMoreResults).
     pub multi_query_ids: Vec<String>,
     /// Index of the next child result to fetch in `multi_query_ids`.
     pub multi_current_idx: usize,
+    /// `SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT` — multi-statement execution count.
+    /// -1 = auto-detect (default), 0 = single statement, N > 0 = expect exactly N statements.
+    pub multi_statement_count: i16,
 }
 
 // Safety: StatementInner contains raw pointers (descriptor fields like bind_offset_ptr,
@@ -1390,9 +1481,22 @@ impl Statement {
                 used_extended_fetch: false,
                 prepared_param_count: None,
                 metadata_id,
+                query_timeout: 0,
+                noscan: SQL_NOSCAN_OFF,
+                max_rows: 0,
+                rows_returned: 0,
+                sql_text: None,
+                concurrency: SQL_CONCUR_READ_ONLY,
+                cursor_scrollable: SQL_NONSCROLLABLE,
+                cursor_sensitivity: SQL_UNSPECIFIED,
+                keyset_size: 0,
+                simulate_cursor: SQL_SC_NON_UNIQUE,
+                retrieve_data: SQL_RD_ON,
+                last_sent_max_rows: None,
                 last_query_id: None,
                 multi_query_ids: Vec::new(),
                 multi_current_idx: 0,
+                multi_statement_count: -1,
             }),
             active_cancel: parking_lot::Mutex::new(None),
         }

--- a/odbc_tests/tests/odbc-api/connecting/conn_attr_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/conn_attr_tests.cpp
@@ -84,11 +84,10 @@ TEST_CASE("should return SQL_CD_TRUE after disconnect", "[odbc-api][conn_attr][c
   } else {
     // Validate that the failure is for an expected reason: HY010 (function sequence error)
     // or 08003 (connection not open), depending on the DM.
-    char sqlstate[6] = {};
-    SQLRETURN diag_ret = SQLGetDiagRec(SQL_HANDLE_DBC, dbc.getHandle(), 1, reinterpret_cast<SQLCHAR*>(sqlstate),
-                                       nullptr, nullptr, 0, nullptr);
+    SQLCHAR sqlstate[6] = {};
+    SQLRETURN diag_ret = SQLGetDiagRec(SQL_HANDLE_DBC, dbc.getHandle(), 1, sqlstate, nullptr, nullptr, 0, nullptr);
     CHECK(SQL_SUCCEEDED(diag_ret));
-    std::string state(sqlstate);
+    std::string state(reinterpret_cast<const char*>(sqlstate));
     CHECK((state == "HY010" || state == "08003"));
   }
 }
@@ -271,6 +270,10 @@ TEST_CASE("should set SQL_ATTR_CURRENT_CATALOG to current value successfully",
 // where the DM passes the call through to our driver.
 TEST_CASE("should return 3D000 when setting SQL_ATTR_CURRENT_CATALOG to nonexistent database",
           "[odbc-api][conn_attr][current_catalog][error][connecting]") {
+  // Old driver executes USE "<db>" via Simba SDK but does not map the failure to 3D000.
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not map invalid catalog to 3D000; Simba framework returns HY000/42000");
+
   // Given A connected DBC handle
   Connection conn;
 
@@ -279,16 +282,8 @@ TEST_CASE("should return 3D000 when setting SQL_ATTR_CURRENT_CATALOG to nonexist
   SQLRETURN ret = SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_CURRENT_CATALOG,
                                     reinterpret_cast<SQLPOINTER>(bad_catalog), SQL_NTS);
 
-  // Then:
-  // - New driver: validates the catalog against the server and explicitly returns 3D000.
-  // - Old driver: executes USE "<db>" on the server via the Simba SDK; the resulting Snowflake
-  //   server error is propagated as SQL_ERROR, but with HY000/42000 rather than 3D000 (the
-  //   Simba framework does not map USE failures to the ODBC 3D000 state).
-  if (get_driver_type() == DRIVER_TYPE::NEW) {
-    REQUIRE_EXPECTED_ERROR(ret, "3D000", conn.handleWrapper().getHandle(), SQL_HANDLE_DBC);
-  } else {
-    CHECK(ret == SQL_ERROR);
-  }
+  // Then the new driver validates the catalog against the server and returns 3D000.
+  REQUIRE_EXPECTED_ERROR(ret, "3D000", conn.handleWrapper().getHandle(), SQL_HANDLE_DBC);
 }
 #endif  // !defined(_WIN32)
 

--- a/odbc_tests/tests/odbc-api/connecting/stmt_attr_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/stmt_attr_tests.cpp
@@ -9,6 +9,7 @@
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "test_macros.hpp"
 
 // ============================================================================
@@ -111,4 +112,788 @@ TEST_CASE("statement SQL_ATTR_METADATA_ID is independent from connection after a
     REQUIRE(ret == SQL_SUCCESS);
     CHECK(metadata_id == SQL_FALSE);
   }
+}
+
+// ============================================================================
+// SQL_ATTR_QUERY_TIMEOUT (0) — query timeout in seconds
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_QUERY_TIMEOUT default as 0", "[odbc-api][stmt_attr][query_timeout]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_QUERY_TIMEOUT is queried without being set
+  SQLULEN timeout = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_QUERY_TIMEOUT, &timeout, 0, nullptr);
+
+  // Then It should return 0 (no timeout) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(timeout == 0);
+}
+
+TEST_CASE("should set and get SQL_ATTR_QUERY_TIMEOUT", "[odbc-api][stmt_attr][query_timeout]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_QUERY_TIMEOUT is set to 30 seconds
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_QUERY_TIMEOUT, reinterpret_cast<SQLPOINTER>(30), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Getting the attribute should return 30
+  SQLULEN timeout = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_QUERY_TIMEOUT, &timeout, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(timeout == 30);
+}
+
+// ============================================================================
+// SQL_ATTR_MAX_ROWS (1) — maximum rows returned
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_MAX_ROWS default as 0", "[odbc-api][stmt_attr][max_rows]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_MAX_ROWS is queried without being set
+  SQLULEN max_rows = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, &max_rows, 0, nullptr);
+
+  // Then It should return 0 (no limit) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(max_rows == 0);
+}
+
+TEST_CASE("should set and get SQL_ATTR_MAX_ROWS", "[odbc-api][stmt_attr][max_rows]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_MAX_ROWS is set to 100
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(100), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Getting the attribute should return 100
+  SQLULEN max_rows = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, &max_rows, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(max_rows == 100);
+}
+
+TEST_CASE("should limit fetched rows to SQL_ATTR_MAX_ROWS", "[odbc-api][stmt_attr][max_rows]") {
+  // Given A statement with SQL_ATTR_MAX_ROWS set to 2
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(2), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When A query returning 3 rows is executed
+  std::string query = "SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3";
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(query.c_str()), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Only 2 rows should be fetchable
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQL_ATTR_NOSCAN (2) — whether to scan for ODBC escape sequences
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_NOSCAN default as SQL_NOSCAN_OFF", "[odbc-api][stmt_attr][noscan]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_NOSCAN is queried without being set
+  SQLULEN noscan = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_NOSCAN, &noscan, 0, nullptr);
+
+  // Then It should return SQL_NOSCAN_OFF (0) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(noscan == SQL_NOSCAN_OFF);
+}
+
+TEST_CASE("should set and get SQL_ATTR_NOSCAN with SQL_NOSCAN_ON", "[odbc-api][stmt_attr][noscan]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_NOSCAN is set to SQL_NOSCAN_ON
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_NOSCAN, reinterpret_cast<SQLPOINTER>(SQL_NOSCAN_ON), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Getting the attribute should return SQL_NOSCAN_ON
+  SQLULEN noscan = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_NOSCAN, &noscan, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(noscan == SQL_NOSCAN_ON);
+}
+
+TEST_CASE("should return HY024 for invalid SQL_ATTR_NOSCAN value", "[odbc-api][stmt_attr][noscan][error]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_NOSCAN is set to an invalid value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_NOSCAN, reinterpret_cast<SQLPOINTER>(99), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HY024
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HY024");
+}
+
+// ============================================================================
+// SQL_ATTR_CONCURRENCY (7) — cursor concurrency
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_CONCURRENCY default as SQL_CONCUR_READ_ONLY", "[odbc-api][stmt_attr][concurrency]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CONCURRENCY is queried without being set
+  SQLULEN concurrency = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, &concurrency, 0, nullptr);
+
+  // Then It should return SQL_CONCUR_READ_ONLY (1) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(concurrency == SQL_CONCUR_READ_ONLY);
+}
+
+TEST_CASE("should accept SQL_ATTR_CONCURRENCY SQL_CONCUR_READ_ONLY directly", "[odbc-api][stmt_attr][concurrency]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CONCURRENCY is set to SQL_CONCUR_READ_ONLY
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, reinterpret_cast<SQLPOINTER>(SQL_CONCUR_READ_ONLY), 0);
+
+  // Then It should succeed without warnings
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN concurrency = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, &concurrency, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(concurrency == SQL_CONCUR_READ_ONLY);
+}
+
+TEST_CASE("should substitute SQL_ATTR_CONCURRENCY non-read-only values with 01S02",
+          "[odbc-api][stmt_attr][concurrency][warning]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not substitute unsupported concurrency modes; new driver substitutes with "
+                  "SQL_CONCUR_READ_ONLY and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CONCURRENCY is set to SQL_CONCUR_LOCK (Snowflake does not support locking)
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, reinterpret_cast<SQLPOINTER>(SQL_CONCUR_LOCK), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_CONCUR_READ_ONLY
+  SQLULEN concurrency = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, &concurrency, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(concurrency == SQL_CONCUR_READ_ONLY);
+}
+
+TEST_CASE("should return 24000 when setting SQL_ATTR_CONCURRENCY with open cursor",
+          "[odbc-api][stmt_attr][concurrency][error]") {
+  // Given A statement with an open cursor
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQL_ATTR_CONCURRENCY is set while cursor is open
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, reinterpret_cast<SQLPOINTER>(SQL_CONCUR_READ_ONLY), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE 24000
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "24000");
+}
+
+TEST_CASE("should return HY024 for invalid SQL_ATTR_CONCURRENCY value", "[odbc-api][stmt_attr][concurrency][error]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CONCURRENCY is set to an invalid value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, reinterpret_cast<SQLPOINTER>(99), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HY024
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HY024");
+}
+
+// ============================================================================
+// SQL_ATTR_CURSOR_SCROLLABLE (-1) — cursor scrollability
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_CURSOR_SCROLLABLE default as SQL_NONSCROLLABLE",
+          "[odbc-api][stmt_attr][cursor_scrollable]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SCROLLABLE is queried without being set
+  SQLULEN scrollable = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, &scrollable, 0, nullptr);
+
+  // Then It should return SQL_NONSCROLLABLE (0) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(scrollable == SQL_NONSCROLLABLE);
+}
+
+TEST_CASE("should accept SQL_ATTR_CURSOR_SCROLLABLE SQL_NONSCROLLABLE directly",
+          "[odbc-api][stmt_attr][cursor_scrollable]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SCROLLABLE is set to SQL_NONSCROLLABLE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, reinterpret_cast<SQLPOINTER>(SQL_NONSCROLLABLE), 0);
+
+  // Then It should succeed without warnings
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN scrollable = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, &scrollable, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(scrollable == SQL_NONSCROLLABLE);
+}
+
+TEST_CASE("should substitute SQL_ATTR_CURSOR_SCROLLABLE SQL_SCROLLABLE with 01S02",
+          "[odbc-api][stmt_attr][cursor_scrollable][warning]") {
+  SKIP_OLD_DRIVER(
+      "SNOW-3235552",
+      "Old driver does not substitute SQL_SCROLLABLE; new driver substitutes with SQL_NONSCROLLABLE and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SCROLLABLE is set to SQL_SCROLLABLE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, reinterpret_cast<SQLPOINTER>(SQL_SCROLLABLE), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_NONSCROLLABLE
+  SQLULEN scrollable = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, &scrollable, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(scrollable == SQL_NONSCROLLABLE);
+}
+
+TEST_CASE("should return HY024 for invalid SQL_ATTR_CURSOR_SCROLLABLE value",
+          "[odbc-api][stmt_attr][cursor_scrollable][error]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SCROLLABLE is set to an invalid value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, reinterpret_cast<SQLPOINTER>(99), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HY024
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HY024");
+}
+
+TEST_CASE("should return 24000 when setting SQL_ATTR_CURSOR_SCROLLABLE with open cursor",
+          "[odbc-api][stmt_attr][cursor_scrollable][error]") {
+  // Given A statement with an open cursor
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQL_ATTR_CURSOR_SCROLLABLE is set while cursor is open
+  ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SCROLLABLE, reinterpret_cast<SQLPOINTER>(SQL_NONSCROLLABLE), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE 24000
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "24000");
+}
+
+// ============================================================================
+// SQL_ATTR_CURSOR_SENSITIVITY (-2) — cursor sensitivity
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_CURSOR_SENSITIVITY default as SQL_UNSPECIFIED",
+          "[odbc-api][stmt_attr][cursor_sensitivity]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is queried without being set
+  SQLULEN sensitivity = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, &sensitivity, 0, nullptr);
+
+  // Then It should return SQL_UNSPECIFIED (0) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(sensitivity == SQL_UNSPECIFIED);
+}
+
+TEST_CASE("should accept SQL_ATTR_CURSOR_SENSITIVITY SQL_UNSPECIFIED directly",
+          "[odbc-api][stmt_attr][cursor_sensitivity]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver may not support SQL_UNSPECIFIED cursor sensitivity; new driver accepts it directly");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is set to SQL_UNSPECIFIED
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, reinterpret_cast<SQLPOINTER>(SQL_UNSPECIFIED), 0);
+
+  // Then It should succeed without warnings
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN sensitivity = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, &sensitivity, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(sensitivity == SQL_UNSPECIFIED);
+}
+
+TEST_CASE("should substitute SQL_ATTR_CURSOR_SENSITIVITY SQL_INSENSITIVE with 01S02",
+          "[odbc-api][stmt_attr][cursor_sensitivity][warning]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not substitute unsupported sensitivity values; new driver substitutes with "
+                  "SQL_UNSPECIFIED and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is set to SQL_INSENSITIVE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, reinterpret_cast<SQLPOINTER>(SQL_INSENSITIVE), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_UNSPECIFIED
+  SQLULEN sensitivity = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, &sensitivity, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(sensitivity == SQL_UNSPECIFIED);
+}
+
+TEST_CASE("should substitute SQL_ATTR_CURSOR_SENSITIVITY SQL_SENSITIVE with 01S02",
+          "[odbc-api][stmt_attr][cursor_sensitivity][warning]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not substitute unsupported sensitivity values; new driver substitutes with "
+                  "SQL_UNSPECIFIED and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is set to SQL_SENSITIVE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, reinterpret_cast<SQLPOINTER>(SQL_SENSITIVE), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_UNSPECIFIED
+  SQLULEN sensitivity = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, &sensitivity, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(sensitivity == SQL_UNSPECIFIED);
+}
+
+TEST_CASE("should return HY024 for invalid SQL_ATTR_CURSOR_SENSITIVITY value",
+          "[odbc-api][stmt_attr][cursor_sensitivity][error]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is set to an invalid value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, reinterpret_cast<SQLPOINTER>(99), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HY024
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HY024");
+}
+
+TEST_CASE("should return 24000 when setting SQL_ATTR_CURSOR_SENSITIVITY with open cursor",
+          "[odbc-api][stmt_attr][cursor_sensitivity][error]") {
+  // Given A statement with an open cursor
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQL_ATTR_CURSOR_SENSITIVITY is set while cursor is open
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CURSOR_SENSITIVITY, reinterpret_cast<SQLPOINTER>(SQL_UNSPECIFIED), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE 24000
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "24000");
+}
+
+// ============================================================================
+// SQL_ATTR_ENABLE_AUTO_IPD (15) — automatic population of IPD
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_ENABLE_AUTO_IPD as SQL_FALSE", "[odbc-api][stmt_attr][enable_auto_ipd]") {
+  SKIP_OLD_DRIVER(
+      "SNOW-3235552",
+      "Old driver may return a different default for SQL_ATTR_ENABLE_AUTO_IPD; new driver always returns SQL_FALSE");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ENABLE_AUTO_IPD is queried
+  SQLULEN auto_ipd = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ENABLE_AUTO_IPD, &auto_ipd, 0, nullptr);
+
+  // Then It should always return SQL_FALSE (0)
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(auto_ipd == SQL_FALSE);
+}
+
+TEST_CASE("should accept SQL_ATTR_ENABLE_AUTO_IPD SQL_FALSE", "[odbc-api][stmt_attr][enable_auto_ipd]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ENABLE_AUTO_IPD is set to SQL_FALSE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ENABLE_AUTO_IPD, reinterpret_cast<SQLPOINTER>(SQL_FALSE), 0);
+
+  // Then It should succeed
+  REQUIRE(ret == SQL_SUCCESS);
+}
+
+TEST_CASE("should return HYC00 for SQL_ATTR_ENABLE_AUTO_IPD SQL_TRUE",
+          "[odbc-api][stmt_attr][enable_auto_ipd][error]") {
+  SKIP_OLD_DRIVER("SNOW-3235552", "Old driver does not return HYC00 for SQL_TRUE; new driver explicitly rejects it");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ENABLE_AUTO_IPD is set to SQL_TRUE (not supported)
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ENABLE_AUTO_IPD, reinterpret_cast<SQLPOINTER>(SQL_TRUE), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HYC00
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HYC00");
+}
+
+// ============================================================================
+// SQL_ATTR_KEYSET_SIZE (8) — keyset size
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_KEYSET_SIZE default as 0", "[odbc-api][stmt_attr][keyset_size]") {
+  SKIP_OLD_DRIVER("SNOW-3235552", "Old driver does not expose SQL_ATTR_KEYSET_SIZE; new driver supports get/set");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_KEYSET_SIZE is queried without being set
+  SQLULEN keyset_size = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_KEYSET_SIZE, &keyset_size, 0, nullptr);
+
+  // Then It should return 0 by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(keyset_size == 0);
+}
+
+TEST_CASE("should set and get SQL_ATTR_KEYSET_SIZE", "[odbc-api][stmt_attr][keyset_size]") {
+  SKIP_OLD_DRIVER("SNOW-3235552", "Old driver does not expose SQL_ATTR_KEYSET_SIZE; new driver supports get/set");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_KEYSET_SIZE is set to 10
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_KEYSET_SIZE, reinterpret_cast<SQLPOINTER>(10), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Getting the attribute should return 10
+  SQLULEN keyset_size = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_KEYSET_SIZE, &keyset_size, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(keyset_size == 10);
+}
+
+// ============================================================================
+// SQL_ATTR_SIMULATE_CURSOR (10) — simulate positioned update/delete
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_SIMULATE_CURSOR default as SQL_SC_NON_UNIQUE",
+          "[odbc-api][stmt_attr][simulate_cursor]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver may not support SQL_ATTR_SIMULATE_CURSOR; new driver defaults to SQL_SC_NON_UNIQUE");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_SIMULATE_CURSOR is queried without being set
+  SQLULEN simulate = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, &simulate, 0, nullptr);
+
+  // Then It should return SQL_SC_NON_UNIQUE (0) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(simulate == SQL_SC_NON_UNIQUE);
+}
+
+TEST_CASE("should substitute SQL_ATTR_SIMULATE_CURSOR non-unique values with 01S02",
+          "[odbc-api][stmt_attr][simulate_cursor][warning]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not substitute unsupported simulate cursor values; new driver substitutes with "
+                  "SQL_SC_NON_UNIQUE and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_SIMULATE_CURSOR is set to SQL_SC_UNIQUE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, reinterpret_cast<SQLPOINTER>(SQL_SC_UNIQUE), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_SC_NON_UNIQUE
+  SQLULEN simulate = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, &simulate, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(simulate == SQL_SC_NON_UNIQUE);
+}
+
+TEST_CASE("should substitute SQL_ATTR_SIMULATE_CURSOR SQL_SC_TRY_UNIQUE with 01S02",
+          "[odbc-api][stmt_attr][simulate_cursor][warning]") {
+  SKIP_OLD_DRIVER("SNOW-3235552",
+                  "Old driver does not substitute unsupported simulate cursor values; new driver substitutes with "
+                  "SQL_SC_NON_UNIQUE and warns 01S02");
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_SIMULATE_CURSOR is set to SQL_SC_TRY_UNIQUE
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, reinterpret_cast<SQLPOINTER>(SQL_SC_TRY_UNIQUE), 0);
+
+  // Then It should return SQL_SUCCESS_WITH_INFO with 01S02
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "01S02");
+
+  // And the stored value should be SQL_SC_NON_UNIQUE
+  SQLULEN simulate = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, &simulate, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(simulate == SQL_SC_NON_UNIQUE);
+}
+
+TEST_CASE("should return 24000 when setting SQL_ATTR_SIMULATE_CURSOR with open cursor",
+          "[odbc-api][stmt_attr][simulate_cursor][error]") {
+  // Given A statement with an open cursor
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQL_ATTR_SIMULATE_CURSOR is set while cursor is open
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_SIMULATE_CURSOR, reinterpret_cast<SQLPOINTER>(SQL_SC_NON_UNIQUE), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE 24000
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "24000");
+}
+
+// ============================================================================
+// SQL_ATTR_RETRIEVE_DATA (11) — whether to retrieve data after positioned update
+// ============================================================================
+
+TEST_CASE("should get SQL_ATTR_RETRIEVE_DATA default as SQL_RD_ON", "[odbc-api][stmt_attr][retrieve_data]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_RETRIEVE_DATA is queried without being set
+  SQLULEN retrieve = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_RETRIEVE_DATA, &retrieve, 0, nullptr);
+
+  // Then It should return SQL_RD_ON (1) by default
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieve == SQL_RD_ON);
+}
+
+TEST_CASE("should set and get SQL_ATTR_RETRIEVE_DATA SQL_RD_OFF", "[odbc-api][stmt_attr][retrieve_data]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_RETRIEVE_DATA is set to SQL_RD_OFF
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_RETRIEVE_DATA, reinterpret_cast<SQLPOINTER>(SQL_RD_OFF), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then Getting the attribute should return SQL_RD_OFF
+  SQLULEN retrieve = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_RETRIEVE_DATA, &retrieve, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieve == SQL_RD_OFF);
+}
+
+TEST_CASE("should return HY024 for invalid SQL_ATTR_RETRIEVE_DATA value",
+          "[odbc-api][stmt_attr][retrieve_data][error]") {
+  // Given A connected statement handle
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_RETRIEVE_DATA is set to an invalid value (not 0 or 1)
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_RETRIEVE_DATA, reinterpret_cast<SQLPOINTER>(99), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE HY024
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "HY024");
+}
+
+// ============================================================================
+// SQL_ATTR_MAX_ROWS — prepared execute and toggle
+// ============================================================================
+
+TEST_CASE("should limit rows via SQL_ATTR_MAX_ROWS with SQLPrepare + SQLExecute", "[odbc-api][stmt_attr][max_rows]") {
+  // Given A statement prepared with a query returning 3 rows, MAX_ROWS set to 2
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(2), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When The prepared statement is executed
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then Only 2 rows should be fetchable
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+TEST_CASE("should remove row limit when SQL_ATTR_MAX_ROWS is toggled to 0 between executions",
+          "[odbc-api][stmt_attr][max_rows]") {
+  // Given A prepared statement with MAX_ROWS=2 that has been executed and closed
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(2), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Drain and close the cursor
+  while (SQLFetch(stmt.getHandle()) == SQL_SUCCESS) {
+  }
+  ret = SQLFreeStmt(stmt.getHandle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When MAX_ROWS is cleared and the statement is re-executed
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(0), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then All 3 rows should be fetchable
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+// ============================================================================
+// SQL_ATTR_CONCURRENCY — cursor attribute rejected in Done state
+// ============================================================================
+
+TEST_CASE("should return 24000 when setting SQL_ATTR_CONCURRENCY after all rows fetched (Done state)",
+          "[odbc-api][stmt_attr][concurrency][error]") {
+  // Given A statement whose cursor has reached the Done state (all rows fetched)
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Fetch the single row to advance into Fetching/Done
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Fetch again to exhaust the result set and enter Done state
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_NO_DATA);
+
+  // When SQL_ATTR_CONCURRENCY is set while cursor is in Done state
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_CONCURRENCY, reinterpret_cast<SQLPOINTER>(SQL_CONCUR_READ_ONLY), 0);
+
+  // Then It should return SQL_ERROR with SQLSTATE 24000
+  REQUIRE(ret == SQL_ERROR);
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!records.empty());
+  CHECK(records[0].sqlState == "24000");
 }

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -552,6 +552,7 @@ message StatementGetParameterSchemaResponse {
 message StatementExecuteQueryRequest {
   StatementHandle stmt_handle = 1;
   optional QueryBindings bindings = 2;  // None = no bindings
+  optional uint32 timeout_seconds = 3;  // 0 / absent = no timeout override
 }
 
 message ExecuteQueryResponse {

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -286,7 +286,7 @@ pub struct PrepareResult {
 impl DatabaseDriverV1 {
     pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
         let result = self
-            .execute_query_internal(stmt_handle, None, Some(true))
+            .execute_query_internal(stmt_handle, None, Some(true), None)
             .await?;
         let descriptor = result.into_descriptor();
 
@@ -377,8 +377,9 @@ impl DatabaseDriverV1 {
         &self,
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
+        timeout_seconds: Option<u32>,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        self.execute_query_internal(stmt_handle, bindings, None)
+        self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds)
             .await
     }
 
@@ -387,6 +388,7 @@ impl DatabaseDriverV1 {
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
         describe_only: Option<bool>,
+        timeout_seconds: Option<u32>,
     ) -> Result<ExecuteQueryResult, ApiError> {
         let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
             InvalidArgumentSnafu {
@@ -408,7 +410,7 @@ impl DatabaseDriverV1 {
             sql: query.clone(),
             bindings: query_bindings,
             describe_only,
-            query_parameters: build_query_parameters(&stmt.settings),
+            query_parameters: build_query_parameters_with_timeout(&stmt.settings, timeout_seconds),
         };
 
         let conn_arc = stmt.conn.clone();
@@ -1086,6 +1088,24 @@ fn build_query_parameters(settings: &ParamStore) -> Option<HashMap<String, serde
         if let Some(setting) = settings.get(*key) {
             params.insert(server_name.to_string(), setting_to_json_value(setting));
         }
+    }
+    if params.is_empty() {
+        None
+    } else {
+        Some(params)
+    }
+}
+
+fn build_query_parameters_with_timeout(
+    settings: &ParamStore,
+    timeout_seconds: Option<u32>,
+) -> Option<HashMap<String, serde_json::Value>> {
+    let mut params = build_query_parameters(settings).unwrap_or_default();
+    if let Some(t) = timeout_seconds.filter(|&t| t > 0) {
+        params.insert(
+            "STATEMENT_TIMEOUT_IN_SECONDS".to_string(),
+            serde_json::Value::Number(t.into()),
+        );
     }
     if params.is_empty() {
         None

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -806,9 +806,11 @@ impl DatabaseDriver for DatabaseDriverImpl {
                 ..Default::default()
             })?;
 
+        let timeout_seconds = input.timeout_seconds;
+
         let result = self
             .driver
-            .statement_execute_query(stmt_handle.into(), bindings_opt)
+            .statement_execute_query(stmt_handle.into(), bindings_opt, timeout_seconds)
             .await
             .to_protobuf()?;
 

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -209,6 +209,7 @@ impl SnowflakeTestClient {
             .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(*stmt),
                 bindings,
+                timeout_seconds: None,
             })
             .unwrap()
             .result
@@ -287,6 +288,7 @@ impl SnowflakeTestClient {
             .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(stmt_handle),
                 bindings: None,
+                timeout_seconds: None,
             })
             .unwrap();
 
@@ -316,6 +318,7 @@ impl SnowflakeTestClient {
                 .statement_execute_query_blocking(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     bindings: None,
+                    timeout_seconds: None,
                 }) {
                 Ok(response) => Ok(response.result.unwrap()),
                 Err(e) => match *e {
@@ -403,6 +406,7 @@ impl SnowflakeTestClient {
                 .statement_execute_query_blocking(StatementExecuteQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     bindings: None,
+                    timeout_seconds: None,
                 }) {
                 Ok(response) => Ok(response.result.unwrap()),
                 Err(e) => match *e {

--- a/sf_core/tests/integration/http/sync_retry.rs
+++ b/sf_core/tests/integration/http/sync_retry.rs
@@ -188,6 +188,121 @@ async fn should_use_sync_mode_by_default() {
     }
 }
 
+#[tokio::test]
+async fn should_include_statement_timeout_in_parameters_when_set() {
+    // Given a server that captures the request body
+    let captured_bodies = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured_clone = captured_bodies.clone();
+
+    let (addr, server) = spawn_capture_server(1, move |request| {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            captured_clone
+                .lock()
+                .unwrap()
+                .push(request[body_start + 4..].to_string());
+        }
+        json_response(
+            r#"{"success":true,"data":{"queryId":"test-query-id","rowtype":[],"rowset":[]}}"#,
+        )
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let query_params = test_query_params(&addr);
+
+    // When I execute a query with timeout_seconds set
+    let result = snowflake_query_with_client(
+        &client,
+        query_params,
+        "test-token",
+        QueryInput {
+            sql: "SELECT 1".to_string(),
+            bindings: None,
+            describe_only: None,
+            query_parameters: Some({
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "STATEMENT_TIMEOUT_IN_SECONDS".to_string(),
+                    serde_json::Value::Number(42u32.into()),
+                );
+                m
+            }),
+        },
+        &RetryPolicy::default(),
+        QueryExecutionMode::Blocking,
+    )
+    .await;
+
+    assert!(result.is_ok(), "Query should succeed");
+    server.abort();
+
+    // Then the request body should include STATEMENT_TIMEOUT_IN_SECONDS=42 in the parameters field
+    let bodies = captured_bodies.lock().unwrap();
+    assert!(!bodies.is_empty(), "Should have captured a request body");
+    let body = &bodies[0];
+    let body_json: serde_json::Value = serde_json::from_str(body)
+        .unwrap_or_else(|e| panic!("Invalid JSON body: {e}. Body: {body}"));
+    let timeout = &body_json["parameters"]["STATEMENT_TIMEOUT_IN_SECONDS"];
+    assert!(
+        !timeout.is_null(),
+        "Request body should contain parameters.STATEMENT_TIMEOUT_IN_SECONDS: {}",
+        body
+    );
+    assert_eq!(
+        timeout.as_u64(),
+        Some(42),
+        "STATEMENT_TIMEOUT_IN_SECONDS should be 42: {}",
+        body
+    );
+}
+
+#[tokio::test]
+async fn should_not_include_parameters_when_timeout_not_set() {
+    // Given a server that captures the request body
+    let captured_bodies = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured_clone = captured_bodies.clone();
+
+    let (addr, server) = spawn_capture_server(1, move |request| {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            captured_clone
+                .lock()
+                .unwrap()
+                .push(request[body_start + 4..].to_string());
+        }
+        json_response(
+            r#"{"success":true,"data":{"queryId":"test-query-id","rowtype":[],"rowset":[]}}"#,
+        )
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let query_params = test_query_params(&addr);
+
+    // When I execute a query with no timeout
+    let result = snowflake_query_with_client(
+        &client,
+        query_params,
+        "test-token",
+        QueryInput::new("SELECT 1"),
+        &RetryPolicy::default(),
+        QueryExecutionMode::Blocking,
+    )
+    .await;
+
+    assert!(result.is_ok(), "Query should succeed");
+    server.abort();
+
+    // Then the request body should not include a parameters field
+    let bodies = captured_bodies.lock().unwrap();
+    assert!(!bodies.is_empty(), "Should have captured a request body");
+    let body = &bodies[0];
+    assert!(
+        !body.contains("STATEMENT_TIMEOUT_IN_SECONDS"),
+        "Request body should not contain STATEMENT_TIMEOUT_IN_SECONDS: {}",
+        body
+    );
+}
+
 // Helper functions
 
 fn test_query_params(addr: &SocketAddr) -> QueryParameters {

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -164,6 +164,7 @@ pub fn get_server_version(rt: &DriverRuntime, conn_handle: ConnectionHandle) -> 
         .statement_execute_query_blocking(StatementExecuteQueryRequest {
             stmt_handle: Some(version_stmt),
             bindings: None,
+            timeout_seconds: None,
         })
         .map_err(|e| format!("Query execution failed: {:?}", e))?;
 
@@ -231,6 +232,7 @@ pub fn execute_setup_queries(
             .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(stmt_handle),
                 bindings: None,
+                timeout_seconds: None,
             })
             .map_err(|e| format!("Setup query execution failed: {:?}", e))?;
 

--- a/tests/performance/drivers/core/app/src/put_execution.rs
+++ b/tests/performance/drivers/core/app/src/put_execution.rs
@@ -127,6 +127,7 @@ fn execute_put_get_iteration(
         .statement_execute_query_blocking(StatementExecuteQueryRequest {
             stmt_handle: Some(stmt_handle),
             bindings: None,
+            timeout_seconds: None,
         })
         .map_err(|e| format!("PUT/GET execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();

--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -167,6 +167,7 @@ fn execute_iteration(rt: &DriverRuntime, stmt_handle: StatementHandle) -> Result
         .statement_execute_query_blocking(StatementExecuteQueryRequest {
                 stmt_handle: Some(stmt_handle),
                 bindings: None,
+                timeout_seconds: None,
             })
         .map_err(|e| format!("Query execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();


### PR DESCRIPTION
## Description

This pull request implements comprehensive support for ODBC statement attributes, adding handling for 11 new statement attributes including query timeout, row limits, cursor properties, and concurrency settings.

**Key Features Added:**

  - **SQL_ATTR_QUERY_TIMEOUT**: Passes `STATEMENT_TIMEOUT_IN_SECONDS` via the `parameters` field in the REST query request body on both synchronous and asynchronous execution paths. A value of 0 (the default) sends no parameter, leaving the session timeout in effect. Values exceeding `u32::MAX` are rejected with HY024.
  - **SQL_ATTR_MAX_ROWS**: Enforces row limits via two complementary mechanisms: (1) injects a `LIMIT N` clause into SELECT/WITH queries at execution time to reduce server-side work, and (2) stops `SQLFetch` once `rows_returned` reaches the limit, resetting `SQL_ATTR_ROWS_FETCHED_PTR` to 0 and marking the row status array as `SQL_ROW_NOROW` on `SQL_NO_DATA`.
- **Cursor attributes**: Adds support for `SQL_ATTR_CURSOR_SCROLLABLE`, `SQL_ATTR_CURSOR_SENSITIVITY`, `SQL_ATTR_CONCURRENCY` with appropriate fallbacks and warnings for unsupported values
- **Additional attributes**: Implements `SQL_ATTR_NOSCAN`, `SQL_ATTR_ENABLE_AUTO_IPD`, `SQL_ATTR_KEYSET_SIZE`, `SQL_ATTR_SIMULATE_CURSOR`, and `SQL_ATTR_RETRIEVE_DATA`

**Implementation Details:**

- Adds new fields to the `Statement` struct to track attribute values and row counts
- Modifies `fetch_impl` to respect `max_rows` limits and track `rows_returned`
- Updates statement allocation to initialize new attributes with ODBC-compliant defaults
- Implements proper error handling with SQLSTATE codes (HY024, HYC00, 24000)
- Provides option value substitution with 01S02 warnings for unsupported cursor features
- Resets `rows_returned` counter on each query execution

## Testing

Adds comprehensive test coverage with 25 new test cases covering:
- Default value verification for all new attributes
- Set/get operations for configurable attributes  
- Row limiting functionality with `SQL_ATTR_MAX_ROWS`
- Error handling for invalid attribute values
- Warning generation for unsupported cursor features
- Cursor state validation for concurrency changes