### PR TITLE
NO-SNOW: Use is_multiple_of instead of modulo in decfloat formatting

### DIFF
--- a/odbc/src/conversion/decfloat.rs
+++ b/odbc/src/conversion/decfloat.rs
@@ -100,7 +100,7 @@ pub(crate) fn format_decfloat(sig: i128, exp: i16, max_plain_digits: usize) -> S
     let mut exp = exp as i64;
 
     // Normalize: strip trailing zeros from significand
-    while abs_sig % 10 == 0 {
+    while abs_sig.is_multiple_of(10) {
         abs_sig /= 10;
         exp += 1;
     }


### PR DESCRIPTION
### TL;DR

Replaced modulo operation with `is_multiple_of` method for checking if a number is divisible by 10 in decimal float formatting.

### What changed?

Changed the condition `abs_sig % 10 == 0` to `abs_sig.is_multiple_of(10)` in the decimal float normalization loop that strips trailing zeros from the significand.

### How to test?

Run existing tests for decimal float conversion and formatting to ensure the normalization behavior remains unchanged. Test with decimal values that have trailing zeros to verify they are properly stripped.

### Why make this change?

The `is_multiple_of` method provides a more semantic and potentially more efficient way to check divisibility compared to using the modulo operator and comparing to zero.