### PR TITLE
SNOW-3240584: SQLCloseCursor Implementation

### DIFF
--- a/odbc/exports.def
+++ b/odbc/exports.def
@@ -10,6 +10,7 @@ EXPORTS
     SQLBindCol
     SQLBindParameter
     SQLCancel
+    SQLCloseCursor
     SQLColAttributeW
     SQLConnectW
     SQLDescribeColW

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -2,9 +2,10 @@ use crate::api::CDataType;
 use crate::api::encoding::OdbcEncoding;
 use crate::api::error::{
     ArrowArrayStreamReaderCreationSnafu, CursorAlreadyOpenSnafu, DisconnectedSnafu,
-    InvalidBufferLengthSnafu, InvalidHandleSnafu, InvalidParameterNumberSnafu,
-    InvalidPrecisionOrScaleSnafu, JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu,
-    OdbcRuntimeSnafu, ReadOnlyAttributeSnafu, Required, StatementNotExecutedSnafu,
+    InvalidBufferLengthSnafu, InvalidCursorStateSnafu, InvalidHandleSnafu,
+    InvalidParameterNumberSnafu, InvalidPrecisionOrScaleSnafu, JsonBindingSnafu, NoMoreDataSnafu,
+    NullPointerSnafu, OdbcRuntimeSnafu, ReadOnlyAttributeSnafu, Required,
+    StatementNotExecutedSnafu,
 };
 use crate::api::runtime::global;
 use crate::api::{
@@ -39,12 +40,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     let stmt = stmt_from_handle(statement_handle);
     tracing::debug!("exec_direct: statement_handle={:?}", statement_handle);
 
-    if matches!(
-        stmt.state.as_ref(),
-        StatementState::QueryExecuted { .. }
-            | StatementState::Fetching { .. }
-            | StatementState::Done { .. }
-    ) {
+    if stmt.state.as_ref().has_open_cursor() {
         tracing::error!("exec_direct: cursor is already open");
         return CursorAlreadyOpenSnafu.fail();
     }
@@ -180,12 +176,7 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
     tracing::debug!("prepare: statement_handle={:?}", statement_handle);
     let stmt = stmt_from_handle(statement_handle);
 
-    if matches!(
-        stmt.state.as_ref(),
-        StatementState::QueryExecuted { .. }
-            | StatementState::Fetching { .. }
-            | StatementState::Done { .. }
-    ) {
+    if stmt.state.as_ref().has_open_cursor() {
         tracing::error!("prepare: cursor is already open");
         return CursorAlreadyOpenSnafu.fail();
     }
@@ -250,12 +241,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("execute: statement_handle={:?}", statement_handle);
     let stmt = stmt_from_handle(statement_handle);
 
-    if matches!(
-        stmt.state.as_ref(),
-        StatementState::QueryExecuted { .. }
-            | StatementState::Fetching { .. }
-            | StatementState::Done { .. }
-    ) {
+    if stmt.state.as_ref().has_open_cursor() {
         tracing::error!("execute: cursor is already open");
         return CursorAlreadyOpenSnafu.fail();
     }
@@ -604,6 +590,21 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
     }
 
     Ok(())
+}
+
+/// Close the cursor on a statement, returning SQLSTATE 24000 if no cursor is open.
+/// Unlike `free_stmt(SQL_CLOSE)`, which silently no-ops when no cursor is open,
+/// this function errors per the ODBC spec for `SQLCloseCursor`.
+pub fn close_cursor(statement_handle: sql::Handle) -> OdbcResult<()> {
+    tracing::debug!("close_cursor: statement_handle={statement_handle:?}");
+
+    let stmt = stmt_from_handle(statement_handle);
+
+    if !stmt.state.as_ref().has_open_cursor() {
+        return InvalidCursorStateSnafu.fail();
+    }
+
+    free_stmt(statement_handle, FreeStmtOption::Close)
 }
 
 /// Return the number of parameters in the statement via the IPD descriptor.

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -915,6 +915,18 @@ pub enum StatementState {
     Error,
 }
 
+impl StatementState {
+    /// A cursor is open in `QueryExecuted` (S5), `Fetching` (S6), and `Done` (S7).
+    pub fn has_open_cursor(&self) -> bool {
+        matches!(
+            self,
+            StatementState::QueryExecuted { .. }
+                | StatementState::Fetching { .. }
+                | StatementState::Done { .. }
+        )
+    }
+}
+
 pub struct State<T> {
     current_state: Option<T>,
 }

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -100,6 +100,19 @@ pub unsafe extern "C" fn SQLFreeStmt(
 
 /// # Safety
 /// This function is called by the ODBC driver manager.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLCloseCursor(statement_handle: sql::Handle) -> sql::RetCode {
+    if statement_handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
+    let result = api::statement::close_cursor(statement_handle);
+    api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    result.to_sql_code()
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
 ///
 /// ODBC allows SQLCancel to be called from a different thread.
 /// `cancel()` accesses the `Statement` via `stmt_from_handle()` — the

--- a/odbc_tests/tests/odbc-api/terminating_statement/close_cursor_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/close_cursor_tests.cpp
@@ -7,7 +7,6 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
@@ -18,8 +17,6 @@
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close and re-execute",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -33,14 +30,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close and re-execute",
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Fetch after close",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -53,8 +49,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Fetch after close",
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Repeated close-execute cycles",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   constexpr int values[] = {10, 20, 30};
   for (const int expected : values) {
     char sql[64];
@@ -67,7 +61,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Repeated close-execute 
     REQUIRE(ret == SQL_SUCCESS);
 
     SQLINTEGER val = 0;
-    SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
     REQUIRE(val == expected);
 
     ret = SQLCloseCursor(stmt_handle());
@@ -77,8 +72,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Repeated close-execute 
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close after partial fetch of multi-row result",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret =
       SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3)"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
@@ -99,7 +92,8 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close after partial fet
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 99);
 }
 
@@ -109,8 +103,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close after partial fet
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves prepared statement",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -127,14 +119,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves prepared stat
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 42);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves bound parameters",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -157,14 +148,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves bound paramet
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(val == 77);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves bound columns",
                  "[odbc-api][closecursor][terminating_statement]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLINTEGER col_val = 0;
   SQLLEN indicator = 0;
   SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &col_val, 0, &indicator);
@@ -194,16 +184,12 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Preserves bound columns
 
 TEST_CASE("SQLCloseCursor: SQL_INVALID_HANDLE for null statement handle",
           "[odbc-api][closecursor][terminating_statement][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   const SQLRETURN ret = SQLCloseCursor(SQL_NULL_HSTMT);
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - No cursor open",
                  "[odbc-api][closecursor][terminating_statement][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   const SQLRETURN ret = SQLCloseCursor(stmt_handle());
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 }
@@ -216,7 +202,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: HY010 - Called during S
   REQUIRE(ret == SQL_SUCCESS);
 
   SQLLEN dae_indicator = SQL_DATA_AT_EXEC;
-  SQLINTEGER param_id = 1;
+  constexpr SQLINTEGER param_id = 1;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
                          reinterpret_cast<SQLPOINTER>(static_cast<SQLLEN>(param_id)), 0, &dae_indicator);
   REQUIRE(ret == SQL_SUCCESS);
@@ -230,8 +216,6 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: HY010 - Called during S
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - Double close",
                  "[odbc-api][closecursor][terminating_statement][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -240,4 +224,305 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - Double close",
 
   ret = SQLCloseCursor(stmt_handle());
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+// ============================================================================
+// SQLCloseCursor - 24000 Error Cases (no cursor open)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - No cursor after DML",
+                 "[odbc-api][closecursor][terminating_statement][error]") {
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE OR REPLACE TEMPORARY TABLE test_closecursor_dml (id INTEGER)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("INSERT INTO test_closecursor_dml VALUES (1)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - No cursor after DDL",
+                 "[odbc-api][closecursor][terminating_statement][error]") {
+  SQLRETURN ret = SQLExecDirect(
+      stmt_handle(), sqlchar("CREATE OR REPLACE TEMPORARY TABLE test_closecursor_ddl (id INTEGER)"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: 24000 - Prepared but not executed",
+                 "[odbc-api][closecursor][terminating_statement][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+// ============================================================================
+// SQLCloseCursor - State Transitions (cursor is open, close succeeds)
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Close from Done state",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_NO_DATA);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Resets used_extended_fetch flag",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN row_count = 0;
+  SQLUSMALLINT row_status = 0;
+  ret = SQLExtendedFetch(stmt_handle(), SQL_FETCH_NEXT, 0, &row_count, &row_status);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(row_count == 1);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Resets get_data_state",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 'abcdefghijklmnopqrstuvwxyz'"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  char small_buf[4] = {};
+  SQLLEN ind = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_CHAR, small_buf, sizeof(small_buf), &ind);
+  REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 42);
+}
+
+// ============================================================================
+// SQLCloseCursor - Cross-API Interactions after Close
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: SQLNumResultCols after close on prepared statement",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SKIP_OLD_DRIVER("BD#22", "Old driver does not preserve column metadata after SQL_CLOSE on prepared statement");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1, 2, 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT col_count = 0;
+  ret = SQLNumResultCols(stmt_handle(), &col_count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(col_count == 3);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: SQLDescribeCol after close on prepared statement",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SKIP_OLD_DRIVER("BD#23", "Old driver does not preserve column metadata after SQL_CLOSE on prepared statement");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS COL_A, 2 AS COL_B"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(reinterpret_cast<char*>(col_name)) == "COL_A");
+
+  ret = SQLDescribeCol(stmt_handle(), 2, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(std::string(reinterpret_cast<char*>(col_name)) == "COL_B");
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER val1 = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val1, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val1 == 1);
+
+  SQLINTEGER val2 = 0;
+  ret = SQLGetData(stmt_handle(), 2, SQL_C_SLONG, &val2, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(val2 == 2);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: SQLDescribeCol fails with HY010 after close on exec_direct",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1 AS COL_Y"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: SQLRowCount returns HY010 after close on exec_direct",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLLEN row_count = 0;
+  ret = SQLRowCount(stmt_handle(), &row_count);
+  REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: Re-prepare with different query after close",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1, 2, 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLSMALLINT col_count = 0;
+  ret = SQLNumResultCols(stmt_handle(), &col_count);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(col_count == 3);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCloseCursor: SQLDescribeCol after close from prepared Fetching state",
+                 "[odbc-api][closecursor][terminating_statement]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1 AS COL_A UNION ALL SELECT 2"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLCloseCursor(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLCHAR col_name[128] = {};
+  SQLSMALLINT name_len = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN col_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  ret = SQLDescribeCol(stmt_handle(), 1, col_name, sizeof(col_name), &name_len, &data_type, &col_size, &decimal_digits,
+                       &nullable);
+  OLD_DRIVER_ONLY("BD#23") { REQUIRE_EXPECTED_ERROR(ret, "07009", stmt_handle(), SQL_HANDLE_STMT); }
+  NEW_DRIVER_ONLY("BD#23") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(std::string(reinterpret_cast<char*>(col_name)) == "COL_A");
+  }
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(val == 1);
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(val == 2);
+
+  ret = SQLFetch(stmt_handle());
+  CHECK(ret == SQL_NO_DATA);
 }


### PR DESCRIPTION
### TL;DR

Implemented the `SQLCloseCursor` ODBC API function with proper error handling and state management.

### What changed?

- Added `SQLCloseCursor` export to the ODBC driver exports definition
- Implemented `close_cursor` function that validates cursor state and returns `SQLSTATE 24000` when no cursor is open, unlike `free_stmt(SQL_CLOSE)` which silently succeeds
- Added `has_open_cursor()` helper method to `StatementState` enum to check if a cursor is open (states S5, S6, S7)
- Refactored existing cursor state checks in `exec_direct_impl`, `prepare_impl`, and `execute` to use the new helper method
- Added `InvalidCursorStateSnafu` error type for proper SQLSTATE 24000 handling
- Exposed `SQLCloseCursor` C API function with proper error handling and diagnostics
- Enabled comprehensive test suite covering various cursor states, error conditions, and cross-API interactions

### How to test?

Run the existing ODBC test suite, particularly the `close_cursor_tests.cpp` file which now includes tests for:
- Basic cursor close and re-execute functionality
- Error cases (no cursor open, double close, invalid handle)
- State transitions from different cursor states
- Preservation of prepared statements, bound parameters, and bound columns
- Cross-API interactions after cursor close

### Why make this change?

This implements a required ODBC API function that was previously missing. `SQLCloseCursor` provides stricter semantics than `SQLFreeStmt` with `SQL_CLOSE` option by properly returning errors when no cursor is open, which is required by the ODBC specification and expected by ODBC applications.