### PR TITLE
SNOW-3235553 Parameter Array Attributes

### DIFF
--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -85,6 +85,12 @@ fn get_ard_field(
                 }
                 Ok(())
             }
+            DescField::ArrayStatusPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+                }
+                Ok(())
+            }
             _ => {
                 tracing::warn!("get_desc_field: unsupported ARD header field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
@@ -284,6 +290,12 @@ fn set_ard_field(
                 let ptr = value_ptr as *mut sql::Len;
                 tracing::debug!("set_desc_field: ARD BindOffsetPtr = {:?}", ptr);
                 desc.bind_offset_ptr = ptr;
+                Ok(())
+            }
+            DescField::ArrayStatusPtr => {
+                let ptr = value_ptr as *mut u16;
+                tracing::debug!("set_desc_field: APD ArrayStatusPtr = {:?}", ptr);
+                desc.array_status_ptr = ptr;
                 Ok(())
             }
             _ => {

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -10,12 +10,12 @@ use crate::api::error::{
 use crate::api::runtime::global;
 use crate::api::{
     ApdRecord, ConnectionState, FreeStmtOption, IpdRecord, OdbcResult, ParamDirection,
-    SQL_CONCUR_LOCK, SQL_CONCUR_READ_ONLY, SQL_CONCUR_VALUES, SQL_INSENSITIVE, SQL_NONSCROLLABLE,
-    SQL_NOSCAN_OFF, SQL_NOSCAN_ON, SQL_SCROLLABLE, SQL_SENSITIVE, SQL_UNSPECIFIED, SqlType,
-    Statement, StatementState, stmt_from_handle,
+    ParameterBinding, SQL_CONCUR_LOCK, SQL_CONCUR_READ_ONLY, SQL_CONCUR_VALUES, SQL_INSENSITIVE,
+    SQL_NONSCROLLABLE, SQL_NOSCAN_OFF, SQL_NOSCAN_ON, SQL_SCROLLABLE, SQL_SENSITIVE,
+    SQL_UNSPECIFIED, SqlType, Statement, StatementState, stmt_from_handle,
 };
 use crate::conversion::Binding;
-use crate::conversion::param_binding::odbc_bindings_to_json;
+use crate::conversion::param_binding::{odbc_bindings_to_json, odbc_bindings_to_json_array};
 use arrow::array::RecordBatchReader;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use odbc_sys as sql;
@@ -56,6 +56,10 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             db_handle: _,
             conn_handle,
         } => {
+            let array_size = stmt.apd.array_size;
+            let rows_processed_ptr = stmt.ipd.rows_processed_ptr;
+            let param_status_ptr = stmt.ipd.array_status_ptr;
+            let operation_ptr = stmt.apd.array_status_ptr as *const u16;
             let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, false)?;
             let stmt_handle = stmt.stmt_handle;
             let query_timeout = stmt.query_timeout;
@@ -100,6 +104,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             let response = response?;
 
             let query_id = response.result.as_ref().map(|r| r.query_id.clone());
+            write_param_array_status(rows_processed_ptr, param_status_ptr, array_size, operation_ptr);
             update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
             let execute_state = create_execute_state(response, false)?;
             let is_zero_dml = matches!(
@@ -286,6 +291,10 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let sql_text = stmt.sql_text.clone();
     let stmt_handle = stmt.stmt_handle;
     let multi_statement_count = stmt.multi_statement_count;
+    let array_size = stmt.apd.array_size;
+    let rows_processed_ptr = stmt.ipd.rows_processed_ptr;
+    let param_status_ptr = stmt.ipd.array_status_ptr;
+    let operation_ptr = stmt.apd.array_status_ptr as *const u16;
     let conn = unsafe { &mut *stmt.conn_ptr() };
     match &mut conn.state {
         ConnectionState::Connected {
@@ -329,6 +338,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             })?;
 
             tracing::info!("execute: Successfully executed statement");
+            write_param_array_status(rows_processed_ptr, param_status_ptr, array_size, operation_ptr);
             update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
 
             let query_id = response.result.as_ref().map(|r| r.query_id.clone());
@@ -416,12 +426,64 @@ fn create_execute_state(
     })
 }
 
+/// Per-parameter-set status constants written to `SQL_ATTR_PARAM_STATUS_PTR`.
+const SQL_PARAM_SUCCESS: u16 = 0;
+/// Written for rows skipped via `SQL_ATTR_PARAM_OPERATION_PTR`.
+const SQL_PARAM_UNUSED: u16 = 7;
+/// Value in the operation array that marks a row as ignored.
+const SQL_PARAM_IGNORE_OP: u16 = 1;
+
+/// After a successful execution with parameter arrays, write status values to the
+/// IPD pointers set via `SQL_ATTR_PARAMS_PROCESSED_PTR` and `SQL_ATTR_PARAM_STATUS_PTR`.
+///
+/// `rows_processed_ptr` receives the count of parameter sets actually sent (excluding
+/// ignored rows). `array_status_ptr` receives `SQL_PARAM_SUCCESS` for each processed
+/// row and `SQL_PARAM_UNUSED` for rows skipped via `operation_ptr`.
+fn write_param_array_status(
+    rows_processed_ptr: *mut sql::ULen,
+    array_status_ptr: *mut u16,
+    array_size: usize,
+    operation_ptr: *const u16,
+) {
+    let ignored = if operation_ptr.is_null() {
+        0
+    } else {
+        (0..array_size)
+            .filter(|&i| unsafe { *operation_ptr.add(i) } == SQL_PARAM_IGNORE_OP)
+            .count()
+    };
+
+    if !rows_processed_ptr.is_null() {
+        unsafe { *rows_processed_ptr = (array_size - ignored) as sql::ULen };
+    }
+
+    if !array_status_ptr.is_null() {
+        for i in 0..array_size {
+            let status = if !operation_ptr.is_null()
+                && unsafe { *operation_ptr.add(i) } == SQL_PARAM_IGNORE_OP
+            {
+                SQL_PARAM_UNUSED
+            } else {
+                SQL_PARAM_SUCCESS
+            };
+            unsafe { *array_status_ptr.add(i) = status };
+        }
+    }
+}
+
 /// Build JSON query bindings from ODBC parameter bindings.
 ///
 /// When `prepared` is true (SQLPrepare+SQLExecute flow), the IPD has server-
 /// provided parameter count and we validate that the APD covers every marker.
 /// When `prepared` is false (SQLExecDirect), the IPD only has records from
 /// SQLBindParameter — we send whatever the APD has and let the server validate.
+///
+/// When `apd.array_size > 1`, emits an array binding JSON where each parameter's
+/// `"value"` is a JSON array of values (one per row).
+///
+/// Returns `(bindings, json_owner)`. The caller **must** keep `json_owner` alive
+/// until after the bindings have been consumed by `statement_execute_query`,
+/// because `BinaryDataPtr` holds a raw pointer into the owned `String`.
 fn apply_parameter_bindings(
     apd: &crate::api::ApdDescriptor,
     ipd: &crate::api::IpdDescriptor,
@@ -459,12 +521,37 @@ fn apply_parameter_bindings(
             }
         }
     }
+
+    let array_size = apd.array_size;
     tracing::info!(
-        "apply_parameter_bindings: Found {} bound parameters",
-        apd.records.len()
+        "apply_parameter_bindings: Found {} bound parameters, array_size={}",
+        apd.records.len(),
+        array_size,
     );
 
-    let json_string = odbc_bindings_to_json(apd, ipd).context(JsonBindingSnafu {})?;
+    let json_string = if array_size > 1 {
+        // Build ParameterBinding map for array execution.
+        let max_key = apd.desc_count().max(ipd.desc_count());
+        let mut parameter_bindings = std::collections::HashMap::new();
+        for param_num in 1..=max_key {
+            if let (Some(apd_rec), Some(ipd_rec)) =
+                (apd.records.get(&param_num), ipd.records.get(&param_num))
+            {
+                parameter_bindings.insert(param_num, ParameterBinding::from_apd_ipd(apd_rec, ipd_rec));
+            }
+        }
+        let bind_type = apd.bind_type as usize;
+        let bind_offset = if apd.bind_offset_ptr.is_null() {
+            0
+        } else {
+            unsafe { *apd.bind_offset_ptr }
+        };
+        let operation_ptr = apd.array_status_ptr as *const u16;
+        odbc_bindings_to_json_array(&parameter_bindings, array_size, bind_type, bind_offset, operation_ptr)
+            .context(JsonBindingSnafu {})?
+    } else {
+        odbc_bindings_to_json(apd, ipd).context(JsonBindingSnafu {})?
+    };
 
     let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
     let json_data_len = json_string.len();
@@ -1098,6 +1185,55 @@ pub fn set_stmt_attr(
             stmt.retrieve_data = val;
             Ok(())
         }
+        StmtAttr::ParamsetSize => {
+            let size = value_ptr as usize;
+            let effective = if size == 0 {
+                tracing::warn!("set_stmt_attr: ParamsetSize value 0 is invalid; coercing to 1");
+                1
+            } else {
+                size
+            };
+            tracing::debug!("set_stmt_attr: ParamsetSize = {}", effective);
+            stmt.apd.array_size = effective;
+            Ok(())
+        }
+        StmtAttr::ParamBindType => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: ParamBindType = {}", val);
+            stmt.apd.bind_type = val;
+            Ok(())
+        }
+        StmtAttr::ParamBindOffsetPtr => {
+            let ptr = value_ptr as *mut sql::Len;
+            tracing::debug!("set_stmt_attr: ParamBindOffsetPtr = {:?}", ptr);
+            stmt.apd.bind_offset_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamStatusPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: ParamStatusPtr = {:?}", ptr);
+            stmt.ipd.array_status_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamsProcessedPtr => {
+            let ptr = value_ptr as *mut sql::ULen;
+            tracing::debug!("set_stmt_attr: ParamsProcessedPtr = {:?}", ptr);
+            stmt.ipd.rows_processed_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamOperationPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: ParamOperationPtr = {:?}", ptr);
+            stmt.apd.array_status_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::SnowflakeLastQueryId => {
+            // Read-only attribute — cannot be set
+            crate::api::error::ReadOnlyAttributeSnafu {
+                attribute: attr as i32,
+            }
+            .fail()
+        }
         StmtAttr::SnowflakeMultiStatementCount => {
             let val = value_ptr as i64;
             if val < -1 {
@@ -1341,6 +1477,59 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
             if !string_length_ptr.is_null() {
                 unsafe { *string_length_ptr = size_of::<sql::ULen>() as sql::Integer };
             }
+            Ok(())
+        }
+        StmtAttr::ParamsetSize => {
+            unsafe {
+                *(value_ptr as *mut sql::ULen) = stmt.apd.array_size as sql::ULen;
+                if !string_length_ptr.is_null() {
+                    *string_length_ptr = size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamBindType => {
+            unsafe {
+                *(value_ptr as *mut sql::ULen) = stmt.apd.bind_type;
+                if !string_length_ptr.is_null() {
+                    *string_length_ptr = size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamBindOffsetPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut sql::Len) = stmt.apd.bind_offset_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::ParamStatusPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut u16) = stmt.ipd.array_status_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::ParamsProcessedPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut sql::ULen) = stmt.ipd.rows_processed_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::ParamOperationPtr => {
+            unsafe {
+                *(value_ptr as *mut *mut u16) = stmt.apd.array_status_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::SnowflakeLastQueryId => {
+            let id = stmt.last_query_id.as_deref().unwrap_or("");
+            write_string_bytes_i32::<E>(
+                id,
+                value_ptr as *mut E::Char,
+                buffer_length,
+                string_length_ptr,
+                None,
+            );
             Ok(())
         }
         StmtAttr::SnowflakeMultiStatementCount => {

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -317,6 +317,18 @@ pub enum StmtAttr {
     UseBookmarks = 12,
     /// `SQL_ATTR_ENABLE_AUTO_IPD` (15) — automatic population of the IPD.
     EnableAutoIpd = 15,
+    /// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` (17) — pointer to offset applied to parameter binding pointers (APD).
+    ParamBindOffsetPtr = 17,
+    /// `SQL_ATTR_PARAM_BIND_TYPE` (18) — column-wise (0) or row-wise binding for parameters (APD).
+    ParamBindType = 18,
+    /// `SQL_ATTR_PARAM_OPERATION_PTR` (19) — pointer to per-parameter operation array (APD).
+    ParamOperationPtr = 19,
+    /// `SQL_ATTR_PARAM_STATUS_PTR` (20) — pointer to per-parameter status array (IPD).
+    ParamStatusPtr = 20,
+    /// `SQL_ATTR_PARAMS_PROCESSED_PTR` (21) — pointer to count of parameters processed (IPD).
+    ParamsProcessedPtr = 21,
+    /// `SQL_ATTR_PARAMSET_SIZE` (22) — number of parameter sets in the parameter arrays (APD).
+    ParamsetSize = 22,
     /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
     RowBindOffsetPtr = 23,
     /// `SQL_ATTR_ROW_STATUS_PTR` (25) — pointer to per-row status array.
@@ -362,6 +374,12 @@ impl TryFrom<i32> for StmtAttr {
             11 => Ok(StmtAttr::RetrieveData),
             12 => Ok(StmtAttr::UseBookmarks),
             15 => Ok(StmtAttr::EnableAutoIpd),
+            17 => Ok(StmtAttr::ParamBindOffsetPtr),
+            18 => Ok(StmtAttr::ParamBindType),
+            19 => Ok(StmtAttr::ParamOperationPtr),
+            20 => Ok(StmtAttr::ParamStatusPtr),
+            21 => Ok(StmtAttr::ParamsProcessedPtr),
+            22 => Ok(StmtAttr::ParamsetSize),
             23 => Ok(StmtAttr::RowBindOffsetPtr),
             25 => Ok(StmtAttr::RowStatusPtr),
             26 => Ok(StmtAttr::RowsFetchedPtr),
@@ -691,6 +709,8 @@ pub struct ArdDescriptor {
     pub bind_type: sql::ULen,
     /// `SQL_DESC_BIND_OFFSET_PTR` / `SQL_ATTR_ROW_BIND_OFFSET_PTR` — default null.
     pub bind_offset_ptr: *mut sql::Len,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` on APD / `SQL_ATTR_PARAM_OPERATION_PTR` — default null.
+    pub array_status_ptr: *mut u16,
 }
 
 impl Default for ArdDescriptor {
@@ -707,6 +727,7 @@ impl ArdDescriptor {
             array_size: 1,
             bind_type: 0,
             bind_offset_ptr: std::ptr::null_mut(),
+            array_status_ptr: std::ptr::null_mut(),
         }
     }
 
@@ -744,6 +765,8 @@ pub struct ApdDescriptor {
     pub bind_type: sql::ULen,
     /// `SQL_DESC_BIND_OFFSET_PTR` — default null.
     pub bind_offset_ptr: *mut sql::Len,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` / `SQL_ATTR_PARAM_OPERATION_PTR` — default null.
+    pub array_status_ptr: *mut u16,
 }
 
 impl Default for ApdDescriptor {
@@ -760,6 +783,7 @@ impl ApdDescriptor {
             array_size: 1,
             bind_type: 0,
             bind_offset_ptr: std::ptr::null_mut(),
+            array_status_ptr: std::ptr::null_mut(),
         }
     }
 
@@ -1036,6 +1060,8 @@ impl Default for IpdRecord {
 #[derive(Debug, Clone)]
 pub struct ParameterBinding {
     pub sql_data_type: sql::SqlDataType,
+    /// Alias for `sql_data_type` used by the array execution path.
+    pub parameter_type: sql::SqlDataType,
     pub value_type: CDataType,
     pub parameter_value_ptr: sql::Pointer,
     pub buffer_length: sql::Len,
@@ -1046,6 +1072,7 @@ impl ParameterBinding {
     pub fn from_apd_ipd(apd: &ApdRecord, ipd: &IpdRecord) -> Self {
         Self {
             sql_data_type: ipd.sql_data_type,
+            parameter_type: ipd.sql_data_type,
             value_type: apd.value_type,
             parameter_value_ptr: apd.data_ptr,
             buffer_length: apd.buffer_length,

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ffi::{CStr, c_char},
     mem, slice, str,
 };
@@ -15,7 +16,8 @@ use super::boolean::SnowflakeBoolean;
 use super::date::SnowflakeDate;
 use super::error::{
     InvalidParameterIndicesSnafu, InvalidUtf8Snafu, JsonBindingError, NullPointerSnafu,
-    NumericMagnitudeOverflowSnafu, SerializationSnafu, UnsupportedParameterTypeSnafu,
+    NumericMagnitudeOverflowSnafu, SerializationSnafu, UnsupportedCDataTypeSnafu,
+    UnsupportedParameterTypeSnafu,
     WCharConversionSnafu,
 };
 use super::number::{NumericSqlType, SnowflakeNumber};
@@ -482,6 +484,222 @@ pub(crate) fn read_wchar_str(binding: &ParameterBinding) -> Result<String, JsonB
         unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u16, unit_len) }
     };
     String::from_utf16(units).map_err(|_| WCharConversionSnafu.build())
+}
+
+// =============================================================================
+// Array binding support
+// =============================================================================
+
+/// Map SQL data type to the Snowflake logical type string used in array binding JSON.
+///
+/// This mirrors `make_converter` but returns only the type label without requiring
+/// a value to convert. Used for array bindings where the type is set once for all rows.
+fn sql_type_to_sf_logical_type(
+    sql_type: &sql::SqlDataType,
+) -> Result<SnowflakeLogicalType, JsonBindingError> {
+    match *sql_type {
+        sql::SqlDataType::INTEGER
+        | sql::SqlDataType::SMALLINT
+        | sql::SqlDataType::EXT_BIG_INT
+        | sql::SqlDataType::EXT_TINY_INT
+        | sql::SqlDataType::DECIMAL
+        | sql::SqlDataType::NUMERIC => Ok(SnowflakeLogicalType::Fixed),
+
+        sql::SqlDataType::REAL | sql::SqlDataType::FLOAT | sql::SqlDataType::DOUBLE => {
+            Ok(SnowflakeLogicalType::Real)
+        }
+
+        sql::SqlDataType::VARCHAR
+        | sql::SqlDataType::CHAR
+        | sql::SqlDataType::EXT_LONG_VARCHAR
+        | sql::SqlDataType::EXT_W_CHAR
+        | sql::SqlDataType::EXT_W_VARCHAR
+        | sql::SqlDataType::EXT_W_LONG_VARCHAR => Ok(SnowflakeLogicalType::Text),
+
+        sql::SqlDataType::EXT_BIT => Ok(SnowflakeLogicalType::Boolean),
+
+        sql::SqlDataType::EXT_BINARY
+        | sql::SqlDataType::EXT_VAR_BINARY
+        | sql::SqlDataType::EXT_LONG_VAR_BINARY => Ok(SnowflakeLogicalType::Binary),
+
+        sql::SqlDataType::DATE => Ok(SnowflakeLogicalType::Date),
+
+        sql::SqlDataType::TIME => Ok(SnowflakeLogicalType::Time),
+
+        sql::SqlDataType::TIMESTAMP | sql::SqlDataType::EXT_TIMESTAMP => {
+            Ok(SnowflakeLogicalType::TimestampNtz)
+        }
+
+        _ => {
+            tracing::error!(
+                "sql_type_to_sf_logical_type: unsupported type {:?}",
+                sql_type
+            );
+            UnsupportedParameterTypeSnafu {
+                sql_type: *sql_type,
+            }
+            .fail()
+        }
+    }
+}
+
+/// Compute the byte stride between consecutive elements in column-wise array binding.
+///
+/// Uses `buffer_length` when positive; falls back to the natural size of fixed-width C
+/// types when `buffer_length <= 0`. Returns an error for variable-length types that
+/// require an explicit `buffer_length`.
+fn column_wise_stride(binding: &ParameterBinding) -> Result<usize, JsonBindingError> {
+    if binding.buffer_length > 0 {
+        return Ok(binding.buffer_length as usize);
+    }
+    let size = match binding.value_type {
+        CDataType::Bit | CDataType::UTinyInt | CDataType::STinyInt => 1,
+        CDataType::Short | CDataType::UShort | CDataType::SShort => 2,
+        CDataType::Long | CDataType::ULong | CDataType::SLong => 4,
+        CDataType::SBigInt | CDataType::UBigInt => 8,
+        CDataType::Float => 4,
+        CDataType::Double => 8,
+        other => {
+            tracing::error!(
+                "column_wise_stride: variable-length C type {other:?} requires buffer_length > 0"
+            );
+            return UnsupportedCDataTypeSnafu { c_type: other }.fail();
+        }
+    };
+    Ok(size)
+}
+
+/// Compute `(value_ptr, ind_ptr)` for a specific row within a parameter array.
+///
+/// Handles both column-wise (`bind_type == 0`) and row-wise (`bind_type == struct_size`)
+/// layouts, plus the optional byte offset from `bind_offset`.
+fn compute_element_ptrs(
+    binding: &ParameterBinding,
+    row: usize,
+    bind_type: usize,
+    bind_offset: sql::Len,
+) -> Result<(sql::Pointer, *mut sql::Len), JsonBindingError> {
+    let byte_offset = if bind_offset > 0 {
+        bind_offset as usize
+    } else {
+        0
+    };
+
+    if bind_type == 0 {
+        // Column-wise: consecutive elements advance by buffer_length (or type size)
+        let stride = column_wise_stride(binding)?;
+        let eff_val = unsafe {
+            (binding.parameter_value_ptr as *const u8)
+                .add(byte_offset)
+                .add(row * stride) as sql::Pointer
+        };
+        let eff_ind = if binding.str_len_or_ind_ptr.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe {
+                let base =
+                    (binding.str_len_or_ind_ptr as *const u8).add(byte_offset) as *mut sql::Len;
+                base.add(row)
+            }
+        };
+        Ok((eff_val, eff_ind))
+    } else {
+        // Row-wise: both data and indicator advance by the struct size
+        let struct_size = bind_type;
+        let eff_val = unsafe {
+            (binding.parameter_value_ptr as *const u8)
+                .add(byte_offset)
+                .add(row * struct_size) as sql::Pointer
+        };
+        let eff_ind = if binding.str_len_or_ind_ptr.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe {
+                (binding.str_len_or_ind_ptr as *const u8)
+                    .add(byte_offset)
+                    .add(row * struct_size) as *mut sql::Len
+            }
+        };
+        Ok((eff_val, eff_ind))
+    }
+}
+
+/// `SQL_PARAM_IGNORE` value in the operation array (`SQL_ATTR_PARAM_OPERATION_PTR`).
+const SQL_PARAM_IGNORE: u16 = 1;
+
+/// Convert ODBC parameter array bindings to JSON for server-side binding.
+///
+/// When `array_size > 1`, each parameter's `"value"` becomes a JSON array:
+/// ```json
+/// {"1": {"type": "FIXED", "value": ["1", "2", "3"]}}
+/// ```
+/// Rows where `operation_ptr[row] == SQL_PARAM_IGNORE` are omitted from the arrays.
+///
+/// # Safety
+/// All `parameter_value_ptr` and `str_len_or_ind_ptr` pointers in `bindings` must remain
+/// valid for the duration of this call. `operation_ptr`, if non-null, must point to an
+/// array of at least `array_size` elements.
+pub fn odbc_bindings_to_json_array(
+    bindings: &HashMap<u16, ParameterBinding>,
+    array_size: usize,
+    bind_type: usize,
+    bind_offset: sql::Len,
+    operation_ptr: *const u16,
+) -> Result<String, JsonBindingError> {
+    let mut json_bindings = Map::new();
+    let max_key = bindings.keys().copied().max().unwrap_or(0);
+
+    for param_num in 1..=max_key {
+        let binding = bindings.get(&param_num).ok_or_else(|| {
+            tracing::error!(
+                "odbc_bindings_to_json_array: parameter #{param_num} not found. \
+                 Bindings must be contiguous and start at 1."
+            );
+            InvalidParameterIndicesSnafu.build()
+        })?;
+
+        let converter = make_converter(&binding.parameter_type)?;
+        let snowflake_type = sql_type_to_sf_logical_type(&binding.parameter_type)?;
+
+        let mut value_array = Vec::with_capacity(array_size);
+        for row in 0..array_size {
+            if !operation_ptr.is_null() && unsafe { *operation_ptr.add(row) } == SQL_PARAM_IGNORE {
+                continue;
+            }
+
+            let (eff_val, eff_ind) = compute_element_ptrs(binding, row, bind_type, bind_offset)?;
+
+            let row_binding = ParameterBinding {
+                sql_data_type: binding.parameter_type,
+                parameter_type: binding.parameter_type,
+                value_type: binding.value_type,
+                parameter_value_ptr: eff_val,
+                buffer_length: binding.buffer_length,
+                str_len_or_ind_ptr: eff_ind,
+            };
+
+            let json_val = if is_null_indicator(&row_binding) {
+                Value::Null
+            } else {
+                if row_binding.parameter_value_ptr.is_null() {
+                    return NullPointerSnafu.fail();
+                }
+                let (_, v) = converter.convert(&row_binding)?;
+                v
+            };
+            value_array.push(json_val);
+        }
+
+        let mut binding_obj = Map::new();
+        binding_obj.insert(
+            "type".to_string(),
+            Value::String(snowflake_type.as_str().to_string()),
+        );
+        binding_obj.insert("value".to_string(), Value::Array(value_array));
+        json_bindings.insert(param_num.to_string(), Value::Object(binding_obj));
+    }
+
+    serde_json::to_string(&Value::Object(json_bindings)).context(SerializationSnafu)
 }
 
 // =============================================================================

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -37,6 +37,7 @@ add_odbc_test(e2e_query_sql_set_pos query/sql_set_pos.cpp)
 add_odbc_test(e2e_query_sql_bulk_operations query/sql_bulk_operations.cpp)
 add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 add_odbc_test(e2e_query_sf_stmt_attrs query/sf_stmt_attrs.cpp)
+add_odbc_test(e2e_query_param_array_attrs query/param_array_attrs.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/param_array_attrs.cpp
+++ b/odbc_tests/tests/e2e/query/param_array_attrs.cpp
@@ -1,0 +1,354 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+
+// ============================================================================
+// SQL_ATTR_PARAMSET_SIZE
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE default value is 1.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is queried on a fresh statement
+  SQLULEN value = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value 1
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 1);
+}
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is set to 5
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)5, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved value should be 5
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 5);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_BIND_TYPE
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_TYPE default value is SQL_PARAM_BIND_BY_COLUMN.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_TYPE is queried on a fresh statement
+  SQLULEN value = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value 0
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == SQL_PARAM_BIND_BY_COLUMN);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_TYPE can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_TYPE is set to a row size
+  const SQLULEN row_size = 128;
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER)row_size, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved value should match
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == row_size);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_BIND_OFFSET_PTR
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_OFFSET_PTR default value is NULL.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_OFFSET_PTR is queried on a fresh statement
+  SQLLEN* ptr = reinterpret_cast<SQLLEN*>(0xdeadbeef);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value NULL
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_OFFSET_PTR can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_OFFSET_PTR is set to a pointer
+  SQLLEN offset = 0;
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &offset, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved pointer should match
+  SQLLEN* retrieved = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &retrieved, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieved == &offset);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_STATUS_PTR
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_STATUS_PTR default value is NULL.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_STATUS_PTR is queried on a fresh statement
+  SQLUSMALLINT* ptr = reinterpret_cast<SQLUSMALLINT*>(0xdeadbeef);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value NULL
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_STATUS_PTR can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_STATUS_PTR is set to a pointer
+  SQLUSMALLINT status[5] = {};
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved pointer should match
+  SQLUSMALLINT* retrieved = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, &retrieved, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieved == status);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAMS_PROCESSED_PTR
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAMS_PROCESSED_PTR default value is NULL.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMS_PROCESSED_PTR is queried on a fresh statement
+  SQLULEN* ptr = reinterpret_cast<SQLULEN*>(0xdeadbeef);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value NULL
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAMS_PROCESSED_PTR can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMS_PROCESSED_PTR is set to a pointer
+  SQLULEN processed = 0;
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved pointer should match
+  SQLULEN* retrieved = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &retrieved, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieved == &processed);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_OPERATION_PTR
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_OPERATION_PTR default value is NULL.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_OPERATION_PTR is queried on a fresh statement
+  SQLUSMALLINT* ptr = reinterpret_cast<SQLUSMALLINT*>(0xdeadbeef);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value NULL
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_OPERATION_PTR can be set and retrieved.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_OPERATION_PTR is set to a pointer
+  SQLUSMALLINT ops[5] = {};
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, ops, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then it should return SQL_SUCCESS and the retrieved pointer should match
+  SQLUSMALLINT* retrieved = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, &retrieved, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieved == ops);
+}
+
+// ============================================================================
+// Array execution
+// ============================================================================
+
+TEST_CASE("PARAMSET_SIZE greater than 1 executes multiple parameter sets.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  const std::string table = "param_array_test_paramset_size";
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE " + table + " (v INTEGER)");
+
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called with PARAMSET_SIZE set to 3 and an array of 3 integer values
+  SQLINTEGER values[3] = {10, 20, 30};
+  SQLLEN indicators[3] = {0, 0, 0};
+
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                                   sizeof(SQLINTEGER), indicators);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)("INSERT INTO " + table + " VALUES (?)").c_str(), SQL_NTS);
+
+  // Then it should return SQL_SUCCESS and insert all 3 rows
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Verify 3 rows were inserted
+  auto verify_stmt = conn.execute("SELECT COUNT(*) FROM " + table);
+  SQLLEN count = 0;
+  SQLBindCol(verify_stmt.getHandle(), 1, SQL_C_SLONG, &count, 0, nullptr);
+  SQLFetch(verify_stmt.getHandle());
+  CHECK(count == 3);
+
+  conn.execute("DROP TABLE IF EXISTS " + table);
+}
+
+TEST_CASE("PARAMS_PROCESSED_PTR is written with the number of parameter sets after execution.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  const std::string table = "param_array_test_params_processed";
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE " + table + " (v INTEGER)");
+
+  auto stmt = conn.createStatement();
+
+  SQLINTEGER values[3] = {1, 2, 3};
+  SQLLEN indicators[3] = {0, 0, 0};
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                                   sizeof(SQLINTEGER), indicators);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQLExecDirect is called with PARAMSET_SIZE set to 3 and PARAMS_PROCESSED_PTR bound
+  SQLULEN processed = 0;
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)("INSERT INTO " + table + " VALUES (?)").c_str(), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then PARAMS_PROCESSED_PTR should contain 3 after execution
+  CHECK(processed == 3);
+
+  conn.execute("DROP TABLE IF EXISTS " + table);
+}
+
+TEST_CASE("PARAM_STATUS_PTR is written with SQL_PARAM_SUCCESS for each row after execution.") {
+  SKIP_OLD_DRIVER("SNOW-3235556", "Parameter array statement attributes are new driver feature");
+
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  const std::string table = "param_array_test_param_status";
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE " + table + " (v INTEGER)");
+
+  auto stmt = conn.createStatement();
+
+  SQLINTEGER values[3] = {7, 8, 9};
+  SQLLEN indicators[3] = {0, 0, 0};
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                                   sizeof(SQLINTEGER), indicators);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQLExecDirect is called with PARAMSET_SIZE set to 3 and PARAM_STATUS_PTR bound
+  SQLUSMALLINT status[3] = {0xFFFF, 0xFFFF, 0xFFFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)("INSERT INTO " + table + " VALUES (?)").c_str(), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then each slot of PARAM_STATUS_PTR should contain SQL_PARAM_SUCCESS after execution
+  CHECK(status[0] == SQL_PARAM_SUCCESS);
+  CHECK(status[1] == SQL_PARAM_SUCCESS);
+  CHECK(status[2] == SQL_PARAM_SUCCESS);
+
+  conn.execute("DROP TABLE IF EXISTS " + table);
+}

--- a/tests/definitions/odbc/query/param_array_attrs.feature
+++ b/tests/definitions/odbc/query/param_array_attrs.feature
@@ -1,0 +1,94 @@
+@odbc
+Feature: Parameter array statement attributes
+  # Tests for SQL_ATTR_PARAMSET_SIZE, SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  # SQL_ATTR_PARAM_STATUS_PTR, SQL_ATTR_PARAMS_PROCESSED_PTR, and SQL_ATTR_PARAM_OPERATION_PTR
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAMSET_SIZE default value is 1.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAMSET_SIZE is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value 1
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAMSET_SIZE can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAMSET_SIZE is set to 5
+    Then it should return SQL_SUCCESS and the retrieved value should be 5
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_BIND_TYPE default value is SQL_PARAM_BIND_BY_COLUMN.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_BIND_TYPE is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value 0
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_BIND_TYPE can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_BIND_TYPE is set to a row size
+    Then it should return SQL_SUCCESS and the retrieved value should match
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_BIND_OFFSET_PTR default value is NULL.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_BIND_OFFSET_PTR is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value NULL
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_BIND_OFFSET_PTR can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_BIND_OFFSET_PTR is set to a pointer
+    Then it should return SQL_SUCCESS and the retrieved pointer should match
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_STATUS_PTR default value is NULL.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_STATUS_PTR is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value NULL
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_STATUS_PTR can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_STATUS_PTR is set to a pointer
+    Then it should return SQL_SUCCESS and the retrieved pointer should match
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAMS_PROCESSED_PTR default value is NULL.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAMS_PROCESSED_PTR is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value NULL
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAMS_PROCESSED_PTR can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAMS_PROCESSED_PTR is set to a pointer
+    Then it should return SQL_SUCCESS and the retrieved pointer should match
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_OPERATION_PTR default value is NULL.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_OPERATION_PTR is queried on a fresh statement
+    Then it should return SQL_SUCCESS and the value NULL
+
+  @odbc_e2e
+  Scenario: SQL_ATTR_PARAM_OPERATION_PTR can be set and retrieved.
+    Given Snowflake client is logged in
+    When SQL_ATTR_PARAM_OPERATION_PTR is set to a pointer
+    Then it should return SQL_SUCCESS and the retrieved pointer should match
+
+  @odbc_e2e
+  Scenario: PARAMSET_SIZE greater than 1 executes multiple parameter sets.
+    Given Snowflake client is logged in
+    When SQLExecDirect is called with PARAMSET_SIZE set to 3 and an array of 3 integer values
+    Then it should return SQL_SUCCESS and insert all 3 rows
+
+  @odbc_e2e
+  Scenario: PARAMS_PROCESSED_PTR is written with the number of parameter sets after execution.
+    Given Snowflake client is logged in
+    When SQLExecDirect is called with PARAMSET_SIZE set to 3 and PARAMS_PROCESSED_PTR bound
+    Then PARAMS_PROCESSED_PTR should contain 3 after execution
+
+  @odbc_e2e
+  Scenario: PARAM_STATUS_PTR is written with SQL_PARAM_SUCCESS for each row after execution.
+    Given Snowflake client is logged in
+    When SQLExecDirect is called with PARAMSET_SIZE set to 3 and PARAM_STATUS_PTR bound
+    Then each slot of PARAM_STATUS_PTR should contain SQL_PARAM_SUCCESS after execution


### PR DESCRIPTION
## Description

Implements ODBC parameter array execution support by adding six new statement attributes for handling multiple parameter sets in a single execution:

- `SQL_ATTR_PARAMSET_SIZE` - Controls the number of parameter sets to execute (default: 1)
- `SQL_ATTR_PARAM_BIND_TYPE` - Specifies column-wise (0) or row-wise binding layout
- `SQL_ATTR_PARAM_BIND_OFFSET_PTR` - Pointer to offset applied to parameter binding pointers
- `SQL_ATTR_PARAM_STATUS_PTR` - Pointer to per-parameter status array (receives `SQL_PARAM_SUCCESS` or `SQL_PARAM_UNUSED`)
- `SQL_ATTR_PARAMS_PROCESSED_PTR` - Pointer to count of parameters processed
- `SQL_ATTR_PARAM_OPERATION_PTR` - Pointer to per-parameter operation array (allows skipping rows with `SQL_PARAM_IGNORE`)

When `PARAMSET_SIZE > 1`, the driver converts ODBC parameter arrays into JSON array bindings where each parameter's value becomes a JSON array. The implementation handles both column-wise and row-wise binding layouts, respects operation arrays for skipping rows, and writes appropriate status information after execution.

Adds `ArrayStatusPtr` field to APD and ARD descriptors with corresponding get/set operations in the descriptor API. Extends parameter binding conversion to support array execution through `odbc_bindings_to_json_array()` function that processes multiple parameter sets and generates appropriate JSON for the server.

## Testing

Adds comprehensive C++ test suite covering all six parameter array attributes including default values, set/get operations, and functional array execution scenarios. Tests verify proper handling of multiple parameter sets, status reporting, and parameter counting functionality.