### PR TITLE
feat: implement SQLNativeSql/SQLNativeSqlW pass-through

### DIFF
--- a/odbc/exports.def
+++ b/odbc/exports.def
@@ -30,6 +30,7 @@ EXPORTS
     SQLGetInfoW
     SQLGetStmtAttrW
     SQLMoreResults
+    SQLNativeSqlW
     SQLNumParams
     SQLNumResultCols
     SQLDescribeParam

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -6,7 +6,8 @@ use crate::api::encoding::{
 use crate::api::error::Required;
 use crate::api::error::{
     AttributeCannotBeSetNowSnafu, DataSourceNotFoundSnafu, InvalidBufferLengthSnafu,
-    InvalidPortSnafu, OdbcRuntimeSnafu, UnknownAttributeSnafu, UnsupportedAttributeSnafu,
+    InvalidPortSnafu, NullPointerSnafu, OdbcRuntimeSnafu, UnknownAttributeSnafu,
+    UnsupportedAttributeSnafu,
 };
 use crate::api::runtime::global;
 use crate::api::{
@@ -511,6 +512,59 @@ pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
             }
         });
     }
+
+    Ok(())
+}
+
+/// Translate SQL text to its native form (SQLNativeSql / SQLNativeSqlW).
+///
+/// Snowflake does not perform ODBC escape sequence translation, so this is
+/// a simple pass-through that copies the input SQL to the output buffer.
+pub fn native_sql<E: OdbcEncoding>(
+    connection_handle: sql::Handle,
+    in_statement_text: *const E::Char,
+    text_length1: sql::Integer,
+    out_statement_text: *mut E::Char,
+    buffer_length: sql::Integer,
+    text_length2_ptr: *mut sql::Integer,
+    warnings: &mut Warnings,
+) -> OdbcResult<()> {
+    tracing::debug!("native_sql: connection_handle={connection_handle:?}");
+
+    if in_statement_text.is_null() {
+        return NullPointerSnafu.fail();
+    }
+    if text_length1 != sql::NTS as sql::Integer && text_length1 < 0 {
+        return InvalidBufferLengthSnafu {
+            length: text_length1 as i64,
+        }
+        .fail();
+    }
+    if !out_statement_text.is_null() && buffer_length < 0 {
+        return InvalidBufferLengthSnafu {
+            length: buffer_length as i64,
+        }
+        .fail();
+    }
+
+    let conn = conn_from_handle(connection_handle);
+    if matches!(conn.state, ConnectionState::Disconnected) {
+        return crate::api::error::DisconnectedSnafu.fail();
+    }
+
+    let sql_text = if text_length1 == 0 {
+        String::new()
+    } else {
+        E::read_string(in_statement_text, text_length1)?
+    };
+
+    write_string_bytes_i32::<E>(
+        &sql_text,
+        out_statement_text,
+        buffer_length,
+        text_length2_ptr,
+        Some(warnings),
+    );
 
     Ok(())
 }

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -1011,6 +1011,74 @@ pub unsafe extern "C" fn SQLMoreResults(statement_handle: sql::Handle) -> sql::R
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLNativeSql(
+    connection_handle: sql::Handle,
+    in_statement_text: *const sql::Char,
+    text_length1: sql::Integer,
+    out_statement_text: *mut sql::Char,
+    buffer_length: sql::Integer,
+    text_length2_ptr: *mut sql::Integer,
+) -> sql::RetCode {
+    if connection_handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    api::diagnostic::clear_diag_info(sql::HandleType::Dbc, connection_handle);
+    let mut warnings = vec![];
+    let result = api::connection::native_sql::<Narrow>(
+        connection_handle,
+        in_statement_text,
+        text_length1,
+        out_statement_text,
+        buffer_length,
+        text_length2_ptr,
+        &mut warnings,
+    );
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Dbc,
+        connection_handle,
+        &warnings,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Dbc, connection_handle, &result);
+    result.to_sql_code_with_warnings(&warnings)
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLNativeSqlW(
+    connection_handle: sql::Handle,
+    in_statement_text: *const sql::WChar,
+    text_length1: sql::Integer,
+    out_statement_text: *mut sql::WChar,
+    buffer_length: sql::Integer,
+    text_length2_ptr: *mut sql::Integer,
+) -> sql::RetCode {
+    if connection_handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    api::diagnostic::clear_diag_info(sql::HandleType::Dbc, connection_handle);
+    let mut warnings = vec![];
+    let result = api::connection::native_sql::<Wide>(
+        connection_handle,
+        in_statement_text,
+        text_length1,
+        out_statement_text,
+        buffer_length,
+        text_length2_ptr,
+        &mut warnings,
+    );
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Dbc,
+        connection_handle,
+        &warnings,
+    );
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Dbc, connection_handle, &result);
+    result.to_sql_code_with_warnings(&warnings)
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLGetDescField(
     descriptor_handle: sql::Handle,
     rec_number: sql::SmallInt,

--- a/odbc_tests/tests/odbc-api/submitting_request/num_params_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/num_params_tests.cpp
@@ -12,6 +12,26 @@
 #include "test_setup.hpp"
 
 // ============================================================================
+// SQLNumParams Tests
+//
+// Tested SQLSTATEs (from Microsoft ODBC spec):
+//   SQL_INVALID_HANDLE — null statement handle
+//   HY010             — function sequence error (before prepare, during NEED_DATA)
+//
+// Not tested (Driver Manager or infrastructure responsibility):
+//   01000 (General warning)     — driver-specific, no reliable trigger
+//   08S01 (Communication link)  — requires network fault injection
+//   HY000 (General error)       — catch-all, not directly provokable
+//   HY001 (Memory allocation)   — requires OOM simulation
+//   HY008 (Operation canceled)  — requires async + cancel timing
+//   HY013 (Memory management)   — requires low-memory conditions
+//   HY117 (Suspended connection)— requires unknown transaction state
+//   HYT01 (Connection timeout)  — requires timeout simulation
+//   IM001 (Not supported)       — we support it, so N/A
+//   IM017/IM018 (Async notify)  — notification mode not implemented
+// ============================================================================
+
+// ============================================================================
 // SQLNumParams - Basic Functionality
 // ============================================================================
 
@@ -76,6 +96,49 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLNumParams: Succeeds with NULL Parame
 
   ret = SQLNumParams(stmt_handle(), nullptr);
   REQUIRE(ret == SQL_SUCCESS);
+}
+
+// ============================================================================
+// SQLNumParams - Parser Edge Cases
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLNumParams: Ignores ? inside single-quoted string literal",
+                 "[odbc-api][numparams][submitting_request]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT '?' FROM t WHERE c = ?"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT count = -1;
+  ret = SQLNumParams(stmt_handle(), &count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(count == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLNumParams: Ignores ? inside line comment",
+                 "[odbc-api][numparams][submitting_request]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? -- is this counted?\nFROM t"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT count = -1;
+  ret = SQLNumParams(stmt_handle(), &count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(count == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLNumParams: Handles escaped quotes in literal",
+                 "[odbc-api][numparams][submitting_request]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 'it''s a ?', ?"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT count = -1;
+  ret = SQLNumParams(stmt_handle(), &count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(count == 1);
 }
 
 // ============================================================================


### PR DESCRIPTION
Add connection-level SQL translation function that passes SQL text
through unchanged (Snowflake does not perform ODBC escape sequence
translation). Handles:
- Pass-through copy of input to output buffer
- Truncation detection with SQL_SUCCESS_WITH_INFO + 01004
- Null output buffer (returns length only via TextLength2Ptr)
- Zero TextLength1 (returns empty string)
- Validation: null InStatementText (HY009), negative lengths (HY090),
  disconnected state (08003), null handle (SQL_INVALID_HANDLE)

Add SQLNativeSqlW to exports.def.

Made-with: Cursor