### PR TITLE
add cpu/memory perf metrics for core

### DIFF
--- a/tests/performance/drivers/core/app/Cargo.toml
+++ b/tests/performance/drivers/core/app/Cargo.toml
@@ -16,5 +16,6 @@ arrow = { version = "56.0.0", features = ["ffi"] }
 arrow-array = "56.0.0"
 regex = "1.10"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+libc = "0.2"
 
 sf_core = { path = "../../../../../sf_core" }

--- a/tests/performance/drivers/core/app/src/main.rs
+++ b/tests/performance/drivers/core/app/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod connection;
 mod put_execution;
 mod query_execution;
+mod resource_monitor;
 mod results;
 mod test_types;
 mod types;

--- a/tests/performance/drivers/core/app/src/put_execution.rs
+++ b/tests/performance/drivers/core/app/src/put_execution.rs
@@ -5,12 +5,13 @@ use regex::Regex;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use std::fs;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::connection::{DriverRuntime, reset_statement_query};
+use crate::resource_monitor::ResourceMonitor;
 use crate::results::{
     current_unix_timestamp, print_statistics_put_get, write_csv_results_put_get,
-    write_metadata_if_not_replay,
+    write_memory_timeline, write_metadata_if_not_replay,
 };
 use crate::types::PutGetResult;
 
@@ -24,30 +25,41 @@ pub fn execute_put_get_test(
     test_name: &str,
 ) -> Result<()> {
     println!("\n=== Executing PUT_GET Test ===");
-    println!("Query: {}", sql_command);
+    println!("Query: {sql_command}");
 
     // Warmup
     run_warmup_put_get(rt, stmt_handle, sql_command, warmup_iterations)
-        .map_err(|e| format!("Warmup phase failed: {:?}", e))?;
+        .map_err(|e| format!("Warmup phase failed: {e:?}"))?;
 
     if warmup_iterations > 0 {
         reset_statement_query(rt, stmt_handle, sql_command)
-            .map_err(|e| format!("Failed to reset statement after warmup: {:?}", e))?;
+            .map_err(|e| format!("Failed to reset statement after warmup: {e:?}"))?;
     }
+
+    let mut monitor = ResourceMonitor::new(Duration::from_millis(100));
+    monitor.start();
 
     // Execute
     let results = run_test_iterations_put_get(rt, stmt_handle, sql_command, iterations)
-        .map_err(|e| format!("Test phase failed: {:?}", e))?;
+        .map_err(|e| format!("Test phase failed: {e:?}"))?;
+
+    let memory_timeline = monitor.stop();
 
     // Write & print
     let results_file = write_csv_results_put_get(&results, test_name)
-        .map_err(|e| format!("Failed to write results: {:?}", e))?;
+        .map_err(|e| format!("Failed to write results: {e:?}"))?;
+
+    write_memory_timeline(&memory_timeline, test_name);
 
     write_metadata_if_not_replay(rt, conn_handle)?;
 
     print_statistics_put_get(&results);
+    println!(
+        "  Memory timeline: {} samples collected",
+        memory_timeline.len()
+    );
 
-    println!("\n✓ Complete → {}", results_file);
+    println!("\n✓ Complete → {results_file}");
 
     Ok(())
 }
@@ -81,11 +93,14 @@ pub fn run_test_iterations_put_get(
     let mut results = Vec::with_capacity(iterations);
 
     for i in 0..iterations {
-        let query_time = execute_put_get_iteration(rt, stmt_handle, sql)?;
+        let (query_time, cpu_time_s, peak_rss_mb) =
+            execute_put_get_iteration(rt, stmt_handle, sql)?;
 
         results.push(PutGetResult {
             timestamp: current_unix_timestamp(),
             query_time_s: query_time,
+            cpu_time_s,
+            peak_rss_mb,
         });
 
         if i < iterations - 1 {
@@ -100,9 +115,12 @@ fn execute_put_get_iteration(
     rt: &DriverRuntime,
     stmt_handle: StatementHandle,
     sql: &str,
-) -> Result<f64> {
+) -> Result<(f64, f64, f64)> {
+    use crate::resource_monitor::{get_peak_rss_mb, process_cpu_seconds};
+
     create_get_target_directory(sql)?;
 
+    let cpu_before = process_cpu_seconds();
     let start_query = Instant::now();
     rt.block_on(async |c| {
         c.statement_execute_query(StatementExecuteQueryRequest {
@@ -111,10 +129,12 @@ fn execute_put_get_iteration(
         })
         .await
     })
-    .map_err(|e| format!("PUT/GET execution failed: {:?}", e))?;
+    .map_err(|e| format!("PUT/GET execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();
+    let cpu_time_s = process_cpu_seconds() - cpu_before;
+    let peak_rss_mb = get_peak_rss_mb();
 
-    Ok(query_time)
+    Ok((query_time, cpu_time_s, peak_rss_mb))
 }
 
 /// For GET commands:

--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -2,12 +2,14 @@
 
 type Result<T> = std::result::Result<T, String>;
 use sf_core::protobuf::generated::database_driver_v1::*;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::arrow::fetch_result_rows;
 use crate::connection::{DriverRuntime, reset_statement_query};
+use crate::resource_monitor::ResourceMonitor;
 use crate::results::{
-    current_unix_timestamp, print_statistics, write_csv_results, write_metadata_if_not_replay,
+    current_unix_timestamp, print_statistics, write_csv_results, write_memory_timeline,
+    write_metadata_if_not_replay,
 };
 use crate::types::IterationResult;
 
@@ -21,30 +23,41 @@ pub fn execute_fetch_test(
     test_name: &str,
 ) -> Result<()> {
     println!("\n=== Executing SELECT Test ===");
-    println!("Query: {}", sql_command);
+    println!("Query: {sql_command}");
 
     // Warmup
     run_warmup(rt, stmt_handle, sql_command, warmup_iterations)
-        .map_err(|e| format!("Warmup phase failed: {:?}", e))?;
+        .map_err(|e| format!("Warmup phase failed: {e:?}"))?;
 
     if warmup_iterations > 0 {
         reset_statement_query(rt, stmt_handle, sql_command)
-            .map_err(|e| format!("Failed to reset statement after warmup: {:?}", e))?;
+            .map_err(|e| format!("Failed to reset statement after warmup: {e:?}"))?;
     }
+
+    let mut monitor = ResourceMonitor::new(Duration::from_millis(100));
+    monitor.start();
 
     // Execute
     let results = run_test_iterations(rt, stmt_handle, sql_command, iterations)
-        .map_err(|e| format!("Test phase failed: {:?}", e))?;
+        .map_err(|e| format!("Test phase failed: {e:?}"))?;
+
+    let memory_timeline = monitor.stop();
 
     // Write & print
     let results_file = write_csv_results(&results, test_name)
-        .map_err(|e| format!("Failed to write results: {:?}", e))?;
+        .map_err(|e| format!("Failed to write results: {e:?}"))?;
+
+    write_memory_timeline(&memory_timeline, test_name);
 
     write_metadata_if_not_replay(rt, conn_handle)?;
 
     print_statistics(&results);
+    println!(
+        "  Memory timeline: {} samples collected",
+        memory_timeline.len()
+    );
 
-    println!("\n✓ Complete → {}", results_file);
+    println!("\n✓ Complete → {results_file}");
 
     Ok(())
 }
@@ -60,7 +73,7 @@ pub fn run_warmup(
     }
 
     for i in 0..warmup_iterations {
-        let (_query_time, _fetch_time, _row_count) = execute_iteration(rt, stmt_handle)?;
+        let _ = execute_iteration(rt, stmt_handle)?;
 
         if i < warmup_iterations - 1 {
             reset_statement_query(rt, stmt_handle, sql)?;
@@ -79,7 +92,8 @@ pub fn run_test_iterations(
     let mut expected_row_count = get_expected_row_count();
 
     for i in 0..iterations {
-        let (query_time, fetch_time, row_count) = execute_iteration(rt, stmt_handle)?;
+        let (query_time, fetch_time, row_count, cpu_time_s, peak_rss_mb) =
+            execute_iteration(rt, stmt_handle)?;
 
         expected_row_count = validate_row_count(row_count, expected_row_count, i)?;
 
@@ -88,6 +102,8 @@ pub fn run_test_iterations(
             query_time_s: query_time,
             fetch_time_s: fetch_time,
             row_count,
+            cpu_time_s,
+            peak_rss_mb,
         });
 
         if i < iterations - 1 {
@@ -139,7 +155,9 @@ fn validate_row_count(
 fn execute_iteration(
     rt: &DriverRuntime,
     stmt_handle: StatementHandle,
-) -> Result<(f64, f64, usize)> {
+) -> Result<(f64, f64, usize, f64, f64)> {
+    use crate::resource_monitor::{get_peak_rss_mb, process_cpu_seconds};
+
     let start_query = Instant::now();
     let response = rt
         .block_on(async |c| {
@@ -149,17 +167,19 @@ fn execute_iteration(
             })
             .await
         })
-        .map_err(|e| format!("Query execution failed: {:?}", e))?;
+        .map_err(|e| format!("Query execution failed: {e:?}"))?;
     let query_time = start_query.elapsed().as_secs_f64();
 
-    // Fetch results outside the runtime so ChunkReader can use its own block_on
+    let cpu_before = process_cpu_seconds();
     let start_fetch = Instant::now();
     let row_count = if let Some(result) = response.result {
-        fetch_result_rows(result).map_err(|e| format!("Failed to fetch results: {:?}", e))?
+        fetch_result_rows(result).map_err(|e| format!("Failed to fetch results: {e:?}"))?
     } else {
         0
     };
     let fetch_time = start_fetch.elapsed().as_secs_f64();
+    let cpu_time_s = process_cpu_seconds() - cpu_before;
+    let peak_rss_mb = get_peak_rss_mb();
 
-    Ok((query_time, fetch_time, row_count))
+    Ok((query_time, fetch_time, row_count, cpu_time_s, peak_rss_mb))
 }

--- a/tests/performance/drivers/core/app/src/resource_monitor.rs
+++ b/tests/performance/drivers/core/app/src/resource_monitor.rs
@@ -1,0 +1,122 @@
+//! Background memory timeline monitor using /proc/self/statm (Linux only).
+//!
+//! Spawns a thread that samples RSS and virtual memory at a configurable
+//! interval (default 100 ms). On non-Linux platforms start/stop are no-ops
+//! returning an empty timeline.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+pub struct MemorySample {
+    pub timestamp_ms: u64,
+    pub rss_bytes: u64,
+    pub vm_bytes: u64,
+}
+
+pub struct ResourceMonitor {
+    interval: Duration,
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<Vec<MemorySample>>>,
+}
+
+impl ResourceMonitor {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            stop: Arc::new(AtomicBool::new(false)),
+            thread: None,
+        }
+    }
+
+    pub fn start(&mut self) {
+        if !cfg!(target_os = "linux") {
+            return;
+        }
+
+        self.stop.store(false, Ordering::Relaxed);
+        let stop = Arc::clone(&self.stop);
+        let interval = self.interval;
+
+        self.thread = Some(std::thread::spawn(move || {
+            let mut samples = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                if let Some(s) = take_sample() {
+                    samples.push(s);
+                }
+                std::thread::sleep(interval);
+            }
+            if let Some(s) = take_sample() {
+                samples.push(s);
+            }
+            samples
+        }));
+    }
+
+    pub fn stop(&mut self) -> Vec<MemorySample> {
+        self.stop.store(true, Ordering::Relaxed);
+        self.thread
+            .take()
+            .map(|h| h.join().unwrap_or_default())
+            .unwrap_or_default()
+    }
+}
+
+fn take_sample() -> Option<MemorySample> {
+    let (rss, vm) = read_statm()?;
+    Some(MemorySample {
+        timestamp_ms: now_ms(),
+        rss_bytes: rss,
+        vm_bytes: vm,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_statm() -> Option<(u64, u64)> {
+    let content = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let mut parts = content.split_whitespace();
+    let vm_pages: u64 = parts.next()?.parse().ok()?;
+    let rss_pages: u64 = parts.next()?.parse().ok()?;
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) } as u64;
+    Some((rss_pages * page_size, vm_pages * page_size))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_statm() -> Option<(u64, u64)> {
+    None
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+/// CPU time (user + system) for the process in seconds via `getrusage`.
+pub fn process_cpu_seconds() -> f64 {
+    unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        libc::getrusage(libc::RUSAGE_SELF, &mut usage);
+        timeval_to_secs(&usage.ru_utime) + timeval_to_secs(&usage.ru_stime)
+    }
+}
+
+/// Process peak RSS in MB. ru_maxrss is KB on Linux, bytes on macOS.
+pub fn get_peak_rss_mb() -> f64 {
+    unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        libc::getrusage(libc::RUSAGE_SELF, &mut usage);
+        let raw = usage.ru_maxrss as f64;
+        if cfg!(target_os = "macos") {
+            raw / (1024.0 * 1024.0)
+        } else {
+            raw / 1024.0
+        }
+    }
+}
+
+fn timeval_to_secs(tv: &libc::timeval) -> f64 {
+    tv.tv_sec as f64 + tv.tv_usec as f64 / 1_000_000.0
+}

--- a/tests/performance/drivers/core/app/src/results.rs
+++ b/tests/performance/drivers/core/app/src/results.rs
@@ -1,6 +1,7 @@
 //! Results output and CSV formatting
 
 use crate::connection::{DriverRuntime, get_server_version as get_server_version_internal};
+use crate::resource_monitor::MemorySample;
 use crate::types::{IterationResult, PutGetResult};
 use sf_core::protobuf::generated::database_driver_v1::ConnectionHandle;
 use std::fs;
@@ -11,15 +12,23 @@ type Result<T> = std::result::Result<T, String>;
 
 pub fn write_csv_results(results: &[IterationResult], test_name: &str) -> Result<String> {
     write_csv_file(test_name, |file| {
-        writeln!(file, "timestamp,query_s,fetch_s,row_count")
-            .map_err(|e| format!("Failed to write: {:?}", e))?;
-        for result in results {
+        writeln!(
+            file,
+            "timestamp,query_s,fetch_s,row_count,cpu_time_s,peak_rss_mb"
+        )
+        .map_err(|e| format!("Failed to write: {e:?}"))?;
+        for r in results {
             writeln!(
                 file,
-                "{},{:.6},{:.6},{}",
-                result.timestamp, result.query_time_s, result.fetch_time_s, result.row_count
+                "{},{:.6},{:.6},{},{:.6},{:.1}",
+                r.timestamp,
+                r.query_time_s,
+                r.fetch_time_s,
+                r.row_count,
+                r.cpu_time_s,
+                r.peak_rss_mb
             )
-            .map_err(|e| format!("Failed to write: {:?}", e))?;
+            .map_err(|e| format!("Failed to write: {e:?}"))?;
         }
         Ok(())
     })
@@ -40,13 +49,45 @@ pub fn print_statistics(results: &[IterationResult]) {
 
 pub fn write_csv_results_put_get(results: &[PutGetResult], test_name: &str) -> Result<String> {
     write_csv_file(test_name, |file| {
-        writeln!(file, "timestamp,query_s").map_err(|e| format!("Failed to write: {:?}", e))?;
-        for result in results {
-            writeln!(file, "{},{:.6}", result.timestamp, result.query_time_s)
-                .map_err(|e| format!("Failed to write: {:?}", e))?;
+        writeln!(file, "timestamp,query_s,cpu_time_s,peak_rss_mb")
+            .map_err(|e| format!("Failed to write: {e:?}"))?;
+        for r in results {
+            writeln!(
+                file,
+                "{},{:.6},{:.6},{:.1}",
+                r.timestamp, r.query_time_s, r.cpu_time_s, r.peak_rss_mb
+            )
+            .map_err(|e| format!("Failed to write: {e:?}"))?;
         }
         Ok(())
     })
+}
+
+pub fn write_memory_timeline(samples: &[MemorySample], test_name: &str) {
+    if samples.is_empty() {
+        return;
+    }
+
+    let timestamp = current_unix_timestamp();
+    let results_dir = std::env::var("RESULTS_DIR").unwrap_or_else(|_| "/results".to_string());
+    let results_path = PathBuf::from(&results_dir);
+    let filename = results_path.join(format!("memory_timeline_{test_name}_core_{timestamp}.csv"));
+
+    let Ok(mut file) = fs::File::create(&filename) else {
+        eprintln!("⚠️  Warning: Could not create memory timeline file");
+        return;
+    };
+
+    let _ = writeln!(file, "timestamp_ms,rss_bytes,vm_bytes");
+    for s in samples {
+        let _ = writeln!(file, "{},{},{}", s.timestamp_ms, s.rss_bytes, s.vm_bytes);
+    }
+
+    println!(
+        "✓ Memory timeline → {} ({} samples)",
+        filename.display(),
+        samples.len()
+    );
 }
 
 pub fn print_statistics_put_get(results: &[PutGetResult]) {

--- a/tests/performance/drivers/core/app/src/types.rs
+++ b/tests/performance/drivers/core/app/src/types.rs
@@ -46,10 +46,14 @@ pub struct IterationResult {
     pub query_time_s: f64,
     pub fetch_time_s: f64,
     pub row_count: usize,
+    pub cpu_time_s: f64,
+    pub peak_rss_mb: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PutGetResult {
     pub timestamp: i64,
     pub query_time_s: f64,
+    pub cpu_time_s: f64,
+    pub peak_rss_mb: f64,
 }


### PR DESCRIPTION
Add CPU time, peak RSS, and memory timeline tracking to Core performance tests

Per-iteration metrics (new columns in results CSV):

- cpu_time_s -- CPU time scoped to the fetch phase (SELECT) or execute phase (PUT/GET)
- peak_rss_mb -- process peak RSS via getrusage(RUSAGE_SELF).ru_maxrss

Memory timeline (new CSV file per test):

- Background thread samples RSS and VM from /proc/self/statm at ~100ms intervals (Linux only)
- Uploaded to Benchstore as time-series gauge metrics (rss_memory_mb, vm_memory_mb)

Aggregate metrics (new Benchstore run aggregates):

- rss_memory_delta_mb -- max(rss) - min(rss) across all timeline samples; detects working memory regressions
- rss_memory_growth_mb -- min(rss in last iteration) - min(rss in first iteration); detects memory leaks by comparing idle baselines