### PR TITLE
Change ODBC test authentication to keypair

### DIFF
--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -9,6 +9,14 @@
 #include <set>
 #include <sstream>
 
+#ifdef _WIN32
+#include <process.h>
+inline int current_pid() { return _getpid(); }
+#else
+#include <unistd.h>
+inline int current_pid() { return getpid(); }
+#endif
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "ODBCConfig.hpp"
@@ -95,12 +103,25 @@ inline std::string get_or_create_private_key_file(const picojson::object& params
   if (!path.empty()) {
     return path;
   }
-  static const std::string tmp_path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+  static const std::string shared_path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+
+  std::error_code ec;
+  if (std::filesystem::exists(shared_path, ec) && !ec && std::filesystem::file_size(shared_path, ec) > 0 && !ec) {
+    return shared_path;
+  }
+
   std::string pem = read_private_key(params);
-  std::ofstream f(tmp_path, std::ios::out | std::ios::trunc);
+  std::string staging = shared_path + "." + std::to_string(current_pid());
+  std::ofstream f(staging, std::ios::out | std::ios::trunc);
   REQUIRE(f.is_open());
   f << pem;
-  return tmp_path;
+  f.close();
+
+  std::filesystem::rename(staging, shared_path, ec);
+  if (ec) {
+    std::filesystem::remove(staging, ec);
+  }
+  return shared_path;
 }
 
 inline void configure_driver_string(std::stringstream& ss) {

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "ODBCConfig.hpp"
+#include "utils.hpp"
 
 inline picojson::object get_test_parameters(const std::string& connection_name) {
   const char* parameter_path_env_value = std::getenv("PARAMETER_PATH");
@@ -129,7 +130,9 @@ inline std::string get_connection_string() {
   auto params = get_test_parameters("testconnection");
   std::stringstream ss;
   read_default_params(ss, params);
-  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_PASSWORD", "PWD");
+  ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
+  ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(read_private_key(params)) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_FILE_PWD");
   return ss.str();
 }
 

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -3,6 +3,7 @@
 
 #include <picojson.h>
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -63,7 +64,7 @@ inline void add_param_optional(std::stringstream& ss, const picojson::object& pa
 
 inline std::string get_private_key_file_path(const picojson::object& params) {
   auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
-  if (it != params.end() && it->second.is<std::string>()) {
+  if (it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
     return it->second.get<std::string>();
   }
   return "";
@@ -87,6 +88,19 @@ inline std::string read_private_key(const picojson::object& params) {
     private_key_stream << line.get<std::string>() << "\n";
   }
   return private_key_stream.str();
+}
+
+inline std::string get_or_create_private_key_file(const picojson::object& params) {
+  auto path = get_private_key_file_path(params);
+  if (!path.empty()) {
+    return path;
+  }
+  static const std::string tmp_path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+  std::string pem = read_private_key(params);
+  std::ofstream f(tmp_path, std::ios::out | std::ios::trunc);
+  REQUIRE(f.is_open());
+  f << pem;
+  return tmp_path;
 }
 
 inline void configure_driver_string(std::stringstream& ss) {
@@ -131,8 +145,13 @@ inline std::string get_connection_string() {
   std::stringstream ss;
   read_default_params(ss, params);
   ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  ss << "PRIV_KEY_FILE=" << get_or_create_private_key_file(params) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_FILE_PWD");
+#else
   ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(read_private_key(params)) << ";";
   add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_PWD");
+#endif
   return ss.str();
 }
 

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -131,7 +131,11 @@ inline std::string get_connection_string() {
   std::stringstream ss;
   read_default_params(ss, params);
   ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  ss << "PRIV_KEY_FILE=" << get_private_key_file_path(params) << ";";
+#else
   ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(read_private_key(params)) << ";";
+#endif
   add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_FILE_PWD");
   return ss.str();
 }

--- a/odbc_tests/common/include/test_setup.hpp
+++ b/odbc_tests/common/include/test_setup.hpp
@@ -131,12 +131,8 @@ inline std::string get_connection_string() {
   std::stringstream ss;
   read_default_params(ss, params);
   ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
-#ifdef SNOWFLAKE_OLD_DRIVER
-  ss << "PRIV_KEY_FILE=" << get_private_key_file_path(params) << ";";
-#else
   ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(read_private_key(params)) << ";";
-#endif
-  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_FILE_PWD");
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "PRIV_KEY_PWD");
   return ss.str();
 }
 

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -1,5 +1,6 @@
 #include <picojson.h>
 
+#include <filesystem>
 #include <fstream>
 #include <random>
 #include <sstream>
@@ -22,6 +23,21 @@ static std::string read_private_key_pem(const picojson::object& params) {
     ss << line.get<std::string>() << "\n";
   }
   return ss.str();
+}
+
+static std::string get_or_create_private_key_file(const picojson::object& params) {
+  if (const auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
+      it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
+    return it->second.get<std::string>();
+  }
+  static const std::string path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+  std::string pem = read_private_key_pem(params);
+  std::ofstream f(path, std::ios::out | std::ios::trunc);
+  if (!f.is_open()) {
+    throw std::runtime_error("Cannot create temp key file: " + path);
+  }
+  f << pem;
+  return path;
 }
 
 DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {
@@ -50,7 +66,11 @@ DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name)
   config.parameters_["UID"] = get_string(params, "SNOWFLAKE_TEST_USER", "");
   config.parameters_["ACCOUNT"] = get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "");
   config.parameters_["AUTHENTICATOR"] = "SNOWFLAKE_JWT";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  config.parameters_["PRIV_KEY_FILE"] = get_or_create_private_key_file(params);
+#else
   config.parameters_["PRIV_KEY_BASE64"] = test_utils::base64_encode(read_private_key_pem(params));
+#endif
   if (auto pwd = get_string(params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", ""); !pwd.empty()) {
     config.parameters_["PRIV_KEY_FILE_PWD"] = pwd;
   }
@@ -78,7 +98,13 @@ DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name)
 }
 
 DataSourceConfig DataSourceConfig::SnowflakeNoAuth(const std::string& connection_name) {
-  return Snowflake(connection_name).remove("UID").remove("PWD");
+  return Snowflake(connection_name)
+      .remove("UID")
+      .remove("PWD")
+      .remove("AUTHENTICATOR")
+      .remove("PRIV_KEY_BASE64")
+      .remove("PRIV_KEY_FILE")
+      .remove("PRIV_KEY_FILE_PWD");
 }
 
 DataSourceConfig& DataSourceConfig::set(const std::string& key, const std::string& value) {

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -6,10 +6,23 @@
 #include <stdexcept>
 
 #include "ODBCConfig.hpp"
+#include "utils.hpp"
 
 // ============================================================================
 // DataSourceConfig
 // ============================================================================
+
+static std::string read_private_key_pem(const picojson::object& params) {
+  const auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS");
+  if (it == params.end() || !it->second.is<picojson::array>()) {
+    throw std::runtime_error("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS not found or not an array");
+  }
+  std::stringstream ss;
+  for (const auto& line : it->second.get<picojson::array>()) {
+    ss << line.get<std::string>() << "\n";
+  }
+  return ss.str();
+}
 
 DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {
   const auto params = load_parameters(connection_name);
@@ -35,8 +48,12 @@ DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name)
   config.parameters_["PORT"] = "443";
   config.parameters_["SSL"] = "on";
   config.parameters_["UID"] = get_string(params, "SNOWFLAKE_TEST_USER", "");
-  config.parameters_["PWD"] = get_string(params, "SNOWFLAKE_TEST_PASSWORD", "");
   config.parameters_["ACCOUNT"] = get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "");
+  config.parameters_["AUTHENTICATOR"] = "SNOWFLAKE_JWT";
+  config.parameters_["PRIV_KEY_BASE64"] = test_utils::base64_encode(read_private_key_pem(params));
+  if (auto pwd = get_string(params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", ""); !pwd.empty()) {
+    config.parameters_["PRIV_KEY_FILE_PWD"] = pwd;
+  }
 
   // Optional parameters
   if (auto db = get_string(params, "SNOWFLAKE_TEST_DATABASE", ""); !db.empty()) {

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -6,8 +6,22 @@
 #include <sstream>
 #include <stdexcept>
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "ODBCConfig.hpp"
 #include "utils.hpp"
+
+static int current_pid() {
+#ifdef _WIN32
+  return _getpid();
+#else
+  return getpid();
+#endif
+}
 
 // ============================================================================
 // DataSourceConfig
@@ -30,14 +44,27 @@ static std::string get_or_create_private_key_file(const picojson::object& params
       it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
     return it->second.get<std::string>();
   }
-  static const std::string path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+  static const std::string shared_path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+
+  std::error_code ec;
+  if (std::filesystem::exists(shared_path, ec) && !ec && std::filesystem::file_size(shared_path, ec) > 0 && !ec) {
+    return shared_path;
+  }
+
   std::string pem = read_private_key_pem(params);
-  std::ofstream f(path, std::ios::out | std::ios::trunc);
+  std::string staging = shared_path + "." + std::to_string(current_pid());
+  std::ofstream f(staging, std::ios::out | std::ios::trunc);
   if (!f.is_open()) {
-    throw std::runtime_error("Cannot create temp key file: " + path);
+    throw std::runtime_error("Cannot create temp key file: " + staging);
   }
   f << pem;
-  return path;
+  f.close();
+
+  std::filesystem::rename(staging, shared_path, ec);
+  if (ec) {
+    std::filesystem::remove(staging, ec);
+  }
+  return shared_path;
 }
 
 DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -1,6 +1,5 @@
 #include <picojson.h>
 
-#include <filesystem>
 #include <fstream>
 #include <random>
 #include <sstream>
@@ -23,21 +22,6 @@ static std::string read_private_key_pem(const picojson::object& params) {
     ss << line.get<std::string>() << "\n";
   }
   return ss.str();
-}
-
-static std::string get_or_create_private_key_file(const picojson::object& params) {
-  if (const auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
-      it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
-    return it->second.get<std::string>();
-  }
-  static const std::string path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
-  std::string pem = read_private_key_pem(params);
-  std::ofstream f(path, std::ios::out | std::ios::trunc);
-  if (!f.is_open()) {
-    throw std::runtime_error("Cannot create temp key file: " + path);
-  }
-  f << pem;
-  return path;
 }
 
 DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {
@@ -66,13 +50,9 @@ DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name)
   config.parameters_["UID"] = get_string(params, "SNOWFLAKE_TEST_USER", "");
   config.parameters_["ACCOUNT"] = get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "");
   config.parameters_["AUTHENTICATOR"] = "SNOWFLAKE_JWT";
-#ifdef SNOWFLAKE_OLD_DRIVER
-  config.parameters_["PRIV_KEY_FILE"] = get_or_create_private_key_file(params);
-#else
   config.parameters_["PRIV_KEY_BASE64"] = test_utils::base64_encode(read_private_key_pem(params));
-#endif
   if (auto pwd = get_string(params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", ""); !pwd.empty()) {
-    config.parameters_["PRIV_KEY_FILE_PWD"] = pwd;
+    config.parameters_["PRIV_KEY_PWD"] = pwd;
   }
 
   // Optional parameters
@@ -103,8 +83,7 @@ DataSourceConfig DataSourceConfig::SnowflakeNoAuth(const std::string& connection
       .remove("PWD")
       .remove("AUTHENTICATOR")
       .remove("PRIV_KEY_BASE64")
-      .remove("PRIV_KEY_FILE")
-      .remove("PRIV_KEY_FILE_PWD");
+      .remove("PRIV_KEY_PWD");
 }
 
 DataSourceConfig& DataSourceConfig::set(const std::string& key, const std::string& value) {

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -63,6 +63,9 @@ static std::string get_or_create_private_key_file(const picojson::object& params
   std::filesystem::rename(staging, shared_path, ec);
   if (ec) {
     std::filesystem::remove(staging, ec);
+    if (!std::filesystem::exists(shared_path, ec) || ec || std::filesystem::file_size(shared_path, ec) == 0 || ec) {
+      throw std::runtime_error("Failed to create shared key file: " + shared_path);
+    }
   }
   return shared_path;
 }

--- a/odbc_tests/common/src/DataSourceConfig.cpp
+++ b/odbc_tests/common/src/DataSourceConfig.cpp
@@ -1,5 +1,6 @@
 #include <picojson.h>
 
+#include <filesystem>
 #include <fstream>
 #include <random>
 #include <sstream>
@@ -22,6 +23,21 @@ static std::string read_private_key_pem(const picojson::object& params) {
     ss << line.get<std::string>() << "\n";
   }
   return ss.str();
+}
+
+static std::string get_or_create_private_key_file(const picojson::object& params) {
+  if (const auto it = params.find("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
+      it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
+    return it->second.get<std::string>();
+  }
+  static const std::string path = (std::filesystem::temp_directory_path() / "odbc_test_rsa_key.p8").string();
+  std::string pem = read_private_key_pem(params);
+  std::ofstream f(path, std::ios::out | std::ios::trunc);
+  if (!f.is_open()) {
+    throw std::runtime_error("Cannot create temp key file: " + path);
+  }
+  f << pem;
+  return path;
 }
 
 DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name) {
@@ -50,10 +66,17 @@ DataSourceConfig DataSourceConfig::Snowflake(const std::string& connection_name)
   config.parameters_["UID"] = get_string(params, "SNOWFLAKE_TEST_USER", "");
   config.parameters_["ACCOUNT"] = get_string(params, "SNOWFLAKE_TEST_ACCOUNT", "");
   config.parameters_["AUTHENTICATOR"] = "SNOWFLAKE_JWT";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  config.parameters_["PRIV_KEY_FILE"] = get_or_create_private_key_file(params);
+  if (auto pwd = get_string(params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", ""); !pwd.empty()) {
+    config.parameters_["PRIV_KEY_FILE_PWD"] = pwd;
+  }
+#else
   config.parameters_["PRIV_KEY_BASE64"] = test_utils::base64_encode(read_private_key_pem(params));
   if (auto pwd = get_string(params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", ""); !pwd.empty()) {
     config.parameters_["PRIV_KEY_PWD"] = pwd;
   }
+#endif
 
   // Optional parameters
   if (auto db = get_string(params, "SNOWFLAKE_TEST_DATABASE", ""); !db.empty()) {
@@ -83,7 +106,9 @@ DataSourceConfig DataSourceConfig::SnowflakeNoAuth(const std::string& connection
       .remove("PWD")
       .remove("AUTHENTICATOR")
       .remove("PRIV_KEY_BASE64")
-      .remove("PRIV_KEY_PWD");
+      .remove("PRIV_KEY_FILE")
+      .remove("PRIV_KEY_PWD")
+      .remove("PRIV_KEY_FILE_PWD");
 }
 
 DataSourceConfig& DataSourceConfig::set(const std::string& key, const std::string& value) {

--- a/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
@@ -169,10 +169,6 @@ TEST_CASE("should authenticate using unencrypted private key file", "[private_ke
 }
 
 TEST_CASE("should authenticate using private_key as base64 string", "[private_key_auth]") {
-  // Old driver requires PRIV_KEY_FILE even when PRIV_KEY_BASE64 is provided.
-  // TODO: Re-enable once DSN support is implemented (provide PRIV_KEY_FILE via DSN).
-  SKIP_OLD_DRIVER("", "Old driver requires PRIV_KEY_FILE even when PRIV_KEY_BASE64 is set");
-
   // Given Authentication is set to JWT and private key is provided as base64-encoded string
   auto params = get_test_parameters("testconnection");
 

--- a/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
@@ -169,6 +169,8 @@ TEST_CASE("should authenticate using unencrypted private key file", "[private_ke
 }
 
 TEST_CASE("should authenticate using private_key as base64 string", "[private_key_auth]") {
+  SKIP_OLD_DRIVER("", "Old driver 3.16.0 on Linux does not support PRIV_KEY_BASE64 in connection strings");
+
   // Given Authentication is set to JWT and private key is provided as base64-encoded string
   auto params = get_test_parameters("testconnection");
 

--- a/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/e2e/authentication/private_key_auth.cpp
@@ -169,7 +169,7 @@ TEST_CASE("should authenticate using unencrypted private key file", "[private_ke
 }
 
 TEST_CASE("should authenticate using private_key as base64 string", "[private_key_auth]") {
-  SKIP_OLD_DRIVER("", "Old driver 3.16.0 on Linux does not support PRIV_KEY_BASE64 in connection strings");
+  SKIP_OLD_DRIVER("", "Old driver does not support PRIV_KEY_BASE64 in connection strings");
 
   // Given Authentication is set to JWT and private key is provided as base64-encoded string
   auto params = get_test_parameters("testconnection");


### PR DESCRIPTION
Change ODBC test suite authentication method to keypair (aligned with other wrappers) instead of user + password