### PR TITLE
SNOW-3264599: Python - cursor exposes QueryResultStats

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -136,6 +136,14 @@ message ColumnMetadata {
   bool nullable = 7;
 }
 
+// DML operation statistics
+message QueryStats {
+  optional int64 num_rows_inserted = 1;
+  optional int64 num_rows_updated = 2;
+  optional int64 num_rows_deleted = 3;
+  optional int64 num_dml_duplicates = 4;
+}
+
 // Execute result
 message ExecuteResult {
   ArrowArrayStreamPtr stream = 1;
@@ -145,6 +153,7 @@ message ExecuteResult {
   optional int64 statement_type_id = 5;
   string query = 6;
   optional string sql_state = 7;
+  optional QueryStats stats = 8;
 }
 
 // Partitioned result

--- a/python/src/snowflake/connector/cursor.py
+++ b/python/src/snowflake/connector/cursor.py
@@ -34,6 +34,7 @@ from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     BinaryDataPtr,
     ExecuteResult,
     QueryBindings,
+    QueryStats,
     StatementExecuteQueryRequest,
     StatementNewRequest,
     StatementReleaseRequest,
@@ -96,6 +97,29 @@ class ResultMetadata(NamedTuple):
 
 # Backward compatibility alias
 ResultMetadataV2 = ResultMetadata
+
+
+class QueryResultStats(NamedTuple):
+    """DML operation statistics returned by Snowflake.
+
+    Exposes per-operation row counts for INSERT, UPDATE, DELETE,
+    and the number of duplicate rows skipped during DML.
+    """
+
+    num_rows_inserted: int | None = None
+    num_rows_deleted: int | None = None
+    num_rows_updated: int | None = None
+    num_dml_duplicates: int | None = None
+
+    @classmethod
+    def from_query_stats(cls, s: QueryStats) -> QueryResultStats:
+        """Create a ``QueryResultStats`` from a protobuf ``QueryStats``."""
+        return cls(
+            num_rows_inserted=s.num_rows_inserted if s.HasField("num_rows_inserted") else None,
+            num_rows_deleted=s.num_rows_deleted if s.HasField("num_rows_deleted") else None,
+            num_rows_updated=s.num_rows_updated if s.HasField("num_rows_updated") else None,
+            num_dml_duplicates=s.num_dml_duplicates if s.HasField("num_dml_duplicates") else None,
+        )
 
 
 class FetchMode(enum.Enum):
@@ -285,6 +309,13 @@ class SnowflakeCursorBase(abc.ABC):
         if self.execute_result is None:
             return None
         return self.execute_result.query_id if self.execute_result.query_id else None
+
+    @property
+    def stats(self) -> QueryResultStats | None:
+        """Returns detailed row-level statistics for DML operations."""
+        if self.execute_result is None or not self.execute_result.HasField("stats"):
+            return QueryResultStats()
+        return QueryResultStats.from_query_stats(self.execute_result.stats)
 
     @pep249
     def callproc(self, procname: str, parameters: Sequence[Any] | None = None) -> Sequence[Any]:
@@ -1047,4 +1078,4 @@ CursorType = Union[type[SnowflakeCursor], type[DictCursor]]
 CursorInstance = Union[SnowflakeCursor, DictCursor]
 
 
-__all__ = ["SnowflakeCursor", "SnowflakeCursorBase", "DictCursor"]
+__all__ = ["SnowflakeCursor", "SnowflakeCursorBase", "DictCursor", "QueryResultStats"]

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.cursor import QueryResultStats, SnowflakeCursor
 from snowflake.connector.errors import NotSupportedError, ProgrammingError
 from tests.e2e.types.utils import assert_sequential_values
 
@@ -562,6 +562,183 @@ class TestCursorRowcount:
 
         # Then rowcount should be 1
         assert cursor.rowcount == 1
+
+
+class TestCursorStats:
+    """Integration tests for Cursor.stats property."""
+
+    def test_stats_returns_all_none_before_execute(self, connection):
+        """Test that stats returns all-None QueryResultStats before any query is executed."""
+        # Given a new cursor
+        cursor = connection.cursor()
+
+        # When accessing stats before execute
+        result = cursor.stats
+
+        # Then all fields should be None
+        assert isinstance(result, QueryResultStats)
+        assert result == QueryResultStats(None, None, None, None)
+
+    def test_stats_returns_query_result_stats_type(self, cursor):
+        """Test that stats always returns a QueryResultStats instance."""
+        # Given a cursor that executes a query
+        cursor.execute("SELECT 1")
+
+        # When accessing stats
+        result = cursor.stats
+
+        # Then it should be a QueryResultStats instance
+        assert isinstance(result, QueryResultStats)
+
+    def test_stats_after_insert(self, cursor, tmp_schema):
+        """Test stats.num_rows_inserted is populated after INSERT."""
+        # Given a table to insert into
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_insert (id INTEGER, name VARCHAR)")
+
+        # When inserting rows
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_insert VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+        # Then num_rows_inserted should reflect the number of inserted rows
+        assert cursor.stats.num_rows_inserted == 3
+
+    def test_stats_after_single_row_insert(self, cursor, tmp_schema):
+        """Test stats.num_rows_inserted for a single row INSERT."""
+        # Given a table
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_single_insert (id INTEGER)")
+
+        # When inserting a single row
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_single_insert VALUES (1)")
+
+        # Then num_rows_inserted should be 1
+        assert cursor.stats.num_rows_inserted == 1
+
+    def test_stats_after_update(self, cursor, tmp_schema):
+        """Test stats.num_rows_updated is populated after UPDATE."""
+        # Given a table with data
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_update (id INTEGER, value INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_update VALUES (1, 10), (2, 20), (3, 30)")
+
+        # When updating some rows
+        cursor.execute(f"UPDATE {tmp_schema}.test_stats_update SET value = 100 WHERE id <= 2")
+
+        # Then num_rows_updated should reflect the number of updated rows
+        assert cursor.stats.num_rows_updated == 2
+
+    def test_stats_after_update_zero_rows(self, cursor, tmp_schema):
+        """Test stats when no rows match the UPDATE condition."""
+        # Given a table with data
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_update_zero (id INTEGER, value INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_update_zero VALUES (1, 10), (2, 20)")
+
+        # When updating with a condition that matches no rows
+        cursor.execute(f"UPDATE {tmp_schema}.test_stats_update_zero SET value = 999 WHERE id > 100")
+
+        # Then stats should have no DML counts (server omits stats when 0 rows affected)
+        assert cursor.stats.num_rows_updated is None
+
+    def test_stats_after_delete(self, cursor, tmp_schema):
+        """Test stats.num_rows_deleted is populated after DELETE."""
+        # Given a table with data
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_delete (id INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_delete VALUES (1), (2), (3), (4), (5)")
+
+        # When deleting some rows
+        cursor.execute(f"DELETE FROM {tmp_schema}.test_stats_delete WHERE id > 2")
+
+        # Then num_rows_deleted should reflect the number of deleted rows
+        assert cursor.stats.num_rows_deleted == 3
+
+    def test_stats_after_delete_zero_rows(self, cursor, tmp_schema):
+        """Test stats when no rows match the DELETE condition."""
+        # Given a table with data
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_delete_zero (id INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_delete_zero VALUES (1), (2), (3)")
+
+        # When deleting with a condition that matches no rows
+        cursor.execute(f"DELETE FROM {tmp_schema}.test_stats_delete_zero WHERE id > 100")
+
+        # Then stats should have no DML counts (server omits stats when 0 rows affected)
+        assert cursor.stats.num_rows_deleted is None
+
+    def test_stats_after_select(self, cursor):
+        """Test that stats has no DML counts after a SELECT statement."""
+        # Given a cursor that executes a SELECT query
+        cursor.execute("SELECT 1")
+
+        # When accessing stats
+        result = cursor.stats
+
+        # Then DML-specific fields should be None (SELECT is not a DML operation)
+        assert result.num_rows_inserted is None
+        assert result.num_rows_deleted is None
+        assert result.num_rows_updated is None
+
+    def test_stats_persists_after_fetchall(self, cursor, tmp_schema):
+        """Test that stats persists after fetching results."""
+        # Given a table with an INSERT
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_persist (id INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_persist VALUES (1), (2)")
+        stats_before = cursor.stats
+
+        # When doing a SELECT and fetching all
+        cursor.execute(f"SELECT * FROM {tmp_schema}.test_stats_persist")
+        cursor.fetchall()
+
+        # Then stats should reflect the latest query (the SELECT)
+        # and the old stats from the INSERT should no longer be there
+        assert cursor.stats != stats_before or stats_before.num_rows_inserted is None
+
+    def test_stats_updates_with_new_execute(self, cursor, tmp_schema):
+        """Test that stats updates to reflect the most recent DML operation."""
+        # Given a table
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_updates (id INTEGER, value INTEGER)")
+
+        # When performing an INSERT
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_updates VALUES (1, 10), (2, 20)")
+        insert_stats = cursor.stats
+
+        # Then INSERT stats should be populated
+        assert insert_stats.num_rows_inserted == 2
+
+        # When performing a DELETE
+        cursor.execute(f"DELETE FROM {tmp_schema}.test_stats_updates WHERE id = 1")
+        delete_stats = cursor.stats
+
+        # Then DELETE stats should be populated
+        assert delete_stats.num_rows_deleted == 1
+
+    def test_stats_after_insert_select(self, cursor, tmp_schema):
+        """Test stats after INSERT ... SELECT."""
+        # Given source and target tables
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_src (id INTEGER)")
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_src VALUES (1), (2), (3)")
+        cursor.execute(f"CREATE TABLE {tmp_schema}.test_stats_dst (id INTEGER)")
+
+        # When inserting via SELECT
+        cursor.execute(f"INSERT INTO {tmp_schema}.test_stats_dst SELECT * FROM {tmp_schema}.test_stats_src")
+
+        # Then num_rows_inserted should reflect the number of rows inserted
+        assert cursor.stats.num_rows_inserted == 3
+
+    def test_stats_num_dml_duplicates_after_update_with_duplicate_join(self, cursor):
+        """Test stats.num_dml_duplicates is populated when UPDATE joins to duplicate source rows."""
+        # Given a target with one row and a source where multiple rows match the same target
+        cursor.execute("CREATE OR REPLACE TEMP TABLE test_dup_src (c1 INT, c2 INT)")
+        cursor.execute("CREATE OR REPLACE TEMP TABLE test_dup_target (c INT)")
+        cursor.execute("INSERT INTO test_dup_src VALUES (0, 100), (0, 200), (0, 300)")
+        cursor.execute("INSERT INTO test_dup_target VALUES (0)")
+
+        # When updating via a join that produces duplicate matches
+        cursor.execute("""
+            UPDATE test_dup_target t
+            SET c = s.c1
+            FROM test_dup_src s
+            WHERE s.c1 = t.c
+        """)
+
+        # Then one source row wins the update and the rest are counted as duplicates
+        assert cursor.stats.num_rows_updated == 1
+        assert cursor.stats.num_dml_duplicates == 1
 
 
 class TestCursorRownumber:

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -18,7 +18,7 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     StatementHandle,
 )
-from snowflake.connector.cursor import FetchMode, SnowflakeCursor, SnowflakeCursorBase
+from snowflake.connector.cursor import FetchMode, QueryResultStats, SnowflakeCursor, SnowflakeCursorBase
 from snowflake.connector.errors import ProgrammingError
 
 
@@ -612,6 +612,246 @@ class TestSqlstate:
         mock_connection.db_api.statement_execute_query.return_value.result = success_result
         cursor.execute("SELECT 2")
         assert cursor.sqlstate is None
+
+
+class TestQueryResultStats:
+    """Unit tests for QueryResultStats NamedTuple."""
+
+    def test_default_all_none(self):
+        """All fields default to None."""
+        stats = QueryResultStats()
+        assert stats.num_rows_inserted is None
+        assert stats.num_rows_deleted is None
+        assert stats.num_rows_updated is None
+        assert stats.num_dml_duplicates is None
+
+    def test_positional_construction(self):
+        """Fields can be set by position."""
+        stats = QueryResultStats(10, 20, 30, 5)
+        assert stats.num_rows_inserted == 10
+        assert stats.num_rows_deleted == 20
+        assert stats.num_rows_updated == 30
+        assert stats.num_dml_duplicates == 5
+
+    def test_keyword_construction(self):
+        """Fields can be set by keyword."""
+        stats = QueryResultStats(num_rows_inserted=1, num_rows_updated=2)
+        assert stats.num_rows_inserted == 1
+        assert stats.num_rows_deleted is None
+        assert stats.num_rows_updated == 2
+        assert stats.num_dml_duplicates is None
+
+    def test_is_named_tuple(self):
+        """QueryResultStats is a proper NamedTuple with tuple semantics."""
+        stats = QueryResultStats(1, 2, 3, 4)
+        assert isinstance(stats, tuple)
+        assert len(stats) == 4
+        assert stats[0] == 1
+        assert stats._fields == ("num_rows_inserted", "num_rows_deleted", "num_rows_updated", "num_dml_duplicates")
+
+    def test_equality(self):
+        """Two instances with identical values are equal."""
+        a = QueryResultStats(1, 2, 3, 4)
+        b = QueryResultStats(1, 2, 3, 4)
+        assert a == b
+
+    def test_all_none_equality(self):
+        """Default instance equals explicit all-None instance."""
+        assert QueryResultStats() == QueryResultStats(None, None, None, None)
+
+    def test_from_query_stats_all_fields_present(self):
+        """from_query_stats maps all present protobuf fields."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 10
+        mock_stats.num_rows_deleted = 5
+        mock_stats.num_rows_updated = 3
+        mock_stats.num_dml_duplicates = 1
+        mock_stats.HasField.return_value = True
+
+        result = QueryResultStats.from_query_stats(mock_stats)
+
+        assert result == QueryResultStats(10, 5, 3, 1)
+
+    def test_from_query_stats_partial_fields(self):
+        """from_query_stats returns None for absent protobuf fields."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 42
+        mock_stats.HasField.side_effect = lambda name: name == "num_rows_inserted"
+
+        result = QueryResultStats.from_query_stats(mock_stats)
+
+        assert result == QueryResultStats(
+            num_rows_inserted=42, num_rows_deleted=None, num_rows_updated=None, num_dml_duplicates=None
+        )
+
+    def test_from_query_stats_no_fields_present(self):
+        """from_query_stats returns all None when no fields are set."""
+        mock_stats = MagicMock()
+        mock_stats.HasField.return_value = False
+
+        result = QueryResultStats.from_query_stats(mock_stats)
+
+        assert result == QueryResultStats()
+
+    def test_from_query_stats_zero_values(self):
+        """from_query_stats preserves zero values (distinct from absent)."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 0
+        mock_stats.num_rows_deleted = 0
+        mock_stats.num_rows_updated = 0
+        mock_stats.num_dml_duplicates = 0
+        mock_stats.HasField.return_value = True
+
+        result = QueryResultStats.from_query_stats(mock_stats)
+
+        assert result == QueryResultStats(0, 0, 0, 0)
+
+
+class TestStats:
+    """Unit tests for Cursor.stats property."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def cursor(self, mock_connection):
+        return SnowflakeCursor(mock_connection)
+
+    def test_stats_returns_all_none_before_execute(self, cursor):
+        """stats returns QueryResultStats with all None fields on a fresh cursor."""
+        result = cursor.stats
+        assert result == QueryResultStats(None, None, None, None)
+
+    def test_stats_returns_all_none_when_no_stats_field(self, cursor):
+        """stats returns all-None when execute_result has no stats field."""
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = False
+        cursor.execute_result = mock_result
+
+        result = cursor.stats
+
+        assert result == QueryResultStats(None, None, None, None)
+        mock_result.HasField.assert_called_with("stats")
+
+    def test_stats_returns_all_fields_when_present(self, cursor):
+        """stats returns all populated fields from execute_result."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 10
+        mock_stats.num_rows_deleted = 5
+        mock_stats.num_rows_updated = 3
+        mock_stats.num_dml_duplicates = 1
+        mock_stats.HasField.return_value = True
+
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = True
+        mock_result.stats = mock_stats
+        cursor.execute_result = mock_result
+
+        result = cursor.stats
+
+        assert result == QueryResultStats(
+            num_rows_inserted=10,
+            num_rows_deleted=5,
+            num_rows_updated=3,
+            num_dml_duplicates=1,
+        )
+
+    def test_stats_returns_partial_fields(self, cursor):
+        """stats returns None for fields not present in the protobuf."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 10
+        mock_stats.num_rows_deleted = 0
+        mock_stats.num_rows_updated = 0
+        mock_stats.num_dml_duplicates = 0
+
+        def has_field(name):
+            return name == "num_rows_inserted"
+
+        mock_stats.HasField.side_effect = has_field
+
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = True
+        mock_result.stats = mock_stats
+        cursor.execute_result = mock_result
+
+        result = cursor.stats
+
+        assert result.num_rows_inserted == 10
+        assert result.num_rows_deleted is None
+        assert result.num_rows_updated is None
+        assert result.num_dml_duplicates is None
+
+    def test_stats_distinguishes_zero_from_absent(self, cursor):
+        """A field present with value 0 is returned as 0, not None."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 0
+        mock_stats.num_rows_deleted = 0
+        mock_stats.num_rows_updated = 0
+        mock_stats.num_dml_duplicates = 0
+        mock_stats.HasField.return_value = True
+
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = True
+        mock_result.stats = mock_stats
+        cursor.execute_result = mock_result
+
+        result = cursor.stats
+
+        assert result == QueryResultStats(0, 0, 0, 0)
+
+    def test_stats_returns_query_result_stats_type(self, cursor):
+        """stats always returns a QueryResultStats instance."""
+        assert isinstance(cursor.stats, QueryResultStats)
+
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = False
+        cursor.execute_result = mock_result
+        assert isinstance(cursor.stats, QueryResultStats)
+
+    def test_stats_updates_on_subsequent_execute(self, cursor):
+        """stats reflects the most recent execute_result."""
+        first_stats = MagicMock()
+        first_stats.num_rows_inserted = 5
+        first_stats.HasField.return_value = True
+
+        first_result = MagicMock()
+        first_result.HasField.return_value = True
+        first_result.stats = first_stats
+        cursor.execute_result = first_result
+
+        assert cursor.stats.num_rows_inserted == 5
+
+        second_stats = MagicMock()
+        second_stats.num_rows_inserted = 20
+        second_stats.HasField.return_value = True
+
+        second_result = MagicMock()
+        second_result.HasField.return_value = True
+        second_result.stats = second_stats
+        cursor.execute_result = second_result
+
+        assert cursor.stats.num_rows_inserted == 20
+
+    def test_stats_only_insert_field(self, cursor):
+        """stats correctly returns only num_rows_inserted when only that field is present."""
+        mock_stats = MagicMock()
+        mock_stats.num_rows_inserted = 42
+
+        def has_field(name):
+            return name == "num_rows_inserted"
+
+        mock_stats.HasField.side_effect = has_field
+
+        mock_result = MagicMock()
+        mock_result.HasField.return_value = True
+        mock_result.stats = mock_stats
+        cursor.execute_result = mock_result
+
+        result = cursor.stats
+        assert result == QueryResultStats(
+            num_rows_inserted=42, num_rows_deleted=None, num_rows_updated=None, num_dml_duplicates=None
+        )
 
 
 class TestFetchmanyArraysizeAttribute:

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -12,7 +12,7 @@ use crate::config::param_registry::param_names;
 use crate::config::rest_parameters::QueryParameters;
 use crate::config::settings::Setting;
 use crate::handle_manager::Handle;
-use crate::rest::snowflake::query_response::Data;
+use crate::rest::snowflake::query_response::{Data, Stats};
 use crate::rest::snowflake::{QueryExecutionMode, QueryInput, snowflake_query_with_client};
 
 use arrow::ffi_stream::FFI_ArrowArrayStream;
@@ -265,6 +265,7 @@ pub struct ExecuteResult {
     pub statement_type_id: Option<i64>,
     pub query: String,
     pub sql_state: Option<String>,
+    pub stats: Option<Stats>,
 }
 
 impl DatabaseDriverV1 {
@@ -412,8 +413,9 @@ impl DatabaseDriverV1 {
                 .collect()
         });
 
-        // Extract sql_state from response
+        // Extract sql_state and stats from response
         let sql_state = response.data.sql_state;
+        let stats = response.data.stats;
 
         let result = ExecuteResult {
             stream: rowset_stream,
@@ -423,6 +425,7 @@ impl DatabaseDriverV1 {
             statement_type_id,
             query,
             sql_state,
+            stats,
         };
         stmt.state = StatementState::Executed;
         Ok(result)

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -1239,6 +1239,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
                 statement_type_id: result.statement_type_id,
                 query: result.query,
                 sql_state: result.sql_state,
+                stats: result.stats.map(|s| QueryStats {
+                    num_rows_inserted: s.num_rows_inserted,
+                    num_rows_updated: s.num_rows_updated,
+                    num_rows_deleted: s.num_rows_deleted,
+                    num_dml_duplicates: s.num_dml_duplicates,
+                }),
             }),
         })
     }


### PR DESCRIPTION
### TL;DR

Added DML operation statistics tracking to database cursors, exposing row counts for INSERT, UPDATE, DELETE operations and duplicate row counts.

### What changed?

- Added `QueryStats` message to the protobuf schema with fields for tracking DML operation row counts (`num_rows_inserted`, `num_rows_updated`, `num_rows_deleted`, `num_dml_duplicates`)
- Extended `ExecuteResult` to include optional `QueryStats` field
- Introduced `QueryResultStats` NamedTuple in Python cursor implementation to expose DML statistics
- Added `stats` property to `SnowflakeCursorBase` that returns `QueryResultStats` with populated values from the most recent query execution
- Updated Rust implementation to extract and pass through statistics from query responses
- Added `QueryResultStats` to the public API exports