### PR TITLE
Change sf_core crate-type from dylib to cdylib

### DIFF
--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 
 [lib]
 name = "sf_core"
-crate-type = ["dylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["protobuf"]


### PR DESCRIPTION
Switch to cdylib for a stable C ABI. This change reduces the Python wheel (mostly core) size from ~75 MB to ~60 MB.

Made-with: Cursor