### PR TITLE
Modernize ODBC test code style

### DIFF
--- a/odbc_tests/tests/bindings_tests/test.cpp
+++ b/odbc_tests/tests/bindings_tests/test.cpp
@@ -10,12 +10,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test integer single column, single row bind
     auto stmt = conn.createStatement();
 
     SQLRETURN ret = SQLPrepare(
-        stmt.getHandle(),
-        (SQLCHAR*)"INSERT INTO universal_driver_odbc_small_binding_integer_test_table (id) VALUES (?)", SQL_NTS);
+        stmt.getHandle(), sqlchar("INSERT INTO universal_driver_odbc_small_binding_integer_test_table (id) VALUES (?)"),
+        SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLINTEGER value = 1;
-    ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &value, 0, NULL);
+    ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &value, 0, nullptr);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());
@@ -26,7 +26,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test integer single column, single row bind
     auto stmt = conn.createStatement();
 
     SQLRETURN ret = SQLExecDirect(
-        stmt.getHandle(), (SQLCHAR*)"SELECT * FROM universal_driver_odbc_small_binding_integer_test_table", SQL_NTS);
+        stmt.getHandle(), sqlchar("SELECT * FROM universal_driver_odbc_small_binding_integer_test_table"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLFetch(stmt.getHandle());

--- a/odbc_tests/tests/e2e/query/sql_fetch.cpp
+++ b/odbc_tests/tests/e2e/query/sql_fetch.cpp
@@ -6,7 +6,6 @@
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
-#include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"

--- a/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
+++ b/odbc_tests/tests/e2e/query/sql_num_result_cols.cpp
@@ -4,7 +4,6 @@
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
-#include "compatibility.hpp"
 #include "get_diag_rec.hpp"
 
 // =============================================================================
@@ -24,11 +23,11 @@ TEST_CASE("SQLNumResultCols returns 1 for SELECT with single column.", "[query]"
   Connection conn;
 
   // When a SELECT query with one column is executed
-  auto stmt = conn.execute("SELECT 42 AS value");
+  const auto stmt = conn.execute("SELECT 42 AS value");
 
   // Then SQLNumResultCols should return 1
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
   REQUIRE_ODBC(ret, stmt);
   CHECK(num_cols == 1);
 }
@@ -42,11 +41,11 @@ TEST_CASE("SQLNumResultCols returns correct count for SELECT with many columns."
   Connection conn;
 
   // When a SELECT query with 5 columns is executed
-  auto stmt = conn.execute("SELECT 1 AS a, 2 AS b, 3 AS c, 4 AS d, 5 AS e");
+  const auto stmt = conn.execute("SELECT 1 AS a, 2 AS b, 3 AS c, 4 AS d, 5 AS e");
 
   // Then SQLNumResultCols should return 5
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
   REQUIRE_ODBC(ret, stmt);
   CHECK(num_cols == 5);
 }
@@ -61,11 +60,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns correct count for 
   conn.execute("CREATE TABLE num_cols_test (id INT, name VARCHAR(100), active BOOLEAN)");
 
   // When SELECT * is executed on the table
-  auto stmt = conn.execute("SELECT * FROM num_cols_test");
+  const auto stmt = conn.execute("SELECT * FROM num_cols_test");
 
   // Then SQLNumResultCols should return 3
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
   REQUIRE_ODBC(ret, stmt);
   CHECK(num_cols == 3);
 }
@@ -84,11 +83,11 @@ TEST_CASE("SQLNumResultCols returns correct column count for empty result set.",
   Connection conn;
 
   // When a SELECT query with WHERE 1=0 is executed (empty result set but with columns)
-  auto stmt = conn.execute("SELECT 1 AS col1, 2 AS col2 WHERE 1=0");
+  const auto stmt = conn.execute("SELECT 1 AS col1, 2 AS col2 WHERE 1=0");
 
   // Then SQLNumResultCols should still return the column count (2)
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
   REQUIRE_ODBC(ret, stmt);
   CHECK(num_cols == 2);
 }
@@ -106,7 +105,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns 0 after DDL statem
   const auto stmt = conn.createStatement();
 
   // When a DDL statement is executed
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE ddl_numcols_test (id INT)", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TABLE ddl_numcols_test (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLNumResultCols should return 0 (DDL produces no result set columns)
@@ -126,11 +125,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLNumResultCols returns correct count afte
       "RETURNS VARCHAR LANGUAGE SQL AS 'BEGIN RETURN p1; END'");
 
   // When the stored procedure is called
-  auto stmt = conn.execute("CALL numcols_proc('hello')");
+  const auto stmt = conn.execute("CALL numcols_proc('hello')");
 
   // Then SQLNumResultCols should return 1
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
   REQUIRE_ODBC(ret, stmt);
   CHECK(num_cols == 1);
 }
@@ -146,11 +145,11 @@ TEST_CASE("SQLNumResultCols returns HY010 when called on freshly allocated state
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLNumResultCols is called without any prepare or execute
   SQLSMALLINT num_cols = 0;
-  SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+  const SQLRETURN ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
 
   // Then it should return SQL_ERROR with SQLSTATE HY010
   REQUIRE(ret == SQL_ERROR);
@@ -168,10 +167,10 @@ TEST_CASE("SQLNumResultCols returns column count after SQLPrepare.", "[query]") 
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a SELECT statement is prepared but not executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS a, 2 AS b, 3 AS c", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS a, 2 AS b, 3 AS c"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLNumResultCols should return the column count
@@ -194,7 +193,7 @@ TEST_CASE("SQLNumResultCols updates column count after re-execution with differe
   auto stmt = conn.createStatement();
 
   // When a query with 3 columns is executed
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS a, 2 AS b, 3 AS c", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS a, 2 AS b, 3 AS c"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLNumResultCols is called
@@ -208,7 +207,7 @@ TEST_CASE("SQLNumResultCols updates column count after re-execution with differe
   REQUIRE_ODBC(ret, stmt);
 
   // And a different query with 1 column is executed on the same statement
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 42 AS only_col", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 42 AS only_col"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLNumResultCols should return the updated column count
@@ -231,7 +230,7 @@ TEST_CASE("SQLNumResultCols returns same value as SQL_DESC_COUNT of the IRD.", "
   auto stmt = conn.createStatement();
 
   // When a query with 4 columns is executed
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS a, 2 AS b, 3 AS c, 4 AS d", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS a, 2 AS b, 3 AS c, 4 AS d"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLNumResultCols is called
@@ -241,11 +240,11 @@ TEST_CASE("SQLNumResultCols returns same value as SQL_DESC_COUNT of the IRD.", "
 
   // And the IRD SQL_DESC_COUNT is read
   SQLHDESC ird = SQL_NULL_HDESC;
-  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_ROW_DESC, &ird, 0, NULL);
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr);
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLSMALLINT ird_count = 0;
-  ret = SQLGetDescField(ird, 0, SQL_DESC_COUNT, &ird_count, 0, NULL);
+  ret = SQLGetDescField(ird, 0, SQL_DESC_COUNT, &ird_count, 0, nullptr);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Then both values should be equal

--- a/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
+++ b/odbc_tests/tests/e2e/query/sql_prepare_execute.cpp
@@ -28,7 +28,7 @@ TEST_CASE("SQLPrepare + SQLExecute retrieves result from simple SELECT.", "[quer
   auto stmt = conn.createStatement();
 
   // When a simple SELECT is prepared and executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 42 AS value", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 42 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -54,7 +54,7 @@ TEST_CASE("SQLPrepare + SQLExecute retrieves result with multiple columns.", "[q
   auto stmt = conn.createStatement();
 
   // When a SELECT with multiple columns is prepared and executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS a, 'hello' AS b, 3.14 AS c", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS a, 'hello' AS b, 3.14 AS c"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -80,7 +80,7 @@ TEST_CASE("SQLPrepare + SQLExecute can be executed multiple times with SQLCloseC
   auto stmt = conn.createStatement();
 
   // When a SELECT is prepared
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 100 AS value", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 100 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And executed a first time
@@ -124,10 +124,10 @@ TEST_CASE("Re-prepare replaces previous statement on same handle.", "[query][pre
   auto stmt = conn.createStatement();
 
   // When a SELECT is prepared and replaced with a different query
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 999 AS replaced_value", SQL_NTS);
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 999 AS replaced_value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -153,8 +153,8 @@ TEST_CASE("SQLPrepare with explicit text length (not SQL_NTS).", "[query][prepar
   auto stmt = conn.createStatement();
 
   // When a SELECT is prepared with explicit text length
-  const char* sql = "SELECT 77 AS value";
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)sql, (SQLINTEGER)strlen(sql));
+  auto sql = "SELECT 77 AS value";
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar(sql), static_cast<SQLINTEGER>(strlen(sql)));
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -180,8 +180,8 @@ TEST_CASE("SQLPrepare with explicit length shorter than string uses partial SQL.
   auto stmt = conn.createStatement();
 
   // When a SELECT is prepared with a length shorter than the full string
-  const char* sql = "SELECT 55 AS value";  // 18 chars; passing only 9 gives "SELECT 55" which is still valid
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)sql, 9);
+  auto sql = "SELECT 55 AS value";  // 18 chars; passing only 9 gives "SELECT 55" which is still valid
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar(sql), 9);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -201,10 +201,10 @@ TEST_CASE("SQLNumResultCols available after SQLPrepare without execute.", "[quer
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a SELECT with 3 columns is prepared
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS a, 2 AS b, 3 AS c", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS a, 2 AS b, 3 AS c"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLNumResultCols should return the column count without needing execute
@@ -221,14 +221,14 @@ TEST_CASE("SQLDescribeCol available after SQLPrepare without execute.", "[query]
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a SELECT is prepared
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 42 AS MY_COL", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 42 AS MY_COL"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLDescribeCol should return metadata for the prepared column
-  SQLCHAR col_name[128] = {0};
+  SQLCHAR col_name[128] = {};
   SQLSMALLINT name_length = 0;
   SQLSMALLINT data_type = 0;
   SQLULEN col_size = 0;
@@ -254,7 +254,8 @@ TEST_CASE("SQLPrepareW + SQLExecute basic flow.", "[query][prepare]") {
 
   // When a SELECT is prepared using the wide variant
   std::u16string sql = u"SELECT 88 AS wide_value";
-  SQLRETURN ret = SQLPrepareW(stmt.getHandle(), (SQLWCHAR*)sql.data(), (SQLINTEGER)sql.size());
+  SQLRETURN ret =
+      SQLPrepareW(stmt.getHandle(), reinterpret_cast<SQLWCHAR*>(sql.data()), static_cast<SQLINTEGER>(sql.size()));
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -282,7 +283,8 @@ TEST_CASE("SQLPrepareW with Unicode content in query.", "[query][prepare]") {
 
   // When a SELECT with Unicode string literal is prepared using SQLPrepareW
   std::u16string sql = u"SELECT '日本語テスト' AS unicode_col";
-  SQLRETURN ret = SQLPrepareW(stmt.getHandle(), (SQLWCHAR*)sql.data(), (SQLINTEGER)sql.size());
+  SQLRETURN ret =
+      SQLPrepareW(stmt.getHandle(), reinterpret_cast<SQLWCHAR*>(sql.data()), static_cast<SQLINTEGER>(sql.size()));
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -305,10 +307,10 @@ TEST_CASE("SQLExecute without prior SQLPrepare returns HY010.", "[query][prepare
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLExecute is called without a prior SQLPrepare
-  SQLRETURN ret = SQLExecute(stmt.getHandle());
+  const SQLRETURN ret = SQLExecute(stmt.getHandle());
 
   // Then it should return SQL_ERROR with SQLSTATE HY010
   REQUIRE(ret == SQL_ERROR);
@@ -325,13 +327,13 @@ TEST_CASE("SQLExecute with bound parameters via SQLBindParameter.", "[query][pre
   auto stmt = conn.createStatement();
 
   // When a parameterized query is prepared and parameters are bound
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR AS param_val", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR AS param_val"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   std::string param = "bound_value";
   SQLLEN param_len = param.size();
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, param.size(), 0,
-                         (SQLCHAR*)param.c_str(), param.size(), &param_len);
+                         sqlchar(param.c_str()), param.size(), &param_len);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -354,7 +356,7 @@ TEST_CASE("SQLExecute with different parameter values on re-execution.", "[query
   auto stmt = conn.createStatement();
 
   // When a parameterized query is prepared
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::INTEGER AS val", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::INTEGER AS val"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   SQLINTEGER param_value = 10;
@@ -398,7 +400,7 @@ TEST_CASE("SQLExecute returns 24000 when cursor is not closed before re-execute 
   auto stmt = conn.createStatement();
 
   // When a SELECT is prepared and executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -426,7 +428,8 @@ TEST_CASE("SQLExecDirectW basic flow.", "[query][prepare]") {
 
   // When a SELECT is executed via SQLExecDirectW
   std::u16string sql = u"SELECT 123 AS direct_w_val";
-  SQLRETURN ret = SQLExecDirectW(stmt.getHandle(), (SQLWCHAR*)sql.data(), (SQLINTEGER)sql.size());
+  SQLRETURN ret =
+      SQLExecDirectW(stmt.getHandle(), reinterpret_cast<SQLWCHAR*>(sql.data()), static_cast<SQLINTEGER>(sql.size()));
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLFetch(stmt.getHandle());
@@ -454,10 +457,10 @@ TEST_CASE("SQLExecDirect with bound parameters via SQLBindParameter.", "[query][
   std::string param = "direct_bound";
   SQLLEN param_len = param.size();
   SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, param.size(), 0,
-                                   (SQLCHAR*)param.c_str(), param.size(), &param_len);
+                                   sqlchar(param.c_str()), param.size(), &param_len);
   REQUIRE_ODBC(ret, stmt);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR AS bound_val", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR AS bound_val"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLFetch(stmt.getHandle());
@@ -476,7 +479,7 @@ TEST_CASE("SQLPrepare with null statement handle returns SQL_INVALID_HANDLE.", "
   // https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprepare-function#returns
 
   // When SQLPrepare is called with a null statement handle
-  SQLRETURN ret = SQLPrepare(SQL_NULL_HSTMT, (SQLCHAR*)"SELECT 1", SQL_NTS);
+  const SQLRETURN ret = SQLPrepare(SQL_NULL_HSTMT, sqlchar("SELECT 1"), SQL_NTS);
 
   // Then it should return SQL_INVALID_HANDLE
   REQUIRE(ret == SQL_INVALID_HANDLE);
@@ -488,10 +491,10 @@ TEST_CASE("SQLPrepare with null SQL text pointer returns HY009.", "[query][prepa
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLPrepare is called with a null SQL text pointer
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), nullptr, SQL_NTS);
+  const SQLRETURN ret = SQLPrepare(stmt.getHandle(), nullptr, SQL_NTS);
 
   // Then it should return SQL_ERROR with SQLSTATE HY009
   REQUIRE(ret == SQL_ERROR);
@@ -505,10 +508,10 @@ TEST_CASE("SQLPrepare with negative TextLength returns HY090.", "[query][prepare
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLPrepare is called with a negative text length
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1", -5);
+  const SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1"), -5);
 
   // Then it should return SQL_ERROR with SQLSTATE HY090
   REQUIRE(ret == SQL_ERROR);
@@ -522,10 +525,10 @@ TEST_CASE("SQLPrepare with zero TextLength returns HY090.", "[query][prepare][er
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLPrepare is called with zero text length
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1", 0);
+  const SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1"), 0);
 
   // Then it should return SQL_ERROR with SQLSTATE HY090
   REQUIRE(ret == SQL_ERROR);
@@ -541,7 +544,7 @@ TEST_CASE("SQLPrepare with empty SQL string returns HY090.", "[query][prepare][e
   auto stmt = conn.createStatement();
 
   // When SQLPrepare is called with an empty SQL string
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar(""), SQL_NTS);
 
   // Then it should return SQL_ERROR with SQLSTATE HY090
   REQUIRE(ret == SQL_ERROR);
@@ -560,10 +563,10 @@ TEST_CASE("SQLPrepare with invalid SQL syntax returns 42000.", "[query][prepare]
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLPrepare is called with invalid SQL syntax
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"NOT VALID SQL SYNTAX!!!", SQL_NTS);
+  const SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("NOT VALID SQL SYNTAX!!!"), SQL_NTS);
 
   // Then it should return SQL_ERROR with SQLSTATE 42000
   REQUIRE(ret == SQL_ERROR);
@@ -576,14 +579,14 @@ TEST_CASE("SQLPrepare with cursor already open returns 24000.", "[query][prepare
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // And a query has been executed leaving a cursor open
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When SQLPrepare is called while the cursor is still open
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 2 AS new_value", SQL_NTS);
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 2 AS new_value"), SQL_NTS);
 
   // Then it should return SQL_ERROR with SQLSTATE 24000
   REQUIRE(ret == SQL_ERROR);
@@ -603,7 +606,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "DDL via SQLPrepare + SQLExecute.", "[query]
 
   // When a CREATE TABLE is prepared and executed
   SQLRETURN ret =
-      SQLPrepare(stmt.getHandle(), (SQLCHAR*)"CREATE TABLE prep_ddl_test (id INT, name VARCHAR(100))", SQL_NTS);
+      SQLPrepare(stmt.getHandle(), sqlchar("CREATE TABLE prep_ddl_test (id INT, name VARCHAR(100))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -628,10 +631,10 @@ TEST_CASE_METHOD(ConnSchemaFixture, "DML returning SQL_NO_DATA via SQLPrepare + 
 
   // Given Snowflake client is logged in
   conn.execute("CREATE TABLE prep_dml_nodata (id INT)");
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a DELETE that affects no rows is prepared and executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"DELETE FROM prep_dml_nodata WHERE 1=0", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("DELETE FROM prep_dml_nodata WHERE 1=0"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
@@ -650,7 +653,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "INSERT via SQLPrepare + SQLExecute with ver
   // When an INSERT is prepared with bound parameters and executed
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO prep_insert_test VALUES (?, ?)", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO prep_insert_test VALUES (?, ?)"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLINTEGER id_val = 1;
@@ -662,7 +665,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "INSERT via SQLPrepare + SQLExecute with ver
     std::string name_val = "test_name";
     SQLLEN name_len = name_val.size();
     ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, name_val.size(), 0,
-                           (SQLCHAR*)name_val.c_str(), name_val.size(), &name_len);
+                           sqlchar(name_val.c_str()), name_val.size(), &name_len);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());

--- a/odbc_tests/tests/e2e/query/sql_row_count.cpp
+++ b/odbc_tests/tests/e2e/query/sql_row_count.cpp
@@ -10,11 +10,11 @@
 TEST_CASE("SQLRowCount returns HY010 when called without executing statement.", "[query]") {
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLRowCount is called without executing any statement first
   SQLLEN rows_affected = 0;
-  SQLRETURN ret = SQLRowCount(stmt.getHandle(), &rows_affected);
+  const SQLRETURN ret = SQLRowCount(stmt.getHandle(), &rows_affected);
 
   // Then SQLRowCount should return SQL_ERROR with SQLSTATE HY010 (Function sequence error)
   REQUIRE(ret == SQL_ERROR);
@@ -25,7 +25,7 @@ TEST_CASE("SQLRowCount returns HY009 when called with null pointer.", "[query]")
   // Given Snowflake client is logged in and a statement has been executed
   Connection conn;
   auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When SQLRowCount is called with a null pointer for RowCountPtr
@@ -42,9 +42,9 @@ TEST_CASE("SQLRowCount returns HY009 when called with null pointer.", "[query]")
 TEST_CASE("SQLRowCount returns data about number of rows affected.") {
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
   // When SQLExecDirect is called to execute the query that returns 1 row
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 42 AS value", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 42 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   // And SQLRowCount is called to get the number of rows affected
   SQLLEN rows_affected = 0;
@@ -80,11 +80,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSER
 TEST_CASE("SQLRowCount returns correct count for SELECT with many rows.") {
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When SQLExecDirect is called to execute a query that returns 10 rows
   SQLRETURN ret = SQLExecDirect(
-      stmt.getHandle(), (SQLCHAR*)"SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10)) ORDER BY id", SQL_NTS);
+      stmt.getHandle(), sqlchar("SELECT seq8() as id FROM TABLE(GENERATOR(ROWCOUNT => 10)) ORDER BY id"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called to get the number of rows affected
@@ -120,9 +120,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for ALTER TABLE DDL 
 
   // When an ALTER TABLE DDL statement is executed
   SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_alter_t (id INT)", SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE OR REPLACE TABLE rowcount_alter_t (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"ALTER TABLE rowcount_alter_t ADD COLUMN value VARCHAR(50)", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("ALTER TABLE rowcount_alter_t ADD COLUMN value VARCHAR(50)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -140,9 +140,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns -1 for DROP TABLE DDL s
 
   // When a DROP TABLE DDL statement is executed
   SQLRETURN ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE OR REPLACE TABLE rowcount_drop_t (id INT)", SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE OR REPLACE TABLE rowcount_drop_t (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DROP TABLE rowcount_drop_t", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("DROP TABLE rowcount_drop_t"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -168,20 +168,20 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for MERGE
 
   // When a MERGE statement affecting rows is executed
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE merge_target (id INT, value VARCHAR(50))", SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE merge_target (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO merge_target VALUES (1, 'old1'), (2, 'old2')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO merge_target VALUES (1, 'old1'), (2, 'old2')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE merge_source (id INT, value VARCHAR(50))",
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE merge_source (id INT, value VARCHAR(50))"),
                       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO merge_source VALUES (2, 'new2'), (3, 'new3')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO merge_source VALUES (2, 'new2'), (3, 'new3')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecDirect(stmt.getHandle(),
-                      (SQLCHAR*)"MERGE INTO merge_target t USING merge_source s ON t.id = s.id "
-                                "WHEN MATCHED THEN UPDATE SET t.value = s.value "
-                                "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)",
+                      sqlchar("MERGE INTO merge_target t USING merge_source s ON t.id = s.id "
+                              "WHEN MATCHED THEN UPDATE SET t.value = s.value "
+                              "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)"),
                       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
@@ -189,6 +189,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for MERGE
   SQLLEN rows_affected = 0;
   ret = SQLRowCount(stmt.getHandle(), &rows_affected);
 
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
   // Then the number of rows affected should be 2 (1 updated + 1 inserted)
   REQUIRE(rows_affected == 2);
 }
@@ -202,30 +203,30 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for MERGE
 
   // And a target table with data exists
   SQLRETURN ret = SQLExecDirect(
-      stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE merge_del_target (id INT, value VARCHAR(50))", SQL_NTS);
+      stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE merge_del_target (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret =
       SQLExecDirect(stmt.getHandle(),
-                    (SQLCHAR*)"INSERT INTO merge_del_target VALUES (1, 'keep'), (2, 'remove'), (3, 'update')", SQL_NTS);
+                    sqlchar("INSERT INTO merge_del_target VALUES (1, 'keep'), (2, 'remove'), (3, 'update')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And a source table with actions exists
   ret = SQLExecDirect(
       stmt.getHandle(),
-      (SQLCHAR*)"CREATE TEMPORARY TABLE merge_del_source (id INT, value VARCHAR(50), action VARCHAR(10))", SQL_NTS);
+      sqlchar("CREATE TEMPORARY TABLE merge_del_source (id INT, value VARCHAR(50), action VARCHAR(10))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(
       stmt.getHandle(),
-      (SQLCHAR*)"INSERT INTO merge_del_source VALUES (2, 'x', 'delete'), (3, 'new3', 'update'), (4, 'new4', 'insert')",
+      sqlchar("INSERT INTO merge_del_source VALUES (2, 'x', 'delete'), (3, 'new3', 'update'), (4, 'new4', 'insert')"),
       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When a MERGE with INSERT, UPDATE, and DELETE clauses is executed
   ret = SQLExecDirect(stmt.getHandle(),
-                      (SQLCHAR*)"MERGE INTO merge_del_target t USING merge_del_source s ON t.id = s.id "
-                                "WHEN MATCHED AND s.action = 'delete' THEN DELETE "
-                                "WHEN MATCHED AND s.action = 'update' THEN UPDATE SET t.value = s.value "
-                                "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)",
+                      sqlchar("MERGE INTO merge_del_target t USING merge_del_source s ON t.id = s.id "
+                              "WHEN MATCHED AND s.action = 'delete' THEN DELETE "
+                              "WHEN MATCHED AND s.action = 'update' THEN UPDATE SET t.value = s.value "
+                              "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)"),
                       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
@@ -248,14 +249,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for UPDAT
 
   // And a table with data exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE update_test (id INT, value VARCHAR(50))", SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE update_test (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(),
-                      (SQLCHAR*)"INSERT INTO update_test VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')", SQL_NTS);
+                      sqlchar("INSERT INTO update_test VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When an UPDATE statement affecting 2 rows is executed
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"UPDATE update_test SET value = 'updated' WHERE id <= 2", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("UPDATE update_test SET value = 'updated' WHERE id <= 2"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -275,23 +276,22 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for UPDAT
 
   // And a target table and a source table exist
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE upd_target (id INT, status VARCHAR(20))", SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE upd_target (id INT, status VARCHAR(20))"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(),
+                      sqlchar("INSERT INTO upd_target VALUES (1, 'pending'), (2, 'pending'), (3, 'shipped')"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE upd_source (id INT, new_status VARCHAR(20))"),
+                      SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret =
-      SQLExecDirect(stmt.getHandle(),
-                    (SQLCHAR*)"INSERT INTO upd_target VALUES (1, 'pending'), (2, 'pending'), (3, 'shipped')", SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE upd_source (id INT, new_status VARCHAR(20))",
-                      SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO upd_source VALUES (1, 'shipped'), (2, 'shipped')",
-                      SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO upd_source VALUES (1, 'shipped'), (2, 'shipped')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When an UPDATE with JOIN affecting 2 rows is executed
   ret = SQLExecDirect(stmt.getHandle(),
-                      (SQLCHAR*)"UPDATE upd_target t SET t.status = s.new_status "
-                                "FROM upd_source s WHERE t.id = s.id",
+                      sqlchar("UPDATE upd_target t SET t.status = s.new_status "
+                              "FROM upd_source s WHERE t.id = s.id"),
                       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
@@ -314,14 +314,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for DELET
 
   // And a table with data exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE delete_test (id INT, value VARCHAR(50))", SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE delete_test (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO delete_test VALUES (1, 'a'), (2, 'b'), (3, 'c')", SQL_NTS);
+      SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO delete_test VALUES (1, 'a'), (2, 'b'), (3, 'c')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When a DELETE statement affecting 2 rows is executed
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DELETE FROM delete_test WHERE id >= 2", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("DELETE FROM delete_test WHERE id >= 2"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -338,11 +338,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns total count for DELETE 
   auto stmt = conn.createStatement();
 
   // When a DELETE without WHERE clause is executed on a table with 4 rows
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE delete_all (id INT)", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE delete_all (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO delete_all VALUES (1), (2), (3), (4)", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO delete_all VALUES (1), (2), (3), (4)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DELETE FROM delete_all", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("DELETE FROM delete_all"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -360,12 +360,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns total count for UPDATE 
 
   // When an UPDATE without WHERE clause is executed on a table with 3 rows
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE update_all (id INT, value VARCHAR(50))", SQL_NTS);
+                                sqlchar("CREATE TEMPORARY TABLE update_all (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret =
-      SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO update_all VALUES (1, 'a'), (2, 'b'), (3, 'c')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO update_all VALUES (1, 'a'), (2, 'b'), (3, 'c')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"UPDATE update_all SET value = 'updated'", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("UPDATE update_all SET value = 'updated'"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -382,15 +381,15 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSER
   auto stmt = conn.createStatement();
 
   // When INSERT INTO ... SELECT copies 3 rows from a source table
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE src_table (id INT, value VARCHAR(50))", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE src_table (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO src_table VALUES (1, 'a'), (2, 'b'), (3, 'c')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO src_table VALUES (1, 'a'), (2, 'b'), (3, 'c')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE dst_table (id INT, value VARCHAR(50))",
-                      SQL_NTS);
+  ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE dst_table (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO dst_table SELECT * FROM src_table", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO dst_table SELECT * FROM src_table"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -410,25 +409,25 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount returns correct count for INSER
   auto stmt = conn.createStatement();
 
   // And two source tables and a destination table exist
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE ins_src_a (id INT, value VARCHAR(50))", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE ins_src_a (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO ins_src_a VALUES (1, 'a'), (2, 'b')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO ins_src_a VALUES (1, 'a'), (2, 'b')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE ins_src_b (id INT, label VARCHAR(50))",
-                      SQL_NTS);
+  ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE ins_src_b (id INT, label VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO ins_src_b VALUES (1, 'x'), (2, 'y'), (3, 'z')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO ins_src_b VALUES (1, 'x'), (2, 'y'), (3, 'z')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret =
       SQLExecDirect(stmt.getHandle(),
-                    (SQLCHAR*)"CREATE TEMPORARY TABLE ins_dst (id INT, value VARCHAR(50), label VARCHAR(50))", SQL_NTS);
+                    sqlchar("CREATE TEMPORARY TABLE ins_dst (id INT, value VARCHAR(50), label VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When INSERT from a multi-table JOIN subquery is executed
   ret = SQLExecDirect(
       stmt.getHandle(),
-      (SQLCHAR*)"INSERT INTO ins_dst SELECT a.id, a.value, b.label FROM ins_src_a a JOIN ins_src_b b ON a.id = b.id",
+      sqlchar("INSERT INTO ins_dst SELECT a.id, a.value, b.label FROM ins_src_a a JOIN ins_src_b b ON a.id = b.id"),
       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
@@ -456,7 +455,7 @@ TEST_CASE("SQLRowCount returns HY010 after SQLFreeStmt SQL_CLOSE.", "[query]") {
   auto stmt = conn.createStatement();
 
   // When a query is executed and then SQLFreeStmt(SQL_CLOSE) resets the statement
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLFreeStmt(stmt.getHandle(), SQL_CLOSE);
   REQUIRE_ODBC(ret, stmt);
@@ -476,10 +475,10 @@ TEST_CASE("SQLRowCount returns HY010 after SQLPrepare without execute.", "[query
 
   // Given Snowflake client is logged in
   Connection conn;
-  auto stmt = conn.createStatement();
+  const auto stmt = conn.createStatement();
 
   // When a statement is prepared but not executed
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1 AS value", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1 AS value"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -504,9 +503,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount works with SQLPrepare and SQLEx
   auto stmt = conn.createStatement();
 
   // When a statement is prepared and executed via SQLPrepare and SQLExecute
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE prep_test (id INT)", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE prep_test (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO prep_test VALUES (1), (2), (3)", SQL_NTS);
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO prep_test VALUES (1), (2), (3)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
@@ -535,24 +534,24 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount updates correctly across differ
   auto stmt = conn.createStatement();
 
   // When INSERT, UPDATE, and DELETE are executed sequentially on the same statement
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                (SQLCHAR*)"CREATE TEMPORARY TABLE mixed_dml (id INT, value VARCHAR(50))", SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE mixed_dml (id INT, value VARCHAR(50))"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO mixed_dml VALUES (1, 'a'), (2, 'b'), (3, 'c')", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO mixed_dml VALUES (1, 'a'), (2, 'b'), (3, 'c')"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN rows_affected = 0;
   ret = SQLRowCount(stmt.getHandle(), &rows_affected);
   REQUIRE_ODBC(ret, stmt);
   REQUIRE(rows_affected == 3);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"UPDATE mixed_dml SET value = 'updated' WHERE id <= 2", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("UPDATE mixed_dml SET value = 'updated' WHERE id <= 2"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLRowCount(stmt.getHandle(), &rows_affected);
   REQUIRE_ODBC(ret, stmt);
   REQUIRE(rows_affected == 2);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"DELETE FROM mixed_dml WHERE id = 3", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("DELETE FROM mixed_dml WHERE id = 3"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLRowCount(stmt.getHandle(), &rows_affected);
   REQUIRE_ODBC(ret, stmt);
@@ -578,7 +577,7 @@ TEST_CASE("SQLRowCount returns cached count after SQLFetch has started.", "[quer
 
   // When a SELECT query returning 5 rows is executed
   SQLRETURN ret = SQLExecDirect(
-      stmt.getHandle(), (SQLCHAR*)"SELECT seq8() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY id", SQL_NTS);
+      stmt.getHandle(), sqlchar("SELECT seq8() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY id"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And some rows are fetched
@@ -609,11 +608,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount updates after re-execution with
   auto stmt = conn.createStatement();
 
   // And a table exists
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"CREATE TEMPORARY TABLE reexec_test (id INT)", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("CREATE TEMPORARY TABLE reexec_test (id INT)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When an INSERT of 3 rows is executed
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO reexec_test VALUES (1), (2), (3)", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO reexec_test VALUES (1), (2), (3)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And SQLRowCount is called
@@ -623,7 +622,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "SQLRowCount updates after re-execution with
   REQUIRE(rows_affected == 3);
 
   // And a second INSERT of 1 row is executed on the same statement
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"INSERT INTO reexec_test VALUES (4)", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO reexec_test VALUES (4)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then SQLRowCount should return the updated count

--- a/odbc_tests/tests/e2e/types/string.cpp
+++ b/odbc_tests/tests/e2e/types/string.cpp
@@ -61,7 +61,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string literals", "
 
   // When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3"
   // is executed
-  auto stmt = conn.execute_fetch("SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3");
+  const auto stmt =
+      conn.execute_fetch("SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3");
 
   // Then the result should contain:
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "hello");
@@ -74,9 +75,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select hardcoded string literals usi
 
   // When Query "SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3" is executed
   auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(
-      stmt.getHandle(), (SQLCHAR*)"SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3",
-      SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(),
+                    sqlchar("SELECT 'hello' AS str1, 'Hello World' AS str2, 'Snowflake Driver Test' AS str3"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And Columns are bound using SQLBindCol
@@ -244,7 +245,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should insert and select back hardcoded str
     std::string value = "Test binding value 日本語";
     SQLLEN value_len = value.size();
     ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, value.size(), 0,
-                           (SQLCHAR*)value.c_str(), value.size(), &value_len);
+                           sqlchar(value.c_str()), value.size(), &value_len);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());
@@ -266,7 +267,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select string literals using paramet
   // Given Snowflake client is logged in
 
   auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   std::string value1 = "hello";
@@ -278,13 +279,13 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select string literals using paramet
   SQLLEN len3 = value3.size();
 
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, value1.size(), 0,
-                         (SQLCHAR*)value1.c_str(), value1.size(), &len1);
+                         sqlchar(value1.c_str()), value1.size(), &len1);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, value2.size(), 0,
-                         (SQLCHAR*)value2.c_str(), value2.size(), &len2);
+                         sqlchar(value2.c_str()), value2.size(), &len2);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, value3.size(), 0,
-                         (SQLCHAR*)value3.c_str(), value3.size(), &len3);
+                         sqlchar(value3.c_str()), value3.size(), &len3);
   REQUIRE_ODBC(ret, stmt);
   // When Query "SELECT ?::VARCHAR, ?::VARCHAR, ?::VARCHAR" is executed with bound string values ['hello', 'Hello
   // World', '日本語テスト']
@@ -307,12 +308,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values usi
   // When Query "SELECT ?::VARCHAR" is executed with each corner case string value bound
   auto test_bound_value = [&](const std::string& value, const std::string& expected) {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLLEN len = value.size();
     ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
-                           value.size() > 0 ? value.size() : 1, 0, (SQLCHAR*)value.c_str(), value.size(), &len);
+                           value.size() > 0 ? value.size() : 1, 0, sqlchar(value.c_str()), value.size(), &len);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());
@@ -328,12 +329,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values usi
   // Helper lambda to test a single bound wide value
   auto test_bound_wvalue = [&](const std::u16string& value, const std::u16string& expected) {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLLEN len = value.size() * sizeof(char16_t);
     ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR,
-                           value.size() > 0 ? value.size() : 1, 0, (SQLWCHAR*)value.c_str(), len, &len);
+                           value.size() > 0 ? value.size() : 1, 0, const_cast<char16_t*>(value.c_str()), len, &len);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());
@@ -381,7 +382,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should select corner case string values usi
   // Test NULL value
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT ?::VARCHAR", SQL_NTS);
+    SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?::VARCHAR"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLLEN null_indicator = SQL_NULL_DATA;
@@ -413,9 +414,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download string data in multiple chu
   // When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY
   // id" is executed
   auto stmt = conn.createStatement();
-  const char* sql =
+  auto sql =
       "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id";
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar(sql), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then there are 10000 rows returned and all string values should match the generated values in order
@@ -491,14 +492,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should download string data in multiple chu
   // Given Snowflake client is logged in
 
   // And Expected row count is defined
-  const int expected_row_count = 10000;
+  constexpr int expected_row_count = 10000;
 
   // When Query "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY
   // 1" is executed
   auto stmt = conn.createStatement();
-  const char* sql =
+  auto sql =
       "SELECT seq8() AS id, TO_VARCHAR(seq8()) AS str_val FROM TABLE(GENERATOR(ROWCOUNT => 10000)) v ORDER BY id";
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)sql, SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar(sql), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // And Columns are bound using SQLBindCol

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_char.cpp
@@ -17,11 +17,10 @@
 #include "SchemaFixtures.hpp"
 #include "compatibility.hpp"
 #include "get_data.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
-static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>(static_cast<unsigned char>(c)); }
+static unsigned int to_unsigned_int(const char c) { return static_cast<unsigned char>(c); }
 
 // ============================================================================
 // STRING TRUNCATION
@@ -49,7 +48,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should truncate string data when byte lengt
   CHECK(buffer[sizeof(buffer) - 1] == 0);
 
   // And the indicator should show the actual length of the original string
-  if (is_ascii_locale() || (get_platform() == PLATFORM::PLATFORM_WINDOWS)) {
+  if (is_ascii_locale() || get_platform() == PLATFORM::PLATFORM_WINDOWS) {
     // TODO: We are not guaranteed to get length of string, due to charset conversion
     CHECK((indicator == SQL_NO_TOTAL || indicator == 49));
   } else {
@@ -439,7 +438,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test string basic query", "[e2e][types][str
   conn.execute("INSERT INTO test_string_basic (str_col) VALUES ('Hello World')");
   auto stmt = conn.createStatement();
 
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT str_col FROM test_string_basic", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT str_col FROM test_string_basic"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLFetch(stmt.getHandle());
@@ -463,20 +462,20 @@ TEST_CASE_METHOD(ConnSchemaFixture, "Test basic string binding", "[e2e][types][s
   auto stmt = conn.createStatement();
 
   SQLRETURN ret =
-      SQLPrepare(stmt.getHandle(), (SQLCHAR*)"INSERT INTO test_string_basic_binding (str_col) VALUES (?)", SQL_NTS);
+      SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO test_string_basic_binding (str_col) VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
-  const char* test_value = "Hello World";
+  auto test_value = "Hello World";
   SQLLEN str_len = strlen(test_value);
 
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, str_len, 0,
-                         (SQLPOINTER)test_value, str_len, &str_len);
+                         const_cast<SQLPOINTER>(static_cast<const void*>(test_value)), str_len, &str_len);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT str_col FROM test_string_basic_binding", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT str_col FROM test_string_basic_binding"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   ret = SQLFetch(stmt.getHandle());

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_integer.cpp
@@ -152,7 +152,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting string literals with
   // Given Snowflake client is logged in
 
   // When Query selecting string literals with leading/trailing whitespace is executed
-  auto stmt = conn.execute_fetch("SELECT 'abc' AS invalid, '456' AS whole, '6' AS single_digit, '1.1' AS fractional");
+  const auto stmt =
+      conn.execute_fetch("SELECT 'abc' AS invalid, '456' AS whole, '6' AS single_digit, '1.1' AS fractional");
 
   // Then the string values should fail to convert to SQL_C_BIT
   check_invalid_string<SQL_C_BIT>(stmt, 1);
@@ -262,7 +263,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
         "'-9223372036854775809' AS less_than_min");
     // Then the string values should be truncated when converted to integer types
     CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 1) == 9223372036854775807LL);
-    CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 2) == -9223372036854775808LL);
+    CHECK(check_no_truncation<SQL_C_SBIGINT>(stmt, 2) == -9223372036854775807LL);
     check_numeric_out_of_range<SQL_C_SBIGINT>(stmt, 3);
     check_numeric_out_of_range<SQL_C_SBIGINT>(stmt, 4);
   }
@@ -343,7 +344,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to integer types usi
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_LONG
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '12345' AS str_num", SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT '12345' AS str_num"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLINTEGER value;
@@ -362,7 +363,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to integer types usi
   // And invalid string should fail binding with SQLSTATE 22018
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 'not_a_number' AS str_val", SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 'not_a_number' AS str_val"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLINTEGER value;

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_interval.cpp
@@ -51,45 +51,45 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to single-co
   // Then <c_type> conversions should work
   {
     INFO("SQL_C_INTERVAL_YEAR");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_YEAR>(stmt, 1);
-    CHECK(interval.interval_type == SQL_IS_YEAR);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.year_month.year == 5);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_YEAR>(stmt, 1);
+    CHECK(interval_type == SQL_IS_YEAR);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.year_month.year == 5);
   }
   {
     INFO("SQL_C_INTERVAL_MONTH");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_MONTH>(stmt, 2);
-    CHECK(interval.interval_type == SQL_IS_MONTH);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.year_month.month == 10);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_MONTH>(stmt, 2);
+    CHECK(interval_type == SQL_IS_MONTH);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.year_month.month == 10);
   }
   {
     INFO("SQL_C_INTERVAL_DAY");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_DAY>(stmt, 3);
-    CHECK(interval.interval_type == SQL_IS_DAY);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.day == 15);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_DAY>(stmt, 3);
+    CHECK(interval_type == SQL_IS_DAY);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.day == 15);
   }
   {
     INFO("SQL_C_INTERVAL_HOUR");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_HOUR>(stmt, 4);
-    CHECK(interval.interval_type == SQL_IS_HOUR);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.hour == 8);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_HOUR>(stmt, 4);
+    CHECK(interval_type == SQL_IS_HOUR);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.hour == 8);
   }
   {
     INFO("SQL_C_INTERVAL_MINUTE");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_MINUTE>(stmt, 5);
-    CHECK(interval.interval_type == SQL_IS_MINUTE);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.minute == 30);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_MINUTE>(stmt, 5);
+    CHECK(interval_type == SQL_IS_MINUTE);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.minute == 30);
   }
   {
     INFO("SQL_C_INTERVAL_SECOND");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_SECOND>(stmt, 6);
-    CHECK(interval.interval_type == SQL_IS_SECOND);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.second == 45);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_SECOND>(stmt, 6);
+    CHECK(interval_type == SQL_IS_SECOND);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.second == 45);
   }
 }
 
@@ -103,24 +103,24 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert negative c_type string liter
   // Then negative <c_type> should be correctly parsed
   {
     INFO("SQL_C_INTERVAL_YEAR");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_YEAR>(stmt, 1);
-    CHECK(interval.interval_type == SQL_IS_YEAR);
-    CHECK(interval.interval_sign == SQL_TRUE);
-    CHECK(interval.intval.year_month.year == 5);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_YEAR>(stmt, 1);
+    CHECK(interval_type == SQL_IS_YEAR);
+    CHECK(interval_sign == SQL_TRUE);
+    CHECK(intval.year_month.year == 5);
   }
   {
     INFO("SQL_C_INTERVAL_MONTH");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_MONTH>(stmt, 2);
-    CHECK(interval.interval_type == SQL_IS_MONTH);
-    CHECK(interval.interval_sign == SQL_TRUE);
-    CHECK(interval.intval.year_month.month == 10);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_MONTH>(stmt, 2);
+    CHECK(interval_type == SQL_IS_MONTH);
+    CHECK(interval_sign == SQL_TRUE);
+    CHECK(intval.year_month.month == 10);
   }
   {
     INFO("SQL_C_INTERVAL_DAY");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_DAY>(stmt, 3);
-    CHECK(interval.interval_type == SQL_IS_DAY);
-    CHECK(interval.interval_sign == SQL_TRUE);
-    CHECK(interval.intval.day_second.day == 15);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_DAY>(stmt, 3);
+    CHECK(interval_type == SQL_IS_DAY);
+    CHECK(interval_sign == SQL_TRUE);
+    CHECK(intval.day_second.day == 15);
   }
 }
 
@@ -137,29 +137,29 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to year-mont
 
   // Then SQL_C_INTERVAL_YEAR_TO_MONTH conversions should work
   {
-    auto interval = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 1);
-    CHECK(interval.interval_type == SQL_IS_YEAR_TO_MONTH);
-    CHECK(interval.interval_sign == SQL_FALSE);  // Positive
-    CHECK(interval.intval.year_month.year == 3);
-    CHECK(interval.intval.year_month.month == 6);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 1);
+    CHECK(interval_type == SQL_IS_YEAR_TO_MONTH);
+    CHECK(interval_sign == SQL_FALSE);  // Positive
+    CHECK(intval.year_month.year == 3);
+    CHECK(intval.year_month.month == 6);
   }
 
   // And negative year-month should be correctly parsed
   {
-    auto interval = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 2);
-    CHECK(interval.interval_type == SQL_IS_YEAR_TO_MONTH);
-    CHECK(interval.interval_sign == SQL_TRUE);  // Negative
-    CHECK(interval.intval.year_month.year == 2);
-    CHECK(interval.intval.year_month.month == 9);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 2);
+    CHECK(interval_type == SQL_IS_YEAR_TO_MONTH);
+    CHECK(interval_sign == SQL_TRUE);  // Negative
+    CHECK(intval.year_month.year == 2);
+    CHECK(intval.year_month.month == 9);
   }
 
   // And zero years with months should work
   {
-    auto interval = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 3);
-    CHECK(interval.interval_type == SQL_IS_YEAR_TO_MONTH);
-    CHECK(interval.interval_sign == SQL_FALSE);  // Positive
-    CHECK(interval.intval.year_month.year == 0);
-    CHECK(interval.intval.year_month.month == 11);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 3);
+    CHECK(interval_type == SQL_IS_YEAR_TO_MONTH);
+    CHECK(interval_sign == SQL_FALSE);  // Positive
+    CHECK(intval.year_month.year == 0);
+    CHECK(intval.year_month.month == 11);
   }
 }
 
@@ -176,55 +176,55 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to compound 
   // Then <c_type> conversions should work
   {
     INFO("SQL_C_INTERVAL_DAY_TO_HOUR");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_DAY_TO_HOUR>(stmt, 1);
-    CHECK(interval.interval_type == SQL_IS_DAY_TO_HOUR);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.day == 5);
-    CHECK(interval.intval.day_second.hour == 10);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_DAY_TO_HOUR>(stmt, 1);
+    CHECK(interval_type == SQL_IS_DAY_TO_HOUR);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.day == 5);
+    CHECK(intval.day_second.hour == 10);
   }
   {
     INFO("SQL_C_INTERVAL_DAY_TO_MINUTE");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_DAY_TO_MINUTE>(stmt, 2);
-    CHECK(interval.interval_type == SQL_IS_DAY_TO_MINUTE);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.day == 3);
-    CHECK(interval.intval.day_second.hour == 14);
-    CHECK(interval.intval.day_second.minute == 30);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_DAY_TO_MINUTE>(stmt, 2);
+    CHECK(interval_type == SQL_IS_DAY_TO_MINUTE);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.day == 3);
+    CHECK(intval.day_second.hour == 14);
+    CHECK(intval.day_second.minute == 30);
   }
   {
     INFO("SQL_C_INTERVAL_DAY_TO_SECOND");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_DAY_TO_SECOND>(stmt, 3);
-    CHECK(interval.interval_type == SQL_IS_DAY_TO_SECOND);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.day == 2);
-    CHECK(interval.intval.day_second.hour == 8);
-    CHECK(interval.intval.day_second.minute == 15);
-    CHECK(interval.intval.day_second.second == 30);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_DAY_TO_SECOND>(stmt, 3);
+    CHECK(interval_type == SQL_IS_DAY_TO_SECOND);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.day == 2);
+    CHECK(intval.day_second.hour == 8);
+    CHECK(intval.day_second.minute == 15);
+    CHECK(intval.day_second.second == 30);
   }
   {
     INFO("SQL_C_INTERVAL_HOUR_TO_MINUTE");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_HOUR_TO_MINUTE>(stmt, 4);
-    CHECK(interval.interval_type == SQL_IS_HOUR_TO_MINUTE);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.hour == 10);
-    CHECK(interval.intval.day_second.minute == 45);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_HOUR_TO_MINUTE>(stmt, 4);
+    CHECK(interval_type == SQL_IS_HOUR_TO_MINUTE);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.hour == 10);
+    CHECK(intval.day_second.minute == 45);
   }
   {
     INFO("SQL_C_INTERVAL_HOUR_TO_SECOND");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_HOUR_TO_SECOND>(stmt, 5);
-    CHECK(interval.interval_type == SQL_IS_HOUR_TO_SECOND);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.hour == 12);
-    CHECK(interval.intval.day_second.minute == 30);
-    CHECK(interval.intval.day_second.second == 45);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_HOUR_TO_SECOND>(stmt, 5);
+    CHECK(interval_type == SQL_IS_HOUR_TO_SECOND);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.hour == 12);
+    CHECK(intval.day_second.minute == 30);
+    CHECK(intval.day_second.second == 45);
   }
   {
     INFO("SQL_C_INTERVAL_MINUTE_TO_SECOND");
-    auto interval = check_no_truncation<SQL_C_INTERVAL_MINUTE_TO_SECOND>(stmt, 6);
-    CHECK(interval.interval_type == SQL_IS_MINUTE_TO_SECOND);
-    CHECK(interval.interval_sign == SQL_FALSE);
-    CHECK(interval.intval.day_second.minute == 45);
-    CHECK(interval.intval.day_second.second == 30);
+    auto [interval_type, interval_sign, intval] = check_no_truncation<SQL_C_INTERVAL_MINUTE_TO_SECOND>(stmt, 6);
+    CHECK(interval_type == SQL_IS_MINUTE_TO_SECOND);
+    CHECK(interval_sign == SQL_FALSE);
+    CHECK(intval.day_second.minute == 45);
+    CHECK(intval.day_second.second == 30);
   }
 }
 
@@ -317,7 +317,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is
 
   // Default leading precision is typically 2 digits for intervals
   // When Query selecting interval values with leading field exceeding precision is executed
-  auto stmt = conn.execute_fetch("SELECT '10000' AS large_year, '99999' AS very_large_year");
+  const auto stmt = conn.execute_fetch("SELECT '10000' AS large_year, '99999' AS very_large_year");
 
   // Then values exceeding leading field precision should fail with 22015
   check_interval_precision_lost<SQL_C_INTERVAL_YEAR>(stmt, 1);
@@ -329,7 +329,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is
   // Given Snowflake client is logged in
 
   // When Query selecting interval values with leading field exceeding precision is executed
-  auto stmt = conn.execute_fetch("SELECT '10000' AS large_month, '99999' AS very_large_month");
+  const auto stmt = conn.execute_fetch("SELECT '10000' AS large_month, '99999' AS very_large_month");
 
   // Then values exceeding leading field precision should fail with 22015
   check_interval_precision_lost<SQL_C_INTERVAL_MONTH>(stmt, 1);
@@ -341,7 +341,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is
   // Given Snowflake client is logged in
 
   // When Query selecting interval values with leading field exceeding precision is executed
-  auto stmt = conn.execute_fetch("SELECT '10000' AS large_day, '99999' AS very_large_day");
+  const auto stmt = conn.execute_fetch("SELECT '10000' AS large_day, '99999' AS very_large_day");
 
   // Then values exceeding leading field precision should fail with 22015
   check_interval_precision_lost<SQL_C_INTERVAL_DAY>(stmt, 1);
@@ -353,7 +353,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is
   // Given Snowflake client is logged in
 
   // When Query selecting interval values with leading field exceeding precision is executed
-  auto stmt = conn.execute_fetch("SELECT '10000' AS large_hour, '99999' AS very_large_hour");
+  const auto stmt = conn.execute_fetch("SELECT '10000' AS large_hour, '99999' AS very_large_hour");
 
   // Then values exceeding leading field precision should fail with 22015
   check_interval_precision_lost<SQL_C_INTERVAL_HOUR>(stmt, 1);
@@ -365,7 +365,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail when leading field precision is
   // Given Snowflake client is logged in
 
   // When Query selecting compound interval values with leading field exceeding precision is executed
-  auto stmt = conn.execute_fetch("SELECT '10000-6' AS large_year_month, '99999 10:30:45' AS large_day_second");
+  const auto stmt = conn.execute_fetch("SELECT '10000-6' AS large_year_month, '99999 10:30:45' AS large_day_second");
 
   // Then values exceeding leading field precision should fail with 22015
   check_interval_precision_lost<SQL_C_INTERVAL_YEAR_TO_MONTH>(stmt, 1);
@@ -381,7 +381,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting invalid interval str
   // Given Snowflake client is logged in
 
   // When Query selecting invalid interval strings is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT 'not-an-interval' AS invalid1, 'abc' AS invalid2, "
       "'12.34.56' AS invalid3, '' AS empty");
 
@@ -397,7 +397,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed interval s
   // Given Snowflake client is logged in
 
   // When Query selecting malformed year-month interval strings is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '3/6' AS wrong_separator, '3.6' AS decimal_separator, "
       "'year-month' AS text, '3 6' AS space_separator");
 
@@ -413,7 +413,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed interval s
   // Given Snowflake client is logged in
 
   // When Query selecting malformed day-time interval strings is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '5-10' AS wrong_separator, 'day hour' AS text_values, "
       "'5:10:30:45' AS too_many_components, '::' AS empty_components");
 
@@ -548,16 +548,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL string when converting t
   // Given Snowflake client is logged in
 
   // When Query selecting NULL is executed
-  auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_interval");
+  const auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_interval");
 
   // Then NULL should return SQL_NULL_DATA indicator
-  {
-    SQL_INTERVAL_STRUCT interval;
-    SQLLEN indicator;
-    SQLRETURN ret = get_data_raw(stmt, 1, SQL_C_INTERVAL_YEAR, &interval, &indicator);
-    REQUIRE_ODBC(ret, stmt);
-    CHECK(indicator == SQL_NULL_DATA);
-  }
+  SQL_INTERVAL_STRUCT interval;
+  SQLLEN indicator;
+  SQLRETURN ret = get_data_raw(stmt, 1, SQL_C_INTERVAL_YEAR, &interval, &indicator);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
 }
 
 // ============================================================================
@@ -571,7 +569,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to interval types us
   // When Query selecting interval value is executed with SQLBindCol for SQL_C_INTERVAL_YEAR
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '5' AS interval_year", SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT '5' AS interval_year"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQL_INTERVAL_STRUCT interval;
@@ -591,7 +589,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to interval types us
   // And invalid interval string should fail binding with SQLSTATE 22018
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 'not_an_interval' AS str_val", SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 'not_an_interval' AS str_val"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQL_INTERVAL_STRUCT interval;

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_real.cpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <limits>
 #include <string>
-#include <vector>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -21,7 +20,6 @@
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
@@ -35,7 +33,7 @@ static long long numeric_val_to_int(const SQL_NUMERIC_STRUCT& num) {
   return result;
 }
 
-static unsigned int to_unsigned_int(char c) { return static_cast<unsigned int>((unsigned char)c); }
+static unsigned int to_unsigned_int(const char c) { return static_cast<unsigned char>(c); }
 
 // ============================================================================
 // SUCCESSFUL CONVERSIONS - String to Floating Point Types
@@ -174,7 +172,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting non-numeric strings 
   // Given Snowflake client is logged in
 
   // When Query selecting various non-numeric strings is executed
-  auto stmt = conn.execute_fetch("SELECT 'not a number' AS c1, 'abc123' AS c2");
+  const auto stmt = conn.execute_fetch("SELECT 'not a number' AS c1, 'abc123' AS c2");
 
   // Then text should fail for SQL_C_FLOAT
   check_invalid_string<SQL_C_FLOAT>(stmt, 1);
@@ -191,7 +189,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting malformed numeric st
   // Given Snowflake client is logged in
 
   // When Query selecting various malformed numeric strings is executed
-  auto stmt = conn.execute_fetch("SELECT '123.456.789' AS c1, '123,456' AS c2");
+  const auto stmt = conn.execute_fetch("SELECT '123.456.789' AS c1, '123,456' AS c2");
 
   // Then multiple decimal points should fail for SQL_C_DOUBLE
   check_invalid_string<SQL_C_DOUBLE>(stmt, 1);
@@ -208,16 +206,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle NULL string when converting t
   // Given Snowflake client is logged in
 
   // When Query selecting NULL is executed
-  auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_double");
+  const auto stmt = conn.execute_fetch("SELECT NULL::STRING AS null_double");
 
   // Then SQL_C_DOUBLE should return SQL_NULL_DATA indicator
-  {
-    SQLDOUBLE value = 999.0;
-    SQLLEN indicator;
-    SQLRETURN ret = get_data_raw(stmt, 1, SQL_C_DOUBLE, &value, &indicator);
-    REQUIRE_ODBC(ret, stmt);
-    CHECK(indicator == SQL_NULL_DATA);
-  }
+  SQLDOUBLE value = 999.0;
+  SQLLEN indicator;
+  const SQLRETURN ret = get_data_raw(stmt, 1, SQL_C_DOUBLE, &value, &indicator);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
 }
 
 // ============================================================================
@@ -231,7 +227,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert strings to floating point ty
   // When Query selecting string numeric value is executed with SQLBindCol for SQL_C_DOUBLE
   {
     auto stmt = conn.createStatement();
-    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT '987.654' AS str_num", SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT '987.654' AS str_num"), SQL_NTS);
     REQUIRE_ODBC(ret, stmt);
 
     SQLDOUBLE value;
@@ -334,26 +330,26 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to SQL_C_NUM
 
   // And very large integer '123456789012345678901234567890' should convert correctly to 18EE90FF6C373E0EE4E3F0AD2
   {
-    auto num = get_data<SQL_C_NUMERIC>(stmt, 9);
-    CHECK(num.precision == 38);
-    CHECK(num.scale == 0);
-    CHECK(num.sign == 1);  // Positive
-    CHECK(to_unsigned_int(num.val[0]) == 0xD2);
-    CHECK(to_unsigned_int(num.val[1]) == 0x0A);
-    CHECK(to_unsigned_int(num.val[2]) == 0x3F);
-    CHECK(to_unsigned_int(num.val[3]) == 0x4E);
-    CHECK(to_unsigned_int(num.val[4]) == 0xEE);
-    CHECK(to_unsigned_int(num.val[5]) == 0xE0);
-    CHECK(to_unsigned_int(num.val[6]) == 0x73);
-    CHECK(to_unsigned_int(num.val[7]) == 0xC3);
-    CHECK(to_unsigned_int(num.val[8]) == 0xF6);
-    CHECK(to_unsigned_int(num.val[9]) == 0x0F);
-    CHECK(to_unsigned_int(num.val[10]) == 0xE9);
-    CHECK(to_unsigned_int(num.val[11]) == 0x8E);
-    CHECK(to_unsigned_int(num.val[12]) == 0x01);
-    CHECK(to_unsigned_int(num.val[13]) == 0x00);
-    CHECK(to_unsigned_int(num.val[14]) == 0x00);
-    CHECK(to_unsigned_int(num.val[15]) == 0x00);
+    auto [precision, scale, sign, val] = get_data<SQL_C_NUMERIC>(stmt, 9);
+    CHECK(precision == 38);
+    CHECK(scale == 0);
+    CHECK(sign == 1);  // Positive
+    CHECK(to_unsigned_int(val[0]) == 0xD2);
+    CHECK(to_unsigned_int(val[1]) == 0x0A);
+    CHECK(to_unsigned_int(val[2]) == 0x3F);
+    CHECK(to_unsigned_int(val[3]) == 0x4E);
+    CHECK(to_unsigned_int(val[4]) == 0xEE);
+    CHECK(to_unsigned_int(val[5]) == 0xE0);
+    CHECK(to_unsigned_int(val[6]) == 0x73);
+    CHECK(to_unsigned_int(val[7]) == 0xC3);
+    CHECK(to_unsigned_int(val[8]) == 0xF6);
+    CHECK(to_unsigned_int(val[9]) == 0x0F);
+    CHECK(to_unsigned_int(val[10]) == 0xE9);
+    CHECK(to_unsigned_int(val[11]) == 0x8E);
+    CHECK(to_unsigned_int(val[12]) == 0x01);
+    CHECK(to_unsigned_int(val[13]) == 0x00);
+    CHECK(to_unsigned_int(val[14]) == 0x00);
+    CHECK(to_unsigned_int(val[15]) == 0x00);
   }
 
   // And NULL should return SQL_NULL_DATA indicator

--- a/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
+++ b/odbc_tests/tests/e2e/types/string_conversion_to_c_temporal.cpp
@@ -16,10 +16,7 @@
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
 #include "SchemaFixtures.hpp"
-#include "compatibility.hpp"
 #include "conversion_checks.hpp"
-#include "get_data.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
@@ -40,38 +37,46 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert string literals to c_type",
   // Then <c_type> conversions should work
   {
     INFO("SQL_C_TYPE_DATE");
-    auto date1 = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 1);
-    CHECK(date1.year == 2024);
-    CHECK(date1.month == 1);
-    CHECK(date1.day == 15);
-
-    auto date2 = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 2);
-    CHECK(date2.year == 1999);
-    CHECK(date2.month == 12);
-    CHECK(date2.day == 31);
-
-    auto y2k = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 3);
-    CHECK(y2k.year == 2000);
-    CHECK(y2k.month == 1);
-    CHECK(y2k.day == 1);
+    {
+      auto [year, month, day] = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 1);
+      CHECK(year == 2024);
+      CHECK(month == 1);
+      CHECK(day == 15);
+    }
+    {
+      auto [year, month, day] = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 2);
+      CHECK(year == 1999);
+      CHECK(month == 12);
+      CHECK(day == 31);
+    }
+    {
+      auto [year, month, day] = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 3);
+      CHECK(year == 2000);
+      CHECK(month == 1);
+      CHECK(day == 1);
+    }
   }
 
   {
     INFO("SQL_C_TYPE_TIME");
-    auto time1 = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 4);
-    CHECK(time1.hour == 14);
-    CHECK(time1.minute == 30);
-    CHECK(time1.second == 45);
-
-    auto midnight = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 5);
-    CHECK(midnight.hour == 0);
-    CHECK(midnight.minute == 0);
-    CHECK(midnight.second == 0);
-
-    auto end_of_day = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 6);
-    CHECK(end_of_day.hour == 23);
-    CHECK(end_of_day.minute == 59);
-    CHECK(end_of_day.second == 59);
+    {
+      auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 4);
+      CHECK(hour == 14);
+      CHECK(minute == 30);
+      CHECK(second == 45);
+    }
+    {
+      auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 5);
+      CHECK(hour == 0);
+      CHECK(minute == 0);
+      CHECK(second == 0);
+    }
+    {
+      auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 6);
+      CHECK(hour == 23);
+      CHECK(minute == 59);
+      CHECK(second == 59);
+    }
   }
 
   {
@@ -155,20 +160,24 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert timestamp string to SQL_C_TY
       "SELECT '2024-01-15 14:30:45' AS c1, '1999-12-31 23:59:59' AS c2, '2000-06-15 00:00:00' AS c3");
 
   // Then SQL_C_TYPE_DATE should extract the date component (time is truncated)
-  auto date1 = check_fractional_truncation<SQL_C_TYPE_DATE>(stmt, 1);
-  CHECK(date1.year == 2024);
-  CHECK(date1.month == 1);
-  CHECK(date1.day == 15);
-
-  auto date2 = check_fractional_truncation<SQL_C_TYPE_DATE>(stmt, 2);
-  CHECK(date2.year == 1999);
-  CHECK(date2.month == 12);
-  CHECK(date2.day == 31);
-
-  auto date3 = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 3);
-  CHECK(date3.year == 2000);
-  CHECK(date3.month == 6);
-  CHECK(date3.day == 15);
+  {
+    auto [year, month, day] = check_fractional_truncation<SQL_C_TYPE_DATE>(stmt, 1);
+    CHECK(year == 2024);
+    CHECK(month == 1);
+    CHECK(day == 15);
+  }
+  {
+    auto [year, month, day] = check_fractional_truncation<SQL_C_TYPE_DATE>(stmt, 2);
+    CHECK(year == 1999);
+    CHECK(month == 12);
+    CHECK(day == 31);
+  }
+  {
+    auto [year, month, day] = check_no_truncation<SQL_C_TYPE_DATE>(stmt, 3);
+    CHECK(year == 2000);
+    CHECK(month == 6);
+    CHECK(day == 15);
+  }
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should convert timestamp string to SQL_C_TYPE_TIME",
@@ -180,20 +189,24 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should convert timestamp string to SQL_C_TY
       "SELECT '2024-01-15 14:30:45' AS c1, '1999-12-31 23:59:59' AS c2, '2000-06-15 00:00:00' AS c3");
 
   // Then SQL_C_TYPE_TIME should extract the time component (date is truncated)
-  auto time1 = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 1);
-  CHECK(time1.hour == 14);
-  CHECK(time1.minute == 30);
-  CHECK(time1.second == 45);
-
-  auto time2 = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 2);
-  CHECK(time2.hour == 23);
-  CHECK(time2.minute == 59);
-  CHECK(time2.second == 59);
-
-  auto time3 = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 3);
-  CHECK(time3.hour == 0);
-  CHECK(time3.minute == 0);
-  CHECK(time3.second == 0);
+  {
+    auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 1);
+    CHECK(hour == 14);
+    CHECK(minute == 30);
+    CHECK(second == 45);
+  }
+  {
+    auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 2);
+    CHECK(hour == 23);
+    CHECK(minute == 59);
+    CHECK(second == 59);
+  }
+  {
+    auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 3);
+    CHECK(hour == 0);
+    CHECK(minute == 0);
+    CHECK(second == 0);
+  }
 }
 
 // ============================================================================
@@ -205,7 +218,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting invalid date/time st
   // Given Snowflake client is logged in
 
   // When Query selecting invalid date/time strings is executed
-  auto stmt = conn.execute_fetch("SELECT 'not-a-date' AS c1, 'not-a-time' AS c2, 'invalid-timestamp' AS c3");
+  const auto stmt = conn.execute_fetch("SELECT 'not-a-date' AS c1, 'not-a-time' AS c2, 'invalid-timestamp' AS c3");
 
   // Then invalid date/time strings should fail
   check_invalid_string<SQL_C_TYPE_DATE>(stmt, 1);
@@ -222,7 +235,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible date valu
   // Given Snowflake client is logged in
 
   // When Query selecting date strings with correct syntax but impossible values is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '2024-13-01' AS month_13, '2024-00-15' AS month_0, '2024-01-32' AS day_32, "
       "'2024-02-30' AS feb_30, '2024-04-31' AS apr_31, '2024-01-00' AS day_0");
 
@@ -258,10 +271,10 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible time valu
 
   // And second 60 might behave differently in the old driver
   INFO("Converting impossible time: second 60");
-  auto time = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 4);
-  CHECK(time.hour == 14);
-  CHECK(time.minute == 30);
-  CHECK(time.second == 60);
+  auto [hour, minute, second] = check_no_truncation<SQL_C_TYPE_TIME>(stmt, 4);
+  CHECK(hour == 14);
+  CHECK(minute == 30);
+  CHECK(second == 60);
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible timestamp values",
@@ -269,7 +282,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting impossible timestamp
   // Given Snowflake client is logged in
 
   // When Query selecting timestamp strings with correct syntax but impossible values is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '2024-13-01 14:30:45' AS month_13, '2024-01-15 25:00:00' AS hour_25, "
       "'2024-02-30 12:00:00' AS feb_30, '2024-01-15 14:60:00' AS minute_60");
 
@@ -292,7 +305,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative date for
   // Given Snowflake client is logged in
 
   // When Query selecting multiple date strings in alternative formats is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '01/15/2024' AS us_format, '15.01.2024' AS european_format, '2024/01/15' AS slash_format, 'January 15, "
       "2024' AS spelled_month, '15-Jan-2024' AS abbreviated_month, '15-01-2024' AS reversed_format, '24-01-15' AS "
       "two_digit_year, '2024-1-5' AS single_digit");
@@ -322,7 +335,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative time for
   // Given Snowflake client is logged in
 
   // When Query selecting multiple time strings in alternative formats is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '2:30:45 PM' AS twelve_hour_format, '14:30' AS no_seconds, '14.30.45' AS dot_separator, '9:5:3' AS "
       "single_digit");
 
@@ -347,7 +360,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should fail converting alternative timestam
   // Given Snowflake client is logged in
 
   // When Query selecting multiple timestamp strings in alternative formats is executed
-  auto stmt = conn.execute_fetch(
+  const auto stmt = conn.execute_fetch(
       "SELECT '2024-01-15T14:30:45' AS iso_t_separator, '2024-01-15 14:30:45+05:00' AS timezone_offset, "
       "'2024-01-15T14:30:45Z' AS utc_suffix, '01/15/2024 14:30:45' AS us_format");
 

--- a/odbc_tests/tests/e2e/types/string_lob.cpp
+++ b/odbc_tests/tests/e2e/types/string_lob.cpp
@@ -20,14 +20,12 @@
 #include "Connection.hpp"
 #include "HandleWrapper.hpp"
 #include "SchemaFixtures.hpp"
-#include "compatibility.hpp"
-#include "get_data.hpp"
 #include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
 // Helper to generate random ASCII string for LOB tests
-static std::string generate_random_ascii_string(std::mt19937& gen, size_t length) {
-  static const char charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+static std::string generate_random_ascii_string(std::mt19937& gen, const size_t length) {
+  static constexpr char charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   std::uniform_int_distribution<> dist(0, sizeof(charset) - 2);
   std::string result;
   result.reserve(length);
@@ -55,7 +53,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB 
   conn.execute("CREATE OR REPLACE TABLE lob_128mb (val VARCHAR(134217728))");
 
   // When A string of 134217728 ASCII characters is generated and inserted
-  const size_t string_length = 134217728;  // 128 MB
+  constexpr size_t string_length = 134217728;  // 128 MB
   std::string lob_string = generate_random_ascii_string(gen, string_length);
 
   {
@@ -65,7 +63,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB 
 
     SQLLEN value_len = static_cast<SQLLEN>(lob_string.size());
     ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, lob_string.size(), 0,
-                           (SQLCHAR*)lob_string.c_str(), lob_string.size(), &value_len);
+                           sqlchar(lob_string.c_str()), lob_string.size(), &value_len);
     REQUIRE_ODBC(ret, stmt);
     ret = SQLExecute(stmt.getHandle());
     REQUIRE_ODBC(ret, stmt);
@@ -108,7 +106,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 M
   conn.execute("CREATE OR REPLACE TABLE lob_16mb (val VARCHAR)");
 
   // When A string of 16777216 ASCII characters is generated and inserted
-  const size_t string_length = 16777216;  // 16 MB
+  constexpr size_t string_length = 16777216;  // 16 MB
   std::string lob_string = generate_random_ascii_string(gen, string_length);
 
   {
@@ -118,7 +116,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 M
 
     SQLLEN value_len = static_cast<SQLLEN>(lob_string.size());
     ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, lob_string.size(), 0,
-                           (SQLCHAR*)lob_string.c_str(), lob_string.size(), &value_len);
+                           sqlchar(lob_string.c_str()), lob_string.size(), &value_len);
     REQUIRE_ODBC(ret, stmt);
 
     ret = SQLExecute(stmt.getHandle());


### PR DESCRIPTION
Apply const-correctness (const auto, const SQLRETURN), replace
C-style casts with sqlchar() helper and static_cast, use structured
bindings for interval/temporal check results, remove unused includes,
and prefer constexpr for compile-time constants.