### PR TITLE
SNOW-3235556 Snowflake Custom Statement Attributes

### DIFF
--- a/odbc/include/sf_odbc.h
+++ b/odbc/include/sf_odbc.h
@@ -33,23 +33,21 @@
 /* Private key as base64-encoded string */
 #define SQL_SF_CONN_ATTR_PRIV_KEY_BASE64 (SQL_SF_CONN_ATTR_BASE + 5)
 
-/* Statement attribute base for Snowflake-specific statement attributes.
- * Uses SQL_DRIVER_STMT_ATTR_BASE from system ODBC headers (1000 on Windows, 16384 on iODBC).
- * Formula: (SQL_DRIVER_STMT_ATTR_BASE + 0x106).
- * The Rust implementation accepts both Windows (1263/1264) and Unix (16647/16648) values. */
+/* -------------------------------------------------------------------------
+ * Snowflake-specific statement attributes
+ * Base matches SQL_DRIVER_STMT_ATTR_BASE (0x4000) + 0x106, in sync with the
+ * old snowflake-odbc driver's sf_odbc.h.
+ * -------------------------------------------------------------------------*/
 #ifndef SQL_DRIVER_STMT_ATTR_BASE
-#define SQL_DRIVER_STMT_ATTR_BASE 16384
+#define SQL_DRIVER_STMT_ATTR_BASE 0x00004000
 #endif
 
 #define SQL_SF_STMT_ATTR_BASE (SQL_DRIVER_STMT_ATTR_BASE + 0x106)
 
-/* Last query ID — the ID of the most recently executed query on the statement.
- * Read-only string attribute. */
+/* Query ID of the last executed statement (read-only string) */
 #define SQL_SF_STMT_ATTR_LAST_QUERY_ID (SQL_SF_STMT_ATTR_BASE + 1)
 
-/* Multi-statement count — set via SQLSetStmtAttr before executing a
- * multi-statement SQL string.  Value is the number of semicolon-separated
- * statements in the batch. */
+/* Multi-statement execution count: -1 = auto, 0 = single, N = exact count */
 #define SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT (SQL_SF_STMT_ATTR_BASE + 2)
 
 #endif /* SF_ODBC_H */

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -145,6 +145,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
                     .await?;
                 }
 
+
                 c.statement_set_sql_query(StatementSetSqlQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     query: effective_query,
@@ -1742,7 +1743,7 @@ pub fn set_stmt_attr(
             }
         }
         StmtAttr::SnowflakeMultiStatementCount => {
-            let val = value_ptr as i64;
+            let val = value_ptr as isize as i64;
             if val < -1 || val > i16::MAX as i64 {
                 return InvalidAttributeValueSnafu {
                     attribute,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -145,7 +145,6 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
                     .await?;
                 }
 
-
                 c.statement_set_sql_query(StatementSetSqlQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     query: effective_query,

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -341,8 +341,9 @@ pub enum StmtAttr {
     ImpParamDesc = 10013,
     /// `SQL_ATTR_METADATA_ID` (10014) — identifier vs. pattern treatment for catalog functions.
     MetadataId = 10014,
-    /// `SQL_SF_STMT_ATTR_LAST_QUERY_ID` — last query ID (read-only string).
-    /// Platform-dependent: 1263 (Windows/MDAC) or 16647 (Unix/iODBC).
+
+    // Custom Snowflake statement attributes (SQL_SF_STMT_ATTR_BASE = 0x4000 + 0x106)
+    /// `SQL_SF_STMT_ATTR_LAST_QUERY_ID` (0x4107 = 16647) — query ID of last execution (read-only).
     SnowflakeLastQueryId = 16647,
     /// `SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT` (0x4108 = 16648) — multi-statement count.
     SnowflakeMultiStatementCount = 16648,
@@ -1444,7 +1445,8 @@ pub struct StatementInner {
     /// `None` = never sent. Used to detect when a LIMIT must be added, removed,
     /// or changed on re-execution of a prepared statement.
     pub last_sent_max_rows: Option<sql::ULen>,
-    /// Query ID of the last executed query (`SQL_SF_STMT_ATTR_LAST_QUERY_ID`).
+    /// `SQL_SF_STMT_ATTR_LAST_QUERY_ID` — query ID from the last successful execution (read-only).
+    /// `None` before any execution; `Some("")` if sf_core returned an empty string.
     pub last_query_id: Option<String>,
     /// Child query IDs for multi-statement execution (consumed by SQLMoreResults).
     pub multi_query_ids: Vec<String>,

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -632,3 +632,17 @@ behavior_differences:
       Applications that rely on the reference driver's lenient parsing (accepting bare integers as YEAR_TO_MONTH leading fields, out-of-range trailing day-time fields, or silently truncating zero-magnitude fractions) will see new 22018 errors or 01S07 warnings. Applications that set `SQL_DESC_DATETIME_INTERVAL_PRECISION` on the ARD now actually get the precision they asked for instead of the silent default. Callers that previously caught 22018 on '5.5' -> SQL_C_INTERVAL_YEAR must now also handle the 01S07 success-with-info case.
     description: |
       Spec reference: ODBC Appendix D, "Converting Data from SQL to C Data Types" - "Character to Interval" (https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/converting-data-from-sql-to-c-data-types). The strict trailing-field range enforcement implements outcome #4 ("Not a valid interval value", SQLSTATE 22018, "Invalid character value for cast specification") as defined by the same Appendix D conversion table; the canonical ANSI ranges (HOUR 0..23, MINUTE/SECOND 0..59, MONTH 0..11 in YEAR_TO_MONTH composites) are taken from ANSI SQL/Foundation interval literal grammar.
+
+  56:
+    name: "SQL_SF_STMT_ATTR_LAST_QUERY_ID (SQLPrepare+SQLExecute path) and SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT are only fully supported by the new driver"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      SQL_SF_STMT_ATTR_LAST_QUERY_ID: The old driver returns SQL_SUCCESS with an empty string before any execution and returns a valid query UUID after SQLExecDirect. However it does not populate the query ID after SQLPrepare+SQLExecute and does not return SQL_ERROR when the attribute is set (read-only violation is silently ignored).
+      SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT: The old driver does not implement this attribute. SQLGetStmtAttr returns an error or garbage. SQLSetStmtAttr silently accepts any value including invalid ones (e.g. -2) without error. The count is not forwarded to the server.
+    new_driver_behavior: |
+      SQL_SF_STMT_ATTR_LAST_QUERY_ID (read-only): returns empty string before any execution, a valid UUID after SQLExecDirect or SQLPrepare+SQLExecute, and SQL_ERROR with HY092 on any set attempt.
+      SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT: default -1 (auto-detect), supports set/get roundtrip for values -1 to 32767, returns SQL_ERROR with HY024 for values < -1, and forwards the count to the server enabling multi-statement result sets via SQLMoreResults.
+    impact: |
+      Applications relying on SQL_SF_STMT_ATTR_LAST_QUERY_ID after SQLPrepare+SQLExecute or on SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT must target the new driver. Basic last-query-id retrieval after SQLExecDirect works on both drivers.

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -39,6 +39,7 @@ add_odbc_test(e2e_query_sql_set_pos query/sql_set_pos.cpp)
 add_odbc_test(e2e_query_sql_bulk_operations query/sql_bulk_operations.cpp)
 add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 add_odbc_test(e2e_query_last_query_id query/last_query_id.cpp)
+add_odbc_test(e2e_query_sf_stmt_attrs query/sf_stmt_attrs.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/sf_stmt_attrs.cpp
+++ b/odbc_tests/tests/e2e/query/sf_stmt_attrs.cpp
@@ -1,0 +1,224 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "get_data.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "sf_odbc.h"
+
+// ============================================================================
+// SQL_SF_STMT_ATTR_LAST_QUERY_ID
+// ============================================================================
+
+TEST_CASE("SQL_SF_STMT_ATTR_LAST_QUERY_ID returns empty string before any execution.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_SF_STMT_ATTR_LAST_QUERY_ID is queried on a fresh statement
+  char query_id[256] = {};
+  SQLINTEGER len = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, query_id, sizeof(query_id), &len);
+
+  // Then it should return SQL_SUCCESS and an empty string (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(std::string(query_id).empty());
+  }
+  // Old driver silently accepts the call and returns SQL_SUCCESS
+  OLD_DRIVER_ONLY("BD#56") { REQUIRE(ret == SQL_SUCCESS); }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_LAST_QUERY_ID set returns HY092.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_SF_STMT_ATTR_LAST_QUERY_ID is set to any value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, (SQLPOINTER) "some-id", SQL_NTS);
+
+  // Then it should return SQL_ERROR with SQLSTATE HY092 (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "HY092");
+  }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_LAST_QUERY_ID returns non-empty query ID after SQLExecDirect.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called to execute a simple SELECT query
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // And SQL_SF_STMT_ATTR_LAST_QUERY_ID is queried
+  char query_id[256] = {};
+  SQLINTEGER len = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, query_id, sizeof(query_id), &len);
+
+  // Then it should return SQL_SUCCESS and a non-empty query ID string (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(!std::string(query_id).empty());
+    CHECK(len > 0);
+  }
+  // Old driver silently accepts the call and returns SQL_SUCCESS
+  OLD_DRIVER_ONLY("BD#56") { REQUIRE(ret == SQL_SUCCESS); }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_LAST_QUERY_ID returns non-empty query ID after SQLPrepare and SQLExecute.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLPrepare and SQLExecute are called to execute a simple SELECT query
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // And SQL_SF_STMT_ATTR_LAST_QUERY_ID is queried
+  char query_id[256] = {};
+  SQLINTEGER len = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, query_id, sizeof(query_id), &len);
+
+  // Then it should return SQL_SUCCESS and a non-empty query ID string (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(!std::string(query_id).empty());
+    CHECK(len > 0);
+  }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_LAST_QUERY_ID each execution produces a distinct query ID.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called twice on the same statement
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  char first_id[256] = {};
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, first_id, sizeof(first_id), nullptr);
+  ret = SQLFreeStmt(stmt.getHandle(), SQL_CLOSE);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 2", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  char second_id[256] = {};
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, second_id, sizeof(second_id), nullptr);
+
+  // Then each SQL_SF_STMT_ATTR_LAST_QUERY_ID value should be non-empty and different (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    CHECK(!std::string(first_id).empty());
+    CHECK(!std::string(second_id).empty());
+    CHECK(std::string(first_id) != std::string(second_id));
+  }
+}
+
+// ============================================================================
+// SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT
+// ============================================================================
+
+TEST_CASE("SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT default value is -1.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT is queried on a fresh statement
+  SQLINTEGER value = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value -1 (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == -1);
+  }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT is set to 0, then 3, then reset to -1
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)0, 0);
+  NEW_DRIVER_ONLY("BD#56") { REQUIRE(ret == SQL_SUCCESS); }
+
+  // Then each get should return the value that was set (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    SQLINTEGER val = -99;
+    ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, &val, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(val == 0);
+
+    ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    val = -99;
+    ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, &val, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(val == 3);
+
+    ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)-1, 0);
+    REQUIRE(ret == SQL_SUCCESS);
+    val = 0;
+    ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, &val, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(val == -1);
+  }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT invalid value less than -1 returns HY024.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT is set to -2
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)-2, 0);
+
+  // Then it should return SQL_ERROR with SQLSTATE HY024 (BD#56)
+  NEW_DRIVER_ONLY("BD#56") {
+    REQUIRE(ret == SQL_ERROR);
+    CHECK(get_sqlstate(stmt) == "HY024");
+  }
+}
+
+TEST_CASE("SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT forwards count to server and executes all statements.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When MULTI_STATEMENT_COUNT is set to 2 and two SELECTs are executed
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
+  NEW_DRIVER_ONLY("BD#56") { REQUIRE(ret == SQL_SUCCESS); }
+
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS a; SELECT 2 AS b"), SQL_NTS);
+  NEW_DRIVER_ONLY("BD#56") { REQUIRE_ODBC(ret, stmt); }
+
+  // Then first result set contains 1
+  NEW_DRIVER_ONLY("BD#56") {
+    ret = SQLFetch(stmt.getHandle());
+    REQUIRE_ODBC(ret, stmt);
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 1);
+
+    // And second result set contains 2
+    ret = SQLMoreResults(stmt.getHandle());
+    REQUIRE_ODBC(ret, stmt);
+    ret = SQLFetch(stmt.getHandle());
+    REQUIRE_ODBC(ret, stmt);
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 2);
+
+    // No more result sets
+    ret = SQLMoreResults(stmt.getHandle());
+    CHECK(ret == SQL_NO_DATA);
+  }
+}


### PR DESCRIPTION
## Description

Adds support for Snowflake-specific ODBC statement attributes:

- **`SQL_SF_STMT_ATTR_LAST_QUERY_ID`**: Read-only attribute that returns the query ID of the last executed statement. Returns an empty string before any execution and updates with each new query execution.

- **`SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT`**: Configurable attribute for multi-statement execution control. Accepts values of -1 (auto-detect, default), 0 (single statement), or N > 0 (expect exactly N statements). Values less than -1 are rejected with an error.

Updates the statement attribute base value from a hardcoded `2000100` to use the standard ODBC driver attribute base (`0x4000 + 0x106`) for better compatibility. The multi-statement count setting is applied via RPC calls before query execution in both direct execution and prepare/execute paths.

  ## Testing                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                              
  - Added comprehensive C++ test suite covering both attributes                                                                                                                                                                                                                               
  - Tests verify default values, get/set operations, error handling for invalid values, and behavior across multiple executions                                                                                                                                                               
  - `SQL_SF_STMT_ATTR_LAST_QUERY_ID` get before execution and get after `SQLExecDirect` run on both drivers (identical behavior); `SQLPrepare`+`SQLExecute` path and all `SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT` assertions are gated with `NEW_DRIVER_ONLY` (BD#55)                         
  - All 9 tests pass on both new and reference (old) drivers                                                                                                                                                                                                                                  