### PR TITLE
SNOW-3307200: SQLCancelHandle scaffolding

### DIFF
--- a/odbc/exports.def
+++ b/odbc/exports.def
@@ -10,6 +10,7 @@ EXPORTS
     SQLBindCol
     SQLBindParameter
     SQLCancel
+    SQLCancelHandle
     SQLCloseCursor
     SQLColAttributeW
     SQLConnectW

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -37,6 +37,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("Invalid handle type for this operation: {handle_type}"))]
+    InvalidHandleType {
+        handle_type: i16,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid descriptor kind: {kind}"))]
     InvalidDescriptorKind {
         kind: u16,
@@ -480,6 +487,7 @@ impl OdbcError {
         match self {
             OdbcError::Disconnected { .. } => SqlState::ConnectionDoesNotExist,
             OdbcError::InvalidHandle { .. } => SqlState::InvalidConnectionName,
+            OdbcError::InvalidHandleType { .. } => SqlState::InvalidAttributeOptionIdentifier,
             OdbcError::NullPointer { .. } => SqlState::InvalidUseOfNullPointer,
             OdbcError::InvalidDescriptorKind { .. } => SqlState::GeneralError,
             OdbcError::InvalidBufferLength { .. } => SqlState::InvalidStringOrBufferLength,

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -154,6 +154,58 @@ pub unsafe extern "C" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCod
 
 /// # Safety
 /// This function is called by the ODBC driver manager.
+///
+/// `SQLCancelHandle` is the ODBC 3.8 generalization of `SQLCancel` that
+/// accepts both statement and connection handles.
+///
+/// For **SQL_HANDLE_STMT** the behavior is identical to `SQLCancel`:
+/// this calls `api::statement::cancel(handle)`, which follows the same
+/// handle-to-statement path as `SQLCancel` and therefore has the same
+/// aliasing caveat described there. Diagnostics are not touched
+/// (same reasoning as `SQLCancel`).
+///
+/// For **SQL_HANDLE_DBC** this is currently a no-op returning SUCCESS.
+/// Connection-level cancel (async connect, cross-thread
+/// `SQLDriverConnect`) will be implemented after the connection state
+/// machine is hardened (SNOW-3307201).
+///
+/// **SQL_HANDLE_ENV** and **SQL_HANDLE_DESC** return `SQL_ERROR` with
+/// SQLSTATE HY092 per the ODBC 3.8 spec. Any truly unknown handle
+/// type returns `SQL_INVALID_HANDLE`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLCancelHandle(
+    handle_type: sql::HandleType,
+    handle: sql::Handle,
+) -> sql::RetCode {
+    if handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    match handle_type {
+        sql::HandleType::Stmt => {
+            let result = api::statement::cancel(handle);
+            result.to_sql_code()
+        }
+        // TODO(SNOW-3307201): implement connection-level cancel after
+        // the connection state machine is hardened.
+        sql::HandleType::Dbc => {
+            api::diagnostic::clear_diag_info(handle_type, handle);
+            sql::SqlReturn::SUCCESS.0
+        }
+        sql::HandleType::Env | sql::HandleType::Desc => {
+            api::diagnostic::clear_diag_info(handle_type, handle);
+            let result: api::OdbcResult<()> = api::error::InvalidHandleTypeSnafu {
+                handle_type: handle_type as i16,
+            }
+            .fail();
+            api::diagnostic::set_diag_info_from_result(handle_type, handle, &result);
+            result.to_sql_code()
+        }
+        _ => sql::SqlReturn::INVALID_HANDLE.0,
+    }
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLConnect(
     connection_handle: sql::Handle,

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -486,3 +486,18 @@ behavior_differences:
       of range) per the ODBC specification, which states that when the byte
       length of the data exceeds BufferLength for SQL_C_BINARY, the result
       is undefined and SQLSTATE 22003 must be returned.
+
+  45:
+    name: "SQLGetFunctions does not report SQLCancelHandle as supported"
+    description: |
+      OLD driver: SQLGetFunctions returns SQL_FALSE for SQL_API_SQLCANCELHANDLE
+      even though the reference driver exports and handles the function.
+      The internal supported-functions bitmap does not include the ODBC 3.8
+      SQLCancelHandle entry, so the function works at runtime but the
+      SQLGetFunctions report is missing.
+      NEW driver: Will report SQL_API_SQLCANCELHANDLE as supported once
+      SQLGetFunctions is implemented.
+      Impact: Applications that probe SQLGetFunctions before calling
+      SQLCancelHandle will incorrectly believe the old driver does not
+      support it. The function works regardless of what SQLGetFunctions
+      reports.

--- a/odbc_tests/common/include/cross_thread_cancel.hpp
+++ b/odbc_tests/common/include/cross_thread_cancel.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <sql.h>
-#include <sqlext.h>
 
 #include <atomic>
 #include <chrono>
@@ -26,15 +25,20 @@ struct CrossThreadCancel {
   std::atomic<SQLRETURN> exec_result{SQL_NO_DATA};
   SQLRETURN cancel_result = SQL_ERROR;
 
-  void run(SQLHSTMT stmt, const char* query, std::chrono::seconds pre_cancel_delay) {
+  void run(const SQLHSTMT stmt, const char* query, const std::chrono::seconds pre_cancel_delay) {
+    run(stmt, query, pre_cancel_delay, [](const SQLHSTMT s) { return SQLCancel(s); });
+  }
+
+  template <typename CancelFn>
+  void run(SQLHSTMT stmt, const char* query, const std::chrono::seconds pre_cancel_delay, CancelFn cancel_fn) {
     std::mutex mtx;
     std::condition_variable cv;
-    bool executing = false;
+    std::atomic<bool> executing{false};  // NOLINT: read by cv.wait predicate on another thread
 
     std::thread executor([&]() {
       {
         std::lock_guard lk(mtx);
-        executing = true;
+        executing.store(true);
       }
       cv.notify_one();
       exec_result.store(SQLExecDirect(stmt, sqlchar(query), SQL_NTS));
@@ -43,14 +47,14 @@ struct CrossThreadCancel {
 
     {
       std::unique_lock lk(mtx);
-      cv.wait(lk, [&] { return executing; });
+      cv.wait(lk, [&] { return executing.load(); });
     }
 
     if (pre_cancel_delay.count() > 0) {
       std::this_thread::sleep_for(pre_cancel_delay);
     }
 
-    cancel_result = SQLCancel(stmt);
+    cancel_result = cancel_fn(stmt);
   }
 };
 

--- a/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
@@ -98,6 +98,7 @@ static const FunctionTest ALL_ODBC_FUNCTIONS[] = {
 
     // Statement Termination Functions
     {SQL_API_SQLCANCEL, "SQLCancel", true},
+    {SQL_API_SQLCANCELHANDLE, "SQLCancelHandle", false},
     {SQL_API_SQLCLOSECURSOR, "SQLCloseCursor", false},
     {SQL_API_SQLENDTRAN, "SQLEndTran", false},
     {SQL_API_SQLFREESTMT, "SQLFreeStmt", true},
@@ -125,6 +126,11 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
     // Windows DM does not report deprecated SQLSetScrollOptions
     WINDOWS_ONLY {
       if (func.functionId == SQL_API_SQLSETSCROLLOPTIONS) continue;
+    }
+    // BD#45: Reference driver's SQLGetFunctions bitmap omits SQL_API_SQLCANCELHANDLE
+    // even though the reference driver exports and handles the function.
+    OLD_DRIVER_ONLY("BD#45") {
+      if (func.functionId == SQL_API_SQLCANCELHANDLE) continue;
     }
     INFO("Function: " << func.name << " (ID=" << func.functionId << ")");
     REQUIRE(SQL_FUNC_EXISTS(supported, func.functionId));
@@ -277,6 +283,10 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: All known supported fun
   for (const auto& func : ALL_ODBC_FUNCTIONS) {
     WINDOWS_ONLY {
       if (func.functionId == SQL_API_SQLSETSCROLLOPTIONS) continue;
+    }
+    // BD#45: Reference driver's SQLGetFunctions bitmap omits SQL_API_SQLCANCELHANDLE
+    OLD_DRIVER_ONLY("BD#45") {
+      if (func.functionId == SQL_API_SQLCANCELHANDLE) continue;
     }
     SQLUSMALLINT supported = SQL_FALSE;
     ret = SQLGetFunctions(dbc_handle(), func.functionId, &supported);

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
@@ -2,15 +2,28 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
+#include <chrono>
+#include <thread>
+
 #include <catch2/catch_test_macros.hpp>
 
-#include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
+#include "Schema.hpp"
 #include "compatibility.hpp"
+#include "cross_thread_cancel.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "test_macros.hpp"
+#include "odbc_matchers.hpp"
 #include "test_setup.hpp"
+
+// NOTE: SQLCancelHandle(SQL_HANDLE_STMT, ...) behaves identically to SQLCancel
+// per the ODBC 3.8 spec. The Driver Manager maps it to SQLCancel when the
+// driver does not export SQLCancelHandle. The same Unix DM cursor-closing
+// behavior described in cancel_tests.cpp applies here.
+
+namespace {
+constexpr int kMaxPollIterations = 300;
+}  // namespace
 
 // ============================================================================
 // SQLCancelHandle - Statement Handle: Basic Functionality
@@ -21,16 +34,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on idle stateme
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -39,20 +53,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after query exe
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open and usable
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: Per ODBC 3.5 spec, cancel when no async processing is in progress
-    // should have no effect keeping the cursor open and usable. The reference
-    // driver unconditionally closes cursors during cancel.
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -66,21 +76,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after fetch",
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_NO_DATA);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
   }
   UNIX_ONLY {
-    // Note: Same reference driver bug as above
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -94,19 +102,20 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on prepared but
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -119,21 +128,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: After cancel on execut
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: Same reference driver bug
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -147,25 +154,26 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Statement recoverable 
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -174,22 +182,84 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: SQLCloseCursor fails a
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open and closeable
     ret = SQLCloseCursor(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: SQLCloseCursor fails because the reference driver already invalidated
-    // the cursor during cancel.
     ret = SQLCloseCursor(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
   }
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after error recovery and re-execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM nonexistent_table_xyz_999"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 99);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on never-executed statement then use and free",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT fresh_stmt = SQL_NULL_HSTMT;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(fresh_stmt, sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(fresh_stmt, 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on idle statement",
@@ -198,17 +268,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on id
 
   for (int i = 0; i < 3; i++) {
     const SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 99);
 }
 
@@ -223,22 +294,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves bound column
   SQLINTEGER col_val = 0;
   SQLLEN indicator = 0;
   SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &col_val, 0, &indicator);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(col_val == 99);
 }
 
@@ -247,32 +318,75 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves bound parame
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER param = 55;
   SQLLEN ind = 0;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   param = 88;
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 88);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Parameter bindings preserved after cancel with open cursor",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER param = 55;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 55);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  param = 123;
+  ret = SQLExecute(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 123);
 }
 
 // ============================================================================
@@ -284,36 +398,241 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancels data-at-execut
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_indicator = SQL_DATA_AT_EXEC;
   SQLINTEGER param_id = 1;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
                          reinterpret_cast<SQLPOINTER>(static_cast<SQLLEN>(param_id)), 0, &dae_indicator);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 77"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 77);
 }
 
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Re-execute immediately after canceling data-at-execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_indicator = SQL_DATA_AT_EXEC;
+  SQLINTEGER param_id = 1;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
+                         reinterpret_cast<SQLPOINTER>(static_cast<SQLLEN>(param_id)), 0, &dae_indicator);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
 // ============================================================================
-// SQLCancelHandle - Statement Handle: Diagnostic Information
+// SQLCancelHandle - Statement Handle: State Coverage
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after all rows fetched",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after DDL execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  Schema::use_temp_session_schema(dbc_handle());
+
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE TEMPORARY TABLE cancel_handle_test_tmp (id INT)"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on statement in Error state",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  Schema::use_temp_session_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM nonexistent_table"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Cursor Preservation
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cursor remains usable after cancel on multi-row result",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT column1 FROM VALUES (1),(2),(3) ORDER BY 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 1);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  WINDOWS_ONLY {
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    REQUIRE(val == 2);
+
+    ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    REQUIRE(val == 3);
+
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+  }
+  UNIX_ONLY {
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+  }
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Isolation
+// ============================================================================
+
+TEST_CASE_METHOD(TwoStmtDefaultDSNFixture, "SQLCancelHandle: Does not affect other statements on same connection",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt2_handle(), sqlchar("SELECT 2"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt2_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt2_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 2);
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Attribute Preservation
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves statement attributes after cancel",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLULEN max_length = 1024;
+  SQLRETURN ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_MAX_LENGTH, reinterpret_cast<SQLPOINTER>(max_length), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLULEN retrieved_max_length = 0;
+  ret = SQLGetStmtAttr(stmt_handle(), SQL_ATTR_MAX_LENGTH, &retrieved_max_length, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(retrieved_max_length == max_length);
+
+  SQLULEN cursor_type = 0;
+  ret = SQLGetStmtAttr(stmt_handle(), SQL_ATTR_CURSOR_TYPE, &cursor_type, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(cursor_type == SQL_CURSOR_FORWARD_ONLY);
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Diagnostic Behavior
 // ============================================================================
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Diagnostics after cancel error state",
@@ -321,42 +640,148 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Diagnostics after canc
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
-  // Note: 24000 because of the reference driver bug, re-execution should succeed.
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 2"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Does not post diagnostic records on no-op cancel",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLCHAR sql_state[6] = {};
+  SQLINTEGER native_error = 0;
+  SQLCHAR message[256] = {};
+  SQLSMALLINT msg_len = 0;
+  ret = SQLGetDiagRec(SQL_HANDLE_STMT, stmt_handle(), 1, sql_state, &native_error, message, sizeof(message), &msg_len);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Async Cancel
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Async cancel interrupts execution with HY008",
+                 "[odbc-api][cancelhandle][terminating_statement][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  SKIP_OLD_DRIVER("BD#32", "Async cancel does not interrupt in-progress operations on reference driver");
+
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  SQLRETURN cancel_ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(cancel_ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  int polls = 0;
+  SQLRETURN poll_ret = SQL_STILL_EXECUTING;
+  while (poll_ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    poll_ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  }
+  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
+
+  REQUIRE_EXPECTED_ERROR(poll_ret, "HY008", stmt_handle(), SQL_HANDLE_STMT);
+
+  ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Async cancel clears diagnostics and posts its own",
+                 "[odbc-api][cancelhandle][terminating_statement][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  SKIP_OLD_DRIVER("BD#32", "Async cancel does not interrupt in-progress operations on reference driver");
+
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  SQLRETURN cancel_ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(cancel_ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  int polls = 0;
+  SQLRETURN poll_ret = SQL_STILL_EXECUTING;
+  while (poll_ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    poll_ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  }
+  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
+
+  REQUIRE_EXPECTED_ERROR(poll_ret, "HY008", stmt_handle(), SQL_HANDLE_STMT);
+
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE(!records.empty());
+  REQUIRE(records.size() == 1);
+  REQUIRE(records[0].sqlState == "HY008");
+
+  ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Cross-Thread Cancel
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cross-thread cancel interrupts execution with HY008",
+                 "[odbc-api][cancelhandle][terminating_statement][cross_thread]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = stmt_handle();
+  odbc_test::CrossThreadCancel ctx;
+  ctx.run(stmt, "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 60))", std::chrono::seconds(5),
+          [](SQLHSTMT s) { return SQLCancelHandle(SQL_HANDLE_STMT, s); });
+
+  REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+
+  SQLRETURN exec_ret = ctx.exec_result.load();
+  REQUIRE_EXPECTED_ERROR(exec_ret, "HY008", stmt, SQL_HANDLE_STMT);
+
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt);
+  REQUIRE(records.size() == 1);
+  REQUIRE(records[0].sqlState == "HY008");
 }
 
 // ============================================================================
 // SQLCancelHandle - Connection Handle
 // ============================================================================
 
-// Note: The reference driver does not support connection-level cancel
-// (SFConnection::OnCancel is a no-op that only reports unsupported telemetry).
 // The ODBC 3.8 spec intends SQLCancelHandle(SQL_HANDLE_DBC) to cancel
 // in-progress connection operations (e.g. a blocking SQLDriverConnect from
-// another thread). Since this is unsupported, all connection-handle cancel
-// calls silently succeed without any observable effect.
+// another thread). Connection-level cancel is a no-op for now because no
+// async or cross-thread connection operations are supported.
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on idle connection",
                  "[odbc-api][cancelhandle][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 123"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 123);
 }
 
@@ -365,16 +790,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel connection with
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -382,21 +808,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel connection betw
                  "[odbc-api][cancelhandle][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  // Issuing a connection-level cancel between prepare and execute has no effect
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -406,17 +832,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on id
 
   for (int i = 0; i < 3; i++) {
     const SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
   }
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 99);
 }
 
@@ -440,14 +867,41 @@ TEST_CASE("SQLCancelHandle: SQL_INVALID_HANDLE for null connection handle",
   REQUIRE(ret == SQL_INVALID_HANDLE);
 }
 
-TEST_CASE_METHOD(EnvFixture, "SQLCancelHandle: SQL_INVALID_HANDLE for environment handle type",
+TEST_CASE_METHOD(EnvFixture, "SQLCancelHandle: SQL_ERROR with HY092 for environment handle type",
                  "[odbc-api][cancelhandle][terminating_statement][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   const SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_ENV, env_handle());
+  // The DM typically intercepts this before reaching the driver.
+  // Windows DM returns SQL_ERROR with HY092 (per spec).
+  // Unix DM (unixODBC) may return SQL_INVALID_HANDLE instead.
   WINDOWS_ONLY {
-    // Windows DM returns SQL_ERROR instead of SQL_INVALID_HANDLE for unsupported handle types
     REQUIRE(ret == SQL_ERROR);
+    REQUIRE(get_sqlstate(SQL_HANDLE_ENV, env_handle()) == "HY092");
   }
-  UNIX_ONLY { REQUIRE(ret == SQL_INVALID_HANDLE); }
+  UNIX_ONLY {
+    // unixODBC returns SQL_INVALID_HANDLE for unsupported handle types.
+    REQUIRE(ret == SQL_INVALID_HANDLE);
+  }
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: SQL_ERROR with HY092 for descriptor handle type",
+                 "[odbc-api][cancelhandle][terminating_statement][error]") {
+  // Obtain an implicit descriptor handle (ARD) from the statement.
+  SQLHDESC ard = SQL_NULL_HDESC;
+  SQLRETURN ret = SQLGetStmtAttr(stmt_handle(), SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(ard != SQL_NULL_HDESC);
+
+  ret = SQLCancelHandle(SQL_HANDLE_DESC, static_cast<SQLHANDLE>(ard));
+  // The DM typically intercepts this before reaching the driver.
+  // Windows DM returns SQL_ERROR with HY092 (per spec).
+  // Unix DM (unixODBC) may return SQL_INVALID_HANDLE instead.
+  WINDOWS_ONLY {
+    REQUIRE(ret == SQL_ERROR);
+    // TODO(SNOW-3307200): verify HY092 SQLSTATE once descriptor diagnostic
+    // infrastructure lands.
+  }
+  UNIX_ONLY {
+    // unixODBC returns SQL_INVALID_HANDLE for unsupported handle types.
+    REQUIRE(ret == SQL_INVALID_HANDLE);
+  }
 }


### PR DESCRIPTION
### TL;DR

Implements `SQLCancelHandle` (ODBC 3.8) as a proper exported driver entry point, with full test coverage across statement and connection handle types.

### What changed?

`SQLCancelHandle` is now exported from the driver (`exports.def`) and implemented in `c_api.rs`. The function dispatches based on handle type:

- **`SQL_HANDLE_STMT`**: delegates to the same `api::statement::cancel` path used by `SQLCancel`.
- **`SQL_HANDLE_DBC`**: returns `SQL_SUCCESS` as a no-op; connection-level cancel (async connect, cross-thread `SQLDriverConnect`) is deferred to SNOW-3307201.
- **`SQL_HANDLE_ENV` / `SQL_HANDLE_DESC`**: returns `SQL_ERROR` with SQLSTATE `HY092` (`InvalidAttributeOptionIdentifier`) per the ODBC 3.8 spec.
- **Null or unknown handle**: returns `SQL_INVALID_HANDLE`.

A new `InvalidHandleType` error variant was added to `OdbcError` to carry the `HY092` SQLSTATE for the unsupported handle type cases.

`CrossThreadCancel` in the test helper was refactored to accept a templated `cancel_fn` parameter, allowing tests to supply either `SQLCancel` or `SQLCancelHandle` as the cancellation function without duplicating the threading logic.

Test coverage was significantly expanded to include: idle/prepared/executed/fetched/error statement states, data-at-execution cancel and re-execute, cross-thread cancel with `HY008` verification, async cancel with diagnostic record validation, statement isolation (cancel on one statement does not affect another), attribute preservation after cancel, DDL execution followed by cancel, and descriptor/environment handle rejection. A behavior difference entry (BD#45) was added noting that `SQLGetFunctions` does not yet report `SQL_API_SQLCANCELHANDLE` as supported.

### How to test?

Run the existing ODBC test suite targeting the `[cancelhandle]` tag. The new and updated tests in `cancel_handle_tests.cpp` cover all handle types and state transitions. Cross-thread and async cancel tests require a live Snowflake connection and will be skipped on the old reference driver where applicable (`SKIP_OLD_DRIVER("BD#32", ...)`).

### Why make this change?

ODBC 3.8 applications and driver managers expect `SQLCancelHandle` to be exported and callable directly. Without this export, applications that probe `SQLGetFunctions` or call `SQLCancelHandle` directly (rather than relying on the driver manager's fallback to `SQLCancel`) would fail. This change brings the driver into conformance with the ODBC 3.8 specification for handle-type-aware cancellation.