### PR TITLE
Add Python 3.12, protobuf, and uv to shell.nix dev environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,8 +5,8 @@ pkgs.mkShell {
     pkgs.pkg-config
     pkgs.cmake
     pkgs.rustup
-    pkgs.protobuf_33
-    pkgs.python312
+    pkgs.protobuf_32
+    pkgs.python313
     pkgs.uv
   ];
 
@@ -17,9 +17,9 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    if [ ! -d python/.venv ]; then
-      uv venv python/.venv --python python3.12
+    if [ ! -d "python/.venv" ] || [ ! -f "python/.venv/bin/activate" ]; then
+      uv venv "python/.venv" --python python3.13
     fi
-    source python/.venv/bin/activate
+    source "python/.venv/bin/activate"
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,9 @@ pkgs.mkShell {
     pkgs.pkg-config
     pkgs.cmake
     pkgs.rustup
+    pkgs.protobuf_33
+    pkgs.python312
+    pkgs.uv
   ];
 
   buildInputs = [
@@ -12,4 +15,11 @@ pkgs.mkShell {
     pkgs.unixODBC
     pkgs.zlib
   ];
+
+  shellHook = ''
+    if [ ! -d python/.venv ]; then
+      uv venv python/.venv --python python3.12
+    fi
+    source python/.venv/bin/activate
+  '';
 }


### PR DESCRIPTION
Add protobuf_33, python312, and uv to nativeBuildInputs. Add shellHook to automatically create and activate a Python venv in python/.venv.