### PR TITLE
Fix Python codecov tests

### DIFF
--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -224,8 +224,12 @@ pipeline {
                                             export PYTHONPATH=$(pwd)/src:$PYTHONPATH
                                             mkdir -p reports
                                             hatch run test.py3.9:cov -- \
-                                                --cov-report=term \
-                                                --cov-report=xml:reports/coverage-python.xml
+                                                --cov-report=term
+                                            test_status=$?
+                                            if [ -f coverage.xml ]; then
+                                                mv coverage.xml reports/coverage-python.xml
+                                            fi
+                                            exit $test_status
                                         ''')
                                         if (testExitCode != 0) {
                                             echo "Python tests failed with exit code ${testExitCode}, continuing to generate coverage"

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -223,8 +223,7 @@ pipeline {
                                             export PARAMETER_PATH=$(pwd)/../parameters.json
                                             export PYTHONPATH=$(pwd)/src:$PYTHONPATH
                                             mkdir -p reports
-                                            hatch run test.py3.9:all -- \
-                                                --cov=src/snowflake \
+                                            hatch run test.py3.9:cov -- \
                                                 --cov-report=term \
                                                 --cov-report=xml:reports/coverage-python.xml
                                         ''')


### PR DESCRIPTION
Modified the Jenkins coverage pipeline to use `cov` instead of `all` with the `--cov=src/snowflake` flag. The coverage source specification is now handled by the `cov` command configuration rather than being passed as a command-line argument.