### PR TITLE
Fix flakiness

### DIFF
--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -4,12 +4,10 @@
 #include <sql.h>
 #include <sqlext.h>
 
-#include <chrono>
 #include <functional>
 #include <random>
 #include <stdexcept>
 #include <string>
-#include <thread>
 
 #include "Connection.hpp"
 #include "get_diag_rec.hpp"
@@ -20,15 +18,14 @@ class Schema {
  public:
   Schema(Connection& conn, const std::string& schema_name)
       : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
-    SQLHANDLE dbc_handle = conn.handleWrapper().getHandle();
-    create_schema_with_diagnostics(dbc_handle);
-    use_schema_with_retry(dbc_handle);
+    create_schema_with_diagnostics(conn.handleWrapper().getHandle());
+    execute_fn("USE SCHEMA " + schema_name);
   }
 
   Schema(const SQLHDBC dbc, const std::string& schema_name)
       : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
     create_schema_with_diagnostics(dbc);
-    use_schema_with_retry(dbc);
+    execute_fn("USE SCHEMA " + schema_name);
   }
 
   static Schema use_random_schema(Connection& conn) { return Schema(conn, generate_random_name()); }
@@ -84,78 +81,27 @@ class Schema {
 
     ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
 
-    auto diags = get_diag_rec(SQL_HANDLE_STMT, stmt);
-    SQLLEN row_count = -1;
-    SQLRowCount(stmt, &row_count);
+    if (!SQL_SUCCEEDED(ret)) {
+      auto diags = get_diag_rec(SQL_HANDLE_STMT, stmt);
+      SQLLEN row_count = -1;
+      SQLRowCount(stmt, &row_count);
 
-    WARN("[Schema] CREATE " << schema_name << ": ret=" << return_code_to_string(ret) << " row_count=" << row_count
-                            << " diag_count=" << diags.size());
+      WARN("[Schema] CREATE " << schema_name << " FAILED: ret=" << return_code_to_string(ret)
+                              << " row_count=" << row_count << " diag_count=" << diags.size());
 
-    for (size_t i = 0; i < diags.size(); ++i) {
-      WARN("[Schema]   diag[" << i << "] SQLSTATE=" << diags[i].sqlState << " NativeError=" << diags[i].nativeError
-                              << " " << diags[i].messageText);
-    }
-
-    if (SQL_SUCCEEDED(ret) && row_count != 0) {
-      SQLSMALLINT col_count = 0;
-      SQLNumResultCols(stmt, &col_count);
-      while (SQLFetch(stmt) == SQL_SUCCESS) {
-        std::string row;
-        for (SQLSMALLINT col = 1; col <= col_count; ++col) {
-          char buf[1024] = {};
-          SQLLEN indicator = 0;
-          SQLGetData(stmt, col, SQL_C_CHAR, buf, sizeof(buf), &indicator);
-          if (!row.empty()) row += ", ";
-          row += (indicator == SQL_NULL_DATA) ? "NULL" : std::string(buf);
-        }
-        WARN("[Schema]   row: " << row);
+      for (size_t i = 0; i < diags.size(); ++i) {
+        WARN("[Schema]   diag[" << i << "] SQLSTATE=" << diags[i].sqlState << " NativeError=" << diags[i].nativeError
+                                << " " << diags[i].messageText);
       }
+
+      SQLFreeStmt(stmt, SQL_CLOSE);
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+      execute_fn(sql);
+      return;
     }
 
     SQLFreeStmt(stmt, SQL_CLOSE);
     SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-
-    if (!SQL_SUCCEEDED(ret)) {
-      execute_fn(sql);
-    }
-  }
-
-  // Retry USE SCHEMA with exponential backoff: 250ms, 500ms, 1000ms (~2s total),
-  // but only for SQLSTATE 42000 ("Object does not exist") to avoid masking real errors.
-  // On the final attempt, fall through to execute_fn so failures produce
-  // the same diagnostics as the original non-retry code path.
-  void use_schema_with_retry(SQLHANDLE dbc) {
-    static constexpr int delays_ms[] = {250, 500, 1000};
-    const std::string sql = "USE SCHEMA " + schema_name;
-
-    for (int delay_ms : delays_ms) {
-      SQLHSTMT stmt = SQL_NULL_HSTMT;
-      SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
-      if (!SQL_SUCCEEDED(ret)) {
-        break;
-      }
-
-      ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
-
-      if (SQL_SUCCEEDED(ret)) {
-        SQLFreeStmt(stmt, SQL_CLOSE);
-        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-        return;
-      }
-
-      std::string state = get_sqlstate(SQL_HANDLE_STMT, stmt);
-      SQLFreeStmt(stmt, SQL_CLOSE);
-      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-
-      if (state != "42000") {
-        break;
-      }
-
-      WARN("[Schema] USE SCHEMA " << schema_name << " failed (SQLSTATE 42000), retrying in " << delay_ms << "ms");
-      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-    }
-
-    execute_fn(sql);
   }
 
   static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include "Connection.hpp"
+#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 
 class Schema {
@@ -68,7 +69,8 @@ class Schema {
     return "SCHEMA_" + std::to_string(gen());
   }
 
-  // Retry USE SCHEMA with exponential backoff: 250ms, 500ms, 1000ms (~2s total).
+  // Retry USE SCHEMA with exponential backoff: 250ms, 500ms, 1000ms (~2s total),
+  // but only for SQLSTATE 42000 ("Object does not exist") to avoid masking real errors.
   // On the final attempt, fall through to execute_fn so failures produce
   // the same diagnostics as the original non-retry code path.
   void use_schema_with_retry(SQLHANDLE dbc) {
@@ -83,14 +85,22 @@ class Schema {
       }
 
       ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
-      SQLFreeStmt(stmt, SQL_CLOSE);
-      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 
       if (SQL_SUCCEEDED(ret)) {
+        SQLFreeStmt(stmt, SQL_CLOSE);
+        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
         return;
       }
 
-      WARN("[Schema] USE SCHEMA " << schema_name << " failed, retrying in " << delay_ms << "ms");
+      std::string state = get_sqlstate(SQL_HANDLE_STMT, stmt);
+      SQLFreeStmt(stmt, SQL_CLOSE);
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+
+      if (state != "42000") {
+        break;
+      }
+
+      WARN("[Schema] USE SCHEMA " << schema_name << " failed (SQLSTATE 42000), retrying in " << delay_ms << "ms");
       std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
     }
 

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -90,7 +90,7 @@ class Schema {
         return;
       }
 
-      std::fprintf(stderr, "[Schema] USE SCHEMA %s failed, retrying in %dms\n", schema_name.c_str(), delay_ms);
+      WARN("[Schema] USE SCHEMA " << schema_name << " failed, retrying in " << delay_ms << "ms");
       std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
     }
 

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -4,10 +4,12 @@
 #include <sql.h>
 #include <sqlext.h>
 
+#include <chrono>
 #include <functional>
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 #include "Connection.hpp"
 #include "odbc_cast.hpp"
@@ -17,13 +19,13 @@ class Schema {
   Schema(Connection& conn, const std::string& schema_name)
       : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
     execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    execute_fn("USE SCHEMA " + schema_name);
+    use_schema_with_retry(conn.handleWrapper().getHandle());
   }
 
   Schema(const SQLHDBC dbc, const std::string& schema_name)
       : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
     execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    execute_fn("USE SCHEMA " + schema_name);
+    use_schema_with_retry(dbc);
   }
 
   static Schema use_random_schema(Connection& conn) { return Schema(conn, generate_random_name()); }
@@ -64,6 +66,35 @@ class Schema {
     std::random_device rd;
     std::mt19937_64 gen(rd());
     return "SCHEMA_" + std::to_string(gen());
+  }
+
+  // Retry USE SCHEMA with exponential backoff: 250ms, 500ms, 1000ms (~2s total).
+  // On the final attempt, fall through to execute_fn so failures produce
+  // the same diagnostics as the original non-retry code path.
+  void use_schema_with_retry(SQLHANDLE dbc) {
+    static constexpr int delays_ms[] = {250, 500, 1000};
+    const std::string sql = "USE SCHEMA " + schema_name;
+
+    for (int delay_ms : delays_ms) {
+      SQLHSTMT stmt = SQL_NULL_HSTMT;
+      SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+      if (!SQL_SUCCEEDED(ret)) {
+        break;
+      }
+
+      ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+      SQLFreeStmt(stmt, SQL_CLOSE);
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+
+      if (SQL_SUCCEEDED(ret)) {
+        return;
+      }
+
+      std::fprintf(stderr, "[Schema] USE SCHEMA %s failed, retrying in %dms\n", schema_name.c_str(), delay_ms);
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+
+    execute_fn(sql);
   }
 
   static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -14,18 +14,20 @@
 #include "Connection.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
+#include "odbc_return_code.hpp"
 
 class Schema {
  public:
   Schema(Connection& conn, const std::string& schema_name)
       : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
-    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    use_schema_with_retry(conn.handleWrapper().getHandle());
+    SQLHANDLE dbc_handle = conn.handleWrapper().getHandle();
+    create_schema_with_diagnostics(dbc_handle);
+    use_schema_with_retry(dbc_handle);
   }
 
   Schema(const SQLHDBC dbc, const std::string& schema_name)
       : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
-    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
+    create_schema_with_diagnostics(dbc);
     use_schema_with_retry(dbc);
   }
 
@@ -67,6 +69,55 @@ class Schema {
     std::random_device rd;
     std::mt19937_64 gen(rd());
     return "SCHEMA_" + std::to_string(gen());
+  }
+
+  void create_schema_with_diagnostics(SQLHANDLE dbc) {
+    const std::string sql = "CREATE SCHEMA IF NOT EXISTS " + schema_name;
+
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+    if (!SQL_SUCCEEDED(ret)) {
+      WARN("[Schema] CREATE: SQLAllocHandle failed for " << schema_name);
+      execute_fn(sql);
+      return;
+    }
+
+    ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+
+    auto diags = get_diag_rec(SQL_HANDLE_STMT, stmt);
+    SQLLEN row_count = -1;
+    SQLRowCount(stmt, &row_count);
+
+    WARN("[Schema] CREATE " << schema_name << ": ret=" << return_code_to_string(ret) << " row_count=" << row_count
+                            << " diag_count=" << diags.size());
+
+    for (size_t i = 0; i < diags.size(); ++i) {
+      WARN("[Schema]   diag[" << i << "] SQLSTATE=" << diags[i].sqlState << " NativeError=" << diags[i].nativeError
+                              << " " << diags[i].messageText);
+    }
+
+    if (SQL_SUCCEEDED(ret) && row_count != 0) {
+      SQLSMALLINT col_count = 0;
+      SQLNumResultCols(stmt, &col_count);
+      while (SQLFetch(stmt) == SQL_SUCCESS) {
+        std::string row;
+        for (SQLSMALLINT col = 1; col <= col_count; ++col) {
+          char buf[1024] = {};
+          SQLLEN indicator = 0;
+          SQLGetData(stmt, col, SQL_C_CHAR, buf, sizeof(buf), &indicator);
+          if (!row.empty()) row += ", ";
+          row += (indicator == SQL_NULL_DATA) ? "NULL" : std::string(buf);
+        }
+        WARN("[Schema]   row: " << row);
+      }
+    }
+
+    SQLFreeStmt(stmt, SQL_CLOSE);
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+
+    if (!SQL_SUCCEEDED(ret)) {
+      execute_fn(sql);
+    }
   }
 
   // Retry USE SCHEMA with exponential backoff: 250ms, 500ms, 1000ms (~2s total),

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -10,21 +10,19 @@
 #include <string>
 
 #include "Connection.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "odbc_return_code.hpp"
 
 class Schema {
  public:
   Schema(Connection& conn, const std::string& schema_name)
       : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
-    create_schema_with_diagnostics(conn.handleWrapper().getHandle());
+    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
     execute_fn("USE SCHEMA " + schema_name);
   }
 
   Schema(const SQLHDBC dbc, const std::string& schema_name)
       : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
-    create_schema_with_diagnostics(dbc);
+    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
     execute_fn("USE SCHEMA " + schema_name);
   }
 
@@ -66,42 +64,6 @@ class Schema {
     std::random_device rd;
     std::mt19937_64 gen(rd());
     return "SCHEMA_" + std::to_string(gen());
-  }
-
-  void create_schema_with_diagnostics(SQLHANDLE dbc) {
-    const std::string sql = "CREATE SCHEMA IF NOT EXISTS " + schema_name;
-
-    SQLHSTMT stmt = SQL_NULL_HSTMT;
-    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
-    if (!SQL_SUCCEEDED(ret)) {
-      WARN("[Schema] CREATE: SQLAllocHandle failed for " << schema_name);
-      execute_fn(sql);
-      return;
-    }
-
-    ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
-
-    if (!SQL_SUCCEEDED(ret)) {
-      auto diags = get_diag_rec(SQL_HANDLE_STMT, stmt);
-      SQLLEN row_count = -1;
-      SQLRowCount(stmt, &row_count);
-
-      WARN("[Schema] CREATE " << schema_name << " FAILED: ret=" << return_code_to_string(ret)
-                              << " row_count=" << row_count << " diag_count=" << diags.size());
-
-      for (size_t i = 0; i < diags.size(); ++i) {
-        WARN("[Schema]   diag[" << i << "] SQLSTATE=" << diags[i].sqlState << " NativeError=" << diags[i].nativeError
-                                << " " << diags[i].messageText);
-      }
-
-      SQLFreeStmt(stmt, SQL_CLOSE);
-      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-      execute_fn(sql);
-      return;
-    }
-
-    SQLFreeStmt(stmt, SQL_CLOSE);
-    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   }
 
   static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {

--- a/sf_core/src/crl/disk_tests.rs
+++ b/sf_core/src/crl/disk_tests.rs
@@ -144,14 +144,18 @@ mod disk_crl_tests {
                     crl.iter_revoked_certificates().count(),
                 );
 
-                // Performance assertions (reasonable limits for CI environments)
+                let check_limit_ms = if std::env::var("JENKINS_URL").is_ok() {
+                    500
+                } else {
+                    200
+                };
                 assert!(
                     parse_duration.as_millis() < 500,
                     "CRL parsing should be fast (< 500ms)"
                 );
                 assert!(
-                    check_duration.as_millis() < 200,
-                    "Certificate checking should be fast (< 200ms)"
+                    check_duration.as_millis() < check_limit_ms,
+                    "Certificate checking should be fast (< {check_limit_ms}ms)"
                 );
             }
         }

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -914,11 +914,24 @@ mod tests {
 
         const THREAD_COUNT: usize = 10;
 
+        // On Windows ARM64, `RemoveDirectory` is asynchronous and the
+        // "pending delete" state can persist noticeably longer than on
+        // x64, especially on CI runners.  This causes `CreateDirectory`
+        // to return transient errors (`ERROR_DELETE_PENDING`,
+        // `ERROR_ACCESS_DENIED`, etc.) for extended periods, so threads
+        // need a larger retry budget to avoid spurious lock-exhaustion
+        // failures under high contention.
+        const LOCK_RETRY_COUNT: u32 = if cfg!(all(windows, target_arch = "aarch64")) {
+            1000
+        } else {
+            100
+        };
+
         fn create_shared_cache() -> (tempfile::TempDir, Arc<FileTokenCache>) {
             let dir = tempfile::tempdir().expect("Failed to create temp dir");
             let cache = Arc::new(
                 FileTokenCache::with_directory(dir.path().to_path_buf())
-                    .retry_count(100)
+                    .retry_count(LOCK_RETRY_COUNT)
                     .retry_delay(Duration::from_millis(50)),
             );
             (dir, cache)

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -816,11 +816,30 @@ mod tests {
         #[cfg(target_os = "linux")]
         #[test]
         fn validate_file_fd_rejects_file_not_owned_by_current_user() {
-            let path = Path::new("/etc/hosts");
-            let file = fs::File::open(path).expect("/etc/hosts should be readable");
+            use std::os::unix::fs::MetadataExt;
 
-            let err = validate_file_fd(&file, path)
-                .expect_err("Expected FileNotOwnedByCurrentUser for root-owned file");
+            let current_uid = unsafe { libc::getuid() };
+
+            let (path, _dir) = if current_uid == 0 {
+                let dir = tempfile::tempdir().unwrap();
+                let p = dir.path().join("not_mine");
+                fs::write(&p, "test").unwrap();
+                let c_path = std::ffi::CString::new(p.to_str().unwrap()).unwrap();
+                let ret = unsafe { libc::chown(c_path.as_ptr(), 65534, 65534) };
+                assert_eq!(ret, 0, "chown failed");
+                assert_ne!(
+                    fs::metadata(&p).unwrap().uid(),
+                    current_uid,
+                    "File should be owned by a different user after chown"
+                );
+                (p, Some(dir))
+            } else {
+                (Path::new("/etc/hosts").to_path_buf(), None)
+            };
+
+            let file = fs::File::open(&path).expect("Should be able to open file");
+            let err = validate_file_fd(&file, &path)
+                .expect_err("Expected FileNotOwnedByCurrentUser for file owned by another user");
             assert!(
                 matches!(err, TokenCacheError::FileNotOwnedByCurrentUser { .. }),
                 "Expected FileNotOwnedByCurrentUser, got: {err}"

--- a/sf_core/tests/common/mod.rs
+++ b/sf_core/tests/common/mod.rs
@@ -7,4 +7,5 @@ pub mod mocks;
 pub mod private_key_helper;
 pub mod put_get_common;
 pub mod snowflake_test_client;
+pub mod test_utils;
 pub mod tls_proxy;

--- a/sf_core/tests/common/test_utils.rs
+++ b/sf_core/tests/common/test_utils.rs
@@ -1,10 +1,32 @@
-/// Generates a unique table name by appending a nanosecond timestamp to the
-/// base name. Prevents collisions when concurrent CI runs share the same
-/// Snowflake schema.
+/// Generates a unique table name by appending a UUID v4 (sourced from OS
+/// entropy, i.e. /dev/urandom) to the base name. Prevents collisions when
+/// concurrent CI runs share the same Snowflake schema.
 pub fn unique_table_name(base: &str) -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    format!("{base}_{nanos}")
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    format!("{base}_{id}")
+}
+
+/// RAII guard that executes a cleanup function on drop, ensuring table cleanup
+/// even if the test panics. Swallows panics in the cleanup to avoid double-panic
+/// aborts during stack unwinding.
+pub struct TableCleanupGuard<'a> {
+    table_name: String,
+    drop_fn: Box<dyn Fn(&str) + 'a>,
+}
+
+impl<'a> TableCleanupGuard<'a> {
+    pub fn new(table_name: String, drop_fn: impl Fn(&str) + 'a) -> Self {
+        Self {
+            table_name,
+            drop_fn: Box::new(drop_fn),
+        }
+    }
+}
+
+impl Drop for TableCleanupGuard<'_> {
+    fn drop(&mut self) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (self.drop_fn)(&self.table_name);
+        }));
+    }
 }

--- a/sf_core/tests/common/test_utils.rs
+++ b/sf_core/tests/common/test_utils.rs
@@ -1,0 +1,10 @@
+/// Generates a unique table name by appending a nanosecond timestamp to the
+/// base name. Prevents collisions when concurrent CI runs share the same
+/// Snowflake schema.
+pub fn unique_table_name(base: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{base}_{nanos}")
+}

--- a/sf_core/tests/integration/authentication/native_okta.rs
+++ b/sf_core/tests/integration/authentication/native_okta.rs
@@ -256,7 +256,7 @@ fn should_fail_when_saml_html_is_missing_form_action() {
 
     // And Wiremock has Okta SSO returning SAML HTML without form action
     fixture.mock.mount(okta::okta_sso_missing_form_action());
-    fixture.set_option("authentication_timeout", "5");
+    fixture.set_option("authentication_timeout", "15");
 
     // When Trying to Connect
     let result = fixture.connect();

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -2,6 +2,7 @@ use crate::common::arrow_result_helper::{
     ArrowResultHelper, assert_record_batches_match, assert_schemas_match,
 };
 use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::test_utils::unique_table_name;
 
 #[test]
 fn should_return_arrow_even_if_json_result_set_is_returned_for_all_types() {
@@ -158,22 +159,32 @@ fn should_return_array_as_arrow_even_if_json_result_set_is_returned() {
 }
 
 fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, select_query: &str) {
+    let after_table = &create_table_query[create_table_query.find("TABLE ").unwrap() + 6..];
+    let base_name = after_table
+        .split(|c: char| c.is_whitespace() || c == '(')
+        .next()
+        .unwrap();
+    let table_name = unique_table_name(base_name);
+    let create_table_query = create_table_query.replace(base_name, &table_name);
+    let insert_query = insert_query.replace(base_name, &table_name);
+    let select_query = select_query.replace(base_name, &table_name);
+
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();
 
-    client.set_sql_query(&stmt, create_table_query);
+    client.set_sql_query(&stmt, &create_table_query);
     client.execute_statement_query(&stmt);
 
     client.set_sql_query(&stmt, "ALTER SESSION SET TIMEZONE = 'Pacific/Honolulu'");
     client.execute_statement_query(&stmt);
 
-    client.set_sql_query(&stmt, insert_query);
+    client.set_sql_query(&stmt, &insert_query);
     client.execute_statement_query(&stmt);
 
     client.set_sql_query(&stmt, "ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
     client.execute_statement_query(&stmt);
 
-    client.set_sql_query(&stmt, select_query);
+    client.set_sql_query(&stmt, &select_query);
     let arrow_result = client.execute_statement_query(&stmt);
 
     client.set_sql_query(
@@ -183,7 +194,7 @@ fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, se
     let result = client.execute_statement_query(&stmt);
     assert_eq!(result.rows_affected(), 1, "Cannot force JSON result set");
 
-    client.set_sql_query(&stmt, select_query);
+    client.set_sql_query(&stmt, &select_query);
     let json_result = client.execute_statement_query(&stmt);
 
     let mut arrow_result_helper = ArrowResultHelper::from_result(arrow_result);
@@ -197,6 +208,9 @@ fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, se
     let json_columns = json_result_helper.next_batch().unwrap();
 
     assert_record_batches_match(&arrow_columns, &json_columns);
+
+    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table_name}"));
+    client.execute_statement_query(&stmt);
 
     client.release_statement(&stmt);
 }

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -2,7 +2,7 @@ use crate::common::arrow_result_helper::{
     ArrowResultHelper, assert_record_batches_match, assert_schemas_match,
 };
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use crate::common::test_utils::unique_table_name;
+use crate::common::test_utils::{TableCleanupGuard, unique_table_name};
 
 #[test]
 fn should_return_arrow_even_if_json_result_set_is_returned_for_all_types() {
@@ -170,6 +170,12 @@ fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, se
     let select_query = select_query.replace(base_name, &table_name);
 
     let client = SnowflakeTestClient::connect_with_default_auth();
+    let _guard = TableCleanupGuard::new(table_name.clone(), |name| {
+        let stmt = client.new_statement();
+        client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {name}"));
+        client.execute_statement_query(&stmt);
+        client.release_statement(&stmt);
+    });
     let stmt = client.new_statement();
 
     client.set_sql_query(&stmt, &create_table_query);
@@ -208,9 +214,6 @@ fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, se
     let json_columns = json_result_helper.next_batch().unwrap();
 
     assert_record_batches_match(&arrow_columns, &json_columns);
-
-    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table_name}"));
-    client.execute_statement_query(&stmt);
 
     client.release_statement(&stmt);
 }

--- a/sf_core/tests/integration/query/json_result_set_nulls.rs
+++ b/sf_core/tests/integration/query/json_result_set_nulls.rs
@@ -1,5 +1,6 @@
 use crate::common::arrow_result_helper::ArrowResultHelper;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::test_utils::unique_table_name;
 use arrow::array::Array;
 
 /// Forces the session to return JSON result format and executes the given query.
@@ -22,45 +23,46 @@ fn execute_json_query(client: &SnowflakeTestClient, query: &str) -> ArrowResultH
 
 #[test]
 fn should_handle_null_values_in_json_result_set() {
+    let table = unique_table_name("json_null_test");
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();
 
-    // Create table with nullable columns of various types
     client.set_sql_query(
         &stmt,
-        "CREATE OR REPLACE TABLE json_null_test (
+        &format!(
+            "CREATE OR REPLACE TABLE {table} (
             str_col STRING,
             int_col INTEGER,
             bool_col BOOLEAN,
             real_col DOUBLE,
             date_col DATE,
             ntz_col TIMESTAMP_NTZ(3)
-        )",
+        )"
+        ),
     );
     client.execute_statement_query(&stmt);
 
-    // Insert rows with null values in different columns
     client.set_sql_query(
         &stmt,
-        "INSERT INTO json_null_test VALUES
+        &format!(
+            "INSERT INTO {table} VALUES
             ('hello', 42, true, 3.14, '2024-01-15', '2024-01-15 10:30:00.123'),
             (null, null, null, null, null, null),
-            ('world', 7, false, 2.71, '2024-06-01', '2024-06-01 12:00:00.456')",
+            ('world', 7, false, 2.71, '2024-06-01', '2024-06-01 12:00:00.456')"
+        ),
     );
     client.execute_statement_query(&stmt);
     client.release_statement(&stmt);
 
-    // Query with JSON format
     let mut helper = execute_json_query(
         &client,
-        "SELECT * FROM json_null_test ORDER BY str_col NULLS FIRST",
+        &format!("SELECT * FROM {table} ORDER BY str_col NULLS FIRST"),
     );
 
     let batch = helper.next_batch().expect("Expected a record batch");
     assert_eq!(batch.num_rows(), 3);
     assert_eq!(batch.num_columns(), 6);
 
-    // First row should be all nulls (NULLS FIRST ordering)
     for col_idx in 0..batch.num_columns() {
         assert!(
             batch.column(col_idx).is_null(0),
@@ -69,7 +71,6 @@ fn should_handle_null_values_in_json_result_set() {
         );
     }
 
-    // Second and third rows should have valid values
     for col_idx in 0..batch.num_columns() {
         assert!(
             batch.column(col_idx).is_valid(1),
@@ -82,6 +83,11 @@ fn should_handle_null_values_in_json_result_set() {
             batch.schema().field(col_idx).name()
         );
     }
+
+    let stmt = client.new_statement();
+    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table}"));
+    client.execute_statement_query(&stmt);
+    client.release_statement(&stmt);
 }
 
 #[test]
@@ -101,40 +107,42 @@ fn should_handle_show_schemas_json_result_with_nulls() {
 
 #[test]
 fn should_match_null_positions_between_arrow_and_json_formats() {
+    let table = unique_table_name("json_null_parity");
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();
 
-    // Create table with sparse nulls across different types
     client.set_sql_query(
         &stmt,
-        "CREATE OR REPLACE TABLE json_null_parity (
+        &format!(
+            "CREATE OR REPLACE TABLE {table} (
             txt STRING,
             num INTEGER,
             ntz TIMESTAMP_NTZ
-        )",
+        )"
+        ),
     );
     client.execute_statement_query(&stmt);
 
     client.set_sql_query(
         &stmt,
-        "INSERT INTO json_null_parity VALUES
+        &format!(
+            "INSERT INTO {table} VALUES
             ('a', 1, '2024-01-01 00:00:00'),
             (null, 2, '2024-01-02 00:00:00'),
             ('c', null, '2024-01-03 00:00:00'),
-            ('d', 4, null)",
+            ('d', 4, null)"
+        ),
     );
     client.execute_statement_query(&stmt);
 
-    // Get Arrow result
     client.set_sql_query(
         &stmt,
-        "SELECT * FROM json_null_parity ORDER BY txt NULLS FIRST",
+        &format!("SELECT * FROM {table} ORDER BY txt NULLS FIRST"),
     );
     let arrow_result = client.execute_statement_query(&stmt);
     let mut arrow_helper = ArrowResultHelper::from_result(arrow_result);
     let arrow_batch = arrow_helper.next_batch().expect("Expected arrow batch");
 
-    // Get JSON result
     client.set_sql_query(
         &stmt,
         "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
@@ -143,17 +151,15 @@ fn should_match_null_positions_between_arrow_and_json_formats() {
 
     client.set_sql_query(
         &stmt,
-        "SELECT * FROM json_null_parity ORDER BY txt NULLS FIRST",
+        &format!("SELECT * FROM {table} ORDER BY txt NULLS FIRST"),
     );
     let json_result = client.execute_statement_query(&stmt);
     let mut json_helper = ArrowResultHelper::from_result(json_result);
     let json_batch = json_helper.next_batch().expect("Expected json batch");
 
-    // Verify both have the same number of rows
     assert_eq!(arrow_batch.num_rows(), json_batch.num_rows());
     assert_eq!(arrow_batch.num_columns(), json_batch.num_columns());
 
-    // Verify null positions match between Arrow and JSON-converted-to-Arrow
     for col_idx in 0..arrow_batch.num_columns() {
         let arrow_col = arrow_batch.column(col_idx);
         let json_col = json_batch.column(col_idx);
@@ -173,6 +179,9 @@ fn should_match_null_positions_between_arrow_and_json_formats() {
             );
         }
     }
+
+    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table}"));
+    client.execute_statement_query(&stmt);
 
     client.release_statement(&stmt);
 }

--- a/sf_core/tests/integration/query/json_result_set_nulls.rs
+++ b/sf_core/tests/integration/query/json_result_set_nulls.rs
@@ -1,6 +1,6 @@
 use crate::common::arrow_result_helper::ArrowResultHelper;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use crate::common::test_utils::unique_table_name;
+use crate::common::test_utils::{TableCleanupGuard, unique_table_name};
 use arrow::array::Array;
 
 /// Forces the session to return JSON result format and executes the given query.
@@ -25,6 +25,12 @@ fn execute_json_query(client: &SnowflakeTestClient, query: &str) -> ArrowResultH
 fn should_handle_null_values_in_json_result_set() {
     let table = unique_table_name("json_null_test");
     let client = SnowflakeTestClient::connect_with_default_auth();
+    let _guard = TableCleanupGuard::new(table.clone(), |name| {
+        let stmt = client.new_statement();
+        client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {name}"));
+        client.execute_statement_query(&stmt);
+        client.release_statement(&stmt);
+    });
     let stmt = client.new_statement();
 
     client.set_sql_query(
@@ -83,11 +89,6 @@ fn should_handle_null_values_in_json_result_set() {
             batch.schema().field(col_idx).name()
         );
     }
-
-    let stmt = client.new_statement();
-    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table}"));
-    client.execute_statement_query(&stmt);
-    client.release_statement(&stmt);
 }
 
 #[test]
@@ -109,6 +110,12 @@ fn should_handle_show_schemas_json_result_with_nulls() {
 fn should_match_null_positions_between_arrow_and_json_formats() {
     let table = unique_table_name("json_null_parity");
     let client = SnowflakeTestClient::connect_with_default_auth();
+    let _guard = TableCleanupGuard::new(table.clone(), |name| {
+        let stmt = client.new_statement();
+        client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {name}"));
+        client.execute_statement_query(&stmt);
+        client.release_statement(&stmt);
+    });
     let stmt = client.new_statement();
 
     client.set_sql_query(
@@ -179,9 +186,6 @@ fn should_match_null_positions_between_arrow_and_json_formats() {
             );
         }
     }
-
-    client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {table}"));
-    client.execute_statement_query(&stmt);
 
     client.release_statement(&stmt);
 }


### PR DESCRIPTION
## Fix flaky test failures and improve CI reliability across different environments

Addresses timing-sensitive test failures and resource contention issues that occur in various CI environments, particularly on Windows ARM64 systems and Jenkins runners.

### Performance Test Adjustments
- Add dynamic performance limits for CRL certificate checking tests based on CI environment detection
- Set 500ms limit for Jenkins environments and 200ms for local development to account for varying CI runner performance

### Windows ARM64 File Cache Improvements
- Increase lock retry count from 100 to 1000 specifically for Windows ARM64 builds
- Windows ARM64 exhibits longer "pending delete" states for directory removal operations, causing `CreateDirectory` to return transient errors (`ERROR_DELETE_PENDING`, `ERROR_ACCESS_DENIED`) for extended periods under high contention

### Authentication Timeout Extension
- Extend authentication timeout from 5 to 15 seconds in native Okta integration test to prevent timeouts on slower CI runners

### Test Infrastructure Enhancements
- Add `unique_table_name()` function to generate UUID-based table names preventing collisions in concurrent CI runs
- Implement `TableCleanupGuard` RAII pattern ensuring proper table cleanup even when tests panic
- Update JSON result set tests to use unique table names and automatic cleanup
- Improve file ownership validation test to work correctly when running as root user by creating and chowning temporary files