### PR TITLE
NO-SNOW Propagate unrecognised driver parameters as session parameters

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/session/SessionParametersTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/session/SessionParametersTests.java
@@ -1,0 +1,32 @@
+package net.snowflake.jdbc.e2e.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class SessionParametersTests extends SnowflakeIntegrationTestBase {
+
+  @Test
+  public void shouldForwardUnrecognizedConnectionOptionAsSessionParameter() throws Exception {
+    // Given Snowflake client is logged in with connection option QUERY_TAG set to
+    // "session_param_e2e_test"
+    Properties props = loadConnectionProperties();
+    props.setProperty("QUERY_TAG", "session_param_e2e_test");
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props);
+        // When Query "SELECT CURRENT_QUERY_TAG()" is executed
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT CURRENT_QUERY_TAG()")) {
+      // Then the result should contain value "session_param_e2e_test"
+      assertTrue(rs.next(), "Expected one row");
+      assertEquals("session_param_e2e_test", rs.getString(1));
+    }
+  }
+}

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -224,7 +224,15 @@ fn connect_with_params(
                         }
                     }
                     _ => {
-                        tracing::warn!("connect_with_params: unknown connection string key: {key:?}");
+                        tracing::info!(
+                            "connect_with_params: forwarding unrecognized key {key:?} to sf_core"
+                        );
+                        c.connection_set_option_string(ConnectionSetOptionStringRequest {
+                            conn_handle: Some(conn_handle),
+                            key,
+                            value,
+                        })
+                        .await?;
                     }
                 }
             }

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -31,6 +31,9 @@ add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)
 
+# session
+add_odbc_test(e2e_session_session_parameters session/session_parameters.cpp)
+
 # types
 add_odbc_test(e2e_types_binary types/binary.cpp)
 add_odbc_test(e2e_types_binary_conversion_to_c_binary types/binary_conversion_to_c_binary.cpp)

--- a/odbc_tests/tests/e2e/session/session_parameters.cpp
+++ b/odbc_tests/tests/e2e/session/session_parameters.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "get_data.hpp"
+#include "test_setup.hpp"
+
+TEST_CASE("should forward unrecognized connection option as session parameter", "[session]") {
+  SKIP_OLD_DRIVER("", "Old driver does not forward unknown connection options as session parameters");
+  // Given Snowflake client is logged in with connection option QUERY_TAG set to
+  // "session_param_e2e_test"
+  auto conn_str = get_connection_string() + "QUERY_TAG=session_param_e2e_test;";
+  Connection conn(conn_str);
+
+  // When Query "SELECT CURRENT_QUERY_TAG()" is executed
+  auto stmt = conn.execute_fetch("SELECT CURRENT_QUERY_TAG()");
+
+  // Then the result should contain value "session_param_e2e_test"
+  auto value = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(value == "session_param_e2e_test");
+}

--- a/python/tests/e2e/session/test_session_parameters.py
+++ b/python/tests/e2e/session/test_session_parameters.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+# This test verifies that unrecognized connection options are forwarded as
+# session parameters in the login request — a feature of sf_core that the
+# reference driver does not support.
+@pytest.mark.skip_reference(reason="Reference driver does not forward unknown options as session parameters")
+class TestSessionParametersViaConnectionOptions:
+    def test_should_forward_unrecognized_connection_option_as_session_parameter(self, connection_factory):
+        """Unrecognized kwargs should become session parameters at login."""
+        # Given Snowflake client is logged in with connection option QUERY_TAG
+        # set to "session_param_e2e_test"
+        with connection_factory(QUERY_TAG="session_param_e2e_test") as conn:
+            cursor = conn.cursor()
+            # When Query "SELECT CURRENT_QUERY_TAG()" is executed
+            cursor.execute("SELECT CURRENT_QUERY_TAG()")
+            row = cursor.fetchone()
+            # Then the result should contain value "session_param_e2e_test"
+            assert row[0] == "session_param_e2e_test"

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -9,8 +9,9 @@ use super::Setting;
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
 use super::validation::{
-    ValidationIssue, ValidationSeverity, canonicalize_setting_key, normalize_host_underscores,
-    resolve_options, validate_connection_seed_write, validate_session_override_write,
+    ValidationIssue, ValidationSeverity, canonicalize_setting_key, collect_unknown_settings,
+    normalize_host_underscores, resolve_options, validate_connection_seed_write,
+    validate_session_override_write,
 };
 use crate::config::ParamStore;
 use crate::config::connection_config::ConnectionConfig;
@@ -47,6 +48,29 @@ impl DatabaseDriverV1 {
                         ClientInfo::from_settings(&resolved).context(ConfigurationSnafu)?;
                     let init_params = conn.init_session_parameters.clone();
                     let resolved_snapshot = resolved.clone();
+
+                    // Forward unrecognized settings as session parameters so
+                    // drivers can set arbitrary Snowflake session params
+                    // via regular connection options.
+                    let unknown_settings = collect_unknown_settings(&conn.connection_seed);
+                    let init_params = match init_params {
+                        Some(explicit) => {
+                            // Normalize explicit keys to uppercase so precedence
+                            // is case-insensitive (unknown settings are uppercased).
+                            let mut merged: HashMap<String, String> = explicit
+                                .into_iter()
+                                .map(|(k, v)| (k.to_uppercase(), v))
+                                .collect();
+                            // Explicit session params take precedence
+                            for (k, v) in unknown_settings {
+                                merged.entry(k).or_insert(v);
+                            }
+                            Some(merged)
+                        }
+                        None if !unknown_settings.is_empty() => Some(unknown_settings),
+                        None => None,
+                    };
+
                     (
                         config,
                         host,

--- a/sf_core/src/apis/database_driver_v1/validation.rs
+++ b/sf_core/src/apis/database_driver_v1/validation.rs
@@ -353,6 +353,28 @@ pub(crate) fn validate_statement_option_write(
     Ok(())
 }
 
+/// Collect string-typed settings whose keys are not recognized by the param
+/// registry. These are forwarded as session parameters at login time so that
+/// drivers can set arbitrary Snowflake session parameters (e.g. `QUERY_TAG`)
+/// via regular connection options.
+pub(crate) fn collect_unknown_settings(settings: &ParamStore) -> HashMap<String, String> {
+    let registry = param_registry::registry();
+    settings
+        .iter()
+        .filter(|(key, _)| registry.resolve(key).is_none())
+        .filter_map(|(key, value)| {
+            let str_value = match value {
+                Setting::String(s) => s.clone(),
+                Setting::Int(i) => i.to_string(),
+                Setting::Bool(b) => b.to_string(),
+                Setting::Double(d) => d.to_string(),
+                Setting::Bytes(_) => return None,
+            };
+            Some((key.to_uppercase(), str_value))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -669,5 +691,32 @@ mod tests {
                 "abc_test.snowflakecomputing.com".to_string()
             )),
         );
+    }
+
+    #[test]
+    fn collect_unknown_settings_returns_only_unregistered_keys() {
+        let mut store = ParamStore::new();
+        // Known key — should NOT appear in result
+        store.insert(
+            "host".to_string(),
+            Setting::String("example.com".to_string()),
+        );
+        // Unknown string key — should appear uppercased
+        store.insert(
+            "query_tag".to_string(),
+            Setting::String("my_tag".to_string()),
+        );
+        // Unknown non-string keys — should be stringified
+        store.insert("some_int_key".to_string(), Setting::Int(42));
+        store.insert("some_bool_key".to_string(), Setting::Bool(true));
+
+        let unknown = collect_unknown_settings(&store);
+
+        assert_eq!(unknown.len(), 3);
+        assert_eq!(unknown.get("QUERY_TAG"), Some(&"my_tag".to_string()));
+        assert_eq!(unknown.get("SOME_INT_KEY"), Some(&"42".to_string()));
+        assert_eq!(unknown.get("SOME_BOOL_KEY"), Some(&"true".to_string()));
+        assert!(!unknown.contains_key("host"));
+        assert!(!unknown.contains_key("HOST"));
     }
 }

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -15,6 +15,10 @@ impl ParamStore {
         }
     }
 
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &Setting)> {
+        self.inner.iter()
+    }
+
     pub fn get(&self, key: ParamKey) -> Option<&Setting> {
         self.inner.get(key.as_str())
     }

--- a/sf_core/tests/e2e/session/mod.rs
+++ b/sf_core/tests/e2e/session/mod.rs
@@ -1,1 +1,2 @@
+mod session_parameters;
 mod session_refresh;

--- a/sf_core/tests/e2e/session/session_parameters.rs
+++ b/sf_core/tests/e2e/session/session_parameters.rs
@@ -1,0 +1,19 @@
+use crate::common::arrow_result_helper::ArrowResultHelper;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+
+#[test]
+fn should_forward_unrecognized_connection_option_as_session_parameter() {
+    // Given Snowflake client is logged in with connection option QUERY_TAG set to "session_param_e2e_test"
+    let client = SnowflakeTestClient::with_default_jwt_auth_params();
+    client.set_connection_option("QUERY_TAG", "session_param_e2e_test");
+    client.connect().unwrap();
+
+    // When Query "SELECT CURRENT_QUERY_TAG()" is executed
+    let result = client.execute_query("SELECT CURRENT_QUERY_TAG()");
+
+    // Then the result should contain value "session_param_e2e_test"
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<String>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], "session_param_e2e_test");
+}

--- a/tests/definitions/shared/session/session_parameters.feature
+++ b/tests/definitions/shared/session/session_parameters.feature
@@ -1,0 +1,12 @@
+@core @python @jdbc @odbc
+Feature: Session parameters via connection options
+
+  Unrecognized connection options should be forwarded as session
+  parameters in the login request, so drivers can set arbitrary
+  Snowflake session parameters without explicit support.
+
+  @core_e2e @python_e2e @jdbc_e2e @odbc_e2e
+  Scenario: should forward unrecognized connection option as session parameter
+    Given Snowflake client is logged in with connection option QUERY_TAG set to "session_param_e2e_test"
+    When Query "SELECT CURRENT_QUERY_TAG()" is executed
+    Then the result should contain value "session_param_e2e_test"


### PR DESCRIPTION
### TL;DR

Added functionality to forward unrecognized connection options as session parameters during login, allowing drivers to set arbitrary Snowflake session parameters like `QUERY_TAG` through connection strings.

### What changed?

- Modified `sf_core` to collect unrecognized string-typed connection settings and forward them as session parameters during login
- Updated ODBC driver to forward unknown connection string keys to `sf_core` instead of logging warnings
- Added `collect_unknown_settings()` function to identify and collect unregistered connection options
- Added `iter()` method to `ParamStore` to enable iteration over stored settings
- Explicit session parameters take precedence over forwarded connection options when both are present

### How to test?

Run the new end-to-end tests across all drivers:
- Set `QUERY_TAG=session_param_e2e_test` as a connection option
- Execute `SELECT CURRENT_QUERY_TAG()` 
- Verify the result returns `"session_param_e2e_test"`

Tests are available for JDBC, ODBC, Python, and sf_core, along with a shared Gherkin feature definition.

### Why make this change?

This enables drivers to support arbitrary Snowflake session parameters without requiring explicit implementation for each parameter. Users can now set session parameters like `QUERY_TAG`, `TIMEZONE`, or any other Snowflake session parameter directly through connection options, improving flexibility and reducing the need for driver-specific parameter support.