### PR TITLE
Fix timeout by scoping metadata queries to current database/schema

### DIFF
--- a/odbc_tests/common/include/Database.hpp
+++ b/odbc_tests/common/include/Database.hpp
@@ -20,7 +20,7 @@
 // The database is NOT dropped automatically -- each test creates its own
 // connection, so there is no single connection that outlives them all.
 // Snowflake account-level cleanup (or a CI post-step) should remove stale
-// CATALOG_TEST_DB_* databases.
+// CATALOGTESTDB* databases.
 class CatalogTestDatabase {
  public:
   CatalogTestDatabase() = delete;
@@ -42,7 +42,10 @@ class CatalogTestDatabase {
   static std::string generate_name() {
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    return "CATALOG_TEST_DB_" + std::to_string(gen());
+    // No underscores: ODBC treats '_' as a single-char wildcard in pattern
+    // arguments, which can prevent the reference driver from scoping metadata
+    // queries to the correct database.
+    return "CATALOGTESTDB" + std::to_string(gen());
   }
 
   static void execute(SQLHDBC dbc, const std::string& sql) {

--- a/odbc_tests/common/include/Database.hpp
+++ b/odbc_tests/common/include/Database.hpp
@@ -1,0 +1,65 @@
+#ifndef DATABASE_HPP
+#define DATABASE_HPP
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <random>
+#include <stdexcept>
+#include <string>
+
+#include "odbc_cast.hpp"
+
+// Process-scoped shared database for catalog tests.
+//
+// Creates a small, isolated database on the first call to use() and
+// switches every subsequent connection to it via USE DATABASE.  Because the
+// database contains only the objects each test creates (in random schemas),
+// information_schema queries are fast.
+//
+// The database is NOT dropped automatically -- each test creates its own
+// connection, so there is no single connection that outlives them all.
+// Snowflake account-level cleanup (or a CI post-step) should remove stale
+// CATALOG_TEST_DB_* databases.
+class CatalogTestDatabase {
+ public:
+  CatalogTestDatabase() = delete;
+
+  // Ensures the shared catalog database exists and is the active database
+  // on the given connection.  The first call creates the database; subsequent
+  // calls only execute USE DATABASE.
+  static void use(SQLHDBC dbc) {
+    if (name_.empty()) {
+      name_ = generate_name();
+      execute(dbc, "CREATE DATABASE IF NOT EXISTS " + name_);
+    }
+    execute(dbc, "USE DATABASE " + name_);
+  }
+
+  static const std::string& name() { return name_; }
+
+ private:
+  static std::string generate_name() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    return "CATALOG_TEST_DB_" + std::to_string(gen());
+  }
+
+  static void execute(SQLHDBC dbc, const std::string& sql) {
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+    if (!SQL_SUCCEEDED(ret)) {
+      throw std::runtime_error("CatalogTestDatabase: SQLAllocHandle failed for: " + sql);
+    }
+    ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+    SQLFreeStmt(stmt, SQL_CLOSE);
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    if (!SQL_SUCCEEDED(ret)) {
+      throw std::runtime_error("CatalogTestDatabase: SQLExecDirect failed for: " + sql);
+    }
+  }
+
+  static inline std::string name_;
+};
+
+#endif  // DATABASE_HPP

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -12,6 +12,7 @@
 
 #include "HandleWrapper.hpp"
 #include "ODBCConfig.hpp"
+#include "ScopedSessionParam.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
 
@@ -137,6 +138,18 @@ class StmtFixture : public DbcFixture {
 class StmtDefaultDSNFixture : public StmtFixture {
  public:
   StmtDefaultDSNFixture() : StmtFixture(DataSourceConfig::Snowflake()) {}
+};
+
+// ============================================================================
+// Catalog Fixture (scopes metadata queries to the current database/schema)
+// ============================================================================
+
+class CatalogStmtDefaultDSNFixture : public StmtDefaultDSNFixture {
+  ScopedSessionParam ctx_;
+
+ public:
+  CatalogStmtDefaultDSNFixture()
+      : StmtDefaultDSNFixture(), ctx_(ScopedSessionParam::use_connection_ctx(dbc_handle())) {}
 };
 
 // ============================================================================

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -148,8 +148,9 @@ class CatalogStmtDefaultDSNFixture : public StmtDefaultDSNFixture {
   ScopedSessionParam ctx_;
 
  public:
-  CatalogStmtDefaultDSNFixture()
-      : StmtDefaultDSNFixture(), ctx_(ScopedSessionParam::use_connection_ctx(dbc_handle())) {}
+  CatalogStmtDefaultDSNFixture() : StmtDefaultDSNFixture(), ctx_(ScopedSessionParam::use_connection_ctx(dbc_handle())) {
+    REQUIRE(ctx_.is_active());
+  }
 };
 
 // ============================================================================

--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -10,6 +10,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "Database.hpp"
 #include "HandleWrapper.hpp"
 #include "ODBCConfig.hpp"
 #include "ScopedSessionParam.hpp"
@@ -149,6 +150,7 @@ class CatalogStmtDefaultDSNFixture : public StmtDefaultDSNFixture {
 
  public:
   CatalogStmtDefaultDSNFixture() : StmtDefaultDSNFixture(), ctx_(ScopedSessionParam::use_connection_ctx(dbc_handle())) {
+    CatalogTestDatabase::use(dbc_handle());
     REQUIRE(ctx_.is_active());
   }
 };

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -63,7 +63,10 @@ class Schema {
   static std::string generate_random_name() {
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    return "SCHEMA_" + std::to_string(gen());
+    // No underscores: ODBC treats '_' as a single-char wildcard in pattern
+    // arguments (SchemaName, TableName), which prevents the reference driver
+    // from scoping SHOW commands to the specific schema.
+    return "SCHEMA" + std::to_string(gen());
   }
 
   static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {

--- a/odbc_tests/common/include/ScopedSessionParam.hpp
+++ b/odbc_tests/common/include/ScopedSessionParam.hpp
@@ -14,15 +14,16 @@
 // test's own statement handle.
 class ScopedSessionParam {
  public:
-  ScopedSessionParam(SQLHDBC dbc, const std::string& param, const std::string& value) : dbc_(dbc), param_(param) {
-    execute("ALTER SESSION SET " + param_ + "=" + value);
-  }
+  ScopedSessionParam(SQLHDBC dbc, const std::string& param, const std::string& value)
+      : dbc_(dbc), param_(param), active_(execute("ALTER SESSION SET " + param_ + "=" + value)) {}
 
   ~ScopedSessionParam() {
-    if (dbc_ != SQL_NULL_HDBC && !param_.empty()) {
+    if (active_) {
       execute("ALTER SESSION UNSET " + param_);
     }
   }
+
+  [[nodiscard]] bool is_active() const { return active_; }
 
   static ScopedSessionParam use_connection_ctx(SQLHDBC dbc) {
     return ScopedSessionParam(dbc, "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
@@ -31,36 +32,42 @@ class ScopedSessionParam {
   ScopedSessionParam(const ScopedSessionParam&) = delete;
   ScopedSessionParam& operator=(const ScopedSessionParam&) = delete;
 
-  ScopedSessionParam(ScopedSessionParam&& other) noexcept : dbc_(other.dbc_), param_(std::move(other.param_)) {
+  ScopedSessionParam(ScopedSessionParam&& other) noexcept
+      : dbc_(other.dbc_), param_(std::move(other.param_)), active_(other.active_) {
     other.dbc_ = SQL_NULL_HDBC;
     other.param_.clear();
+    other.active_ = false;
   }
 
   ScopedSessionParam& operator=(ScopedSessionParam&& other) noexcept {
     if (this != &other) {
-      if (dbc_ != SQL_NULL_HDBC && !param_.empty()) {
+      if (active_) {
         execute("ALTER SESSION UNSET " + param_);
       }
       dbc_ = other.dbc_;
       param_ = std::move(other.param_);
+      active_ = other.active_;
       other.dbc_ = SQL_NULL_HDBC;
       other.param_.clear();
+      other.active_ = false;
     }
     return *this;
   }
 
  private:
-  void execute(const std::string& sql) {
-    if (dbc_ == SQL_NULL_HDBC) return;
+  bool execute(const std::string& sql) {
+    if (dbc_ == SQL_NULL_HDBC) return false;
     SQLHSTMT stmt = SQL_NULL_HSTMT;
-    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt))) return;
-    SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt))) return false;
+    const SQLRETURN ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
     SQLFreeStmt(stmt, SQL_CLOSE);
     SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    return SQL_SUCCEEDED(ret);
   }
 
   SQLHDBC dbc_;
   std::string param_;
+  bool active_;
 };
 
 #endif  // SCOPEDSESSIONPARAM_HPP

--- a/odbc_tests/common/include/ScopedSessionParam.hpp
+++ b/odbc_tests/common/include/ScopedSessionParam.hpp
@@ -1,0 +1,66 @@
+#ifndef SCOPEDSESSIONPARAM_HPP
+#define SCOPEDSESSIONPARAM_HPP
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <string>
+
+#include "odbc_cast.hpp"
+
+// RAII wrapper that sets a Snowflake session parameter on construction and
+// unsets it (restoring the server default) on destruction.  Allocates a
+// temporary statement handle internally so it never interferes with the
+// test's own statement handle.
+class ScopedSessionParam {
+ public:
+  ScopedSessionParam(SQLHDBC dbc, const std::string& param, const std::string& value) : dbc_(dbc), param_(param) {
+    execute("ALTER SESSION SET " + param_ + "=" + value);
+  }
+
+  ~ScopedSessionParam() {
+    if (dbc_ != SQL_NULL_HDBC && !param_.empty()) {
+      execute("ALTER SESSION UNSET " + param_);
+    }
+  }
+
+  static ScopedSessionParam use_connection_ctx(SQLHDBC dbc) {
+    return ScopedSessionParam(dbc, "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
+  }
+
+  ScopedSessionParam(const ScopedSessionParam&) = delete;
+  ScopedSessionParam& operator=(const ScopedSessionParam&) = delete;
+
+  ScopedSessionParam(ScopedSessionParam&& other) noexcept : dbc_(other.dbc_), param_(std::move(other.param_)) {
+    other.dbc_ = SQL_NULL_HDBC;
+    other.param_.clear();
+  }
+
+  ScopedSessionParam& operator=(ScopedSessionParam&& other) noexcept {
+    if (this != &other) {
+      if (dbc_ != SQL_NULL_HDBC && !param_.empty()) {
+        execute("ALTER SESSION UNSET " + param_);
+      }
+      dbc_ = other.dbc_;
+      param_ = std::move(other.param_);
+      other.dbc_ = SQL_NULL_HDBC;
+      other.param_.clear();
+    }
+    return *this;
+  }
+
+ private:
+  void execute(const std::string& sql) {
+    if (dbc_ == SQL_NULL_HDBC) return;
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt))) return;
+    SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+    SQLFreeStmt(stmt, SQL_CLOSE);
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+  }
+
+  SQLHDBC dbc_;
+  std::string param_;
+};
+
+#endif  // SCOPEDSESSIONPARAM_HPP

--- a/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/column_privileges_tests.cpp
@@ -24,7 +24,7 @@
 // SQLColumnPrivileges - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has correct number of columns",
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -45,7 +45,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set has cor
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -81,7 +81,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Result set column 
 // SQLColumnPrivileges - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty result set for existing table",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty result set for existing table",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Snowflake does NOT support traditional SQL column-level GRANT privileges
   // (e.g., GRANT SELECT(col)). SQLColumnPrivileges always returns an empty result set.
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Returns empty resu
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter combinations return empty",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter combinations return empty",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Cannot verify actual search pattern/parameter behavior since Snowflake doesn't
   // support column privileges. These tests only verify that various parameter combinations
@@ -147,7 +147,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Various parameter 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table returns empty result set",
                  "[odbc-api][catalog][columnprivileges]") {
   // Note: Cannot distinguish between "table doesn't exist" and "no privileges exist"
   // since Snowflake doesn't support column privileges - both return empty result sets.
@@ -168,7 +168,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Non-existent table
 // SQLColumnPrivileges - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple times after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple times after close cursor",
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -192,7 +192,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: Can call multiple 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount returns -1",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: SQLRowCount returns -1",
                  "[odbc-api][catalog][columnprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -223,40 +223,40 @@ TEST_CASE("SQLColumnPrivileges: SQL_INVALID_HANDLE for null statement handle",
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY009 - NULL TableName pointer",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: HY009 - NULL TableName pointer",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, nullptr, SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative CatalogName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
       SQLColumnPrivileges(stmt_handle(), sqlchar("DB"), -999, nullptr, 0, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
       SQLColumnPrivileges(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative TableName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret = SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative ColumnName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: HY090 - Negative ColumnName length",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const SQLRETURN ret =
       SQLColumnPrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), SQL_NTS, sqlchar("COLUMN"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumnPrivileges: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumnPrivileges: 24000 - Cursor already open",
                  "[odbc-api][catalog][columnprivileges][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 

--- a/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/columns_tests.cpp
@@ -21,7 +21,7 @@
 // SQLColumns - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Result set has correct number of columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -35,7 +35,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set has correct numb
   REQUIRE(numCols == 19);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Result set column names match ODBC 3.x spec",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -72,7 +72,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Result set column names mat
 // SQLColumns - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column metadata for known table",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Returns correct column metadata for known table",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct column meta
   REQUIRE(columnNames[3] == "ACTIVE");
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types for known columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Returns correct data types for known columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -169,7 +169,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Returns correct data types 
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequential starting from 1",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequential starting from 1",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -199,7 +199,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ORDINAL_POSITION is sequent
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports correct nullability",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports correct nullability",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -238,7 +238,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULLABLE column reports cor
 // SQLColumns - Search Patterns
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % returns all columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % returns all columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -262,7 +262,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: ColumnName wildcard % retur
   REQUIRE(rowCount == 3);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all columns",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -286,7 +286,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: NULL ColumnName returns all
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters results",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters results",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -314,7 +314,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Specific ColumnName filters
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard matches single character",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard matches single character",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -348,7 +348,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Underscore _ wildcard match
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Non-existent table returns empty result set",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -368,7 +368,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Non-existent table returns 
 // SQLColumns - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinations are accepted",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: Various parameter combinations are accepted",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -409,7 +409,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Various parameter combinati
 // SQLColumns - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLColumns: Can call multiple times on same statement after close cursor",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -443,7 +444,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: Can call multiple times on 
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: SQLRowCount after catalog function call",
                  "[odbc-api][columns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -466,7 +467,7 @@ TEST_CASE("SQLColumns: SQL_INVALID_HANDLE for null statement handle", "[odbc-api
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: HY090 - Negative CatalogName length",
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -475,7 +476,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative CatalogNam
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: HY090 - Negative SchemaName length",
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -483,7 +484,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative SchemaName
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: HY090 - Negative TableName length",
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -491,7 +492,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative TableName 
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative ColumnName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: HY090 - Negative ColumnName length",
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -499,7 +500,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: HY090 - Negative ColumnName
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLColumns: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLColumns: 24000 - Cursor already open",
                  "[odbc-api][columns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 

--- a/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/foreign_keys_tests.cpp
@@ -21,7 +21,7 @@
 // SQLForeignKeys - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct number of columns",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -53,7 +53,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set has correct 
   REQUIRE(numCols == 14);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: Result set column names match ODBC 3.x spec",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Result set column names
 // SQLForeignKeys - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreign key referencing PK table",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreign key referencing PK table",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -153,7 +153,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: FK table returns foreig
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreign keys referencing it",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreign keys referencing it",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -199,7 +199,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: PK table returns foreig
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table specified returns matching relationship",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLForeignKeys: Both PK and FK table specified returns matching relationship",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -238,7 +239,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Both PK and FK table sp
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture,
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
                  "SQLForeignKeys: PK table referenced by multiple children returns all relationships",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
@@ -280,7 +281,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign keys returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign keys returns empty result set",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -301,7 +302,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Table without foreign k
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table returns empty result set",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -322,7 +323,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Non-existent table retu
 // SQLForeignKeys - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLForeignKeys: Can call multiple times on same statement after close cursor",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -362,7 +364,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: Can call multiple times
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: SQLRowCount after catalog function call",
                  "[odbc-api][foreignkeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -394,7 +396,7 @@ TEST_CASE("SQLForeignKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY009 - Both PKTableName and FKTableName are null",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: HY009 - Both PKTableName and FKTableName are null",
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -402,7 +404,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY009 - Both PKTableNam
   REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative PKCatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative PKCatalogName length",
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -411,7 +413,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative PKCata
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTableName length",
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -420,7 +422,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: HY090 - Negative FKTabl
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLForeignKeys: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLForeignKeys: 24000 - Cursor already open",
                  "[odbc-api][foreignkeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 

--- a/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/primary_keys_tests.cpp
@@ -21,7 +21,7 @@
 // SQLPrimaryKeys - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct number of columns",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -44,7 +44,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set has correct 
   REQUIRE(numCols == 6);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names match ODBC 3.x spec",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -85,7 +85,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Result set column names
 // SQLPrimaryKeys - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for single-column PK",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for single-column PK",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -127,7 +127,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns primary key for
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite primary key with correct KEY_SEQ",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite primary key with correct KEY_SEQ",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -167,7 +167,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Returns composite prima
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary key returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary key returns empty result set",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -188,7 +188,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Table without primary k
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table returns empty result set",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -208,7 +208,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Non-existent table retu
 // SQLPrimaryKeys - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combinations are accepted",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combinations are accepted",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -248,7 +248,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Various parameter combi
 // SQLPrimaryKeys - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLPrimaryKeys: Can call multiple times on same statement after close cursor",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -280,7 +281,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: Can call multiple times
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: SQLRowCount after catalog function call",
                  "[odbc-api][primarykeys][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -311,7 +312,7 @@ TEST_CASE("SQLPrimaryKeys: SQL_INVALID_HANDLE for null statement handle", "[odbc
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative CatalogName length",
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -319,7 +320,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative Catalo
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative SchemaName length",
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -327,7 +328,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative Schema
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableName length",
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -335,7 +336,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: HY090 - Negative TableN
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPrimaryKeys: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLPrimaryKeys: 24000 - Cursor already open",
                  "[odbc-api][primarykeys][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 

--- a/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedure_columns_tests.cpp
@@ -21,7 +21,7 @@
 // SQLProcedureColumns - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Result set has correct number of columns",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -47,7 +47,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set has cor
   REQUIRE(numCols == 21);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Result set column names match ODBC 3.x spec",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -97,7 +97,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Result set column 
 // SQLProcedureColumns - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters for known procedure",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters for known procedure",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Returns parameters
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent procedure returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent procedure returns empty result set",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Non-existent proce
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnName filters results",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnName filters results",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -200,7 +200,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Specific ColumnNam
 // SQLProcedureColumns - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter combinations are accepted",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
@@ -245,7 +245,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: Various parameter 
 // SQLProcedureColumns - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture,
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
                  "SQLProcedureColumns: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
@@ -283,7 +283,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture,
   REQUIRE(count2 == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: SQLRowCount after catalog function call",
                  "[odbc-api][procedurecolumns][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -319,7 +319,7 @@ TEST_CASE("SQLProcedureColumns: SQL_INVALID_HANDLE for null statement handle",
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative CatalogName length",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -328,7 +328,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative C
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative SchemaName length",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -337,7 +337,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative S
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ProcName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ProcName length",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -345,7 +345,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative P
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ColumnName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative ColumnName length",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -354,7 +354,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: HY090 - Negative C
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedureColumns: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedureColumns: 24000 - Cursor already open",
                  "[odbc-api][procedurecolumns][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 

--- a/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/procedures_tests.cpp
@@ -20,7 +20,7 @@
 // SQLProcedures - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Result set has correct number of columns",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -46,7 +46,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set has correct n
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Result set column names match ODBC 3.x spec",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -92,7 +92,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Result set column names 
 // SQLProcedures - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure with correct metadata",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Returns known procedure with correct metadata",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Returns known procedure 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds procedure",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds procedure",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -162,7 +162,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Wildcard search finds pr
   REQUIRE(std::string(name) == "TEST_PROCS_WILDCARD");
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returning procs are all returned",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returning procs are all returned",
                  "[odbc-api][procedures][catalog][known-bug]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -199,7 +199,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple VARCHAR-returni
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is returned alongside VARCHAR proc",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLProcedures: NUMBER-returning proc is returned alongside VARCHAR proc",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -235,7 +236,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: NUMBER-returning proc is
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returning procs are all returned",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returning procs are all returned",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -271,7 +272,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Multiple NUMBER-returnin
   REQUIRE(rowCount == 2);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure returns empty result set",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -291,7 +292,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Non-existent procedure r
 // SQLProcedures - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combinations are accepted",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: Various parameter combinations are accepted",
                  "[odbc-api][procedures][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
@@ -335,7 +336,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Various parameter combin
 // SQLProcedures - Statement Reuse
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times on same statement after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLProcedures: Can call multiple times on same statement after close cursor",
                  "[odbc-api][procedures][catalog]") {
   SKIP("Long-running: multiple catalog round-trips cause timeout");
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
@@ -371,7 +373,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: Can call multiple times 
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalog function call",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: SQLRowCount after catalog function call",
                  "[odbc-api][procedures][catalog]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -406,7 +408,7 @@ TEST_CASE("SQLProcedures: SQL_INVALID_HANDLE for null statement handle", "[odbc-
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative CatalogName length",
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -414,7 +416,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative Catalog
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative SchemaName length",
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -422,7 +424,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative SchemaN
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcName length",
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
@@ -430,7 +432,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: HY090 - Negative ProcNam
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLProcedures: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLProcedures: 24000 - Cursor already open",
                  "[odbc-api][procedures][catalog][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 

--- a/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/special_columns_tests.cpp
@@ -24,7 +24,7 @@
 // SQLSpecialColumns - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: Result set has correct number of columns",
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -46,7 +46,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set has corre
   REQUIRE(numCols == 8);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -83,7 +83,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Result set column na
 // SQLSpecialColumns - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID returns empty result set",
                  "[odbc-api][catalog][specialcolumns]") {
   // Note: Snowflake does not support row identifiers, so SQLSpecialColumns
   // always returns an empty result set for SQL_BEST_ROWID.
@@ -106,7 +106,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_BEST_ROWID retur
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns empty result set",
                  "[odbc-api][catalog][specialcolumns]") {
   // Note: Snowflake does not have auto-updated version columns, so
   // SQLSpecialColumns always returns an empty result set for SQL_ROWVER.
@@ -129,7 +129,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQL_ROWVER returns e
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nullable combinations return empty",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture,
+                 "SQLSpecialColumns: Various scope and nullable combinations return empty",
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -161,7 +162,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Various scope and nu
 // SQLSpecialColumns - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple times after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple times after close cursor",
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -187,7 +188,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: Can call multiple ti
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns -1",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: SQLRowCount returns -1",
                  "[odbc-api][catalog][specialcolumns]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -219,14 +220,14 @@ TEST_CASE("SQLSpecialColumns: SQL_INVALID_HANDLE for null statement handle",
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: HY090 - Negative TableName length",
                  "[odbc-api][catalog][specialcolumns][error]") {
   const SQLRETURN ret = SQLSpecialColumns(stmt_handle(), SQL_BEST_ROWID, nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999,
                                           SQL_SCOPE_SESSION, SQL_NULLABLE);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLSpecialColumns: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLSpecialColumns: 24000 - Cursor already open",
                  "[odbc-api][catalog][specialcolumns][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 

--- a/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/statistics_tests.cpp
@@ -24,7 +24,7 @@
 // SQLStatistics - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: Result set has correct number of columns",
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -45,7 +45,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set has correct n
   REQUIRE(numCols == 13);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -83,7 +83,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Result set column names 
 // SQLStatistics - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Returns empty result set for table with primary key",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: Returns empty result set for table with primary key",
                  "[odbc-api][catalog][statistics]") {
   // Note: Snowflake does not expose index/statistics metadata through ODBC.
   // SQLStatistics always returns an empty result set.
@@ -105,7 +105,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Returns empty result set
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns empty",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns empty",
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -127,7 +127,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQL_INDEX_UNIQUE returns
 // SQLStatistics - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: Can call multiple times after close cursor",
                  "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -151,7 +151,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: Can call multiple times 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1", "[odbc-api][catalog][statistics]") {
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: SQLRowCount returns -1",
+                 "[odbc-api][catalog][statistics]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret =
@@ -181,14 +182,14 @@ TEST_CASE("SQLStatistics: SQL_INVALID_HANDLE for null statement handle", "[odbc-
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: HY090 - Negative TableName length",
                  "[odbc-api][catalog][statistics][error]") {
   const SQLRETURN ret =
       SQLStatistics(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999, SQL_INDEX_ALL, SQL_QUICK);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLStatistics: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLStatistics: 24000 - Cursor already open",
                  "[odbc-api][catalog][statistics][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 

--- a/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/table_privileges_tests.cpp
@@ -24,7 +24,7 @@
 // SQLTablePrivileges - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: Result set has correct number of columns",
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -45,7 +45,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set has corr
   REQUIRE(numCols == 7);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -81,7 +81,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Result set column n
 // SQLTablePrivileges - Empty Result Set (Snowflake limitation)
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty result set for existing table",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty result set for existing table",
                  "[odbc-api][catalog][tableprivileges]") {
   // Note: Snowflake does not expose table-level privilege metadata through ODBC.
   // SQLTablePrivileges always returns an empty result set.
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Returns empty resul
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL parameters return empty",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL parameters return empty",
                  "[odbc-api][catalog][tableprivileges]") {
   const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("%"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -116,7 +116,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Wildcard and NULL p
 // SQLTablePrivileges - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple times after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple times after close cursor",
                  "[odbc-api][catalog][tableprivileges]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -140,7 +140,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: Can call multiple t
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns -1",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: SQLRowCount returns -1",
                  "[odbc-api][catalog][tableprivileges]") {
   const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -161,20 +161,20 @@ TEST_CASE("SQLTablePrivileges: SQL_INVALID_HANDLE for null statement handle",
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative TableName length",
                  "[odbc-api][catalog][tableprivileges][error]") {
   const SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("TABLE"), -999);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][tableprivileges][error]") {
   const SQLRETURN ret =
       SQLTablePrivileges(stmt_handle(), nullptr, 0, sqlchar("SCHEMA"), -999, sqlchar("TABLE"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTablePrivileges: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTablePrivileges: 24000 - Cursor already open",
                  "[odbc-api][catalog][tableprivileges][error]") {
   SQLRETURN ret = SQLTablePrivileges(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("ANY_TABLE"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);

--- a/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
+++ b/odbc_tests/tests/odbc-api/catalog/tables_tests.cpp
@@ -20,7 +20,7 @@
 // SQLTables - Result Set Structure
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct number of columns",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Result set has correct number of columns",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -42,7 +42,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set has correct numbe
   REQUIRE(numCols == 5);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names match ODBC 3.x spec",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Result set column names match ODBC 3.x spec",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -77,7 +77,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Result set column names matc
 // SQLTables - Data Verification
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with correct metadata",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Returns known table with correct metadata",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -114,7 +114,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns known table with cor
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE VIEW", "[odbc-api][catalog][tables]") {
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE VIEW",
+                 "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_base (id INT)"), SQL_NTS);
@@ -142,7 +143,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Returns view with TABLE_TYPE
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Non-existent table returns empty result set",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Non-existent table returns empty result set",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
   const std::string currentDb = get_current_database(dbc_handle());
@@ -155,7 +156,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Non-existent table returns e
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts results",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts results",
                  "[odbc-api][catalog][tables]") {
   auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -215,7 +216,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: TABLE_TYPE filter restricts 
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table", "[odbc-api][catalog][tables]") {
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Wildcard search finds table",
+                 "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_wild (id INT)"), SQL_NTS);
@@ -240,7 +242,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Wildcard search finds table"
 // SQLTables - Parameter Variations
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinations are accepted",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Various parameter combinations are accepted",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -277,7 +279,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Various parameter combinatio
 // SQLTables - Statement Reuse & SQLRowCount
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times after close cursor",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: Can call multiple times after close cursor",
                  "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
@@ -305,7 +307,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: Can call multiple times afte
   REQUIRE(count2 == 1);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: SQLRowCount returns -1", "[odbc-api][catalog][tables]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE test_tbl_rowcount (id INT)"), SQL_NTS);
@@ -333,25 +335,25 @@ TEST_CASE("SQLTables: SQL_INVALID_HANDLE for null statement handle", "[odbc-api]
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative CatalogName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: HY090 - Negative CatalogName length",
                  "[odbc-api][catalog][tables][error]") {
   const SQLRETURN ret = SQLTables(stmt_handle(), sqlchar("DB"), -999, nullptr, 0, sqlchar("T"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative SchemaName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: HY090 - Negative SchemaName length",
                  "[odbc-api][catalog][tables][error]") {
   const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, sqlchar("S"), -999, sqlchar("T"), SQL_NTS, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: HY090 - Negative TableName length",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: HY090 - Negative TableName length",
                  "[odbc-api][catalog][tables][error]") {
   const SQLRETURN ret = SQLTables(stmt_handle(), nullptr, 0, nullptr, 0, sqlchar("T"), -999, nullptr, 0);
   REQUIRE_EXPECTED_ERROR(ret, "HY090", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLTables: 24000 - Cursor already open",
+TEST_CASE_METHOD(CatalogStmtDefaultDSNFixture, "SQLTables: 24000 - Cursor already open",
                  "[odbc-api][catalog][tables][error]") {
   const auto schema = Schema::use_random_schema(dbc_handle());
 


### PR DESCRIPTION
### Summary

**SQLTables:**

| **Test** | **Before** | **After** |
| --- | --- | --- |
| Returns known table with correct metadata | 162\.87s | 5\.49s |
| Non-existent table returns empty result set | 158\.33s | 4\.96s |
| Wildcard search finds table | 158\.02s | 4\.92s |
| Returns view with TABLE_TYPE VIEW | 177\.10s | 6\.97s |
| Various parameter combinations | 310\.19s | 6\.05s |
| Can call multiple times after close cursor | 350\.14s | 6\.05s |
| TABLE_TYPE filter restricts results | 428\.09s | 8\.65s |

**SQLProcedures:**

| **Test** | **Before** | **After** |
| --- | --- | --- |
| Returns known procedure with correct metadata | Timed out or >1300s | 5\.68s |
| Wildcard search finds procedure | Timed out or >1300s | 6\.31s |
| Multiple VARCHAR-returning procs are all returned | Timed out or >1300s | 6\.86s |
| NUMBER-returning proc is returned alongside VARCHAR proc | Timed out or >1300s | 6\.05s |
| Multiple NUMBER-returning procs are all returned | Timed out or >1300s | 6\.00s |
| Non-existent procedure returns empty result set | Timed out or >1300s | 5\.77s |
| Various parameter combinations | Skipped | Skipped |
| Can call multiple times after close cursor | Skipped | Skipped |

**SQLProcedureColumns:**

| **Test** | **Before** | **After** |
| --- | --- | --- |
| Returns parameters for known procedure | Timed out or >1300s | 8\.31s |
| Non-existent procedure returns empty result set | Timed out or >1300s | 5\.09s |
| Specific ColumnName filters results | Timed out or >1300s | 5\.99s |
| Various parameter combinations | Skipped | Skipped |
| Can call multiple times after close cursor | Skipped | Skipped |

Before the dedicated database and schema fix, these same data-fetching tests were each taking **1390-1500 seconds** in CI. The fix reduced them from ~1400s to ~6s each -- roughly a **230x speedup**.

### TL;DR

Added catalog test infrastructure with isolated database and session parameter management to improve ODBC catalog function test reliability and performance.

### What changed?

- **New** **`CatalogTestDatabase`** **class**: Creates process-scoped isolated databases for catalog tests with randomly generated names (avoiding underscores to prevent ODBC wildcard conflicts)
- **New** **`ScopedSessionParam`** **class**: RAII wrapper for managing Snowflake session parameters with automatic cleanup
- **New** **`CatalogStmtDefaultDSNFixture`**: Test fixture that combines database isolation with connection context session parameters
- **Updated all catalog tests**: Migrated from `StmtDefaultDSNFixture` to `CatalogStmtDefaultDSNFixture` across column privileges, columns, foreign keys, primary keys, procedure columns, procedures, special columns, statistics, table privileges, and tables tests
- **Schema naming fix**: Removed underscores from randomly generated schema names to avoid ODBC pattern matching issues

### How to test?

Run the existing catalog test suites - they should now execute faster due to database isolation and have more reliable results due to scoped session parameters and wildcard-safe naming.

### Why make this change?

- **Performance**: Isolated databases contain only test-created objects, making information_schema queries significantly faster
- **Reliability**: Session parameter management ensures consistent test behavior and proper cleanup
- **Isolation**: Each test process gets its own database, preventing cross-test interference
- **ODBC Compliance**: Removing underscores from generated names prevents unintended wildcard matching in ODBC pattern arguments