### PR TITLE
track cpu/memory metrics in perf tests for python wrapper

### DIFF
--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -8,6 +8,7 @@
 - [Architecture](#architecture)
 - [Driver Containers](#driver-containers)
 - [Results](#results)
+- [Metrics Reference](#metrics-reference)
 - [Docker Builds Approach](#docker-builds-approach)
 
 ---
@@ -284,9 +285,11 @@ hatch run python-universal-local tests/test_select_1M_recorded_http.py::test_sel
 │  - Connects to Snowflake                                        │
 │  - Executes setup queries                                       │
 │  - Runs warmup iterations                                       │
+│  - Starts memory timeline monitor (background thread, 100ms)    │
 │  - Executes test iterations                                     │
-│  - Measures query and fetch times                               │
-│  - Writes results to CSV files                                  │
+│  - Measures query/fetch times, CPU time, and peak RSS           │
+│  - Stops memory timeline monitor                                │
+│  - Writes per-iteration results CSV and memory timeline CSV     │
 │  - Writes run metadata                                          │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -374,44 +377,132 @@ Each driver container must generate:
 ```
 results/
 └── run_20251030_113045/
-    ├── select_string_1000000_rows_python_universal_1761734615.csv
-    ├── select_string_1000000_rows_python_old_1761734627.csv
-    ├── select_number_1000000_rows_python_universal_1761734660.csv
-    ├── select_number_1000000_rows_python_old_1761734671.csv
+    ├── select_string_1M_arrow_python_universal_1761734615.csv
+    ├── select_string_1M_arrow_python_old_1761734627.csv
+    ├── memory_timeline_select_string_1M_arrow_python_universal_1761734615.csv
+    ├── memory_timeline_select_string_1M_arrow_python_old_1761734627.csv
+    ├── select_number_1M_arrow_python_universal_1761734660.csv
+    ├── select_number_1M_arrow_python_old_1761734671.csv
+    ├── memory_timeline_select_number_1M_arrow_python_universal_1761734660.csv
+    ├── memory_timeline_select_number_1M_arrow_python_old_1761734671.csv
     ├── run_metadata_python_universal.json
     └── run_metadata_python_old.json
 ```
 
 ### CSV Format
 
-Results CSV files contain per-iteration timing data with actual execution timestamps.
+Results CSV files contain per-iteration timing, CPU, and memory data with actual execution timestamps.
 
 **For SELECT tests:**
 ```csv
-timestamp,query_s,fetch_s
-1762522370,1.583121,21.441600
-1762522392,1.812228,20.262202
-1762522414,1.799454,20.156388
+timestamp,query_s,fetch_s,row_count,cpu_time_s,peak_rss_mb
+1762522370,0.005432,1.583121,1000000,1.571032,236.2
+1762522372,0.005118,1.812228,1000000,1.798445,237.4
+1762522374,0.004987,1.799454,1000000,1.785123,236.1
 ```
 
 **For PUT/GET tests:**
 ```csv
-timestamp,query_s
-1762522254,6.595445
-1762522271,4.385419
-1762522288,5.123456
+timestamp,query_s,cpu_time_s,peak_rss_mb
+1762522254,6.595445,0.312456,85.3
+1762522271,4.385419,0.298234,85.1
+1762522288,5.123456,0.305678,85.2
 ```
 
 **Columns**:
-- `timestamp`: Unix timestamp (seconds since epoch) when the iteration was executed
-- `query_s`: Time to execute query and get initial response (seconds, 6 decimal places)
-- `fetch_s`: Time to fetch all result data (seconds, 6 decimal places) - **only for SELECT tests**
+- `timestamp`: Unix timestamp (seconds since epoch) when the iteration completed
+- `query_s`: Wall-clock time to execute the query (`cursor.execute()`) and get initial response (seconds)
+- `fetch_s`: Wall-clock time to fetch all result rows via `fetchmany()` (seconds) — **SELECT tests only**
+- `row_count`: Number of rows fetched — **SELECT tests only**
+- `cpu_time_s`: CPU time consumed during the fetch phase (seconds, via `time.process_time()`) — see [Metrics Reference](#metrics-reference)
+- `peak_rss_mb`: Process-wide peak Resident Set Size (MB, via `getrusage(RUSAGE_SELF).ru_maxrss`)
 
 **Notes**:
 - Each row represents one test iteration (warmup iterations are not included)
-- PUT/GET tests only measure `query_s` since file operations don't have a separate fetch phase
-- Timestamps are captured at the end of each iteration and uploaded to Benchstore for accurate time-series analysis
-- Total time for SELECT tests can be calculated as `query_s + fetch_s`
+- PUT/GET tests have no separate fetch phase — `query_s` covers the entire file operation
+- Timestamps are captured at the end of each iteration and uploaded to Benchstore for time-series analysis
+- Total wall-clock time for SELECT tests = `query_s + fetch_s`
+
+### Memory Timeline Files
+
+In addition to per-iteration CSVs, a separate memory timeline CSV is generated per test. A background thread samples process memory at ~100ms intervals across all test iterations (excluding warmup).
+
+**Filename pattern:** `memory_timeline_{test_name}_{driver}_{driver_type}_{timestamp}.csv`
+
+```csv
+timestamp_ms,rss_bytes,vm_bytes
+1773060664000,175636480,536870912
+1773060664100,196083712,536870912
+1773060664200,247463936,536870912
+```
+
+**Columns**:
+- `timestamp_ms`: Epoch time in milliseconds when the sample was taken
+- `rss_bytes`: Resident Set Size — physical memory currently used by the process
+- `vm_bytes`: Virtual Memory Size — total virtual address space of the process
+
+---
+
+## Metrics Reference
+
+### Per-Iteration Metrics (Time Series)
+
+These are recorded once per test iteration and uploaded to Benchstore as time-series sample points.
+
+| Metric | Scope | Measures | Unit | Purpose |
+|--------|-------|----------|------|---------|
+| `query_s` | `cursor.execute()` | Wall-clock time for query submission and server response | seconds | Network latency + server processing time |
+| `fetch_s` | `cursor.fetchmany()` loop | Wall-clock time to fetch and deserialize all rows | seconds | Data transfer + deserialization throughput |
+| `cpu_time_s` | Fetch phase only (SELECT) / Execute phase (PUT/GET) | CPU time (user + system) consumed by the process | seconds | CPU efficiency of deserialization; excludes I/O waits and GIL-released time |
+| `peak_rss_mb` | Entire process lifetime | Maximum physical memory (Resident Set Size) ever used | MB | Absolute memory ceiling; useful for memory budget tracking |
+
+**`cpu_time_s` details:**
+- Python: measured via `time.process_time()` (user + system CPU, all threads)
+- ODBC/C++: measured via `getrusage(RUSAGE_SELF)` delta (user + system CPU, all threads)
+- For SELECT tests: wraps only the fetch loop, excluding the query phase. This means `cpu_time_s` directly corresponds to `fetch_s` — the ratio `cpu_time_s / fetch_s` indicates CPU saturation during deserialization (1.0 = fully CPU-bound, <1.0 = some I/O waits)
+- For PUT/GET tests: wraps the execute call since there is no separate fetch phase
+- Both methods report process-wide CPU across all threads. For multi-threaded drivers, `cpu_time_s` may exceed `fetch_s` (the excess reflects work done by background threads)
+
+**`peak_rss_mb` details:**
+- Read from `getrusage(RUSAGE_SELF).ru_maxrss` (kernel-tracked `VmHWM`)
+- This is the process-wide peak — it captures all memory from both the language wrapper and the Rust `sf_core` library (they share the same process)
+- The value is monotonically non-decreasing across iterations (it's a lifetime high-water mark). To see per-iteration memory behavior, use the memory timeline
+
+**Platform note:** `cpu_time_s` and `peak_rss_mb` work on both Linux and macOS. Memory timeline sampling (`/proc/self/statm`) is Linux-only — on macOS, the timeline is silently empty. All metrics are available on any Linux distribution (the APIs are kernel-level, not distro-specific).
+
+### Memory Timeline Metrics (Time Series)
+
+Sampled at ~100ms intervals by a background monitoring thread. Uploaded to Benchstore as time-series sample points. **Linux only** — relies on `/proc/self/statm` which is part of the Linux kernel's procfs (available on all distributions and architectures). On non-Linux platforms the monitor is silently disabled.
+
+| Metric | Source | Unit | Purpose |
+|--------|--------|------|---------|
+| `rss_memory_mb` | `/proc/self/statm` (RSS pages × page size) | MB | Instantaneous physical memory at each sample point; shows memory shape across iterations |
+| `vm_memory_mb` | `/proc/self/statm` (VM pages × page size) | MB | Virtual memory size; useful for detecting address space growth independent of physical memory |
+
+**Timeline scope:** The monitor starts after warmup and stops after the last test iteration. Setup queries, connection setup, and result writing are excluded.
+
+### Aggregate Metrics (Single Value per Run)
+
+Computed from memory timeline data and uploaded to Benchstore as run aggregates.
+
+| Metric | Computation | Unit | Detects |
+|--------|-------------|------|---------|
+| `rss_memory_delta_mb` | `max(rss) - min(rss)` across all timeline samples | MB | Working memory regression |
+| `rss_memory_growth_mb` | `min(rss in last iteration) - min(rss in first iteration)` | MB | Memory leaks |
+
+**`rss_memory_delta_mb`** measures the working memory swing during test execution — how much memory the driver allocates on top of its idle baseline to process results. Compare this value across builds to detect regressions: if a code change causes the driver to allocate more memory during query processing, this number increases.
+
+**`rss_memory_growth_mb`** measures whether memory is being freed between iterations. It compares the idle (resting) RSS of the first iteration to the idle RSS of the last iteration. A value near 0 means memory is fully released. A positive value means memory is accumulating across iterations (potential leak). Requires at least 2 iterations (skipped for single-iteration runs).
+
+The metric uses `min()` within each iteration's timeline segment to extract the idle baseline, rather than comparing the raw first and last RSS samples. This matters because the monitor can start or stop mid-iteration when RSS is at its peak (~152 MB instead of ~103 MB idle). A raw `end - start` comparison would be timing-dependent and could falsely report ~48 MB of "growth" when the driver actually freed all working memory. The `min()` approach reliably finds the idle baseline regardless of timing.
+
+**How the three memory metrics work together:**
+
+| Metric | What it guards | Example alert |
+|--------|----------------|---------------|
+| `peak_rss_mb` | Absolute memory ceiling | "Process exceeded 256 MB budget" |
+| `rss_memory_delta_mb` | Per-test working memory | "Decoding now uses 80 MB instead of 48 MB" |
+| `rss_memory_growth_mb` | Memory leak across iterations | "Idle RSS grew by 10 MB over 5 iterations" |
 
 ### Benchstore Metrics
 
@@ -420,13 +511,25 @@ When uploading to Benchstore (with `--upload-to-benchstore`), each test uploads 
 - **Consistent metric names**: All drivers use identical metric names for the same test (e.g., `select_string_1000000_rows_query_s`)
 - **Tag-based separation**: Results are distinguished by tags (driver, version, cloud provider, architecture, etc.)
 
-**Example**: The test `test_select_string_1000000_rows` uploads:
-- Metric names: 
-  - `select_string_1000000_rows_query_s` (query execution time)
-  - `select_string_1000000_rows_fetch_s` (data fetching time)
+**Example**: The test `test_select_string_1000000_rows` uploads these time-series metrics per iteration:
+- `select_string_1000000_rows_query_s` — query execution time
+- `select_string_1000000_rows_fetch_s` — data fetching time
+- `select_string_1000000_rows_cpu_time_s` — CPU time during fetch
+- `select_string_1000000_rows_peak_rss_mb` — peak process memory
 
-**PUT/GET Tests**: Tests like `test_put_files_12mx100` only upload:
-- Metric name: `put_files_12mx100_query_s` (query execution time)
+And these memory timeline metrics (sampled at ~100ms):
+- `select_string_1000000_rows_rss_memory_mb` — RSS at each sample point
+- `select_string_1000000_rows_vm_memory_mb` — virtual memory at each sample point
+
+And these run aggregates:
+- `select_string_1000000_rows_rss_memory_delta_mb` — max-min RSS delta (working memory swing)
+- `select_string_1000000_rows_rss_memory_growth_mb` — idle RSS growth between first and last iteration (leak indicator)
+
+**PUT/GET Tests**: Tests like `test_put_files_12mx100` upload:
+- `put_files_12mx100_query_s` — file operation time
+- `put_files_12mx100_cpu_time_s` — CPU time during operation
+- `put_files_12mx100_peak_rss_mb` — peak process memory
+- Plus memory timeline, delta, and growth metrics (same as above)
 
 #### Benchstore Tags
 

--- a/tests/performance/drivers/python/app/common.py
+++ b/tests/performance/drivers/python/app/common.py
@@ -1,7 +1,19 @@
 """Common utilities for performance testing."""
 
+import resource
 import statistics
+import sys
 from typing import List, Dict, Callable, Any
+
+
+def get_peak_rss_mb() -> float:
+    """Return process peak RSS in MB (Linux, macOS). Returns 0 on unsupported platforms."""
+    if sys.platform == "win32":
+        return 0.0
+    ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return ru_maxrss / (1024 * 1024)  # bytes -> MB on macOS
+    return ru_maxrss / 1024  # KB -> MB on Linux
 
 
 def run_warmup(execute_fn: Callable, cursor, sql: str, warmup_iterations: int) -> None:

--- a/tests/performance/drivers/python/app/main.py
+++ b/tests/performance/drivers/python/app/main.py
@@ -5,7 +5,7 @@ from config import TestConfig
 from connection import create_connection, get_server_version, execute_setup_queries
 from put_execution import execute_put_get_test
 from query_execution import execute_fetch_test
-from results import write_csv_results, write_run_metadata
+from results import write_csv_results, write_memory_timeline, write_run_metadata
 from test_types import TestType
 
 TEST_EXECUTORS = {
@@ -43,7 +43,7 @@ def main():
         conn.close()
         sys.exit(1)
     
-    results = execute_test(
+    results, memory_timeline = execute_test(
         config.test_type, 
         cursor, 
         config.sql_command, 
@@ -62,8 +62,11 @@ def main():
     conn.close()
 
     filename = write_csv_results(results, config.test_name, config.driver_type, config.test_type)
+    timeline_filename = write_memory_timeline(memory_timeline, config.test_name, config.driver_type)
     
     print(f"\n✓ Complete → {filename}")
+    if timeline_filename:
+        print(f"✓ Memory timeline → {timeline_filename}")
 
 
 if __name__ == "__main__":

--- a/tests/performance/drivers/python/app/put_execution.py
+++ b/tests/performance/drivers/python/app/put_execution.py
@@ -1,10 +1,11 @@
 """PUT/GET execution and performance measurement."""
 
-import time
 import os
 import re
 import shutil
-from common import run_warmup, run_test_iterations, print_timing_stats
+import time
+from common import run_warmup, run_test_iterations, print_timing_stats, get_peak_rss_mb
+from resource_monitor import ResourceMonitor
 
 
 def execute_put_get_test(cursor, sql_command, warmup_iterations, iterations):
@@ -12,16 +13,24 @@ def execute_put_get_test(cursor, sql_command, warmup_iterations, iterations):
     Execute a complete PUT/GET test: warmup, iterations, and statistics.
     
     Returns:
-        list: Test results for CSV output
+        tuple: (results list, memory_timeline list)
     """
     print("\n=== Executing PUT_GET Test ===")
     print(f"Query: {sql_command}")
     
     run_warmup(_execute_put_get, cursor, sql_command, warmup_iterations)
+
+    monitor = ResourceMonitor(interval_s=0.1)
+    monitor.start()
+
     results = run_test_iterations(_execute_put_get, cursor, sql_command, iterations)
+
+    memory_timeline = monitor.stop()
+
     print_statistics(results)
+    print(f"  Memory timeline: {len(memory_timeline)} samples collected")
     
-    return results
+    return results, memory_timeline
 
 
 def print_statistics(results):
@@ -37,19 +46,26 @@ def _execute_put_get(cursor, sql):
     Execute a PUT or GET command and collect metrics.
     
     Returns:
-        dict: Dictionary with timestamp and query_time_s
+        dict: Dictionary with timestamp, query_time_s, cpu_time_s, and peak_rss_mb
     """
     _create_get_target_directory(sql)
     
+    cpu_start = time.process_time()
+
     query_start = time.time()
     cursor.execute(sql)
     query_time = time.time() - query_start
-    
+
+    cpu_time_s = time.process_time() - cpu_start
+    peak_rss_mb = get_peak_rss_mb()
+
     timestamp = int(time.time())
     
     return {
         "timestamp": timestamp,
         "query_time_s": query_time,
+        "cpu_time_s": cpu_time_s,
+        "peak_rss_mb": peak_rss_mb,
     }
 
 

--- a/tests/performance/drivers/python/app/query_execution.py
+++ b/tests/performance/drivers/python/app/query_execution.py
@@ -1,7 +1,8 @@
 """Query execution and performance measurement."""
 import os
 import time
-from common import run_warmup, run_test_iterations, print_timing_stats
+from common import run_warmup, run_test_iterations, print_timing_stats, get_peak_rss_mb
+from resource_monitor import ResourceMonitor
 
 _FETCH_BATCH_SIZE = 1024
 
@@ -11,17 +12,25 @@ def execute_fetch_test(cursor, sql_command, warmup_iterations, iterations):
     Execute a complete SELECT test: warmup, iterations, and statistics.
     
     Returns:
-        list: Test results for CSV output
+        tuple: (results list, memory_timeline list)
     """
     print("\n=== Executing SELECT Test ===")
     print(f"Query: {sql_command}")
     
     run_warmup(_execute_query, cursor, sql_command, warmup_iterations)
+
+    monitor = ResourceMonitor(interval_s=0.1)
+    monitor.start()
+
     results = run_test_iterations(_execute_query, cursor, sql_command, iterations)
+
+    memory_timeline = monitor.stop()
+
     _validate_row_counts(results)
     _print_statistics(results)
+    print(f"  Memory timeline: {len(memory_timeline)} samples collected")
     
-    return results
+    return results, memory_timeline
 
 
 def _validate_row_counts(results):
@@ -85,12 +94,14 @@ def _execute_query(cursor, sql):
     """Execute a single query and collect metrics.
     
     Returns:
-        dict: Dictionary with timestamp, query_time_s, fetch_time_s, and row_count
+        dict: Dictionary with timestamp, query_time_s, fetch_time_s, row_count,
+              cpu_time_s, and peak_rss_mb
     """
     query_start = time.time()
     cursor.execute(sql)
     query_time = time.time() - query_start
     
+    cpu_start = time.process_time()
     fetch_start = time.time()
     row_count = 0
     while True:
@@ -100,6 +111,9 @@ def _execute_query(cursor, sql):
         row_count += len(rows)
     fetch_time = time.time() - fetch_start
 
+    cpu_time_s = time.process_time() - cpu_start
+    peak_rss_mb = get_peak_rss_mb()
+
     timestamp = int(time.time())
     
     return {
@@ -107,5 +121,7 @@ def _execute_query(cursor, sql):
         "query_time_s": query_time,
         "fetch_time_s": fetch_time,
         "row_count": row_count,
+        "cpu_time_s": cpu_time_s,
+        "peak_rss_mb": peak_rss_mb,
     }
 

--- a/tests/performance/drivers/python/app/resource_monitor.py
+++ b/tests/performance/drivers/python/app/resource_monitor.py
@@ -1,0 +1,76 @@
+"""In-process memory timeline monitor using /proc/self/statm.
+
+Spawns a lightweight background thread that samples RSS and virtual memory
+at a configurable interval (default 100ms). The thread reads /proc/self/statm
+which is a single kernel-provided pseudo-file — no fork/exec overhead.
+
+Linux only: /proc/self/statm is a Linux kernel interface. On other platforms
+the monitor silently returns an empty timeline.
+
+GIL note: both Event.wait() and file I/O release the GIL, so the monitor
+thread does not contend with the main thread's CPU-bound work.
+"""
+
+import os
+import sys
+import threading
+import time
+
+IS_LINUX = sys.platform == "linux"
+
+
+class MemorySample:
+    __slots__ = ("timestamp_ms", "rss_bytes", "vm_bytes")
+
+    def __init__(self, timestamp_ms: int, rss_bytes: int, vm_bytes: int):
+        self.timestamp_ms = timestamp_ms
+        self.rss_bytes = rss_bytes
+        self.vm_bytes = vm_bytes
+
+
+class ResourceMonitor:
+    def __init__(self, interval_s: float = 0.1):
+        self._interval = interval_s
+        self._samples: list[MemorySample] = []
+        self._stop = threading.Event()
+        self._page_size = os.sysconf("SC_PAGE_SIZE") if IS_LINUX else 0
+        self._thread: threading.Thread | None = None
+
+    def _read_statm(self) -> tuple[int, int]:
+        with open("/proc/self/statm") as f:
+            parts = f.read().split()
+        vm_pages = int(parts[0])
+        rss_pages = int(parts[1])
+        return rss_pages * self._page_size, vm_pages * self._page_size
+
+    def start(self):
+        if not IS_LINUX:
+            return
+        self._samples.clear()
+        self._stop.clear()
+
+        def _run():
+            while not self._stop.is_set():
+                rss, vm = self._read_statm()
+                self._samples.append(
+                    MemorySample(int(time.time() * 1000), rss, vm)
+                )
+                self._stop.wait(self._interval)
+
+            rss, vm = self._read_statm()
+            self._samples.append(
+                MemorySample(int(time.time() * 1000), rss, vm)
+            )
+
+        self._thread = threading.Thread(
+            target=_run, name="mem-monitor", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> list[MemorySample]:
+        if not IS_LINUX:
+            return []
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        return list(self._samples)

--- a/tests/performance/drivers/python/app/results.py
+++ b/tests/performance/drivers/python/app/results.py
@@ -29,17 +29,21 @@ def write_csv_results(results, test_name, driver_type, test_type: TestType = Tes
     
     with open(filename, 'w', newline='') as f:
         if test_type == TestType.PUT_GET:
-            # PUT/GET tests: timestamp and query_s
-            writer = csv.DictWriter(f, fieldnames=["timestamp", "query_s"])
+            writer = csv.DictWriter(f, fieldnames=[
+                "timestamp", "query_s", "cpu_time_s", "peak_rss_mb",
+            ])
             writer.writeheader()
             for result in results:
                 writer.writerow({
                     "timestamp": result['timestamp'],
                     "query_s": f"{result['query_time_s']:.6f}",
+                    "cpu_time_s": f"{result['cpu_time_s']:.6f}",
+                    "peak_rss_mb": f"{result['peak_rss_mb']:.1f}",
                 })
         else:
-            # SELECT tests: timestamp, query_s, fetch_s, and row_count
-            writer = csv.DictWriter(f, fieldnames=["timestamp", "query_s", "fetch_s", "row_count"])
+            writer = csv.DictWriter(f, fieldnames=[
+                "timestamp", "query_s", "fetch_s", "row_count", "cpu_time_s", "peak_rss_mb",
+            ])
             writer.writeheader()
             for result in results:
                 writer.writerow({
@@ -47,8 +51,43 @@ def write_csv_results(results, test_name, driver_type, test_type: TestType = Tes
                     "query_s": f"{result['query_time_s']:.6f}",
                     "fetch_s": f"{result['fetch_time_s']:.6f}",
                     "row_count": result.get('row_count', 0),
+                    "cpu_time_s": f"{result['cpu_time_s']:.6f}",
+                    "peak_rss_mb": f"{result['peak_rss_mb']:.1f}",
                 })
     
+    return filename
+
+
+def write_memory_timeline(memory_timeline, test_name, driver_type):
+    """Write memory timeline samples to a separate CSV file.
+    
+    Args:
+        memory_timeline: List of MemorySample objects from ResourceMonitor
+        test_name: Name of the test
+        driver_type: Driver type (universal or old)
+    
+    Returns:
+        Path: Path to the created CSV file, or None if no samples
+    """
+    if not memory_timeline:
+        return None
+
+    timestamp = int(time.time())
+    results_dir = Path("/results")
+    results_dir.mkdir(exist_ok=True)
+
+    filename = results_dir / f"memory_timeline_{test_name}_python_{driver_type}_{timestamp}.csv"
+
+    with open(filename, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=["timestamp_ms", "rss_bytes", "vm_bytes"])
+        writer.writeheader()
+        for sample in memory_timeline:
+            writer.writerow({
+                "timestamp_ms": sample.timestamp_ms,
+                "rss_bytes": sample.rss_bytes,
+                "vm_bytes": sample.vm_bytes,
+            })
+
     return filename
 
 

--- a/tests/performance/pyproject.toml
+++ b/tests/performance/pyproject.toml
@@ -32,6 +32,8 @@ pre-install-commands = [
 PIP_EXTRA_INDEX_URL = "https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/api/pypi/internal-production-pypi-snowflake-virtual/simple"
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
+norecursedirs = ["drivers/python/old_driver_src"]
 log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s"

--- a/tests/performance/runner/benchstore_upload.py
+++ b/tests/performance/runner/benchstore_upload.py
@@ -315,10 +315,81 @@ def read_csv_results(csv_path: Path) -> List[Dict]:
             
             if 'fetch_s' in row:
                 result['fetch_s'] = float(row['fetch_s'])
+            if 'cpu_time_s' in row:
+                result['cpu_time_s'] = float(row['cpu_time_s'])
+            if 'peak_rss_mb' in row:
+                result['peak_rss_mb'] = float(row['peak_rss_mb'])
             
             results.append(result)
     
     return results
+
+
+def parse_memory_timeline_filename(filename: str) -> Optional[Dict[str, str]]:
+    """
+    Parse memory timeline CSV filename.
+    
+    Expected formats:
+      - memory_timeline_{test_name}_{driver}_{driver_type}_{timestamp}.csv
+      - memory_timeline_{test_name}_{driver}_{timestamp}.csv (core)
+    Examples:
+      - memory_timeline_select_string_1M_arrow_recorded_http_python_universal_1773658001.csv
+      - memory_timeline_select_string_1M_arrow_recorded_http_core_1773658001.csv
+    
+    Args:
+        filename: CSV filename
+        
+    Returns:
+        Dict with test_name, driver, driver_type, timestamp or None if not a timeline file
+    """
+    pattern_with_type = r'memory_timeline_(.+)_(python|odbc|jdbc)_(universal|old)_(\d+)\.csv'
+    match = re.match(pattern_with_type, filename)
+    if match:
+        return {
+            'test_name': match.group(1),
+            'driver': match.group(2),
+            'driver_type': match.group(3),
+            'timestamp': match.group(4),
+        }
+    
+    pattern_core = r'memory_timeline_(.+)_(core)_(\d+)\.csv'
+    match = re.match(pattern_core, filename)
+    if match:
+        return {
+            'test_name': match.group(1),
+            'driver': match.group(2),
+            'driver_type': 'universal',
+            'timestamp': match.group(3),
+        }
+    
+    return None
+
+
+def read_memory_timeline(csv_path: Path) -> List[Dict]:
+    """
+    Read memory timeline samples from CSV file.
+    
+    Args:
+        csv_path: Path to memory timeline CSV file
+        
+    Returns:
+        List of dicts with timestamp_ms, rss_bytes, vm_bytes
+    """
+    samples = []
+    with open(csv_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['timestamp_ms'] and row['rss_bytes'] and row['vm_bytes']:
+                samples.append({
+                    'timestamp_ms': int(row['timestamp_ms']),
+                    'rss_bytes': int(row['rss_bytes']),
+                    'vm_bytes': int(row['vm_bytes']),
+                })
+    return samples
+
+
+def bytes_to_mb(size_in_bytes: int) -> float:
+    return round(size_in_bytes / (1024 * 1024), 2)
 
 
 def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = False, parameters_json_path: Optional[str] = None):
@@ -399,16 +470,26 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
     
     # Group CSV files by their tag set (driver + driver_type)
     csv_groups = defaultdict(list)
+    timeline_groups = defaultdict(list)
     
     for csv_file in csv_files:
-        # Parse filename to get driver info
+        # Check if this is a memory timeline file first
+        timeline_info = parse_memory_timeline_filename(csv_file.name)
+        if timeline_info is not None:
+            test_name = timeline_info['test_name']
+            if test_name.endswith('_record'):
+                logger.info(f"Skipping recording phase timeline: {csv_file.name}")
+                continue
+            group_key = (timeline_info['driver'], timeline_info['driver_type'])
+            timeline_groups[group_key].append((csv_file, timeline_info))
+            continue
+        
+        # Parse as regular results CSV
         file_info = parse_csv_filename(csv_file.name)
         if file_info is None:
             logger.warning(f"Skipping {csv_file.name} - could not parse filename")
             continue
         
-        # Skip recording phase results (e.g., select_string_1M_arrow_recorded_http_record_*)
-        # Recording phase test names end with "_record" suffix
         test_name = file_info['test_name']
         if test_name.endswith('_record'):
             logger.info(f"Skipping recording phase result: {csv_file.name}")
@@ -492,6 +573,8 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
         # Open Quickstore once for all CSV files in this group
         try:
             with Quickstore(quickstore_input, snowflake_connection_params=snowflake_connection_params) as quickstore:
+                results_by_test = {}
+                
                 # Upload all CSV files in this group
                 for csv_file, file_info in csv_file_list:
                     test_name = file_info['test_name']
@@ -507,6 +590,8 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
                         logger.warning(f"No results in {csv_file.name}")
                         continue
                     
+                    results_by_test[test_name] = results
+                    
                     # Upload all iterations from this CSV
                     for idx, result in enumerate(results, 1):
                         metrics = {
@@ -516,6 +601,10 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
                         # fetch_s is only present in SELECT tests, not PUT/GET tests
                         if 'fetch_s' in result:
                             metrics[f"{test_name}_fetch_s"] = result['fetch_s']
+                        if 'cpu_time_s' in result:
+                            metrics[f"{test_name}_cpu_time_s"] = result['cpu_time_s']
+                        if 'peak_rss_mb' in result:
+                            metrics[f"{test_name}_peak_rss_mb"] = result['peak_rss_mb']
                         
                         timestamp = Timestamp()
                         timestamp.FromSeconds(result['timestamp'])
@@ -528,12 +617,87 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
                         )
                         
                         total_uploaded += 1
+                
+                # Upload memory timeline data for this driver group (gauge metrics)
+                # Per BenchStore docs: memory is a gauge - upload periodic samples and
+                # let Quickstore auto-compute aggregates (max, min, mean, median, percentiles)
+                group_key = (driver, driver_type)
+                if group_key in timeline_groups:
+                    for timeline_file, timeline_info in timeline_groups[group_key]:
+                        test_name = timeline_info['test_name']
+                        
+                        try:
+                            samples = read_memory_timeline(timeline_file)
+                        except Exception as e:
+                            logger.error(f"Failed to read timeline {timeline_file.name}: {e}")
+                            continue
+                        
+                        if not samples:
+                            logger.warning(f"No samples in {timeline_file.name}")
+                            continue
+                        
+                        rss_metric = f"{test_name}_rss_memory_mb"
+                        vm_metric = f"{test_name}_vm_memory_mb"
+                        
+                        for sample in samples:
+                            timestamp = Timestamp()
+                            timestamp.FromMilliseconds(sample['timestamp_ms'])
+                            
+                            quickstore.add_sample_point_from_input(
+                                benchstore_pb2.AddSamplePointInput(
+                                    timestamp=timestamp,
+                                    metrics={
+                                        rss_metric: bytes_to_mb(sample['rss_bytes']),
+                                        vm_metric: bytes_to_mb(sample['vm_bytes']),
+                                    },
+                                )
+                            )
+                        
+                        # Upload max RSS delta as a run aggregate for quick regression detection
+                        rss_values = [s['rss_bytes'] for s in samples]
+                        rss_delta_mb = bytes_to_mb(max(rss_values) - min(rss_values))
+                        quickstore.add_run_aggregate(
+                            benchstore_pb2.AddRunAggregateInput(
+                                custom_aggregate_label=f"{test_name}_rss_memory_delta_mb",
+                                custom_aggregate_value=rss_delta_mb,
+                            )
+                        )
+                        
+                        # Upload memory growth for leak detection.
+                        # Compares the idle (minimum) RSS of the first iteration to the
+                        # last iteration. A growing value indicates memory not being
+                        # freed between iterations (potential leak).
+                        if test_name in results_by_test:
+                            iteration_results = results_by_test[test_name]
+                            if len(iteration_results) >= 2:
+                                iter_end_times_ms = [r['timestamp'] * 1000 for r in iteration_results]
+                                first_iter_rss = [s['rss_bytes'] for s in samples if s['timestamp_ms'] <= iter_end_times_ms[0]]
+                                last_iter_rss = [s['rss_bytes'] for s in samples if s['timestamp_ms'] > iter_end_times_ms[-2]]
+                                
+                                if first_iter_rss and last_iter_rss:
+                                    growth_mb = bytes_to_mb(min(last_iter_rss) - min(first_iter_rss))
+                                    quickstore.add_run_aggregate(
+                                        benchstore_pb2.AddRunAggregateInput(
+                                            custom_aggregate_label=f"{test_name}_rss_memory_growth_mb",
+                                            custom_aggregate_value=growth_mb,
+                                        )
+                                    )
+                                    logger.info(f"  Memory growth for {test_name}: {growth_mb} MB")
+                        
+                        timeline_uploaded = len(samples)
+                        total_uploaded += timeline_uploaded
+                        logger.info(f"  Uploaded {timeline_uploaded} memory timeline samples for {test_name}")
             
             logger.critical(f"✓ Uploaded {driver} ({driver_type}) [{architecture}/{os_info}] driver data to Benchstore")
                 
         except Exception as e:
             logger.error(f"Failed to upload {driver} ({driver_type}): {e}")
             continue
+    
+    # Warn about timeline files with no matching results group
+    orphaned = set(timeline_groups.keys()) - set(csv_groups.keys())
+    for key in orphaned:
+        logger.warning(f"Memory timeline files for {key} have no matching results CSVs - skipped")
 
 
 def main():


### PR DESCRIPTION
Add CPU time, peak RSS, and memory timeline tracking to Python performance tests

A more precise description is added to the project README.

Per-iteration metrics (new columns in results CSV):

- cpu_time_s -- CPU time via time.process_time(), scoped to the fetch phase (SELECT) or execute phase (PUT/GET)
- peak_rss_mb -- process peak RSS via getrusage(RUSAGE_SELF).ru_maxrss

Memory timeline (new CSV file per test):

- Background thread samples RSS and VM from /proc/self/statm at ~100ms intervals (Linux only)
- Uploaded to Benchstore as time-series gauge metrics (rss_memory_mb, vm_memory_mb)

Aggregate metrics (new Benchstore run aggregates):

- rss_memory_delta_mb -- max(rss) - min(rss) across all timeline samples; detects working memory regressions
- rss_memory_growth_mb -- min(rss in last iteration) - min(rss in first iteration); detects memory leaks by comparing idle baselines

Example results: https://bench-dash.ordevmisc1.us-west-2.aws-dev.app.snowflake.com/run/4007196?metrics=193%2C195%2C196&tab=chart