### PR TITLE
SNOW-3243343: Add support for TIMESTAMP_OUTPUT_FORMAT in python wrapper

### DIFF
--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -37,3 +37,9 @@ behavior_differences:
     description: |
       NEW driver: Retrieving an option from a ConfigManager with no file_path returns an empty config and raises MissingConfigOptionError.
       OLD driver: Retrieving an option from a ConfigManager with no file_path raises ConfigManagerError about missing file_path.
+
+  15:
+    name: "Session parameter updates visible across cursors without execute"
+    description: |
+      NEW driver: cursor session parameters (e.g. cursor.timestamp_output_format) read from a shared connection-level cache, so changes made by one cursor are immediately visible to other cursors on the same connection without requiring a query.
+      OLD driver: Each cursor populates its session parameters independently from query responses, so a cursor that has not executed a query will not reflect changes made by another cursor.

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -682,7 +682,7 @@ class SnowflakeCursorBase(abc.ABC):
     @property
     def timestamp_output_format(self) -> str | None:
         """The session's ``TIMESTAMP_OUTPUT_FORMAT`` parameter value."""
-        raise NotImplementedError("timestamp_output_format is not yet implemented")
+        return self._connection._get_session_parameter("TIMESTAMP_OUTPUT_FORMAT")
 
     @property
     def timestamp_ltz_output_format(self) -> str | None:

--- a/python/tests/integ/test_cursor_format_properties.py
+++ b/python/tests/integ/test_cursor_format_properties.py
@@ -1,0 +1,67 @@
+"""
+Integration tests for cursor.timestamp_output_format property.
+
+This property exposes the session-level TIMESTAMP_OUTPUT_FORMAT parameter
+as read-only metadata on the cursor. It is populated from the server
+response parameters after query execution.
+"""
+
+import pytest
+
+
+class TestTimestampOutputFormat:
+    """Tests for cursor.timestamp_output_format property."""
+
+    def test_set_at_connect_time(self, connection_factory):
+        with connection_factory(session_parameters={"TIMESTAMP_OUTPUT_FORMAT": "YYYY-MM-DD"}) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            assert cursor.timestamp_output_format == "YYYY-MM-DD"
+
+    def test_reflects_alter_session_change(self, cursor):
+        cursor.execute("ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'YYYY-MM-DD HH24:MI:SS'")
+        assert cursor.timestamp_output_format == "YYYY-MM-DD HH24:MI:SS"
+
+        cursor.execute("ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'MM/DD/YYYY HH24:MI'")
+        assert cursor.timestamp_output_format == "MM/DD/YYYY HH24:MI"
+
+    @pytest.mark.skip_reference(
+        reason="UD uses shared connection cache; cursor_b sees update without executing a query"
+    )
+    def test_alter_session_visible_across_cursors_without_execute(self, connection):
+        cursor_a = connection.cursor()
+        cursor_b = connection.cursor()
+
+        cursor_a.execute("ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'YYYY/MM/DD'")
+        assert cursor_a.timestamp_output_format == "YYYY/MM/DD"
+        assert cursor_b.timestamp_output_format == "YYYY/MM/DD"
+
+    def test_alter_session_visible_across_cursors(self, connection):
+        cursor_a = connection.cursor()
+        cursor_b = connection.cursor()
+
+        cursor_a.execute("ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'YYYY/MM/DD'")
+        cursor_b.execute("SELECT 1")
+        assert cursor_a.timestamp_output_format == "YYYY/MM/DD"
+        assert cursor_b.timestamp_output_format == "YYYY/MM/DD"
+
+    def test_alter_session_overrides_connect_time_value(self, connection_factory):
+        with connection_factory(session_parameters={"TIMESTAMP_OUTPUT_FORMAT": "YYYY-MM-DD"}) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            assert cursor.timestamp_output_format == "YYYY-MM-DD"
+
+            cursor.execute("ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'MM/DD/YYYY HH24:MI'")
+            assert cursor.timestamp_output_format == "MM/DD/YYYY HH24:MI"
+
+    def test_independent_connections_have_independent_formats(self, connection_factory):
+        with (
+            connection_factory(session_parameters={"TIMESTAMP_OUTPUT_FORMAT": "YYYY-MM-DD"}) as conn_a,
+            connection_factory(session_parameters={"TIMESTAMP_OUTPUT_FORMAT": "MM/DD/YYYY"}) as conn_b,
+        ):
+            cursor_a = conn_a.cursor()
+            cursor_b = conn_b.cursor()
+            cursor_a.execute("SELECT 1")
+            cursor_b.execute("SELECT 1")
+            assert cursor_a.timestamp_output_format == "YYYY-MM-DD"
+            assert cursor_b.timestamp_output_format == "MM/DD/YYYY"


### PR DESCRIPTION
### TL;DR

Implemented the `timestamp_output_format` property on cursor objects to expose the session's `TIMESTAMP_OUTPUT_FORMAT` parameter value.

### What changed?

The `timestamp_output_format` property in the cursor class now returns the actual session parameter value by calling `self._connection._get_session_parameter("TIMESTAMP_OUTPUT_FORMAT")` instead of raising a `NotImplementedError`.

### How to test?

Run the new integration tests in `test_cursor_format_properties.py` which verify:
- Property reflects format set at connection time via session parameters
- Property updates when `ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT` is executed
- Changes are visible across multiple cursors on the same connection
- Independent connections maintain their own format settings

### Why make this change?

This provides users with programmatic access to the current timestamp output format setting for their session, enabling applications to adapt their timestamp handling logic based on the configured format without needing to track session parameter changes manually.