### PR TITLE
feat: auto-IPD — parse ? markers in SQLPrepare to populate IPD

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -167,6 +167,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("COUNT field incorrect: {reason}"))]
+    CountFieldIncorrect {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid cursor state: no result set associated with the statement"))]
     InvalidCursorState {
         #[snafu(implicit)]
@@ -434,6 +441,7 @@ impl OdbcError {
             OdbcError::AttributeCannotBeSetNow { .. } => SqlState::AttributeCannotBeSetNow,
             OdbcError::InvalidParameterNumber { .. } => SqlState::InvalidDescriptorIndex,
             OdbcError::StatementNotExecuted { .. } => SqlState::FunctionSequenceError,
+            OdbcError::CountFieldIncorrect { .. } => SqlState::CountFieldIncorrect,
             OdbcError::InvalidCursorState { .. } => SqlState::InvalidCursorState,
             OdbcError::DataNotFetched { .. } => SqlState::FunctionSequenceError,
             OdbcError::NoMoreData { .. } => SqlState::NoDataFound,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -43,7 +43,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, false)?;
             let stmt_handle = stmt.stmt_handle;
 
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
@@ -109,6 +109,19 @@ fn update_numeric_settings(
             settings.treat_big_number_as_string = bool_value;
             tracing::info!("Server parameter ODBC_TREAT_BIG_NUMBER_AS_STRING = {bool_value}");
         }
+
+        if let Ok(resp) = c
+            .connection_get_parameter(ConnectionGetParameterRequest {
+                conn_handle: Some(*conn_handle),
+                key: "VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT".to_string(),
+            })
+            .await
+            && let Some(value) = resp.value
+            && let Ok(size) = value.parse::<u64>()
+        {
+            settings.max_varchar_size = size;
+            tracing::info!("Server parameter VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT = {size}");
+        }
     });
     Ok(())
 }
@@ -131,29 +144,6 @@ fn reader_from_protobuf_stream(stream: ArrowArrayStreamPtr) -> OdbcResult<ArrowA
     let reader =
         ArrowArrayStreamReader::try_new(stream).context(ArrowArrayStreamReaderCreationSnafu {})?;
     Ok(reader)
-}
-
-/// Count `?` parameter markers in a SQL string, ignoring markers
-/// inside single-quoted string literals and `--` line comments.
-fn count_parameter_markers(sql: &str) -> usize {
-    let mut count = 0;
-    let mut in_single_quote = false;
-    let mut chars = sql.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '\'' => in_single_quote = !in_single_quote,
-            '-' if !in_single_quote && chars.peek() == Some(&'-') => {
-                for c in chars.by_ref() {
-                    if c == '\n' {
-                        break;
-                    }
-                }
-            }
-            '?' if !in_single_quote => count += 1,
-            _ => {}
-        }
-    }
-    count
 }
 
 fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
@@ -203,14 +193,17 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
             let schema = reader.schema();
             stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
 
-            let param_count = count_parameter_markers(query);
-            stmt.ipd.clear();
+            let param_count = result.number_of_binds.max(0) as usize;
+            let max_varchar = stmt.conn.numeric_settings.max_varchar_size;
+            stmt.ipd.records.retain(|&k, _| (k as usize) <= param_count);
             for i in 1..=param_count {
-                stmt.ipd.records.insert(i as u16, IpdRecord::default());
+                stmt.ipd
+                    .records
+                    .entry(i as u16)
+                    .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
             }
             tracing::info!(
-                "prepare: auto-IPD populated {} parameter markers",
-                param_count
+                "prepare: auto-IPD populated {param_count} parameter markers (from server)"
             );
 
             stmt.state.set(StatementState::Prepared { schema });
@@ -250,7 +243,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, prepared)?;
 
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                 c.statement_execute_query(StatementExecuteQueryRequest {
@@ -355,27 +348,46 @@ fn create_execute_state(
 
 /// Build JSON query bindings from ODBC parameter bindings.
 ///
-/// Returns `(bindings, json_owner)`. The caller **must** keep `json_owner` alive
-/// until after the bindings have been consumed by `statement_execute_query`,
-/// because `BinaryDataPtr` holds a raw pointer into the owned `String`.
+/// When `prepared` is true (SQLPrepare+SQLExecute flow), the IPD has server-
+/// provided parameter count and we validate that the APD covers every marker.
+/// When `prepared` is false (SQLExecDirect), the IPD only has records from
+/// SQLBindParameter — we send whatever the APD has and let the server validate.
 fn apply_parameter_bindings(
     apd: &crate::api::ApdDescriptor,
     ipd: &crate::api::IpdDescriptor,
+    prepared: bool,
 ) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
-    let ipd_count = ipd.desc_count() as usize;
-    let apd_count = apd.desc_count() as usize;
-
-    if ipd_count > 0 && apd_count < ipd_count {
-        return crate::api::error::CountFieldIncorrectSnafu {
-            reason: format!(
-                "statement has {ipd_count} parameter markers but only {apd_count} are bound"
-            ),
+    if apd.records.is_empty() {
+        if prepared {
+            let ipd_count = ipd.desc_count() as usize;
+            if ipd_count > 0 {
+                return crate::api::error::CountFieldIncorrectSnafu {
+                    reason: format!(
+                        "parameter 1 is not bound (statement has {ipd_count} parameter markers)"
+                    ),
+                }
+                .fail();
+            }
         }
-        .fail();
+        return Ok((None, None));
     }
 
-    if apd.records.is_empty() {
+    let ipd_count = ipd.desc_count() as usize;
+    if ipd_count == 0 && !prepared {
         return Ok((None, None));
+    }
+
+    if prepared {
+        for i in 1..=ipd_count {
+            if !apd.records.contains_key(&(i as u16)) {
+                return crate::api::error::CountFieldIncorrectSnafu {
+                    reason: format!(
+                        "parameter {i} is not bound (statement has {ipd_count} parameter markers)"
+                    ),
+                }
+                .fail();
+            }
+        }
     }
     tracing::info!(
         "apply_parameter_bindings: Found {} bound parameters",
@@ -914,69 +926,5 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
             tracing::warn!("get_stmt_attr: unsupported attribute {:?}", attr);
             crate::api::error::UnknownAttributeSnafu { attribute }.fail()
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::count_parameter_markers;
-
-    #[test]
-    fn no_markers() {
-        assert_eq!(count_parameter_markers("SELECT 1"), 0);
-    }
-
-    #[test]
-    fn single_marker() {
-        assert_eq!(count_parameter_markers("SELECT ?"), 1);
-    }
-
-    #[test]
-    fn multiple_markers() {
-        assert_eq!(count_parameter_markers("SELECT ?, ?, ?"), 3);
-    }
-
-    #[test]
-    fn marker_inside_single_quoted_literal_is_ignored() {
-        assert_eq!(count_parameter_markers("SELECT '?' FROM t WHERE c = ?"), 1);
-    }
-
-    #[test]
-    fn marker_inside_line_comment_is_ignored() {
-        assert_eq!(
-            count_parameter_markers("SELECT ? -- is this a param?\nFROM t"),
-            1
-        );
-    }
-
-    #[test]
-    fn escaped_single_quote_in_literal() {
-        assert_eq!(
-            count_parameter_markers("SELECT 'it''s a ?', ?"),
-            1
-        );
-    }
-
-    #[test]
-    fn comment_at_end_without_newline() {
-        assert_eq!(count_parameter_markers("SELECT ? -- trailing"), 1);
-    }
-
-    #[test]
-    fn empty_string() {
-        assert_eq!(count_parameter_markers(""), 0);
-    }
-
-    #[test]
-    fn only_comment() {
-        assert_eq!(count_parameter_markers("-- SELECT ?"), 0);
-    }
-
-    #[test]
-    fn marker_in_insert() {
-        assert_eq!(
-            count_parameter_markers("INSERT INTO t(a, b) VALUES(?, ?)"),
-            2
-        );
     }
 }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -133,6 +133,29 @@ fn reader_from_protobuf_stream(stream: ArrowArrayStreamPtr) -> OdbcResult<ArrowA
     Ok(reader)
 }
 
+/// Count `?` parameter markers in a SQL string, ignoring markers
+/// inside single-quoted string literals and `--` line comments.
+fn count_parameter_markers(sql: &str) -> usize {
+    let mut count = 0;
+    let mut in_single_quote = false;
+    let mut chars = sql.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' => in_single_quote = !in_single_quote,
+            '-' if !in_single_quote && chars.peek() == Some(&'-') => {
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        break;
+                    }
+                }
+            }
+            '?' if !in_single_quote => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
 fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
     if statement_handle.is_null() {
         return InvalidHandleSnafu.fail();
@@ -179,6 +202,17 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
             let reader = reader_from_protobuf_stream(stream_ptr)?;
             let schema = reader.schema();
             stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
+
+            let param_count = count_parameter_markers(query);
+            stmt.ipd.clear();
+            for i in 1..=param_count {
+                stmt.ipd.records.insert(i as u16, IpdRecord::default());
+            }
+            tracing::info!(
+                "prepare: auto-IPD populated {} parameter markers",
+                param_count
+            );
+
             stmt.state.set(StatementState::Prepared { schema });
             tracing::info!("prepare: Successfully prepared statement");
             Ok(())
@@ -328,6 +362,18 @@ fn apply_parameter_bindings(
     apd: &crate::api::ApdDescriptor,
     ipd: &crate::api::IpdDescriptor,
 ) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
+    let ipd_count = ipd.desc_count() as usize;
+    let apd_count = apd.desc_count() as usize;
+
+    if ipd_count > 0 && apd_count < ipd_count {
+        return crate::api::error::CountFieldIncorrectSnafu {
+            reason: format!(
+                "statement has {ipd_count} parameter markers but only {apd_count} are bound"
+            ),
+        }
+        .fail();
+    }
+
     if apd.records.is_empty() {
         return Ok((None, None));
     }
@@ -508,9 +554,8 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
             stmt.ard.unbind_all();
         }
         FreeStmtOption::ResetParams => {
-            tracing::info!("free_stmt: Resetting all parameters");
+            tracing::info!("free_stmt: Resetting all parameter bindings (APD)");
             stmt.apd.clear();
-            stmt.ipd.clear();
         }
     }
 
@@ -518,8 +563,9 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
 }
 
 /// Return the number of parameters in the statement via the IPD descriptor.
-// TODO: Once auto-IPD is implemented (parsing ? markers during SQLPrepare),
-// this will also work for statements that haven't had SQLBindParameter called.
+///
+/// After `SQLPrepare`, auto-IPD populates the IPD with one record per `?`
+/// marker, so this works even without prior `SQLBindParameter` calls.
 pub fn num_params(
     statement_handle: sql::Handle,
     param_count_ptr: *mut sql::SmallInt,
@@ -544,9 +590,10 @@ pub fn num_params(
     Ok(())
 }
 
-/// Describe a bound parameter via the IPD descriptor.
-// TODO: Once auto-IPD is implemented, this will also work for parameters
-// that were not explicitly bound but inferred from ? markers in SQLPrepare.
+/// Describe a parameter via the IPD descriptor.
+///
+/// Works for both explicitly bound parameters and auto-IPD markers
+/// populated during `SQLPrepare`.
 pub fn describe_param(
     statement_handle: sql::Handle,
     parameter_number: sql::USmallInt,
@@ -867,5 +914,69 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
             tracing::warn!("get_stmt_attr: unsupported attribute {:?}", attr);
             crate::api::error::UnknownAttributeSnafu { attribute }.fail()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_parameter_markers;
+
+    #[test]
+    fn no_markers() {
+        assert_eq!(count_parameter_markers("SELECT 1"), 0);
+    }
+
+    #[test]
+    fn single_marker() {
+        assert_eq!(count_parameter_markers("SELECT ?"), 1);
+    }
+
+    #[test]
+    fn multiple_markers() {
+        assert_eq!(count_parameter_markers("SELECT ?, ?, ?"), 3);
+    }
+
+    #[test]
+    fn marker_inside_single_quoted_literal_is_ignored() {
+        assert_eq!(count_parameter_markers("SELECT '?' FROM t WHERE c = ?"), 1);
+    }
+
+    #[test]
+    fn marker_inside_line_comment_is_ignored() {
+        assert_eq!(
+            count_parameter_markers("SELECT ? -- is this a param?\nFROM t"),
+            1
+        );
+    }
+
+    #[test]
+    fn escaped_single_quote_in_literal() {
+        assert_eq!(
+            count_parameter_markers("SELECT 'it''s a ?', ?"),
+            1
+        );
+    }
+
+    #[test]
+    fn comment_at_end_without_newline() {
+        assert_eq!(count_parameter_markers("SELECT ? -- trailing"), 1);
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(count_parameter_markers(""), 0);
+    }
+
+    #[test]
+    fn only_comment() {
+        assert_eq!(count_parameter_markers("-- SELECT ?"), 0);
+    }
+
+    #[test]
+    fn marker_in_insert() {
+        assert_eq!(
+            count_parameter_markers("INSERT INTO t(a, b) VALUES(?, ?)"),
+            2
+        );
     }
 }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -2,8 +2,8 @@ use crate::api::bitmask::Bitmask;
 use crate::api::error::InvalidDescriptorKindSnafu;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::conversion::Binding;
-use crate::conversion::NumericSettings;
 use crate::conversion::warning::Warnings;
+use crate::conversion::{NumericSettings, SF_DEFAULT_VARCHAR_MAX_LEN};
 use arrow::{array::RecordBatch, datatypes::SchemaRef, ffi_stream::ArrowArrayStreamReader};
 use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::{
@@ -691,10 +691,6 @@ impl IpdDescriptor {
     pub fn desc_count(&self) -> u16 {
         self.records.keys().copied().max().unwrap_or(0)
     }
-
-    pub fn clear(&mut self) {
-        self.records.clear();
-    }
 }
 
 /// A resolved descriptor reference returned by `desc_ref_from_handle`.
@@ -835,20 +831,23 @@ pub struct IpdRecord {
     pub nullable: sql::SmallInt,
 }
 
-/// Snowflake maximum VARCHAR column size used as the auto-IPD default.
-/// Matches the reference (old) driver's behavior for `SQLDescribeParam`
-/// on untyped `?` markers.
-pub const SNOWFLAKE_MAX_VARCHAR_SIZE: sql::ULen = 134_217_728;
+impl IpdRecord {
+    /// Create a default IPD record for an untyped `?` marker, using the
+    /// server-provided max VARCHAR size as `column_size`.
+    pub fn with_varchar_size(max_varchar_size: u64) -> Self {
+        Self {
+            sql_data_type: sql::SqlDataType::VARCHAR,
+            column_size: max_varchar_size.min(sql::ULen::MAX as u64) as sql::ULen,
+            decimal_digits: 0,
+            direction: sql::ParamType::Input as sql::SmallInt,
+            nullable: 1, // SQL_NULLABLE — per ODBC spec
+        }
+    }
+}
 
 impl Default for IpdRecord {
     fn default() -> Self {
-        Self {
-            sql_data_type: sql::SqlDataType::VARCHAR,
-            column_size: SNOWFLAKE_MAX_VARCHAR_SIZE,
-            decimal_digits: 0,
-            direction: sql::ParamType::Input as sql::SmallInt,
-            nullable: 1, // SQL_NULLABLE — per ODBC spec: "dynamic parameters are always nullable"
-        }
+        Self::with_varchar_size(SF_DEFAULT_VARCHAR_MAX_LEN)
     }
 }
 

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -835,11 +835,16 @@ pub struct IpdRecord {
     pub nullable: sql::SmallInt,
 }
 
+/// Snowflake maximum VARCHAR column size used as the auto-IPD default.
+/// Matches the reference (old) driver's behavior for `SQLDescribeParam`
+/// on untyped `?` markers.
+pub const SNOWFLAKE_MAX_VARCHAR_SIZE: sql::ULen = 134_217_728;
+
 impl Default for IpdRecord {
     fn default() -> Self {
         Self {
             sql_data_type: sql::SqlDataType::VARCHAR,
-            column_size: 0,
+            column_size: SNOWFLAKE_MAX_VARCHAR_SIZE,
             decimal_digits: 0,
             direction: sql::ParamType::Input as sql::SmallInt,
             nullable: 1, // SQL_NULLABLE — per ODBC spec: "dynamic parameters are always nullable"

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -41,7 +41,7 @@ pub use traits::{Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCT
 pub use error::{
     ArrowArrayDowncastSnafu, ConversionError, FieldMetadataParsingSnafu, MissingFieldMetadataSnafu,
 };
-pub use number::NumericSettings;
+pub use number::{NumericSettings, SF_DEFAULT_VARCHAR_MAX_LEN};
 
 use crate::conversion::error::{
     IncompatibleFieldMetadataSnafu, ReadArrowValueSnafu, UnsupportedArrowDataTypeSnafu,

--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -18,7 +18,7 @@ use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
 /// Controls how FIXED numeric columns are reported to ODBC applications.
 /// These settings match the Snowflake server-side session parameters
 /// `ODBC_TREAT_DECIMAL_AS_INT` and `ODBC_TREAT_BIG_NUMBER_AS_STRING`.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct NumericSettings {
     /// When true, FIXED columns with scale=0 are reported as SQL_BIGINT
     /// instead of SQL_DECIMAL. Default C type becomes SQL_C_SBIGINT.
@@ -27,6 +27,24 @@ pub struct NumericSettings {
     /// When true, FIXED columns with precision > 18 are reported as SQL_VARCHAR.
     /// Takes precedence over `treat_decimal_as_int` for high-precision columns.
     pub treat_big_number_as_string: bool,
+    /// Server-reported maximum VARCHAR size (from session parameter
+    /// `VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT`). Used as the default
+    /// `column_size` in auto-populated IPD records for untyped `?` markers.
+    pub max_varchar_size: u64,
+}
+
+/// Snowflake default max VARCHAR size (16 MB). Overridden by the server's
+/// `VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT` session parameter after login.
+pub const SF_DEFAULT_VARCHAR_MAX_LEN: u64 = 16_777_216;
+
+impl Default for NumericSettings {
+    fn default() -> Self {
+        Self {
+            treat_decimal_as_int: false,
+            treat_big_number_as_string: false,
+            max_varchar_size: SF_DEFAULT_VARCHAR_MAX_LEN,
+        }
+    }
 }
 
 /// Represents the SQL numeric data types as defined by the ODBC specification.

--- a/odbc/src/conversion/number_tests.rs
+++ b/odbc/src/conversion/number_tests.rs
@@ -12,21 +12,25 @@ mod tests {
     const SETTINGS_DEFAULT: NumericSettings = NumericSettings {
         treat_decimal_as_int: false,
         treat_big_number_as_string: false,
+        max_varchar_size: 16_777_216,
     };
 
     const SETTINGS_DECIMAL_AS_INT: NumericSettings = NumericSettings {
         treat_decimal_as_int: true,
         treat_big_number_as_string: false,
+        max_varchar_size: 16_777_216,
     };
 
     const SETTINGS_BOTH: NumericSettings = NumericSettings {
         treat_decimal_as_int: true,
         treat_big_number_as_string: true,
+        max_varchar_size: 16_777_216,
     };
 
     const SETTINGS_BIG_NUMBER_AS_STRING: NumericSettings = NumericSettings {
         treat_decimal_as_int: false,
         treat_big_number_as_string: true,
+        max_varchar_size: 16_777_216,
     };
 
     fn make_decimal(scale: u32, precision: u32) -> SnowflakeNumber {

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -194,7 +194,31 @@ TEST_CASE("should replace binding when same ParameterNumber is rebound.", "[quer
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 222);
 }
 
-// TODO: Add 07002 (SQL_RESET_PARAMS) test in PR #566 once auto-IPD is implemented (BD#29).
+TEST_CASE("should fail with 07002 after SQL_RESET_PARAMS clears bindings.", "[query][bind_parameter]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a parameterized SELECT is prepared and executed successfully
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  SQLINTEGER param = 42;
+  SQLLEN indicator = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // And all parameter bindings are reset
+  ret = SQLFreeStmt(stmt.getHandle(), SQL_RESET_PARAMS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then re-executing should fail with SQLSTATE 07002
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("07002"));
+}
 
 TEST_CASE("should reflect changed bound variable on re-execution.", "[query][bind_parameter]") {
   // Given Snowflake client is logged in

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -220,6 +220,28 @@ TEST_CASE("should fail with 07002 after SQL_RESET_PARAMS clears bindings.", "[qu
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("07002"));
 }
 
+TEST_CASE("should fail with 07002 when parameter bindings have a gap.", "[query][bind_parameter]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a query with 3 parameter markers is prepared
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?, ?, ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // And only parameters 1 and 3 are bound (gap at parameter 2)
+  SQLINTEGER p1 = 1, p3 = 3;
+  SQLLEN ind1 = 0, ind3 = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p1, 0, &ind1);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &p3, 0, &ind3);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Then executing should fail with SQLSTATE 07002
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("07002"));
+}
+
 TEST_CASE("should reflect changed bound variable on re-execution.", "[query][bind_parameter]") {
   // Given Snowflake client is logged in
   Connection conn;

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -489,6 +489,7 @@ message StatementSetSubstraitPlanResponse {
 message PrepareResult {
   ArrowArrayStreamPtr stream = 1;
   repeated ColumnMetadata columns = 4;
+  int32 number_of_binds = 5;
 }
 
 message StatementPrepareRequest {

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -260,6 +260,7 @@ impl DatabaseDriverV1 {
 pub struct PrepareResult {
     pub stream: Box<FFI_ArrowArrayStream>,
     pub columns: Vec<ColumnMetadata>,
+    pub number_of_binds: i32,
 }
 
 impl DatabaseDriverV1 {
@@ -270,6 +271,7 @@ impl DatabaseDriverV1 {
         Ok(PrepareResult {
             stream: result.stream,
             columns: result.columns,
+            number_of_binds: result.number_of_binds,
         })
     }
 }
@@ -294,6 +296,7 @@ pub struct ExecuteResult {
     pub query: String,
     pub sql_state: Option<String>,
     pub stats: Option<Stats>,
+    pub number_of_binds: i32,
 }
 
 impl DatabaseDriverV1 {
@@ -536,6 +539,8 @@ async fn response_to_execute_result(
             .collect()
     });
 
+    let number_of_binds = data.number_of_binds.unwrap_or(0);
+
     Ok(ExecuteResult {
         stream,
         rows_affected,
@@ -545,6 +550,7 @@ async fn response_to_execute_result(
         query,
         sql_state: data.sql_state,
         stats: data.stats,
+        number_of_binds,
     })
 }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -1236,6 +1236,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
             result: Some(PrepareResult {
                 stream: Some(result_ptr),
                 columns: result.columns.into_iter().map(|cm| cm.into()).collect(),
+                number_of_binds: result.number_of_binds,
             }),
         })
     }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -73,7 +73,7 @@ pub struct Data {
     #[serde(rename = "finalRoleName")]
     pub final_role_name: Option<String>,
     #[serde(rename = "numberOfBinds")]
-    _number_of_binds: Option<i32>,
+    pub number_of_binds: Option<i32>,
     #[serde(rename = "statementTypeId")]
     pub statement_type_id: Option<i64>,
     #[serde(rename = "version")]

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -89,6 +89,13 @@ Feature: ODBC SQLBindParameter spec compliance
     Then re-executing should fail with SQLSTATE 07002
 
   @odbc_e2e
+  Scenario: should fail with 07002 when parameter bindings have a gap.
+    Given Snowflake client is logged in
+    When a query with 3 parameter markers is prepared
+    And only parameters 1 and 3 are bound (gap at parameter 2)
+    Then executing should fail with SQLSTATE 07002
+
+  @odbc_e2e
   Scenario: should reflect changed bound variable on re-execution.
     Given Snowflake client is logged in
     When a parameterized SELECT is prepared and bound to a variable

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -81,8 +81,12 @@ Feature: ODBC SQLBindParameter spec compliance
     And parameter 1 is rebound to value 222
     Then executing should return the latest bound value
 
-  # TODO: Uncomment in PR #566 once auto-IPD is implemented (BD#29)
-  # Scenario: should fail with 07002 after SQL_RESET_PARAMS clears bindings.
+  @odbc_e2e
+  Scenario: should fail with 07002 after SQL_RESET_PARAMS clears bindings.
+    Given Snowflake client is logged in
+    When a parameterized SELECT is prepared and executed successfully
+    And all parameter bindings are reset
+    Then re-executing should fail with SQLSTATE 07002
 
   @odbc_e2e
   Scenario: should reflect changed bound variable on re-execution.


### PR DESCRIPTION
## Summary

Populate the IPD with parameter metadata after SQLPrepare using the server-provided numberOfBinds count, so SQLNumParams and SQLDescribeParam work without requiring SQLBindParameter first.

### Auto-IPD population (server-driven)
- Wire numberOfBinds from the Snowflake HTTP response through sf_core (ExecuteResult, PrepareResult, protobuf) to the ODBC layer
- SQLPrepare uses the server-reported parameter count to populate IPD with default SQL_VARCHAR records (matching old driver behavior)
- Default column_size is fetched from the VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT session parameter (default 16 MB), not hardcoded
- Preserve existing IPD records set by SQLBindParameter — only insert defaults for markers that do not already have explicit metadata
- Remove stale IPD records beyond the current marker count

### 07002 (COUNT field incorrect) detection
- For prepared statements (SQLPrepare + SQLExecute): validate that APD contains a binding for every parameter index 1..=ipd_count, catching both missing bindings and gaps (e.g. binding 1 and 3 but not 2)
- For direct execution (SQLExecDirect): send whatever APD bindings exist and let the server validate parameter count mismatches

### SQL_RESET_PARAMS behavior
- SQL_RESET_PARAMS only clears the APD (bindings), preserving the IPD (prepare metadata) per ODBC spec

### Other
- Add CountFieldIncorrect error variant mapped to SQLSTATE 07002
- Remove unused IpdDescriptor::clear()
- Clamp u64 to ULen::MAX in IpdRecord::with_varchar_size for 32-bit safety
- Deduplicate default VARCHAR size constant (SF_DEFAULT_VARCHAR_MAX_LEN)

## Tests
- E2E: 07002 after SQL_RESET_PARAMS clears bindings
- E2E: 07002 when parameter bindings have a gap (bind 1 and 3, skip 2)
- Existing E2E tests for bind lifecycle, descriptors, and SQLNumParams unchanged

Made-with: Cursor