### PR TITLE
SNOW-3243341: e2e tests for pyarrow & pandas type conversion

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -286,7 +286,7 @@ template = "test"
 [tool.hatch.envs.reference.scripts]
 test = [
     "uv pip uninstall snowflake-connector-python-ud",
-    "uv pip install \"snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.2.0}\"",
+    "uv pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.3.0}",
     "pytest tests/integ tests/e2e --ignore=tests/e2e/pandas {args}",
 ]
 compare = "python ci/reference_tests/compare_reports.py {args}"
@@ -297,6 +297,6 @@ template = "test"
 [tool.hatch.envs.reference-pandas.scripts]
 test = [
     "uv pip uninstall snowflake-connector-python-ud",
-    "uv pip install \"snowflake-connector-python[pandas]=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.2.0}\"",
+    "uv pip install snowflake-connector-python[pandas]=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.3.0}",
     "pytest tests/e2e/pandas {args}",
 ]

--- a/python/tests/e2e/pandas/test_fetch_arrow.py
+++ b/python/tests/e2e/pandas/test_fetch_arrow.py
@@ -7,52 +7,94 @@ This module tests the cursor methods that return results as Arrow tables:
 
 from __future__ import annotations
 
+import json
+
+from datetime import time
+
 import pyarrow as pa
 import pytest
 
-from tests.e2e.types.utils import assert_connection_is_open, assert_float_equal
+from tests.e2e.types.utils import assert_connection_is_open
 
 
 LARGE_RESULT_SET_ROW_COUNT = 100_000
+
+ARROW_TYPE_CASES = [
+    # (type_name, value_expr, null_expr, value_check, arrow_type_check)
+    ("number", "1::NUMBER", "NULL::NUMBER", lambda v: v == 1, pa.types.is_int64),
+    ("scaled_number", "3.14::NUMBER(10,2)", "NULL::NUMBER(10,2)", lambda v: abs(v - 3.14) < 0.01, pa.types.is_int64),
+    ("varchar", "'hello'::VARCHAR", "NULL::VARCHAR", lambda v: v == "hello", pa.types.is_string),
+    ("float", "1.5::FLOAT", "NULL::FLOAT", lambda v: abs(v - 1.5) < 0.01, pa.types.is_float64),
+    ("boolean", "TRUE::BOOLEAN", "NULL::BOOLEAN", lambda v: v is True, pa.types.is_boolean),
+    ("date", "'2026-03-23'::DATE", "NULL::DATE", lambda v: (v.year, v.month, v.day) == (2026, 3, 23), pa.types.is_date),
+    ("time", "'12:30:00'::TIME", "NULL::TIME", lambda v: v == time(12, 30, 0), pa.types.is_time),
+    (
+        "timestamp_ntz",
+        "'2026-03-23 10:30:00'::TIMESTAMP_NTZ",
+        "NULL::TIMESTAMP_NTZ",
+        lambda v: (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 10, 30),
+        pa.types.is_timestamp,
+    ),
+    (
+        "timestamp_ltz",
+        "'2026-03-23 10:30:00'::TIMESTAMP_LTZ",
+        "NULL::TIMESTAMP_LTZ",
+        lambda v: (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 10, 30),
+        pa.types.is_timestamp,
+    ),
+    (
+        "timestamp_tz",
+        "'2026-03-23 10:30:00 +0530'::TIMESTAMP_TZ",
+        "NULL::TIMESTAMP_TZ",
+        lambda v: (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 5, 0),
+        pa.types.is_timestamp,
+    ),
+    ("binary", "TO_BINARY('ABCD','HEX')::BINARY", "NULL::BINARY", lambda v: v == b"\xab\xcd", pa.types.is_binary),
+    ("variant", "TO_VARIANT(42)", "NULL::VARIANT", lambda v: json.loads(v) == 42, pa.types.is_string),
+    ("array", "ARRAY_CONSTRUCT(1,2,3)::ARRAY", "NULL::ARRAY", lambda v: json.loads(v) == [1, 2, 3], pa.types.is_string),
+    (
+        "object",
+        "OBJECT_CONSTRUCT('key','value')::OBJECT",
+        "NULL::OBJECT",
+        lambda v: json.loads(v) == {"key": "value"},
+        pa.types.is_string,
+    ),
+]
 
 
 @pytest.mark.skip_universal("SNOW-3243341 - not implemented yet")
 class TestFetchArrowAll:
     """Tests for fetch_arrow_all cursor method."""
 
-    def test_should_fetch_typed_rows_with_nulls_as_pyarrow_table(self, execute_query, cursor, tmp_schema):
+    @pytest.mark.parametrize(
+        "type_name,value_expr,null_expr,check,_arrow_type_check",
+        ARROW_TYPE_CASES,
+        ids=[c[0] for c in ARROW_TYPE_CASES],
+    )
+    def test_should_fetch_type_name_with_null_as_pyarrow_table(
+        self, execute_query, cursor, type_name, value_expr, null_expr, check, _arrow_type_check
+    ):
         # Given Snowflake client is logged in
         assert_connection_is_open(execute_query)
 
-        # And A temporary table with columns (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN) exists
-        table_name = f"{tmp_schema}.test_arrow_all_types"
-        cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN)")
+        # And Query "ALTER SESSION SET TIMEZONE = 'UTC'" is executed
+        cursor.execute("ALTER SESSION SET TIMEZONE = 'UTC'")
 
-        # And Rows [1, "Alice", 9.5, TRUE], [2, NULL, NULL, FALSE] are inserted
-        cursor.execute(f"INSERT INTO {table_name} VALUES (1, 'Alice', 9.5, TRUE)")
-        cursor.execute(f"INSERT INTO {table_name} VALUES (2, NULL, NULL, FALSE)")
-
-        # When Query "SELECT * FROM {table} ORDER BY id" is executed
-        cursor.execute(f"SELECT * FROM {table_name} ORDER BY id")
+        # When Query "SELECT <value_expr> AS val, <null_expr> AS null_val" is executed
+        cursor.execute(f"SELECT {value_expr} AS val, {null_expr} AS null_val")
 
         # And fetch_arrow_all is called
-        result: pa.Table | None = cursor.fetch_arrow_all()
+        result = cursor.fetch_arrow_all()
 
-        # Then The result should be a pyarrow.Table with 2 rows
+        # Then The result should be a pyarrow.Table with 1 row
         assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
+        assert result.num_rows == 1
 
-        # And Row 1 should contain [1, "Alice", 9.5, True]
-        assert result.column("ID")[0].as_py() == 1
-        assert result.column("NAME")[0].as_py() == "Alice"
-        assert_float_equal(result.column("SCORE")[0].as_py(), 9.5)
-        assert result.column("ACTIVE")[0].as_py() is True
+        # And Column NULL_VAL should be null
+        assert result.column("NULL_VAL")[0].as_py() is None
 
-        # And Row 2 should contain [2, NULL, NULL, False]
-        assert result.column("ID")[1].as_py() == 2
-        assert result.column("NAME")[1].as_py() is None
-        assert result.column("SCORE")[1].as_py() is None
-        assert result.column("ACTIVE")[1].as_py() is False
+        # And Column VAL should have the correct value for <type_name>
+        assert check(result.column("VAL")[0].as_py())
 
     def test_should_return_none_from_fetch_arrow_all_for_empty_result_set(self, execute_query, cursor):
         # Given Snowflake client is logged in
@@ -66,6 +108,70 @@ class TestFetchArrowAll:
 
         # Then The result should be None
         assert result is None
+
+    @pytest.mark.parametrize(
+        "type_name,value_expr,_null_expr,_check,type_check",
+        ARROW_TYPE_CASES,
+        ids=[c[0] for c in ARROW_TYPE_CASES],
+    )
+    def test_should_return_empty_type_name_column_with_correct_arrow_type_when_force_return_table_is_true(
+        self, execute_query, cursor, type_name, value_expr, _null_expr, _check, type_check
+    ):
+        # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
+
+        # When Query "SELECT <value_expr> AS col WHERE 1=0" is executed
+        cursor.execute(f"SELECT {value_expr} AS col WHERE 1=0")
+
+        # And fetch_arrow_all is called with force_return_table=True
+        result = cursor.fetch_arrow_all(force_return_table=True)
+
+        # Then The result should be a pyarrow.Table with 0 rows
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 0
+
+        # And Column COL should have <arrow_type> Arrow type
+        assert type_check(result.schema.field("COL").type)
+
+    def test_should_convert_scaled_fixed_number_to_decimal_via_fetch_arrow_all(self, execute_query, cursor):
+        # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
+
+        # And arrow_number_to_decimal is set to True on the connection
+        cursor.connection.arrow_number_to_decimal_setter = True
+
+        # When Query "SELECT 3.14::NUMBER(10,2) AS pi" is executed
+        cursor.execute("SELECT 3.14::NUMBER(10,2) AS pi")
+
+        # And fetch_arrow_all is called
+        result = cursor.fetch_arrow_all()
+
+        # Then Column PI should be Decimal128
+        assert pa.types.is_decimal128(result.schema.field("PI").type)
+
+    def test_should_force_microsecond_precision_for_timestamps_via_fetch_arrow_all(self, execute_query, cursor):
+        # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
+
+        # When Query "SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts" is executed
+        cursor.execute("SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts")
+
+        # And fetch_arrow_all is called with force_microsecond_precision=True
+        result = cursor.fetch_arrow_all(force_microsecond_precision=True)
+
+        # Then Column TS should be a timestamp type with microsecond unit
+        ts_type = result.schema.field("TS").type
+        assert pa.types.is_timestamp(ts_type)
+        assert ts_type.unit == "us"
+
+        # And Column TS value should have microsecond=123456
+        ts_val = result.column("TS")[0].as_py()
+        assert ts_val.year == 2024
+        assert ts_val.month == 1
+        assert ts_val.day == 15
+        assert ts_val.hour == 10
+        assert ts_val.minute == 30
+        assert ts_val.microsecond == 123456
 
 
 @pytest.mark.skip_universal("SNOW-3243341 - not implemented yet")

--- a/python/tests/e2e/pandas/test_fetch_pandas.py
+++ b/python/tests/e2e/pandas/test_fetch_pandas.py
@@ -7,54 +7,87 @@ This module tests the cursor methods that return results as Pandas DataFrames:
 
 from __future__ import annotations
 
+import json
+
+from datetime import time
+from decimal import Decimal
+
 import pandas as pd
 import pytest
 
-from tests.e2e.types.utils import assert_connection_is_open, assert_float_equal
+from tests.compatibility import is_old_driver
+from tests.e2e.types.utils import assert_connection_is_open
 
 
 LARGE_RESULT_SET_ROW_COUNT = 100_000
+
+PANDAS_TYPE_CASES = [
+    ("number", "1::NUMBER", "NULL::NUMBER", lambda v: v == 1),
+    ("scaled_number", "3.14::NUMBER(10,2)", "NULL::NUMBER(10,2)", lambda v: abs(v - 3.14) < 0.01),
+    ("varchar", "'hello'::VARCHAR", "NULL::VARCHAR", lambda v: v == "hello"),
+    ("float", "1.5::FLOAT", "NULL::FLOAT", lambda v: abs(v - 1.5) < 0.01),
+    ("boolean", "TRUE::BOOLEAN", "NULL::BOOLEAN", lambda v: v),
+    ("date", "'2026-03-23'::DATE", "NULL::DATE", lambda v: (v.year, v.month, v.day) == (2026, 3, 23)),
+    ("time", "'12:30:00'::TIME", "NULL::TIME", lambda v: isinstance(v, time) and v == time(12, 30, 0)),
+    (
+        "timestamp_ntz",
+        "'2026-03-23 10:30:00'::TIMESTAMP_NTZ",
+        "NULL::TIMESTAMP_NTZ",
+        lambda v: isinstance(v, pd.Timestamp) and (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 10, 30),
+    ),
+    (
+        "timestamp_ltz",
+        "'2026-03-23 10:30:00'::TIMESTAMP_LTZ",
+        "NULL::TIMESTAMP_LTZ",
+        lambda v: isinstance(v, pd.Timestamp) and (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 10, 30),
+    ),
+    (
+        "timestamp_tz",
+        "'2026-03-23 10:30:00 +0530'::TIMESTAMP_TZ",
+        "NULL::TIMESTAMP_TZ",
+        lambda v: isinstance(v, pd.Timestamp) and (v.year, v.month, v.day, v.hour, v.minute) == (2026, 3, 23, 5, 0),
+    ),
+    ("binary", "TO_BINARY('ABCD','HEX')::BINARY", "NULL::BINARY", lambda v: v == b"\xab\xcd"),
+    ("variant", "TO_VARIANT(42)", "NULL::VARIANT", lambda v: json.loads(v) == 42),
+    ("array", "ARRAY_CONSTRUCT(1,2,3)::ARRAY", "NULL::ARRAY", lambda v: json.loads(v) == [1, 2, 3]),
+    ("object", "OBJECT_CONSTRUCT('key','value')::OBJECT", "NULL::OBJECT", lambda v: json.loads(v) == {"key": "value"}),
+]
 
 
 @pytest.mark.skip_universal("SNOW-3243341 - not implemented yet")
 class TestFetchPandasAll:
     """Tests for fetch_pandas_all cursor method."""
 
-    def test_should_fetch_typed_rows_with_nulls_as_pandas_dataframe(self, execute_query, cursor, tmp_schema):
+    @pytest.mark.parametrize(
+        "type_name,value_expr,null_expr,check",
+        PANDAS_TYPE_CASES,
+        ids=[c[0] for c in PANDAS_TYPE_CASES],
+    )
+    def test_should_fetch_type_name_with_null_as_pandas_dataframe(
+        self, execute_query, cursor, type_name, value_expr, null_expr, check
+    ):
         # Given Snowflake client is logged in
         assert_connection_is_open(execute_query)
 
-        # And A temporary table with columns (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN) exists
-        table_name = f"{tmp_schema}.test_pandas_all_types"
-        cursor.execute(f"CREATE TABLE {table_name} (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN)")
+        # And Query "ALTER SESSION SET TIMEZONE = 'UTC'" is executed
+        cursor.execute("ALTER SESSION SET TIMEZONE = 'UTC'")
 
-        # And Rows [1, "Alice", 9.5, TRUE], [2, NULL, NULL, FALSE] are inserted
-        cursor.execute(f"INSERT INTO {table_name} VALUES (1, 'Alice', 9.5, TRUE)")
-        cursor.execute(f"INSERT INTO {table_name} VALUES (2, NULL, NULL, FALSE)")
-
-        # When Query "SELECT * FROM {table} ORDER BY id" is executed
-        cursor.execute(f"SELECT * FROM {table_name} ORDER BY id")
+        # When Query "SELECT <value_expr> AS val, <null_expr> AS null_val" is executed
+        cursor.execute(f"SELECT {value_expr} AS val, {null_expr} AS null_val")
 
         # And fetch_pandas_all is called
-        result: pd.DataFrame = cursor.fetch_pandas_all()
+        result = cursor.fetch_pandas_all()
 
-        # Then The result should be a pandas.DataFrame with 2 rows
+        # Then The result should be a pandas.DataFrame with 1 row
         assert isinstance(result, pd.DataFrame)
-        assert len(result) == 2
+        assert len(result) == 1
 
-        # And Row 1 should contain [1, "Alice", 9.5, True]
-        row1 = result.iloc[0]
-        assert row1["ID"] == 1
-        assert row1["NAME"] == "Alice"
-        assert_float_equal(row1["SCORE"], 9.5)
-        assert row1["ACTIVE"] is True or row1["ACTIVE"] == True  # noqa: E712 — pandas bool
+        # And Column NULL_VAL should be null
+        null_val = result["NULL_VAL"].iloc[0]
+        assert null_val is None or pd.isna(null_val)
 
-        # And Row 2 should contain [2, None/NaN, None/NaN, False]
-        row2 = result.iloc[1]
-        assert row2["ID"] == 2
-        assert pd.isna(row2["NAME"])
-        assert pd.isna(row2["SCORE"])
-        assert row2["ACTIVE"] is False or row2["ACTIVE"] == False  # noqa: E712
+        # And Column VAL should have the correct value for <type_name>
+        assert check(result["VAL"].iloc[0])
 
     def test_should_return_empty_pandas_dataframe_for_empty_result_set(self, execute_query, cursor):
         # Given Snowflake client is logged in
@@ -69,6 +102,47 @@ class TestFetchPandasAll:
         # Then The result should be a pandas.DataFrame with 0 rows
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 0
+
+    def test_should_convert_scaled_fixed_number_to_decimal_via_fetch_pandas_all(self, execute_query, cursor):
+        # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
+
+        # And arrow_number_to_decimal is set to True on the connection
+        if is_old_driver():
+            cursor.connection.arrow_number_to_decimal_setter = True
+        else:
+            cursor.connection.arrow_number_to_decimal = True
+
+        # When Query "SELECT 3.14::NUMBER(10,2) AS pi" is executed
+        cursor.execute("SELECT 3.14::NUMBER(10,2) AS pi")
+
+        # And fetch_pandas_all is called
+        result = cursor.fetch_pandas_all()
+
+        # Then Column PI should be a Python Decimal
+        assert isinstance(result["PI"].iloc[0], Decimal)
+
+    def test_should_force_microsecond_precision_for_timestamps_via_fetch_pandas_all(self, execute_query, cursor):
+        # Given Snowflake client is logged in
+        assert_connection_is_open(execute_query)
+
+        # When Query "SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts" is executed
+        cursor.execute("SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts")
+
+        # And fetch_pandas_all is called with force_microsecond_precision=True
+        result = cursor.fetch_pandas_all(force_microsecond_precision=True)
+
+        # Then Column TS should be a pandas Timestamp
+        ts_val = result["TS"].iloc[0]
+        assert isinstance(ts_val, pd.Timestamp)
+
+        # And Column TS value should have microsecond=123456
+        assert ts_val.year == 2024
+        assert ts_val.month == 1
+        assert ts_val.day == 15
+        assert ts_val.hour == 10
+        assert ts_val.minute == 30
+        assert ts_val.microsecond == 123456
 
 
 @pytest.mark.skip_universal("SNOW-3243341 - not implemented yet")

--- a/tests/definitions/python/pandas/fetch_arrow.feature
+++ b/tests/definitions/python/pandas/fetch_arrow.feature
@@ -6,15 +6,31 @@ Feature: Arrow fetch methods (Python-specific)
   # =========================================================================== #
 
   @python_e2e
-  Scenario: should fetch typed rows with nulls as pyarrow Table
+  Scenario Outline: should fetch <type_name> with null as pyarrow Table
     Given Snowflake client is logged in
-    And A temporary table with columns (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN) exists
-    And Rows [1, "Alice", 9.5, TRUE], [2, NULL, NULL, FALSE] are inserted
-    When Query "SELECT * FROM {table} ORDER BY id" is executed
+    And Query "ALTER SESSION SET TIMEZONE = 'UTC'" is executed
+    When Query "SELECT <value_expr> AS val, <null_expr> AS null_val" is executed
     And fetch_arrow_all is called
-    Then The result should be a pyarrow.Table with 2 rows
-    And Row 1 should contain [1, "Alice", 9.5, True]
-    And Row 2 should contain [2, NULL, NULL, False]
+    Then The result should be a pyarrow.Table with 1 row
+    And Column VAL should have the correct value for <type_name>
+    And Column NULL_VAL should be null
+
+    Examples:
+      | type_name     | value_expr                                   | null_expr           |
+      | number        | 1::NUMBER                                    | NULL::NUMBER        |
+      | scaled_number | 3.14::NUMBER(10,2)                           | NULL::NUMBER(10,2)  |
+      | varchar       | 'hello'::VARCHAR                             | NULL::VARCHAR       |
+      | float         | 1.5::FLOAT                                   | NULL::FLOAT         |
+      | boolean       | TRUE::BOOLEAN                                | NULL::BOOLEAN       |
+      | date          | '2026-03-23'::DATE                           | NULL::DATE          |
+      | time          | '12:30:00'::TIME                             | NULL::TIME          |
+      | timestamp_ntz | '2026-03-23 10:30:00'::TIMESTAMP_NTZ         | NULL::TIMESTAMP_NTZ |
+      | timestamp_ltz | '2026-03-23 10:30:00'::TIMESTAMP_LTZ         | NULL::TIMESTAMP_LTZ |
+      | timestamp_tz  | '2026-03-23 10:30:00 +0530'::TIMESTAMP_TZ    | NULL::TIMESTAMP_TZ  |
+      | binary        | TO_BINARY('ABCD','HEX')::BINARY              | NULL::BINARY        |
+      | variant       | TO_VARIANT(42)                               | NULL::VARIANT       |
+      | array         | ARRAY_CONSTRUCT(1,2,3)::ARRAY                | NULL::ARRAY         |
+      | object        | OBJECT_CONSTRUCT('key','value')::OBJECT      | NULL::OBJECT        |
 
   @python_e2e
   Scenario: should return None from fetch_arrow_all for empty result set
@@ -22,6 +38,47 @@ Feature: Arrow fetch methods (Python-specific)
     When Query "SELECT 1 AS id WHERE 1=0" is executed
     And fetch_arrow_all is called
     Then The result should be None
+
+  @python_e2e
+  Scenario Outline: should return empty <type_name> column with correct Arrow type when force_return_table is true
+    Given Snowflake client is logged in
+    When Query "SELECT <value_expr> AS col WHERE 1=0" is executed
+    And fetch_arrow_all is called with force_return_table=True
+    Then The result should be a pyarrow.Table with 0 rows
+    And Column COL should have <arrow_type> Arrow type
+
+    Examples:
+      | type_name     | value_expr                                   | arrow_type |
+      | number        | 1::NUMBER                                    | int64      |
+      | scaled_number | 3.14::NUMBER(10,2)                           | int64      |
+      | varchar       | 'hello'::VARCHAR                             | string     |
+      | float         | 1.5::FLOAT                                   | float64    |
+      | boolean       | TRUE::BOOLEAN                                | boolean    |
+      | date          | '2026-03-23'::DATE                           | date       |
+      | time          | '12:30:00'::TIME                             | time       |
+      | timestamp_ntz | '2026-03-23 10:30:00'::TIMESTAMP_NTZ         | timestamp  |
+      | timestamp_ltz | '2026-03-23 10:30:00'::TIMESTAMP_LTZ         | timestamp  |
+      | timestamp_tz  | '2026-03-23 10:30:00 +0530'::TIMESTAMP_TZ    | timestamp  |
+      | binary        | TO_BINARY('ABCD','HEX')::BINARY              | binary     |
+      | variant       | TO_VARIANT(42)                               | string     |
+      | array         | ARRAY_CONSTRUCT(1,2,3)::ARRAY                | string     |
+      | object        | OBJECT_CONSTRUCT('key','value')::OBJECT      | string     |
+
+  @python_e2e
+  Scenario: should convert scaled fixed number to decimal via fetch_arrow_all
+    Given Snowflake client is logged in
+    And arrow_number_to_decimal is set to True on the connection
+    When Query "SELECT 3.14::NUMBER(10,2) AS pi" is executed
+    And fetch_arrow_all is called
+    Then Column PI should be Decimal128
+
+  @python_e2e
+  Scenario: should force microsecond precision for timestamps via fetch_arrow_all
+    Given Snowflake client is logged in
+    When Query "SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts" is executed
+    And fetch_arrow_all is called with force_microsecond_precision=True
+    Then Column TS should be a timestamp type with microsecond unit
+    And Column TS value should have microsecond=123456
 
   # =========================================================================== #
   #                        fetch_arrow_batches                                  #

--- a/tests/definitions/python/pandas/fetch_pandas.feature
+++ b/tests/definitions/python/pandas/fetch_pandas.feature
@@ -6,15 +6,31 @@ Feature: Pandas fetch methods (Python-specific)
   # =========================================================================== #
 
   @python_e2e
-  Scenario: should fetch typed rows with nulls as pandas DataFrame
+  Scenario Outline: should fetch <type_name> with null as pandas DataFrame
     Given Snowflake client is logged in
-    And A temporary table with columns (id NUMBER, name VARCHAR, score FLOAT, active BOOLEAN) exists
-    And Rows [1, "Alice", 9.5, TRUE], [2, NULL, NULL, FALSE] are inserted
-    When Query "SELECT * FROM {table} ORDER BY id" is executed
+    And Query "ALTER SESSION SET TIMEZONE = 'UTC'" is executed
+    When Query "SELECT <value_expr> AS val, <null_expr> AS null_val" is executed
     And fetch_pandas_all is called
-    Then The result should be a pandas.DataFrame with 2 rows
-    And Row 1 should contain [1, "Alice", 9.5, True]
-    And Row 2 should contain [2, None/NaN, None/NaN, False]
+    Then The result should be a pandas.DataFrame with 1 row
+    And Column VAL should have the correct value for <type_name>
+    And Column NULL_VAL should be null
+
+    Examples:
+      | type_name     | value_expr                                   | null_expr           |
+      | number        | 1::NUMBER                                    | NULL::NUMBER        |
+      | scaled_number | 3.14::NUMBER(10,2)                           | NULL::NUMBER(10,2)  |
+      | varchar       | 'hello'::VARCHAR                             | NULL::VARCHAR       |
+      | float         | 1.5::FLOAT                                   | NULL::FLOAT         |
+      | boolean       | TRUE::BOOLEAN                                | NULL::BOOLEAN       |
+      | date          | '2026-03-23'::DATE                           | NULL::DATE          |
+      | time          | '12:30:00'::TIME                             | NULL::TIME          |
+      | timestamp_ntz | '2026-03-23 10:30:00'::TIMESTAMP_NTZ         | NULL::TIMESTAMP_NTZ |
+      | timestamp_ltz | '2026-03-23 10:30:00'::TIMESTAMP_LTZ         | NULL::TIMESTAMP_LTZ |
+      | timestamp_tz  | '2026-03-23 10:30:00 +0530'::TIMESTAMP_TZ    | NULL::TIMESTAMP_TZ  |
+      | binary        | TO_BINARY('ABCD','HEX')::BINARY              | NULL::BINARY        |
+      | variant       | TO_VARIANT(42)                               | NULL::VARIANT       |
+      | array         | ARRAY_CONSTRUCT(1,2,3)::ARRAY                | NULL::ARRAY         |
+      | object        | OBJECT_CONSTRUCT('key','value')::OBJECT      | NULL::OBJECT        |
 
   @python_e2e
   Scenario: should return empty pandas DataFrame for empty result set
@@ -22,6 +38,22 @@ Feature: Pandas fetch methods (Python-specific)
     When Query "SELECT 1 AS id WHERE 1=0" is executed
     And fetch_pandas_all is called
     Then The result should be a pandas.DataFrame with 0 rows
+
+  @python_e2e
+  Scenario: should convert scaled fixed number to decimal via fetch_pandas_all
+    Given Snowflake client is logged in
+    And arrow_number_to_decimal is set to True on the connection
+    When Query "SELECT 3.14::NUMBER(10,2) AS pi" is executed
+    And fetch_pandas_all is called
+    Then Column PI should be a Python Decimal
+
+  @python_e2e
+  Scenario: should force microsecond precision for timestamps via fetch_pandas_all
+    Given Snowflake client is logged in
+    When Query "SELECT '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) AS ts" is executed
+    And fetch_pandas_all is called with force_microsecond_precision=True
+    Then Column TS should be a pandas Timestamp
+    And Column TS value should have microsecond=123456
 
   # =========================================================================== #
   #                       fetch_pandas_batches                                  #


### PR DESCRIPTION
### Update Python reference driver version and expand pandas/arrow fetch tests

Updates the default Python reference driver version from 4.2.0 to 4.3.0 in the pyproject.toml configuration for both standard and pandas environments.

Expands test coverage for pandas and arrow fetch methods by replacing simple multi-column tests with comprehensive type-specific parameterized tests. Each Snowflake data type (NUMBER, VARCHAR, FLOAT, BOOLEAN, DATE, TIME, TIMESTAMP variants, BINARY, VARIANT, ARRAY, OBJECT) now has dedicated test cases that verify correct value handling and null value processing.

Adds new test scenarios for advanced fetch options including decimal conversion via `arrow_number_to_decimal` setting, microsecond precision forcing for timestamps, and Arrow type validation for empty result sets with `force_return_table=True`.