### PR TITLE
NO_SNOW: Per test-run schema

### DIFF
--- a/.cursor/rules/odbc-test-generation.mdc
+++ b/.cursor/rules/odbc-test-generation.mdc
@@ -109,11 +109,42 @@ REQUIRE_THAT(OdbcResult(ret, stmt),
 ```
 
 ### Schema & Table Management
-Use `Schema::use_random_schema(conn)` when the test creates tables. The schema destructor drops CASCADE, so `DROP TABLE IF EXISTS` is redundant inside a random schema.
-```cpp
-auto random_schema = Schema::use_random_schema(conn);
-conn.execute("CREATE OR REPLACE TABLE test_table (col VARCHAR(1000))");
-```
+
+Call `Schema::use_temp_session_schema(conn)` (or the `SQLHDBC` overload) before creating any tables. In CI, all test processes share a single schema (`ODBC_TEST_SCHEMA` env var); in IDE/direct runs, each process gets its own random schema with automatic cleanup.
+
+**Table creation strategy (ordered by preference):**
+
+1. **`CREATE TEMPORARY TABLE`** (default) — session-scoped, auto-dropped on disconnect, session-isolated so names can be simple. Use for all normal data tests.
+   ```cpp
+   Schema::use_temp_session_schema(conn);
+   conn.execute("CREATE TEMPORARY TABLE my_table (id INT, value VARCHAR(100))");
+   ```
+
+2. **`ScopedTable` RAII class** — for permanent tables that must be visible cross-session or show `TABLE_TYPE = 'TABLE'` in catalog queries. Generates a unique name with PID+random, drops in destructor.
+   ```cpp
+   #include "ScopedTable.hpp"
+   Schema::use_temp_session_schema(conn);
+   ScopedTable table(conn, "catalog_test", "id INT, value VARCHAR(100)");
+   // use table.name() in queries
+   // table is dropped automatically when it goes out of scope
+   ```
+
+3. **`CREATE OR REPLACE TABLE` with a hardcoded name** — only for tests that specifically exercise DDL on named permanent tables (e.g., `ALTER TABLE`, `DROP TABLE`, `SQLRowCount` after DDL). Names must be globally unique: `<file_stem>_<scenario>_t`.
+   ```cpp
+   Schema::use_temp_session_schema(conn);
+   conn.execute("CREATE OR REPLACE TABLE rowcount_alter_t (id INT, val VARCHAR(50))");
+   ```
+
+**When TEMPORARY tables are NOT suitable:**
+- Catalog tests (`SQLTables`) that verify `TABLE_TYPE == 'TABLE'` (temp tables show as `LOCAL TEMPORARY`)
+- Tests requiring cross-session table visibility
+- Tests exercising DDL specific to permanent tables (`ALTER TABLE`, `GRANT`, `DROP TABLE`)
+- Tests that check `SQLRowCount` behavior after DDL statements on permanent tables
+
+**Naming rules for hardcoded permanent table names:**
+- Must be globally unique across the entire test suite (all tests share one schema in CI)
+- Convention: `<file_stem>_<scenario>_t` (e.g., `sql_fetch_scroll_t`, `rowcount_alter_t`)
+- Why: duplicate names cause flaky test failures when tests run in parallel
 
 ### Data Retrieval
 ```cpp
@@ -171,7 +202,7 @@ REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 Available matchers: `Succeeded()`, `IsSuccess()`, `IsSuccessWithInfo()`, `IsError()`, `HasSqlState(code)`, `HasDiagMessage(substring)`. Compose with `&&` / `||`.
 
 ### Abstraction Levels
-- **Given (setup)**: use high-level abstractions — `Connection`, `Schema::use_random_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
+- **Given (setup)**: use high-level abstractions — `Connection`, `Schema::use_temp_session_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
 - **When/Then (test)**: use raw ODBC calls (`SQLExecDirect`, `SQLFetch`, `SQLGetData`) or purpose-built helpers to make the tested code path explicit and auditable.
 - Do not use raw ODBC for setup or high-level wrappers for the behaviour under test.
 
@@ -232,6 +263,7 @@ odbc_tests/tests/
 - `get_data.hpp` - `get_data<>()` and `get_data_optional<>()` typed data retrieval helpers
 - `conversion_checks.hpp` - Helpers for type conversion tests
 - `Schema.hpp` - Schema management
+- `ScopedTable.hpp` - RAII wrapper for permanent tables with unique names (PID+random)
 - `put_get_utils.hpp` - PUT/GET operation utilities
 - `compatibility.hpp` - `OLD_DRIVER_ONLY`, `NEW_DRIVER_ONLY` macros
 

--- a/.cursor/rules/odbc-test-reviewer.mdc
+++ b/.cursor/rules/odbc-test-reviewer.mdc
@@ -12,8 +12,8 @@ When asked to review ODBC test code, systematically check each category below. R
 
 - All ODBC handles must use RAII wrappers (`Connection`, `Schema`, `TestTable`, `HandleWrapper` variants).
 - Flag manual `SQLAllocHandle` / `SQLDisconnect` / `SQLFreeHandle` — these leak on test failure.
-- `Schema::use_random_schema(conn)` is required when the test creates tables. Do NOT flag its absence for literal-only queries.
-- Flag `DROP TABLE IF EXISTS` inside a random schema — the schema destructor drops CASCADE, making it redundant. Suggest `CREATE OR REPLACE TABLE` or plain `CREATE TABLE`.
+- `Schema::use_temp_session_schema(conn)` is required when the test creates tables. Do NOT flag its absence for literal-only queries.
+- Prefer `CREATE OR REPLACE TABLE` over `DROP TABLE IF EXISTS` + `CREATE TABLE` — saves a server round-trip.
 
 ## 2. Test Structure
 
@@ -69,7 +69,7 @@ Available matchers: `Succeeded()`, `IsSuccess()`, `IsSuccessWithInfo()`, `IsErro
 
 ## 8. Abstraction Levels
 
-- **Given (setup)**: high-level abstractions — `Connection`, `Schema::use_random_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
+- **Given (setup)**: high-level abstractions — `Connection`, `Schema::use_temp_session_schema`, `TestTable`, `get_data<>()`, `conn.execute_fetch()`.
 - **When/Then (test)**: raw ODBC calls (`SQLExecDirect`, `SQLFetch`, `SQLGetData`) or purpose-built helpers to make the tested code path explicit and auditable.
 - Flag tests that use raw ODBC for setup or high-level wrappers for the behaviour under test.
 

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -160,20 +160,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         id: run_odbc_ref_tests_linux
         continue-on-error: ${{ github.event_name == 'merge_group' }}
-        run: |
-          export DRIVER_PATH=/usr/lib/snowflake/odbc/lib/libSnowflake.so
-          export PARAMETER_PATH=$(pwd)/parameters.json
-          cd odbc_tests/
-          mkdir -p cmake-build
-          cmake -B cmake-build \
-              -D ODBC_LIBRARY="/usr/lib/x86_64-linux-gnu/libodbc.so" \
-              -D ODBC_INCLUDE_DIR="/usr/include" \
-              -D DRIVER_TYPE=OLD \
-              -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -D CMAKE_C_COMPILER_LAUNCHER=ccache \
-              .
-          cmake --build cmake-build -- -j $(($(nproc) * 2))
-          ctest -j $(($(nproc) * 4)) -C Debug --test-dir cmake-build --output-on-failure
+        run: ./scripts/odbc/run_tests_unix.sh
+        env:
+          DRIVER_PATH: /usr/lib/snowflake/odbc/lib/libSnowflake.so
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          DRIVER_TYPE: OLD
 
       - name: Rerun failed Old ODBC tests (Linux)
         if: steps.run_odbc_ref_tests_linux.outcome == 'failure' && github.event_name == 'merge_group'
@@ -202,6 +193,19 @@ jobs:
           DRIVER_PATH: C:\Program Files\Snowflake ODBC Driver\Bin\SnowflakeDSII.dll
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           DRIVER_TYPE: OLD
+
+      - name: Cleanup orphaned test schemas
+        if: always() && matrix.os == 'ubuntu-latest'
+        run: |
+          TOOL="odbc_tests/cmake-build/tools/schema_tool"
+          if [[ -x "$TOOL" ]]; then
+            "$TOOL" cleanup --age-days 2
+          else
+            echo "schema_tool not found (build may have failed), skipping cleanup"
+          fi
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          DRIVER_PATH: /usr/lib/snowflake/odbc/lib/libSnowflake.so
 
       - name: Save test dependencies cache
         if: always()
@@ -461,6 +465,19 @@ jobs:
           DRIVER_PATH: ${{ github.workspace }}\target\debug\${{ matrix.driver_lib }}
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           DRIVER_TYPE: NEW
+
+      - name: Cleanup orphaned test schemas
+        if: always() && runner.os == 'Linux'
+        run: |
+          TOOL="odbc_tests/cmake-build/tools/schema_tool"
+          if [[ -x "$TOOL" ]]; then
+            "$TOOL" cleanup --age-days 2
+          else
+            echo "schema_tool not found (build may have failed), skipping cleanup"
+          fi
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
 
       - name: Save test dependencies cache
         if: always()

--- a/odbc_tests/CMakeLists.txt
+++ b/odbc_tests/CMakeLists.txt
@@ -42,9 +42,12 @@ message(STATUS "ODBC_INCLUDE_DIRS: ${ODBC_INCLUDE_DIRS}")
 message(STATUS "ODBC_LIBRARIES: ${ODBC_LIBRARIES}")
 
 add_subdirectory(common)
+add_subdirectory(tools)
 
 function(add_odbc_test name)
   add_executable(${name} ${ARGN})
+  target_sources(${name} PRIVATE
+      "${PROJECT_SOURCE_DIR}/common/src/schema_cleanup_listener.cpp")
   target_link_libraries(${name} PRIVATE Catch2::Catch2WithMain ODBC::ODBC common Threads::Threads)
   if(NOT WIN32)
     target_link_libraries(${name} PRIVATE ${CMAKE_DL_LIBS})

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -4,87 +4,95 @@
 #include <sql.h>
 #include <sqlext.h>
 
-#include <functional>
+#include <cstdlib>
 #include <random>
 #include <stdexcept>
 #include <string>
 
 #include "Connection.hpp"
 #include "odbc_cast.hpp"
+#include "test_setup.hpp"
 
+// Static utility class that manages the test schema for the current process.
+//
+// Two modes of operation:
+//
+// 1. Shared schema (ODBC_TEST_SCHEMA env var set by runner script):
+//    The runner pre-creates a single schema for all test processes.
+//    use_temp_session_schema() just issues USE SCHEMA — no CREATE.
+//    The runner's trap/finally drops the schema on exit.
+//
+// 2. Fallback (no env var — IDE, direct ctest, individual binary):
+//    Generates a random schema name, issues CREATE SCHEMA IF NOT EXISTS.
+//    The Catch2 SchemaCleanupListener drops it in testRunEnded.
+//
+// Schemas are NOT dropped via std::atexit because the ODBC driver's Rust
+// runtime tears down TLS before C++ atexit handlers run, making any ODBC
+// call from atexit unsafe (causes abort via Rust panic on macOS ARM64).
 class Schema {
  public:
-  Schema(Connection& conn, const std::string& schema_name)
-      : execute_fn([&conn](const std::string& sql) { conn.execute(sql); }), schema_name(schema_name) {
-    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    execute_fn("USE SCHEMA " + schema_name);
-  }
-
-  Schema(const SQLHDBC dbc, const std::string& schema_name)
-      : execute_fn(make_dbc_executor(dbc)), schema_name(schema_name) {
-    execute_fn("CREATE SCHEMA IF NOT EXISTS " + schema_name);
-    execute_fn("USE SCHEMA " + schema_name);
-  }
-
-  static Schema use_random_schema(Connection& conn) { return Schema(conn, generate_random_name()); }
-
-  static Schema use_random_schema(const SQLHDBC dbc) { return Schema(dbc, generate_random_name()); }
-
-  const std::string& name() const { return schema_name; }
-
-  ~Schema() {
-    if (execute_fn) {
-      execute_fn("DROP SCHEMA IF EXISTS " + schema_name + " CASCADE");
-    }
-  }
-
+  Schema() = delete;
   Schema(const Schema&) = delete;
   Schema& operator=(const Schema&) = delete;
+  Schema(Schema&&) = delete;
+  Schema& operator=(Schema&&) = delete;
 
-  Schema(Schema&& other) noexcept : execute_fn(std::move(other.execute_fn)), schema_name(std::move(other.schema_name)) {
-    other.execute_fn = nullptr;
-    other.schema_name.clear();
-  }
-
-  Schema& operator=(Schema&& other) noexcept {
-    if (this != &other) {
-      if (execute_fn) {
-        execute_fn("DROP SCHEMA IF EXISTS " + schema_name + " CASCADE");
-      }
-      execute_fn = std::move(other.execute_fn);
-      schema_name = std::move(other.schema_name);
-      other.execute_fn = nullptr;
-      other.schema_name.clear();
+  static void use_temp_session_schema(Connection& conn) {
+    used_ = true;
+    if (!is_external_schema()) {
+      conn.execute("CREATE SCHEMA IF NOT EXISTS " + session_schema_name());
     }
-    return *this;
+    conn.execute("USE SCHEMA " + session_schema_name());
   }
+
+  static void use_temp_session_schema(SQLHDBC dbc) {
+    used_ = true;
+    if (!is_external_schema()) {
+      execute_on_dbc(dbc, "CREATE SCHEMA IF NOT EXISTS " + session_schema_name());
+    }
+    execute_on_dbc(dbc, "USE SCHEMA " + session_schema_name());
+  }
+
+  static const std::string& name() { return session_schema_name(); }
+
+  static bool is_external_schema() {
+    static const bool external = (std::getenv("ODBC_TEST_SCHEMA") != nullptr);
+    return external;
+  }
+
+  static bool was_used() { return used_; }
 
  private:
+  static inline bool used_ = false;
+
+  static const std::string& session_schema_name() {
+    static std::string schema_name = [] {
+      const char* env = std::getenv("ODBC_TEST_SCHEMA");
+      return env ? std::string(env) : generate_random_name();
+    }();
+    return schema_name;
+  }
+
   static std::string generate_random_name() {
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    return "SCHEMA_" + std::to_string(gen());
+    return "TEMP_TEST_SCHEMA_" + std::to_string(gen());
   }
 
-  static std::function<void(const std::string&)> make_dbc_executor(SQLHDBC dbc) {
-    return [dbc](const std::string& sql) {
-      SQLHSTMT stmt = SQL_NULL_HSTMT;
-      SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
-      if (!SQL_SUCCEEDED(ret)) {
-        throw std::runtime_error("Schema: SQLAllocHandle(SQL_HANDLE_STMT) failed for: " + sql);
-      }
-      ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
-      if (!SQL_SUCCEEDED(ret)) {
-        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-        throw std::runtime_error("Schema: SQLExecDirect failed for: " + sql);
-      }
-      SQLFreeStmt(stmt, SQL_CLOSE);
+  static void execute_on_dbc(const SQLHDBC dbc, const std::string& sql) {
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
+    if (!SQL_SUCCEEDED(ret)) {
+      throw std::runtime_error("Schema: SQLAllocHandle failed for: " + sql);
+    }
+    ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+    if (!SQL_SUCCEEDED(ret)) {
       SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-    };
+      throw std::runtime_error("Schema: SQLExecDirect failed for: " + sql);
+    }
+    SQLFreeStmt(stmt, SQL_CLOSE);
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   }
-
-  std::function<void(const std::string&)> execute_fn;
-  std::string schema_name;
 };
 
 #endif  // SCHEMA_HPP

--- a/odbc_tests/common/include/Schema.hpp
+++ b/odbc_tests/common/include/Schema.hpp
@@ -19,12 +19,18 @@
 //
 // 1. Shared schema (ODBC_TEST_SCHEMA env var set by runner script):
 //    The runner pre-creates a single schema for all test processes.
-//    use_temp_session_schema() just issues USE SCHEMA — no CREATE.
+//    use_temp_session_schema() issues USE SCHEMA to select it.
 //    The runner's trap/finally drops the schema on exit.
 //
 // 2. Fallback (no env var — IDE, direct ctest, individual binary):
-//    Generates a random schema name, issues CREATE SCHEMA IF NOT EXISTS.
-//    The Catch2 SchemaCleanupListener drops it in testRunEnded.
+//    Generates a random schema name, issues CREATE SCHEMA IF NOT EXISTS
+//    then USE SCHEMA. The Catch2 SchemaCleanupListener drops it in
+//    testRunEnded.
+//
+// USE SCHEMA is always executed because each ConnSchemaFixture creates a
+// new connection whose active schema defaults to PUBLIC. CREATE SCHEMA
+// alone only auto-selects on actual creation, not when IF NOT EXISTS
+// hits an already-existing schema.
 //
 // Schemas are NOT dropped via std::atexit because the ODBC driver's Rust
 // runtime tears down TLS before C++ atexit handlers run, making any ODBC
@@ -38,42 +44,42 @@ class Schema {
   Schema& operator=(Schema&&) = delete;
 
   static void use_temp_session_schema(Connection& conn) {
-    used_ = true;
+    initiated_ = true;
     if (!is_external_schema()) {
-      conn.execute("CREATE SCHEMA IF NOT EXISTS " + session_schema_name());
+      conn.execute("CREATE SCHEMA IF NOT EXISTS " + resolve_schema_name());
     }
-    conn.execute("USE SCHEMA " + session_schema_name());
+    conn.execute("USE SCHEMA " + resolve_schema_name());
   }
 
   static void use_temp_session_schema(SQLHDBC dbc) {
-    used_ = true;
+    initiated_ = true;
     if (!is_external_schema()) {
-      execute_on_dbc(dbc, "CREATE SCHEMA IF NOT EXISTS " + session_schema_name());
+      execute_on_dbc(dbc, "CREATE SCHEMA IF NOT EXISTS " + resolve_schema_name());
     }
-    execute_on_dbc(dbc, "USE SCHEMA " + session_schema_name());
+    execute_on_dbc(dbc, "USE SCHEMA " + resolve_schema_name());
   }
 
-  static const std::string& name() { return session_schema_name(); }
+  static const std::string& name() { return resolve_schema_name(); }
 
   static bool is_external_schema() {
     static const bool external = (std::getenv("ODBC_TEST_SCHEMA") != nullptr);
     return external;
   }
 
-  static bool was_used() { return used_; }
+  static bool was_initiated() { return initiated_; }
 
  private:
-  static inline bool used_ = false;
+  static inline bool initiated_ = false;
 
-  static const std::string& session_schema_name() {
+  static const std::string& resolve_schema_name() {
     static std::string schema_name = [] {
       const char* env = std::getenv("ODBC_TEST_SCHEMA");
-      return env ? std::string(env) : generate_random_name();
+      return env ? std::string(env) : generate_random_schema_name();
     }();
     return schema_name;
   }
 
-  static std::string generate_random_name() {
+  static std::string generate_random_schema_name() {
     std::random_device rd;
     std::mt19937_64 gen(rd());
     return "TEMP_TEST_SCHEMA_" + std::to_string(gen());

--- a/odbc_tests/common/include/SchemaFixtures.hpp
+++ b/odbc_tests/common/include/SchemaFixtures.hpp
@@ -1,0 +1,25 @@
+#ifndef SCHEMA_FIXTURES_HPP
+#define SCHEMA_FIXTURES_HPP
+
+#include "ODBCFixtures.hpp"
+#include "Schema.hpp"
+
+// Connection RAII fixtures (SQLDriverConnect via connection string)
+// Prefixed with "Conn" to distinguish from raw-handle fixtures in ODBCFixtures.hpp.
+
+struct ConnFixture {
+  Connection conn;
+};
+
+struct ConnSchemaFixture {
+  Connection conn;
+  ConnSchemaFixture() { Schema::use_temp_session_schema(conn); }
+};
+
+// Raw-handle fixture with session schema (extends existing StmtDefaultDSNFixture)
+
+struct StmtSessionSchemaFixture : StmtDefaultDSNFixture {
+  StmtSessionSchemaFixture() { Schema::use_temp_session_schema(dbc_handle()); }
+};
+
+#endif  // SCHEMA_FIXTURES_HPP

--- a/odbc_tests/common/include/ScopedTable.hpp
+++ b/odbc_tests/common/include/ScopedTable.hpp
@@ -1,0 +1,54 @@
+#ifndef SCOPED_TABLE_HPP
+#define SCOPED_TABLE_HPP
+
+#include <cstdlib>
+#include <random>
+#include <string>
+
+#include "Connection.hpp"
+
+#ifdef _WIN32
+#include <process.h>
+#define GET_PID() _getpid()
+#else
+#include <unistd.h>
+#define GET_PID() getpid()
+#endif
+
+// RAII wrapper that creates a permanent table with a unique name and drops it
+// on destruction.  Use this when SQL TEMPORARY tables are not suitable (e.g.
+// catalog tests that check TABLE_TYPE = 'TABLE', cross-session visibility).
+//
+// Prefer CREATE TEMPORARY TABLE for normal data tests — it is session-scoped,
+// auto-dropped on disconnect, and collision-free.
+class ScopedTable {
+ public:
+  ScopedTable(Connection& conn, const std::string& prefix, const std::string& columns)
+      : conn_(conn), name_(generate_name(prefix)) {
+    conn_.execute("CREATE OR REPLACE TABLE " + name_ + " (" + columns + ")");
+  }
+
+  ~ScopedTable() {
+    try {
+      conn_.execute("DROP TABLE IF EXISTS " + name_);
+    } catch (...) {
+    }
+  }
+
+  ScopedTable(const ScopedTable&) = delete;
+  ScopedTable& operator=(const ScopedTable&) = delete;
+
+  const std::string& name() const { return name_; }
+
+ private:
+  static std::string generate_name(const std::string& prefix) {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    return prefix + "_" + std::to_string(GET_PID()) + "_" + std::to_string(gen());
+  }
+
+  Connection& conn_;
+  std::string name_;
+};
+
+#endif  // SCOPED_TABLE_HPP

--- a/odbc_tests/common/include/TestTable.hpp
+++ b/odbc_tests/common/include/TestTable.hpp
@@ -9,7 +9,7 @@ class TestTable {
  public:
   TestTable(Connection& conn, const std::string& name, const std::string& columns, const std::string& values)
       : conn_(conn), name_(name) {
-    conn_.execute("CREATE OR REPLACE TABLE " + name_ + " (" + columns + ")");
+    conn_.execute("CREATE TEMPORARY TABLE " + name_ + " (" + columns + ")");
     conn_.execute("INSERT INTO " + name_ + " VALUES " + values);
   }
 

--- a/odbc_tests/common/src/schema_cleanup_listener.cpp
+++ b/odbc_tests/common/src/schema_cleanup_listener.cpp
@@ -1,0 +1,85 @@
+#include <sql.h>
+#include <sqlext.h>
+
+#include <iostream>
+#include <string>
+
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+#include "ODBCConfig.hpp"
+#include "Schema.hpp"
+#include "odbc_cast.hpp"
+
+// Catch2 event listener that drops per-process schemas in fallback mode.
+//
+// testRunEnded fires during normal Catch2 execution, before main() returns
+// and before Rust TLS teardown — so ODBC calls are still safe here (unlike
+// std::atexit which fires too late).
+//
+// IMPORTANT: This listener must NOT use the Connection class or any function
+// that calls Catch2 assertion macros (REQUIRE, CHECK, FAIL, etc.), because
+// testRunEnded fires outside any test case context.  Catch2 assertions require
+// an active test case; calling them here dereferences a null IResultCapture*
+// and SEGFAULTs.
+//
+// Skips cleanup when:
+//  - ODBC_TEST_SCHEMA is set (runner script handles the shared schema)
+//  - Schema was never used in this process (no schema to drop)
+struct SchemaCleanupListener : Catch::EventListenerBase {
+  using EventListenerBase::EventListenerBase;
+
+  void testRunEnded(const Catch::TestRunStats&) override {
+    if (Schema::is_external_schema() || !Schema::was_used()) {
+      return;
+    }
+    try {
+      drop_schema_raw(Schema::name());
+    } catch (const std::exception& e) {
+      std::cerr << "SchemaCleanupListener: failed to drop schema " << Schema::name() << ": " << e.what() << "\n";
+    } catch (...) {
+      std::cerr << "SchemaCleanupListener: failed to drop schema " << Schema::name() << ": unknown error\n";
+    }
+  }
+
+ private:
+  static void drop_schema_raw(const std::string& schema_name) {
+    auto dsn_config = DataSourceConfig::Snowflake();
+    auto installation = dsn_config.install();
+    std::string conn_str = dsn_config.connection_string();
+
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
+
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env))) {
+      return;
+    }
+    SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc))) {
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    SQLRETURN ret =
+        SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    if (!SQL_SUCCEEDED(ret)) {
+      SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
+
+    std::string sql = "DROP SCHEMA IF EXISTS " + schema_name + " CASCADE";
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    if (SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt))) {
+      SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    }
+
+    SQLDisconnect(dbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    SQLFreeHandle(SQL_HANDLE_ENV, env);
+  }
+};
+
+CATCH_REGISTER_LISTENER(SchemaCleanupListener)

--- a/odbc_tests/common/src/schema_cleanup_listener.cpp
+++ b/odbc_tests/common/src/schema_cleanup_listener.cpp
@@ -25,12 +25,12 @@
 //
 // Skips cleanup when:
 //  - ODBC_TEST_SCHEMA is set (runner script handles the shared schema)
-//  - Schema was never used in this process (no schema to drop)
+//  - Schema was never initiated in this process (no schema to drop)
 struct SchemaCleanupListener : Catch::EventListenerBase {
   using EventListenerBase::EventListenerBase;
 
   void testRunEnded(const Catch::TestRunStats&) override {
-    if (Schema::is_external_schema() || !Schema::was_used()) {
+    if (Schema::is_external_schema() || !Schema::was_initiated()) {
       return;
     }
     try {
@@ -45,7 +45,7 @@ struct SchemaCleanupListener : Catch::EventListenerBase {
  private:
   static void drop_schema_raw(const std::string& schema_name) {
     auto dsn_config = DataSourceConfig::Snowflake();
-    auto installation = dsn_config.install();
+    [[maybe_unused]] auto installation = dsn_config.install();
     std::string conn_str = dsn_config.connection_string();
 
     SQLHENV env = SQL_NULL_HENV;
@@ -54,7 +54,11 @@ struct SchemaCleanupListener : Catch::EventListenerBase {
     if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env))) {
       return;
     }
-    SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    if (!SQL_SUCCEEDED(SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0))) {
+      std::cerr << "SchemaCleanupListener: SQLSetEnvAttr(SQL_OV_ODBC3) failed\n";
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+      return;
+    }
 
     if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc))) {
       SQLFreeHandle(SQL_HANDLE_ENV, env);

--- a/odbc_tests/run.sh
+++ b/odbc_tests/run.sh
@@ -38,9 +38,13 @@ pushd odbc_tests
     # --- Schema lifecycle ---
     SCHEMA_TOOL="$(pwd)/cmake-build/tools/schema_tool"
     if SCHEMA_NAME=$("$SCHEMA_TOOL" create); then
-        export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
-        trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
-        echo "run: using shared schema $SCHEMA_NAME"
+        if [[ ! "$SCHEMA_NAME" =~ ^TEMP_TEST_SCHEMA_[0-9]+$ ]]; then
+            echo "run: schema_tool returned invalid name '$SCHEMA_NAME', falling back to per-process"
+        else
+            export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
+            trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
+            echo "run: using shared schema $SCHEMA_NAME"
+        fi
     else
         echo "run: schema pre-creation failed, falling back to per-process"
     fi

--- a/odbc_tests/run.sh
+++ b/odbc_tests/run.sh
@@ -34,5 +34,16 @@ pushd odbc_tests
             .
     fi
     cmake --build cmake-build -- -j 16
+
+    # --- Schema lifecycle ---
+    SCHEMA_TOOL="$(pwd)/cmake-build/tools/schema_tool"
+    if SCHEMA_NAME=$("$SCHEMA_TOOL" create); then
+        export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
+        trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
+        echo "run: using shared schema $SCHEMA_NAME"
+    else
+        echo "run: schema pre-creation failed, falling back to per-process"
+    fi
+
     ctest -j $(nproc) -C Debug --test-dir cmake-build --output-on-failure "$@"
 popd

--- a/odbc_tests/run_reference.sh
+++ b/odbc_tests/run_reference.sh
@@ -69,9 +69,13 @@ docker run --rm \
         # Schema lifecycle
         SCHEMA_TOOL=\"./cmake-build-reference/tools/schema_tool\"
         if SCHEMA_NAME=\$(\"\$SCHEMA_TOOL\" create); then
-            export ODBC_TEST_SCHEMA=\"\$SCHEMA_NAME\"
-            trap '\"\$SCHEMA_TOOL\" drop \"\$SCHEMA_NAME\" 2>/dev/null || true' EXIT
-            echo \"run_reference: using shared schema \$SCHEMA_NAME\"
+            if [[ ! \"\$SCHEMA_NAME\" =~ ^TEMP_TEST_SCHEMA_[0-9]+$ ]]; then
+                echo \"run_reference: schema_tool returned invalid name, falling back to per-process\"
+            else
+                export ODBC_TEST_SCHEMA=\"\$SCHEMA_NAME\"
+                trap '\"\$SCHEMA_TOOL\" drop \"\$SCHEMA_NAME\" 2>/dev/null || true' EXIT
+                echo \"run_reference: using shared schema \$SCHEMA_NAME\"
+            fi
         else
             echo \"run_reference: schema pre-creation failed, falling back to per-process\"
         fi

--- a/odbc_tests/run_reference.sh
+++ b/odbc_tests/run_reference.sh
@@ -66,6 +66,16 @@ docker run --rm \
         # Build tests
         cmake --build cmake-build-reference -- -j \$(nproc)
         
+        # Schema lifecycle
+        SCHEMA_TOOL=\"./cmake-build-reference/tools/schema_tool\"
+        if SCHEMA_NAME=\$(\"\$SCHEMA_TOOL\" create); then
+            export ODBC_TEST_SCHEMA=\"\$SCHEMA_NAME\"
+            trap '\"\$SCHEMA_TOOL\" drop \"\$SCHEMA_NAME\" 2>/dev/null || true' EXIT
+            echo \"run_reference: using shared schema \$SCHEMA_NAME\"
+        else
+            echo \"run_reference: schema pre-creation failed, falling back to per-process\"
+        fi
+        
         # Run tests
         echo 'Running ODBC reference tests...'
         ctest -j \$(nproc) -C Debug --test-dir cmake-build-reference --output-on-failure \"\$@\"

--- a/odbc_tests/tests/bindings_tests/test.cpp
+++ b/odbc_tests/tests/bindings_tests/test.cpp
@@ -1,13 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 
-TEST_CASE("Test integer single column, single row binding", "[bindings_tests]") {
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("DROP TABLE IF EXISTS universal_driver_odbc_small_binding_integer_test_table");
-  conn.execute("CREATE TABLE universal_driver_odbc_small_binding_integer_test_table (id NUMBER)");
+TEST_CASE_METHOD(ConnSchemaFixture, "Test integer single column, single row binding", "[bindings_tests]") {
+  conn.execute("CREATE OR REPLACE TABLE universal_driver_odbc_small_binding_integer_test_table (id NUMBER)");
 
   {
     auto stmt = conn.createStatement();

--- a/odbc_tests/tests/bindings_tests/test.cpp
+++ b/odbc_tests/tests/bindings_tests/test.cpp
@@ -4,7 +4,7 @@
 #include "SchemaFixtures.hpp"
 
 TEST_CASE_METHOD(ConnSchemaFixture, "Test integer single column, single row binding", "[bindings_tests]") {
-  conn.execute("CREATE OR REPLACE TABLE universal_driver_odbc_small_binding_integer_test_table (id NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE universal_driver_odbc_small_binding_integer_test_table (id NUMBER)");
 
   {
     auto stmt = conn.createStatement();

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_array.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_array.cpp
@@ -10,7 +10,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> ARRAY col
                  "[conversion_matrix][bindparam][array]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_array (val ARRAY)");
+  conn.execute("CREATE TEMPORARY TABLE cm_array (val ARRAY)");
   ResultWriter report(get_report_path("bindparam_to_array"));
 
   // When each C type is bound to SQL_VARCHAR targeting an ARRAY column

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_array.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_array.cpp
@@ -6,12 +6,10 @@ static const SqlTypeInfo ARRAY_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> ARRAY column via SQLBindParameter",
-          "[conversion_matrix][bindparam][array]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> ARRAY column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][array]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_array (val ARRAY)");
   ResultWriter report(get_report_path("bindparam_to_array"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_binary.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_binary.cpp
@@ -12,7 +12,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> BINARY SQ
                  "[conversion_matrix][bindparam][binary]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_binary (val BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE cm_binary (val BINARY)");
   ResultWriter report(get_report_path("bindparam_to_binary"));
 
   // When each C type is bound to each BINARY SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_binary.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_binary.cpp
@@ -8,12 +8,10 @@ static const SqlTypeInfo BINARY_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> BINARY SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> BINARY SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][binary]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_binary (val BINARY)");
   ResultWriter report(get_report_path("bindparam_to_binary"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_boolean.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_boolean.cpp
@@ -10,7 +10,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> BOOLEAN S
                  "[conversion_matrix][bindparam][boolean]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_boolean (val BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE cm_boolean (val BOOLEAN)");
   ResultWriter report(get_report_path("bindparam_to_boolean"));
 
   // When each C type is bound to SQL_BIT and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_boolean.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_boolean.cpp
@@ -6,12 +6,10 @@ static const SqlTypeInfo BOOLEAN_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> BOOLEAN SQL type via SQLBindParameter",
-          "[conversion_matrix][bindparam][boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> BOOLEAN SQL type via SQLBindParameter",
+                 "[conversion_matrix][bindparam][boolean]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_boolean (val BOOLEAN)");
   ResultWriter report(get_report_path("bindparam_to_boolean"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_date.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_date.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> DATE SQL 
                  "[conversion_matrix][bindparam][date]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_date (val DATE)");
+  conn.execute("CREATE TEMPORARY TABLE cm_date (val DATE)");
   ResultWriter report(get_report_path("bindparam_to_date"));
 
   // When each C type is bound to each DATE SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_date.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_date.cpp
@@ -7,12 +7,10 @@ static const SqlTypeInfo DATE_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> DATE SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> DATE SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][date]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_date (val DATE)");
   ResultWriter report(get_report_path("bindparam_to_date"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_decfloat.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_decfloat.cpp
@@ -9,12 +9,10 @@ static const SqlTypeInfo DECFLOAT_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> DECFLOAT column via SQLBindParameter",
-          "[conversion_matrix][bindparam][decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> DECFLOAT column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][decfloat]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_decfloat (val DECFLOAT)");
   ResultWriter report(get_report_path("bindparam_to_decfloat"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_decfloat.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_decfloat.cpp
@@ -13,7 +13,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> DECFLOAT 
                  "[conversion_matrix][bindparam][decfloat]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_decfloat (val DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE cm_decfloat (val DECFLOAT)");
   ResultWriter report(get_report_path("bindparam_to_decfloat"));
 
   // When each C type is bound to each candidate SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_fixed.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_fixed.cpp
@@ -15,7 +15,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> FIXED SQL
                  "[conversion_matrix][bindparam][fixed]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_fixed (val NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE cm_fixed (val NUMBER)");
   ResultWriter report(get_report_path("bindparam_to_fixed"));
 
   // When each C type is bound to each FIXED SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_fixed.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_fixed.cpp
@@ -11,12 +11,10 @@ static const SqlTypeInfo FIXED_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> FIXED SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> FIXED SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][fixed]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_fixed (val NUMBER)");
   ResultWriter report(get_report_path("bindparam_to_fixed"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_interval.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_interval.cpp
@@ -22,7 +22,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> INTERVAL 
                  "[conversion_matrix][bindparam][interval]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_interval (val VARCHAR)");
+  conn.execute("CREATE TEMPORARY TABLE cm_interval (val VARCHAR)");
   ResultWriter report(get_report_path("bindparam_to_interval"));
 
   // When each C type is bound to each INTERVAL SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_interval.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_interval.cpp
@@ -18,12 +18,10 @@ static const SqlTypeInfo INTERVAL_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> INTERVAL SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][interval]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> INTERVAL SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][interval]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_interval (val VARCHAR)");
   ResultWriter report(get_report_path("bindparam_to_interval"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_object.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_object.cpp
@@ -6,12 +6,10 @@ static const SqlTypeInfo OBJECT_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> OBJECT column via SQLBindParameter",
-          "[conversion_matrix][bindparam][object]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> OBJECT column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][object]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_object (val OBJECT)");
   ResultWriter report(get_report_path("bindparam_to_object"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_object.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_object.cpp
@@ -10,7 +10,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> OBJECT co
                  "[conversion_matrix][bindparam][object]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_object (val OBJECT)");
+  conn.execute("CREATE TEMPORARY TABLE cm_object (val OBJECT)");
   ResultWriter report(get_report_path("bindparam_to_object"));
 
   // When each C type is bound to SQL_VARCHAR targeting an OBJECT column

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_real.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_real.cpp
@@ -14,7 +14,7 @@ TEST_CASE("conversion matrix: all C types -> REAL SQL types via SQLBindParameter
   // Given Snowflake client is logged in
   Connection conn;
   Schema::use_temp_session_schema(conn);
-  conn.execute("CREATE OR REPLACE TABLE cm_real (val FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE cm_real (val FLOAT)");
   ResultWriter report(get_report_path("bindparam_to_real"));
 
   // When each C type is bound to each REAL SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_real.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_real.cpp
@@ -13,7 +13,7 @@ TEST_CASE("conversion matrix: all C types -> REAL SQL types via SQLBindParameter
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_real (val FLOAT)");
   ResultWriter report(get_report_path("bindparam_to_real"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_text.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_text.cpp
@@ -15,7 +15,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TEXT SQL 
                  "[conversion_matrix][bindparam][text]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_text (val VARCHAR)");
+  conn.execute("CREATE TEMPORARY TABLE cm_text (val VARCHAR)");
   ResultWriter report(get_report_path("bindparam_to_text"));
 
   // When each C type is bound to each TEXT SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_text.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_text.cpp
@@ -11,12 +11,10 @@ static const SqlTypeInfo TEXT_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> TEXT SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][text]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TEXT SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][text]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_text (val VARCHAR)");
   ResultWriter report(get_report_path("bindparam_to_text"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_time.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_time.cpp
@@ -7,12 +7,10 @@ static const SqlTypeInfo TIME_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> TIME SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIME SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][time]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_time (val TIME)");
   ResultWriter report(get_report_path("bindparam_to_time"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_time.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_time.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIME SQL 
                  "[conversion_matrix][bindparam][time]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_time (val TIME)");
+  conn.execute("CREATE TEMPORARY TABLE cm_time (val TIME)");
   ResultWriter report(get_report_path("bindparam_to_time"));
 
   // When each C type is bound to each TIME SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP
                  "[conversion_matrix][bindparam][timestamp]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_timestamp (val TIMESTAMP_NTZ)");
+  conn.execute("CREATE TEMPORARY TABLE cm_timestamp (val TIMESTAMP_NTZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp"));
 
   // When each C type is bound to each TIMESTAMP SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp.cpp
@@ -7,12 +7,10 @@ static const SqlTypeInfo TIMESTAMP_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> TIMESTAMP SQL types via SQLBindParameter",
-          "[conversion_matrix][bindparam][timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP SQL types via SQLBindParameter",
+                 "[conversion_matrix][bindparam][timestamp]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_timestamp (val TIMESTAMP_NTZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_ltz.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_ltz.cpp
@@ -7,12 +7,10 @@ static const SqlTypeInfo TIMESTAMP_LTZ_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> TIMESTAMP_LTZ column via SQLBindParameter",
-          "[conversion_matrix][bindparam][timestamp_ltz]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP_LTZ column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][timestamp_ltz]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_timestamp_ltz (val TIMESTAMP_LTZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp_ltz"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_ltz.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_ltz.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP
                  "[conversion_matrix][bindparam][timestamp_ltz]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_timestamp_ltz (val TIMESTAMP_LTZ)");
+  conn.execute("CREATE TEMPORARY TABLE cm_timestamp_ltz (val TIMESTAMP_LTZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp_ltz"));
 
   // When each C type is bound to each TIMESTAMP SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_tz.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_tz.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP
                  "[conversion_matrix][bindparam][timestamp_tz]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_timestamp_tz (val TIMESTAMP_TZ)");
+  conn.execute("CREATE TEMPORARY TABLE cm_timestamp_tz (val TIMESTAMP_TZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp_tz"));
 
   // When each C type is bound to each TIMESTAMP SQL type and executed

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_tz.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_timestamp_tz.cpp
@@ -7,12 +7,10 @@ static const SqlTypeInfo TIMESTAMP_TZ_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> TIMESTAMP_TZ column via SQLBindParameter",
-          "[conversion_matrix][bindparam][timestamp_tz]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> TIMESTAMP_TZ column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][timestamp_tz]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_timestamp_tz (val TIMESTAMP_TZ)");
   ResultWriter report(get_report_path("bindparam_to_timestamp_tz"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_variant.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_variant.cpp
@@ -6,12 +6,10 @@ static const SqlTypeInfo VARIANT_SQL_TYPES[] = {
 };
 // clang-format on
 
-TEST_CASE("conversion matrix: all C types -> VARIANT column via SQLBindParameter",
-          "[conversion_matrix][bindparam][variant]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> VARIANT column via SQLBindParameter",
+                 "[conversion_matrix][bindparam][variant]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE OR REPLACE TABLE cm_variant (val VARIANT)");
   ResultWriter report(get_report_path("bindparam_to_variant"));
 

--- a/odbc_tests/tests/conversion_matrix/bindparam_to_variant.cpp
+++ b/odbc_tests/tests/conversion_matrix/bindparam_to_variant.cpp
@@ -10,7 +10,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "conversion matrix: all C types -> VARIANT c
                  "[conversion_matrix][bindparam][variant]") {
   SKIP_UNLESS_PROGRESS_REPORT();
   // Given Snowflake client is logged in
-  conn.execute("CREATE OR REPLACE TABLE cm_variant (val VARIANT)");
+  conn.execute("CREATE TEMPORARY TABLE cm_variant (val VARIANT)");
   ResultWriter report(get_report_path("bindparam_to_variant"));
 
   // When each C type is bound to SQL_VARCHAR targeting a VARIANT column

--- a/odbc_tests/tests/conversion_matrix/conversion_matrix_common.hpp
+++ b/odbc_tests/tests/conversion_matrix/conversion_matrix_common.hpp
@@ -20,7 +20,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 

--- a/odbc_tests/tests/e2e/query/basic_execute_query.cpp
+++ b/odbc_tests/tests/e2e/query/basic_execute_query.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
@@ -96,10 +96,8 @@ TEST_CASE("should execute SELECT returning NULL values", "[query]") {
 // DDL STATEMENTS
 // =============================================================================
 
-TEST_CASE("should execute CREATE and DROP TABLE statements", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should execute CREATE and DROP TABLE statements", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When CREATE TABLE statement is executed
   conn.execute("CREATE TABLE basic_exec_test (id INT, name VARCHAR(100))");
@@ -116,10 +114,8 @@ TEST_CASE("should execute CREATE and DROP TABLE statements", "[query]") {
 // DML STATEMENTS
 // =============================================================================
 
-TEST_CASE("should execute INSERT and retrieve inserted data", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should execute INSERT and retrieve inserted data", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table is created
   conn.execute("CREATE TEMPORARY TABLE insert_test (id INT, value VARCHAR(100))");

--- a/odbc_tests/tests/e2e/query/sql_bind_col.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_col.cpp
@@ -3,7 +3,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -4,7 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
@@ -363,10 +363,9 @@ TEST_CASE("should bind NULL via SQL_NULL_DATA indicator.", "[query][bind_paramet
   CHECK(!result.has_value());
 }
 
-TEST_CASE("should alternate NULL and non-NULL across sequential executions.", "[query][bind_parameter]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should alternate NULL and non-NULL across sequential executions.",
+                 "[query][bind_parameter]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto schema = Schema::use_random_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE bind_null_seq (val INTEGER)");
   auto stmt = conn.createStatement();
 

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -5,7 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
@@ -984,14 +984,13 @@ TEST_CASE("SQLFetch returns 22018 when invalid date string is bound to SQL_C_TYP
   REQUIRE(ret == SQL_ERROR);
   CHECK(get_sqlstate(stmt) == "22018");
 }
-TEST_CASE("SQLFetch returns 24000 when no result set exists.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLFetch returns 24000 when no result set exists.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto schema = Schema::use_random_schema(conn);
 
   // When a non-SELECT statement is executed (no result set)
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE test_table (id INT)", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE fetch_no_resultset_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLFetch should return SQL_ERROR with SQLSTATE 24000 (Invalid cursor state)
@@ -1368,18 +1367,17 @@ TEST_CASE("SQLFetchScroll returns HY010 when called without executing statement.
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("HY010"));
 }
 
-TEST_CASE("SQLFetchScroll returns 24000 when no result set exists after DDL.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLFetchScroll returns 24000 when no result set exists after DDL.", "[query]") {
   // Doc: "24000 - Invalid cursor state: The StatementHandle was in an executed state
   //       but no result set was associated with the StatementHandle."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlfetchscroll-function#diagnostics
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto schema = Schema::use_random_schema(conn);
 
   // When a DDL statement is executed (no result set)
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TABLE fetch_scroll_test (id INT)"), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE OR REPLACE TABLE fetch_scroll_test (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLFetchScroll is called on the statement with no result set

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -990,7 +990,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLFetch returns 24000 when no result set e
 
   // When a non-SELECT statement is executed (no result set)
   SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE fetch_no_resultset_t (id INT)", SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE fetch_no_resultset_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLFetch should return SQL_ERROR with SQLSTATE 24000 (Invalid cursor state)
@@ -1377,7 +1377,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLFetchScroll returns 24000 when no result
 
   // When a DDL statement is executed (no result set)
   SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE OR REPLACE TABLE fetch_scroll_test (id INT)"), SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE fetch_scroll_test (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLFetchScroll is called on the statement with no result set

--- a/odbc_tests/tests/e2e/query/sql_get_data.cpp
+++ b/odbc_tests/tests/e2e/query/sql_get_data.cpp
@@ -4,7 +4,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 

--- a/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
+++ b/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
@@ -3,7 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 
@@ -51,13 +51,11 @@ TEST_CASE("SQLNumResultCols returns correct count for SELECT with many columns."
   CHECK(num_cols == 5);
 }
 
-TEST_CASE("SQLNumResultCols returns correct count for SELECT * from table.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns correct count for SELECT * from table.", "[query]") {
   // Doc: "SQLNumResultCols returns the number of columns in a result set."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlnumresultcols-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a table with 3 columns exists
   conn.execute("CREATE TABLE num_cols_test (id INT, name VARCHAR(100), active BOOLEAN)");
@@ -99,15 +97,13 @@ TEST_CASE("SQLNumResultCols returns correct column count for empty result set.",
 // DDL / No Result Set
 // =============================================================================
 
-TEST_CASE("SQLNumResultCols returns 0 after DDL statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns 0 after DDL statement.", "[query]") {
   // Doc: "If the statement associated with StatementHandle does not return columns,
   //       SQLNumResultCols sets *ColumnCountPtr to 0."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlnumresultcols-function#comments
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a DDL statement is executed
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE ddl_numcols_test (id INT)", SQL_NTS);
@@ -120,10 +116,9 @@ TEST_CASE("SQLNumResultCols returns 0 after DDL statement.", "[query]") {
   CHECK(num_cols == 0);
 }
 
-TEST_CASE("SQLNumResultCols returns correct count after calling a stored procedure.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns correct count after calling a stored procedure.",
+                 "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a stored procedure exists that returns one column
   conn.execute(

--- a/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
+++ b/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
@@ -58,7 +58,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns correct count for 
   // Given Snowflake client is logged in
 
   // And a table with 3 columns exists
-  conn.execute("CREATE TABLE num_cols_test (id INT, name VARCHAR(100), active BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE num_cols_test (id INT, name VARCHAR(100), active BOOLEAN)");
 
   // When SELECT * is executed on the table
   auto stmt = conn.execute("SELECT * FROM num_cols_test");

--- a/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
+++ b/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
@@ -627,7 +627,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "DML returning SQL_NO_DATA via SQLPrepare + 
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlexecute-function#returns
 
   // Given Snowflake client is logged in
-  conn.execute("CREATE TABLE prep_dml_nodata (id INT)");
+  conn.execute("CREATE TEMPORARY TABLE prep_dml_nodata (id INT)");
   auto stmt = conn.createStatement();
 
   // When a DELETE that affects no rows is prepared and executed
@@ -645,7 +645,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "INSERT via SQLPrepare + SQLExecute with ver
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprepare-function#summary
 
   // Given Snowflake client is logged in
-  conn.execute("CREATE TABLE prep_insert_test (id INT, name VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE prep_insert_test (id INT, name VARCHAR(100))");
 
   // When an INSERT is prepared with bound parameters and executed
   {

--- a/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
+++ b/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
@@ -3,7 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
@@ -594,13 +594,11 @@ TEST_CASE("SQLPrepare with cursor already open returns 24000.", "[query][prepare
 // DDL / DML Edge Cases
 // =============================================================================
 
-TEST_CASE("DDL via SQLPrepare + SQLExecute.", "[query][prepare]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "DDL via SQLPrepare + SQLExecute.", "[query][prepare]") {
   // Doc: "SQLPrepare prepares an SQL string for execution."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprepare-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   auto stmt = conn.createStatement();
 
   // When a CREATE TABLE is prepared and executed
@@ -623,14 +621,12 @@ TEST_CASE("DDL via SQLPrepare + SQLExecute.", "[query][prepare]") {
   CHECK(count == 0);
 }
 
-TEST_CASE("DML returning SQL_NO_DATA via SQLPrepare + SQLExecute.", "[query][prepare]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "DML returning SQL_NO_DATA via SQLPrepare + SQLExecute.", "[query][prepare]") {
   // Doc: "SQL_NO_DATA is returned if the SQL statement was an UPDATE, INSERT,
   //       or DELETE statement that did not affect any rows."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlexecute-function#returns
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE TABLE prep_dml_nodata (id INT)");
   auto stmt = conn.createStatement();
 
@@ -644,13 +640,11 @@ TEST_CASE("DML returning SQL_NO_DATA via SQLPrepare + SQLExecute.", "[query][pre
   CHECK(ret == SQL_NO_DATA);
 }
 
-TEST_CASE("INSERT via SQLPrepare + SQLExecute with verify.", "[query][prepare]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "INSERT via SQLPrepare + SQLExecute with verify.", "[query][prepare]") {
   // Doc: "SQLPrepare prepares an SQL string for execution."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprepare-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("CREATE TABLE prep_insert_test (id INT, name VARCHAR(100))");
 
   // When an INSERT is prepared with bound parameters and executed

--- a/odbc_tests/tests/e2e/query/sql_row_count.cpp
+++ b/odbc_tests/tests/e2e/query/sql_row_count.cpp
@@ -3,7 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 
@@ -32,8 +32,8 @@ TEST_CASE("SQLRowCount returns HY009 when called with null pointer.", "[query]")
   ret = SQLRowCount(stmt.getHandle(), nullptr);
 
   // Then SQLRowCount should return SQL_ERROR with SQLSTATE HY009 (Invalid use of null pointer)
-  OLD_DRIVER_ONLY("BD#25") { REQUIRE(ret == SQL_SUCCESS); }
-  NEW_DRIVER_ONLY("BD#25") {
+  OLD_DRIVER_ONLY("BD#27") { REQUIRE(ret == SQL_SUCCESS); }
+  NEW_DRIVER_ONLY("BD#27") {
     REQUIRE(ret == SQL_ERROR);
     CHECK(get_sqlstate(stmt) == "HY009");
   }
@@ -54,20 +54,18 @@ TEST_CASE("SQLRowCount returns data about number of rows affected.") {
   REQUIRE(rows_affected == 1);
 }
 
-TEST_CASE("SQLRowCount returns correct count for INSERT statement.") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSERT statement.") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // Create a temporary table
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE test_table (id INT, value VARCHAR(50))", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(
+      stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE rowcount_insert_t (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When SQLExecDirect is called to execute an INSERT statement
   ret = SQLExecDirect(stmt.getHandle(),
-                      (SQLCHAR*)"INSERT INTO test_table VALUES (1, 'test'), (2, 'test2'), (3, 'test3')", SQL_NTS);
+                      sqlchar("INSERT INTO rowcount_insert_t VALUES (1, 'test'), (2, 'test2'), (3, 'test3')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called to get the number of rows affected
@@ -98,15 +96,13 @@ TEST_CASE("SQLRowCount returns correct count for SELECT with many rows.") {
   REQUIRE(rows_affected == 10);
 }
 
-TEST_CASE("SQLRowCount returns 0 for DDL statements.") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns 0 for DDL statements.") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
+  const auto stmt = conn.createStatement();
 
   // When SQLExecDirect is called to execute a DDL statement
-  SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE test_table (id INT, value VARCHAR(50))", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
+                                sqlchar("CREATE OR REPLACE TABLE rowcount_ddl_t (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called to get the number of rows affected
@@ -118,16 +114,15 @@ TEST_CASE("SQLRowCount returns 0 for DDL statements.") {
   REQUIRE(rows_affected == -1);
 }
 
-TEST_CASE("SQLRowCount returns -1 for ALTER TABLE DDL statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for ALTER TABLE DDL statement.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When an ALTER TABLE DDL statement is executed
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE alter_test (id INT)", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_alter_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"ALTER TABLE alter_test ADD COLUMN value VARCHAR(50)", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"ALTER TABLE rowcount_alter_t ADD COLUMN value VARCHAR(50)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -139,16 +134,15 @@ TEST_CASE("SQLRowCount returns -1 for ALTER TABLE DDL statement.", "[query]") {
   REQUIRE(rows_affected == -1);
 }
 
-TEST_CASE("SQLRowCount returns -1 for DROP TABLE DDL statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for DROP TABLE DDL statement.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When a DROP TABLE DDL statement is executed
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE drop_test (id INT)", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_drop_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DROP TABLE drop_test", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DROP TABLE rowcount_drop_t", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -164,15 +158,13 @@ TEST_CASE("SQLRowCount returns -1 for DROP TABLE DDL statement.", "[query]") {
 // MERGE statement
 // =============================================================================
 
-TEST_CASE("SQLRowCount returns correct count for MERGE statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for MERGE statement.", "[query]") {
   // Doc: "SQLRowCount returns the number of rows affected by an UPDATE, INSERT,
   //       or DELETE statement."  MERGE combines these operations.
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When a MERGE statement affecting rows is executed
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -201,14 +193,12 @@ TEST_CASE("SQLRowCount returns correct count for MERGE statement.", "[query]") {
   REQUIRE(rows_affected == 2);
 }
 
-TEST_CASE("SQLRowCount returns correct count for MERGE with DELETE clause.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for MERGE with DELETE clause.", "[query]") {
   // Doc: MERGE can combine INSERT, UPDATE, and DELETE operations.
   //      SQLRowCount should return the total rows affected across all clauses.
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a target table with data exists
   SQLRETURN ret = SQLExecDirect(
@@ -248,15 +238,13 @@ TEST_CASE("SQLRowCount returns correct count for MERGE with DELETE clause.", "[q
   REQUIRE(rows_affected == 3);
 }
 
-TEST_CASE("SQLRowCount returns correct count for UPDATE statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for UPDATE statement.", "[query]") {
   // Doc: "SQLRowCount returns the number of rows affected by an UPDATE, INSERT,
   //       or DELETE statement."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a table with data exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -279,13 +267,11 @@ TEST_CASE("SQLRowCount returns correct count for UPDATE statement.", "[query]") 
   REQUIRE(rows_affected == 2);
 }
 
-TEST_CASE("SQLRowCount returns correct count for UPDATE with JOIN.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for UPDATE with JOIN.", "[query]") {
   // Doc: Validates calculate_rows_affected() for multi-joined updates.
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a target table and a source table exist
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -318,15 +304,13 @@ TEST_CASE("SQLRowCount returns correct count for UPDATE with JOIN.", "[query]") 
   REQUIRE(rows_affected == 2);
 }
 
-TEST_CASE("SQLRowCount returns correct count for DELETE statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for DELETE statement.", "[query]") {
   // Doc: "SQLRowCount returns the number of rows affected by an UPDATE, INSERT,
   //       or DELETE statement."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#summary
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a table with data exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -349,11 +333,9 @@ TEST_CASE("SQLRowCount returns correct count for DELETE statement.", "[query]") 
   REQUIRE(rows_affected == 2);
 }
 
-TEST_CASE("SQLRowCount returns total count for DELETE all rows.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns total count for DELETE all rows.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When a DELETE without WHERE clause is executed on a table with 4 rows
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE delete_all (id INT)", SQL_NTS);
@@ -372,11 +354,9 @@ TEST_CASE("SQLRowCount returns total count for DELETE all rows.", "[query]") {
   REQUIRE(rows_affected == 4);
 }
 
-TEST_CASE("SQLRowCount returns total count for UPDATE all rows.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns total count for UPDATE all rows.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When an UPDATE without WHERE clause is executed on a table with 3 rows
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -397,11 +377,9 @@ TEST_CASE("SQLRowCount returns total count for UPDATE all rows.", "[query]") {
   REQUIRE(rows_affected == 3);
 }
 
-TEST_CASE("SQLRowCount returns correct count for INSERT INTO SELECT.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSERT INTO SELECT.", "[query]") {
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When INSERT INTO ... SELECT copies 3 rows from a source table
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -424,14 +402,12 @@ TEST_CASE("SQLRowCount returns correct count for INSERT INTO SELECT.", "[query]"
   REQUIRE(rows_affected == 3);
 }
 
-TEST_CASE("SQLRowCount returns correct count for INSERT from multi-table JOIN.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSERT from multi-table JOIN.", "[query]") {
   // Doc: Validates calculate_rows_affected() for multi-table inserts
   //      where the source involves a JOIN across multiple tables.
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And two source tables and a destination table exist
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -519,15 +495,13 @@ TEST_CASE("SQLRowCount returns HY010 after SQLPrepare without execute.", "[query
 // Prepared statement execution
 // =============================================================================
 
-TEST_CASE("SQLRowCount works with SQLPrepare and SQLExecute flow.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount works with SQLPrepare and SQLExecute flow.", "[query]") {
   // Doc: "SQLRowCount returns the number of rows affected by an UPDATE, INSERT,
   //       or DELETE statement" — applies to both SQLExecDirect and SQLExecute.
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#related-functions
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When a statement is prepared and executed via SQLPrepare and SQLExecute
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE prep_test (id INT)", SQL_NTS);
@@ -550,16 +524,15 @@ TEST_CASE("SQLRowCount works with SQLPrepare and SQLExecute flow.", "[query]") {
 // Mixed DML on same statement
 // =============================================================================
 
-TEST_CASE("SQLRowCount updates correctly across different DML types on same statement.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount updates correctly across different DML types on same statement.",
+                 "[query]") {
   // Doc: "When SQLExecute, SQLExecDirect, SQLBulkOperations, SQLSetPos, or
   //       SQLMoreResults is called, the SQL_DIAG_ROW_COUNT field … is set to
   //       the row count, and the row count is cached."
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When INSERT, UPDATE, and DELETE are executed sequentially on the same statement
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
@@ -625,7 +598,7 @@ TEST_CASE("SQLRowCount returns cached count after SQLFetch has started.", "[quer
 // Re-execution
 // =============================================================================
 
-TEST_CASE("SQLRowCount updates after re-execution with different INSERT.", "[query]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount updates after re-execution with different INSERT.", "[query]") {
   // Doc: "When SQLExecute, SQLExecDirect, SQLBulkOperations, SQLSetPos, or
   //       SQLMoreResults is called, the SQL_DIAG_ROW_COUNT field of the diagnostic
   //       data structure is set to the row count, and the row count is cached in
@@ -633,9 +606,7 @@ TEST_CASE("SQLRowCount updates after re-execution with different INSERT.", "[que
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlrowcount-function#arguments
 
   // Given Snowflake client is logged in
-  Connection conn;
   auto stmt = conn.createStatement();
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And a table exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE reexec_test (id INT)", SQL_NTS);

--- a/odbc_tests/tests/e2e/query/sql_row_count.cpp
+++ b/odbc_tests/tests/e2e/query/sql_row_count.cpp
@@ -32,8 +32,8 @@ TEST_CASE("SQLRowCount returns HY009 when called with null pointer.", "[query]")
   ret = SQLRowCount(stmt.getHandle(), nullptr);
 
   // Then SQLRowCount should return SQL_ERROR with SQLSTATE HY009 (Invalid use of null pointer)
-  OLD_DRIVER_ONLY("BD#27") { REQUIRE(ret == SQL_SUCCESS); }
-  NEW_DRIVER_ONLY("BD#27") {
+  OLD_DRIVER_ONLY("BD#25") { REQUIRE(ret == SQL_SUCCESS); }
+  NEW_DRIVER_ONLY("BD#25") {
     REQUIRE(ret == SQL_ERROR);
     CHECK(get_sqlstate(stmt) == "HY009");
   }
@@ -102,7 +102,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns 0 for DDL statements.")
 
   // When SQLExecDirect is called to execute a DDL statement
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                sqlchar("CREATE OR REPLACE TABLE rowcount_ddl_t (id INT, value VARCHAR(50))"), SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE rowcount_ddl_t (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called to get the number of rows affected
@@ -120,7 +120,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for ALTER TABLE DDL 
 
   // When an ALTER TABLE DDL statement is executed
   SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_alter_t (id INT)", SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE rowcount_alter_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"ALTER TABLE rowcount_alter_t ADD COLUMN value VARCHAR(50)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
@@ -139,8 +139,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for DROP TABLE DDL s
   auto stmt = conn.createStatement();
 
   // When a DROP TABLE DDL statement is executed
-  SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_drop_t (id INT)", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE rowcount_drop_t (id INT)", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DROP TABLE rowcount_drop_t", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/binary.cpp
+++ b/odbc_tests/tests/e2e/types/binary.cpp
@@ -128,7 +128,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select binary values from table", "[
   // Given Snowflake client is logged in
 
   // And A temporary table with BINARY column is created
-  conn.execute("CREATE TABLE binary_table (col BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_table (col BINARY)");
 
   // And The table is populated with binary values [X'48656C6C6F', X'576F726C64', X'0123456789ABCDEF']
   conn.execute("INSERT INTO binary_table VALUES (X'48656C6C6F'), (X'576F726C64'), (X'0123456789ABCDEF')");
@@ -154,7 +154,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case binary values fro
   // Given Snowflake client is logged in
 
   // And A temporary table with BINARY column is created
-  conn.execute("CREATE TABLE binary_corner_table (col BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_corner_table (col BINARY)");
 
   // And The table is populated with corner case binary values
   conn.execute(
@@ -179,7 +179,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select NULL binary values from table
   // Given Snowflake client is logged in
 
   // And A temporary table with BINARY column is created
-  conn.execute("CREATE TABLE binary_null_table (col BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_null_table (col BINARY)");
 
   // And The table is populated with NULL and non-NULL binary values [NULL, X'ABCD', NULL]
   conn.execute("INSERT INTO binary_null_table VALUES (NULL), (X'ABCD'), (NULL)");
@@ -219,7 +219,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select binary with specified length 
   // Given Snowflake client is logged in
 
   // And Table with columns (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY) exists
-  conn.execute("CREATE TABLE binary_len_table (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_len_table (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY)");
 
   // And Row (X'0102030405', X'01020304050607080910', X'48656C6C6F') is inserted
   conn.execute("INSERT INTO binary_len_table VALUES (X'0102030405', X'01020304050607080910', X'48656C6C6F')");
@@ -310,7 +310,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert binary using parameter bindin
   // Given Snowflake client is logged in
 
   // And Table with BINARY column exists
-  conn.execute("CREATE TABLE binary_insert_table (col BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_insert_table (col BINARY)");
 
   // When Binary values [0x48656C6C6F, 0x576F726C64, 0x00, 0xFF, 0x] are inserted using binding
   SQLCHAR vals[][5] = {{0x48, 0x65, 0x6C, 0x6C, 0x6F}, {0x57, 0x6F, 0x72, 0x6C, 0x64}, {}, {0xFF}, {}};
@@ -404,7 +404,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle VARBINARY as synonym for BINA
   // Given Snowflake client is logged in
 
   // And A temporary table with VARBINARY column is created
-  conn.execute("CREATE TABLE varbinary_test (col VARBINARY)");
+  conn.execute("CREATE TEMPORARY TABLE varbinary_test (col VARBINARY)");
 
   // And The table is populated with binary values via VARBINARY column
   conn.execute("INSERT INTO varbinary_test VALUES (X'48656C6C6F'), (X'ABCDEF'), (X'00FF01')");
@@ -458,7 +458,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download binary data in multiple chu
   // Given Snowflake client is logged in
 
   // And Table with (bin_data BINARY) exists with 30000 sequential binary values
-  conn.execute("CREATE TABLE binary_large_table (bin_data BINARY)");
+  conn.execute("CREATE TEMPORARY TABLE binary_large_table (bin_data BINARY)");
   conn.execute(
       "INSERT INTO binary_large_table "
       "SELECT TO_BINARY(LPAD(TO_VARCHAR(seq8()), 10, '0'), 'UTF-8') FROM TABLE(GENERATOR(ROWCOUNT => 30000))");

--- a/odbc_tests/tests/e2e/types/binary.cpp
+++ b/odbc_tests/tests/e2e/types/binary.cpp
@@ -10,7 +10,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
@@ -124,10 +124,8 @@ TEST_CASE("should handle NULL binary values from literals", "[datatype][binary]"
   REQUIRE(get_binary_hex_optional(stmt, 3) == std::nullopt);
 }
 
-TEST_CASE("should select binary values from table", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select binary values from table", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with BINARY column is created
   conn.execute("CREATE TABLE binary_table (col BINARY)");
@@ -152,10 +150,8 @@ TEST_CASE("should select binary values from table", "[datatype][binary]") {
   REQUIRE(SQLFetch(stmt.getHandle()) == SQL_NO_DATA);
 }
 
-TEST_CASE("should select corner case binary values from table", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case binary values from table", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with BINARY column is created
   conn.execute("CREATE TABLE binary_corner_table (col BINARY)");
@@ -179,10 +175,8 @@ TEST_CASE("should select corner case binary values from table", "[datatype][bina
   REQUIRE(SQLFetch(stmt.getHandle()) == SQL_NO_DATA);
 }
 
-TEST_CASE("should select NULL binary values from table", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select NULL binary values from table", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with BINARY column is created
   conn.execute("CREATE TABLE binary_null_table (col BINARY)");
@@ -221,10 +215,8 @@ TEST_CASE("should select NULL binary values from table", "[datatype][binary]") {
   REQUIRE(value_count == 1);
 }
 
-TEST_CASE("should select binary with specified length from table", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select binary with specified length from table", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY) exists
   conn.execute("CREATE TABLE binary_len_table (bin5 BINARY(5), bin10 BINARY(10), bin_default BINARY)");
@@ -314,10 +306,8 @@ TEST_CASE("should select binary literals using parameter binding", "[datatype][b
   REQUIRE(get_binary_hex(stmt, 3) == "0123456789ABCDEF");
 }
 
-TEST_CASE("should insert binary using parameter binding", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert binary using parameter binding", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with BINARY column exists
   conn.execute("CREATE TABLE binary_insert_table (col BINARY)");
@@ -410,10 +400,8 @@ TEST_CASE("should bind corner case binary values", "[datatype][binary]") {
   }
 }
 
-TEST_CASE("should handle VARBINARY as synonym for BINARY", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle VARBINARY as synonym for BINARY", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with VARBINARY column is created
   conn.execute("CREATE TABLE varbinary_test (col VARBINARY)");
@@ -466,10 +454,8 @@ TEST_CASE("should download binary data in multiple chunks using GENERATOR", "[da
   REQUIRE(row_count == 30000);
 }
 
-TEST_CASE("should download binary data in multiple chunks from table", "[datatype][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download binary data in multiple chunks from table", "[datatype][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with (bin_data BINARY) exists with 30000 sequential binary values
   conn.execute("CREATE TABLE binary_large_table (bin_data BINARY)");

--- a/odbc_tests/tests/e2e/types/boolean.cpp
+++ b/odbc_tests/tests/e2e/types/boolean.cpp
@@ -97,7 +97,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select boolean values from table", "
   // Given Snowflake client is logged in
 
   // And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
-  conn.execute("CREATE TABLE boolean_table (c1 BOOLEAN, c2 BOOLEAN, c3 BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE boolean_table (c1 BOOLEAN, c2 BOOLEAN, c3 BOOLEAN)");
 
   // And Row (TRUE, FALSE, TRUE) is inserted
   conn.execute("INSERT INTO boolean_table VALUES (TRUE, FALSE, TRUE)");
@@ -115,7 +115,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table", "[bo
   // Given Snowflake client is logged in
 
   // And Table with BOOLEAN column exists
-  conn.execute("CREATE TABLE boolean_null_table (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE boolean_null_table (col BOOLEAN)");
 
   // And Rows [NULL, TRUE, FALSE] are inserted
   conn.execute("INSERT INTO boolean_null_table VALUES (NULL), (TRUE), (FALSE)");
@@ -155,7 +155,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set with multi
   // Given Snowflake client is logged in
 
   // And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
-  conn.execute("CREATE TABLE boolean_large_table (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE boolean_large_table (col BOOLEAN)");
   conn.execute(
       "INSERT INTO boolean_large_table "
       "SELECT (seq8() % 2 = 0)::BOOLEAN FROM TABLE(GENERATOR(ROWCOUNT => 1000000))");
@@ -250,7 +250,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert boolean using parameter bindi
   // Given Snowflake client is logged in
 
   // And Table with BOOLEAN column exists
-  conn.execute("CREATE TABLE boolean_bind_table (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE boolean_bind_table (col BOOLEAN)");
 
   // When Boolean values [TRUE, FALSE, NULL] are bulk-inserted using multirow binding
   constexpr SQLULEN num_rows = 3;

--- a/odbc_tests/tests/e2e/types/boolean.cpp
+++ b/odbc_tests/tests/e2e/types/boolean.cpp
@@ -5,7 +5,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
@@ -93,10 +93,8 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR"
   REQUIRE(false_count == 500000);
 }
 
-TEST_CASE("should select boolean values from table", "[boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select boolean values from table", "[boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (BOOLEAN, BOOLEAN, BOOLEAN) exists
   conn.execute("CREATE TABLE boolean_table (c1 BOOLEAN, c2 BOOLEAN, c3 BOOLEAN)");
@@ -113,10 +111,8 @@ TEST_CASE("should select boolean values from table", "[boolean]") {
   REQUIRE(get_data<SQL_C_BIT>(stmt, 3) == 1);
 }
 
-TEST_CASE("should handle NULL values from table", "[boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table", "[boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with BOOLEAN column exists
   conn.execute("CREATE TABLE boolean_null_table (col BOOLEAN)");
@@ -155,10 +151,8 @@ TEST_CASE("should handle NULL values from table", "[boolean]") {
   REQUIRE(null_count == 1);
 }
 
-TEST_CASE("should download large result set with multiple chunks from table", "[boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set with multiple chunks from table", "[boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with BOOLEAN column exists with 500000 TRUE and 500000 FALSE values
   conn.execute("CREATE TABLE boolean_large_table (col BOOLEAN)");
@@ -251,11 +245,9 @@ TEST_CASE("should select null boolean using parameter binding", "[boolean]") {
   REQUIRE(get_data_optional<SQL_C_BIT>(stmt, 1) == std::nullopt);
 }
 
-TEST_CASE("should insert boolean using parameter binding", "[boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert boolean using parameter binding", "[boolean]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with BOOLEAN column exists
   conn.execute("CREATE TABLE boolean_bind_table (col BOOLEAN)");

--- a/odbc_tests/tests/e2e/types/c_bit_conversion_to_sql_numeric.cpp
+++ b/odbc_tests/tests/e2e/types/c_bit_conversion_to_sql_numeric.cpp
@@ -2,17 +2,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_BIT true to SQL_INTEGER", "[c_bit][conversion][sql_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT true to SQL_INTEGER", "[c_bit][conversion][sql_numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bit_int (col INT)");
+  conn.execute("CREATE TEMPORARY TABLE t_bit_int (col INT)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -35,12 +33,10 @@ TEST_CASE("should bind SQL_C_BIT true to SQL_INTEGER", "[c_bit][conversion][sql_
   CHECK(get_data<SQL_C_SBIGINT>(sel, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_BIT false to SQL_INTEGER", "[c_bit][conversion][sql_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT false to SQL_INTEGER", "[c_bit][conversion][sql_numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bit_int0 (col INT)");
+  conn.execute("CREATE TEMPORARY TABLE t_bit_int0 (col INT)");
 
   SQLCHAR val = 0;
   SQLLEN ind = 0;
@@ -63,12 +59,10 @@ TEST_CASE("should bind SQL_C_BIT false to SQL_INTEGER", "[c_bit][conversion][sql
   CHECK(get_data<SQL_C_SBIGINT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_BIT to SQL_DOUBLE", "[c_bit][conversion][sql_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT to SQL_DOUBLE", "[c_bit][conversion][sql_numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bit_flt (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t_bit_flt (col FLOAT)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -91,12 +85,10 @@ TEST_CASE("should bind SQL_C_BIT to SQL_DOUBLE", "[c_bit][conversion][sql_numeri
   CHECK(get_data<SQL_C_DOUBLE>(sel, 1) == Catch::Approx(1.0));
 }
 
-TEST_CASE("should bind SQL_C_BIT to SQL_BIT", "[c_bit][conversion][sql_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT to SQL_BIT", "[c_bit][conversion][sql_numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bit_bool (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_bit_bool (col BOOLEAN)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -119,12 +111,10 @@ TEST_CASE("should bind SQL_C_BIT to SQL_BIT", "[c_bit][conversion][sql_numeric]"
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_BIT with NULL indicator", "[c_bit][conversion][sql_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT with NULL indicator", "[c_bit][conversion][sql_numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bit_null (col INT)");
+  conn.execute("CREATE TEMPORARY TABLE t_bit_null (col INT)");
 
   SQLCHAR val = 0;
   SQLLEN ind = SQL_NULL_DATA;

--- a/odbc_tests/tests/e2e/types/c_bit_conversion_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_bit_conversion_to_sql_real.cpp
@@ -2,16 +2,14 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_BIT one to SQL_DOUBLE", "[c_bit][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT one to SQL_DOUBLE", "[c_bit][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_BIT 1 is bound to SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -29,11 +27,9 @@ TEST_CASE("should bind SQL_C_BIT one to SQL_DOUBLE", "[c_bit][conversion][sql_re
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(1.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_BIT zero to SQL_DOUBLE", "[c_bit][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT zero to SQL_DOUBLE", "[c_bit][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_BIT 0 is bound to SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -51,11 +47,9 @@ TEST_CASE("should bind SQL_C_BIT zero to SQL_DOUBLE", "[c_bit][conversion][sql_r
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(0.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_BIT one to SQL_REAL", "[c_bit][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT one to SQL_REAL", "[c_bit][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_BIT 1 is bound to SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -73,11 +67,9 @@ TEST_CASE("should bind SQL_C_BIT one to SQL_REAL", "[c_bit][conversion][sql_real
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(1.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_BIT zero to SQL_REAL", "[c_bit][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT zero to SQL_REAL", "[c_bit][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_BIT 0 is bound to SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -95,11 +87,10 @@ TEST_CASE("should bind SQL_C_BIT zero to SQL_REAL", "[c_bit][conversion][sql_rea
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(0.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_BIT with NULL indicator to SQL_REAL", "[c_bit][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT with NULL indicator to SQL_REAL",
+                 "[c_bit][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_BIT is bound with SQL_NULL_DATA to SQL_REAL and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_fixed.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_fixed.cpp
@@ -3,17 +3,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_CHAR integer string to SQL_INTEGER", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR integer string to SQL_INTEGER",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_CHAR "42" is bound to SQL_INTEGER and inserted
   auto stmt = conn.createStatement();
@@ -31,11 +30,10 @@ TEST_CASE("should bind SQL_C_CHAR integer string to SQL_INTEGER", "[c_char][conv
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 42);
 }
 
-TEST_CASE("should bind SQL_C_CHAR negative integer string to SQL_BIGINT", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR negative integer string to SQL_BIGINT",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_CHAR "-9999999999" is bound to SQL_BIGINT and inserted
   auto stmt = conn.createStatement();
@@ -53,11 +51,10 @@ TEST_CASE("should bind SQL_C_CHAR negative integer string to SQL_BIGINT", "[c_ch
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -9999999999LL);
 }
 
-TEST_CASE("should bind SQL_C_CHAR decimal string to SQL_DECIMAL", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR decimal string to SQL_DECIMAL",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER(10,2))");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER(10,2))");
 
   // When SQL_C_CHAR "3.14" is bound to SQL_DECIMAL and inserted
   auto stmt = conn.createStatement();
@@ -75,11 +72,10 @@ TEST_CASE("should bind SQL_C_CHAR decimal string to SQL_DECIMAL", "[c_char][conv
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "3.14");
 }
 
-TEST_CASE("should bind SQL_C_WCHAR integer string to SQL_INTEGER", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR integer string to SQL_INTEGER",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_WCHAR "77" is bound to SQL_INTEGER and inserted
   auto stmt = conn.createStatement();
@@ -97,11 +93,10 @@ TEST_CASE("should bind SQL_C_WCHAR integer string to SQL_INTEGER", "[c_char][con
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 77);
 }
 
-TEST_CASE("should bind SQL_C_WCHAR negative integer string to SQL_BIGINT", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR negative integer string to SQL_BIGINT",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_WCHAR "-1234567890" is bound to SQL_BIGINT and inserted
   auto stmt = conn.createStatement();
@@ -119,11 +114,10 @@ TEST_CASE("should bind SQL_C_WCHAR negative integer string to SQL_BIGINT", "[c_c
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -1234567890LL);
 }
 
-TEST_CASE("should bind SQL_C_WCHAR decimal string to SQL_DECIMAL", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR decimal string to SQL_DECIMAL",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER(10,2))");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER(10,2))");
 
   // When SQL_C_WCHAR "6.28" is bound to SQL_DECIMAL and inserted
   auto stmt = conn.createStatement();
@@ -152,11 +146,10 @@ TEST_CASE("should bind SQL_C_WCHAR decimal string to SQL_DECIMAL", "[c_char][con
 #endif
 }
 
-TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_INTEGER", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR with NULL indicator to SQL_INTEGER",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_CHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();
@@ -173,11 +166,10 @@ TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_INTEGER", "[c_char]
   CHECK_FALSE(get_data_optional<SQL_C_SBIGINT>(fetch_stmt, 1).has_value());
 }
 
-TEST_CASE("should bind SQL_C_WCHAR with NULL indicator to SQL_INTEGER", "[c_char][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR with NULL indicator to SQL_INTEGER",
+                 "[c_char][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When SQL_C_WCHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_real.cpp
@@ -5,16 +5,15 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_CHAR float string to SQL_DOUBLE", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR float string to SQL_DOUBLE",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_CHAR "3.14" is bound to SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -32,11 +31,10 @@ TEST_CASE("should bind SQL_C_CHAR float string to SQL_DOUBLE", "[c_char][convers
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(3.14, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR integer string to SQL_REAL", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR integer string to SQL_REAL",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_CHAR "100" is bound to SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -54,11 +52,9 @@ TEST_CASE("should bind SQL_C_CHAR integer string to SQL_REAL", "[c_char][convers
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(100.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR to SQL_FLOAT synonym", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to SQL_FLOAT synonym", "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_CHAR "1.23" is bound to SQL_FLOAT and inserted
   auto stmt = conn.createStatement();
@@ -76,11 +72,9 @@ TEST_CASE("should bind SQL_C_CHAR to SQL_FLOAT synonym", "[c_char][conversion][s
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(1.23, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR to FLOAT4 column", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to FLOAT4 column", "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT4)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT4)");
 
   // When SQL_C_CHAR "5.5" is bound to SQL_DOUBLE and inserted into a FLOAT4 column
   auto stmt = conn.createStatement();
@@ -98,11 +92,9 @@ TEST_CASE("should bind SQL_C_CHAR to FLOAT4 column", "[c_char][conversion][sql_r
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(5.5, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR to FLOAT8 column", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to FLOAT8 column", "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT8)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT8)");
 
   // When SQL_C_CHAR "9.81" is bound to SQL_DOUBLE and inserted into a FLOAT8 column
   auto stmt = conn.createStatement();
@@ -120,11 +112,10 @@ TEST_CASE("should bind SQL_C_CHAR to FLOAT8 column", "[c_char][conversion][sql_r
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(9.81, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR to DOUBLE PRECISION column", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to DOUBLE PRECISION column",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DOUBLE PRECISION)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DOUBLE PRECISION)");
 
   // When SQL_C_CHAR "2.22" is bound to SQL_DOUBLE and inserted into a DOUBLE PRECISION column
   auto stmt = conn.createStatement();
@@ -142,11 +133,9 @@ TEST_CASE("should bind SQL_C_CHAR to DOUBLE PRECISION column", "[c_char][convers
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(2.22, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR to REAL column", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to REAL column", "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col REAL)");
+  conn.execute("CREATE TEMPORARY TABLE t (col REAL)");
 
   // When SQL_C_CHAR "7.77" is bound to SQL_REAL and inserted into a REAL column
   auto stmt = conn.createStatement();
@@ -164,11 +153,10 @@ TEST_CASE("should bind SQL_C_CHAR to REAL column", "[c_char][conversion][sql_rea
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(7.77, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_WCHAR float string to SQL_DOUBLE", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR float string to SQL_DOUBLE",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_WCHAR "2.71" is bound to SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -186,11 +174,10 @@ TEST_CASE("should bind SQL_C_WCHAR float string to SQL_DOUBLE", "[c_char][conver
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(2.71, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_WCHAR integer string to SQL_REAL", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR integer string to SQL_REAL",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_WCHAR "200" is bound to SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -208,11 +195,10 @@ TEST_CASE("should bind SQL_C_WCHAR integer string to SQL_REAL", "[c_char][conver
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinAbs(200.0, 0.001));
 }
 
-TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_DOUBLE", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR with NULL indicator to SQL_DOUBLE",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_CHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();
@@ -229,11 +215,10 @@ TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_DOUBLE", "[c_char][
   CHECK(get_data_optional<SQL_C_DOUBLE>(fetch_stmt, 1) == std::nullopt);
 }
 
-TEST_CASE("should bind SQL_C_WCHAR with NULL indicator to SQL_DOUBLE", "[c_char][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR with NULL indicator to SQL_DOUBLE",
+                 "[c_char][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_C_WCHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -3,18 +3,17 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_CHAR to SQL_VARCHAR and read back", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR to SQL_VARCHAR and read back",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_CHAR "hello world" is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -32,11 +31,10 @@ TEST_CASE("should bind SQL_C_CHAR to SQL_VARCHAR and read back", "[c_char][conve
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "hello world");
 }
 
-TEST_CASE("should bind SQL_C_CHAR empty string to SQL_VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR empty string to SQL_VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_CHAR empty string is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -54,11 +52,10 @@ TEST_CASE("should bind SQL_C_CHAR empty string to SQL_VARCHAR", "[c_char][conver
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "");
 }
 
-TEST_CASE("should bind SQL_C_CHAR at max length to fixed-size VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR at max length to fixed-size VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(5))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(5))");
 
   // When SQL_C_CHAR "abcde" is bound to VARCHAR(5) and inserted
   auto stmt = conn.createStatement();
@@ -76,11 +73,10 @@ TEST_CASE("should bind SQL_C_CHAR at max length to fixed-size VARCHAR", "[c_char
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "abcde");
 }
 
-TEST_CASE("should reject SQL_C_CHAR exceeding fixed-size VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-size VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(5))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(5))");
 
   // When SQL_C_CHAR "hello world" is bound to VARCHAR(5) and inserted
   auto stmt = conn.createStatement();
@@ -100,11 +96,10 @@ TEST_CASE("should reject SQL_C_CHAR exceeding fixed-size VARCHAR", "[c_char][con
   NEW_DRIVER_ONLY("BD#40") { CHECK(get_sqlstate(stmt) == "22001"); }
 }
 
-TEST_CASE("should bind SQL_C_WCHAR to SQL_VARCHAR and read back", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR to SQL_VARCHAR and read back",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_WCHAR "test" is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -123,11 +118,10 @@ TEST_CASE("should bind SQL_C_WCHAR to SQL_VARCHAR and read back", "[c_char][conv
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "test");
 }
 
-TEST_CASE("should bind SQL_C_WCHAR empty string to SQL_VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR empty string to SQL_VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_WCHAR empty string is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -146,11 +140,10 @@ TEST_CASE("should bind SQL_C_WCHAR empty string to SQL_VARCHAR", "[c_char][conve
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "");
 }
 
-TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_CHAR with NULL indicator to SQL_VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_CHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();
@@ -167,11 +160,10 @@ TEST_CASE("should bind SQL_C_CHAR with NULL indicator to SQL_VARCHAR", "[c_char]
   CHECK(get_data_optional<SQL_C_CHAR>(fetch_stmt, 1) == std::nullopt);
 }
 
-TEST_CASE("should bind SQL_C_WCHAR with NULL indicator to SQL_VARCHAR", "[c_char][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR with NULL indicator to SQL_VARCHAR",
+                 "[c_char][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(200))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(200))");
 
   // When SQL_C_WCHAR is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
@@ -1,16 +1,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_TYPE_DATE to SQL_TYPE_DATE and read back", "[c_date][conversion][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to SQL_TYPE_DATE and read back",
+                 "[c_date][conversion][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   // When SQL_C_TYPE_DATE 2026-04-13 is bound to SQL_TYPE_DATE and inserted
   auto stmt = conn.createStatement();
@@ -35,11 +34,10 @@ TEST_CASE("should bind SQL_C_TYPE_DATE to SQL_TYPE_DATE and read back", "[c_date
   CHECK(result.day == 13);
 }
 
-TEST_CASE("should bind SQL_C_TYPE_DATE with NULL indicator to SQL_TYPE_DATE", "[c_date][conversion][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indicator to SQL_TYPE_DATE",
+                 "[c_date][conversion][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   // When SQL_C_TYPE_DATE is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_fixed.cpp
+++ b/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_fixed.cpp
@@ -11,17 +11,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_DOUBLE to SQL_INTEGER and read back", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE to SQL_INTEGER and read back",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A double value is bound and inserted
   auto stmt = conn.createStatement();
@@ -39,11 +38,10 @@ TEST_CASE("should bind SQL_C_DOUBLE to SQL_INTEGER and read back", "[c_float][co
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 42);
 }
 
-TEST_CASE("should bind SQL_C_FLOAT to SQL_INTEGER and read back", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_FLOAT to SQL_INTEGER and read back",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A float value is bound and inserted
   auto stmt = conn.createStatement();
@@ -61,11 +59,10 @@ TEST_CASE("should bind SQL_C_FLOAT to SQL_INTEGER and read back", "[c_float][con
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -100);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE with fraction to SQL_INTEGER truncates", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE with fraction to SQL_INTEGER truncates",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A fractional double is bound to INTEGER and inserted
   auto stmt = conn.createStatement();
@@ -83,11 +80,9 @@ TEST_CASE("should bind SQL_C_DOUBLE with fraction to SQL_INTEGER truncates", "[c
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 42);
 }
 
-TEST_CASE("should bind SQL_C_FLOAT zero to SQL_INTEGER", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_FLOAT zero to SQL_INTEGER", "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When Float zero is bound and inserted
   auto stmt = conn.createStatement();
@@ -105,11 +100,10 @@ TEST_CASE("should bind SQL_C_FLOAT zero to SQL_INTEGER", "[c_float][conversion][
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE negative to SQL_BIGINT", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE negative to SQL_BIGINT",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A negative double is bound to BIGINT and inserted
   auto stmt = conn.createStatement();
@@ -127,11 +121,10 @@ TEST_CASE("should bind SQL_C_DOUBLE negative to SQL_BIGINT", "[c_float][conversi
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -123456);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE to SQL_DECIMAL and read back", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE to SQL_DECIMAL and read back",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER(10,2))");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER(10,2))");
 
   // When A double is bound to DECIMAL(10,2) and inserted
   auto stmt = conn.createStatement();
@@ -150,11 +143,10 @@ TEST_CASE("should bind SQL_C_DOUBLE to SQL_DECIMAL and read back", "[c_float][co
   CHECK(s == "3.14");
 }
 
-TEST_CASE("should reject SQL_C_DOUBLE overflow into NUMBER(3,0)", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE overflow into NUMBER(3,0)",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER(3,0))");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER(3,0))");
 
   // When A double value exceeding the column precision is bound and inserted
   auto stmt = conn.createStatement();
@@ -171,11 +163,10 @@ TEST_CASE("should reject SQL_C_DOUBLE overflow into NUMBER(3,0)", "[c_float][con
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE with NULL indicator to SQL_INTEGER", "[c_float][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE with NULL indicator to SQL_INTEGER",
+                 "[c_float][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When NULL is bound via SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_real.cpp
@@ -12,17 +12,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_DOUBLE to SQL_DOUBLE and read back", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE to SQL_DOUBLE and read back",
+                 "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A double value is bound with SQL_C_DOUBLE and SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -40,11 +39,10 @@ TEST_CASE("should bind SQL_C_DOUBLE to SQL_DOUBLE and read back", "[c_float][con
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(3.14));
 }
 
-TEST_CASE("should bind SQL_C_FLOAT to SQL_REAL and read back", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_FLOAT to SQL_REAL and read back",
+                 "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A float value is bound with SQL_C_FLOAT and SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -62,11 +60,9 @@ TEST_CASE("should bind SQL_C_FLOAT to SQL_REAL and read back", "[c_float][conver
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(1.5).epsilon(1e-6));
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE negative zero", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE negative zero", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When Negative zero is bound as SQL_C_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -86,11 +82,9 @@ TEST_CASE("should bind SQL_C_DOUBLE negative zero", "[c_float][conversion][sql_r
   CHECK(std::fpclassify(read) == FP_ZERO);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE large value", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE large value", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A large double near DBL_MAX is bound and inserted
   auto stmt = conn.createStatement();
@@ -108,11 +102,9 @@ TEST_CASE("should bind SQL_C_DOUBLE large value", "[c_float][conversion][sql_rea
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(1.7e308).epsilon(1e-12));
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE small value", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE small value", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A very small positive double is bound and inserted
   auto stmt = conn.createStatement();
@@ -131,11 +123,9 @@ TEST_CASE("should bind SQL_C_DOUBLE small value", "[c_float][conversion][sql_rea
   NEW_DRIVER_ONLY("BD#36") { CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(2.2e-308).epsilon(1e-12)); }
 }
 
-TEST_CASE("should bind SQL_C_FLOAT max value", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_FLOAT max value", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When FLT_MAX is bound with SQL_C_FLOAT and SQL_REAL and inserted
   auto stmt = conn.createStatement();
@@ -153,11 +143,9 @@ TEST_CASE("should bind SQL_C_FLOAT max value", "[c_float][conversion][sql_real]"
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(static_cast<double>(FLT_MAX)).epsilon(1e-6));
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE with NULL indicator", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE with NULL indicator", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_NULL_DATA is used for the SQL_C_DOUBLE parameter
   auto stmt = conn.createStatement();
@@ -174,11 +162,10 @@ TEST_CASE("should bind SQL_C_DOUBLE with NULL indicator", "[c_float][conversion]
   CHECK(get_data_optional<SQL_C_DOUBLE>(fetch_stmt, 1) == std::nullopt);
 }
 
-TEST_CASE("should bind SQL_C_DEFAULT to SQL_DOUBLE and read back", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DEFAULT to SQL_DOUBLE and read back",
+                 "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A double value is bound with SQL_C_DEFAULT and SQL_DOUBLE and inserted
   auto stmt = conn.createStatement();
@@ -196,11 +183,9 @@ TEST_CASE("should bind SQL_C_DEFAULT to SQL_DOUBLE and read back", "[c_float][co
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == Catch::Approx(2.718));
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE zero", "[c_float][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE zero", "[c_float][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When Zero is bound as SQL_C_DOUBLE and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_float_conversion_to_sql_string.cpp
@@ -3,16 +3,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_DOUBLE to SQL_VARCHAR and read back", "[c_float][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE to SQL_VARCHAR and read back",
+                 "[c_float][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_DOUBLE 3.14 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -31,11 +30,10 @@ TEST_CASE("should bind SQL_C_DOUBLE to SQL_VARCHAR and read back", "[c_float][co
   CHECK(s.find("3.14") != std::string::npos);
 }
 
-TEST_CASE("should bind SQL_C_FLOAT to SQL_VARCHAR and read back", "[c_float][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_FLOAT to SQL_VARCHAR and read back",
+                 "[c_float][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_FLOAT 42.0 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -54,11 +52,10 @@ TEST_CASE("should bind SQL_C_FLOAT to SQL_VARCHAR and read back", "[c_float][con
   CHECK(s.find("42") != std::string::npos);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE with NULL indicator to SQL_VARCHAR", "[c_float][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE with NULL indicator to SQL_VARCHAR",
+                 "[c_float][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_DOUBLE is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_boolean.cpp
+++ b/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_boolean.cpp
@@ -1,17 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG one to SQL_BIT via integer", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG one to SQL_BIT via integer",
+                 "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SLONG 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -29,11 +28,10 @@ TEST_CASE("should bind SQL_C_SLONG one to SQL_BIT via integer", "[c_integer][con
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SLONG zero to SQL_BIT via integer", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG zero to SQL_BIT via integer",
+                 "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SLONG 0 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -51,12 +49,11 @@ TEST_CASE("should bind SQL_C_SLONG zero to SQL_BIT via integer", "[c_integer][co
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_SLONG nonzero >1 to SQL_BIT via integer", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG nonzero >1 to SQL_BIT via integer",
+                 "[c_integer][conversion][sql_boolean]") {
   SKIP_OLD_DRIVER("BD-35", "Old driver rejects integer values other than 0/1 for SQL_BIT");
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SLONG 42 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -74,12 +71,11 @@ TEST_CASE("should bind SQL_C_SLONG nonzero >1 to SQL_BIT via integer", "[c_integ
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SLONG negative to SQL_BIT via integer", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG negative to SQL_BIT via integer",
+                 "[c_integer][conversion][sql_boolean]") {
   SKIP_OLD_DRIVER("BD-35", "Old driver rejects negative integers for SQL_BIT");
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SLONG -99 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -97,11 +93,9 @@ TEST_CASE("should bind SQL_C_SLONG negative to SQL_BIT via integer", "[c_integer
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SBIGINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SBIGINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SBIGINT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -119,11 +113,9 @@ TEST_CASE("should bind SQL_C_SBIGINT to SQL_BIT", "[c_integer][conversion][sql_b
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SSHORT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SSHORT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SSHORT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -141,11 +133,9 @@ TEST_CASE("should bind SQL_C_SSHORT to SQL_BIT", "[c_integer][conversion][sql_bo
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_UTINYINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UTINYINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_UTINYINT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -163,11 +153,9 @@ TEST_CASE("should bind SQL_C_UTINYINT to SQL_BIT", "[c_integer][conversion][sql_
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_ULONG to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_ULONG to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_ULONG 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -185,11 +173,9 @@ TEST_CASE("should bind SQL_C_ULONG to SQL_BIT", "[c_integer][conversion][sql_boo
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_STINYINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_STINYINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_STINYINT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -207,11 +193,9 @@ TEST_CASE("should bind SQL_C_STINYINT to SQL_BIT", "[c_integer][conversion][sql_
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_USHORT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_USHORT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_USHORT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -229,11 +213,9 @@ TEST_CASE("should bind SQL_C_USHORT to SQL_BIT", "[c_integer][conversion][sql_bo
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_UBIGINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UBIGINT to SQL_BIT", "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_UBIGINT 1 is bound to SQL_BIT and inserted
   auto stmt = conn.createStatement();
@@ -251,12 +233,10 @@ TEST_CASE("should bind SQL_C_UBIGINT to SQL_BIT", "[c_integer][conversion][sql_b
   CHECK(get_data<SQL_C_BIT>(fetch_stmt, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator to SQL_BIT via integer",
-          "[c_integer][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator to SQL_BIT via integer",
+                 "[c_integer][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   // When SQL_C_SLONG is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_fixed.cpp
+++ b/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_fixed.cpp
@@ -3,17 +3,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG to SQL_INTEGER and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG to SQL_INTEGER and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When An integer value is bound and inserted
   auto stmt = conn.createStatement();
@@ -31,11 +30,10 @@ TEST_CASE("should bind SQL_C_SLONG to SQL_INTEGER and read back", "[c_integer][c
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 42);
 }
 
-TEST_CASE("should bind SQL_C_SBIGINT to SQL_BIGINT and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SBIGINT to SQL_BIGINT and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A 64-bit integer is bound and inserted
   auto stmt = conn.createStatement();
@@ -53,11 +51,10 @@ TEST_CASE("should bind SQL_C_SBIGINT to SQL_BIGINT and read back", "[c_integer][
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 9999999999LL);
 }
 
-TEST_CASE("should bind SQL_C_SSHORT to SQL_INTEGER and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SSHORT to SQL_INTEGER and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A 16-bit integer at minimum value is bound and inserted
   auto stmt = conn.createStatement();
@@ -75,11 +72,10 @@ TEST_CASE("should bind SQL_C_SSHORT to SQL_INTEGER and read back", "[c_integer][
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -32768);
 }
 
-TEST_CASE("should bind SQL_C_UTINYINT to SQL_INTEGER and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UTINYINT to SQL_INTEGER and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When An unsigned 8-bit integer is bound and inserted
   auto stmt = conn.createStatement();
@@ -97,11 +93,10 @@ TEST_CASE("should bind SQL_C_UTINYINT to SQL_INTEGER and read back", "[c_integer
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 255);
 }
 
-TEST_CASE("should bind SQL_C_ULONG to SQL_BIGINT and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_ULONG to SQL_BIGINT and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A 32-bit unsigned integer is bound and inserted
   auto stmt = conn.createStatement();
@@ -119,11 +114,10 @@ TEST_CASE("should bind SQL_C_ULONG to SQL_BIGINT and read back", "[c_integer][co
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 4000000000LL);
 }
 
-TEST_CASE("should bind SQL_C_UBIGINT to SQL_BIGINT and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UBIGINT to SQL_BIGINT and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When An unsigned 64-bit maximum value is bound and inserted
   auto stmt = conn.createStatement();
@@ -141,11 +135,10 @@ TEST_CASE("should bind SQL_C_UBIGINT to SQL_BIGINT and read back", "[c_integer][
   CHECK(get_data<SQL_C_UBIGINT>(fetch_stmt, 1) == std::numeric_limits<SQLUBIGINT>::max());
 }
 
-TEST_CASE("should bind negative integer to SQL_INTEGER", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind negative integer to SQL_INTEGER",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When INT_MIN is bound as SQL_C_SLONG and inserted
   auto stmt = conn.createStatement();
@@ -163,11 +156,10 @@ TEST_CASE("should bind negative integer to SQL_INTEGER", "[c_integer][conversion
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == std::numeric_limits<SQLINTEGER>::min());
 }
 
-TEST_CASE("should bind SQL_C_STINYINT to SQL_INTEGER and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_STINYINT to SQL_INTEGER and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A signed 8-bit integer at minimum value is bound and inserted
   auto stmt = conn.createStatement();
@@ -185,11 +177,10 @@ TEST_CASE("should bind SQL_C_STINYINT to SQL_INTEGER and read back", "[c_integer
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == -128);
 }
 
-TEST_CASE("should bind SQL_C_USHORT to SQL_INTEGER and read back", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_USHORT to SQL_INTEGER and read back",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When An unsigned 16-bit integer at maximum value is bound and inserted
   auto stmt = conn.createStatement();
@@ -207,11 +198,10 @@ TEST_CASE("should bind SQL_C_USHORT to SQL_INTEGER and read back", "[c_integer][
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 65535);
 }
 
-TEST_CASE("should bind SQL_C_SLONG zero to SQL_INTEGER", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG zero to SQL_INTEGER",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When zero is bound as SQL_C_SLONG and inserted
   auto stmt = conn.createStatement();
@@ -229,11 +219,10 @@ TEST_CASE("should bind SQL_C_SLONG zero to SQL_INTEGER", "[c_integer][conversion
   CHECK(get_data<SQL_C_SBIGINT>(fetch_stmt, 1) == 0);
 }
 
-TEST_CASE("should reject SQL_C_SLONG overflow into NUMBER(3,0)", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG overflow into NUMBER(3,0)",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER(3,0))");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER(3,0))");
 
   // When An integer exceeding the column precision is bound and inserted
   auto stmt = conn.createStatement();
@@ -250,11 +239,10 @@ TEST_CASE("should reject SQL_C_SLONG overflow into NUMBER(3,0)", "[c_integer][co
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator", "[c_integer][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator",
+                 "[c_integer][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   // When A NULL parameter is bound using SQL_NULL_DATA
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_real.cpp
@@ -8,16 +8,15 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When An integer value is bound as SQL_C_SLONG and inserted
   auto stmt = conn.createStatement();
@@ -35,11 +34,10 @@ TEST_CASE("should bind SQL_C_SLONG to SQL_DOUBLE and read back", "[c_integer][co
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == 42.0);
 }
 
-TEST_CASE("should bind SQL_C_SBIGINT to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SBIGINT to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A 64-bit integer is bound as SQL_C_SBIGINT and inserted
   auto stmt = conn.createStatement();
@@ -57,11 +55,10 @@ TEST_CASE("should bind SQL_C_SBIGINT to SQL_DOUBLE and read back", "[c_integer][
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == 1000000.0);
 }
 
-TEST_CASE("should bind SQL_C_SSHORT to SQL_REAL and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SSHORT to SQL_REAL and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col REAL)");
+  conn.execute("CREATE TEMPORARY TABLE t (col REAL)");
 
   // When A 16-bit integer is bound as SQL_C_SSHORT and inserted
   auto stmt = conn.createStatement();
@@ -79,11 +76,10 @@ TEST_CASE("should bind SQL_C_SSHORT to SQL_REAL and read back", "[c_integer][con
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == -100.0);
 }
 
-TEST_CASE("should bind SQL_C_UTINYINT to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UTINYINT to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When An unsigned 8-bit integer is bound as SQL_C_UTINYINT and inserted
   auto stmt = conn.createStatement();
@@ -101,11 +97,10 @@ TEST_CASE("should bind SQL_C_UTINYINT to SQL_DOUBLE and read back", "[c_integer]
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == 255.0);
 }
 
-TEST_CASE("should bind SQL_C_UBIGINT to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UBIGINT to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A large unsigned 64-bit integer is bound as SQL_C_UBIGINT and inserted
   auto stmt = conn.createStatement();
@@ -124,11 +119,10 @@ TEST_CASE("should bind SQL_C_UBIGINT to SQL_DOUBLE and read back", "[c_integer][
   CHECK_THAT(get_data<SQL_C_DOUBLE>(fetch_stmt, 1), Catch::Matchers::WithinRel(expected, 1e-15));
 }
 
-TEST_CASE("should bind SQL_C_STINYINT to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_STINYINT to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When A signed 8-bit integer at minimum value is bound as SQL_C_STINYINT and inserted
   auto stmt = conn.createStatement();
@@ -146,11 +140,10 @@ TEST_CASE("should bind SQL_C_STINYINT to SQL_DOUBLE and read back", "[c_integer]
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == -128.0);
 }
 
-TEST_CASE("should bind SQL_C_USHORT to SQL_DOUBLE and read back", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_USHORT to SQL_DOUBLE and read back",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When An unsigned 16-bit integer at maximum value is bound as SQL_C_USHORT and inserted
   auto stmt = conn.createStatement();
@@ -168,11 +161,9 @@ TEST_CASE("should bind SQL_C_USHORT to SQL_DOUBLE and read back", "[c_integer][c
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == 65535.0);
 }
 
-TEST_CASE("should bind SQL_C_SLONG zero to SQL_DOUBLE", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG zero to SQL_DOUBLE", "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When Zero is bound as SQL_C_SLONG and inserted
   auto stmt = conn.createStatement();
@@ -190,11 +181,10 @@ TEST_CASE("should bind SQL_C_SLONG zero to SQL_DOUBLE", "[c_integer][conversion]
   CHECK(get_data<SQL_C_DOUBLE>(fetch_stmt, 1) == 0.0);
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator to SQL_DOUBLE", "[c_integer][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator to SQL_DOUBLE",
+                 "[c_integer][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   // When SQL_NULL_DATA is used as the length/indicator for the bound parameter
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_integer_conversion_to_sql_string.cpp
@@ -4,16 +4,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_SLONG 42 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -31,11 +30,10 @@ TEST_CASE("should bind SQL_C_SLONG to SQL_VARCHAR and read back", "[c_integer][c
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "42");
 }
 
-TEST_CASE("should bind SQL_C_SBIGINT to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SBIGINT to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_SBIGINT 9999999999 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -53,11 +51,10 @@ TEST_CASE("should bind SQL_C_SBIGINT to SQL_VARCHAR and read back", "[c_integer]
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "9999999999");
 }
 
-TEST_CASE("should bind SQL_C_SSHORT to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SSHORT to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_SSHORT -32768 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -75,11 +72,10 @@ TEST_CASE("should bind SQL_C_SSHORT to SQL_VARCHAR and read back", "[c_integer][
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "-32768");
 }
 
-TEST_CASE("should bind SQL_C_UTINYINT to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UTINYINT to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_UTINYINT 255 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -97,11 +93,10 @@ TEST_CASE("should bind SQL_C_UTINYINT to SQL_VARCHAR and read back", "[c_integer
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "255");
 }
 
-TEST_CASE("should bind SQL_C_ULONG to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_ULONG to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_ULONG 4000000000 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -119,11 +114,10 @@ TEST_CASE("should bind SQL_C_ULONG to SQL_VARCHAR and read back", "[c_integer][c
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "4000000000");
 }
 
-TEST_CASE("should bind SQL_C_STINYINT negative to SQL_VARCHAR", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_STINYINT negative to SQL_VARCHAR",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_STINYINT -128 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -141,11 +135,10 @@ TEST_CASE("should bind SQL_C_STINYINT negative to SQL_VARCHAR", "[c_integer][con
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "-128");
 }
 
-TEST_CASE("should bind SQL_C_USHORT to SQL_VARCHAR and read back", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_USHORT to SQL_VARCHAR and read back",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_USHORT 65535 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -163,11 +156,10 @@ TEST_CASE("should bind SQL_C_USHORT to SQL_VARCHAR and read back", "[c_integer][
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "65535");
 }
 
-TEST_CASE("should bind SQL_C_UBIGINT max to SQL_VARCHAR", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_UBIGINT max to SQL_VARCHAR",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_UBIGINT max is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -185,11 +177,10 @@ TEST_CASE("should bind SQL_C_UBIGINT max to SQL_VARCHAR", "[c_integer][conversio
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == std::to_string(std::numeric_limits<SQLUBIGINT>::max()));
 }
 
-TEST_CASE("should bind SQL_C_SLONG zero to SQL_VARCHAR", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG zero to SQL_VARCHAR",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_SLONG 0 is bound to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();
@@ -207,11 +198,10 @@ TEST_CASE("should bind SQL_C_SLONG zero to SQL_VARCHAR", "[c_integer][conversion
   CHECK(get_data<SQL_C_CHAR>(fetch_stmt, 1) == "0");
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator to SQL_VARCHAR", "[c_integer][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator to SQL_VARCHAR",
+                 "[c_integer][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t (col VARCHAR(100))");
 
   // When SQL_C_SLONG is bound with SQL_NULL_DATA to SQL_VARCHAR and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_numeric_conversion_to_sql_fixed.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_conversion_to_sql_fixed.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -9,12 +9,11 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_NUMERIC to SQL_INTEGER and read back", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC to SQL_INTEGER and read back",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_int (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_int (col NUMBER)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -42,12 +41,11 @@ TEST_CASE("should bind SQL_C_NUMERIC to SQL_INTEGER and read back", "[c_numeric]
   CHECK(get_data<SQL_C_SBIGINT>(sel, 1) == 42);
 }
 
-TEST_CASE("should bind negative SQL_C_NUMERIC to SQL_BIGINT", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind negative SQL_C_NUMERIC to SQL_BIGINT",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_big (col BIGINT)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_big (col BIGINT)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -75,12 +73,11 @@ TEST_CASE("should bind negative SQL_C_NUMERIC to SQL_BIGINT", "[c_numeric][conve
   CHECK(get_data<SQL_C_SBIGINT>(sel, 1) == -99);
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC with scale to SQL_DECIMAL", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC with scale to SQL_DECIMAL",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_dec (col DECIMAL(10,2))");
+  conn.execute("CREATE TEMPORARY TABLE t_num_dec (col DECIMAL(10,2))");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -109,12 +106,10 @@ TEST_CASE("should bind SQL_C_NUMERIC with scale to SQL_DECIMAL", "[c_numeric][co
   NEW_DRIVER_ONLY("BD#33") { CHECK(get_data<SQL_C_CHAR>(sel, 1) == "123.45"); }
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC zero", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC zero", "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_zero (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_zero (col NUMBER)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -142,12 +137,11 @@ TEST_CASE("should bind SQL_C_NUMERIC zero", "[c_numeric][conversion][sql_fixed]"
   CHECK(get_data<SQL_C_SBIGINT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind large SQL_C_NUMERIC exceeding 64-bit range", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind large SQL_C_NUMERIC exceeding 64-bit range",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_big128 (col NUMBER(38,0))");
+  conn.execute("CREATE TEMPORARY TABLE t_num_big128 (col NUMBER(38,0))");
 
   // 10^20 = 100000000000000000000 which exceeds UINT64_MAX
   SQL_NUMERIC_STRUCT ns = {};
@@ -176,12 +170,11 @@ TEST_CASE("should bind large SQL_C_NUMERIC exceeding 64-bit range", "[c_numeric]
   CHECK(get_data<SQL_C_CHAR>(sel, 1) == "100000000000000000000");
 }
 
-TEST_CASE("should reject SQL_C_NUMERIC overflow into NUMBER(3,0)", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC overflow into NUMBER(3,0)",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_ovf (col NUMBER(3,0))");
+  conn.execute("CREATE TEMPORARY TABLE t_num_ovf (col NUMBER(3,0))");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -204,12 +197,11 @@ TEST_CASE("should reject SQL_C_NUMERIC overflow into NUMBER(3,0)", "[c_numeric][
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC with NULL indicator", "[c_numeric][conversion][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC with NULL indicator",
+                 "[c_numeric][conversion][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_null (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_null (col NUMBER)");
 
   SQL_NUMERIC_STRUCT ns = {};
   SQLLEN ind = SQL_NULL_DATA;

--- a/odbc_tests/tests/e2e/types/c_numeric_conversion_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_conversion_to_sql_real.cpp
@@ -2,19 +2,18 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_NUMERIC to SQL_DOUBLE and read back", "[c_numeric][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC to SQL_DOUBLE and read back",
+                 "[c_numeric][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_dbl (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_dbl (col FLOAT)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -41,12 +40,11 @@ TEST_CASE("should bind SQL_C_NUMERIC to SQL_DOUBLE and read back", "[c_numeric][
   CHECK(get_data<SQL_C_DOUBLE>(sel, 1) == Catch::Approx(42.0));
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC with scale to SQL_DOUBLE", "[c_numeric][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC with scale to SQL_DOUBLE",
+                 "[c_numeric][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_dbl_sc (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_dbl_sc (col FLOAT)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -74,12 +72,11 @@ TEST_CASE("should bind SQL_C_NUMERIC with scale to SQL_DOUBLE", "[c_numeric][con
   NEW_DRIVER_ONLY("BD#33") { CHECK(get_data<SQL_C_DOUBLE>(sel, 1) == Catch::Approx(3.14)); }
 }
 
-TEST_CASE("should bind large SQL_C_NUMERIC exceeding 64-bit to SQL_DOUBLE", "[c_numeric][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind large SQL_C_NUMERIC exceeding 64-bit to SQL_DOUBLE",
+                 "[c_numeric][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_dbl_big (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_dbl_big (col FLOAT)");
 
   // 10^20 = 100000000000000000000 which exceeds UINT64_MAX
   SQL_NUMERIC_STRUCT ns = {};
@@ -107,12 +104,11 @@ TEST_CASE("should bind large SQL_C_NUMERIC exceeding 64-bit to SQL_DOUBLE", "[c_
   CHECK(get_data<SQL_C_DOUBLE>(sel, 1) == Catch::Approx(1.0e20));
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC with NULL indicator to SQL_DOUBLE", "[c_numeric][conversion][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC with NULL indicator to SQL_DOUBLE",
+                 "[c_numeric][conversion][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_dbl_null (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_dbl_null (col FLOAT)");
 
   SQL_NUMERIC_STRUCT ns = {};
   SQLLEN ind = SQL_NULL_DATA;

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_date.cpp
@@ -10,16 +10,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLINTEGER val = 20250115;
   SQLLEN ind = 0;
@@ -33,11 +32,10 @@ TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_DATE", "[c_numeric][incom
   check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_DATE, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLDOUBLE val = 20250115.0;
   SQLLEN ind = 0;
@@ -51,11 +49,10 @@ TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_DATE", "[c_numeric][inco
   check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_DATE, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLREAL val = 20250115.0f;
   SQLLEN ind = 0;
@@ -69,11 +66,10 @@ TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_DATE", "[c_numeric][incom
   check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_DATE, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -87,11 +83,10 @@ TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_DATE", "[c_numeric][incompa
   check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_DATE, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 8;
@@ -109,11 +104,10 @@ TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_DATE", "[c_numeric][inc
   check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_DATE, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE("should reject SQL_C_SBIGINT bound to SQL_TYPE_DATE", "[c_numeric][incompatible][sql_date]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_DATE",
+                 "[c_numeric][incompatible][sql_date]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col DATE)");
+  conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLBIGINT val = 20250115;
   SQLLEN ind = 0;

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_time.cpp
@@ -10,16 +10,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLINTEGER val = 123045;
   SQLLEN ind = 0;
@@ -33,11 +32,10 @@ TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_TIME", "[c_numeric][incom
   check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_TIME, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLDOUBLE val = 123045.0;
   SQLLEN ind = 0;
@@ -51,11 +49,10 @@ TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_TIME", "[c_numeric][inco
   check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_TIME, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLREAL val = 123045.0f;
   SQLLEN ind = 0;
@@ -69,11 +66,10 @@ TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_TIME", "[c_numeric][incom
   check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_TIME, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -87,11 +83,10 @@ TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_TIME", "[c_numeric][incompa
   check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_TIME, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 6;
@@ -109,11 +104,10 @@ TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_TIME", "[c_numeric][inc
   check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_TIME, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE("should reject SQL_C_SBIGINT bound to SQL_TYPE_TIME", "[c_numeric][incompatible][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_TIME",
+                 "[c_numeric][incompatible][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLBIGINT val = 123045;
   SQLLEN ind = 0;

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_timestamp.cpp
@@ -10,16 +10,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLINTEGER val = 20250115;
   SQLLEN ind = 0;
@@ -33,11 +32,10 @@ TEST_CASE("should reject SQL_C_SLONG bound to SQL_TYPE_TIMESTAMP", "[c_numeric][
   check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLDOUBLE val = 20250115.0;
   SQLLEN ind = 0;
@@ -51,11 +49,10 @@ TEST_CASE("should reject SQL_C_DOUBLE bound to SQL_TYPE_TIMESTAMP", "[c_numeric]
   check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLREAL val = 20250115.0f;
   SQLLEN ind = 0;
@@ -69,11 +66,10 @@ TEST_CASE("should reject SQL_C_FLOAT bound to SQL_TYPE_TIMESTAMP", "[c_numeric][
   check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -87,11 +83,10 @@ TEST_CASE("should reject SQL_C_BIT bound to SQL_TYPE_TIMESTAMP", "[c_numeric][in
   check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
 }
 
-TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 8;
@@ -109,11 +104,10 @@ TEST_CASE("should reject SQL_C_NUMERIC bound to SQL_TYPE_TIMESTAMP", "[c_numeric
   check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_TIMESTAMP, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE("should reject SQL_C_SBIGINT bound to SQL_TYPE_TIMESTAMP", "[c_numeric][incompatible][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_TIMESTAMP",
+                 "[c_numeric][incompatible][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLBIGINT val = 20250115;
   SQLLEN ind = 0;

--- a/odbc_tests/tests/e2e/types/c_numeric_types_conversion_to_sql_boolean.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_types_conversion_to_sql_boolean.cpp
@@ -3,19 +3,18 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG one to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG one to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_long1 (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_long1 (col BOOLEAN)");
 
   SQLINTEGER val = 1;
   SQLLEN ind = 0;
@@ -38,12 +37,11 @@ TEST_CASE("should bind SQL_C_SLONG one to SQL_BIT", "[c_numeric_types][conversio
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SLONG zero to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG zero to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_long0 (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_long0 (col BOOLEAN)");
 
   SQLINTEGER val = 0;
   SQLLEN ind = 0;
@@ -66,12 +64,11 @@ TEST_CASE("should bind SQL_C_SLONG zero to SQL_BIT", "[c_numeric_types][conversi
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE one to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE one to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_dbl1 (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_dbl1 (col BOOLEAN)");
 
   SQLDOUBLE val = 1.0;
   SQLLEN ind = 0;
@@ -94,12 +91,11 @@ TEST_CASE("should bind SQL_C_DOUBLE one to SQL_BIT", "[c_numeric_types][conversi
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE zero to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE zero to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_dbl0 (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_dbl0 (col BOOLEAN)");
 
   SQLDOUBLE val = 0.0;
   SQLLEN ind = 0;
@@ -122,12 +118,10 @@ TEST_CASE("should bind SQL_C_DOUBLE zero to SQL_BIT", "[c_numeric_types][convers
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_BIT to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_bbit (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_bbit (col BOOLEAN)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -150,12 +144,11 @@ TEST_CASE("should bind SQL_C_BIT to SQL_BIT", "[c_numeric_types][conversion][sql
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 1);
 }
 
-TEST_CASE("should bind SQL_C_SLONG negative to SQL_BIT as true", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG negative to SQL_BIT as true",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_long_neg (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_long_neg (col BOOLEAN)");
 
   SQLINTEGER val = -1;
   SQLLEN ind = 0;
@@ -184,12 +177,11 @@ TEST_CASE("should bind SQL_C_SLONG negative to SQL_BIT as true", "[c_numeric_typ
   }
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC nonzero to SQL_BIT as true", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC nonzero to SQL_BIT as true",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_bool (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_bool (col BOOLEAN)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -222,12 +214,11 @@ TEST_CASE("should bind SQL_C_NUMERIC nonzero to SQL_BIT as true", "[c_numeric_ty
   }
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC zero to SQL_BIT as false", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC zero to SQL_BIT as false",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_bool0 (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_bool0 (col BOOLEAN)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -254,12 +245,11 @@ TEST_CASE("should bind SQL_C_NUMERIC zero to SQL_BIT as false", "[c_numeric_type
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC negative to SQL_BIT as true", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC negative to SQL_BIT as true",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_num_bool_neg (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_num_bool_neg (col BOOLEAN)");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -291,12 +281,11 @@ TEST_CASE("should bind SQL_C_NUMERIC negative to SQL_BIT as true", "[c_numeric_t
   }
 }
 
-TEST_CASE("should bind SQL_C_DEFAULT to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DEFAULT to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_default (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_default (col BOOLEAN)");
 
   SQLCHAR val_true = 1;
   SQLCHAR val_false = 0;
@@ -329,12 +318,11 @@ TEST_CASE("should bind SQL_C_DEFAULT to SQL_BIT", "[c_numeric_types][conversion]
   CHECK(get_data<SQL_C_BIT>(sel, 1) == 0);
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator to SQL_BIT", "[c_numeric_types][conversion][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator to SQL_BIT",
+                 "[c_numeric_types][conversion][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_long_null (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t_long_null (col BOOLEAN)");
 
   SQLINTEGER val = 0;
   SQLLEN ind = SQL_NULL_DATA;

--- a/odbc_tests/tests/e2e/types/c_numeric_types_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_types_conversion_to_sql_string.cpp
@@ -3,19 +3,18 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_SLONG to SQL_VARCHAR and read back", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG to SQL_VARCHAR and read back",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_long (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_long (col VARCHAR(100))");
 
   SQLINTEGER val = 42;
   SQLLEN ind = 0;
@@ -38,12 +37,11 @@ TEST_CASE("should bind SQL_C_SLONG to SQL_VARCHAR and read back", "[c_numeric_ty
   CHECK(get_data<SQL_C_CHAR>(sel, 1) == "42");
 }
 
-TEST_CASE("should bind SQL_C_DOUBLE to SQL_VARCHAR", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_DOUBLE to SQL_VARCHAR",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_dbl (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_dbl (col VARCHAR(100))");
 
   SQLDOUBLE val = 3.14;
   SQLLEN ind = 0;
@@ -67,12 +65,11 @@ TEST_CASE("should bind SQL_C_DOUBLE to SQL_VARCHAR", "[c_numeric_types][conversi
   CHECK(s.find("3.14") != std::string::npos);
 }
 
-TEST_CASE("should bind SQL_C_BIT to SQL_VARCHAR", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_BIT to SQL_VARCHAR",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_bit (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_bit (col VARCHAR(100))");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
@@ -95,12 +92,11 @@ TEST_CASE("should bind SQL_C_BIT to SQL_VARCHAR", "[c_numeric_types][conversion]
   CHECK(get_data<SQL_C_CHAR>(sel, 1) == "1");
 }
 
-TEST_CASE("should bind SQL_C_NUMERIC to SQL_VARCHAR", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_NUMERIC to SQL_VARCHAR",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_num (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_num (col VARCHAR(100))");
 
   SQL_NUMERIC_STRUCT ns = {};
   ns.precision = 10;
@@ -129,12 +125,11 @@ TEST_CASE("should bind SQL_C_NUMERIC to SQL_VARCHAR", "[c_numeric_types][convers
   NEW_DRIVER_ONLY("BD#33") { CHECK(get_data<SQL_C_CHAR>(sel, 1) == "123.45"); }
 }
 
-TEST_CASE("should bind SQL_C_SBIGINT to SQL_VARCHAR", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SBIGINT to SQL_VARCHAR",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_sb (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_sb (col VARCHAR(100))");
 
   SQLBIGINT val = 9999999999LL;
   SQLLEN ind = 0;
@@ -157,12 +152,11 @@ TEST_CASE("should bind SQL_C_SBIGINT to SQL_VARCHAR", "[c_numeric_types][convers
   CHECK(get_data<SQL_C_CHAR>(sel, 1) == "9999999999");
 }
 
-TEST_CASE("should bind SQL_C_SLONG with NULL indicator to SQL_VARCHAR", "[c_numeric_types][conversion][sql_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_SLONG with NULL indicator to SQL_VARCHAR",
+                 "[c_numeric_types][conversion][sql_string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
-  conn.execute("CREATE TABLE t_vc_null (col VARCHAR(100))");
+  conn.execute("CREATE TEMPORARY TABLE t_vc_null (col VARCHAR(100))");
 
   SQLINTEGER val = 0;
   SQLLEN ind = SQL_NULL_DATA;

--- a/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_boolean.cpp
+++ b/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_boolean.cpp
@@ -9,16 +9,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_BIT", "[c_temporal][incompatible][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE bound to SQL_BIT",
+                 "[c_temporal][incompatible][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   SQL_DATE_STRUCT ds = {2025, 1, 15};
   SQLLEN ind = sizeof(ds);
@@ -32,11 +31,10 @@ TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_BIT", "[c_temporal][incomp
   check_incompatible_bindparam(stmt, SQL_C_TYPE_DATE, SQL_BIT, &ds, sizeof(ds), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_BIT", "[c_temporal][incompatible][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME bound to SQL_BIT",
+                 "[c_temporal][incompatible][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   SQL_TIME_STRUCT ts = {12, 30, 45};
   SQLLEN ind = sizeof(ts);
@@ -50,11 +48,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_BIT", "[c_temporal][incomp
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIME, SQL_BIT, &ts, sizeof(ts), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_BIT", "[c_temporal][incompatible][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP bound to SQL_BIT",
+                 "[c_temporal][incompatible][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   SQL_TIMESTAMP_STRUCT tss = {2025, 1, 15, 12, 30, 45, 0};
   SQLLEN ind = sizeof(tss);
@@ -68,11 +65,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_BIT", "[c_temporal][i
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIMESTAMP, SQL_BIT, &tss, sizeof(tss), &ind);
 }
 
-TEST_CASE("should reject SQL_C_GUID bound to SQL_BIT", "[c_temporal][incompatible][sql_boolean]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_GUID bound to SQL_BIT",
+                 "[c_temporal][incompatible][sql_boolean]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col BOOLEAN)");
+  conn.execute("CREATE TEMPORARY TABLE t (col BOOLEAN)");
 
   SQLGUID guid = {0x12345678, 0x1234, 0x5678, {0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78}};
   SQLLEN ind = sizeof(guid);

--- a/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_fixed.cpp
+++ b/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_fixed.cpp
@@ -9,16 +9,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_INTEGER", "[c_temporal][incompatible][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE bound to SQL_INTEGER",
+                 "[c_temporal][incompatible][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   SQL_DATE_STRUCT ds = {2025, 1, 15};
   SQLLEN ind = sizeof(ds);
@@ -32,11 +31,10 @@ TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_INTEGER", "[c_temporal][in
   check_incompatible_bindparam(stmt, SQL_C_TYPE_DATE, SQL_INTEGER, &ds, sizeof(ds), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_INTEGER", "[c_temporal][incompatible][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME bound to SQL_INTEGER",
+                 "[c_temporal][incompatible][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   SQL_TIME_STRUCT ts = {12, 30, 45};
   SQLLEN ind = sizeof(ts);
@@ -50,11 +48,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_INTEGER", "[c_temporal][in
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIME, SQL_INTEGER, &ts, sizeof(ts), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_INTEGER", "[c_temporal][incompatible][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP bound to SQL_INTEGER",
+                 "[c_temporal][incompatible][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   SQL_TIMESTAMP_STRUCT tss = {2025, 1, 15, 12, 30, 45, 0};
   SQLLEN ind = sizeof(tss);
@@ -68,11 +65,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_INTEGER", "[c_tempora
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIMESTAMP, SQL_INTEGER, &tss, sizeof(tss), &ind);
 }
 
-TEST_CASE("should reject SQL_C_GUID bound to SQL_INTEGER", "[c_temporal][incompatible][sql_fixed]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_GUID bound to SQL_INTEGER",
+                 "[c_temporal][incompatible][sql_fixed]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col NUMBER)");
+  conn.execute("CREATE TEMPORARY TABLE t (col NUMBER)");
 
   SQLGUID guid = {0x12345678, 0x1234, 0x5678, {0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78}};
   SQLLEN ind = sizeof(guid);

--- a/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_real.cpp
+++ b/odbc_tests/tests/e2e/types/c_temporal_incompatible_to_sql_real.cpp
@@ -9,16 +9,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_DOUBLE", "[c_temporal][incompatible][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE bound to SQL_DOUBLE",
+                 "[c_temporal][incompatible][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   SQL_DATE_STRUCT ds = {2025, 1, 15};
   SQLLEN ind = sizeof(ds);
@@ -32,11 +31,10 @@ TEST_CASE("should reject SQL_C_TYPE_DATE bound to SQL_DOUBLE", "[c_temporal][inc
   check_incompatible_bindparam(stmt, SQL_C_TYPE_DATE, SQL_DOUBLE, &ds, sizeof(ds), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_DOUBLE", "[c_temporal][incompatible][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME bound to SQL_DOUBLE",
+                 "[c_temporal][incompatible][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   SQL_TIME_STRUCT ts = {12, 30, 45};
   SQLLEN ind = sizeof(ts);
@@ -50,11 +48,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIME bound to SQL_DOUBLE", "[c_temporal][inc
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIME, SQL_DOUBLE, &ts, sizeof(ts), &ind);
 }
 
-TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_DOUBLE", "[c_temporal][incompatible][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP bound to SQL_DOUBLE",
+                 "[c_temporal][incompatible][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   SQL_TIMESTAMP_STRUCT tss = {2025, 1, 15, 12, 30, 45, 0};
   SQLLEN ind = sizeof(tss);
@@ -68,11 +65,10 @@ TEST_CASE("should reject SQL_C_TYPE_TIMESTAMP bound to SQL_DOUBLE", "[c_temporal
   check_incompatible_bindparam(stmt, SQL_C_TYPE_TIMESTAMP, SQL_DOUBLE, &tss, sizeof(tss), &ind);
 }
 
-TEST_CASE("should reject SQL_C_GUID bound to SQL_DOUBLE", "[c_temporal][incompatible][sql_real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_GUID bound to SQL_DOUBLE",
+                 "[c_temporal][incompatible][sql_real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE t (col FLOAT)");
 
   SQLGUID guid = {0x12345678, 0x1234, 0x5678, {0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78}};
   SQLLEN ind = sizeof(guid);

--- a/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
@@ -1,16 +1,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_TYPE_TIME to SQL_TYPE_TIME and read back", "[c_time][conversion][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to SQL_TYPE_TIME and read back",
+                 "[c_time][conversion][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   // When SQL_C_TYPE_TIME 14:30:45 is bound to SQL_TYPE_TIME and inserted
   auto stmt = conn.createStatement();
@@ -35,11 +34,10 @@ TEST_CASE("should bind SQL_C_TYPE_TIME to SQL_TYPE_TIME and read back", "[c_time
   CHECK(time.second == 45);
 }
 
-TEST_CASE("should bind SQL_C_TYPE_TIME with NULL indicator to SQL_TYPE_TIME", "[c_time][conversion][sql_time]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indicator to SQL_TYPE_TIME",
+                 "[c_time][conversion][sql_time]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIME)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   // When SQL_C_TYPE_TIME is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
@@ -1,18 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIMESTAMP and read back",
-          "[c_timestamp][conversion][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIMESTAMP and read back",
+                 "[c_timestamp][conversion][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
-  conn.execute("CREATE TABLE t (col TIMESTAMP_NTZ)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
   // When SQL_C_TYPE_TIMESTAMP 2026-04-13 14:30:45 is bound and inserted
   auto stmt = conn.createStatement();
@@ -44,12 +42,10 @@ TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIMESTAMP and read back"
   CHECK(result.second == 45);
 }
 
-TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to SQL_TYPE_TIMESTAMP",
-          "[c_timestamp][conversion][sql_timestamp]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to SQL_TYPE_TIMESTAMP",
+                 "[c_timestamp][conversion][sql_timestamp]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-  conn.execute("CREATE TABLE t (col TIMESTAMP_NTZ)");
+  conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
   // When SQL_C_TYPE_TIMESTAMP is bound with SQL_NULL_DATA and inserted
   auto stmt = conn.createStatement();

--- a/odbc_tests/tests/e2e/types/decfloat.cpp
+++ b/odbc_tests/tests/e2e/types/decfloat.cpp
@@ -181,7 +181,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select decfloats from table", "[decf
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
-  conn.execute("CREATE OR REPLACE TABLE decfloat_table (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_table (col DECFLOAT)");
   conn.execute("INSERT INTO decfloat_table VALUES ('0'), ('123.456'), ('-789.012'), ('1.23E+20'), ('-9.87E-15')");
 
   // When Query "SELECT * FROM <table>" is executed
@@ -216,7 +216,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle full 38-digit precision value
 
   // And Table with DECFLOAT column exists with values [12345678901234567890123456789012345678,
   // 1.2345678901234567890123456789012345678E+100, 1.2345678901234567890123456789012345678E-100]
-  conn.execute("CREATE OR REPLACE TABLE decfloat_precision_table (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_precision_table (col DECFLOAT)");
   conn.execute(
       "INSERT INTO decfloat_precision_table VALUES "
       "('12345678901234567890123456789012345678'), "
@@ -258,7 +258,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle extreme exponent values from 
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
-  conn.execute("CREATE OR REPLACE TABLE decfloat_extreme_table (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_extreme_table (col DECFLOAT)");
   conn.execute(
       "INSERT INTO decfloat_extreme_table VALUES "
       "('1E+16384'), ('1E-16383'), ('-1.234E+8000'), ('9.876E-8000')");
@@ -302,7 +302,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table", "[de
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
-  conn.execute("CREATE OR REPLACE TABLE decfloat_null_table (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_null_table (col DECFLOAT)");
   conn.execute("INSERT INTO decfloat_null_table VALUES (NULL), ('123.456'), (NULL), ('-789.012')");
 
   // When Query "SELECT * FROM <table>" is executed
@@ -332,7 +332,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set with multi
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists with values from 0 to 19999
-  conn.execute("CREATE OR REPLACE TABLE decfloat_large_table (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_large_table (col DECFLOAT)");
   conn.execute(
       "INSERT INTO decfloat_large_table "
       "SELECT seq8()::DECFLOAT FROM TABLE(GENERATOR(ROWCOUNT => 20000))");
@@ -470,7 +470,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert decfloat using parameter bind
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists
-  conn.execute("CREATE OR REPLACE TABLE decfloat_bind_insert (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_bind_insert (col DECFLOAT)");
 
   // When DECFLOAT values [0, 123.456, -789.012, NULL] are inserted using explicit binding
   const char* values[] = {"0", "123.456", "-789.012"};
@@ -526,7 +526,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert extreme decfloat values using
   // Given Snowflake client is logged in
 
   // And Table with DECFLOAT column exists
-  conn.execute("CREATE OR REPLACE TABLE decfloat_extreme_bind (col DECFLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE decfloat_extreme_bind (col DECFLOAT)");
 
   // When DECFLOAT values [1E+16384, 1E-16383, -1.234E+8000] are inserted using explicit binding
   const char* values[] = {"1E+16384", "1E-16383", "-1.234E+8000"};

--- a/odbc_tests/tests/e2e/types/decfloat.cpp
+++ b/odbc_tests/tests/e2e/types/decfloat.cpp
@@ -15,7 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
@@ -177,10 +177,8 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR"
 // TABLE OPERATIONS
 // ============================================================================
 
-TEST_CASE("should select decfloats from table", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select decfloats from table", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists with values [0, 123.456, -789.012, 1.23e20, -9.87e-15]
   conn.execute("CREATE OR REPLACE TABLE decfloat_table (col DECFLOAT)");
@@ -213,10 +211,8 @@ TEST_CASE("should select decfloats from table", "[decfloat]") {
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-0.00000000000000987");
 }
 
-TEST_CASE("should handle full 38-digit precision values from table", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle full 38-digit precision values from table", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists with values [12345678901234567890123456789012345678,
   // 1.2345678901234567890123456789012345678E+100, 1.2345678901234567890123456789012345678E-100]
@@ -258,10 +254,8 @@ TEST_CASE("should handle full 38-digit precision values from table", "[decfloat]
   }
 }
 
-TEST_CASE("should handle extreme exponent values from table", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle extreme exponent values from table", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists with values [1E+16384, 1E-16383, -1.234E+8000, 9.876E-8000]
   conn.execute("CREATE OR REPLACE TABLE decfloat_extreme_table (col DECFLOAT)");
@@ -304,10 +298,8 @@ TEST_CASE("should handle extreme exponent values from table", "[decfloat]") {
   }
 }
 
-TEST_CASE("should handle NULL values from table", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists with values [NULL, 123.456, NULL, -789.012]
   conn.execute("CREATE OR REPLACE TABLE decfloat_null_table (col DECFLOAT)");
@@ -336,10 +328,8 @@ TEST_CASE("should handle NULL values from table", "[decfloat]") {
   CHECK(get_data_optional<SQL_C_CHAR>(stmt, 1) == "-789.012");
 }
 
-TEST_CASE("should download large result set with multiple chunks from table", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set with multiple chunks from table", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists with values from 0 to 19999
   conn.execute("CREATE OR REPLACE TABLE decfloat_large_table (col DECFLOAT)");
@@ -476,10 +466,8 @@ TEST_CASE("should select case decfloat using parameter binding", "[decfloat]") {
   }
 }
 
-TEST_CASE("should insert decfloat using parameter binding", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert decfloat using parameter binding", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists
   conn.execute("CREATE OR REPLACE TABLE decfloat_bind_insert (col DECFLOAT)");
@@ -534,10 +522,8 @@ TEST_CASE("should insert decfloat using parameter binding", "[decfloat]") {
   CHECK(!get_data_optional<SQL_C_CHAR>(stmt, 1).has_value());
 }
 
-TEST_CASE("should insert extreme decfloat values using parameter binding", "[decfloat]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert extreme decfloat values using parameter binding", "[decfloat]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with DECFLOAT column exists
   conn.execute("CREATE OR REPLACE TABLE decfloat_extreme_bind (col DECFLOAT)");

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_binary.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_binary.cpp
@@ -5,16 +5,14 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("SQL_DECIMAL to SQL_C_BINARY", "[fixed][conversion][c_binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL to SQL_C_BINARY", "[fixed][conversion][c_binary]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("integer value");
@@ -46,13 +44,12 @@ TEST_CASE("SQL_DECIMAL to SQL_C_BINARY", "[fixed][conversion][c_binary]") {
   }
 }
 
-TEST_CASE("SQL_DECIMAL SQL_C_BINARY buffer too small returns 22003", "[fixed][conversion][c_binary][22003]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL SQL_C_BINARY buffer too small returns 22003",
+                 "[fixed][conversion][c_binary][22003]") {
   SKIP_OLD_DRIVER("BD#12",
                   "Old driver does not return SQL_ERROR (22003) when SQL_C_BINARY buffer is too small for "
                   "SQL_NUMERIC_STRUCT");
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NUMBER value is fetched as SQL_C_BINARY into a buffer smaller than SQL_NUMERIC_STRUCT
   auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
@@ -65,10 +62,8 @@ TEST_CASE("SQL_DECIMAL SQL_C_BINARY buffer too small returns 22003", "[fixed][co
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_BINARY", "[fixed][conversion][c_binary][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_BINARY", "[fixed][conversion][c_binary][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_bit.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_bit.cpp
@@ -5,16 +5,13 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("SQL_C_BIT spec compliance", "[fixed][conversion][c_bit]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_C_BIT spec compliance", "[fixed][conversion][c_bit]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
   {
     INFO("0 and 1 succeed");
     // When Various NUMBER/DECIMAL values are fetched as SQL_C_BIT
@@ -74,11 +71,8 @@ TEST_CASE("SQL_C_BIT spec compliance", "[fixed][conversion][c_bit]") {
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_BIT", "[fixed][conversion][c_bit][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_BIT", "[fixed][conversion][c_bit][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
   // When A NULL NUMBER value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
   // Then Indicator returns SQL_NULL_DATA

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_char.cpp
@@ -8,7 +8,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
@@ -16,10 +16,9 @@
 #include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("Test decimal to SQL_C_CHAR and SQL_C_DEFAULT conversion", "[fixed][conversion][c_char]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test decimal to SQL_C_CHAR and SQL_C_DEFAULT conversion",
+                 "[fixed][conversion][c_char]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with various DECIMAL/NUMBER/INT columns is queried
   TestTable table(conn, "test_number",
@@ -43,10 +42,8 @@ TEST_CASE("Test decimal to SQL_C_CHAR and SQL_C_DEFAULT conversion", "[fixed][co
   }
 }
 
-TEST_CASE("SQL_DECIMAL default conversion", "[fixed][conversion][c_char][default]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL default conversion", "[fixed][conversion][c_char][default]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("basic values from table");
@@ -163,10 +160,9 @@ TEST_CASE("SQL_DECIMAL default conversion", "[fixed][conversion][c_char][default
   }
 }
 
-TEST_CASE("SQL_DECIMAL default conversion - large precision", "[fixed][conversion][c_char][default]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL default conversion - large precision",
+                 "[fixed][conversion][c_char][default]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("large values");
@@ -204,10 +200,8 @@ TEST_CASE("SQL_DECIMAL default conversion - large precision", "[fixed][conversio
   }
 }
 
-TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR", "[fixed][conversion][c_wchar]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL to SQL_C_WCHAR", "[fixed][conversion][c_wchar]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("basic values");
@@ -246,10 +240,8 @@ TEST_CASE("SQL_DECIMAL to SQL_C_WCHAR", "[fixed][conversion][c_wchar]") {
   }
 }
 
-TEST_CASE("SQL_DECIMAL SQL_C_CHAR buffer handling", "[fixed][conversion][c_char][buffer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL SQL_C_CHAR buffer handling", "[fixed][conversion][c_char][buffer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NUMBER values are fetched into various buffer sizes
   (void)0;  // SECTIONs below perform the fetch
@@ -319,10 +311,9 @@ TEST_CASE("SQL_DECIMAL SQL_C_CHAR buffer handling", "[fixed][conversion][c_char]
   }
 }
 
-TEST_CASE("Without TREAT_DECIMAL_AS_INT default is SQL_C_CHAR for scale=0", "[fixed][conversion][c_char][default]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Without TREAT_DECIMAL_AS_INT default is SQL_C_CHAR for scale=0",
+                 "[fixed][conversion][c_char][default]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When An integer DECIMAL value is queried with SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 42::DECIMAL(10,0)");
@@ -337,10 +328,8 @@ TEST_CASE("Without TREAT_DECIMAL_AS_INT default is SQL_C_CHAR for scale=0", "[fi
   CHECK(std::string(buffer, indicator) == "42");
 }
 
-TEST_CASE("Test string at limits", "[fixed][conversion][c_char][limits]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test string at limits", "[fixed][conversion][c_char][limits]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Max and min 37-digit NUMBER values are fetched as SQL_C_CHAR and SQL_C_DEFAULT
   std::string max_val = std::string(37, '9');
@@ -354,10 +343,8 @@ TEST_CASE("Test string at limits", "[fixed][conversion][c_char][limits]") {
   CHECK(get_data_default_as_string(stmt, 2) == min_val);
 }
 
-TEST_CASE("DECIMAL multiple rows as SQL_C_CHAR", "[fixed][conversion][c_char][multirow]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "DECIMAL multiple rows as SQL_C_CHAR", "[fixed][conversion][c_char][multirow]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with various DECIMAL(10,2) values is queried
   TestTable table(conn, "test_number_multi", "val DECIMAL(10,2)",
@@ -377,10 +364,8 @@ TEST_CASE("DECIMAL multiple rows as SQL_C_CHAR", "[fixed][conversion][c_char][mu
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_CHAR types", "[fixed][conversion][c_char][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_CHAR types", "[fixed][conversion][c_char][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   const auto query = "SELECT NULL::NUMBER(10,0)";

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_float.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_float.cpp
@@ -8,16 +8,14 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("Test decimal to floating point conversion", "[fixed][conversion][c_float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test decimal to floating point conversion", "[fixed][conversion][c_float]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with DECIMAL/NUMBER/INT columns containing value 123 is queried
   TestTable table(conn, "test_number",
@@ -42,10 +40,9 @@ TEST_CASE("Test decimal to floating point conversion", "[fixed][conversion][c_fl
   }
 }
 
-TEST_CASE("SQL_DECIMAL explicit floating point conversions preserve fraction", "[fixed][conversion][c_float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL explicit floating point conversions preserve fraction",
+                 "[fixed][conversion][c_float]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A fractional DECIMAL value 123.789 is fetched as float and double
   const std::string query = "SELECT 123.789::DECIMAL(10,3)";
@@ -60,10 +57,8 @@ TEST_CASE("SQL_DECIMAL explicit floating point conversions preserve fraction", "
   CHECK(double_val < 123.790);
 }
 
-TEST_CASE("DECIMAL to floating point precision", "[fixed][conversion][c_float][precision]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "DECIMAL to floating point precision", "[fixed][conversion][c_float][precision]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NUMBER values with varying significant digits are fetched as float and double
   (void)0;
@@ -83,10 +78,8 @@ TEST_CASE("DECIMAL to floating point precision", "[fixed][conversion][c_float][p
   }
 }
 
-TEST_CASE("DECIMAL multiple rows as SQL_C_DOUBLE", "[fixed][conversion][c_float][multirow]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "DECIMAL multiple rows as SQL_C_DOUBLE", "[fixed][conversion][c_float][multirow]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with various DECIMAL(10,3) values is queried
   TestTable table(conn, "test_number_double_multi", "val DECIMAL(10,3)", "(0.000), (1.500), (-2.750), (100.125)");
@@ -105,10 +98,9 @@ TEST_CASE("DECIMAL multiple rows as SQL_C_DOUBLE", "[fixed][conversion][c_float]
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_FLOAT and SQL_C_DOUBLE", "[fixed][conversion][c_float][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_FLOAT and SQL_C_DOUBLE",
+                 "[fixed][conversion][c_float][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   const auto query = "SELECT NULL::NUMBER(10,0)";

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_integer.cpp
@@ -11,7 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
@@ -34,10 +34,8 @@ void test_at_limits(Connection& conn) {
         std::numeric_limits<typename MetaOfSqlCType<SQL_C_TYPE>::type>::min());
 }
 
-TEST_CASE("Test decimal to integer conversion", "[fixed][conversion][c_integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test decimal to integer conversion", "[fixed][conversion][c_integer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with various DECIMAL/NUMBER/INT columns is queried
   TestTable table(
@@ -65,10 +63,8 @@ TEST_CASE("Test decimal to integer conversion", "[fixed][conversion][c_integer]"
   check_integer_columns<SQL_C_UBIGINT>(stmt, exact_cols, truncated_cols, expected);
 }
 
-TEST_CASE("Test integer at limits", "[fixed][conversion][c_integer][limits]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test integer at limits", "[fixed][conversion][c_integer][limits]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Max and min values for each integer C type are queried
   test_at_limits<SQL_C_LONG>(conn);
@@ -87,10 +83,9 @@ TEST_CASE("Test integer at limits", "[fixed][conversion][c_integer][limits]") {
   (void)0;  // assertions are inside test_at_limits
 }
 
-TEST_CASE("SQL_DECIMAL explicit integer conversions truncate", "[fixed][conversion][c_integer][truncation]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL explicit integer conversions truncate",
+                 "[fixed][conversion][c_integer][truncation]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A fractional DECIMAL value 123.789 is fetched as each integer C type
   const std::string query = "SELECT 123.789::DECIMAL(10,3)";
@@ -109,10 +104,8 @@ TEST_CASE("SQL_DECIMAL explicit integer conversions truncate", "[fixed][conversi
   CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
 }
 
-TEST_CASE("SQL_DECIMAL truncation and scale", "[fixed][conversion][c_integer][truncation]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL truncation and scale", "[fixed][conversion][c_integer][truncation]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NUMBER values with various scales are fetched as SQL_C_LONG
   (void)0;
@@ -170,10 +163,9 @@ TEST_CASE("SQL_DECIMAL truncation and scale", "[fixed][conversion][c_integer][tr
   }
 }
 
-TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[fixed][conversion][c_integer][scale0]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER scale=0 - INT and INTEGER types",
+                 "[fixed][conversion][c_integer][scale0]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with INT/INTEGER/BIGINT/SMALLINT/TINYINT columns is queried
   TestTable table(conn, "test_int_types", "a INT, b INTEGER, c BIGINT, d SMALLINT, e TINYINT",
@@ -195,10 +187,9 @@ TEST_CASE("NUMBER scale=0 - INT and INTEGER types", "[fixed][conversion][c_integ
   CHECK(check_char_success(stmt, 5) == "120");
 }
 
-TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07", "[fixed][conversion][c_integer][01S07]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL fractional truncation returns 01S07",
+                 "[fixed][conversion][c_integer][01S07]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Fractional DECIMAL values are fetched as integer C types
   (void)0;
@@ -239,10 +230,8 @@ TEST_CASE("SQL_DECIMAL fractional truncation returns 01S07", "[fixed][conversion
   }
 }
 
-TEST_CASE("SQL_DECIMAL overflow returns 22003", "[fixed][conversion][c_integer][22003]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL overflow returns 22003", "[fixed][conversion][c_integer][22003]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Out-of-range NUMBER values are fetched as narrow integer C types
   (void)0;
@@ -323,10 +312,8 @@ TEST_CASE("SQL_DECIMAL overflow returns 22003", "[fixed][conversion][c_integer][
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_INTEGER types", "[fixed][conversion][c_integer][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_INTEGER types", "[fixed][conversion][c_integer][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   const auto query = "SELECT NULL::NUMBER(10,0)";
@@ -343,10 +330,9 @@ TEST_CASE("NUMBER NULL to SQL_C_INTEGER types", "[fixed][conversion][c_integer][
   check_null_via_get_data(conn.execute_fetch(query), 1, SQL_C_UTINYINT);
 }
 
-TEST_CASE("NUMBER NULL mixed with non-NULL in multiple rows", "[fixed][conversion][c_integer][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL mixed with non-NULL in multiple rows",
+                 "[fixed][conversion][c_integer][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with mixed NULL and non-NULL rows is queried
   TestTable table(conn, "test_fixed_null", "val NUMBER(10,0)", "(42), (NULL), (-7), (NULL), (0)");
@@ -374,11 +360,9 @@ TEST_CASE("NUMBER NULL mixed with non-NULL in multiple rows", "[fixed][conversio
   }
 }
 
-TEST_CASE("SQL_DECIMAL SQLGetData NULL without indicator returns 22002",
-          "[fixed][conversion][c_integer][null][22002]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL SQLGetData NULL without indicator returns 22002",
+                 "[fixed][conversion][c_integer][null][22002]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL value is fetched without providing an indicator pointer
   auto stmt = conn.execute_fetch("SELECT NULL::DECIMAL(10,2)");

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_interval.cpp
@@ -4,8 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -16,10 +15,8 @@
 // SUCCESSFUL CONVERSIONS - Single-component interval types
 // ============================================================================
 
-TEST_CASE("NUMBER to single-field interval types", "[datatype][number][interval]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to single-field interval types", "[datatype][number][interval]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Positive, negative, and zero NUMBER values are fetched as SQL_C_INTERVAL_YEAR
   auto stmt = conn.execute_fetch("SELECT 5::NUMBER(10,0)");
@@ -112,10 +109,9 @@ TEST_CASE("NUMBER to single-field interval types", "[datatype][number][interval]
 // TRUNCATION WITH INFO - Fractional truncation (SQLSTATE 01S07)
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - fractional truncation returns 01S07", "[datatype][number][interval][01S07]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - fractional truncation returns 01S07",
+                 "[datatype][number][interval][01S07]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When DECIMAL value with fractional part is fetched as SQL_C_INTERVAL_YEAR
   auto stmt = conn.execute_fetch("SELECT 5.7::DECIMAL(10,1)");
@@ -164,10 +160,9 @@ TEST_CASE("NUMBER to interval - fractional truncation returns 01S07", "[datatype
 // TRUNCATION WITH INFO - Sub-microsecond truncation (SQLSTATE 01S07)
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - sub-microsecond truncation returns 01S07", "[datatype][number][interval][01S07]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - sub-microsecond truncation returns 01S07",
+                 "[datatype][number][interval][01S07]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When DECIMAL with 9-digit fractional part is fetched as SQL_C_INTERVAL_SECOND
   auto stmt = conn.execute_fetch("SELECT 45.123456789::DECIMAL(12,9)");
@@ -194,11 +189,9 @@ TEST_CASE("NUMBER to interval - sub-microsecond truncation returns 01S07", "[dat
 // EDGE CASES - Negative zero handling
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - no negative zero", "[datatype][number][interval][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - no negative zero", "[datatype][number][interval][edge]") {
   SKIP_OLD_DRIVER("BD#17", "Old driver produces negative zero for interval types");
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Negative fractional DECIMAL is fetched as SQL_C_INTERVAL_YEAR
   auto stmt = conn.execute_fetch("SELECT -0.5::DECIMAL(10,1)");
@@ -244,10 +237,9 @@ TEST_CASE("NUMBER to interval - no negative zero", "[datatype][number][interval]
 // ILLEGAL CONVERSIONS - Multi-field interval types (SQLSTATE 22015)
 // ============================================================================
 
-TEST_CASE("NUMBER to multi-field interval returns 22015", "[datatype][number][interval][22015]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to multi-field interval returns 22015",
+                 "[datatype][number][interval][22015]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT 42::NUMBER(10,0)" is executed and fetched as SQL_C_INTERVAL_YEAR_TO_MONTH
   auto stmt = conn.execute_fetch("SELECT 42::NUMBER(10,0)");
@@ -278,10 +270,9 @@ TEST_CASE("NUMBER to multi-field interval returns 22015", "[datatype][number][in
 // NULL VALUE HANDLING
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - NULL returns SQL_NULL_DATA", "[datatype][number][interval][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - NULL returns SQL_NULL_DATA",
+                 "[datatype][number][interval][null]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT NULL::NUMBER(10,0)" is executed and fetched as SQL_C_INTERVAL_YEAR
   auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,0)");
@@ -309,11 +300,10 @@ TEST_CASE("NUMBER to interval - NULL returns SQL_NULL_DATA", "[datatype][number]
 // LEADING FIELD PRECISION - Default precision (SQLSTATE 22015)
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - default precision rejects values >= 100", "[datatype][number][interval][precision]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - default precision rejects values >= 100",
+                 "[datatype][number][interval][precision]") {
   SKIP_OLD_DRIVER("BD#18", "Old driver does not enforce interval leading precision");
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Value 99 is fetched as SQL_C_INTERVAL_YEAR with default precision
   auto stmt = conn.execute_fetch("SELECT 99::NUMBER(10,0)");
@@ -348,12 +338,10 @@ TEST_CASE("NUMBER to interval - default precision rejects values >= 100", "[data
 // LEADING FIELD PRECISION - Custom precision via SQLSetDescField
 // ============================================================================
 
-TEST_CASE("NUMBER to interval - custom precision via SQLSetDescField",
-          "[datatype][number][interval][precision][descriptor]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER to interval - custom precision via SQLSetDescField",
+                 "[datatype][number][interval][precision][descriptor]") {
   SKIP_OLD_DRIVER("BD#18", "Old driver does not support SQL_DESC_DATETIME_INTERVAL_PRECISION");
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When SQL_DESC_DATETIME_INTERVAL_PRECISION is set to 5 on the ARD
   {
@@ -420,10 +408,8 @@ TEST_CASE("NUMBER to interval - custom precision via SQLSetDescField",
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_INTERVAL types", "[fixed][conversion][c_interval][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_INTERVAL types", "[fixed][conversion][c_interval][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   const auto query = "SELECT NULL::NUMBER(10,0)";

--- a/odbc_tests/tests/e2e/types/fixed_conversion_to_c_numeric.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_conversion_to_c_numeric.cpp
@@ -4,18 +4,15 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC", "[fixed][conversion][c_numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL to SQL_C_NUMERIC", "[fixed][conversion][c_numeric]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NUMBER/DECIMAL values are fetched as SQL_C_NUMERIC
   (void)0;
@@ -50,12 +47,10 @@ TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC", "[fixed][conversion][c_numeric]") {
   }
 }
 
-TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC with SQL_DESC_PRECISION and SQL_DESC_SCALE",
-          "[fixed][conversion][c_numeric][descriptor]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_DECIMAL to SQL_C_NUMERIC with SQL_DESC_PRECISION and SQL_DESC_SCALE",
+                 "[fixed][conversion][c_numeric][descriptor]") {
   SKIP_OLD_DRIVER("BD#13", "Old driver ignores SQL_DESC_PRECISION and SQL_DESC_SCALE set via SQLSetDescField");
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("target scale matches source scale - no truncation");
@@ -211,10 +206,8 @@ TEST_CASE("SQL_DECIMAL to SQL_C_NUMERIC with SQL_DESC_PRECISION and SQL_DESC_SCA
   }
 }
 
-TEST_CASE("NUMBER NULL to SQL_C_NUMERIC", "[fixed][conversion][c_numeric][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "NUMBER NULL to SQL_C_NUMERIC", "[fixed][conversion][c_numeric][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL NUMBER value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::NUMBER(10,2)");

--- a/odbc_tests/tests/e2e/types/fixed_treat_decimal_as_int.cpp
+++ b/odbc_tests/tests/e2e/types/fixed_treat_decimal_as_int.cpp
@@ -7,16 +7,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE("TREAT_DECIMAL_AS_INT SQL_C_DEFAULT resolves to SBIGINT for scale=0", "[fixed][treat_decimal_as_int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "TREAT_DECIMAL_AS_INT SQL_C_DEFAULT resolves to SBIGINT for scale=0",
+                 "[fixed][treat_decimal_as_int]") {
   // Given A Snowflake connection with ODBC_TREAT_DECIMAL_AS_INT=true
-  Connection conn;
   conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When DECIMAL values with scale=0 are fetched via SQL_C_DEFAULT
   (void)0;
@@ -74,11 +73,9 @@ TEST_CASE("TREAT_DECIMAL_AS_INT SQL_C_DEFAULT resolves to SBIGINT for scale=0", 
   }
 }
 
-TEST_CASE("TREAT_DECIMAL_AS_INT does not affect scale > 0", "[fixed][treat_decimal_as_int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "TREAT_DECIMAL_AS_INT does not affect scale > 0", "[fixed][treat_decimal_as_int]") {
   // Given A Snowflake connection with ODBC_TREAT_DECIMAL_AS_INT=true
-  Connection conn;
   conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A DECIMAL(10,2) value is fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 123.45::DECIMAL(10,2)");
@@ -93,11 +90,10 @@ TEST_CASE("TREAT_DECIMAL_AS_INT does not affect scale > 0", "[fixed][treat_decim
   CHECK(std::string(buffer, indicator) == "123.45");
 }
 
-TEST_CASE("TREAT_DECIMAL_AS_INT applies to precision > 18 too", "[fixed][treat_decimal_as_int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "TREAT_DECIMAL_AS_INT applies to precision > 18 too",
+                 "[fixed][treat_decimal_as_int]") {
   // Given A Snowflake connection with ODBC_TREAT_DECIMAL_AS_INT=true
-  Connection conn;
   conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NUMBER(38,0) value is fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 42::NUMBER(38,0)");
@@ -112,13 +108,11 @@ TEST_CASE("TREAT_DECIMAL_AS_INT applies to precision > 18 too", "[fixed][treat_d
   CHECK(value == 42);
 }
 
-TEST_CASE("TREAT_BIG_NUMBER_AS_STRING overrides TREAT_DECIMAL_AS_INT for precision > 18",
-          "[fixed][treat_big_number_as_string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "TREAT_BIG_NUMBER_AS_STRING overrides TREAT_DECIMAL_AS_INT for precision > 18",
+                 "[fixed][treat_big_number_as_string]") {
   // Given A Snowflake connection with both TREAT_DECIMAL_AS_INT and TREAT_BIG_NUMBER_AS_STRING
-  Connection conn;
   conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
   conn.execute("ALTER SESSION SET ODBC_TREAT_BIG_NUMBER_AS_STRING=true");
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NUMBER(38,0) and DECIMAL(10,0) values are fetched via SQL_C_DEFAULT
   (void)0;
@@ -150,11 +144,9 @@ TEST_CASE("TREAT_BIG_NUMBER_AS_STRING overrides TREAT_DECIMAL_AS_INT for precisi
   }
 }
 
-TEST_CASE("TREAT_DECIMAL_AS_INT with table columns", "[fixed][treat_decimal_as_int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "TREAT_DECIMAL_AS_INT with table columns", "[fixed][treat_decimal_as_int]") {
   // Given A Snowflake connection with ODBC_TREAT_DECIMAL_AS_INT=true and a table with mixed columns
-  Connection conn;
   conn.execute("ALTER SESSION SET ODBC_TREAT_DECIMAL_AS_INT=true");
-  auto random_schema = Schema::use_random_schema(conn);
 
   std::string table_name = "test_decimal_as_int";
   TestTable table(conn, table_name, "d_int DECIMAL(10,0), d_frac DECIMAL(10,2), d_big NUMBER(38,0)",

--- a/odbc_tests/tests/e2e/types/float.cpp
+++ b/odbc_tests/tests/e2e/types/float.cpp
@@ -213,7 +213,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select floats from table for float a
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
-  conn.execute("CREATE TABLE float_table (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_table (col FLOAT)");
   conn.execute("INSERT INTO float_table VALUES (0.0), (123.456), (-789.012), (1.23e5), (-9.87e-3)");
 
   // When Query "SELECT * FROM float_table" is executed
@@ -243,7 +243,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle special float values from tab
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
-  conn.execute("CREATE TABLE float_special (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_special (col FLOAT)");
   conn.execute("INSERT INTO float_special SELECT 'NaN'::FLOAT");
   conn.execute("INSERT INTO float_special SELECT 'inf'::FLOAT");
   conn.execute("INSERT INTO float_special SELECT '-inf'::FLOAT");
@@ -278,7 +278,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle float boundary values from ta
 
   // And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308,
   // 2.2250738585072014e-308, 5e-324, 123456789012345.0]
-  conn.execute("CREATE TABLE float_boundary (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_boundary (col FLOAT)");
   conn.execute("INSERT INTO float_boundary VALUES (1.7976931348623157e308)");
   conn.execute("INSERT INTO float_boundary VALUES (-1.7976931348623157e308)");
   conn.execute("INSERT INTO float_boundary VALUES (2.2250738585072014e-308)");
@@ -314,7 +314,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table for fl
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
-  conn.execute("CREATE TABLE float_null (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_null (col FLOAT)");
   conn.execute("INSERT INTO float_null VALUES (NULL), (123.456), (NULL), (-789.012)");
 
   // When Query "SELECT * FROM <table>" is executed
@@ -340,7 +340,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select large result set from table f
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists with 50000 sequential values
-  conn.execute("CREATE TABLE float_large (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_large (col FLOAT)");
   conn.execute("INSERT INTO float_large SELECT seq8()::FLOAT FROM TABLE(GENERATOR(ROWCOUNT => 50000))");
 
   // When Query "SELECT * FROM <table>" is executed
@@ -431,7 +431,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert float using parameter binding
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists
-  conn.execute("CREATE TABLE float_bind_insert (col FLOAT)");
+  conn.execute("CREATE TEMPORARY TABLE float_bind_insert (col FLOAT)");
 
   // When Float values [0.0, 123.456, -789.012, NULL] are bulk-inserted using multirow binding
   constexpr SQLULEN num_rows = 4;

--- a/odbc_tests/tests/e2e/types/float.cpp
+++ b/odbc_tests/tests/e2e/types/float.cpp
@@ -9,7 +9,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 
@@ -209,10 +209,8 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR 
 // TABLE OPERATIONS
 // ============================================================================
 
-TEST_CASE("should select floats from table for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select floats from table for float and synonyms", "[float]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with values [0.0, 123.456, -789.012, 1.23e5, -9.87e-3]
   conn.execute("CREATE TABLE float_table (col FLOAT)");
@@ -241,10 +239,8 @@ TEST_CASE("should select floats from table for float and synonyms", "[float]") {
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-0.00987));
 }
 
-TEST_CASE("should handle special float values from table for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle special float values from table for float and synonyms", "[float]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with values [NaN, inf, -inf, 42.0, -42.0]
   conn.execute("CREATE TABLE float_special (col FLOAT)");
@@ -276,10 +272,9 @@ TEST_CASE("should handle special float values from table for float and synonyms"
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == -42.0);
 }
 
-TEST_CASE("should handle float boundary values from table for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle float boundary values from table for float and synonyms",
+                 "[float]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with boundary values [1.7976931348623157e308, -1.7976931348623157e308,
   // 2.2250738585072014e-308, 5e-324, 123456789012345.0]
@@ -315,10 +310,8 @@ TEST_CASE("should handle float boundary values from table for float and synonyms
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(123456789012345.0));
 }
 
-TEST_CASE("should handle NULL values from table for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table for float and synonyms", "[float]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with values [NULL, 123.456, NULL, -789.012]
   conn.execute("CREATE TABLE float_null (col FLOAT)");
@@ -343,10 +336,8 @@ TEST_CASE("should handle NULL values from table for float and synonyms", "[float
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 1) == Catch::Approx(-789.012));
 }
 
-TEST_CASE("should select large result set from table for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select large result set from table for float and synonyms", "[float]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with 50000 sequential values
   conn.execute("CREATE TABLE float_large (col FLOAT)");
@@ -435,11 +426,9 @@ TEST_CASE("should select float using parameter binding for float and synonyms", 
   CHECK(get_data_optional<SQL_C_DOUBLE>(stmt2, 1) == std::nullopt);
 }
 
-TEST_CASE("should insert float using parameter binding for float and synonyms", "[float]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert float using parameter binding for float and synonyms", "[float]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists
   conn.execute("CREATE TABLE float_bind_insert (col FLOAT)");

--- a/odbc_tests/tests/e2e/types/int.cpp
+++ b/odbc_tests/tests/e2e/types/int.cpp
@@ -145,7 +145,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select values from table for int and
   {
     INFO("positive");
     // And Table with <type> column exists with values <insert_values>
-    conn.execute("CREATE TABLE int_table_positive (col BIGINT)");
+    conn.execute("CREATE TEMPORARY TABLE int_table_positive (col BIGINT)");
     conn.execute(
         "INSERT INTO int_table_positive VALUES "
         "(0), (1), (127), (255), (32767), (65535), (2147483647), (4294967295), (9223372036854775807)");
@@ -169,7 +169,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select values from table for int and
   // negative
   {
     // And Table with <type> column exists with values <insert_values>
-    conn.execute("CREATE TABLE int_table_negative (col BIGINT)");
+    conn.execute("CREATE TEMPORARY TABLE int_table_negative (col BIGINT)");
     conn.execute("INSERT INTO int_table_negative VALUES (-1), (-128), (-32768), (-2147483648), (-9223372036854775808)");
 
     // When Query "SELECT * FROM <table> ORDER BY col" is executed
@@ -191,7 +191,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select values from table for int and
   // null
   {
     // And Table with <type> column exists with values <insert_values>
-    conn.execute("CREATE TABLE int_table_null (col BIGINT)");
+    conn.execute("CREATE TEMPORARY TABLE int_table_null (col BIGINT)");
     conn.execute("INSERT INTO int_table_null VALUES (0), (NULL), (42)");
 
     // When Query "SELECT * FROM <table> ORDER BY col" is executed
@@ -221,7 +221,8 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   // Given Snowflake client is logged in
 
   // And Table with four INT columns exists
-  conn.execute("CREATE TABLE int_different_column_sizes (col_int8 INT, col_int16 INT, col_int32 INT, col_int64 INT)");
+  conn.execute(
+      "CREATE TEMPORARY TABLE int_different_column_sizes (col_int8 INT, col_int16 INT, col_int32 INT, col_int64 INT)");
 
   // And Each column contains values of different magnitudes (50000 rows to span multiple Arrow chunks)
   conn.execute(
@@ -309,7 +310,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select large integer values from tab
 
   // And Table with <type> column exists with values [-99999999999999999999999999999999999999,
   // 99999999999999999999999999999999999999]
-  conn.execute("CREATE TABLE int_large_table (col INT)");
+  conn.execute("CREATE TEMPORARY TABLE int_large_table (col INT)");
   conn.execute(
       "INSERT INTO int_large_table VALUES "
       "(-99999999999999999999999999999999999999), "
@@ -335,7 +336,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert integer using parameter bindi
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists
-  conn.execute("CREATE TABLE int_bind_insert (col BIGINT)");
+  conn.execute("CREATE TEMPORARY TABLE int_bind_insert (col BIGINT)");
 
   // When Integer values [0, -2147483648, 2147483647, 9223372036854775807] are inserted using binding
   auto insert_value = [&](int64_t val) {
@@ -383,7 +384,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   // Given Snowflake client is logged in
 
   // And Table with <type> column exists
-  conn.execute("CREATE TABLE int_batch_bind (col BIGINT)");
+  conn.execute("CREATE TEMPORARY TABLE int_batch_bind (col BIGINT)");
 
   // When Integer values [0, 42, -2147483648, 2147483647, 9223372036854775807] are inserted using binding
   constexpr SQLULEN num_rows = 5;

--- a/odbc_tests/tests/e2e/types/int.cpp
+++ b/odbc_tests/tests/e2e/types/int.cpp
@@ -5,7 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 
@@ -139,10 +139,8 @@ TEST_CASE("should download large result set with multiple chunks for int and syn
   REQUIRE(row_count == 50000);
 }
 
-TEST_CASE("should select values from table for int and synonyms", "[int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select values from table for int and synonyms", "[int]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("positive");
@@ -212,7 +210,8 @@ TEST_CASE("should select values from table for int and synonyms", "[int]") {
   }
 }
 
-TEST_CASE("should handle server-side Arrow memory optimization for int columns on multiple chunks", "[int]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should handle server-side Arrow memory optimization for int columns on multiple chunks", "[int]") {
   constexpr int total_rows = 50000;
   constexpr int64_t expected_col1 = 100;
   constexpr int64_t expected_col2 = 30000;
@@ -220,8 +219,6 @@ TEST_CASE("should handle server-side Arrow memory optimization for int columns o
   constexpr int64_t expected_col4 = 9000000000000000000LL;
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with four INT columns exists
   conn.execute("CREATE TABLE int_different_column_sizes (col_int8 INT, col_int16 INT, col_int32 INT, col_int64 INT)");
@@ -307,10 +304,8 @@ TEST_CASE("should handle NULL values for int and synonyms", "[int]") {
 // Table operations - large integers
 // ============================================================================
 
-TEST_CASE("should select large integer values from table for int and synonyms", "[int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select large integer values from table for int and synonyms", "[int]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists with values [-99999999999999999999999999999999999999,
   // 99999999999999999999999999999999999999]
@@ -336,10 +331,8 @@ TEST_CASE("should select large integer values from table for int and synonyms", 
 // Parameter binding
 // ============================================================================
 
-TEST_CASE("should insert integer using parameter binding for int and synonyms", "[int]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert integer using parameter binding for int and synonyms", "[int]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists
   conn.execute("CREATE TABLE int_bind_insert (col BIGINT)");
@@ -383,11 +376,11 @@ TEST_CASE("should insert integer using parameter binding for int and synonyms", 
   CHECK(get_data<SQL_C_SBIGINT>(stmt, 1) == 9223372036854775807LL);
 }
 
-TEST_CASE("should insert and select integers from table using batch parameter binding for int and synonyms", "[int]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should insert and select integers from table using batch parameter binding for int and synonyms",
+                 "[int]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with <type> column exists
   conn.execute("CREATE TABLE int_batch_bind (col BIGINT)");

--- a/odbc_tests/tests/e2e/types/interval.cpp
+++ b/odbc_tests/tests/e2e/types/interval.cpp
@@ -369,7 +369,7 @@ TEST_CASE("should select INTERVAL YEAR TO MONTH values from table", "[interval]"
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR TO MONTH column is created
-  conn.execute("CREATE TABLE interval_ym_table (C1 INTERVAL YEAR TO MONTH)");
+  conn.execute("CREATE TEMPORARY TABLE interval_ym_table (C1 INTERVAL YEAR TO MONTH)");
 
   // And The table is populated with YEAR TO MONTH values including corner cases
   conn.execute(
@@ -407,7 +407,7 @@ TEST_CASE("should select INTERVAL DAY TO SECOND values from table", "[interval]"
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY TO SECOND column is created
-  conn.execute("CREATE TABLE interval_dt_table (C1 INTERVAL DAY TO SECOND)");
+  conn.execute("CREATE TEMPORARY TABLE interval_dt_table (C1 INTERVAL DAY TO SECOND)");
 
   // And The table is populated with DAY TO SECOND values including corner cases
   conn.execute(
@@ -446,7 +446,7 @@ TEST_CASE("should select INTERVAL YEAR(2) TO MONTH values from table", "[interva
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR(2) TO MONTH column is created
-  conn.execute("CREATE TABLE interval_ym2_table (C1 INTERVAL YEAR(2) TO MONTH)");
+  conn.execute("CREATE TEMPORARY TABLE interval_ym2_table (C1 INTERVAL YEAR(2) TO MONTH)");
 
   // And The table is populated with values ['0-0', '1-2', '-1-3', '99-11', '-99-11', NULL]
   conn.execute(
@@ -484,7 +484,7 @@ TEST_CASE("should select INTERVAL YEAR(7) TO MONTH values from table", "[interva
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR(7) TO MONTH column is created
-  conn.execute("CREATE TABLE interval_ym7_table (C1 INTERVAL YEAR(7) TO MONTH)");
+  conn.execute("CREATE TEMPORARY TABLE interval_ym7_table (C1 INTERVAL YEAR(7) TO MONTH)");
 
   // And The table is populated with values ['0-0', '1-2', '-1-3', '9999999-11', '-9999999-11', NULL]
   conn.execute(
@@ -522,7 +522,7 @@ TEST_CASE("should select INTERVAL DAY(3) TO SECOND values from table", "[interva
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY(3) TO SECOND column is created
-  conn.execute("CREATE TABLE interval_dt3_table (C1 INTERVAL DAY(3) TO SECOND)");
+  conn.execute("CREATE TEMPORARY TABLE interval_dt3_table (C1 INTERVAL DAY(3) TO SECOND)");
 
   // And The table is populated with values ['0 0:0:0.0', '1 2:3:4.567', '-1 2:3:4.567',
   //   '999 23:59:59.999999', '-999 23:59:59.999999', NULL]
@@ -566,7 +566,7 @@ TEST_CASE("should insert and select back INTERVAL YEAR TO MONTH values using par
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR TO MONTH column is created
-  conn.execute("CREATE TABLE interval_bind_ym (C1 INTERVAL YEAR TO MONTH)");
+  conn.execute("CREATE TEMPORARY TABLE interval_bind_ym (C1 INTERVAL YEAR TO MONTH)");
 
   // When INTERVAL YEAR TO MONTH values ['0-0', '1-2', '-1-3', '999999999-11', '-999999999-11', NULL]
   //   are inserted using parameter binding
@@ -623,7 +623,7 @@ TEST_CASE("should insert and select back INTERVAL DAY TO SECOND values using par
   Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY TO SECOND column is created
-  conn.execute("CREATE TABLE interval_bind_dt (C1 INTERVAL DAY TO SECOND)");
+  conn.execute("CREATE TEMPORARY TABLE interval_bind_dt (C1 INTERVAL DAY TO SECOND)");
 
   // When INTERVAL DAY TO SECOND values ['0 0:0:0.0', '12 3:4:5.678', '-1 2:3:4.567',
   //   '99999 23:59:59.999999', '-99999 23:59:59.999999', NULL] are inserted using parameter binding

--- a/odbc_tests/tests/e2e/types/interval.cpp
+++ b/odbc_tests/tests/e2e/types/interval.cpp
@@ -366,7 +366,7 @@ TEST_CASE("should select INTERVAL YEAR TO MONTH values from table", "[interval]"
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR TO MONTH column is created
   conn.execute("CREATE TABLE interval_ym_table (C1 INTERVAL YEAR TO MONTH)");
@@ -404,7 +404,7 @@ TEST_CASE("should select INTERVAL DAY TO SECOND values from table", "[interval]"
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY TO SECOND column is created
   conn.execute("CREATE TABLE interval_dt_table (C1 INTERVAL DAY TO SECOND)");
@@ -443,7 +443,7 @@ TEST_CASE("should select INTERVAL YEAR(2) TO MONTH values from table", "[interva
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR(2) TO MONTH column is created
   conn.execute("CREATE TABLE interval_ym2_table (C1 INTERVAL YEAR(2) TO MONTH)");
@@ -481,7 +481,7 @@ TEST_CASE("should select INTERVAL YEAR(7) TO MONTH values from table", "[interva
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR(7) TO MONTH column is created
   conn.execute("CREATE TABLE interval_ym7_table (C1 INTERVAL YEAR(7) TO MONTH)");
@@ -519,7 +519,7 @@ TEST_CASE("should select INTERVAL DAY(3) TO SECOND values from table", "[interva
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY(3) TO SECOND column is created
   conn.execute("CREATE TABLE interval_dt3_table (C1 INTERVAL DAY(3) TO SECOND)");
@@ -563,7 +563,7 @@ TEST_CASE("should insert and select back INTERVAL YEAR TO MONTH values using par
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL YEAR TO MONTH column is created
   conn.execute("CREATE TABLE interval_bind_ym (C1 INTERVAL YEAR TO MONTH)");
@@ -620,7 +620,7 @@ TEST_CASE("should insert and select back INTERVAL DAY TO SECOND values using par
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
 
   // And A temporary table with INTERVAL DAY TO SECOND column is created
   conn.execute("CREATE TABLE interval_bind_dt (C1 INTERVAL DAY TO SECOND)");

--- a/odbc_tests/tests/e2e/types/number.cpp
+++ b/odbc_tests/tests/e2e/types/number.cpp
@@ -2,7 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "get_data.hpp"
 
 TEST_CASE("should cast number values to appropriate type for number and synonyms", "[number]") {
@@ -125,15 +125,14 @@ TEST_CASE("should download large result set with multiple chunks from GENERATOR 
   REQUIRE(row_count == 30000);
 }
 
-TEST_CASE("should select numbers from table with multiple scales for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select numbers from table with multiple scales for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
-  conn.execute("DROP TABLE IF EXISTS number_table");
   conn.execute(
-      "CREATE TABLE number_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3), col4 NUMBER(20,5))");
+      "CREATE OR REPLACE TABLE number_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3), col4 "
+      "NUMBER(20,5))");
 
   // And Row (123, 123.45, 123.456, 12345.67890) is inserted
   conn.execute("INSERT INTO number_table VALUES (123, 123.45, 123.456, 12345.67890)");
@@ -178,14 +177,12 @@ TEST_CASE("should select numbers from table with multiple scales for number and 
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 4) == Catch::Approx(123456.78901).epsilon(0.00001));
 }
 
-TEST_CASE("should handle scale and precision boundaries from table for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle scale and precision boundaries from table for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(5,2), <type>(8,0)) exists
-  conn.execute("DROP TABLE IF EXISTS number_boundary_table");
-  conn.execute("CREATE TABLE number_boundary_table (col1 NUMBER(5,2), col2 NUMBER(8,0))");
+  conn.execute("CREATE OR REPLACE TABLE number_boundary_table (col1 NUMBER(5,2), col2 NUMBER(8,0))");
 
   // And Row (999.99, 99999999) is inserted
   conn.execute("INSERT INTO number_boundary_table VALUES (999.99, 99999999)");
@@ -234,10 +231,9 @@ TEST_CASE("should handle NULL values from literals for number and synonyms", "[n
   CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 4) == std::optional<double>(42.50));
 }
 
-TEST_CASE("should handle NULL values from table with multiple scales for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table with multiple scales for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
   conn.execute("CREATE TABLE number_null_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3))");
@@ -277,15 +273,12 @@ TEST_CASE("should handle NULL values from table with multiple scales for number 
   CHECK(get_data<SQL_C_DOUBLE>(stmt, 3) == -789.012);
 }
 
-TEST_CASE("should download large result set from table for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set from table for number and synonyms", "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from 0 to 29999 in the
   // first column and from 0.12345 to 29999.12345 in the second column
-  conn.execute("DROP TABLE IF EXISTS number_large_table");
-  conn.execute("CREATE TABLE number_large_table (col1 NUMBER(38,0), col2 NUMBER(20,5))");
+  conn.execute("CREATE OR REPLACE TABLE number_large_table (col1 NUMBER(38,0), col2 NUMBER(20,5))");
   conn.execute(
       "INSERT INTO number_large_table SELECT seq8(), seq8() + 0.12345 FROM TABLE(GENERATOR(ROWCOUNT => 30000))");
 
@@ -372,10 +365,9 @@ TEST_CASE("should handle high precision boundaries from literals for number and 
 // High precision table operations
 // ============================================================================
 
-TEST_CASE("should handle high precision values from table for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle high precision values from table for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
   conn.execute(
@@ -403,10 +395,9 @@ TEST_CASE("should handle high precision values from table for number and synonym
   CHECK(get_data<SQL_C_CHAR>(stmt, 4) == "1.2345678901234567890123456789012345678");
 }
 
-TEST_CASE("should handle high precision boundaries from table for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle high precision boundaries from table for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(38,0), <type>(38,37)) exists
   conn.execute("CREATE TABLE number_high_prec_boundary (col1 NUMBER(38,0), col2 NUMBER(38,37))");
@@ -539,10 +530,9 @@ TEST_CASE("should select high precision number using parameter binding for numbe
 // Parameter binding - INSERT
 // ============================================================================
 
-TEST_CASE("should insert number using parameter binding for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert number using parameter binding for number and synonyms",
+                 "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(10,0), <type>(10,2)) exists
   conn.execute("CREATE TABLE number_bind_insert (col1 NUMBER(10,0), col2 NUMBER(10,2))");
@@ -617,10 +607,9 @@ TEST_CASE("should insert number using parameter binding for number and synonyms"
   CHECK(get_data_optional<SQL_C_DOUBLE>(stmt, 2) == std::nullopt);
 }
 
-TEST_CASE("should insert high precision number using parameter binding for number and synonyms", "[number]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should insert high precision number using parameter binding for number and synonyms", "[number]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with columns (<type>(38,0), <type>(38,2)) exists
   conn.execute("CREATE TABLE number_bind_high_prec (col1 NUMBER(38,0), col2 NUMBER(38,2))");

--- a/odbc_tests/tests/e2e/types/number.cpp
+++ b/odbc_tests/tests/e2e/types/number.cpp
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select numbers from table with multi
 
   // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
   conn.execute(
-      "CREATE OR REPLACE TABLE number_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3), col4 "
+      "CREATE TEMPORARY TABLE number_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3), col4 "
       "NUMBER(20,5))");
 
   // And Row (123, 123.45, 123.456, 12345.67890) is inserted
@@ -182,7 +182,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle scale and precision boundarie
   // Given Snowflake client is logged in
 
   // And Table with columns (<type>(5,2), <type>(8,0)) exists
-  conn.execute("CREATE OR REPLACE TABLE number_boundary_table (col1 NUMBER(5,2), col2 NUMBER(8,0))");
+  conn.execute("CREATE TEMPORARY TABLE number_boundary_table (col1 NUMBER(5,2), col2 NUMBER(8,0))");
 
   // And Row (999.99, 99999999) is inserted
   conn.execute("INSERT INTO number_boundary_table VALUES (999.99, 99999999)");
@@ -236,7 +236,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL values from table with m
   // Given Snowflake client is logged in
 
   // And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
-  conn.execute("CREATE TABLE number_null_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3))");
+  conn.execute("CREATE TEMPORARY TABLE number_null_table (col1 NUMBER(10,0), col2 NUMBER(10,2), col3 NUMBER(15,3))");
   // And Row (NULL, NULL, NULL) is inserted
   conn.execute("INSERT INTO number_null_table VALUES (NULL, NULL, NULL)");
   // And Row (123, 123.45, 123.456) is inserted
@@ -278,7 +278,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download large result set from table
 
   // And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows, from 0 to 29999 in the
   // first column and from 0.12345 to 29999.12345 in the second column
-  conn.execute("CREATE OR REPLACE TABLE number_large_table (col1 NUMBER(38,0), col2 NUMBER(20,5))");
+  conn.execute("CREATE TEMPORARY TABLE number_large_table (col1 NUMBER(38,0), col2 NUMBER(20,5))");
   conn.execute(
       "INSERT INTO number_large_table SELECT seq8(), seq8() + 0.12345 FROM TABLE(GENERATOR(ROWCOUNT => 30000))");
 
@@ -371,7 +371,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle high precision values from ta
 
   // And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
   conn.execute(
-      "CREATE TABLE number_high_prec ("
+      "CREATE TEMPORARY TABLE number_high_prec ("
       "col1 NUMBER(38,0), col2 NUMBER(38,2), col3 NUMBER(38,10), col4 NUMBER(38,37))");
 
   // And Row (12345678901234567890123456789012345678, 123456789012345678901234567890123456.78,
@@ -400,7 +400,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle high precision boundaries fro
   // Given Snowflake client is logged in
 
   // And Table with columns (<type>(38,0), <type>(38,37)) exists
-  conn.execute("CREATE TABLE number_high_prec_boundary (col1 NUMBER(38,0), col2 NUMBER(38,37))");
+  conn.execute("CREATE TEMPORARY TABLE number_high_prec_boundary (col1 NUMBER(38,0), col2 NUMBER(38,37))");
 
   // And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678) is inserted
   conn.execute(
@@ -535,7 +535,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert number using parameter bindin
   // Given Snowflake client is logged in
 
   // And Table with columns (<type>(10,0), <type>(10,2)) exists
-  conn.execute("CREATE TABLE number_bind_insert (col1 NUMBER(10,0), col2 NUMBER(10,2))");
+  conn.execute("CREATE TEMPORARY TABLE number_bind_insert (col1 NUMBER(10,0), col2 NUMBER(10,2))");
 
   // When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are inserted using binding
   auto insert_row = [&](const char* val1, const char* val2) {
@@ -612,7 +612,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   // Given Snowflake client is logged in
 
   // And Table with columns (<type>(38,0), <type>(38,2)) exists
-  conn.execute("CREATE TABLE number_bind_high_prec (col1 NUMBER(38,0), col2 NUMBER(38,2))");
+  conn.execute("CREATE TEMPORARY TABLE number_bind_high_prec (col1 NUMBER(38,0), col2 NUMBER(38,2))");
 
   // When Rows (12345678901234567890123456789012345678, 123456789012345678901234567890123456.78),
   // (99999999999999999999999999999999999999, 0.01), (-99999999999999999999999999999999999999, -0.01) are inserted

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_binary.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_binary.cpp
@@ -7,7 +7,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_diag_rec.hpp"
@@ -18,12 +18,10 @@
 // value as SQL_NUMERIC_STRUCT into the buffer.
 // ============================================================================
 
-TEST_CASE("REAL to SQL_C_BINARY", "[e2e][types][real][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL to SQL_C_BINARY", "[e2e][types][real][binary]") {
   // Given A Snowflake connection is established
   SKIP_OLD_DRIVER("BD#14",
                   "Old driver returns raw f64 bytes instead of SQL_NUMERIC_STRUCT for SQL_C_BINARY on FLOAT columns");
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When REAL values are fetched as SQL_C_BINARY
   (void)0;  // Brace blocks below perform the fetch and assertions
@@ -96,11 +94,9 @@ TEST_CASE("REAL to SQL_C_BINARY", "[e2e][types][real][binary]") {
   check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_BINARY);
 }
 
-TEST_CASE("REAL SQL_C_BINARY buffer too small returns 22003", "[e2e][types][real][binary][22003]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_BINARY buffer too small returns 22003",
+                 "[e2e][types][real][binary][22003]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
   // When A REAL value is fetched as SQL_C_BINARY into a buffer smaller than SQL_NUMERIC_STRUCT
   auto stmt = conn.execute_fetch("SELECT 42.0::FLOAT");
   char tiny_buffer[4];
@@ -112,11 +108,9 @@ TEST_CASE("REAL SQL_C_BINARY buffer too small returns 22003", "[e2e][types][real
   CHECK(get_sqlstate(stmt) == "22003");
 }
 
-TEST_CASE("REAL SQL_C_BINARY negative zero", "[e2e][types][real][binary][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_BINARY negative zero", "[e2e][types][real][binary][edge]") {
   // Given A Snowflake connection is established
   SKIP_OLD_DRIVER("BD#14", "Old driver returns raw f64 bytes instead of SQL_NUMERIC_STRUCT for FLOAT columns");
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When -0.5 is fetched as SQL_C_BINARY
   auto stmt = conn.execute_fetch("SELECT -0.5::FLOAT");
@@ -133,11 +127,8 @@ TEST_CASE("REAL SQL_C_BINARY negative zero", "[e2e][types][real][binary][edge]")
   CHECK(numeric.val[0] == 0);
 }
 
-TEST_CASE("REAL NULL to SQL_C_BINARY", "[real][conversion][c_binary][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_BINARY", "[real][conversion][c_binary][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
-
   // When A NULL FLOAT value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");
   // Then NULL FLOAT values return SQL_NULL_DATA

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_bit.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_bit.cpp
@@ -8,14 +8,12 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 
-TEST_CASE("REAL explicit SQL_C_BIT - basic", "[e2e][types][real][conversion][c_bit]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_BIT - basic", "[e2e][types][real][conversion][c_bit]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Various FLOAT values are fetched as SQL_C_BIT
   (void)0;
@@ -28,10 +26,8 @@ TEST_CASE("REAL explicit SQL_C_BIT - basic", "[e2e][types][real][conversion][c_b
   check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -1.5::FLOAT"), 1);
 }
 
-TEST_CASE("REAL SQL_C_BIT spec compliance", "[e2e][types][real][conversion][c_bit]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_BIT spec compliance", "[e2e][types][real][conversion][c_bit]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values are fetched as SQL_C_BIT per ODBC spec
   (void)0;
@@ -58,10 +54,9 @@ TEST_CASE("REAL SQL_C_BIT spec compliance", "[e2e][types][real][conversion][c_bi
   check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 100.0::FLOAT"), 1);
 }
 
-TEST_CASE("REAL SQL_C_BIT rejects negative fractions", "[e2e][types][real][conversion][c_bit][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_BIT rejects negative fractions",
+                 "[e2e][types][real][conversion][c_bit][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Negative fractional FLOAT values are fetched as SQL_C_BIT
   (void)0;
@@ -72,11 +67,10 @@ TEST_CASE("REAL SQL_C_BIT rejects negative fractions", "[e2e][types][real][conve
   check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT -0.9999::FLOAT"), 1);
 }
 
-TEST_CASE("REAL NaN to BIT returns error", "[e2e][types][real][conversion][c_bit][nan][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NaN to BIT returns error",
+                 "[e2e][types][real][conversion][c_bit][nan][edge]") {
   SKIP_OLD_DRIVER("BD#16", "Old driver silently converts NaN to 0 for BIT target");
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NaN FLOAT value is fetched as SQL_C_BIT
   (void)0;
@@ -84,10 +78,9 @@ TEST_CASE("REAL NaN to BIT returns error", "[e2e][types][real][conversion][c_bit
   check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 }
 
-TEST_CASE("REAL Infinity to BIT returns 22003", "[e2e][types][real][conversion][c_bit][infinity][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL Infinity to BIT returns 22003",
+                 "[e2e][types][real][conversion][c_bit][infinity][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Infinity FLOAT values are fetched as SQL_C_BIT
   (void)0;
@@ -96,10 +89,8 @@ TEST_CASE("REAL Infinity to BIT returns 22003", "[e2e][types][real][conversion][
   check_numeric_out_of_range<SQL_C_BIT>(conn.execute_fetch("SELECT '-Infinity'::FLOAT"), 1);
 }
 
-TEST_CASE("REAL NULL to SQL_C_BIT", "[real][conversion][c_bit][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_BIT", "[real][conversion][c_bit][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL FLOAT value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_char.cpp
@@ -8,15 +8,13 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_diag_rec.hpp"
 
-TEST_CASE("REAL explicit SQL_C_CHAR", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_CHAR", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values are fetched as SQL_C_CHAR
   auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT, -99.5::FLOAT, 0::FLOAT");
@@ -31,10 +29,8 @@ TEST_CASE("REAL explicit SQL_C_CHAR", "[e2e][types][real]") {
   CHECK_THAT(std::stod(s3), Catch::Matchers::WithinAbs(0.0, 1e-15));
 }
 
-TEST_CASE("REAL to SQL_C_WCHAR", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL to SQL_C_WCHAR", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values are fetched as SQL_C_WCHAR
   {
@@ -59,10 +55,8 @@ TEST_CASE("REAL to SQL_C_WCHAR", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL SQL_C_CHAR buffer handling", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_CHAR buffer handling", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values are fetched into various buffer sizes as SQL_C_CHAR
   (void)0;  // SECTIONs below perform the fetch
@@ -105,10 +99,8 @@ TEST_CASE("REAL SQL_C_CHAR buffer handling", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL SQL_C_WCHAR buffer handling", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_WCHAR buffer handling", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values are fetched into various buffer sizes as SQL_C_WCHAR
   (void)0;  // SECTIONs below perform the fetch
@@ -148,10 +140,8 @@ TEST_CASE("REAL SQL_C_WCHAR buffer handling", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_CHAR for special values", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Special FLOAT values (integer-valued, negative, very small, very large) are fetched as SQL_C_CHAR
   {
@@ -179,10 +169,8 @@ TEST_CASE("REAL explicit SQL_C_CHAR for special values", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL NaN to CHAR produces NaN string", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NaN to CHAR produces NaN string", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NaN is fetched as SQL_C_CHAR
   auto stmt = conn.execute_fetch("SELECT 'NaN'::FLOAT");
@@ -196,10 +184,8 @@ TEST_CASE("REAL NaN to CHAR produces NaN string", "[e2e][types][real]") {
   CHECK(result == "NaN");
 }
 
-TEST_CASE("REAL NULL to SQL_C_CHAR", "[real][conversion][c_char][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_CHAR", "[real][conversion][c_char][null]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL FLOAT value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_default.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_default.cpp
@@ -13,7 +13,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "conversion_checks.hpp"
 
@@ -32,15 +32,12 @@ inline SQLDOUBLE get_data_default_as_double(const StatementHandleWrapper& stmt, 
 // SQL_C_DEFAULT for FLOAT/DOUBLE columns
 // ============================================================================
 
-TEST_CASE("REAL default conversion - basic values", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - basic values", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT/DOUBLE values are inserted and fetched via SQL_C_DEFAULT
-  conn.execute("DROP TABLE IF EXISTS test_real_default");
   conn.execute(
-      "CREATE TABLE test_real_default ("
+      "CREATE OR REPLACE TABLE test_real_default ("
       "  f1 FLOAT, "
       "  f2 DOUBLE, "
       "  f3 FLOAT)");
@@ -54,10 +51,8 @@ TEST_CASE("REAL default conversion - basic values", "[e2e][types][real]") {
   CHECK(get_data_default_as_double(stmt, 3) == 0.0);
 }
 
-TEST_CASE("REAL default conversion - integer values stored as float", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - integer values stored as float", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Integer values stored as FLOAT are fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 42::FLOAT, -100::FLOAT, 0::FLOAT, 1::FLOAT");
@@ -69,14 +64,11 @@ TEST_CASE("REAL default conversion - integer values stored as float", "[e2e][typ
   CHECK(get_data_default_as_double(stmt, 4) == 1.0);
 }
 
-TEST_CASE("REAL default conversion - extreme values near DBL_MAX", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - extreme values near DBL_MAX", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Extreme values near DBL_MAX are inserted and fetched via SQL_C_DEFAULT
-  conn.execute("DROP TABLE IF EXISTS test_real_extreme");
-  conn.execute("CREATE TABLE test_real_extreme (val DOUBLE)");
+  conn.execute("CREATE OR REPLACE TABLE test_real_extreme (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_extreme VALUES "
       "(1.7976931348623157e308), "
@@ -113,10 +105,8 @@ TEST_CASE("REAL default conversion - extreme values near DBL_MAX", "[e2e][types]
   CHECK(get_data_default_as_double(stmt, 1) == -1.7976931348623157e308);
 }
 
-TEST_CASE("REAL default conversion - very small values", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - very small values", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Very small DOUBLE values are fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch(
@@ -136,15 +126,13 @@ TEST_CASE("REAL default conversion - very small values", "[e2e][types][real]") {
   CHECK(v3 > -1e-300);
 }
 
-TEST_CASE("REAL default conversion - FLOAT, DOUBLE, REAL synonyms produce same result", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - FLOAT, DOUBLE, REAL synonyms produce same result",
+                 "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Same value is stored in FLOAT, DOUBLE, REAL columns and fetched via SQL_C_DEFAULT
-  conn.execute("DROP TABLE IF EXISTS test_real_synonyms");
   conn.execute(
-      "CREATE TABLE test_real_synonyms ("
+      "CREATE OR REPLACE TABLE test_real_synonyms ("
       "  f FLOAT, "
       "  d DOUBLE, "
       "  r REAL)");
@@ -161,14 +149,11 @@ TEST_CASE("REAL default conversion - FLOAT, DOUBLE, REAL synonyms produce same r
   CHECK(d == r);
 }
 
-TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Values are fetched with SQL_C_DOUBLE and SQL_C_DEFAULT
-  conn.execute("DROP TABLE IF EXISTS test_real_default_vs_explicit");
-  conn.execute("CREATE TABLE test_real_default_vs_explicit (val DOUBLE)");
+  conn.execute("CREATE OR REPLACE TABLE test_real_default_vs_explicit (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_default_vs_explicit VALUES "
       "(1.5), (-2.75), (0.0), (999999.999), (1.7976931348623157e308)");
@@ -200,14 +185,11 @@ TEST_CASE("REAL SQL_C_DEFAULT matches explicit SQL_C_DOUBLE", "[e2e][types][real
   }
 }
 
-TEST_CASE("REAL default conversion - multiple rows", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - multiple rows", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Multiple DOUBLE rows are fetched via SQL_C_DEFAULT
-  conn.execute("DROP TABLE IF EXISTS test_real_multi");
-  conn.execute("CREATE TABLE test_real_multi (val DOUBLE)");
+  conn.execute("CREATE OR REPLACE TABLE test_real_multi (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_multi VALUES "
       "(1.5), (-2.75), (0.0), (1e100), (-1e100)");
@@ -226,10 +208,8 @@ TEST_CASE("REAL default conversion - multiple rows", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL default conversion - fractional values", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - fractional values", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Fractional FLOAT values are fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 0.1::FLOAT, 0.5::FLOAT, 0.333333333::FLOAT");
@@ -244,10 +224,8 @@ TEST_CASE("REAL default conversion - fractional values", "[e2e][types][real]") {
   CHECK_THAT(v3, Catch::Matchers::WithinRel(0.333333333));
 }
 
-TEST_CASE("REAL zero is exactly zero", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL zero is exactly zero", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Zero FLOAT value is fetched via SQL_C_DEFAULT
   auto stmt = conn.execute_fetch("SELECT 0.0::FLOAT");
@@ -258,10 +236,8 @@ TEST_CASE("REAL zero is exactly zero", "[e2e][types][real]") {
   CHECK(val == 0.0);
 }
 
-TEST_CASE("REAL table column conversions", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL table column conversions", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with FLOAT, DOUBLE, REAL columns is queried
   TestTable table(conn, "test_real_conversions", "f FLOAT, d DOUBLE, r REAL", "(1.5, -2.75, 100.0)");
@@ -294,10 +270,8 @@ TEST_CASE("REAL table column conversions", "[e2e][types][real]") {
   }
 }
 
-TEST_CASE("REAL NULL to SQL_C_DEFAULT", "[real][conversion][c_default][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_DEFAULT", "[real][conversion][c_default][null]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL FLOAT value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_default.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_default.cpp
@@ -37,7 +37,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - basic values", "[
 
   // When FLOAT/DOUBLE values are inserted and fetched via SQL_C_DEFAULT
   conn.execute(
-      "CREATE OR REPLACE TABLE test_real_default ("
+      "CREATE TEMPORARY TABLE test_real_default ("
       "  f1 FLOAT, "
       "  f2 DOUBLE, "
       "  f3 FLOAT)");
@@ -68,7 +68,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - extreme values ne
   // Given A Snowflake connection
 
   // When Extreme values near DBL_MAX are inserted and fetched via SQL_C_DEFAULT
-  conn.execute("CREATE OR REPLACE TABLE test_real_extreme (val DOUBLE)");
+  conn.execute("CREATE TEMPORARY TABLE test_real_extreme (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_extreme VALUES "
       "(1.7976931348623157e308), "
@@ -132,7 +132,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - FLOAT, DOUBLE, RE
 
   // When Same value is stored in FLOAT, DOUBLE, REAL columns and fetched via SQL_C_DEFAULT
   conn.execute(
-      "CREATE OR REPLACE TABLE test_real_synonyms ("
+      "CREATE TEMPORARY TABLE test_real_synonyms ("
       "  f FLOAT, "
       "  d DOUBLE, "
       "  r REAL)");
@@ -153,7 +153,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_DEFAULT matches explicit SQL_C_D
   // Given A Snowflake connection
 
   // When Values are fetched with SQL_C_DOUBLE and SQL_C_DEFAULT
-  conn.execute("CREATE OR REPLACE TABLE test_real_default_vs_explicit (val DOUBLE)");
+  conn.execute("CREATE TEMPORARY TABLE test_real_default_vs_explicit (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_default_vs_explicit VALUES "
       "(1.5), (-2.75), (0.0), (999999.999), (1.7976931348623157e308)");
@@ -189,7 +189,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "REAL default conversion - multiple rows", "
   // Given A Snowflake connection
 
   // When Multiple DOUBLE rows are fetched via SQL_C_DEFAULT
-  conn.execute("CREATE OR REPLACE TABLE test_real_multi (val DOUBLE)");
+  conn.execute("CREATE TEMPORARY TABLE test_real_multi (val DOUBLE)");
   conn.execute(
       "INSERT INTO test_real_multi VALUES "
       "(1.5), (-2.75), (0.0), (1e100), (-1e100)");

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_float.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_float.cpp
@@ -11,7 +11,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "TestTable.hpp"
 #include "conversion_checks.hpp"
 #include "get_diag_rec.hpp"
@@ -20,10 +20,8 @@
 // Explicit C type conversions from FLOAT columns
 // ============================================================================
 
-TEST_CASE("REAL explicit SQL_C_DOUBLE", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_DOUBLE", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT value is fetched as SQL_C_DOUBLE
   auto stmt = conn.execute_fetch("SELECT 123.456::FLOAT");
@@ -34,10 +32,8 @@ TEST_CASE("REAL explicit SQL_C_DOUBLE", "[e2e][types][real]") {
   CHECK_THAT(val, Catch::Matchers::WithinRel(123.456));
 }
 
-TEST_CASE("REAL explicit SQL_C_FLOAT", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_FLOAT", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT value is fetched as SQL_C_FLOAT
   auto stmt = conn.execute_fetch("SELECT 123.5::FLOAT");
@@ -48,10 +44,9 @@ TEST_CASE("REAL explicit SQL_C_FLOAT", "[e2e][types][real]") {
   CHECK_THAT(val, Catch::Matchers::WithinRel(123.5f));
 }
 
-TEST_CASE("REAL precision - Snowflake FLOAT has ~15 significant digits", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL precision - Snowflake FLOAT has ~15 significant digits",
+                 "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT value with 15 significant digits is fetched as SQL_C_DOUBLE
   auto stmt = conn.execute_fetch("SELECT 1.23456789012345::FLOAT");
@@ -61,10 +56,8 @@ TEST_CASE("REAL precision - Snowflake FLOAT has ~15 significant digits", "[e2e][
   CHECK_THAT(val, Catch::Matchers::WithinRel(1.23456789012345));
 }
 
-TEST_CASE("REAL negative zero", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL negative zero", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Negative zero FLOAT is fetched as SQL_C_DOUBLE
   auto stmt = conn.execute_fetch("SELECT -0.0::FLOAT");
@@ -74,10 +67,8 @@ TEST_CASE("REAL negative zero", "[e2e][types][real]") {
   CHECK(val == 0.0);
 }
 
-TEST_CASE("REAL SQL_C_FLOAT precision loss", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_FLOAT precision loss", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Values representable in f32 are fetched as SQL_C_FLOAT
   auto stmt1 = conn.execute_fetch("SELECT 0.5::FLOAT");
@@ -90,10 +81,8 @@ TEST_CASE("REAL SQL_C_FLOAT precision loss", "[e2e][types][real]") {
   CHECK(check_no_truncation<SQL_C_FLOAT>(stmt2, 1) == 1000000.0f);
 }
 
-TEST_CASE("REAL SQL_C_FLOAT overflow returns 22003", "[e2e][types][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_FLOAT overflow returns 22003", "[e2e][types][real]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Values exceeding f32 range are fetched as SQL_C_FLOAT
   auto stmt_pos = conn.execute_fetch("SELECT 1e300::FLOAT");
@@ -110,10 +99,8 @@ TEST_CASE("REAL SQL_C_FLOAT overflow returns 22003", "[e2e][types][real]") {
   CHECK(check_no_truncation<SQL_C_FLOAT>(stmt_ok, 1) == 1e38f);
 }
 
-TEST_CASE("REAL NULL to SQL_C_FLOAT and SQL_C_DOUBLE", "[real][conversion][c_float][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_FLOAT and SQL_C_DOUBLE", "[real][conversion][c_float][null]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NULL FLOAT values are queried
   const auto query = "SELECT NULL::FLOAT";
@@ -122,10 +109,9 @@ TEST_CASE("REAL NULL to SQL_C_FLOAT and SQL_C_DOUBLE", "[real][conversion][c_flo
   check_null_via_get_data(conn.execute_fetch("SELECT NULL::DOUBLE"), 1, SQL_C_FLOAT);
 }
 
-TEST_CASE("REAL NULL mixed with non-NULL in multiple rows", "[real][conversion][c_float][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL mixed with non-NULL in multiple rows",
+                 "[real][conversion][c_float][null]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A table with mixed NULL and non-NULL FLOAT rows is queried
   TestTable table(conn, "test_real_null", "val FLOAT", "(1.5), (NULL), (-2.75), (NULL), (0.0)");
@@ -153,10 +139,9 @@ TEST_CASE("REAL NULL mixed with non-NULL in multiple rows", "[real][conversion][
   }
 }
 
-TEST_CASE("REAL SQLGetData NULL without indicator returns 22002", "[real][conversion][c_float][null][22002]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQLGetData NULL without indicator returns 22002",
+                 "[real][conversion][c_float][null][22002]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL FLOAT value is fetched without providing an indicator pointer
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_integer.cpp
@@ -10,15 +10,14 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_diag_rec.hpp"
 
-TEST_CASE("REAL explicit integer conversions truncate fractional part", "[e2e][types][real][conversion][c_integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit integer conversions truncate fractional part",
+                 "[e2e][types][real][conversion][c_integer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A fractional FLOAT value 123.789 is fetched as each integer C type
   const std::string query = "SELECT 123.789::FLOAT";
@@ -37,10 +36,9 @@ TEST_CASE("REAL explicit integer conversions truncate fractional part", "[e2e][t
   CHECK(check_fractional_truncation<SQL_C_UBIGINT>(conn.execute_fetch(query), 1) == 123);
 }
 
-TEST_CASE("REAL explicit integer conversions - negative value", "[e2e][types][real][conversion][c_integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit integer conversions - negative value",
+                 "[e2e][types][real][conversion][c_integer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A negative fractional FLOAT value -42.9 is fetched as signed integer C types
   const std::string query = "SELECT -42.9::FLOAT";
@@ -55,10 +53,9 @@ TEST_CASE("REAL explicit integer conversions - negative value", "[e2e][types][re
   CHECK(check_fractional_truncation<SQL_C_SBIGINT>(conn.execute_fetch(query), 1) == -42);
 }
 
-TEST_CASE("REAL explicit SQL_C_SBIGINT with large values", "[e2e][types][real][conversion][c_integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit SQL_C_SBIGINT with large values",
+                 "[e2e][types][real][conversion][c_integer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When The largest integer exactly representable as f64 (2^53) is fetched as SQL_C_SBIGINT
   auto stmt = conn.execute_fetch("SELECT 9007199254740992::FLOAT");
@@ -67,10 +64,9 @@ TEST_CASE("REAL explicit SQL_C_SBIGINT with large values", "[e2e][types][real][c
   CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 1) == 9007199254740992LL);
 }
 
-TEST_CASE("REAL fractional truncation returns 01S07", "[e2e][types][real][conversion][c_integer][01S07]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL fractional truncation returns 01S07",
+                 "[e2e][types][real][conversion][c_integer][01S07]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Fractional FLOAT values are fetched as integer C types
   (void)0;
@@ -112,10 +108,8 @@ TEST_CASE("REAL fractional truncation returns 01S07", "[e2e][types][real][conver
   }
 }
 
-TEST_CASE("REAL overflow returns 22003", "[e2e][types][real][conversion][c_integer][22003]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL overflow returns 22003", "[e2e][types][real][conversion][c_integer][22003]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Out-of-range FLOAT values are fetched as narrow integer C types
   (void)0;
@@ -135,10 +129,9 @@ TEST_CASE("REAL overflow returns 22003", "[e2e][types][real][conversion][c_integ
   check_numeric_out_of_range<SQL_C_UBIGINT>(conn.execute_fetch("SELECT -1.0::FLOAT"), 1);
 }
 
-TEST_CASE("REAL explicit unsigned integer conversions", "[e2e][types][real][conversion][c_integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL explicit unsigned integer conversions",
+                 "[e2e][types][real][conversion][c_integer]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   const std::string q_exact = "SELECT 42.0::FLOAT";
   const std::string q_frac = "SELECT 42.9::FLOAT";
@@ -169,10 +162,9 @@ TEST_CASE("REAL explicit unsigned integer conversions", "[e2e][types][real][conv
   }
 }
 
-TEST_CASE("REAL integer boundary values for overflow", "[e2e][types][real][conversion][c_integer][edge][22003]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL integer boundary values for overflow",
+                 "[e2e][types][real][conversion][c_integer][edge][22003]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When FLOAT values at or just past integer type boundaries are fetched
   (void)0;
@@ -191,11 +183,9 @@ TEST_CASE("REAL integer boundary values for overflow", "[e2e][types][real][conve
   check_numeric_out_of_range<SQL_C_STINYINT>(conn.execute_fetch("SELECT 128.1::FLOAT"), 1);
 }
 
-TEST_CASE("REAL negative fraction to unsigned integer types",
-          "[e2e][types][real][conversion][c_integer][unsigned][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL negative fraction to unsigned integer types",
+                 "[e2e][types][real][conversion][c_integer][unsigned][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Negative fractional FLOAT values are fetched as unsigned integer C types
   (void)0;
@@ -310,11 +300,10 @@ TEST_CASE("REAL negative fraction to unsigned integer types",
   }
 }
 
-TEST_CASE("REAL NaN to integer types returns error", "[e2e][types][real][conversion][c_integer][nan][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NaN to integer types returns error",
+                 "[e2e][types][real][conversion][c_integer][nan][edge]") {
   SKIP_OLD_DRIVER("BD#16", "Old driver silently converts NaN to 0 for integer targets");
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NaN FLOAT value is fetched as integer C types
   (void)0;
@@ -329,10 +318,9 @@ TEST_CASE("REAL NaN to integer types returns error", "[e2e][types][real][convers
   check_numeric_out_of_range<SQL_C_UBIGINT>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
 }
 
-TEST_CASE("REAL Infinity to integer types returns 22003", "[e2e][types][real][conversion][c_integer][infinity][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL Infinity to integer types returns 22003",
+                 "[e2e][types][real][conversion][c_integer][infinity][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Infinity FLOAT values are fetched as integer C types
   (void)0;
@@ -349,10 +337,8 @@ TEST_CASE("REAL Infinity to integer types returns 22003", "[e2e][types][real][co
   check_numeric_out_of_range<SQL_C_SBIGINT>(conn.execute_fetch("SELECT '-Infinity'::FLOAT"), 1);
 }
 
-TEST_CASE("REAL NULL to SQL_C_INTEGER types", "[real][conversion][c_integer][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_INTEGER types", "[real][conversion][c_integer][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NULL FLOAT values are queried
   const auto query = "SELECT NULL::FLOAT";

--- a/odbc_tests/tests/e2e/types/real_conversion_to_c_numeric.cpp
+++ b/odbc_tests/tests/e2e/types/real_conversion_to_c_numeric.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 
 // ============================================================================
@@ -9,10 +9,8 @@
 // The old driver (via Simba SDK) supports SQL_C_NUMERIC for SQL_DOUBLE.
 // ============================================================================
 
-TEST_CASE("REAL to SQL_C_NUMERIC", "[e2e][types][real][numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL to SQL_C_NUMERIC", "[e2e][types][real][numeric]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When REAL values are fetched as SQL_C_NUMERIC
   (void)0;  // Brace blocks below perform the fetch and assertions
@@ -107,10 +105,8 @@ TEST_CASE("REAL to SQL_C_NUMERIC", "[e2e][types][real][numeric]") {
   check_null_via_get_data(conn.execute_fetch("SELECT NULL::FLOAT"), 1, SQL_C_NUMERIC);
 }
 
-TEST_CASE("REAL SQL_C_NUMERIC negative zero", "[e2e][types][real][numeric][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL SQL_C_NUMERIC negative zero", "[e2e][types][real][numeric][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Negative fractional REAL values that truncate to zero are fetched as SQL_C_NUMERIC
   auto numeric1 = check_fractional_truncation<SQL_C_NUMERIC>(conn.execute_fetch("SELECT -0.5::FLOAT"), 1);
@@ -125,10 +121,8 @@ TEST_CASE("REAL SQL_C_NUMERIC negative zero", "[e2e][types][real][numeric][edge]
   CHECK(numeric2.val[0] == 0);
 }
 
-TEST_CASE("REAL NaN to NUMERIC returns error", "[e2e][types][real][nan][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NaN to NUMERIC returns error", "[e2e][types][real][nan][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When NaN is fetched as SQL_C_NUMERIC
   check_numeric_out_of_range<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 'NaN'::FLOAT"), 1);
@@ -136,10 +130,8 @@ TEST_CASE("REAL NaN to NUMERIC returns error", "[e2e][types][real][nan][edge]") 
   (void)0;  // check_numeric_out_of_range asserts 22003
 }
 
-TEST_CASE("REAL Infinity to NUMERIC returns 22003", "[e2e][types][real][infinity][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL Infinity to NUMERIC returns 22003", "[e2e][types][real][infinity][edge]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Infinity is fetched as SQL_C_NUMERIC
   check_numeric_out_of_range<SQL_C_NUMERIC>(conn.execute_fetch("SELECT 'Infinity'::FLOAT"), 1);
@@ -148,10 +140,8 @@ TEST_CASE("REAL Infinity to NUMERIC returns 22003", "[e2e][types][real][infinity
   (void)0;  // check_numeric_out_of_range asserts 22003
 }
 
-TEST_CASE("REAL NULL to SQL_C_NUMERIC", "[real][conversion][c_numeric][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "REAL NULL to SQL_C_NUMERIC", "[real][conversion][c_numeric][null]") {
   // Given A Snowflake connection is established
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A NULL FLOAT value is queried
   auto stmt = conn.execute_fetch("SELECT NULL::FLOAT");

--- a/odbc_tests/tests/e2e/types/semi_structured.cpp
+++ b/odbc_tests/tests/e2e/types/semi_structured.cpp
@@ -12,14 +12,12 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
-#include <cstring>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
-#include "compatibility.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
@@ -37,7 +35,7 @@ static void check_json_equals(const std::u16string& actual_json_text, const std:
 // TYPE CASTING (shared)
 // ============================================================================
 
-TEST_CASE("should cast semi-structured values to appropriate type", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should cast semi-structured values to appropriate type", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -64,7 +62,7 @@ TEST_CASE("should cast semi-structured values to appropriate type", "[semi_struc
 // TYPE CASTING (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should cast semi-structured values to SQL_VARCHAR", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should cast semi-structured values to SQL_VARCHAR", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -91,7 +89,7 @@ TEST_CASE("should cast semi-structured values to SQL_VARCHAR", "[semi_structured
 // SELECT WITH LITERALS (shared)
 // ============================================================================
 
-TEST_CASE("should select semi-structured literals", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select semi-structured literals", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -108,7 +106,7 @@ TEST_CASE("should select semi-structured literals", "[semi_structured]") {
   check_json_equals(get_data<SQL_C_CHAR>(stmt, 3), R"({"a":1,"b":2})");
 }
 
-TEST_CASE("should select deeply nested semi-structured literals", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select deeply nested semi-structured literals", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -123,7 +121,7 @@ TEST_CASE("should select deeply nested semi-structured literals", "[semi_structu
 // NULL HANDLING (shared)
 // ============================================================================
 
-TEST_CASE("should handle NULL semi-structured values from literals", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL semi-structured values from literals", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -140,14 +138,12 @@ TEST_CASE("should handle NULL semi-structured values from literals", "[semi_stru
 // TABLE OPERATIONS (shared)
 // ============================================================================
 
-TEST_CASE("should select semi-structured values from table", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select semi-structured values from table", "[semi_structured]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with VARIANT, OBJECT, and ARRAY columns exists with JSON values
   conn.execute(
-      "CREATE OR REPLACE TABLE semi_struct_table "
+      "CREATE OR REPLACE TEMPORARY TABLE semi_struct_table "
       "(v VARIANT, o OBJECT, a ARRAY)");
   conn.execute(
       "INSERT INTO semi_struct_table "
@@ -181,13 +177,11 @@ TEST_CASE("should select semi-structured values from table", "[semi_structured]"
   check_json_equals(get_data<SQL_C_CHAR>(stmt, 3), R"(["a","b"])");
 }
 
-TEST_CASE("should handle NULL semi-structured values from table", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL semi-structured values from table", "[semi_structured]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with VARIANT column exists containing NULLs and values
-  conn.execute("CREATE OR REPLACE TABLE semi_struct_null_table (v VARIANT, id INT)");
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE semi_struct_null_table (v VARIANT, id INT)");
   conn.execute(
       "INSERT INTO semi_struct_null_table "
       "SELECT PARSE_JSON(column2), column1 FROM VALUES (1, NULL), (2, '{\"a\":1}'), (3, NULL)");
@@ -217,7 +211,8 @@ TEST_CASE("should handle NULL semi-structured values from table", "[semi_structu
 // MULTIPLE CHUNKS DOWNLOADING (shared)
 // ============================================================================
 
-TEST_CASE("should download semi-structured data in multiple chunks", "[semi_structured][large_result_set]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download semi-structured data in multiple chunks",
+                 "[semi_structured][large_result_set]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -251,7 +246,7 @@ TEST_CASE("should download semi-structured data in multiple chunks", "[semi_stru
 // PARAMETER BINDING (shared)
 // ============================================================================
 
-TEST_CASE("should select variant using parameter binding", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select variant using parameter binding", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -275,7 +270,7 @@ TEST_CASE("should select variant using parameter binding", "[semi_structured]") 
   check_json_equals(get_data<SQL_C_CHAR>(stmt, 1), R"({"bound":true})");
 }
 
-TEST_CASE("should select NULL variant using parameter binding", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select NULL variant using parameter binding", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -298,13 +293,11 @@ TEST_CASE("should select NULL variant using parameter binding", "[semi_structure
   CHECK(!get_data_optional<SQL_C_CHAR>(stmt, 1).has_value());
 }
 
-TEST_CASE("should insert variant using parameter binding", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert variant using parameter binding", "[semi_structured]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with VARIANT column exists
-  conn.execute("CREATE OR REPLACE TABLE semi_struct_bind (v VARIANT, id INT)");
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE semi_struct_bind (v VARIANT, id INT)");
 
   // When JSON values are inserted using parameter binding via PARSE_JSON(?)
   const char* values[] = {"{\"x\":1}", "[1,2,3]", "{\"nested\":{\"a\":true}}"};
@@ -345,7 +338,8 @@ TEST_CASE("should insert variant using parameter binding", "[semi_structured]") 
 // CONVERSION TO SQL_C_CHAR - TRUNCATION (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should truncate variant data when buffer is too short", "[semi_structured][conversion][char]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should truncate variant data when buffer is too short",
+                 "[semi_structured][conversion][char]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -374,7 +368,8 @@ TEST_CASE("should truncate variant data when buffer is too short", "[semi_struct
 // CONVERSION TO SQL_C_WCHAR (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should retrieve variant data as SQL_C_WCHAR", "[semi_structured][conversion][wchar]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should retrieve variant data as SQL_C_WCHAR",
+                 "[semi_structured][conversion][wchar]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -389,7 +384,8 @@ TEST_CASE("should retrieve variant data as SQL_C_WCHAR", "[semi_structured][conv
 // CONVERSION TO SQL_C_BINARY (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should retrieve variant data as SQL_C_BINARY", "[semi_structured][conversion][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should retrieve variant data as SQL_C_BINARY",
+                 "[semi_structured][conversion][binary]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -406,7 +402,8 @@ TEST_CASE("should retrieve variant data as SQL_C_BINARY", "[semi_structured][con
   check_json_equals(std::string(reinterpret_cast<char*>(buffer), static_cast<size_t>(indicator)), R"({"b":2})");
 }
 
-TEST_CASE("should return SQL_NULL_DATA for NULL variant as SQL_C_BINARY", "[semi_structured][conversion][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should return SQL_NULL_DATA for NULL variant as SQL_C_BINARY",
+                 "[semi_structured][conversion][binary]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -425,7 +422,7 @@ TEST_CASE("should return SQL_NULL_DATA for NULL variant as SQL_C_BINARY", "[semi
 // EMPTY JSON CONTAINERS (shared)
 // ============================================================================
 
-TEST_CASE("should handle empty JSON containers", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle empty JSON containers", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -438,7 +435,7 @@ TEST_CASE("should handle empty JSON containers", "[semi_structured]") {
   check_json_equals(get_data<SQL_C_CHAR>(stmt, 3), R"({})");
 }
 
-TEST_CASE("should handle empty JSON array literal", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle empty JSON array literal", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -449,14 +446,12 @@ TEST_CASE("should handle empty JSON array literal", "[semi_structured]") {
   check_json_equals(get_data<SQL_C_CHAR>(stmt, 1), R"([])");
 }
 
-TEST_CASE("should round-trip empty JSON containers through a table", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should round-trip empty JSON containers through a table", "[semi_structured]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with VARIANT, OBJECT, and ARRAY columns exists with empty containers
   conn.execute(
-      "CREATE OR REPLACE TABLE semi_struct_empty "
+      "CREATE OR REPLACE TEMPORARY TABLE semi_struct_empty "
       "(v VARIANT, o OBJECT, a ARRAY)");
   conn.execute(
       "INSERT INTO semi_struct_empty "
@@ -479,7 +474,7 @@ TEST_CASE("should round-trip empty JSON containers through a table", "[semi_stru
 // JSON WITH UNICODE CONTENT (shared)
 // ============================================================================
 
-TEST_CASE("should handle JSON with unicode content", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle JSON with unicode content", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -500,7 +495,7 @@ TEST_CASE("should handle JSON with unicode content", "[semi_structured]") {
   CHECK(cjk_it->second.get<std::string>() == "\xe9\x9b\xaa\xe8\x8a\xb1");
 }
 
-TEST_CASE("should handle JSON with unicode in keys", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle JSON with unicode in keys", "[semi_structured]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -521,7 +516,8 @@ TEST_CASE("should handle JSON with unicode in keys", "[semi_structured]") {
   CHECK(flower_it->second.get<std::string>() == "flower");
 }
 
-TEST_CASE("should handle JSON with unicode via SQL_C_WCHAR", "[semi_structured][conversion][wchar]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle JSON with unicode via SQL_C_WCHAR",
+                 "[semi_structured][conversion][wchar]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -542,8 +538,8 @@ TEST_CASE("should handle JSON with unicode via SQL_C_WCHAR", "[semi_structured][
 // CONVERSION TO SQL_C_WCHAR - TRUNCATION (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should truncate variant data as SQL_C_WCHAR when buffer is too short",
-          "[semi_structured][conversion][wchar][01004]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should truncate variant data as SQL_C_WCHAR when buffer is too short",
+                 "[semi_structured][conversion][wchar][01004]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -574,7 +570,8 @@ TEST_CASE("should truncate variant data as SQL_C_WCHAR when buffer is too short"
 // SQLColAttribute - SQL_DESC_TYPE_NAME (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should report SQL_DESC_TYPE_NAME for semi-structured columns", "[semi_structured][metadata]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should report SQL_DESC_TYPE_NAME for semi-structured columns",
+                 "[semi_structured][metadata]") {
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -600,13 +597,12 @@ TEST_CASE("should report SQL_DESC_TYPE_NAME for semi-structured columns", "[semi
 // MULTI-ROW TABLE OPERATIONS (ODBC-specific)
 // ============================================================================
 
-TEST_CASE("should select multi-row table with all semi-structured columns", "[semi_structured]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select multi-row table with all semi-structured columns",
+                 "[semi_structured]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Table with VARIANT, OBJECT, and ARRAY columns exists with multiple rows including NULLs
-  conn.execute("CREATE OR REPLACE TABLE semi_multi (id INT, v VARIANT, o OBJECT, a ARRAY)");
+  conn.execute("CREATE OR REPLACE TEMPORARY TABLE semi_multi (id INT, v VARIANT, o OBJECT, a ARRAY)");
   conn.execute(
       "INSERT INTO semi_multi "
       "SELECT 1, PARSE_JSON('{\"x\":1}'), OBJECT_CONSTRUCT('k','v1'), ARRAY_CONSTRUCT(1,2)");

--- a/odbc_tests/tests/e2e/types/string.cpp
+++ b/odbc_tests/tests/e2e/types/string.cpp
@@ -21,7 +21,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
@@ -31,10 +31,9 @@
 // TYPE CASTING
 // ============================================================================
 
-TEST_CASE("should cast string values to appropriate type for string and synonyms", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should cast string values to appropriate type for string and synonyms",
+                 "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT 'hello'::<type>, 'Hello World'::<type>, '日本語テスト'::<type>" is executed
   std::vector<std::u16string> string_types = {u"VARCHAR",   u"CHAR",         u"CHARACTER",    u"NCHAR",
@@ -57,10 +56,8 @@ TEST_CASE("should cast string values to appropriate type for string and synonyms
 // SIMPLE SELECTS - LITERALS (Happy path, Corner cases)
 // ============================================================================
 
-TEST_CASE("should select hardcoded string literals", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string literals", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3"
   // is executed
@@ -72,10 +69,8 @@ TEST_CASE("should select hardcoded string literals", "[datatype][string]") {
   CHECK(get_data<SQL_C_CHAR>(stmt, 3) == "Snowflake Driver Test");
 }
 
-TEST_CASE("should select hardcoded string literals using SQLBindCol", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string literals using SQLBindCol", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3" is executed
   auto stmt = conn.createStatement();
@@ -104,10 +99,8 @@ TEST_CASE("should select hardcoded string literals using SQLBindCol", "[datatype
   CHECK(std::string(buf3, ind3) == "Snowflake Driver Test");
 }
 
-TEST_CASE("should select string literals with corner case values", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select string literals with corner case values", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting corner case string literals is executed
   auto stmt = conn.executew_fetch(
@@ -144,23 +137,20 @@ TEST_CASE("should select string literals with corner case values", "[datatype][s
 // SIMPLE SELECTS - FROM TABLE (Happy path, Corner cases)
 // ============================================================================
 
-TEST_CASE("should select hardcoded string values from table", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string values from table", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("DROP TABLE IF EXISTS test_string");
-  conn.execute("CREATE TABLE test_string (id INT, val VARCHAR(1000))");
+  conn.execute("CREATE OR REPLACE TABLE str_from_table (id INT, val VARCHAR(1000))");
 
   // And The table is populated with string values
-  conn.execute("INSERT INTO test_string VALUES (1, 'hello')");
-  conn.execute("INSERT INTO test_string VALUES (2, 'Hello World')");
-  conn.execute("INSERT INTO test_string VALUES (3, 'Snowflake Driver Test')");
+  conn.execute("INSERT INTO str_from_table VALUES (1, 'hello')");
+  conn.execute("INSERT INTO str_from_table VALUES (2, 'Hello World')");
+  conn.execute("INSERT INTO str_from_table VALUES (3, 'Snowflake Driver Test')");
 
   // When Query "SELECT * FROM {table}" is executed
   auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val FROM test_string ORDER BY id", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val FROM str_from_table ORDER BY id", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the result should contain the inserted hardcoded string values
@@ -178,32 +168,29 @@ TEST_CASE("should select hardcoded string values from table", "[datatype][string
   CHECK(row == 3);
 }
 
-TEST_CASE("should select corner case string values from table", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values from table", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("DROP TABLE IF EXISTS test_string");
-  conn.execute("CREATE TABLE test_string (id INT, val VARCHAR(10000))");
+  conn.execute("CREATE OR REPLACE TABLE str_corner_cases (id INT, val VARCHAR(10000))");
 
   // And The table is populated with corner case string values
-  conn.execute("INSERT INTO test_string VALUES (1, '')");                // empty string
-  conn.execute("INSERT INTO test_string VALUES (2, 'X')");               // single char
-  conn.execute("INSERT INTO test_string VALUES (3, '   ')");             // whitespace
-  conn.execute("INSERT INTO test_string VALUES (4, '\\t')");             // tab character
-  conn.execute("INSERT INTO test_string VALUES (5, '\\n')");             // newline character
-  conn.executew(u"INSERT INTO test_string VALUES (6, '⛄')");            // unicode snowman
-  conn.executew(u"INSERT INTO test_string VALUES (7, '日本語テスト')");  // Japanese
-  conn.execute("INSERT INTO test_string VALUES (8, '''')");              // escaped quote
-  conn.execute("INSERT INTO test_string VALUES (9, '\\\\')");            // escaped backslash
-  conn.execute("INSERT INTO test_string VALUES (10, NULL)");             // NULL
-  conn.executew(u"INSERT INTO test_string VALUES (11, 'y̆es')");  // combined character (y + combining breve + es)
-  conn.executew(u"INSERT INTO test_string VALUES (12, '𝄞')");    // surrogate pair (musical G clef)
+  conn.execute("INSERT INTO str_corner_cases VALUES (1, '')");                // empty string
+  conn.execute("INSERT INTO str_corner_cases VALUES (2, 'X')");               // single char
+  conn.execute("INSERT INTO str_corner_cases VALUES (3, '   ')");             // whitespace
+  conn.execute("INSERT INTO str_corner_cases VALUES (4, '\\t')");             // tab character
+  conn.execute("INSERT INTO str_corner_cases VALUES (5, '\\n')");             // newline character
+  conn.executew(u"INSERT INTO str_corner_cases VALUES (6, '⛄')");            // unicode snowman
+  conn.executew(u"INSERT INTO str_corner_cases VALUES (7, '日本語テスト')");  // Japanese
+  conn.execute("INSERT INTO str_corner_cases VALUES (8, '''')");              // escaped quote
+  conn.execute("INSERT INTO str_corner_cases VALUES (9, '\\\\')");            // escaped backslash
+  conn.execute("INSERT INTO str_corner_cases VALUES (10, NULL)");             // NULL
+  conn.executew(u"INSERT INTO str_corner_cases VALUES (11, 'y̆es')");  // combined character (y + combining breve + es)
+  conn.executew(u"INSERT INTO str_corner_cases VALUES (12, '𝄞')");    // surrogate pair (musical G clef)
 
   // When Query "SELECT * FROM {table}" is executed
   auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val FROM test_string ORDER BY id", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val FROM str_corner_cases ORDER BY id", SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the result should contain the inserted corner case string values
@@ -240,19 +227,18 @@ TEST_CASE("should select corner case string values from table", "[datatype][stri
 // SIMPLE INSERT WITH BINDING
 // ============================================================================
 
-TEST_CASE("should insert and select back hardcoded string values using parameter binding", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should insert and select back hardcoded string values using parameter binding",
+                 "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("DROP TABLE IF EXISTS test_string");
-  conn.execute("CREATE TABLE test_string (id INT, val VARCHAR(10000))");
+  conn.execute("CREATE OR REPLACE TABLE str_bind_insert (id INT, val VARCHAR(10000))");
 
   // When String value 'Test binding value 日本語' is inserted using parameter binding
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO test_string (id, val) VALUES (1, ?)", SQL_NTS);
+    SQLRETURN ret =
+        SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO str_bind_insert (id, val) VALUES (1, ?)"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     std::string value = "Test binding value 日本語";
@@ -266,7 +252,7 @@ TEST_CASE("should insert and select back hardcoded string values using parameter
   }
 
   // And Query "SELECT * FROM {table}" is executed
-  auto stmt = conn.execute_fetch("SELECT val FROM test_string");
+  auto stmt = conn.execute_fetch("SELECT val FROM str_bind_insert");
 
   // Then the result should contain the bound string value 'Test binding value 日本語'
   CHECK(get_data<SQL_C_WCHAR>(stmt, 1) == u"Test binding value 日本語");
@@ -276,10 +262,8 @@ TEST_CASE("should insert and select back hardcoded string values using parameter
 // SELECT BINDING TESTS
 // ============================================================================
 
-TEST_CASE("should select string literals using parameter binding", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select string literals using parameter binding", "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR", SQL_NTS);
@@ -316,10 +300,9 @@ TEST_CASE("should select string literals using parameter binding", "[datatype][s
   CHECK(get_data<SQL_C_WCHAR>(stmt, 3) == u"日本語テスト");
 }
 
-TEST_CASE("should select corner case string values using parameter binding", "[datatype][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values using parameter binding",
+                 "[datatype][string]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
   auto test_bound_value = [&](const std::string& value, const std::string& expected) {
@@ -420,12 +403,11 @@ TEST_CASE("should select corner case string values using parameter binding", "[d
 // MULTIPLE CHUNKS DOWNLOADING
 // ============================================================================
 
-TEST_CASE("should download string data in multiple chunks", "[datatype][string][large_result_set]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download string data in multiple chunks",
+                 "[datatype][string][large_result_set]") {
   // This test ensures proper handling of large result sets that span multiple chunks
   // ~10^6 values ensures data is downloaded in at least two chunks
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
   const int num_values = 10000;
 
   // When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY
@@ -456,15 +438,13 @@ TEST_CASE("should download string data in multiple chunks", "[datatype][string][
 // UTF-16 TO ASCII CONVERSION
 // ============================================================================
 
-TEST_CASE("should convert UTF-16 to ASCII with 0x1a substitution when using SQL_C_CHAR",
-          "[datatype][string][conversion]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert UTF-16 to ASCII with 0x1a substitution when using SQL_C_CHAR",
+                 "[datatype][string][conversion]") {
   if (!is_ascii_locale()) {
     SKIP("0x1a substitution only applies on non-UTF-8 locales");
   }
 
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting strings with non-ASCII Unicode characters is executed
   auto stmt = conn.executew_fetch(
@@ -506,10 +486,9 @@ TEST_CASE("should convert UTF-16 to ASCII with 0x1a substitution when using SQL_
 // MULTIPLE CHUNKS DOWNLOADING WITH SQLBindCol
 // ============================================================================
 
-TEST_CASE("should download string data in multiple chunks using SQLBindCol", "[datatype][string][large_result_set]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should download string data in multiple chunks using SQLBindCol",
+                 "[datatype][string][large_result_set]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And Expected row count is defined
   const int expected_row_count = 10000;

--- a/odbc_tests/tests/e2e/types/string.cpp
+++ b/odbc_tests/tests/e2e/types/string.cpp
@@ -141,7 +141,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string values from 
   // Given Snowflake client is logged in
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("CREATE OR REPLACE TABLE str_from_table (id INT, val VARCHAR(1000))");
+  conn.execute("CREATE TEMPORARY TABLE str_from_table (id INT, val VARCHAR(1000))");
 
   // And The table is populated with string values
   conn.execute("INSERT INTO str_from_table VALUES (1, 'hello')");
@@ -172,7 +172,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values fro
   // Given Snowflake client is logged in
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("CREATE OR REPLACE TABLE str_corner_cases (id INT, val VARCHAR(10000))");
+  conn.execute("CREATE TEMPORARY TABLE str_corner_cases (id INT, val VARCHAR(10000))");
 
   // And The table is populated with corner case string values
   conn.execute("INSERT INTO str_corner_cases VALUES (1, '')");                // empty string
@@ -232,7 +232,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert and select back hardcoded str
   // Given Snowflake client is logged in
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("CREATE OR REPLACE TABLE str_bind_insert (id INT, val VARCHAR(10000))");
+  conn.execute("CREATE TEMPORARY TABLE str_bind_insert (id INT, val VARCHAR(10000))");
 
   // When String value 'Test binding value 日本語' is inserted using parameter binding
   {

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_binary.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_binary.cpp
@@ -11,7 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_matchers.hpp"
 
@@ -21,10 +21,9 @@ static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>(s
 // SUCCESSFUL CONVERSIONS - String to SQL_C_BINARY
 // ============================================================================
 
-TEST_CASE("should convert string literals to SQL_C_BINARY", "[datatype][string][conversion][binary]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to SQL_C_BINARY",
+                 "[datatype][string][conversion][binary]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting various string literals is executed
   auto stmt = conn.execute_fetch("SELECT 'hello' AS c1, '' AS c2, 'ABC123!@#' AS c3, NULL::STRING AS c4");
@@ -84,10 +83,9 @@ TEST_CASE("should convert string literals to SQL_C_BINARY", "[datatype][string][
 // SUCCESSFUL CONVERSIONS - UTF-8 String to SQL_C_BINARY
 // ============================================================================
 
-TEST_CASE("should convert UTF-8 string literals to SQL_C_BINARY", "[datatype][string][conversion][binary][utf8]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert UTF-8 string literals to SQL_C_BINARY",
+                 "[datatype][string][conversion][binary][utf8]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting UTF-8 string literals is executed
   auto stmt = conn.executew_fetch(

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
@@ -142,7 +142,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test string basic query", "[e2e][types][str
   // Given A Snowflake connection
 
   // When A string value is inserted and selected via SQL_C_CHAR
-  conn.execute("CREATE OR REPLACE TABLE test_string_basic (str_col VARCHAR(1000))");
+  conn.execute("CREATE TEMPORARY TABLE test_string_basic (str_col VARCHAR(1000))");
   conn.execute("INSERT INTO test_string_basic (str_col) VALUES ('Hello World')");
   auto stmt = conn.createStatement();
 
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test basic string binding", "[e2e][types][s
   // Given A Snowflake connection
 
   // When A string value is inserted via parameter binding and selected
-  conn.execute("CREATE OR REPLACE TABLE test_string_basic_binding (str_col VARCHAR(1000))");
+  conn.execute("CREATE TEMPORARY TABLE test_string_basic_binding (str_col VARCHAR(1000))");
   auto stmt = conn.createStatement();
 
   SQLRETURN ret =

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
@@ -14,7 +14,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
@@ -25,11 +25,9 @@
 // ============================================================================
 
 // Byte length of data is longer than the buffer length, so the data is truncated.
-TEST_CASE("should truncate string data when byte length is longer than the buffer length",
-          "[datatype][string][conversion][char]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should truncate string data when byte length is longer than the buffer length",
+                 "[datatype][string][conversion][char]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting a long string is executed
   auto stmt = conn.execute_fetch("SELECT 'This is a very long string that will be truncated' AS long_str");
@@ -56,11 +54,10 @@ TEST_CASE("should truncate string data when byte length is longer than the buffe
   }
 }
 
-TEST_CASE("should truncate wide string data when byte length is longer than the buffer length",
-          "[datatype][string][conversion][wchar]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should truncate wide string data when byte length is longer than the buffer length",
+                 "[datatype][string][conversion][wchar]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting a long string is executed
   auto stmt = conn.execute_fetch("SELECT 'This is a very long string that will be truncated' AS long_str");
@@ -86,8 +83,8 @@ TEST_CASE("should truncate wide string data when byte length is longer than the 
 // UTF-16 TO ASCII CONVERSION
 // ============================================================================
 
-TEST_CASE("should convert UTF-16 to ASCII with 0x1a substitution when using SQL_C_CHAR",
-          "[datatype][string][conversion]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert UTF-16 to ASCII with 0x1a substitution when using SQL_C_CHAR",
+                 "[datatype][string][conversion]") {
   if (!is_ascii_locale()) {
     SKIP("This test is not applicable on non-ASCII locales");
   }
@@ -95,8 +92,6 @@ TEST_CASE("should convert UTF-16 to ASCII with 0x1a substitution when using SQL_
   // on non-UTF-8 locales non-ASCII characters (> 0x7F) are replaced with 0x1a (SUB character),
   // on UTF-8 locales the characters are preserved as UTF-8.
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting strings with non-ASCII Unicode characters is executed
   auto stmt = conn.executew_fetch(
@@ -143,14 +138,11 @@ TEST_CASE("should convert UTF-16 to ASCII with 0x1a substitution when using SQL_
 // BASIC STRING QUERY AND PARAMETER BINDING
 // ============================================================================
 
-TEST_CASE("Test string basic query", "[e2e][types][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test string basic query", "[e2e][types][string]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A string value is inserted and selected via SQL_C_CHAR
-  conn.execute("DROP TABLE IF EXISTS test_string_basic");
-  conn.execute("CREATE TABLE test_string_basic (str_col VARCHAR(1000))");
+  conn.execute("CREATE OR REPLACE TABLE test_string_basic (str_col VARCHAR(1000))");
   conn.execute("INSERT INTO test_string_basic (str_col) VALUES ('Hello World')");
   auto stmt = conn.createStatement();
 
@@ -170,14 +162,11 @@ TEST_CASE("Test string basic query", "[e2e][types][string]") {
   REQUIRE(std::string(buffer, indicator) == "Hello World");
 }
 
-TEST_CASE("Test basic string binding", "[e2e][types][string]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "Test basic string binding", "[e2e][types][string]") {
   // Given A Snowflake connection
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When A string value is inserted via parameter binding and selected
-  conn.execute("DROP TABLE IF EXISTS test_string_basic_binding");
-  conn.execute("CREATE TABLE test_string_basic_binding (str_col VARCHAR(1000))");
+  conn.execute("CREATE OR REPLACE TABLE test_string_basic_binding (str_col VARCHAR(1000))");
   auto stmt = conn.createStatement();
 
   SQLRETURN ret =

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_float.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_float.cpp
@@ -17,7 +17,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -29,10 +29,9 @@
 // SUCCESSFUL CONVERSIONS - String to Floating Point Types
 // ============================================================================
 
-TEST_CASE("should convert string literals to floating point types", "[datatype][string][conversion][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to floating point types",
+                 "[datatype][string][conversion][real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing floating point numbers is executed
   auto stmt = conn.execute_fetch(
@@ -65,11 +64,10 @@ TEST_CASE("should convert string literals to floating point types", "[datatype][
 // DATA OUT OF RANGE - String to Floating Point Types
 // ============================================================================
 
-TEST_CASE("should fail converting string literals to floating point types when data is out of range",
-          "[datatype][string][conversion][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should fail converting string literals to floating point types when data is out of range",
+                 "[datatype][string][conversion][real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing floating point numbers is executed
   {
@@ -103,10 +101,9 @@ TEST_CASE("should fail converting string literals to floating point types when d
   }
 }
 
-TEST_CASE("should handle special floating point string conversions", "[datatype][string][conversion][real][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle special floating point string conversions",
+                 "[datatype][string][conversion][real][edge]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting special float strings is executed
   const auto query = "SELECT 'inf' AS pos_inf, '-inf' AS neg_inf, 'NaN' AS nan";
@@ -135,10 +132,9 @@ TEST_CASE("should handle special floating point string conversions", "[datatype]
 // EDGE CASES - Numeric strings with special formatting
 // ============================================================================
 
-TEST_CASE("should handle edge case floating point string formats", "[datatype][string][conversion][real][edge]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle edge case floating point string formats",
+                 "[datatype][string][conversion][real][edge]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting strings with special formatting is executed
   auto stmt = conn.execute_fetch(
@@ -161,11 +157,9 @@ TEST_CASE("should handle edge case floating point string formats", "[datatype][s
 // FAILING CONVERSIONS - Non-numeric strings to floating point types
 // ============================================================================
 
-TEST_CASE("should fail converting non-numeric strings to floating point types",
-          "[datatype][string][conversion][real][failure]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting non-numeric strings to floating point types",
+                 "[datatype][string][conversion][real][failure]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting various non-numeric strings is executed
   auto stmt = conn.execute_fetch("SELECT 'not a number' AS c1, 'abc123' AS c2");
@@ -180,11 +174,9 @@ TEST_CASE("should fail converting non-numeric strings to floating point types",
 // FAILING CONVERSIONS - Malformed numeric strings
 // ============================================================================
 
-TEST_CASE("should fail converting malformed numeric strings to floating point types",
-          "[datatype][string][conversion][real][failure]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed numeric strings to floating point types",
+                 "[datatype][string][conversion][real][failure]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting various malformed numeric strings is executed
   auto stmt = conn.execute_fetch("SELECT '123.456.789' AS c1, '123,456' AS c2");
@@ -199,11 +191,9 @@ TEST_CASE("should fail converting malformed numeric strings to floating point ty
 // NULL VALUE HANDLING
 // ============================================================================
 
-TEST_CASE("should handle NULL string when converting to floating point types",
-          "[datatype][string][conversion][real][null]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL string when converting to floating point types",
+                 "[datatype][string][conversion][real][null]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting NULL is executed
   auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_double");
@@ -222,10 +212,9 @@ TEST_CASE("should handle NULL string when converting to floating point types",
 // CONVERSION WITH SQLBindCol - Floating point types
 // ============================================================================
 
-TEST_CASE("should convert strings to floating point types using SQLBindCol", "[datatype][string][conversion][real]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to floating point types using SQLBindCol",
+                 "[datatype][string][conversion][real]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_DOUBLE
   {

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
@@ -17,7 +17,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -29,10 +29,9 @@
 // SUCCESSFUL CONVERSIONS - String to Signed Integer Types
 // ============================================================================
 
-TEST_CASE("should convert string literals to signed c_type", "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to signed c_type",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing integers is executed
   auto stmt = conn.execute_fetch(
@@ -87,10 +86,9 @@ TEST_CASE("should convert string literals to signed c_type", "[datatype][string]
 // SUCCESSFUL CONVERSIONS - String to Unsigned Integer Types
 // ============================================================================
 
-TEST_CASE("should convert string literals to unsigned c_type", "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to unsigned c_type",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing unsigned integers is executed
   auto stmt = conn.execute_fetch(
@@ -131,10 +129,9 @@ TEST_CASE("should convert string literals to unsigned c_type", "[datatype][strin
 // SUCCESSFUL CONVERSIONS - String to BIT Type
 // ============================================================================
 
-TEST_CASE("should convert string literals to SQL_C_BIT", "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to SQL_C_BIT",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing boolean values is executed
   auto stmt = conn.execute_fetch("SELECT '1' AS true_val, '0' AS false_val, ' 1 ' AS c3, ' 0 ' AS c4");
@@ -150,10 +147,9 @@ TEST_CASE("should convert string literals to SQL_C_BIT", "[datatype][string][con
 // FAILING CONVERSIONS - String to BIT Type
 // ============================================================================
 
-TEST_CASE("should fail converting string literals with to SQL_C_BIT", "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting string literals with to SQL_C_BIT",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals with leading/trailing whitespace is executed
   auto stmt = conn.execute_fetch("SELECT 'abc' AS invalid, '456' AS whole, '6' AS single_digit, '1.1' AS fractional");
@@ -169,11 +165,10 @@ TEST_CASE("should fail converting string literals with to SQL_C_BIT", "[datatype
 // TRUNCATION TESTS
 // ============================================================================
 
-TEST_CASE("should truncate decimal string literals with fractional part when converting to integer types",
-          "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should truncate decimal string literals with fractional part when converting to integer types",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals with decimal parts is executed
   const auto query =
@@ -254,11 +249,10 @@ TEST_CASE("should truncate decimal string literals with fractional part when con
   }
 }
 
-TEST_CASE("should truncate decimal string literals without fractional part when converting to integer types",
-          "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "should truncate decimal string literals without fractional part when converting to integer types",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   {
     INFO("SQL_C_BIGINT");
@@ -342,10 +336,9 @@ TEST_CASE("should truncate decimal string literals without fractional part when 
 // CONVERSION WITH SQLBindCol - Integer types
 // ============================================================================
 
-TEST_CASE("should convert strings to integer types using SQLBindCol", "[datatype][string][conversion][integer]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to integer types using SQLBindCol",
+                 "[datatype][string][conversion][integer]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_LONG
   {

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
@@ -25,7 +25,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -37,12 +37,11 @@
 // SUCCESSFUL CONVERSIONS - Single-component interval types (no truncation)
 // ============================================================================
 
-TEST_CASE("should convert string literals to single-component c_type", "[datatype][string][conversion][interval]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to single-component c_type",
+                 "[datatype][string][conversion][interval]") {
   // Catch2 needs one test to be present in the suite, so we skip this one.
   SKIP();
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing interval values is executed
   auto stmt = conn.execute_fetch(
@@ -94,10 +93,9 @@ TEST_CASE("should convert string literals to single-component c_type", "[datatyp
   }
 }
 
-TEST_CASE("should convert negative c_type string literals", "[datatype][string][conversion][interval][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert negative c_type string literals",
+                 "[datatype][string][conversion][interval][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting negative interval values is executed
   auto stmt = conn.execute_fetch("SELECT '-5' AS neg_years, '-10' AS neg_months, '-15' AS neg_days");
@@ -130,11 +128,9 @@ TEST_CASE("should convert negative c_type string literals", "[datatype][string][
 // SUCCESSFUL CONVERSIONS - Multi-component interval types (no truncation)
 // ============================================================================
 
-TEST_CASE("should convert string literals to year-month interval type",
-          "[datatype][string][conversion][interval][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to year-month interval type",
+                 "[datatype][string][conversion][interval][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting year-month interval string is executed
   auto stmt = conn.execute_fetch("SELECT '3-6' AS year_month, '-2-9' AS neg_year_month, '0-11' AS zero_year");
@@ -167,10 +163,9 @@ TEST_CASE("should convert string literals to year-month interval type",
   }
 }
 
-TEST_CASE("should convert string literals to compound c_type", "[datatype][string][conversion][interval][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to compound c_type",
+                 "[datatype][string][conversion][interval][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting day-time interval strings is executed
   auto stmt = conn.execute_fetch(
@@ -237,11 +232,9 @@ TEST_CASE("should convert string literals to compound c_type", "[datatype][strin
 // TRUNCATION WITH INFO - Trailing field truncation (SQLSTATE 01S07)
 // ============================================================================
 
-TEST_CASE("should truncate trailing fields when converting interval strings",
-          "[datatype][string][conversion][interval][truncation][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should truncate trailing fields when converting interval strings",
+                 "[datatype][string][conversion][interval][truncation][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval strings with more precision than target type is executed
   auto stmt = conn.execute_fetch(
@@ -276,11 +269,9 @@ TEST_CASE("should truncate trailing fields when converting interval strings",
   check_interval_precision_lost<SQL_C_INTERVAL_MINUTE>(stmt, 4);
 }
 
-TEST_CASE("should truncate trailing fields in day-time intervals",
-          "[datatype][string][conversion][interval][truncation][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should truncate trailing fields in day-time intervals",
+                 "[datatype][string][conversion][interval][truncation][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting day-time interval strings with more precision is executed
   auto stmt = conn.execute_fetch(
@@ -320,11 +311,9 @@ TEST_CASE("should truncate trailing fields in day-time intervals",
 // LEADING FIELD PRECISION LOSS - (SQLSTATE 22015)
 // ============================================================================
 
-TEST_CASE("should fail when leading field precision is lost for year intervals",
-          "[datatype][string][conversion][interval][precision][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is lost for year intervals",
+                 "[datatype][string][conversion][interval][precision][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // Default leading precision is typically 2 digits for intervals
   // When Query selecting interval values with leading field exceeding precision is executed
@@ -335,11 +324,9 @@ TEST_CASE("should fail when leading field precision is lost for year intervals",
   check_interval_precision_lost<SQL_C_INTERVAL_YEAR>(stmt, 2);
 }
 
-TEST_CASE("should fail when leading field precision is lost for month intervals",
-          "[datatype][string][conversion][interval][precision][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is lost for month intervals",
+                 "[datatype][string][conversion][interval][precision][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval values with leading field exceeding precision is executed
   auto stmt = conn.execute_fetch("SELECT '10000' AS large_month, '99999' AS very_large_month");
@@ -349,11 +336,9 @@ TEST_CASE("should fail when leading field precision is lost for month intervals"
   check_interval_precision_lost<SQL_C_INTERVAL_MONTH>(stmt, 2);
 }
 
-TEST_CASE("should fail when leading field precision is lost for day intervals",
-          "[datatype][string][conversion][interval][precision][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is lost for day intervals",
+                 "[datatype][string][conversion][interval][precision][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval values with leading field exceeding precision is executed
   auto stmt = conn.execute_fetch("SELECT '10000' AS large_day, '99999' AS very_large_day");
@@ -363,11 +348,9 @@ TEST_CASE("should fail when leading field precision is lost for day intervals",
   check_interval_precision_lost<SQL_C_INTERVAL_DAY>(stmt, 2);
 }
 
-TEST_CASE("should fail when leading field precision is lost for hour intervals",
-          "[datatype][string][conversion][interval][precision][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is lost for hour intervals",
+                 "[datatype][string][conversion][interval][precision][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval values with leading field exceeding precision is executed
   auto stmt = conn.execute_fetch("SELECT '10000' AS large_hour, '99999' AS very_large_hour");
@@ -377,11 +360,9 @@ TEST_CASE("should fail when leading field precision is lost for hour intervals",
   check_interval_precision_lost<SQL_C_INTERVAL_HOUR>(stmt, 2);
 }
 
-TEST_CASE("should fail when leading field precision is lost for compound intervals",
-          "[datatype][string][conversion][interval][precision][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is lost for compound intervals",
+                 "[datatype][string][conversion][interval][precision][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting compound interval values with leading field exceeding precision is executed
   auto stmt = conn.execute_fetch("SELECT '10000-6' AS large_year_month, '99999 10:30:45' AS large_day_second");
@@ -395,11 +376,9 @@ TEST_CASE("should fail when leading field precision is lost for compound interva
 // INVALID INTERVAL VALUES - (SQLSTATE 22018)
 // ============================================================================
 
-TEST_CASE("should fail converting invalid interval string formats",
-          "[datatype][string][conversion][interval][failure][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting invalid interval string formats",
+                 "[datatype][string][conversion][interval][failure][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting invalid interval strings is executed
   auto stmt = conn.execute_fetch(
@@ -413,11 +392,9 @@ TEST_CASE("should fail converting invalid interval string formats",
   check_invalid_string<SQL_C_INTERVAL_HOUR>(stmt, 4);
 }
 
-TEST_CASE("should fail converting malformed interval strings for year-month type",
-          "[datatype][string][conversion][interval][failure][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed interval strings for year-month type",
+                 "[datatype][string][conversion][interval][failure][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting malformed year-month interval strings is executed
   auto stmt = conn.execute_fetch(
@@ -431,11 +408,9 @@ TEST_CASE("should fail converting malformed interval strings for year-month type
   check_invalid_string<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 4);
 }
 
-TEST_CASE("should fail converting malformed interval strings for day-time types",
-          "[datatype][string][conversion][interval][failure][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed interval strings for day-time types",
+                 "[datatype][string][conversion][interval][failure][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting malformed day-time interval strings is executed
   auto stmt = conn.execute_fetch(
@@ -449,11 +424,9 @@ TEST_CASE("should fail converting malformed interval strings for day-time types"
   check_invalid_string<SQL_C_INTERVAL_MINUTE_TO_SECOND>(stmt, 4);
 }
 
-TEST_CASE("should fail converting out-of-range component values",
-          "[datatype][string][conversion][interval][failure][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting out-of-range component values",
+                 "[datatype][string][conversion][interval][failure][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // Month > 11 in year-month, hour > 23, minute > 59, second > 59
   // When Query selecting interval strings with invalid component ranges is executed
@@ -489,10 +462,9 @@ TEST_CASE("should fail converting out-of-range component values",
 // EDGE CASES - Whitespace and special formatting
 // ============================================================================
 
-TEST_CASE("should handle whitespace in interval strings", "[datatype][string][conversion][interval][edge][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle whitespace in interval strings",
+                 "[datatype][string][conversion][interval][edge][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval strings with leading/trailing whitespace is executed
   auto stmt = conn.execute_fetch(
@@ -520,10 +492,9 @@ TEST_CASE("should handle whitespace in interval strings", "[datatype][string][co
   }
 }
 
-TEST_CASE("should handle zero values in interval strings", "[datatype][string][conversion][interval][edge][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle zero values in interval strings",
+                 "[datatype][string][conversion][interval][edge][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting zero interval values is executed
   auto stmt = conn.execute_fetch(
@@ -572,11 +543,9 @@ TEST_CASE("should handle zero values in interval strings", "[datatype][string][c
 // NULL VALUE HANDLING
 // ============================================================================
 
-TEST_CASE("should handle NULL string when converting to interval types",
-          "[datatype][string][conversion][interval][null][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL string when converting to interval types",
+                 "[datatype][string][conversion][interval][null][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting NULL is executed
   auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_interval");
@@ -595,11 +564,9 @@ TEST_CASE("should handle NULL string when converting to interval types",
 // CONVERSION WITH SQLBindCol - Interval types
 // ============================================================================
 
-TEST_CASE("should convert strings to interval types using SQLBindCol",
-          "[datatype][string][conversion][interval][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to interval types using SQLBindCol",
+                 "[datatype][string][conversion][interval][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval value is executed with SQLBindCol for SQL_C_INTERVAL_YEAR
   {
@@ -642,11 +609,9 @@ TEST_CASE("should convert strings to interval types using SQLBindCol",
 // FRACTIONAL SECONDS HANDLING
 // ============================================================================
 
-TEST_CASE("should handle fractional seconds in interval strings",
-          "[datatype][string][conversion][interval][fractional][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle fractional seconds in interval strings",
+                 "[datatype][string][conversion][interval][fractional][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting interval strings with fractional seconds is executed
   auto stmt = conn.execute_fetch(

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_numeric.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_numeric.cpp
@@ -11,7 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "Connection.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
 
@@ -27,10 +27,9 @@ static long long numeric_val_to_int(const SQL_NUMERIC_STRUCT& num) {
 
 static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>((unsigned char)c); }
 
-TEST_CASE("should convert string literals to SQL_C_NUMERIC", "[datatype][string][conversion][numeric]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to SQL_C_NUMERIC",
+                 "[datatype][string][conversion][numeric]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting various numeric string formats is executed
   auto stmt = conn.execute_fetch(

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
@@ -15,7 +15,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
@@ -27,10 +27,9 @@
 // SUCCESSFUL CONVERSIONS - String to Date/Time Types
 // ============================================================================
 
-TEST_CASE("should convert string literals to c_type", "[datatype][string][conversion][temporal]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to c_type",
+                 "[datatype][string][conversion][temporal]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting string literals representing dates and times is executed
   auto stmt = conn.execute_fetch(
@@ -107,11 +106,9 @@ TEST_CASE("should convert string literals to c_type", "[datatype][string][conver
 // SUCCESSFUL CONVERSIONS - Date/Time strings to TIMESTAMP
 // ============================================================================
 
-TEST_CASE("should convert date-only and time-only strings to SQL_C_TYPE_TIMESTAMP",
-          "[datatype][string][conversion][temporal]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert date-only and time-only strings to SQL_C_TYPE_TIMESTAMP",
+                 "[datatype][string][conversion][temporal]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting date-only string is executed
   auto stmt = conn.execute_fetch("SELECT '2024-01-15' AS date_only, '14:30:45' AS time_only");
@@ -149,10 +146,9 @@ TEST_CASE("should convert date-only and time-only strings to SQL_C_TYPE_TIMESTAM
 // SUCCESSFUL CONVERSIONS - Timestamp strings to DATE or TIME
 // ============================================================================
 
-TEST_CASE("should convert timestamp string to SQL_C_TYPE_DATE", "[datatype][string][conversion][temporal][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert timestamp string to SQL_C_TYPE_DATE",
+                 "[datatype][string][conversion][temporal][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting timestamp strings is executed
   auto stmt = conn.execute_fetch(
@@ -175,10 +171,9 @@ TEST_CASE("should convert timestamp string to SQL_C_TYPE_DATE", "[datatype][stri
   CHECK(date3.day == 15);
 }
 
-TEST_CASE("should convert timestamp string to SQL_C_TYPE_TIME", "[datatype][string][conversion][temporal][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should convert timestamp string to SQL_C_TYPE_TIME",
+                 "[datatype][string][conversion][temporal][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting timestamp strings is executed
   auto stmt = conn.execute_fetch(
@@ -205,10 +200,9 @@ TEST_CASE("should convert timestamp string to SQL_C_TYPE_TIME", "[datatype][stri
 // FAILING CONVERSIONS - Invalid date/time format strings
 // ============================================================================
 
-TEST_CASE("should fail converting invalid date/time strings", "[datatype][string][conversion][temporal][failure]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting invalid date/time strings",
+                 "[datatype][string][conversion][temporal][failure]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting invalid date/time strings is executed
   auto stmt = conn.execute_fetch("SELECT 'not-a-date' AS c1, 'not-a-time' AS c2, 'invalid-timestamp' AS c3");
@@ -223,11 +217,9 @@ TEST_CASE("should fail converting invalid date/time strings", "[datatype][string
 // FAILING CONVERSIONS - Impossible date/time values (correct syntax, invalid values)
 // ============================================================================
 
-TEST_CASE("should fail converting impossible date values",
-          "[datatype][string][conversion][temporal][failure][impossible]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible date values",
+                 "[datatype][string][conversion][temporal][failure][impossible]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting date strings with correct syntax but impossible values is executed
   auto stmt = conn.execute_fetch(
@@ -244,11 +236,9 @@ TEST_CASE("should fail converting impossible date values",
   }
 }
 
-TEST_CASE("should fail converting impossible time values",
-          "[datatype][string][conversion][temporal][failure][impossible][.skip]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible time values",
+                 "[datatype][string][conversion][temporal][failure][impossible][.skip]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting time strings with correct syntax but impossible values is executed
   auto stmt = conn.execute_fetch(
@@ -274,11 +264,9 @@ TEST_CASE("should fail converting impossible time values",
   CHECK(time.second == 60);
 }
 
-TEST_CASE("should fail converting impossible timestamp values",
-          "[datatype][string][conversion][temporal][failure][impossible]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible timestamp values",
+                 "[datatype][string][conversion][temporal][failure][impossible]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting timestamp strings with correct syntax but impossible values is executed
   auto stmt = conn.execute_fetch(
@@ -299,11 +287,9 @@ TEST_CASE("should fail converting impossible timestamp values",
 // FAILING CONVERSIONS - Alternative date serialization formats
 // ============================================================================
 
-TEST_CASE("should fail converting alternative date formats to SQL_C_TYPE_DATE",
-          "[datatype][string][conversion][temporal][failure][date_format]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative date formats to SQL_C_TYPE_DATE",
+                 "[datatype][string][conversion][temporal][failure][date_format]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting multiple date strings in alternative formats is executed
   auto stmt = conn.execute_fetch(
@@ -331,11 +317,9 @@ TEST_CASE("should fail converting alternative date formats to SQL_C_TYPE_DATE",
 // FAILING CONVERSIONS - Alternative time serialization formats
 // ============================================================================
 
-TEST_CASE("should fail converting alternative time formats to SQL_C_TYPE_TIME",
-          "[datatype][string][conversion][temporal][failure][time_format]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative time formats to SQL_C_TYPE_TIME",
+                 "[datatype][string][conversion][temporal][failure][time_format]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting multiple time strings in alternative formats is executed
   auto stmt = conn.execute_fetch(
@@ -358,11 +342,9 @@ TEST_CASE("should fail converting alternative time formats to SQL_C_TYPE_TIME",
 // FAILING CONVERSIONS - Alternative timestamp serialization formats
 // ============================================================================
 
-TEST_CASE("should fail converting alternative timestamp formats to SQL_C_TYPE_TIMESTAMP",
-          "[datatype][string][conversion][temporal][failure][timestamp_format]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative timestamp formats to SQL_C_TYPE_TIMESTAMP",
+                 "[datatype][string][conversion][temporal][failure][timestamp_format]") {
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // When Query selecting multiple timestamp strings in alternative formats is executed
   auto stmt = conn.execute_fetch(

--- a/odbc_tests/tests/e2e/types/string_lob.cpp
+++ b/odbc_tests/tests/e2e/types/string_lob.cpp
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB 
   std::mt19937 gen(seed);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("CREATE OR REPLACE TABLE lob_128mb (val VARCHAR(134217728))");
+  conn.execute("CREATE TEMPORARY TABLE lob_128mb (val VARCHAR(134217728))");
 
   // When A string of 134217728 ASCII characters is generated and inserted
   const size_t string_length = 134217728;  // 128 MB
@@ -105,7 +105,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 M
   std::mt19937 gen(seed);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("CREATE OR REPLACE TABLE lob_16mb (val VARCHAR)");
+  conn.execute("CREATE TEMPORARY TABLE lob_16mb (val VARCHAR)");
 
   // When A string of 16777216 ASCII characters is generated and inserted
   const size_t string_length = 16777216;  // 16 MB

--- a/odbc_tests/tests/e2e/types/string_lob.cpp
+++ b/odbc_tests/tests/e2e/types/string_lob.cpp
@@ -19,7 +19,7 @@
 
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
-#include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
 #include "odbc_matchers.hpp"
@@ -41,11 +41,10 @@ static std::string generate_random_ascii_string(std::mt19937& gen, size_t length
 // LOB (LARGE OBJECT) STRING HANDLING
 // ============================================================================
 
-TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB size", "[datatype][string][lob]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB limit with increased LOB size",
+                 "[datatype][string][lob]") {
   // Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A random seed is initialized and logged
   auto seed = static_cast<unsigned int>(std::chrono::steady_clock::now().time_since_epoch().count());
@@ -53,8 +52,7 @@ TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB s
   std::mt19937 gen(seed);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("DROP TABLE IF EXISTS test_string_lob");
-  conn.execute("CREATE TABLE test_string_lob (val VARCHAR(134217728))");
+  conn.execute("CREATE OR REPLACE TABLE lob_128mb (val VARCHAR(134217728))");
 
   // When A string of 134217728 ASCII characters is generated and inserted
   const size_t string_length = 134217728;  // 128 MB
@@ -62,7 +60,7 @@ TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB s
 
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO test_string_lob VALUES (?)", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO lob_128mb VALUES (?)"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLLEN value_len = static_cast<SQLLEN>(lob_string.size());
@@ -75,8 +73,7 @@ TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB s
 
   // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
   auto stmt = conn.createStatement();
-  SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val, LENGTH(val) as len FROM test_string_lob", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT val, LENGTH(val) as len FROM lob_128mb"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   // Use SQLBindCol to fetch the large string
   std::vector<char> buffer(string_length + 1);
@@ -97,11 +94,9 @@ TEST_CASE("should handle LOB string at maximum 128 MB limit with increased LOB s
   CHECK(retrieved_value == lob_string);
 }
 
-TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][string][lob]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 MB limit", "[datatype][string][lob]") {
   // Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
   // Given Snowflake client is logged in
-  Connection conn;
-  auto random_schema = Schema::use_random_schema(conn);
 
   // And A random seed is initialized and logged
   auto seed = static_cast<unsigned int>(std::chrono::steady_clock::now().time_since_epoch().count());
@@ -110,8 +105,7 @@ TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][stri
   std::mt19937 gen(seed);
 
   // And A temporary table with VARCHAR column is created
-  conn.execute("DROP TABLE IF EXISTS test_string_lob");
-  conn.execute("CREATE TABLE test_string_lob (val VARCHAR)");
+  conn.execute("CREATE OR REPLACE TABLE lob_16mb (val VARCHAR)");
 
   // When A string of 16777216 ASCII characters is generated and inserted
   const size_t string_length = 16777216;  // 16 MB
@@ -119,7 +113,7 @@ TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][stri
 
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO test_string_lob VALUES (?)", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO lob_16mb VALUES (?)"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLLEN value_len = static_cast<SQLLEN>(lob_string.size());
@@ -133,8 +127,7 @@ TEST_CASE("should handle LOB string at historical 16 MB limit", "[datatype][stri
 
   // And Query "SELECT val, LENGTH(val) as len FROM {table}" is executed
   auto stmt = conn.createStatement();
-  SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT val, LENGTH(val) as len FROM test_string_lob", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT val, LENGTH(val) as len FROM lob_16mb"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Use SQLBindCol to fetch the large string

--- a/odbc_tests/tests/e2e/types/timestamp_bind_fetch.cpp
+++ b/odbc_tests/tests/e2e/types/timestamp_bind_fetch.cpp
@@ -20,7 +20,7 @@ TEST_CASE("TIMESTAMP_NTZ round-trip via SQL_C_TYPE_TIMESTAMP bind and fetch",
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("ALTER SESSION SET CLIENT_TIMESTAMP_TYPE_MAPPING = 'TIMESTAMP_NTZ'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_ntz_rt (id INT, ts TIMESTAMP_NTZ)");
   auto stmt = conn.createStatement();
 
@@ -65,7 +65,7 @@ TEST_CASE("TIMESTAMP_NTZ round-trip via SQL_C_CHAR string bind", "[timestamp_ntz
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("ALTER SESSION SET CLIENT_TIMESTAMP_TYPE_MAPPING = 'TIMESTAMP_NTZ'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_ntz_str (id INT, ts TIMESTAMP_NTZ)");
   auto stmt = conn.createStatement();
 
@@ -103,7 +103,7 @@ TEST_CASE("TIMESTAMP_NTZ round-trip NULL via bind parameter", "[timestamp_ntz][b
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("ALTER SESSION SET CLIENT_TIMESTAMP_TYPE_MAPPING = 'TIMESTAMP_NTZ'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_ntz_null (id INT, ts TIMESTAMP_NTZ)");
   auto stmt = conn.createStatement();
 
@@ -133,7 +133,7 @@ TEST_CASE("TIMESTAMP_NTZ round-trip multiple rows with re-execution", "[timestam
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("ALTER SESSION SET CLIENT_TIMESTAMP_TYPE_MAPPING = 'TIMESTAMP_NTZ'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_ntz_multi (id INT, ts TIMESTAMP_NTZ)");
   auto stmt = conn.createStatement();
 
@@ -201,7 +201,7 @@ TEST_CASE("TIMESTAMP_LTZ round-trip via SQL_C_TYPE_TIMESTAMP bind and fetch",
   // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_LTZ column exists
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_ltz_rt (id INT, ts TIMESTAMP_LTZ)");
   auto stmt = conn.createStatement();
 
@@ -245,7 +245,7 @@ TEST_CASE("TIMESTAMP_TZ round-trip via SQL_C_TYPE_TIMESTAMP bind and fetch", "[t
   // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_TZ column exists
   Connection conn;
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
-  auto schema = Schema::use_random_schema(conn);
+  Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_tz_rt (id INT, ts TIMESTAMP_TZ)");
 
   // When A timestamp with an explicit timezone offset is inserted and then fetched back

--- a/odbc_tests/tests/odbc-api/submitting_request/describe_param_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/describe_param_tests.cpp
@@ -10,6 +10,7 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
@@ -62,21 +63,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLDescribeParam: Describes multiple pa
   }
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLDescribeParam: Describes INSERT parameters against typed columns",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLDescribeParam: Describes INSERT parameters against typed columns",
                  "[odbc-api][describeparam][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
   SQLRETURN ret = SQLExecDirect(
       stmt_handle(),
-      sqlchar(
-          ("CREATE OR REPLACE TABLE " + schema.name() + ".dp_typed_t(c1 INTEGER, c2 VARCHAR(100), c3 DOUBLE)").c_str()),
+      sqlchar(("CREATE OR REPLACE TABLE " + Schema::name() + ".dp_typed_t(c1 INTEGER, c2 VARCHAR(100), c3 DOUBLE)")
+                  .c_str()),
       SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLPrepare(stmt_handle(), sqlchar(("INSERT INTO " + schema.name() + ".dp_typed_t VALUES(?, ?, ?)").c_str()),
+  ret = SQLPrepare(stmt_handle(), sqlchar(("INSERT INTO " + Schema::name() + ".dp_typed_t VALUES(?, ?, ?)").c_str()),
                    SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 

--- a/odbc_tests/tests/odbc-api/submitting_request/describe_param_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/describe_param_tests.cpp
@@ -9,7 +9,6 @@
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
 #include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
@@ -68,15 +67,11 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLDescribeParam: Describes INSERT p
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(
-      stmt_handle(),
-      sqlchar(("CREATE OR REPLACE TABLE " + Schema::name() + ".dp_typed_t(c1 INTEGER, c2 VARCHAR(100), c3 DOUBLE)")
-                  .c_str()),
-      SQL_NTS);
+      stmt_handle(), sqlchar("CREATE TEMPORARY TABLE dp_typed_t(c1 INTEGER, c2 VARCHAR(100), c3 DOUBLE)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  ret = SQLPrepare(stmt_handle(), sqlchar(("INSERT INTO " + Schema::name() + ".dp_typed_t VALUES(?, ?, ?)").c_str()),
-                   SQL_NTS);
+  ret = SQLPrepare(stmt_handle(), sqlchar("INSERT INTO dp_typed_t VALUES(?, ?, ?)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Note: The reference driver reports SQL_VARCHAR with the same large fixed

--- a/odbc_tests/tests/odbc-api/submitting_request/exec_direct_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/exec_direct_tests.cpp
@@ -9,7 +9,6 @@
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
 #include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
@@ -44,12 +43,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: Executes DDL statemen
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_ddl_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE ed_ddl_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ed_ddl_t";
+  sql = "SELECT c1 FROM ed_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -57,7 +56,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: Executes DDL statemen
   REQUIRE(ret == SQL_NO_DATA);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DROP TABLE " + Schema::name() + ".ed_ddl_t";
+  sql = "DROP TABLE ed_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 }
@@ -66,12 +65,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: INSERT returns correc
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_ins_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ed_ins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ed_ins_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ed_ins_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -81,7 +80,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: INSERT returns correc
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ed_ins_t ORDER BY c1";
+  sql = "SELECT c1 FROM ed_ins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -107,17 +106,17 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: UPDATE returns correc
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_upd_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ed_upd_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ed_upd_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ed_upd_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "UPDATE " + Schema::name() + ".ed_upd_t SET c1 = c1 + 10";
+  sql = "UPDATE ed_upd_t SET c1 = c1 + 10";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -127,7 +126,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: UPDATE returns correc
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ed_upd_t ORDER BY c1";
+  sql = "SELECT c1 FROM ed_upd_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -153,17 +152,17 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: DELETE returns correc
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_del_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ed_del_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ed_del_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ed_del_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DELETE FROM " + Schema::name() + ".ed_del_t WHERE c1 IN (2, 3)";
+  sql = "DELETE FROM ed_del_t WHERE c1 IN (2, 3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -173,7 +172,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: DELETE returns correc
   REQUIRE(rowCount == 2);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ed_del_t ORDER BY c1";
+  sql = "SELECT c1 FROM ed_del_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -199,12 +198,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: SQL_NO_DATA for DML a
 
   // TODO: Restore SECTIONs once ConfigInstallation supports re-entry within sections
   {
-    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ed_nod_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TEMPORARY TABLE ed_nod_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "DELETE FROM " + Schema::name() + ".ed_nod_t WHERE c1 = 999";
+    std::string dml_sql = "DELETE FROM ed_nod_t WHERE c1 = 999";
     ret = SQLExecDirect(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_NO_DATA);
 
@@ -215,12 +214,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: SQL_NO_DATA for DML a
   }
 
   {
-    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ed_nou_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TEMPORARY TABLE ed_nou_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "UPDATE " + Schema::name() + ".ed_nou_t SET c1 = 2 WHERE c1 = 999";
+    std::string dml_sql = "UPDATE ed_nou_t SET c1 = 2 WHERE c1 = 999";
     ret = SQLExecDirect(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_NO_DATA);
 
@@ -419,7 +418,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42S02 for table not f
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "SELECT * FROM " + Schema::name() + ".nonexistent_table";
+  std::string sql = "SELECT * FROM nonexistent_table";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "42S02", stmt_handle(), SQL_HANDLE_STMT);
 }
@@ -436,12 +435,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 21S01 for INSERT colu
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_mis_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ed_mis_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ed_mis_t(c1) VALUES(1, 2)";
+  sql = "INSERT INTO ed_mis_t(c1) VALUES(1, 2)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "21S01", stmt_handle(), SQL_HANDLE_STMT);
 }
@@ -450,14 +449,14 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 22000 for NOT NULL co
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_nn_t(c1 INTEGER NOT NULL)";
+  std::string sql = "CREATE TEMPORARY TABLE ed_nn_t(c1 INTEGER NOT NULL)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   // Note: The reference driver returns 22000 instead of 23000 in ODBC spec
   // for integrity constraint violations.
-  sql = "INSERT INTO " + Schema::name() + ".ed_nn_t VALUES(NULL)";
+  sql = "INSERT INTO ed_nn_t VALUES(NULL)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "22000", stmt_handle(), SQL_HANDLE_STMT);
 }
@@ -466,7 +465,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42710 for table alrea
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_dup_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE ed_dup_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -484,7 +483,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42601 for CREATE VIEW
   // Note: The reference driver returns 42601 instead of 21S02 in the ODBC
   // spec for a CREATE VIEW where the column list has more names than the
   // SELECT produces.
-  std::string sql = "CREATE VIEW " + Schema::name() + ".ed_vm_v (a, b) AS SELECT 1";
+  std::string sql = "CREATE VIEW ed_vm_v (a, b) AS SELECT 1";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "42601", stmt_handle(), SQL_HANDLE_STMT);
 }

--- a/odbc_tests/tests/odbc-api/submitting_request/exec_direct_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/exec_direct_tests.cpp
@@ -10,6 +10,7 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
 #include "test_macros.hpp"
@@ -39,18 +40,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: Executes SELECT and retu
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: Executes DDL statement and table is queryable",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: Executes DDL statement and table is queryable",
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_ddl_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_ddl_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ed_ddl_t";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ed_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -58,23 +57,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: Executes DDL statement a
   REQUIRE(ret == SQL_NO_DATA);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DROP TABLE " + schema.name() + ".ed_ddl_t";
+  sql = "DROP TABLE " + Schema::name() + ".ed_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: INSERT returns correct SQLRowCount and inserts rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: INSERT returns correct SQLRowCount and inserts rows",
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_ins_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_ins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ed_ins_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ed_ins_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -84,7 +81,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: INSERT returns correct S
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ed_ins_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ed_ins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -106,23 +103,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: INSERT returns correct S
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: UPDATE returns correct SQLRowCount and updates rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: UPDATE returns correct SQLRowCount and updates rows",
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_upd_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_upd_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ed_upd_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ed_upd_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "UPDATE " + schema.name() + ".ed_upd_t SET c1 = c1 + 10";
+  sql = "UPDATE " + Schema::name() + ".ed_upd_t SET c1 = c1 + 10";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -132,7 +127,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: UPDATE returns correct S
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ed_upd_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ed_upd_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -154,23 +149,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: UPDATE returns correct S
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: DELETE returns correct SQLRowCount and removes rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: DELETE returns correct SQLRowCount and removes rows",
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_del_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_del_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ed_del_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ed_del_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DELETE FROM " + schema.name() + ".ed_del_t WHERE c1 IN (2, 3)";
+  sql = "DELETE FROM " + Schema::name() + ".ed_del_t WHERE c1 IN (2, 3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -180,7 +173,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: DELETE returns correct S
   REQUIRE(rowCount == 2);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ed_del_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ed_del_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -200,20 +193,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: DELETE returns correct S
 // SQLExecDirect - SQL_NO_DATA
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: SQL_NO_DATA for DML affecting zero rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: SQL_NO_DATA for DML affecting zero rows",
                  "[odbc-api][execdirect][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
   // TODO: Restore SECTIONs once ConfigInstallation supports re-entry within sections
   {
-    std::string create_sql = "CREATE TABLE " + schema.name() + ".ed_nod_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ed_nod_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "DELETE FROM " + schema.name() + ".ed_nod_t WHERE c1 = 999";
+    std::string dml_sql = "DELETE FROM " + Schema::name() + ".ed_nod_t WHERE c1 = 999";
     ret = SQLExecDirect(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_NO_DATA);
 
@@ -224,12 +215,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: SQL_NO_DATA for DML affe
   }
 
   {
-    std::string create_sql = "CREATE TABLE " + schema.name() + ".ed_nou_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ed_nou_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "UPDATE " + schema.name() + ".ed_nou_t SET c1 = 2 WHERE c1 = 999";
+    std::string dml_sql = "UPDATE " + Schema::name() + ".ed_nou_t SET c1 = 2 WHERE c1 = 999";
     ret = SQLExecDirect(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_NO_DATA);
 
@@ -424,13 +415,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 42000 for syntax error",
   REQUIRE_EXPECTED_ERROR(ret, "42000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 42S02 for table not found",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42S02 for table not found",
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "SELECT * FROM " + schema.name() + ".nonexistent_table";
+  std::string sql = "SELECT * FROM " + Schema::name() + ".nonexistent_table";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "42S02", stmt_handle(), SQL_HANDLE_STMT);
 }
@@ -443,47 +432,41 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 22012 for division by ze
   REQUIRE_EXPECTED_ERROR(ret, "22012", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 21S01 for INSERT column count mismatch",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 21S01 for INSERT column count mismatch",
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_mis_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_mis_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ed_mis_t(c1) VALUES(1, 2)";
+  sql = "INSERT INTO " + Schema::name() + ".ed_mis_t(c1) VALUES(1, 2)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "21S01", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 22000 for NOT NULL constraint violation",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 22000 for NOT NULL constraint violation",
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_nn_t(c1 INTEGER NOT NULL)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_nn_t(c1 INTEGER NOT NULL)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   // Note: The reference driver returns 22000 instead of 23000 in ODBC spec
   // for integrity constraint violations.
-  sql = "INSERT INTO " + schema.name() + ".ed_nn_t VALUES(NULL)";
+  sql = "INSERT INTO " + Schema::name() + ".ed_nn_t VALUES(NULL)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "22000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 42710 for table already exists",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42710 for table already exists",
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ed_dup_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ed_dup_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -494,16 +477,14 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 42710 for table already 
   REQUIRE_EXPECTED_ERROR(ret, "42710", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecDirect: 42601 for CREATE VIEW column list mismatch",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecDirect: 42601 for CREATE VIEW column list mismatch",
                  "[odbc-api][execdirect][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
-  const auto schema = Schema::use_random_schema(dbc_handle());
 
   // Note: The reference driver returns 42601 instead of 21S02 in the ODBC
   // spec for a CREATE VIEW where the column list has more names than the
   // SELECT produces.
-  std::string sql = "CREATE VIEW " + schema.name() + ".ed_vm_v (a, b) AS SELECT 1";
+  std::string sql = "CREATE VIEW " + Schema::name() + ".ed_vm_v (a, b) AS SELECT 1";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "42601", stmt_handle(), SQL_HANDLE_STMT);
 }

--- a/odbc_tests/tests/odbc-api/submitting_request/execute_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/execute_tests.cpp
@@ -9,6 +9,7 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
 #include "test_macros.hpp"
@@ -41,13 +42,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Executes prepared SELECT an
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Executes prepared DDL statement and table is queryable",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Executes prepared DDL statement and table is queryable",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_ddl_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_ddl_t(c1 INTEGER)";
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -55,7 +54,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Executes prepared DDL state
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ex_ddl_t";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ex_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -63,23 +62,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Executes prepared DDL state
   REQUIRE(ret == SQL_NO_DATA);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DROP TABLE " + schema.name() + ".ex_ddl_t";
+  sql = "DROP TABLE " + Schema::name() + ".ex_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: INSERT returns correct SQLRowCount and inserts rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: INSERT returns correct SQLRowCount and inserts rows",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_ins_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_ins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ex_ins_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_ins_t VALUES(1),(2),(3)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -92,7 +89,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: INSERT returns correct SQLR
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ex_ins_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ex_ins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -114,23 +111,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: INSERT returns correct SQLR
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: UPDATE returns correct SQLRowCount and updates rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: UPDATE returns correct SQLRowCount and updates rows",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_upd_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_upd_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ex_upd_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_upd_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "UPDATE " + schema.name() + ".ex_upd_t SET c1 = c1 + 10";
+  sql = "UPDATE " + Schema::name() + ".ex_upd_t SET c1 = c1 + 10";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -143,7 +138,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: UPDATE returns correct SQLR
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ex_upd_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ex_upd_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -165,23 +160,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: UPDATE returns correct SQLR
   REQUIRE(ret == SQL_NO_DATA);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: DELETE returns correct SQLRowCount and removes rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: DELETE returns correct SQLRowCount and removes rows",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_del_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_del_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ex_del_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_del_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DELETE FROM " + schema.name() + ".ex_del_t WHERE c1 IN (2, 3)";
+  sql = "DELETE FROM " + Schema::name() + ".ex_del_t WHERE c1 IN (2, 3)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -194,7 +187,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: DELETE returns correct SQLR
   REQUIRE(rowCount == 2);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ex_del_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ex_del_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -214,20 +207,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: DELETE returns correct SQLR
 // SQLExecute - SQL_NO_DATA
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: SQL_NO_DATA for DML affecting zero rows",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: SQL_NO_DATA for DML affecting zero rows",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
   // TODO: Restore SECTIONs once ConfigInstallation supports re-entry within sections
   {
-    std::string create_sql = "CREATE TABLE " + schema.name() + ".ex_nod_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ex_nod_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "DELETE FROM " + schema.name() + ".ex_nod_t WHERE c1 = 999";
+    std::string dml_sql = "DELETE FROM " + Schema::name() + ".ex_nod_t WHERE c1 = 999";
     ret = SQLPrepare(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
 
@@ -241,12 +232,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: SQL_NO_DATA for DML affecti
   }
 
   {
-    std::string create_sql = "CREATE TABLE " + schema.name() + ".ex_nou_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ex_nou_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "UPDATE " + schema.name() + ".ex_nou_t SET c1 = 2 WHERE c1 = 999";
+    std::string dml_sql = "UPDATE " + Schema::name() + ".ex_nou_t SET c1 = 2 WHERE c1 = 999";
     ret = SQLPrepare(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
 
@@ -298,18 +289,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Re-executes SELECT with upd
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Re-executes INSERT with different parameter each time",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Re-executes INSERT with different parameter each time",
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_reins_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_reins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ex_reins_t VALUES(?)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_reins_t VALUES(?)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -328,7 +317,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: Re-executes INSERT with dif
     REQUIRE(rowCount == 1);
   }
 
-  sql = "SELECT c1 FROM " + schema.name() + ".ex_reins_t ORDER BY c1";
+  sql = "SELECT c1 FROM " + Schema::name() + ".ex_reins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -485,13 +474,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 22012 for division by zero"
   REQUIRE_EXPECTED_ERROR(ret, "22012", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 42S02 for table not found",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42S02 for table not found",
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "SELECT * FROM " + schema.name() + ".nonexistent_table";
+  std::string sql = "SELECT * FROM " + Schema::name() + ".nonexistent_table";
 
   // Note: Snowflake validates table existence at prepare time, so the 42S02
   // error may be raised by SQLPrepare rather than SQLExecute.
@@ -518,20 +505,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 07002 for parameter count m
   REQUIRE_EXPECTED_ERROR(ret, "07002", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 22000 for NOT NULL constraint violation",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 22000 for NOT NULL constraint violation",
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_nn_t(c1 INTEGER NOT NULL)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_nn_t(c1 INTEGER NOT NULL)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   // Note: The reference driver returns 22000 instead of 23000 in ODBC spec
   // for integrity constraint violations.
-  sql = "INSERT INTO " + schema.name() + ".ex_nn_t VALUES(NULL)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_nn_t VALUES(NULL)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -539,13 +524,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 22000 for NOT NULL constrai
   REQUIRE_EXPECTED_ERROR(ret, "22000", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 42710 for table already exists",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42710 for table already exists",
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_dup_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_dup_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -560,18 +543,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 42710 for table already exi
   REQUIRE_EXPECTED_ERROR(ret2, "42710", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 21S01 for INSERT column count mismatch",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 21S01 for INSERT column count mismatch",
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE TABLE " + schema.name() + ".ex_mis_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_mis_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + schema.name() + ".ex_mis_t(c1) VALUES(1, 2)";
+  sql = "INSERT INTO " + Schema::name() + ".ex_mis_t(c1) VALUES(1, 2)";
 
   // Note: Snowflake validates column counts at prepare time, so the 21S01
   // error may be raised by SQLPrepare rather than SQLExecute.
@@ -582,13 +563,11 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 21S01 for INSERT column cou
   REQUIRE_EXPECTED_ERROR(ret2, "21S01", stmt_handle(), SQL_HANDLE_STMT);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLExecute: 42601 for CREATE VIEW column list mismatch",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42601 for CREATE VIEW column list mismatch",
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  const auto schema = Schema::use_random_schema(dbc_handle());
-
-  std::string sql = "CREATE VIEW " + schema.name() + ".ex_vm_v (a, b) AS SELECT 1";
+  std::string sql = "CREATE VIEW " + Schema::name() + ".ex_vm_v (a, b) AS SELECT 1";
 
   // Note: Snowflake validates at prepare time. The reference driver returns
   // 42601 instead of 21S02 in the ODBC spec for a CREATE VIEW where the

--- a/odbc_tests/tests/odbc-api/submitting_request/execute_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/execute_tests.cpp
@@ -8,7 +8,6 @@
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
 #include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
@@ -46,7 +45,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Executes prepared DDL st
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_ddl_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE ex_ddl_t(c1 INTEGER)";
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -54,7 +53,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Executes prepared DDL st
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ex_ddl_t";
+  sql = "SELECT c1 FROM ex_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -62,7 +61,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Executes prepared DDL st
   REQUIRE(ret == SQL_NO_DATA);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DROP TABLE " + Schema::name() + ".ex_ddl_t";
+  sql = "DROP TABLE ex_ddl_t";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 }
@@ -71,12 +70,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: INSERT returns correct S
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_ins_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_ins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ex_ins_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ex_ins_t VALUES(1),(2),(3)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -89,7 +88,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: INSERT returns correct S
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ex_ins_t ORDER BY c1";
+  sql = "SELECT c1 FROM ex_ins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -115,17 +114,17 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: UPDATE returns correct S
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_upd_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_upd_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ex_upd_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ex_upd_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "UPDATE " + Schema::name() + ".ex_upd_t SET c1 = c1 + 10";
+  sql = "UPDATE ex_upd_t SET c1 = c1 + 10";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -138,7 +137,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: UPDATE returns correct S
   REQUIRE(rowCount == 3);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ex_upd_t ORDER BY c1";
+  sql = "SELECT c1 FROM ex_upd_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -164,17 +163,17 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: DELETE returns correct S
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_del_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_del_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ex_del_t VALUES(1),(2),(3)";
+  sql = "INSERT INTO ex_del_t VALUES(1),(2),(3)";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "DELETE FROM " + Schema::name() + ".ex_del_t WHERE c1 IN (2, 3)";
+  sql = "DELETE FROM ex_del_t WHERE c1 IN (2, 3)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -187,7 +186,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: DELETE returns correct S
   REQUIRE(rowCount == 2);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ex_del_t ORDER BY c1";
+  sql = "SELECT c1 FROM ex_del_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -213,12 +212,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: SQL_NO_DATA for DML affe
 
   // TODO: Restore SECTIONs once ConfigInstallation supports re-entry within sections
   {
-    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ex_nod_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TEMPORARY TABLE ex_nod_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "DELETE FROM " + Schema::name() + ".ex_nod_t WHERE c1 = 999";
+    std::string dml_sql = "DELETE FROM ex_nod_t WHERE c1 = 999";
     ret = SQLPrepare(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
 
@@ -232,12 +231,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: SQL_NO_DATA for DML affe
   }
 
   {
-    std::string create_sql = "CREATE TABLE " + Schema::name() + ".ex_nou_t(c1 INTEGER)";
+    std::string create_sql = "CREATE TEMPORARY TABLE ex_nou_t(c1 INTEGER)";
     SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(create_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
     SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-    std::string dml_sql = "UPDATE " + Schema::name() + ".ex_nou_t SET c1 = 2 WHERE c1 = 999";
+    std::string dml_sql = "UPDATE ex_nou_t SET c1 = 2 WHERE c1 = 999";
     ret = SQLPrepare(stmt_handle(), sqlchar(dml_sql.c_str()), SQL_NTS);
     REQUIRE(ret == SQL_SUCCESS);
 
@@ -293,12 +292,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Re-executes INSERT with 
                  "[odbc-api][execute][submitting_request]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_reins_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_reins_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ex_reins_t VALUES(?)";
+  sql = "INSERT INTO ex_reins_t VALUES(?)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -317,7 +316,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: Re-executes INSERT with 
     REQUIRE(rowCount == 1);
   }
 
-  sql = "SELECT c1 FROM " + Schema::name() + ".ex_reins_t ORDER BY c1";
+  sql = "SELECT c1 FROM ex_reins_t ORDER BY c1";
   ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -478,7 +477,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42S02 for table not foun
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "SELECT * FROM " + Schema::name() + ".nonexistent_table";
+  std::string sql = "SELECT * FROM nonexistent_table";
 
   // Note: Snowflake validates table existence at prepare time, so the 42S02
   // error may be raised by SQLPrepare rather than SQLExecute.
@@ -509,14 +508,14 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 22000 for NOT NULL const
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_nn_t(c1 INTEGER NOT NULL)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_nn_t(c1 INTEGER NOT NULL)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
   // Note: The reference driver returns 22000 instead of 23000 in ODBC spec
   // for integrity constraint violations.
-  sql = "INSERT INTO " + Schema::name() + ".ex_nn_t VALUES(NULL)";
+  sql = "INSERT INTO ex_nn_t VALUES(NULL)";
   ret = SQLPrepare(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -528,7 +527,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42710 for table already 
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_dup_t(c1 INTEGER)";
+  std::string sql = "CREATE TABLE ex_dup_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -547,12 +546,12 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 21S01 for INSERT column 
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE TABLE " + Schema::name() + ".ex_mis_t(c1 INTEGER)";
+  std::string sql = "CREATE TEMPORARY TABLE ex_mis_t(c1 INTEGER)";
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar(sql.c_str()), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   SQLFreeStmt(stmt_handle(), SQL_CLOSE);
 
-  sql = "INSERT INTO " + Schema::name() + ".ex_mis_t(c1) VALUES(1, 2)";
+  sql = "INSERT INTO ex_mis_t(c1) VALUES(1, 2)";
 
   // Note: Snowflake validates column counts at prepare time, so the 21S01
   // error may be raised by SQLPrepare rather than SQLExecute.
@@ -567,7 +566,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLExecute: 42601 for CREATE VIEW co
                  "[odbc-api][execute][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  std::string sql = "CREATE VIEW " + Schema::name() + ".ex_vm_v (a, b) AS SELECT 1";
+  std::string sql = "CREATE VIEW ex_vm_v (a, b) AS SELECT 1";
 
   // Note: Snowflake validates at prepare time. The reference driver returns
   // 42601 instead of 21S02 in the ODBC spec for a CREATE VIEW where the

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
@@ -512,7 +512,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cancel after DDL execution",
                  "[odbc-api][cancel][terminating_statement]") {
   Schema::use_temp_session_schema(dbc_handle());
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE OR REPLACE TABLE cancel_test_tmp (id INT)"), SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE cancel_test_tmp (id INT)"), SQL_NTS);
   REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancel(stmt_handle());

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
@@ -510,7 +510,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cancel after all rows fetche
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cancel after DDL execution",
                  "[odbc-api][cancel][terminating_statement]") {
-  auto schema = Schema::use_random_schema(dbc_handle());
+  Schema::use_temp_session_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE OR REPLACE TABLE cancel_test_tmp (id INT)"), SQL_NTS);
   REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
@@ -535,7 +535,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cancel after DDL execution",
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cancel on statement in Error state",
                  "[odbc-api][cancel][terminating_statement]") {
-  auto schema = Schema::use_random_schema(dbc_handle());
+  Schema::use_temp_session_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM nonexistent_table"), SQL_NTS);
   REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());

--- a/odbc_tests/tests/odbc-api/terminating_statement/end_tran_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/end_tran_tests.cpp
@@ -9,6 +9,7 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "Schema.hpp"
+#include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
@@ -19,14 +20,12 @@
 // SQLEndTran - Statement Handle
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Commit persists inserted data",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Commit persists inserted data",
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
-
-  auto schema = Schema::use_random_schema(dbc_handle());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_COMMIT_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -76,14 +75,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Commit persists inserted da
   REQUIRE(ret == SQL_SUCCESS);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Rollback discards inserted data",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback discards inserted data",
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
-
-  auto schema = Schema::use_random_schema(dbc_handle());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -127,14 +124,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Rollback discards inserted 
 // SQLEndTran - Environment Handle
 // ============================================================================
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Commit on environment handle",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Commit on environment handle",
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
-
-  auto schema = Schema::use_random_schema(dbc_handle());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ENV_COMMIT_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -183,14 +178,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Commit on environment handl
   REQUIRE(ret == SQL_SUCCESS);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Rollback on environment handle",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback on environment handle",
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
-
-  auto schema = Schema::use_random_schema(dbc_handle());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ENV_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -294,11 +287,9 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Commit in autocommit mode",
   REQUIRE(ret == SQL_SUCCESS);
 }
 
-TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLEndTran: Rollback in autocommit mode does not undo committed data",
+TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback in autocommit mode does not undo committed data",
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
-  auto schema = Schema::use_random_schema(dbc_handle());
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_AC_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);

--- a/odbc_tests/tests/odbc-api/terminating_statement/end_tran_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/end_tran_tests.cpp
@@ -8,7 +8,6 @@
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
-#include "Schema.hpp"
 #include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_diag_rec.hpp"
@@ -27,7 +26,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Commit persists inserted
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_COMMIT_T (ID INTEGER)"), SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE ENDTRAN_COMMIT_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -82,7 +81,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback discards insert
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE ENDTRAN_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -131,7 +130,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Commit on environment ha
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ENV_COMMIT_T (ID INTEGER)"), SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE ENDTRAN_ENV_COMMIT_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -185,7 +184,7 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback on environment 
   SQLRETURN ret = SQLSetConnectAttr(dbc_handle(), SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_ENV_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
+  ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE ENDTRAN_ENV_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
@@ -291,7 +290,8 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture, "SQLEndTran: Rollback in autocommit m
                  "[odbc-api][endtran][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("CREATE TABLE ENDTRAN_AC_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE ENDTRAN_AC_ROLLBACK_T (ID INTEGER)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);

--- a/odbc_tests/tools/CMakeLists.txt
+++ b/odbc_tests/tools/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(schema_tool schema_tool.cpp)
+target_link_libraries(schema_tool PRIVATE common ODBC::ODBC Threads::Threads)
+if(NOT WIN32)
+  target_link_libraries(schema_tool PRIVATE ${CMAKE_DL_LIBS})
+endif()
+
+# Force flat output directory so the binary is at cmake-build/tools/schema_tool
+# regardless of single-config (Makefile) vs multi-config (MSVC) generators.
+set_target_properties(schema_tool PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools"
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tools"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tools")

--- a/odbc_tests/tools/schema_tool.cpp
+++ b/odbc_tests/tools/schema_tool.cpp
@@ -13,6 +13,7 @@
 #include <sql.h>
 #include <sqlext.h>
 
+#include <cstring>
 #include <iostream>
 #include <optional>
 #include <random>
@@ -50,7 +51,10 @@ struct OdbcConnection {
       std::cerr << TAG << ": SQLAllocHandle(ENV) failed\n";
       return false;
     }
-    SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+    if (!SQL_SUCCEEDED(SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0))) {
+      std::cerr << TAG << ": SQLSetEnvAttr(SQL_OV_ODBC3) failed\n";
+      return false;
+    }
 
     if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc))) {
       std::cerr << TAG << ": SQLAllocHandle(DBC) failed\n";
@@ -134,7 +138,8 @@ static int cmd_create() {
   const std::string name = generate_schema_name();
 
   OdbcConnection conn;
-  if (const auto installation = open_connection(conn); !installation) {
+  auto installation = open_connection(conn);
+  if (!installation) {
     return 1;
   }
   if (!conn.exec("CREATE SCHEMA IF NOT EXISTS " + name)) {

--- a/odbc_tests/tools/schema_tool.cpp
+++ b/odbc_tests/tools/schema_tool.cpp
@@ -1,0 +1,256 @@
+// Standalone utility for managing temporary test schemas via ODBC.
+//
+// Subcommands:
+//   create                  Create a new TEMP_TEST_SCHEMA_<random>, print name to stdout.
+//   drop <name>             Drop a specific schema (validates name format).
+//   cleanup [--age-days N]  Drop orphaned TEMP_TEST_SCHEMA_* schemas older than N days (default 2).
+//
+// Uses DataSourceConfig::Snowflake() from the common library for connection
+// configuration, and raw ODBC API calls to avoid any Catch2 dependency at runtime.
+// Links against the common static library (Catch2's main() is not pulled in
+// because this translation unit already defines main()).
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <iostream>
+#include <optional>
+#include <random>
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "ODBCConfig.hpp"
+#include "odbc_cast.hpp"
+
+static constexpr auto TAG = "schema_tool";
+static const std::regex SCHEMA_NAME_RE("^TEMP_TEST_SCHEMA_[0-9]+$");
+
+struct OdbcConnection {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC dbc = SQL_NULL_HDBC;
+
+  OdbcConnection(const OdbcConnection&) = delete;
+  OdbcConnection& operator=(const OdbcConnection&) = delete;
+
+  OdbcConnection() = default;
+
+  ~OdbcConnection() {
+    if (dbc != SQL_NULL_HDBC) {
+      SQLDisconnect(dbc);
+      SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    }
+    if (env != SQL_NULL_HENV) {
+      SQLFreeHandle(SQL_HANDLE_ENV, env);
+    }
+  }
+
+  bool connect(const std::string& conn_str) {
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env))) {
+      std::cerr << TAG << ": SQLAllocHandle(ENV) failed\n";
+      return false;
+    }
+    SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc))) {
+      std::cerr << TAG << ": SQLAllocHandle(DBC) failed\n";
+      return false;
+    }
+
+    const SQLRETURN ret =
+        SQLDriverConnect(dbc, nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+    if (!SQL_SUCCEEDED(ret)) {
+      std::cerr << TAG << ": SQLDriverConnect failed\n";
+      return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool exec(const std::string& sql) const {
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt))) {
+      std::cerr << TAG << ": SQLAllocHandle(STMT) failed for: " << sql << "\n";
+      return false;
+    }
+    const SQLRETURN ret = SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS);
+    const bool ok = SQL_SUCCEEDED(ret);
+    if (!ok) {
+      std::cerr << TAG << ": SQLExecDirect failed for: " << sql << "\n";
+    }
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    return ok;
+  }
+
+  [[nodiscard]] std::vector<std::string> query_column(const std::string& sql) const {
+    std::vector<std::string> results;
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt))) {
+      std::cerr << TAG << ": SQLAllocHandle(STMT) failed for: " << sql << "\n";
+      return results;
+    }
+    if (!SQL_SUCCEEDED(SQLExecDirect(stmt, sqlchar(sql.c_str()), SQL_NTS))) {
+      std::cerr << TAG << ": SQLExecDirect failed for: " << sql << "\n";
+      SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+      return results;
+    }
+    char buf[512];
+    while (SQL_SUCCEEDED(SQLFetch(stmt))) {
+      SQLLEN indicator = 0;
+      if (SQL_SUCCEEDED(SQLGetData(stmt, 1, SQL_C_CHAR, buf, sizeof(buf), &indicator))) {
+        if (indicator != SQL_NULL_DATA) {
+          results.emplace_back(buf);
+        }
+      }
+    }
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    return results;
+  }
+};
+
+// Opens a connection using DataSourceConfig::Snowflake().  The returned
+// ConfigInstallation keeps odbc.ini/odbcinst.ini alive for the connection's
+// lifetime — callers must hold onto it until they are done with `conn`.
+static std::optional<ConfigInstallation> open_connection(OdbcConnection& conn) {
+  try {
+    auto dsn_config = DataSourceConfig::Snowflake();
+    auto installation = dsn_config.install();
+    if (!conn.connect(dsn_config.connection_string())) {
+      return std::nullopt;
+    }
+    return installation;
+  } catch (const std::exception& e) {
+    std::cerr << TAG << ": " << e.what() << "\n";
+    return std::nullopt;
+  }
+}
+
+static std::string generate_schema_name() {
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  return "TEMP_TEST_SCHEMA_" + std::to_string(gen());
+}
+
+static int cmd_create() {
+  const std::string name = generate_schema_name();
+
+  OdbcConnection conn;
+  if (const auto installation = open_connection(conn); !installation) {
+    return 1;
+  }
+  if (!conn.exec("CREATE SCHEMA IF NOT EXISTS " + name)) {
+    return 1;
+  }
+  std::cerr << TAG << ": created schema " << name << "\n";
+  std::cout << name;
+  return 0;
+}
+
+static int cmd_drop(const std::string& name) {
+  if (!std::regex_match(name, SCHEMA_NAME_RE)) {
+    std::cerr << TAG << ": refusing to drop schema with unexpected name: " << name << "\n";
+    return 1;
+  }
+
+  OdbcConnection conn;
+  auto installation = open_connection(conn);
+  if (!installation) {
+    return 1;
+  }
+  if (!conn.exec("DROP SCHEMA IF EXISTS " + name + " CASCADE")) {
+    return 1;
+  }
+  std::cerr << TAG << ": dropped schema " << name << "\n";
+  return 0;
+}
+
+static int cmd_cleanup(const int age_days) {
+  OdbcConnection conn;
+  auto installation = open_connection(conn);
+  if (!installation) {
+    return 1;
+  }
+
+  std::string query =
+      "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
+      "WHERE SCHEMA_NAME LIKE 'TEMP_TEST_SCHEMA_%' "
+      "AND CREATED < DATEADD(day, -" +
+      std::to_string(age_days) +
+      ", CURRENT_TIMESTAMP()) "
+      "ORDER BY CREATED";
+
+  std::cerr << TAG << ": looking for TEMP_TEST_SCHEMA_% older than " << age_days << " days\n";
+
+  auto schemas = conn.query_column(query);
+  if (schemas.empty()) {
+    std::cerr << TAG << ": no orphaned schemas found\n";
+    return 0;
+  }
+
+  int count = 0;
+  for (const auto& schema : schemas) {
+    if (!std::regex_match(schema, SCHEMA_NAME_RE)) {
+      std::cerr << TAG << ": skipping unexpected schema name: " << schema << "\n";
+      continue;
+    }
+    std::cerr << TAG << ": dropping " << schema << "\n";
+    if (!conn.exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")) {
+      std::cerr << TAG << ": failed to drop schema: " << schema << "\n";
+    }
+    ++count;
+  }
+
+  std::cerr << TAG << ": dropped " << count << " orphaned schema(s)\n";
+  return 0;
+}
+
+static void usage() {
+  std::cerr << "Usage:\n"
+            << "  schema_tool create\n"
+            << "  schema_tool drop <SCHEMA_NAME>\n"
+            << "  schema_tool cleanup [--age-days N]\n";
+}
+
+int main(const int argc, char* argv[]) {
+  if (argc < 2) {
+    usage();
+    return 1;
+  }
+
+  const std::string cmd = argv[1];
+
+  if (cmd == "create") {
+    return cmd_create();
+  }
+
+  if (cmd == "drop") {
+    if (argc < 3) {
+      std::cerr << TAG << ": 'drop' requires a schema name argument\n";
+      usage();
+      return 1;
+    }
+    return cmd_drop(argv[2]);
+  }
+
+  if (cmd == "cleanup") {
+    int age_days = 2;
+    for (int i = 2; i < argc - 1; ++i) {
+      if (std::strcmp(argv[i], "--age-days") == 0) {
+        try {
+          age_days = std::stoi(argv[i + 1]);
+          if (age_days < 0) {
+            age_days = 2;
+          }
+        } catch (...) {
+          std::cerr << TAG << ": invalid --age-days value, using default 2\n";
+          age_days = 2;
+        }
+        break;
+      }
+    }
+    return cmd_cleanup(age_days);
+  }
+
+  std::cerr << TAG << ": unknown command '" << cmd << "'\n";
+  usage();
+  return 1;
+}

--- a/scripts/odbc/run_tests_unix.sh
+++ b/scripts/odbc/run_tests_unix.sh
@@ -3,7 +3,8 @@
 # Required env vars: DRIVER_PATH, PARAMETER_PATH, DRIVER_TYPE
 set -euo pipefail
 
-cd "$(dirname "$0")/../../odbc_tests"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../../odbc_tests"
 
 # Detect ODBC paths
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -30,4 +31,19 @@ cmake -B cmake-build \
     ${CCACHE_ARGS} \
     .
 cmake --build cmake-build -- -j $((NPROC * 2))
-ctest -j $((NPROC * 4)) -C Debug --test-dir cmake-build --output-on-failure
+
+# --- Schema lifecycle: pre-create a shared schema for all test processes ----------
+SCHEMA_TOOL="./cmake-build/tools/schema_tool"
+if SCHEMA_NAME=$("$SCHEMA_TOOL" create); then
+    export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
+    trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
+    echo "run_tests: using shared schema $SCHEMA_NAME"
+else
+    echo "run_tests: schema pre-creation failed, falling back to per-process"
+fi
+
+CTEST_ARGS=()
+if [[ -n "${CTEST_FILTER:-}" ]]; then
+    CTEST_ARGS+=(-R "$CTEST_FILTER")
+fi
+ctest -j $((NPROC * 4)) -C Debug --test-dir cmake-build --output-on-failure ${CTEST_ARGS[@]+"${CTEST_ARGS[@]}"} "$@"

--- a/scripts/odbc/run_tests_unix.sh
+++ b/scripts/odbc/run_tests_unix.sh
@@ -35,9 +35,13 @@ cmake --build cmake-build -- -j $((NPROC * 2))
 # --- Schema lifecycle: pre-create a shared schema for all test processes ----------
 SCHEMA_TOOL="./cmake-build/tools/schema_tool"
 if SCHEMA_NAME=$("$SCHEMA_TOOL" create); then
-    export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
-    trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
-    echo "run_tests: using shared schema $SCHEMA_NAME"
+    if [[ ! "$SCHEMA_NAME" =~ ^TEMP_TEST_SCHEMA_[0-9]+$ ]]; then
+        echo "run_tests: schema_tool returned invalid name '$SCHEMA_NAME', falling back to per-process"
+    else
+        export ODBC_TEST_SCHEMA="$SCHEMA_NAME"
+        trap '"$SCHEMA_TOOL" drop "$SCHEMA_NAME" 2>/dev/null || true' EXIT
+        echo "run_tests: using shared schema $SCHEMA_NAME"
+    fi
 else
     echo "run_tests: schema pre-creation failed, falling back to per-process"
 fi

--- a/scripts/odbc/run_tests_windows.ps1
+++ b/scripts/odbc/run_tests_windows.ps1
@@ -7,7 +7,7 @@ Push-Location (Join-Path $ScriptDir "..\..\odbc_tests")
 
 try {
     $NPROC = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
-    
+
     New-Item -ItemType Directory -Force -Path cmake-build | Out-Null
     $cmakeArgs = @("-B", "cmake-build", "-D", "DRIVER_TYPE=$env:DRIVER_TYPE")
     if (Get-Command ccache -ErrorAction SilentlyContinue) {
@@ -18,6 +18,19 @@ try {
     }
     cmake @cmakeArgs .
     cmake --build cmake-build --config Debug --parallel ($NPROC)
+
+    # --- Schema lifecycle: pre-create a shared schema for all test processes ---
+    $schemaTool = Join-Path $pwd "cmake-build\tools\schema_tool.exe"
+    try {
+        $schemaName = & $schemaTool create 2>$null
+        if ($LASTEXITCODE -eq 0 -and $schemaName) {
+            $env:ODBC_TEST_SCHEMA = $schemaName.Trim()
+            Write-Host "run_tests: using shared schema $($env:ODBC_TEST_SCHEMA)"
+        }
+    } catch {
+        Write-Host "run_tests: schema pre-creation failed, falling back to per-process"
+    }
+
     $ctestArgs = @("-j", ($NPROC * 4), "-C", "Debug", "--test-dir", "cmake-build", "--output-on-failure")
     if ($env:CTEST_FILTER) {
         $ctestArgs += @("-R", $env:CTEST_FILTER)
@@ -26,5 +39,11 @@ try {
     ctest @ctestArgs
 }
 finally {
+    if ($env:ODBC_TEST_SCHEMA) {
+        try {
+            & $schemaTool drop $env:ODBC_TEST_SCHEMA 2>$null
+        } catch {}
+        $env:ODBC_TEST_SCHEMA = $null
+    }
     Pop-Location
 }

--- a/scripts/odbc/run_tests_windows.ps1
+++ b/scripts/odbc/run_tests_windows.ps1
@@ -24,8 +24,13 @@ try {
     try {
         $schemaName = & $schemaTool create 2>$null
         if ($LASTEXITCODE -eq 0 -and $schemaName) {
-            $env:ODBC_TEST_SCHEMA = $schemaName.Trim()
-            Write-Host "run_tests: using shared schema $($env:ODBC_TEST_SCHEMA)"
+            $trimmed = $schemaName.Trim()
+            if ($trimmed -match '^TEMP_TEST_SCHEMA_[0-9]+$') {
+                $env:ODBC_TEST_SCHEMA = $trimmed
+                Write-Host "run_tests: using shared schema $($env:ODBC_TEST_SCHEMA)"
+            } else {
+                Write-Host "run_tests: schema_tool returned invalid name, falling back to per-process"
+            }
         }
     } catch {
         Write-Host "run_tests: schema pre-creation failed, falling back to per-process"

--- a/tests/tests_format_validator/src/driver_handlers/odbc_handler.rs
+++ b/tests/tests_format_validator/src/driver_handlers/odbc_handler.rs
@@ -71,8 +71,8 @@ impl BaseDriverHandler for OdbcHandler {
         while i < lines.len() {
             let line = lines[i].trim();
 
-            // Look for TEST_CASE start
-            if line.starts_with("TEST_CASE(") {
+            // Look for TEST_CASE or TEST_CASE_METHOD start
+            if line.starts_with("TEST_CASE(") || line.starts_with("TEST_CASE_METHOD(") {
                 let start_line = i;
                 let mut test_case_content = String::new();
                 let mut found_closing_paren = false;
@@ -116,14 +116,40 @@ impl BaseDriverHandler for OdbcHandler {
         // Find the method and extract calls within it
         let mut in_method = false;
         let mut brace_count = 0;
+        let mut in_test_decl = false;
 
         for line in &lines {
             let line = line.trim();
 
-            if line.contains(&format!("TEST_CASE(\"{method_name}\"")) && !in_method {
-                in_method = true;
+            // Handle multi-line TEST_CASE_METHOD declarations
+            if in_test_decl {
+                if line.contains(&format!("\"{method_name}\"")) {
+                    in_method = true;
+                }
                 brace_count += line.matches('{').count() as i32 - line.matches('}').count() as i32;
+                if line.contains('{') {
+                    in_test_decl = false;
+                    if !in_method {
+                        brace_count = 0;
+                    }
+                }
                 continue;
+            }
+
+            if (line.starts_with("TEST_CASE(") || line.starts_with("TEST_CASE_METHOD("))
+                && !in_method
+            {
+                if line.contains(&format!("\"{method_name}\"")) {
+                    in_method = true;
+                    brace_count +=
+                        line.matches('{').count() as i32 - line.matches('}').count() as i32;
+                    continue;
+                } else if !line.contains('{') {
+                    in_test_decl = true;
+                    brace_count +=
+                        line.matches('{').count() as i32 - line.matches('}').count() as i32;
+                    continue;
+                }
             }
 
             // Look for method definitions (not calls)
@@ -205,8 +231,8 @@ impl BaseDriverHandler for OdbcHandler {
         for (line_num, line) in lines.iter().enumerate() {
             let line = line.trim();
 
-            // Check for TEST_CASE start (might be multi-line)
-            if line.starts_with("TEST_CASE(") {
+            // Check for TEST_CASE or TEST_CASE_METHOD start (might be multi-line)
+            if line.starts_with("TEST_CASE(") || line.starts_with("TEST_CASE_METHOD(") {
                 if line.contains(&format!("\"{method_name}\"")) {
                     in_method = true;
                     method_start_line = line_num + 1;

--- a/tests/tests_format_validator/src/step_finder.rs
+++ b/tests/tests_format_validator/src/step_finder.rs
@@ -75,9 +75,9 @@ impl LanguageConfig {
 
     fn odbc() -> Self {
         Self {
-            test_annotation: "TEST_CASE(", // Catch2 style
+            test_annotation: "TEST_CASE(", // Catch2 style (also matches TEST_CASE_METHOD)
             method_pattern: |method_name| {
-                format!(r#"TEST_CASE\s*\(\s*"{}""#, regex::escape(method_name))
+                format!(r#"TEST_CASE(?:_METHOD)?\s*\(\s*(?:\w+\s*,\s*)?"{}""#, regex::escape(method_name))
             },
             method_end_patterns: &[
                 // Empty - rely purely on brace counting for C++
@@ -125,7 +125,7 @@ impl MethodBoundaryFinder {
 
         // Pre-compile regexes outside the loop
         let test_method_regex = Regex::new(r"def\s+(test_\w+)\s*\(")?;
-        let catch2_regex = Regex::new(r#"TEST_CASE\s*\(\s*"([^"]+)""#)?;
+        let catch2_regex = Regex::new(r#"TEST_CASE(?:_METHOD)?\s*\(\s*(?:\w+\s*,\s*)?"([^"]+)""#)?;
         // Rust: support optional async before fn
         let fn_regex = Regex::new(r"(?:async\s+)?fn\s+(\w+)")?;
         // Match Java method declarations (not annotation lines like @MethodSource(...))
@@ -147,11 +147,26 @@ impl MethodBoundaryFinder {
                     }
                 }
                 "TEST_CASE(" => {
-                    // C++ Catch2: TEST_CASE("method_name")
-                    if trimmed.starts_with("TEST_CASE(") {
+                    // C++ Catch2: TEST_CASE("method_name") or TEST_CASE_METHOD(Fixture, "method_name")
+                    // Declarations may span multiple lines.
+                    if trimmed.starts_with("TEST_CASE(") || trimmed.starts_with("TEST_CASE_METHOD(") {
                         if let Some(captures) = catch2_regex.captures(trimmed) {
                             let method_name = captures[1].to_string();
-                            methods.push((method_name, i + 1)); // +1 for 1-indexed line numbers
+                            methods.push((method_name, i + 1));
+                        } else {
+                            let mut combined = trimmed.to_string();
+                            for j in (i + 1)..lines.len().min(i + 5) {
+                                combined.push(' ');
+                                combined.push_str(lines[j].trim());
+                                if let Some(captures) = catch2_regex.captures(&combined) {
+                                    let method_name = captures[1].to_string();
+                                    methods.push((method_name, i + 1));
+                                    break;
+                                }
+                                if combined.contains('{') {
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -258,17 +273,33 @@ impl MethodBoundaryFinder {
                 || (self.config.test_annotation.contains("pytest")
                     && trimmed.starts_with("@pytest"))
                 || (self.config.test_annotation == "TEST_CASE("
-                    && trimmed.starts_with("TEST_CASE("))
+                    && (trimmed.starts_with("TEST_CASE(") || trimmed.starts_with("TEST_CASE_METHOD(")))
                 || (self.config.test_annotation == "#[test]"
                     && rust_test_attr_regex.is_match(trimmed))
             {
                 // Rust special-case: generic test attribute matched above
                 // For C++, the TEST_CASE line itself contains the method name
+                // (or on a continuation line for multi-line declarations)
                 if self.config.test_annotation == "TEST_CASE(" {
                     let pattern = (self.config.method_pattern)(method_name);
                     let method_regex = Regex::new(&pattern)?;
                     if method_regex.is_match(trimmed) {
                         method_start_line = Some(i);
+                        break;
+                    }
+                    let mut combined = trimmed.to_string();
+                    for j in (i + 1)..lines.len().min(i + 5) {
+                        combined.push(' ');
+                        combined.push_str(lines[j].trim());
+                        if method_regex.is_match(&combined) {
+                            method_start_line = Some(i);
+                            break;
+                        }
+                        if combined.contains('{') {
+                            break;
+                        }
+                    }
+                    if method_start_line.is_some() {
                         break;
                     }
                 } else {
@@ -729,12 +760,35 @@ impl StepFinder {
                     comment_prefix,
                 )?;
             }
-            let empty_steps = boundary_finder.find_empty_steps_from_boundaries_generic(
+            let mut empty_steps = boundary_finder.find_empty_steps_from_boundaries_generic(
                 &content,
                 start_idx,
                 end_idx,
                 comment_prefix,
             )?;
+
+            // When a Catch2 TEST_CASE_METHOD fixture is used, the "Given" step that
+            // establishes a connection is handled by the fixture constructor — allow
+            // it to be empty.  Recognized phrasings (case-insensitive):
+            //   - "Given Snowflake client is logged in"
+            //   - "Given A Snowflake connection is established"
+            //   - "Given A Snowflake connection"
+            // New fixture-based tests should reuse one of these; add new variants
+            // here if a different phrasing becomes necessary.
+            if !empty_steps.is_empty() {
+                let lines: Vec<&str> = content.lines().collect();
+                let uses_fixture = (start_idx..end_idx.min(lines.len()))
+                    .any(|i| lines[i].trim().starts_with("TEST_CASE_METHOD("));
+                if uses_fixture {
+                    empty_steps.retain(|step| {
+                        let s = step.to_lowercase();
+                        !(s.starts_with("given") && (s.contains("logged in")
+                            || s.contains("connection is established")
+                            || s.contains("snowflake connection")))
+                    });
+                }
+            }
+
             Ok((steps, empty_steps))
         } else {
             Ok((vec![], vec![]))

--- a/tests/tests_format_validator/src/validator.rs
+++ b/tests/tests_format_validator/src/validator.rs
@@ -591,7 +591,7 @@ impl GherkinValidator {
                 }
             }
             Language::Odbc => {
-                let catch2_regex = Regex::new(r#"TEST_CASE\s*\(\s*"([^"]+)""#)?;
+                let catch2_regex = Regex::new(r#"TEST_CASE(?:_METHOD)?\s*\(\s*(?:\w+\s*,\s*)?"([^"]+)""#)?;
                 for captures in catch2_regex.captures_iter(content) {
                     methods.push(captures[1].to_string());
                 }


### PR DESCRIPTION
### TL;DR

Replace per-test-case random schema creation with a single shared schema per test run, reducing Snowflake DDL overhead from O(test-cases) to O(1). Convert ~80 test tables to `CREATE TEMPORARY TABLE` to eliminate name collisions in the shared schema. Introduce `schema_tool` — a standalone C++ binary that manages test schema lifecycle via ODBC, replacing the old bash/REST scripts.

### What changed?

**Schema lifecycle (`schema_tool`)**

- New `odbc_tests/tools/schema_tool.cpp` with `create`, `drop`, and `cleanup` subcommands using raw ODBC calls via the `common` library
- Runner scripts (`run_tests_unix.sh`, `run_tests_windows.ps1`, `run.sh`, `run_reference.sh`) pre-create one shared schema, export `ODBC_TEST_SCHEMA`, and drop via trap/finally
- CI workflow updated: inline reference test script replaced with `run_tests_unix.sh` call; cleanup steps use `schema_tool cleanup --age-days 2`
**Fallback for IDE / direct ctest invocation**
- `SchemaCleanupListener` (Catch2 event listener) creates and drops a per-process schema when `ODBC_TEST_SCHEMA` is unset
- Uses raw ODBC API calls to avoid Catch2 assertion macros outside test context (which would SEGFAULT)
**Table collision prevention (78 test files)**
- ~80 tables converted from `CREATE TABLE` / `CREATE OR REPLACE TABLE` to `CREATE TEMPORARY TABLE` — session-scoped, auto-dropped, no collision risk
- `TestTable` RAII helper also switched to `CREATE TEMPORARY TABLE`
- `ScopedTable` RAII added for cases where permanent tables are needed (PID+UUID naming)
- 9 DDL-specific tests intentionally kept as regular `CREATE TABLE` (testing CREATE/ALTER/DROP behavior)
- Removed all `Schema::name() + "."` table qualifications — redundant since `USE SCHEMA` is set by fixtures
**Deleted**
- `scripts/odbc/create_test_schema.sh`, `drop_test_schema.sh`, `cleanup_test_schemas.sh` (REST-based bash scripts replaced by `schema_tool`)

### Context

Snowflake is read-optimized — `CREATE SCHEMA` / `DROP SCHEMA` are expensive DDL operations. Previously every test binary created its own random schema at startup, resulting in dozens of DDL round-trips per CI run. This consolidates schema lifecycle into the runner scripts with a layered cleanup strategy:

1. Runner script trap/finally (primary — drops the shared schema)
2. Catch2 event listener (IDE/direct ctest fallback — drops per-process schema)
3. `schema_tool cleanup` in every runner + CI `if: always()` (safety net for orphaned schemas >2 days old)

### Test plan

- `pre-commit run --all-files` — all hooks pass (clang-format, tests-format-validator, Rust checks)
- `odbc_tests/run.sh` — local build + full test suite with shared schema lifecycle
- `odbc_tests/run_reference.sh` — Docker-based reference driver tests with schema lifecycle
- `scripts/odbc/run_tests_unix.sh` — CI-style run with `DRIVER_TYPE=NEW`
- Fallback path: `ctest -R "e2e_types_binary:"` without `ODBC_TEST_SCHEMA` — SchemaCleanupListener created and dropped per-process schema, all 14 tests passed
- `schema_tool cleanup --age-days 2` — successfully queries and drops orphaned schemas