### PR TITLE
add cpu/memory perf metrics for odbc wrapper

### DIFF
--- a/tests/performance/drivers/odbc/app/CMakeLists.txt
+++ b/tests/performance/drivers/odbc/app/CMakeLists.txt
@@ -18,9 +18,10 @@ add_executable(odbc-perf-driver
     results.cpp
 )
 
-# Link ODBC
+# Link ODBC and pthreads (for ResourceMonitor background thread)
+find_package(Threads REQUIRED)
 target_include_directories(odbc-perf-driver PRIVATE ${ODBC_INCLUDE_DIR})
-target_link_libraries(odbc-perf-driver ${ODBC_LIBRARY})
+target_link_libraries(odbc-perf-driver ${ODBC_LIBRARY} Threads::Threads)
 
 # Install
 install(TARGETS odbc-perf-driver DESTINATION /usr/local/bin)

--- a/tests/performance/drivers/odbc/app/common.h
+++ b/tests/performance/drivers/odbc/app/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/resource.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
@@ -32,4 +34,21 @@ inline void print_timing_stats(const std::string& label, const std::vector<doubl
   auto stats = calculate_stats(values);
   std::cout << "  " << label << ": median=" << std::fixed << std::setprecision(3) << stats.median
             << "s  min=" << stats.min << "s  max=" << stats.max << "s\n";
+}
+
+/// CPU time (user + system) for the process from a rusage snapshot.
+inline double cpu_seconds(const struct rusage& u) {
+  return static_cast<double>(u.ru_utime.tv_sec) + static_cast<double>(u.ru_utime.tv_usec) / 1e6 +
+         static_cast<double>(u.ru_stime.tv_sec) + static_cast<double>(u.ru_stime.tv_usec) / 1e6;
+}
+
+/// Process peak RSS in MB.  ru_maxrss is KB on Linux, bytes on macOS.
+inline double get_peak_rss_mb() {
+  struct rusage usage;
+  getrusage(RUSAGE_SELF, &usage);
+#ifdef __APPLE__
+  return static_cast<double>(usage.ru_maxrss) / (1024.0 * 1024.0);
+#else
+  return static_cast<double>(usage.ru_maxrss) / 1024.0;
+#endif
 }

--- a/tests/performance/drivers/odbc/app/put_execution.cpp
+++ b/tests/performance/drivers/odbc/app/put_execution.cpp
@@ -24,12 +24,20 @@ void execute_put_get_test(SQLHDBC dbc, const std::string& sql_command, int warmu
   std::cout << "Query: " << sql_command << "\n";
 
   run_warmup_put_get(dbc, sql_command, warmup_iterations);
+
+  ResourceMonitor monitor(std::chrono::milliseconds(100));
+  monitor.start();
+
   auto results = run_test_iterations_put_get(dbc, sql_command, iterations);
+
+  auto memory_timeline = monitor.stop();
 
   std::string filename = generate_results_filename(test_name, driver_type_str, now);
   write_csv_results_put_get(results, filename);
+  write_memory_timeline(memory_timeline, test_name, driver_type_str, now);
 
   print_statistics_put_get(results);
+  std::cout << "  Memory timeline: " << memory_timeline.size() << " samples collected\n";
   finalize_test_execution(dbc, filename, driver_type_str, driver_version_str, now);
 }
 
@@ -79,13 +87,20 @@ PutGetResult run_put_get_query(SQLHDBC dbc, const std::string& sql_command, int 
   SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
   check_odbc_error(ret, SQL_HANDLE_DBC, dbc, "SQLAllocHandle STMT");
 
-  // Execute PUT/GET command
+  struct rusage usage_before;
+  getrusage(RUSAGE_SELF, &usage_before);
+
   auto query_start = std::chrono::high_resolution_clock::now();
   ret = SQLExecDirect(stmt, (SQLCHAR*)sql_command.c_str(), SQL_NTS);
   check_odbc_error(ret, SQL_HANDLE_STMT, stmt, "SQLExecDirect");
   auto query_end = std::chrono::high_resolution_clock::now();
 
+  struct rusage usage_after;
+  getrusage(RUSAGE_SELF, &usage_after);
+
   result.query_time_s = std::chrono::duration<double>(query_end - query_start).count();
+  result.cpu_time_s = cpu_seconds(usage_after) - cpu_seconds(usage_before);
+  result.peak_rss_mb = get_peak_rss_mb();
   result.timestamp = std::time(nullptr);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);

--- a/tests/performance/drivers/odbc/app/put_execution.h
+++ b/tests/performance/drivers/odbc/app/put_execution.h
@@ -6,12 +6,15 @@
 #include <string>
 #include <vector>
 
+#include "resource_monitor.h"
 #include "types.h"
 
 struct PutGetResult {
   int iteration;
   time_t timestamp;
   double query_time_s;
+  double cpu_time_s;
+  double peak_rss_mb;
 };
 
 void execute_put_get_test(SQLHDBC dbc, const std::string& sql_command, int warmup_iterations, int iterations,

--- a/tests/performance/drivers/odbc/app/query_execution.cpp
+++ b/tests/performance/drivers/odbc/app/query_execution.cpp
@@ -32,13 +32,22 @@ void execute_fetch_test(SQLHDBC dbc, const std::string& sql_command, int warmup_
   std::cout << "Query: " << sql_command << "\n";
 
   run_warmup(dbc, sql_command, warmup_iterations);
+
+  ResourceMonitor monitor(std::chrono::milliseconds(100));
+  monitor.start();
+
   auto results = run_test_iterations(dbc, sql_command, iterations);
+
+  auto memory_timeline = monitor.stop();
+
   validate_row_counts(results);
 
   std::string filename = generate_results_filename(test_name, driver_type_str, now);
   write_csv_results(results, filename);
+  write_memory_timeline(memory_timeline, test_name, driver_type_str, now);
 
   print_statistics(results);
+  std::cout << "  Memory timeline: " << memory_timeline.size() << " samples collected\n";
   finalize_test_execution(dbc, filename, driver_type_str, driver_version_str, now);
 }
 
@@ -167,7 +176,9 @@ TestResult run_query(SQLHDBC dbc, const std::string& sql_command, int iteration)
   ret = SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
   check_odbc_error(ret, SQL_HANDLE_STMT, stmt, "SQLSetStmtAttr ROWS_FETCHED_PTR");
 
-  // Bulk fetch loop
+  struct rusage usage_before;
+  getrusage(RUSAGE_SELF, &usage_before);
+
   auto fetch_start = std::chrono::high_resolution_clock::now();
   std::size_t row_count = 0;
 
@@ -178,9 +189,14 @@ TestResult run_query(SQLHDBC dbc, const std::string& sql_command, int iteration)
 
   auto fetch_end = std::chrono::high_resolution_clock::now();
 
+  struct rusage usage_after;
+  getrusage(RUSAGE_SELF, &usage_after);
+
   result.query_time_s = std::chrono::duration<double>(query_end - query_start).count();
   result.fetch_time_s = std::chrono::duration<double>(fetch_end - fetch_start).count();
   result.row_count = row_count;
+  result.cpu_time_s = cpu_seconds(usage_after) - cpu_seconds(usage_before);
+  result.peak_rss_mb = get_peak_rss_mb();
   result.timestamp = std::time(nullptr);
 
   SQLFreeHandle(SQL_HANDLE_STMT, stmt);

--- a/tests/performance/drivers/odbc/app/query_execution.h
+++ b/tests/performance/drivers/odbc/app/query_execution.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "resource_monitor.h"
 #include "types.h"
 
 void execute_fetch_test(SQLHDBC dbc, const std::string& sql_command, int warmup_iterations, int iterations,

--- a/tests/performance/drivers/odbc/app/resource_monitor.h
+++ b/tests/performance/drivers/odbc/app/resource_monitor.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <vector>
+
+#ifdef __linux__
+#include <unistd.h>
+
+#include <fstream>
+#include <thread>
+#endif
+
+struct MemorySample {
+  uint64_t timestamp_ms;
+  uint64_t rss_bytes;
+  uint64_t vm_bytes;
+};
+
+/// Background thread that samples RSS/VM from /proc/self/statm (Linux only).
+/// On non-Linux platforms start()/stop() are no-ops returning an empty timeline.
+class ResourceMonitor {
+ public:
+  explicit ResourceMonitor(std::chrono::milliseconds interval = std::chrono::milliseconds(100))
+      : interval_(interval), stop_(false) {}
+
+  void start() {
+#ifdef __linux__
+    stop_.store(false, std::memory_order_relaxed);
+    samples_.clear();
+    thread_ = std::thread([this]() {
+      while (!stop_.load(std::memory_order_relaxed)) {
+        take_sample();
+        std::this_thread::sleep_for(interval_);
+      }
+      take_sample();
+    });
+#endif
+  }
+
+  std::vector<MemorySample> stop() {
+#ifdef __linux__
+    stop_.store(true, std::memory_order_relaxed);
+    if (thread_.joinable()) thread_.join();
+    return std::move(samples_);
+#else
+    return {};
+#endif
+  }
+
+ private:
+#ifdef __linux__
+  void take_sample() {
+    auto [rss, vm] = read_statm();
+    samples_.push_back({now_ms(), rss, vm});
+  }
+
+  static std::pair<uint64_t, uint64_t> read_statm() {
+    std::ifstream f("/proc/self/statm");
+    uint64_t vm_pages = 0, rss_pages = 0;
+    if (f.is_open()) {
+      f >> vm_pages >> rss_pages;
+    }
+    static const uint64_t page_size = static_cast<uint64_t>(sysconf(_SC_PAGE_SIZE));
+    return {rss_pages * page_size, vm_pages * page_size};
+  }
+
+  static uint64_t now_ms() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
+  }
+#endif
+
+  std::chrono::milliseconds interval_;
+  std::atomic<bool> stop_;
+#ifdef __linux__
+  std::thread thread_;
+#endif
+  std::vector<MemorySample> samples_;
+};

--- a/tests/performance/drivers/odbc/app/results.cpp
+++ b/tests/performance/drivers/odbc/app/results.cpp
@@ -24,10 +24,10 @@ void write_csv_results(const std::vector<TestResult>& results, const std::string
   auto csv = open_csv_file(filename);
   if (!csv) return;
 
-  *csv << "timestamp,query_s,fetch_s,row_count\n";
+  *csv << "timestamp,query_s,fetch_s,row_count,cpu_time_s,peak_rss_mb\n";
   for (const auto& r : results) {
     *csv << r.timestamp << "," << std::fixed << std::setprecision(6) << r.query_time_s << "," << r.fetch_time_s << ","
-         << r.row_count << "\n";
+         << r.row_count << "," << r.cpu_time_s << "," << std::setprecision(1) << r.peak_rss_mb << "\n";
   }
   csv->close();
 }
@@ -36,11 +36,33 @@ void write_csv_results_put_get(const std::vector<PutGetResult>& results, const s
   auto csv = open_csv_file(filename);
   if (!csv) return;
 
-  *csv << "timestamp,query_s\n";
+  *csv << "timestamp,query_s,cpu_time_s,peak_rss_mb\n";
   for (const auto& r : results) {
-    *csv << r.timestamp << "," << std::fixed << std::setprecision(6) << r.query_time_s << "\n";
+    *csv << r.timestamp << "," << std::fixed << std::setprecision(6) << r.query_time_s << "," << r.cpu_time_s << ","
+         << std::setprecision(1) << r.peak_rss_mb << "\n";
   }
   csv->close();
+}
+
+void write_memory_timeline(const std::vector<MemorySample>& samples, const std::string& test_name,
+                           const std::string& driver_type, time_t timestamp) {
+  if (samples.empty()) return;
+
+  std::filesystem::path results_dir("/results");
+  std::stringstream filename_ss;
+  filename_ss << "memory_timeline_" << test_name << "_odbc_" << driver_type << "_" << timestamp << ".csv";
+  std::string filename = (results_dir / filename_ss.str()).string();
+
+  auto csv = open_csv_file(filename);
+  if (!csv) return;
+
+  *csv << "timestamp_ms,rss_bytes,vm_bytes\n";
+  for (const auto& s : samples) {
+    *csv << s.timestamp_ms << "," << s.rss_bytes << "," << s.vm_bytes << "\n";
+  }
+  csv->close();
+
+  std::cout << "✓ Memory timeline → " << filename << " (" << samples.size() << " samples)\n";
 }
 
 std::string generate_results_filename(const std::string& test_name, const std::string& driver_type, time_t timestamp) {

--- a/tests/performance/drivers/odbc/app/results.h
+++ b/tests/performance/drivers/odbc/app/results.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "resource_monitor.h"
 #include "types.h"
 
 // Forward declaration for PutGetResult
@@ -13,6 +14,8 @@ struct PutGetResult;
 
 void write_csv_results(const std::vector<TestResult>& results, const std::string& filename);
 void write_csv_results_put_get(const std::vector<PutGetResult>& results, const std::string& filename);
+void write_memory_timeline(const std::vector<MemorySample>& samples, const std::string& test_name,
+                           const std::string& driver_type, time_t timestamp);
 
 std::string generate_results_filename(const std::string& test_name, const std::string& driver_type, time_t timestamp);
 std::string generate_metadata_filename(const std::string& driver_type);

--- a/tests/performance/drivers/odbc/app/types.h
+++ b/tests/performance/drivers/odbc/app/types.h
@@ -9,4 +9,6 @@ struct TestResult {
   double query_time_s;
   double fetch_time_s;
   std::size_t row_count;
+  double cpu_time_s;
+  double peak_rss_mb;
 };


### PR DESCRIPTION
Add CPU time, peak RSS, and memory timeline tracking to Odbc performance tests

Per-iteration metrics (new columns in results CSV):

- cpu_time_s -- CPU time scoped to the fetch phase (SELECT) or execute phase (PUT/GET)
- peak_rss_mb -- process peak RSS via getrusage(RUSAGE_SELF).ru_maxrss

Memory timeline (new CSV file per test):

- Background thread samples RSS and VM from /proc/self/statm at ~100ms intervals (Linux only)
- Uploaded to Benchstore as time-series gauge metrics (rss_memory_mb, vm_memory_mb)

Aggregate metrics (new Benchstore run aggregates):

- rss_memory_delta_mb -- max(rss) - min(rss) across all timeline samples; detects working memory regressions
- rss_memory_growth_mb -- min(rss in last iteration) - min(rss in first iteration); detects memory leaks by comparing idle baselines