### PR TITLE
feat: support structured C types in SQLBindParameter for string SQL types

### DIFF
--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -838,4 +838,177 @@ mod tests {
         assert_eq!(v, Value::String("3.14".to_string()));
         Ok(())
     }
+
+    // -- Structured C types → VARCHAR -----------------------------------------
+
+    #[test]
+    fn convert_timestamp_as_varchar() -> TestResult {
+        let ts = sql::Timestamp {
+            year: 2024,
+            month: 1,
+            day: 15,
+            hour: 10,
+            minute: 30,
+            second: 45,
+            fraction: 0,
+        };
+        let binding = make_binding(
+            CDataType::TypeTimestamp,
+            sql::SqlDataType::VARCHAR,
+            &ts as *const sql::Timestamp as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("2024-01-15 10:30:45".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_timestamp_with_fraction_as_varchar() -> TestResult {
+        let ts = sql::Timestamp {
+            year: 1,
+            month: 1,
+            day: 1,
+            hour: 1,
+            minute: 1,
+            second: 1,
+            fraction: 1,
+        };
+        let binding = make_binding(
+            CDataType::TimeStamp,
+            sql::SqlDataType::VARCHAR,
+            &ts as *const sql::Timestamp as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(
+            v,
+            Value::String("0001-01-01 01:01:01.000000001".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn convert_date_as_varchar() -> TestResult {
+        let d = sql::Date {
+            year: 2024,
+            month: 12,
+            day: 25,
+        };
+        let binding = make_binding(
+            CDataType::TypeDate,
+            sql::SqlDataType::VARCHAR,
+            &d as *const sql::Date as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("2024-12-25".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_time_as_varchar() -> TestResult {
+        let t = sql::Time {
+            hour: 14,
+            minute: 30,
+            second: 59,
+        };
+        let binding = make_binding(
+            CDataType::TypeTime,
+            sql::SqlDataType::VARCHAR,
+            &t as *const sql::Time as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("14:30:59".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_numeric_as_varchar() -> TestResult {
+        let n = sql::Numeric {
+            precision: 10,
+            scale: 0,
+            sign: 1,
+            val: 42u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::VARCHAR,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("42".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_negative_numeric_as_varchar() -> TestResult {
+        let n = sql::Numeric {
+            precision: 10,
+            scale: 2,
+            sign: 0,
+            val: 12345u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::VARCHAR,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("-123.45".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_numeric_small_scale_as_varchar() -> TestResult {
+        let n = sql::Numeric {
+            precision: 5,
+            scale: 3,
+            sign: 1,
+            val: 5u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::VARCHAR,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("0.005".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_binary_as_varchar() -> TestResult {
+        let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let mut ind: sql::Len = 4;
+        let binding = make_binding(
+            CDataType::Binary,
+            sql::SqlDataType::VARCHAR,
+            val.as_ptr() as sql::Pointer,
+            4,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("deadbeef".to_string()));
+        Ok(())
+    }
 }

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -996,6 +996,50 @@ mod tests {
     }
 
     #[test]
+    fn convert_numeric_negative_scale_as_varchar() -> TestResult {
+        // scale = -2 means value = 123 * 10^2 = 12300
+        let n = sql::Numeric {
+            precision: 10,
+            scale: -2,
+            sign: 1,
+            val: 123u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::VARCHAR,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("12300".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_numeric_negative_scale_negative_value_as_varchar() -> TestResult {
+        // scale = -3, sign = 0 (negative), val = 5 → -5000
+        let n = sql::Numeric {
+            precision: 10,
+            scale: -3,
+            sign: 0,
+            val: 5u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::VARCHAR,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Text);
+        assert_eq!(v, Value::String("-5000".to_string()));
+        Ok(())
+    }
+
+    #[test]
     fn convert_binary_as_varchar() -> TestResult {
         let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
         let mut ind: sql::Len = 4;

--- a/odbc/src/conversion/varchar.rs
+++ b/odbc/src/conversion/varchar.rs
@@ -451,6 +451,9 @@ impl ReadODBC for SnowflakeVarchar {
                         let (whole, frac) = abs_str.split_at(abs_str.len() - s);
                         format!("{}.{}", whole, frac)
                     }
+                } else if n.scale < 0 {
+                    let zeros = (-n.scale) as usize;
+                    format!("{}{}", abs_str, "0".repeat(zeros))
                 } else {
                     abs_str
                 };

--- a/odbc/src/conversion/varchar.rs
+++ b/odbc/src/conversion/varchar.rs
@@ -14,7 +14,9 @@ use crate::conversion::error::{
     InvalidValueSnafu, NumericLiteralParsingSnafu, NumericValueOutOfRangeSnafu, ReadArrowError,
     RustParsingSnafu, UnsupportedCDataTypeSnafu, UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
-use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
+use crate::conversion::param_binding::{
+    buffer_data_len, read_char_str, read_unaligned, read_wchar_str,
+};
 use crate::conversion::parsers::numeric_literal_parser::{Sign, parse_numeric_literal};
 use crate::conversion::traits::Binding;
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
@@ -412,6 +414,61 @@ impl ReadODBC for SnowflakeVarchar {
                 } else {
                     "0".to_string()
                 }
+            }
+            CDataType::TypeTimestamp | CDataType::TimeStamp => {
+                let ts = read_unaligned::<sql::Timestamp>(binding);
+                if ts.fraction == 0 {
+                    format!(
+                        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+                        ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second
+                    )
+                } else {
+                    format!(
+                        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09}",
+                        ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.fraction
+                    )
+                }
+            }
+            CDataType::TypeDate | CDataType::Date => {
+                let d = read_unaligned::<sql::Date>(binding);
+                format!("{:04}-{:02}-{:02}", d.year, d.month, d.day)
+            }
+            CDataType::TypeTime | CDataType::Time => {
+                let t = read_unaligned::<sql::Time>(binding);
+                format!("{:02}:{:02}:{:02}", t.hour, t.minute, t.second)
+            }
+            CDataType::Numeric => {
+                let n = read_unaligned::<sql::Numeric>(binding);
+                let magnitude = u128::from_le_bytes(n.val);
+                let abs_str = magnitude.to_string();
+                let scaled = if n.scale > 0 {
+                    let s = n.scale as usize;
+                    if abs_str.len() <= s {
+                        let padded = format!("{:0>width$}", abs_str, width = s + 1);
+                        let (whole, frac) = padded.split_at(padded.len() - s);
+                        format!("{}.{}", whole, frac)
+                    } else {
+                        let (whole, frac) = abs_str.split_at(abs_str.len() - s);
+                        format!("{}.{}", whole, frac)
+                    }
+                } else {
+                    abs_str
+                };
+                if n.sign == 0 && magnitude != 0 {
+                    format!("-{}", scaled)
+                } else {
+                    scaled
+                }
+            }
+            CDataType::Binary => {
+                let len = buffer_data_len(binding);
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len)
+                };
+                bytes
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<String>()
             }
             _ => {
                 return UnsupportedCDataTypeSnafu {

--- a/odbc/src/conversion/varchar.rs
+++ b/odbc/src/conversion/varchar.rs
@@ -452,7 +452,7 @@ impl ReadODBC for SnowflakeVarchar {
                         format!("{}.{}", whole, frac)
                     }
                 } else if n.scale < 0 {
-                    let zeros = (-n.scale) as usize;
+                    let zeros = (-(i16::from(n.scale))) as usize;
                     format!("{}{}", abs_str, "0".repeat(zeros))
                 } else {
                     abs_str

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -337,3 +337,33 @@ behavior_differences:
       Spec reference: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcancel-function
       Impact: Applications relying on async cancel to abort long-running
       queries will not see cancellation take effect on the old driver.
+
+  33:
+    name: "SQL_C_NUMERIC to VARCHAR applies scale from SQL_NUMERIC_STRUCT instead of ignoring it"
+    type: "Bug Fix"
+    description: |
+      OLD driver: When binding SQL_C_NUMERIC to SQL_VARCHAR, the Simba SDK
+      ignores the scale field of SQL_NUMERIC_STRUCT and converts the raw
+      magnitude to a string without inserting a decimal point or appending
+      trailing zeros. For example, val=12345 with scale=2 produces "12345"
+      instead of "123.45", and val=123 with scale=-2 produces "123" instead
+      of "12300".
+      NEW driver: Honors the scale field per the ODBC specification. Positive
+      scale inserts a decimal point (val=12345, scale=2 → "123.45"). Negative
+      scale appends trailing zeros (val=123, scale=-2 → "12300").
+      Spec reference: The SQL_NUMERIC_STRUCT stores a "scaled integer" where
+      actual_value = val × 10^(−scale).
+      https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/c-data-types
+
+  34:
+    name: "SQL_C_BINARY to VARCHAR hex-encodes bytes instead of failing with HTTP 400"
+    type: "New Feature"
+    description: |
+      OLD driver: When binding SQL_C_BINARY to SQL_VARCHAR, the Simba SDK
+      passes the raw binary data to Snowflake, which rejects the request
+      with HTTP 400.
+      NEW driver: Hex-encodes the binary data before sending (e.g. 0xDEADBEEF
+      → "deadbeef"), which Snowflake accepts as a valid VARCHAR value.
+      Spec reference: ODBC "C to SQL: Character" conversion table lists
+      SQL_C_BINARY as a valid source type for SQL_VARCHAR.
+      https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/converting-data-from-c-to-sql-data-types

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -1413,3 +1413,189 @@ TEST_CASE("should bind SQL_C_SLONG to SQL_WLONGVARCHAR.", "[query][bind_paramete
   // Then the result should be the expected string
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "42");
 }
+
+// =============================================================================
+// C structured type → VARCHAR conversions
+// =============================================================================
+
+TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_TIMESTAMP_STRUCT param = {};
+  param.year = 2024;
+  param.month = 1;
+  param.day = 15;
+  param.hour = 10;
+  param.minute = 30;
+  param.second = 45;
+  param.fraction = 0;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_VARCHAR, 100, 0,
+                                   &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "2024-01-15 10:30:45");
+}
+
+TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP with fraction to SQL_VARCHAR.",
+          "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_TIMESTAMP_STRUCT param = {};
+  param.year = 2024;
+  param.month = 6;
+  param.day = 15;
+  param.hour = 12;
+  param.minute = 0;
+  param.second = 0;
+  param.fraction = 123456789;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_VARCHAR, 100, 0,
+                                   &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "2024-06-15 12:00:00.123456789");
+}
+
+TEST_CASE("should bind SQL_C_TYPE_DATE to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_DATE_STRUCT param = {};
+  param.year = 2024;
+  param.month = 12;
+  param.day = 25;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "2024-12-25");
+}
+
+TEST_CASE("should bind SQL_C_TYPE_TIME to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_TIME_STRUCT param = {};
+  param.hour = 14;
+  param.minute = 30;
+  param.second = 59;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "14:30:59");
+}
+
+TEST_CASE("should bind SQL_C_NUMERIC to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_NUMERIC_STRUCT param = {};
+  param.precision = 10;
+  param.scale = 0;
+  param.sign = 1;
+  memset(param.val, 0, SQL_MAX_NUMERIC_LEN);
+  param.val[0] = 42;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_NUMERIC, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "42");
+}
+
+TEST_CASE("should bind negative SQL_C_NUMERIC with scale to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_NUMERIC_STRUCT param = {};
+  param.precision = 10;
+  param.scale = 2;
+  param.sign = 0;
+  memset(param.val, 0, SQL_MAX_NUMERIC_LEN);
+  // 12345 in little-endian: 0x39, 0x30
+  param.val[0] = 0x39;
+  param.val[1] = 0x30;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_NUMERIC, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-123.45");
+}
+
+TEST_CASE("should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQL_NUMERIC_STRUCT param = {};
+  param.precision = 10;
+  param.scale = static_cast<SQLSCHAR>(-2);
+  param.sign = 1;
+  memset(param.val, 0, SQL_MAX_NUMERIC_LEN);
+  param.val[0] = 123;
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_NUMERIC, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "12300");
+}
+
+TEST_CASE("should bind SQL_C_BINARY to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  unsigned char param[] = {0xDE, 0xAD, 0xBE, 0xEF};
+  SQLLEN indicator = sizeof(param);
+  // When the C type value is bound as a string SQL type and SELECT ? is executed
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR, 100, 0, &param,
+                                   sizeof(param), &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "deadbeef");
+}

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -1443,8 +1443,7 @@ TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP to SQL_VARCHAR.", "[query][bind_para
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "2024-01-15 10:30:45");
 }
 
-TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP with fraction to SQL_VARCHAR.",
-          "[query][bind_parameter][c_to_varchar]") {
+TEST_CASE("should bind SQL_C_TYPE_TIMESTAMP with fraction to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -1479,8 +1478,8 @@ TEST_CASE("should bind SQL_C_TYPE_DATE to SQL_VARCHAR.", "[query][bind_parameter
   param.day = 25;
   SQLLEN indicator = sizeof(param);
   // When the C type value is bound as a string SQL type and SELECT ? is executed
-  SQLRETURN ret =
-      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_VARCHAR, 100, 0, &param,
+                                   0, &indicator);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
@@ -1500,8 +1499,8 @@ TEST_CASE("should bind SQL_C_TYPE_TIME to SQL_VARCHAR.", "[query][bind_parameter
   param.second = 59;
   SQLLEN indicator = sizeof(param);
   // When the C type value is bound as a string SQL type and SELECT ? is executed
-  SQLRETURN ret =
-      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_VARCHAR, 100, 0, &param, 0, &indicator);
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_VARCHAR, 100, 0, &param,
+                                   0, &indicator);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
@@ -1556,7 +1555,13 @@ TEST_CASE("should bind negative SQL_C_NUMERIC with scale to SQL_VARCHAR.", "[que
   ret = SQLFetch(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
   // Then the result should be the expected string
-  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "-123.45");
+  auto result = get_data<SQL_C_CHAR>(stmt, 1);
+  NEW_DRIVER_ONLY("BD#33") {
+    CHECK(result == "-123.45");
+  }
+  OLD_DRIVER_ONLY("BD#33") {
+    CHECK(result == "-12345");
+  }
 }
 
 TEST_CASE("should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
@@ -1579,7 +1584,13 @@ TEST_CASE("should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.", "[que
   ret = SQLFetch(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
   // Then the result should be the expected string
-  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "12300");
+  auto result = get_data<SQL_C_CHAR>(stmt, 1);
+  NEW_DRIVER_ONLY("BD#33") {
+    CHECK(result == "12300");
+  }
+  OLD_DRIVER_ONLY("BD#33") {
+    CHECK(result == "123");
+  }
 }
 
 TEST_CASE("should bind SQL_C_BINARY to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
@@ -1593,9 +1604,14 @@ TEST_CASE("should bind SQL_C_BINARY to SQL_VARCHAR.", "[query][bind_parameter][c
                                    sizeof(param), &indicator);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLFetch(stmt.getHandle());
-  REQUIRE_ODBC(ret, stmt);
-  // Then the result should be the expected string
-  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "deadbeef");
+  NEW_DRIVER_ONLY("BD#34") {
+    REQUIRE_ODBC(ret, stmt);
+    ret = SQLFetch(stmt.getHandle());
+    REQUIRE_ODBC(ret, stmt);
+    // Then the result should be the expected string
+    CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "deadbeef");
+  }
+  OLD_DRIVER_ONLY("BD#34") {
+    CHECK(ret == SQL_ERROR);
+  }
 }

--- a/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
+++ b/odbc_tests/tests/e2e/query/sql_bind_parameter.cpp
@@ -1556,12 +1556,8 @@ TEST_CASE("should bind negative SQL_C_NUMERIC with scale to SQL_VARCHAR.", "[que
   REQUIRE_ODBC(ret, stmt);
   // Then the result should be the expected string
   auto result = get_data<SQL_C_CHAR>(stmt, 1);
-  NEW_DRIVER_ONLY("BD#33") {
-    CHECK(result == "-123.45");
-  }
-  OLD_DRIVER_ONLY("BD#33") {
-    CHECK(result == "-12345");
-  }
+  NEW_DRIVER_ONLY("BD#33") { CHECK(result == "-123.45"); }
+  OLD_DRIVER_ONLY("BD#33") { CHECK(result == "-12345"); }
 }
 
 TEST_CASE("should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
@@ -1585,12 +1581,8 @@ TEST_CASE("should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.", "[que
   REQUIRE_ODBC(ret, stmt);
   // Then the result should be the expected string
   auto result = get_data<SQL_C_CHAR>(stmt, 1);
-  NEW_DRIVER_ONLY("BD#33") {
-    CHECK(result == "12300");
-  }
-  OLD_DRIVER_ONLY("BD#33") {
-    CHECK(result == "123");
-  }
+  NEW_DRIVER_ONLY("BD#33") { CHECK(result == "12300"); }
+  OLD_DRIVER_ONLY("BD#33") { CHECK(result == "123"); }
 }
 
 TEST_CASE("should bind SQL_C_BINARY to SQL_VARCHAR.", "[query][bind_parameter][c_to_varchar]") {
@@ -1611,7 +1603,5 @@ TEST_CASE("should bind SQL_C_BINARY to SQL_VARCHAR.", "[query][bind_parameter][c
     // Then the result should be the expected string
     CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "deadbeef");
   }
-  OLD_DRIVER_ONLY("BD#34") {
-    CHECK(ret == SQL_ERROR);
-  }
+  OLD_DRIVER_ONLY("BD#34") { CHECK(ret == SQL_ERROR); }
 }

--- a/tests/definitions/odbc/query/sql_bind_parameter.feature
+++ b/tests/definitions/odbc/query/sql_bind_parameter.feature
@@ -445,3 +445,55 @@ Feature: ODBC SQLBindParameter spec compliance
     Given Snowflake client is logged in
     When the C type value is bound as a string SQL type and SELECT ? is executed
     Then the result should be the expected string
+
+  # ============================================================================
+  # C structured type → VARCHAR conversions
+  # ============================================================================
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_TYPE_TIMESTAMP to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_TYPE_TIMESTAMP with fraction to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_TYPE_DATE to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_TYPE_TIME to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_NUMERIC to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind negative SQL_C_NUMERIC with scale to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_NUMERIC with negative scale to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
+  Scenario: should bind SQL_C_BINARY to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound as a string SQL type and SELECT ? is executed
+    Then the result should be the expected string


### PR DESCRIPTION
## Summary

Add date, time, timestamp, SQL_NUMERIC_STRUCT, and binary C type
conversions in SnowflakeVarchar::ReadODBC for string SQL parameters.

- SQL_C_TYPE_TIMESTAMP: formats as "YYYY-MM-DD HH:MM:SS[.nnnnnnnnn]"
(matches old driver format from BindCatchTest)
- SQL_C_TYPE_DATE: formats as "YYYY-MM-DD"
- SQL_C_TYPE_TIME: formats as "HH:MM:SS"
- SQL_C_NUMERIC: reads SQL_NUMERIC_STRUCT, converts 128-bit LE magnitude
with sign and scale (including negative scale) to decimal string
- SQL_C_BINARY: hex-encodes raw bytes

### Follow-up from PR #748

Handles the remaining structured C types that were left as `UnsupportedCDataType` in the first PR.

## Test plan

- [x] 7 Rust unit tests for structured type conversions (timestamp, timestamp with fraction, date, time, numeric, negative numeric with scale, numeric with negative scale, negative numeric with negative scale, binary)
- [x] 8 e2e tests:
    - SQL_C_TYPE_TIMESTAMP → SQL_VARCHAR
    - SQL_C_TYPE_TIMESTAMP with fraction → SQL_VARCHAR
    - SQL_C_TYPE_DATE → SQL_VARCHAR
    - SQL_C_TYPE_TIME → SQL_VARCHAR
    - SQL_C_NUMERIC (integer) → SQL_VARCHAR
    - SQL_C_NUMERIC (negative with scale) → SQL_VARCHAR
    - SQL_C_NUMERIC (negative scale) → SQL_VARCHAR
    - SQL_C_BINARY → SQL_VARCHAR
- [x] All existing unit tests continue to pass

SNOW-3031761