### PR TITLE
SNOW-3282028 Convert JSON chunks to Arrow chunks

### DIFF
--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -3,7 +3,7 @@ use crate::arrow_utils::ArrowUtilsError;
 use crate::arrow_utils::{
     boxed_arrow_reader, convert_string_rowset_to_arrow_reader, create_schema,
 };
-use crate::chunks::{ChunkError, ChunkReader, DEFAULT_PREFETCH_THREADS};
+use crate::chunks::{self, ChunkError, ChunkReader, DEFAULT_PREFETCH_THREADS};
 use crate::file_manager;
 use crate::file_manager::{DownloadResult, UploadResult, download_files, upload_files};
 use crate::query_types::RowType;
@@ -124,25 +124,29 @@ async fn read_batches<'a>(
                 .context(RowsetConversionSnafu)
         }
         query_response::RowsetData::JsonRowset { rowset, rowtype } => {
-            let row_types = rowtype
-                .iter()
-                .map(|rt| rt.try_into())
-                .collect::<Result<Vec<_>, _>>()
-                .context(RowTypeParsingSnafu)?;
-
-            // Validate column counts before converting
-            if !rowset.is_empty() {
-                let num_columns_rowset = rowset.first().unwrap().len();
-                let num_columns_rowtype = row_types.len();
-                if num_columns_rowset != num_columns_rowtype {
-                    return ColumnCountMismatchSnafu {
-                        rowtype_count: num_columns_rowtype,
-                        rowset_count: num_columns_rowset,
-                    }
-                    .fail();
-                }
-            }
+            let row_types = parse_row_types(rowtype)?;
+            validate_column_count(rowset, &row_types)?;
             convert_string_rowset_to_arrow_reader(rowset, &row_types).context(RowsetConversionSnafu)
+        }
+        query_response::RowsetData::JsonMultiChunk {
+            rowset,
+            rowtype,
+            chunk_download_data,
+        } => {
+            let row_types = parse_row_types(rowtype)?;
+            validate_column_count(rowset, &row_types)?;
+
+            let reader = chunks::JsonChunkReader::new(
+                rowset,
+                row_types,
+                chunk_download_data,
+                http_client.clone(),
+                DEFAULT_PREFETCH_THREADS,
+            )
+            .await
+            .context(ChunkReadingSnafu)?;
+
+            Ok(Box::new(reader))
         }
         query_response::RowsetData::NoData => {
             // No rowset or rowtype found, return empty reader
@@ -150,6 +154,32 @@ async fn read_batches<'a>(
             Ok(Box::new(reader))
         }
     }
+}
+
+fn parse_row_types(rowtype: &[query_response::RowType]) -> Result<Vec<RowType>, ReadBatchesError> {
+    rowtype
+        .iter()
+        .map(|rt| rt.try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .context(RowTypeParsingSnafu)
+}
+
+fn validate_column_count(
+    rowset: &[Vec<Option<String>>],
+    row_types: &[RowType],
+) -> Result<(), ReadBatchesError> {
+    if !rowset.is_empty() {
+        let num_columns_rowset = rowset.first().unwrap().len();
+        let num_columns_rowtype = row_types.len();
+        if num_columns_rowset != num_columns_rowtype {
+            return ColumnCountMismatchSnafu {
+                rowtype_count: num_columns_rowtype,
+                rowset_count: num_columns_rowset,
+            }
+            .fail();
+        }
+    }
+    Ok(())
 }
 
 /// Helper macro to create string arrays from field accessors

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -3,9 +3,11 @@ use arrow::array::{
     Array, BinaryArray, BooleanArray, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
     StringArray,
 };
+use arrow::datatypes;
 use arrow::datatypes::{DataType, Date32Type, Field, Int32Type, Int64Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
+use datatypes::{Int8Type, Int16Type};
 use hex::FromHexError;
 use snafu::{Location, ResultExt, Snafu};
 use std::collections::HashMap;
@@ -220,31 +222,13 @@ pub fn create_field_with_type(
     }
 }
 
-/// Maps a FIXED column's precision to the narrowest integer Arrow type that can
-/// hold all possible values for that precision. Used as a precision-based
-/// fallback for all-null columns (the non-null path instead infers the type
-/// from the observed min/max values, which may select a different width).
-fn integer_type_for_precision(precision: u64) -> DataType {
-    if precision <= 2 {
-        DataType::Int8
-    } else if precision <= 4 {
-        DataType::Int16
-    } else if precision <= 9 {
-        DataType::Int32
-    } else if precision <= 18 {
-        DataType::Int64
-    } else {
-        DataType::Decimal128(precision as u8, 0)
-    }
-}
-
 fn cast_fixed_to_arrow<T>(
     row_type: &RowType,
     data_type: DataType,
     parsed: Vec<Option<i128>>,
 ) -> Result<(Field, Arc<dyn Array>), ArrowUtilsError>
 where
-    T: arrow::datatypes::ArrowPrimitiveType,
+    T: datatypes::ArrowPrimitiveType,
     T::Native: TryFrom<i128>,
     arrow::array::PrimitiveArray<T>: From<Vec<Option<T::Native>>>,
 {
@@ -405,75 +389,26 @@ fn create_column_array(
             if min_value.is_none() {
                 if *scale > 0 {
                     return Ok((
-                        create_field_with_type(
-                            row_type,
-                            Some(DataType::Decimal128(*precision as u8, *scale as i8)),
-                        )?,
-                        Arc::new(
-                            arrow::array::Decimal128Array::new_null(len)
-                                .with_precision_and_scale(*precision as u8, *scale as i8)
-                                .context(ArrowSnafu {})?,
-                        ),
-                    ));
-                }
-                let inferred = integer_type_for_precision(*precision);
-                return match inferred {
-                    DataType::Int8 => Ok((
                         create_field_with_type(row_type, Some(DataType::Int8))?,
                         Arc::new(Int8Array::new_null(len)),
-                    )),
-                    DataType::Int16 => Ok((
-                        create_field_with_type(row_type, Some(DataType::Int16))?,
-                        Arc::new(Int16Array::new_null(len)),
-                    )),
-                    DataType::Int32 => Ok((
-                        create_field_with_type(row_type, Some(DataType::Int32))?,
-                        Arc::new(Int32Array::new_null(len)),
-                    )),
-                    DataType::Int64 => Ok((
-                        create_field_with_type(row_type, Some(DataType::Int64))?,
-                        Arc::new(Int64Array::new_null(len)),
-                    )),
-                    dt @ DataType::Decimal128(p, s) => Ok((
-                        create_field_with_type(row_type, Some(dt))?,
-                        Arc::new(
-                            arrow::array::Decimal128Array::new_null(len)
-                                .with_precision_and_scale(p, s)
-                                .context(ArrowSnafu {})?,
-                        ),
-                    )),
-                    _ => unreachable!(
-                        "integer_type_for_precision only returns Int8/16/32/64 or Decimal128"
-                    ),
-                };
+                    ));
+                }
+                return Ok((
+                    create_field_with_type(row_type, Some(DataType::Int8))?,
+                    Arc::new(Int8Array::new_null(len)),
+                ));
             }
             let min_value = min_value.unwrap();
             let max_value = max_value.unwrap();
 
             if min_value >= i8::MIN as i128 && max_value <= i8::MAX as i128 {
-                cast_fixed_to_arrow::<arrow::datatypes::Int8Type>(
-                    row_type,
-                    DataType::Int8,
-                    decimal_values,
-                )
+                cast_fixed_to_arrow::<Int8Type>(row_type, DataType::Int8, decimal_values)
             } else if min_value >= i16::MIN as i128 && max_value <= i16::MAX as i128 {
-                cast_fixed_to_arrow::<arrow::datatypes::Int16Type>(
-                    row_type,
-                    DataType::Int16,
-                    decimal_values,
-                )
+                cast_fixed_to_arrow::<Int16Type>(row_type, DataType::Int16, decimal_values)
             } else if min_value >= i32::MIN as i128 && max_value <= i32::MAX as i128 {
-                cast_fixed_to_arrow::<arrow::datatypes::Int32Type>(
-                    row_type,
-                    DataType::Int32,
-                    decimal_values,
-                )
+                cast_fixed_to_arrow::<Int32Type>(row_type, DataType::Int32, decimal_values)
             } else if min_value >= i64::MIN as i128 && max_value <= i64::MAX as i128 {
-                cast_fixed_to_arrow::<arrow::datatypes::Int64Type>(
-                    row_type,
-                    DataType::Int64,
-                    decimal_values,
-                )
+                cast_fixed_to_arrow::<Int64Type>(row_type, DataType::Int64, decimal_values)
             } else {
                 Ok((
                     create_field_with_type(
@@ -1192,7 +1127,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         let col = batch.column(0);
         assert_eq!(col.null_count(), 2);
-        assert_eq!(*col.data_type(), DataType::Int64);
+        assert_eq!(*col.data_type(), DataType::Int8);
     }
 
     #[test]
@@ -1210,34 +1145,6 @@ mod tests {
     }
 
     #[test]
-    fn test_all_null_fixed_column_int16() {
-        let rowset = vec![vec![None], vec![None]];
-        let row_types = vec![RowType::fixed("col", true, 4, 0)];
-
-        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
-        let batch = reader.next().unwrap().unwrap();
-
-        assert_eq!(batch.num_rows(), 2);
-        let col = batch.column(0);
-        assert_eq!(col.null_count(), 2);
-        assert_eq!(*col.data_type(), DataType::Int16);
-    }
-
-    #[test]
-    fn test_all_null_fixed_column_int32() {
-        let rowset = vec![vec![None], vec![None]];
-        let row_types = vec![RowType::fixed("col", true, 9, 0)];
-
-        let mut reader = convert_string_rowset_to_arrow_reader(&rowset, &row_types).unwrap();
-        let batch = reader.next().unwrap().unwrap();
-
-        assert_eq!(batch.num_rows(), 2);
-        let col = batch.column(0);
-        assert_eq!(col.null_count(), 2);
-        assert_eq!(*col.data_type(), DataType::Int32);
-    }
-
-    #[test]
     fn test_all_null_fixed_column_with_scale() {
         let rowset = vec![vec![None], vec![None]];
         let row_types = vec![RowType::fixed("col", true, 10, 2)];
@@ -1248,7 +1155,10 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         let col = batch.column(0);
         assert_eq!(col.null_count(), 2);
-        assert_eq!(*col.data_type(), DataType::Decimal128(10, 2));
+        assert_eq!(*col.data_type(), DataType::Int8);
+        let schema = batch.schema();
+        let field = schema.field(0);
+        assert_eq!(field.metadata().get("scale").unwrap(), "2");
     }
 
     #[test]
@@ -1343,7 +1253,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         let col = batch.column(0);
         assert_eq!(col.null_count(), 2);
-        assert_eq!(*col.data_type(), DataType::Decimal128(20, 0));
+        assert_eq!(*col.data_type(), DataType::Int8);
     }
 
     #[test]

--- a/sf_core/src/chunks.rs
+++ b/sf_core/src/chunks.rs
@@ -3,7 +3,9 @@ use std::io;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::arrow_utils::convert_string_rowset_to_arrow_reader;
 use crate::compression::{CompressionError, decompress_data};
+use crate::query_types::RowType;
 use arrow::array::{RecordBatch, RecordBatchReader};
 use arrow::datatypes::{Fields, Schema, SchemaRef};
 use arrow::error::ArrowError;
@@ -167,6 +169,144 @@ impl Iterator for ChunkReader {
 }
 
 impl RecordBatchReader for ChunkReader {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+/// Reads Arrow record batches from JSON result-set chunks, converting each
+/// chunk from JSON rows to Arrow on demand.
+///
+/// Mirrors `ChunkReader`'s prefetch pattern: a background task downloads
+/// chunks concurrently, parses JSON, converts to Arrow, and sends
+/// `RecordBatch`es through a bounded channel.
+///
+/// See `ChunkReader` for the sync-iteration constraint.
+pub struct JsonChunkReader {
+    schema: SchemaRef,
+    batch_rx: tokio::sync::mpsc::Receiver<Result<RecordBatch, ArrowError>>,
+}
+
+impl JsonChunkReader {
+    pub async fn new(
+        initial_rowset: &[Vec<Option<String>>],
+        row_types: Vec<RowType>,
+        chunk_download_data: Vec<ChunkDownloadData>,
+        client: Client,
+        prefetch_concurrency: usize,
+    ) -> Result<Self, ChunkError> {
+        let reader = convert_string_rowset_to_arrow_reader(initial_rowset, &row_types)
+            .map_err(|e| ArrowError::ExternalError(Box::new(e)))
+            .context(ChunkReadingSnafu)?;
+        let schema = reader.schema();
+        let initial_batches: Vec<RecordBatch> = reader
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .context(ChunkReadingSnafu)?;
+
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        tokio::spawn(prefetch_json_batches(
+            initial_batches,
+            chunk_download_data.into(),
+            row_types,
+            client,
+            tx,
+            prefetch_concurrency,
+        ));
+
+        Ok(Self {
+            schema,
+            batch_rx: rx,
+        })
+    }
+}
+
+/// Background task that sends the initial rowset batches and downloads
+/// remaining JSON chunks concurrently, converting each to Arrow and sending
+/// through `tx`.
+async fn prefetch_json_batches(
+    initial_batches: Vec<RecordBatch>,
+    rest: VecDeque<ChunkDownloadData>,
+    row_types: Vec<RowType>,
+    client: Client,
+    tx: tokio::sync::mpsc::Sender<Result<RecordBatch, ArrowError>>,
+    concurrency: usize,
+) {
+    for batch in initial_batches {
+        if tx.send(Ok(batch)).await.is_err() {
+            return;
+        }
+    }
+
+    let row_types = Arc::new(row_types);
+
+    let mut chunk_stream = stream::iter(rest)
+        .map(move |chunk| {
+            let client = client.clone();
+            let row_types = Arc::clone(&row_types);
+            async move { download_and_parse_json_chunk(&client, &chunk, &row_types).await }
+        })
+        .buffered(concurrency)
+        .map(|result| match result {
+            Ok(batches) => stream::iter(batches.into_iter().map(Ok)).left_stream(),
+            Err(e) => stream::iter(vec![Err(e)]).right_stream(),
+        })
+        .flatten();
+
+    while let Some(result) = chunk_stream.next().await {
+        if tx.send(result).await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn download_and_parse_json_chunk(
+    client: &Client,
+    chunk: &ChunkDownloadData,
+    row_types: &[RowType],
+) -> Result<Vec<RecordBatch>, ArrowError> {
+    let chunk_bytes = get_chunk_data(client, chunk)
+        .await
+        .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+    // Chunk data is comma-separated row arrays without outer brackets,
+    // e.g.: [null,"a",...],\n["b","c",...],\n...
+    // Wrap in [] to make it a valid JSON array.
+    let mut wrapped = Vec::with_capacity(chunk_bytes.len() + 2);
+    wrapped.push(b'[');
+    wrapped.extend_from_slice(&chunk_bytes);
+    wrapped.push(b']');
+
+    let chunk_rows: Vec<Vec<Option<String>>> =
+        serde_json::from_slice(&wrapped).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+    let expected_cols = row_types.len();
+    if let Some((row_idx, row)) = chunk_rows
+        .iter()
+        .enumerate()
+        .find(|(_, r)| r.len() != expected_cols)
+    {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "JSON chunk row {row_idx} has {} columns, expected {expected_cols}",
+            row.len()
+        )));
+    }
+
+    let reader = convert_string_rowset_to_arrow_reader(&chunk_rows, row_types)
+        .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+    reader.into_iter().collect::<Result<Vec<_>, _>>()
+}
+
+impl Iterator for JsonChunkReader {
+    type Item = Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.batch_rx.blocking_recv()
+    }
+}
+
+impl RecordBatchReader for JsonChunkReader {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -452,7 +452,14 @@ impl Data {
             }
             Some("json") => {
                 if let Some((rowset, rowtype)) = self.to_json_rowset() {
-                    RowsetData::JsonRowset { rowset, rowtype }
+                    match self.to_chunk_download_data() {
+                        Some(chunk_download_data) => RowsetData::JsonMultiChunk {
+                            rowset,
+                            rowtype,
+                            chunk_download_data,
+                        },
+                        None => RowsetData::JsonRowset { rowset, rowtype },
+                    }
                 } else {
                     tracing::error!("Rowset and/or rowtype are missing for JSON result format");
                     RowsetData::NoData
@@ -524,6 +531,11 @@ pub enum RowsetData<'a> {
     JsonRowset {
         rowset: &'a Vec<Vec<Option<String>>>,
         rowtype: &'a Vec<RowType>,
+    },
+    JsonMultiChunk {
+        rowset: &'a Vec<Vec<Option<String>>>,
+        rowtype: &'a Vec<RowType>,
+        chunk_download_data: Vec<ChunkDownloadData>,
     },
     NoData,
 }

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -5,6 +5,7 @@ extern crate tracing_subscriber;
 use super::arrow_deserialize::ArrowDeserialize;
 use super::arrow_extract_value::{ArrowExtractError, ArrowExtractValue, extract_arrow_value};
 use arrow::array::{Array, ArrayRef, AsArray};
+use arrow::buffer::NullBuffer;
 use arrow::compute::kernels::cmp::not_distinct;
 use arrow::datatypes::{DataType, FieldRef, Schema};
 use arrow::ffi_stream::ArrowArrayStreamReader;
@@ -124,23 +125,44 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
     match logical_type {
         "TEXT" => &["finalType", "precision", "scale"],
         "FIXED" => &["finalType", "charLength", "byteLength"],
-        "TIMESTAMP_NTZ" | "TIMESTAMP_LTZ" | "TIMESTAMP_TZ" => &[
+        "BOOLEAN" => &[
+            "byteLength",
+            "charLength",
+            "finalType",
+            "precision",
+            "scale",
+        ],
+        "REAL" => &[
+            "byteLength",
+            "charLength",
+            "finalType",
+            "precision",
+            "scale",
+        ],
+        "TIMESTAMP_NTZ" | "TIMESTAMP_LTZ" | "TIMESTAMP_TZ" | "TIME" => &[
             "finalType",
             "charLength",
             "byteLength",
-            "scale",
             "precision",
             "physicalType",
         ],
-        "TIME" => &[
+        "DATE" => &[
             "finalType",
             "charLength",
             "byteLength",
             "precision",
+            "scale",
             "physicalType",
         ],
         "BINARY" => &["finalType", "precision", "scale", "physicalType"],
-        "DECFLOAT" => &["finalType", "precision", "scale", "physicalType"],
+        "DECFLOAT" => &[
+            "finalType",
+            "precision",
+            "scale",
+            "physicalType",
+            "byteLength",
+            "charLength",
+        ],
         "ARRAY" | "OBJECT" | "VARIANT" => &[
             "finalType",
             "byteLength",
@@ -273,7 +295,11 @@ fn assert_arrays_match(left: &ArrayRef, right: &ArrayRef, field_path: &str) {
             );
             for (i, name) in left_struct.column_names().iter().enumerate() {
                 let child_name = format!("{field_path}.{name}");
-                assert_arrays_match(left_struct.column(i), right_struct.column(i), &child_name);
+                // Propagate parent null bitmap into children so we don't compare
+                // filler values at positions where the parent struct is null
+                let left_child = nullify_child(left_struct.nulls(), left_struct.column(i));
+                let right_child = nullify_child(right_struct.nulls(), right_struct.column(i));
+                assert_arrays_match(&left_child, &right_child, &child_name);
             }
         }
         _ => {
@@ -289,7 +315,8 @@ fn assert_arrays_match(left: &ArrayRef, right: &ArrayRef, field_path: &str) {
 
             for idx in mismatches.iter().take(5) {
                 println!(
-                    "Mismatch at idx {:?}, left: {:?}, right: {:?}",
+                    "Mismatch in {:?} at idx {:?}, left: {:?}, right: {:?}",
+                    field_path,
                     idx,
                     extract_arrow_value::<String>(left, *idx),
                     extract_arrow_value::<String>(right, *idx)
@@ -302,4 +329,23 @@ fn assert_arrays_match(left: &ArrayRef, right: &ArrayRef, field_path: &str) {
             );
         }
     }
+}
+
+/// Returns a new array with the parent's null bitmap merged into the child array,
+/// so that positions where the parent struct is null also appear null in the child.
+fn nullify_child(parent_nulls: Option<&NullBuffer>, child: &ArrayRef) -> ArrayRef {
+    let Some(parent_nulls) = parent_nulls else {
+        return Arc::clone(child);
+    };
+    let child_data = child.to_data();
+    let merged_nulls = match child_data.nulls() {
+        Some(child_nulls) => NullBuffer::new(parent_nulls.inner() & child_nulls.inner()),
+        None => parent_nulls.clone(),
+    };
+    let new_data = child_data
+        .into_builder()
+        .null_bit_buffer(Some(merged_nulls.into_inner().into_inner()))
+        .build()
+        .unwrap();
+    arrow::array::make_array(new_data)
 }

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -5,10 +5,10 @@ use crate::common::snowflake_test_client::SnowflakeTestClient;
 use crate::common::test_utils::{TableCleanupGuard, unique_table_name};
 
 #[test]
-fn should_return_arrow_even_if_json_result_set_is_returned_for_all_types() {
+fn should_return_arrow_even_if_json_result_set_is_returned_for_various_types() {
     run_arrow_and_json_and_match(
-        "CREATE OR REPLACE TABLE json_result_set_simple_types (str_col STRING, tinyint_col TINYINT, smallint_col SMALLINT, int_col INT, bigint_col BIGINT, number_scale_0_col NUMBER(38, 0), number_scale_2_col NUMBER(38, 2), ntz TIMESTAMP_NTZ)",
-        "INSERT INTO json_result_set_simple_types VALUES ('abc', 123, 12345, 1234567, 12345678901234567890, 12345678901234567890123456789012345678, 123.45, '2026-01-01 13:13:13')",
+        "CREATE OR REPLACE TABLE json_result_set_simple_types (str_col STRING, tinyint_col TINYINT, smallint_col SMALLINT, int_col INT, bigint_col BIGINT, number_scale_0_col NUMBER(38, 0), number_scale_2_col NUMBER(38, 2), bool BOOLEAN, dbl DOUBLE, date DATE)",
+        "INSERT INTO json_result_set_simple_types VALUES ('abc', 123, 12345, 1234567, 12345678901234567890, 12345678901234567890123456789012345678, 123.45, true, 321.54, '2026-03-04')",
         "SELECT * FROM json_result_set_simple_types",
     );
 }
@@ -156,6 +156,53 @@ fn should_return_array_as_arrow_even_if_json_result_set_is_returned() {
         "INSERT INTO json_result_set_array SELECT PARSE_JSON('[1, \"two\", 3.0, null]')",
         "SELECT * FROM json_result_set_array",
     )
+}
+
+#[test]
+fn should_handle_empty_result_set_for_arrow_and_json() {
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let stmt = client.new_statement();
+
+    let select_query = "SELECT 1 WHERE 1 = 2";
+
+    client.set_sql_query(&stmt, select_query);
+    let arrow_result = client.execute_statement_query(&stmt);
+
+    client.set_sql_query(
+        &stmt,
+        "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
+    );
+    let result = client.execute_statement_query(&stmt);
+    assert_eq!(result.rows_affected(), 1, "Cannot force JSON result set");
+
+    client.set_sql_query(&stmt, select_query);
+    let json_result = client.execute_statement_query(&stmt);
+
+    let mut arrow_helper = ArrowResultHelper::from_result(arrow_result);
+    let mut json_helper = ArrowResultHelper::from_result(json_result);
+
+    let arrow_schema = arrow_helper.schema();
+    let json_schema = json_helper.schema();
+    assert_schemas_match(&arrow_schema, &json_schema);
+
+    let arrow_batch = arrow_helper.next_batch();
+    let json_batch = json_helper.next_batch();
+
+    match (arrow_batch, json_batch) {
+        (None, None) => {
+            // Both result sets are empty, which is expected for this query.
+        }
+        (Some(arrow_batch), Some(json_batch)) => {
+            assert_record_batches_match(&arrow_batch, &json_batch);
+        }
+        (arrow_batch, json_batch) => {
+            panic!(
+                "Arrow and JSON result batches differ: arrow={:?}, json={:?}",
+                arrow_batch, json_batch
+            );
+        }
+    }
+    client.release_statement(&stmt);
 }
 
 fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, select_query: &str) {

--- a/sf_core/tests/integration/query/json_result_set_large.rs
+++ b/sf_core/tests/integration/query/json_result_set_large.rs
@@ -1,0 +1,142 @@
+use crate::common::arrow_deserialize::RecordBatch;
+use crate::common::arrow_result_helper::{
+    ArrowResultHelper, assert_record_batches_match, assert_schemas_match,
+};
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::test_utils::{TableCleanupGuard, unique_table_name};
+use arrow::array::Array;
+use arrow::compute::concat_batches;
+
+#[test]
+fn should_return_arrow_matching_json_for_large_multi_chunk_result() {
+    let table_name = unique_table_name("json_result_set_large");
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let _guard = TableCleanupGuard::new(table_name.clone(), |name| {
+        let stmt = client.new_statement();
+        client.set_sql_query(&stmt, &format!("DROP TABLE IF EXISTS {name}"));
+        client.execute_statement_query(&stmt);
+        client.release_statement(&stmt);
+    });
+    let stmt = client.new_statement();
+
+    client.set_sql_query(
+        &stmt,
+        &format!(
+            "CREATE OR REPLACE TABLE {table_name} (\
+                str_col STRING, \
+                tinyint_col TINYINT, \
+                smallint_col SMALLINT, \
+                int_col INT, \
+                bigint_col BIGINT, \
+                num_col NUMBER(38,0), \
+                num_scale_col NUMBER(38,2), \
+                bool_col BOOLEAN, \
+                real_col DOUBLE, \
+                date_col DATE, \
+                ntz_col TIMESTAMP_NTZ(3), \
+                ntz_hi_col TIMESTAMP_NTZ(9), \
+                ltz_col TIMESTAMP_LTZ(3), \
+                ltz_hi_col TIMESTAMP_LTZ(9), \
+                tz_col TIMESTAMP_TZ(3), \
+                tz_hi_col TIMESTAMP_TZ(9), \
+                time_col TIME(3), \
+                bin_col BINARY, \
+                variant_col VARIANT, \
+                object_col OBJECT, \
+                array_col ARRAY
+            )"
+        ),
+    );
+    client.execute_statement_query(&stmt);
+
+    client.set_sql_query(&stmt, "ALTER SESSION SET TIMEZONE = 'Pacific/Honolulu'");
+    client.execute_statement_query(&stmt);
+
+    client.set_sql_query(
+        &stmt,
+        &format!(
+            "INSERT INTO {table_name} \
+            SELECT \
+                CASE WHEN seq4() % 2 = 1 THEN 'abc' END, \
+                CASE WHEN seq4() % 2 = 1 THEN 42 END, \
+                CASE WHEN seq4() % 2 = 1 THEN 12345 END, \
+                CASE WHEN seq4() % 2 = 1 THEN 1234567 END, \
+                CASE WHEN seq4() % 2 = 1 THEN 1234567890123 END, \
+                CASE WHEN seq4() % 2 = 1 THEN 12345678901234567890123456789012345678 END, \
+                CASE WHEN seq4() % 2 = 1 THEN 123.45 END, \
+                CASE WHEN seq4() % 2 = 1 THEN TRUE END, \
+                CASE WHEN seq4() % 2 = 1 THEN 3.14 END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15'::DATE END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123'::TIMESTAMP_NTZ(3) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123456789'::TIMESTAMP_NTZ(9) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123'::TIMESTAMP_LTZ(3) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123456789'::TIMESTAMP_LTZ(9) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123 +01:00'::TIMESTAMP_TZ(3) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '2024-01-15 10:30:00.123456789 +01:00'::TIMESTAMP_TZ(9) END, \
+                CASE WHEN seq4() % 2 = 1 THEN '10:30:00.123'::TIME(3) END, \
+                CASE WHEN seq4() % 2 = 1 THEN TO_BINARY('hello', 'UTF-8') END, \
+                CASE WHEN seq4() % 2 = 1 THEN TO_VARIANT('test') END, \
+                CASE WHEN seq4() % 2 = 1 THEN PARSE_JSON('{{\"k\": 1}}') END, \
+                CASE WHEN seq4() % 2 = 1 THEN PARSE_JSON('[1, 2]') END \
+            FROM TABLE(GENERATOR(ROWCOUNT => 3000)) v"
+        ),
+    );
+    client.execute_statement_query(&stmt);
+
+    client.set_sql_query(&stmt, "ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
+    client.execute_statement_query(&stmt);
+
+    let select_query = format!("SELECT * FROM {table_name}");
+
+    client.set_sql_query(&stmt, &select_query);
+    let arrow_result = client.execute_statement_query(&stmt);
+
+    client.set_sql_query(
+        &stmt,
+        "ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = JSON",
+    );
+    let result = client.execute_statement_query(&stmt);
+    assert_eq!(result.rows_affected(), 1, "Cannot force JSON result set");
+
+    client.set_sql_query(&stmt, &select_query);
+    let json_result = client.execute_statement_query(&stmt);
+
+    let mut arrow_helper = ArrowResultHelper::from_result(arrow_result);
+    let mut json_helper = ArrowResultHelper::from_result(json_result);
+
+    let arrow_schema = arrow_helper.schema();
+    let json_schema = json_helper.schema();
+    assert_schemas_match(&arrow_schema, &json_schema);
+
+    let arrow_merged = collect_all_batches(&mut arrow_helper);
+    let json_merged = collect_all_batches(&mut json_helper);
+
+    assert_eq!(arrow_merged.num_rows(), 3000);
+    assert_eq!(json_merged.num_rows(), 3000);
+
+    assert_record_batches_match(&arrow_merged, &json_merged);
+
+    // Each column should have exactly 1500 nulls (from the all-null rows)
+    // and 1500 non-null values (from the non-null rows)
+    for col_idx in 0..json_merged.num_columns() {
+        let field_name = json_merged.schema().field(col_idx).name().clone();
+        let col = json_merged.column(col_idx);
+        assert_eq!(
+            col.null_count(),
+            1500,
+            "Column '{field_name}' should have exactly 1500 nulls"
+        );
+    }
+
+    client.release_statement(&stmt);
+}
+
+fn collect_all_batches(helper: &mut ArrowResultHelper) -> RecordBatch {
+    let schema = helper.schema();
+    let mut batches = Vec::new();
+    while let Some(batch) = helper.next_batch() {
+        batches.push(batch);
+    }
+    assert!(!batches.is_empty(), "Expected at least one batch");
+    concat_batches(&schema, &batches).expect("Failed to concatenate batches")
+}

--- a/sf_core/tests/integration/query/mod.rs
+++ b/sf_core/tests/integration/query/mod.rs
@@ -1,2 +1,3 @@
 mod json_result_set;
+mod json_result_set_large;
 mod json_result_set_nulls;


### PR DESCRIPTION
### TL;DR

Added support for multi-chunk JSON result sets by implementing `JsonChunkReader` and refactored Arrow type handling for FIXED columns.

### What changed?

- Implemented `JsonChunkReader` to handle chunked JSON result sets with lazy downloading and on-demand conversion to Arrow format
- Added `JsonMultiChunk` variant to `RowsetData` enum to distinguish between single and multi-chunk JSON responses
- Refactored FIXED column type inference in `arrow_utils.rs` to simplify integer type selection and remove precision-based fallback logic
- Extracted `parse_row_types()` and `validate_column_count()` helper functions in query processing
- Enhanced test infrastructure with better null handling for struct arrays and expanded metadata exclusion lists
- Added comprehensive integration tests for large multi-chunk result sets with various data types