### PR TITLE
SNOW-3277766: Trim ODBC properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "serde_json",
  "sf_core",
  "snafu 0.8.9",
+ "test-case",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -23,5 +23,8 @@ proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }
 tokio = { version = "1.50.0", features = ["rt"] }
 
+[dev-dependencies]
+test-case = "3.3.1"
+
 [[test]]
 name = "odbc_api_tests"

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -55,7 +55,7 @@ fn parse_connection_string(connection_string: &str) -> HashMap<String, String> {
     for pair in connection_string.split(';') {
         let parts: Vec<&str> = pair.splitn(2, '=').collect();
         if parts.len() == 2 {
-            map.insert(parts[0].to_string(), parts[1].to_string());
+            map.insert(parts[0].trim().to_string(), parts[1].trim().to_string());
         }
     }
     map
@@ -585,6 +585,27 @@ pub fn get_info<E: OdbcEncoding>(
                 }
             }
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("UID=admin;SERVER=foo", &[("UID", "admin"), ("SERVER", "foo")] ; "basic")]
+    #[test_case("UID=admin; AUTHENTICATOR=SNOWFLAKE_JWT", &[("UID", "admin"), ("AUTHENTICATOR", "SNOWFLAKE_JWT")] ; "trims keys")]
+    #[test_case("UID= admin ", &[("UID", "admin")] ; "trims values")]
+    #[test_case(" UID = admin ; SERVER = foo ", &[("UID", "admin"), ("SERVER", "foo")] ; "trims both")]
+    #[test_case("PRIV_KEY_FILE=abc=def", &[("PRIV_KEY_FILE", "abc=def")] ; "preserves equals in value")]
+    #[test_case("UID=admin;  ;SERVER=foo", &[("UID", "admin"), ("SERVER", "foo")] ; "skips blank segments")]
+    #[test_case("UID=admin;", &[("UID", "admin")] ; "trailing semicolon")]
+    fn parse_connection_string_cases(input: &str, expected: &[(&str, &str)]) {
+        let map = parse_connection_string(input);
+        assert_eq!(map.len(), expected.len());
+        for (key, value) in expected {
+            assert_eq!(map.get(*key).unwrap(), value);
         }
     }
 }


### PR DESCRIPTION
This PR tightens ODBC connection string parsing by trimming whitespace around property keys and values, improving compatibility with connection strings that include extra spaces and ensuring sensitive keys are properly recognized for redaction/logging.

**Changes:**
- Trim whitespace around keys and values when parsing connection strings in `driver_connect`.
- Add unit tests covering trimming behavior and a few parsing edge cases.
- Add `test-case` as a dev-dependency for parameterized unit tests.