### PR TITLE
SNOW-2433865 print local perf results comparisson

### DIFF
--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -121,15 +121,15 @@ hatch run core-local --parameters-json=parameters/parameters_perf_azure.json
 
 ### Local Performance Compare
 
-When running locally via `hatch run *-local` scripts, results are compared against previous local runs and printed in a summary at session end (after `✓ TESTS COMPLETED`). The feature is enabled by `PERF_LOCAL_COMPARE=1` set in those scripts.
+When running locally via `hatch run *-local` scripts, a session summary is printed at the end of the run (after `✓ TESTS COMPLETED`). UD vs OLD comparisons are always shown when both drivers ran. `PERF_LOCAL_COMPARE=1` (set in those scripts) additionally enables comparisons against previous local runs and single-driver summaries.
 
 **What is shown:**
 
-- **UD vs OLD** (when `--driver-type=both`): percentage difference between Universal and Old driver from the current run. Always shown when both drivers ran.
-- **vs last run**: current median compared to the previous run's median.
-- **vs all prev**: current median compared to the median across all previous runs.
+- **UD vs OLD** (when `--driver-type=both`): percentage difference between Universal and Old driver from the current run. Always shown when both drivers ran, regardless of `PERF_LOCAL_COMPARE`.
+- **vs last run** (requires `PERF_LOCAL_COMPARE=1` and at least 1 previous run): current median compared to the previous run's median.
+- **vs all prev** (requires `PERF_LOCAL_COMPARE=1` and at least 2 previous runs): current median compared to the median across all previous runs.
 
-History comparisons are silently skipped when no previous runs exist.
+History comparisons are silently skipped when there are no previous runs for `vs last run`, or fewer than 2 previous runs for `vs all prev`.
 
 Metric used: `fetch_s` for SELECT tests, `query_s` for PUT/GET tests. Per-run values use the median over all iterations.
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -119,6 +119,39 @@ hatch run core-local --parameters-json=parameters/parameters_perf_azure.json
 | `--preserve-mappings` | Keep WireMock mappings after tests (for debugging) | `false` (enabled in local runs) |
 | `--reuse-mappings` | Reuse existing mappings directory (e.g., `run_20260115_120000`) | None (runs recording phase) |
 
+### Local Performance Compare (Local Only)
+
+When running locally via `hatch run *-local` scripts, results are compared against previous local runs and printed in a summary at session end (after `✓ TESTS COMPLETED`). The feature is enabled by `PERF_LOCAL_COMPARE=1` set in those scripts; CI runs never set it.
+
+**What is shown:**
+
+- **UD vs OLD** (when `--driver-type=both`): percentage difference between Universal and Old driver from the current run. Always shown when both drivers ran.
+- **vs last run**: current median compared to the previous run's median.
+- **vs all prev**: current median compared to the median across all previous runs.
+- **Old driver alone** (`--driver-type=old`): nothing shown.
+
+History comparisons are silently skipped when no previous runs exist.
+
+Metric used: `fetch_s` for SELECT tests, `query_s` for PUT/GET tests. Per-run values use the median over all iterations.
+
+**Session summary format:**
+```
+================================================================================
+SUMMARY
+================================================================================
+
+  select_string_1M_arrow_recorded_http  (python universal)
+    UD vs OLD:    fetch_s  UD=0.327s  OLD=0.459s  UD is -28.7% (faster) than OLD
+    vs last run:  fetch_s  0.459s -> 0.327s  -28.7%  faster  (run_20260326_122102)
+    vs all prev:  fetch_s  median 0.367s -> 0.327s  -10.8%  faster  [N=17]
+
+================================================================================
+```
+
+Previous runs are read from the local `results/` directory. Use `hatch run clean` to reset it.
+
+---
+
 #### Examples with Custom Arguments
 
 ```bash

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -119,16 +119,15 @@ hatch run core-local --parameters-json=parameters/parameters_perf_azure.json
 | `--preserve-mappings` | Keep WireMock mappings after tests (for debugging) | `false` (enabled in local runs) |
 | `--reuse-mappings` | Reuse existing mappings directory (e.g., `run_20260115_120000`) | None (runs recording phase) |
 
-### Local Performance Compare (Local Only)
+### Local Performance Compare
 
-When running locally via `hatch run *-local` scripts, results are compared against previous local runs and printed in a summary at session end (after `✓ TESTS COMPLETED`). The feature is enabled by `PERF_LOCAL_COMPARE=1` set in those scripts; CI runs never set it.
+When running locally via `hatch run *-local` scripts, results are compared against previous local runs and printed in a summary at session end (after `✓ TESTS COMPLETED`). The feature is enabled by `PERF_LOCAL_COMPARE=1` set in those scripts.
 
 **What is shown:**
 
 - **UD vs OLD** (when `--driver-type=both`): percentage difference between Universal and Old driver from the current run. Always shown when both drivers ran.
 - **vs last run**: current median compared to the previous run's median.
 - **vs all prev**: current median compared to the median across all previous runs.
-- **Old driver alone** (`--driver-type=old`): nothing shown.
 
 History comparisons are silently skipped when no previous runs exist.
 
@@ -209,12 +208,12 @@ def test_with_additional_setup(perf_test):
         ]
     )
 
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 def test_put_files_12mx100(perf_test):
     """PUT/GET test: Upload files to Snowflake stage"""
     perf_test(
-        test_type=TestType.PUT_GET,
+        test_type=PerfTestType.PUT_GET,
         s3_download_url="s3://sfc-eng-data/ecosystem/12Mx100/",
         setup_queries=[
             "CREATE TEMPORARY STAGE put_test_stage"
@@ -229,7 +228,7 @@ def test_put_files_12mx100(perf_test):
 **Notes**: 
 - **SELECT tests**: ARROW format (`ALTER SESSION SET QUERY_RESULT_FORMAT = 'ARROW'`) is added to any provided `setup_queries`.
 - **PUT/GET tests**: `USE DATABASE {database}` is added to any provided `setup_queries`. This is required for `CREATE TEMPORARY STAGE` operations which need a database context.
-- PUT/GET tests use `test_type=TestType.PUT_GET` and measure only the file operation time (no separate fetch phase)
+- PUT/GET tests use `test_type=PerfTestType.PUT_GET` and measure only the file operation time (no separate fetch phase)
 - The `s3_download_url` parameter triggers automatic download of test files from S3 before test execution
 
 ### Test Configuration Priority

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -16,6 +16,9 @@ _test_failures = []
 # Track current run directory (session-scoped)
 _current_run_dir = None
 
+# Track performance history comparisons for the session summary
+_perf_comparisons = []
+
 
 def pytest_configure():
     """Configure pytest and suppress verbose library logs"""
@@ -362,7 +365,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         )
     
     def _run_test(
-        sql_command: str, 
+        sql_command: str,
         setup_queries: list[str] = None,
         test_name: str = None,
         test_type: TestType = TestType.SELECT,
@@ -372,14 +375,14 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         # Prepare test parameters
         if test_name is None:
             test_name = _derive_test_name(request.node.name)
-        
+
         final_setup_queries = _prepare_setup_queries(test_type, parameters_json, setup_queries)
         s3_files_dir = _download_s3_files_if_needed(s3_download_url, s3_download_dir)
         is_comparison = _should_run_comparison(driver, driver_type)
-        
+
         # Route to appropriate runner based on test type
         if test_type == TestType.SELECT_RECORDED_HTTP:
-            return _run_wiremock_test(
+            result = _run_wiremock_test(
                 test_name=test_name,
                 sql_command=sql_command,
                 setup_queries=final_setup_queries,
@@ -387,7 +390,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
                 is_comparison=is_comparison,
             )
         else:
-            return _run_e2e_test(
+            result = _run_e2e_test(
                 test_name=test_name,
                 sql_command=sql_command,
                 setup_queries=final_setup_queries,
@@ -395,6 +398,11 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
                 s3_files_dir=s3_files_dir,
                 is_comparison=is_comparison,
             )
+
+        # Performance history comparison
+        _compare_local_results(result, test_name, driver, driver_type, is_comparison, results_dir)
+
+        return result
     
     def _run_wiremock_test(
         test_name: str,
@@ -480,6 +488,55 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
                 s3_files_dir=s3_files_dir,
             )
     
+    def _compare_local_results(result, test_name, driver, driver_type, is_comparison, results_dir):
+        """Collect comparison data for the session summary."""
+        if result is None:
+            return
+
+        from runner.local_compare import compare_with_history, get_file_median
+
+        if is_comparison and isinstance(result, dict):
+            ud_files = result.get("universal", [])
+            old_files = result.get("old", [])
+
+            # Get OLD avg for UD vs OLD section
+            old_result = get_file_median(old_files)
+            old_avg = old_result[1] if old_result else None
+
+            if os.environ.get("PERF_LOCAL_COMPARE") == "1":
+                # Full comparison: UD vs OLD + history
+                comp = compare_with_history(ud_files, results_dir, test_name, driver, "universal", old_median=old_avg)
+            else:
+                # UD vs OLD only
+                ud_result = get_file_median(ud_files)
+                if ud_result is None:
+                    return
+                comp = {
+                    "test_name": test_name,
+                    "driver": driver,
+                    "driver_type": "universal",
+                    "metric_col": ud_result[0],
+                    "current_median": ud_result[1],
+                    "old_median": old_avg,
+                    "history": [],
+                    "last_median": None,
+                    "all_median": None,
+                }
+
+            if comp:
+                _perf_comparisons.append(comp)
+
+        else:
+            # Single driver mode: history for universal only, local runs only
+            if os.environ.get("PERF_LOCAL_COMPARE") != "1":
+                return
+            actual_driver_type = _normalize_driver_type(driver, driver_type)
+            if actual_driver_type == "old":
+                return
+            comp = compare_with_history(result, results_dir, test_name, driver, actual_driver_type)
+            if comp:
+                _perf_comparisons.append(comp)
+
     return _run_test
 
 
@@ -511,7 +568,7 @@ def pytest_runtest_makereport(item, call):
 def pytest_sessionfinish(session, exitstatus):
     """Hook to report all failures at the end of test session and optionally upload to Benchstore"""
     global _current_run_dir
-    
+
     if _test_failures:
         logger.error("\n" + "=" * 80)
         logger.error(f"❌ TEST FAILURES SUMMARY ({len(_test_failures)} failed)")
@@ -524,9 +581,14 @@ def pytest_sessionfinish(session, exitstatus):
         logger.info("\n" + "=" * 80)
         logger.info("✓ TESTS COMPLETED")
         logger.info("=" * 80)
-    
+
     if _current_run_dir:
         logger.info(f"\nResults saved to: {_current_run_dir}")
+
+    # Performance comparison summary
+    if _perf_comparisons:
+        from runner.local_compare import log_summary
+        log_summary(_perf_comparisons)
     
     upload_to_benchstore = session.config.getoption("--upload-to-benchstore")
     local_benchstore_upload = session.config.getoption("--local-benchstore-upload")

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -4,7 +4,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 from runner.utils import perf_tests_root, collect_node_info, log_node_info
 import pytest
 
@@ -308,7 +308,7 @@ def _validate_wiremock_old_driver(driver: str, driver_type: str):
         )
 
 
-def _prepare_setup_queries(test_type: TestType, parameters_json: str, setup_queries: list[str] = None) -> list[str]:
+def _prepare_setup_queries(test_type: PerfTestType, parameters_json: str, setup_queries: list[str] = None) -> list[str]:
     """
     Prepare setup queries based on test type.
     
@@ -321,12 +321,12 @@ def _prepare_setup_queries(test_type: TestType, parameters_json: str, setup_quer
         List of setup queries with test-type-specific prefixes
     """
     match test_type:
-        case TestType.SELECT | TestType.SELECT_RECORDED_HTTP:
+        case PerfTestType.SELECT | PerfTestType.SELECT_RECORDED_HTTP:
             # SELECT tests: always use ARROW format
             arrow_query = "alter session set query_result_format = 'ARROW'"
             return [arrow_query] + (setup_queries or [])
         
-        case TestType.PUT_GET:
+        case PerfTestType.PUT_GET:
             # PUT/GET tests: USE DATABASE is required for TEMPORARY STAGE
             params = json.loads(parameters_json)
             testconn = params.get("testconnection", {})
@@ -368,7 +368,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         sql_command: str,
         setup_queries: list[str] = None,
         test_name: str = None,
-        test_type: TestType = TestType.SELECT,
+        test_type: PerfTestType = PerfTestType.SELECT,
         s3_download_url: str = None,  # S3 URL for PUT/GET tests
         s3_download_dir: str = None  # Local directory for downloaded files
     ):
@@ -381,7 +381,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         is_comparison = _should_run_comparison(driver, driver_type)
 
         # Route to appropriate runner based on test type
-        if test_type == TestType.SELECT_RECORDED_HTTP:
+        if test_type == PerfTestType.SELECT_RECORDED_HTTP:
             result = _run_wiremock_test(
                 test_name=test_name,
                 sql_command=sql_command,
@@ -454,7 +454,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         test_name: str,
         sql_command: str,
         setup_queries: list[str],
-        test_type: TestType,
+        test_type: PerfTestType,
         s3_files_dir,
         is_comparison: bool,
     ):

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -499,13 +499,13 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
             ud_files = result.get("universal", [])
             old_files = result.get("old", [])
 
-            # Get OLD avg for UD vs OLD section
+            # Get OLD median for UD vs OLD section
             old_result = get_file_median(old_files)
-            old_avg = old_result[1] if old_result else None
+            old_median = old_result[1] if old_result else None
 
             if os.environ.get("PERF_LOCAL_COMPARE") == "1":
                 # Full comparison: UD vs OLD + history
-                comp = compare_with_history(ud_files, results_dir, test_name, driver, "universal", old_median=old_avg)
+                comp = compare_with_history(ud_files, results_dir, test_name, driver, "universal", old_median=old_median)
             else:
                 # UD vs OLD only
                 ud_result = get_file_median(ud_files)
@@ -517,7 +517,7 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
                     "driver_type": "universal",
                     "metric_col": ud_result[0],
                     "current_median": ud_result[1],
-                    "old_median": old_avg,
+                    "old_median": old_median,
                     "history": [],
                     "last_median": None,
                     "all_median": None,

--- a/tests/performance/pyproject.toml
+++ b/tests/performance/pyproject.toml
@@ -40,6 +40,9 @@ log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 # Suppress pytest section headers by using short traceback and disabling verbosity for log headers
 addopts = "--tb=short --show-capture=no"
+filterwarnings = [
+    "ignore:The @wait_container_is_ready decorator is deprecated:DeprecationWarning",
+]
 markers = [
     "iterations(n): set number of test iterations for this test",
     "warmup_iterations(n): set number of warmup iterations for this test"
@@ -56,15 +59,15 @@ build = "bash -c 'cd drivers/python && ./build.sh && cd ../core && ./build.sh &&
 
 # Local (always builds before execution, including WireMock for tests that need it)
 # Preserves WireMock mappings for debugging
-core-local = ["build-core", "build-wiremock", "python -m pytest {args:tests/} --driver=core --preserve-mappings -s -v"]
+core-local = ["build-core", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=core --preserve-mappings -s -v"]
 # Core with local binary (no Docker, no build needed)
-core-local-no-docker = "python -m pytest {args:tests/} --driver=core --use-local-binary --preserve-mappings -s -v"
-python-universal-local = ["build-python", "build-wiremock", "python -m pytest {args:tests/} --driver=python --driver-type=universal --preserve-mappings -s -v"]
-python-old-local = ["build-python", "build-wiremock", "python -m pytest {args:tests/} --driver=python --driver-type=old --preserve-mappings -s -v"]
-python-both-local = ["build-python", "build-wiremock", "python -m pytest {args:tests/} --driver=python --driver-type=both --preserve-mappings -s -v"]
-odbc-universal-local = ["build-odbc", "build-wiremock", "python -m pytest {args:tests/} --driver=odbc --driver-type=universal --preserve-mappings -s -v"]
-odbc-old-local = ["build-odbc", "build-wiremock", "python -m pytest {args:tests/} --driver=odbc --driver-type=old --preserve-mappings -s -v"]
-odbc-both-local = ["build-odbc", "build-wiremock", "python -m pytest {args:tests/} --driver=odbc --driver-type=both --preserve-mappings -s -v"]
+core-local-no-docker = "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=core --use-local-binary --preserve-mappings -s -v"
+python-universal-local = ["build-python", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=python --driver-type=universal --preserve-mappings -s -v"]
+python-old-local = ["build-python", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=python --driver-type=old --preserve-mappings -s -v"]
+python-both-local = ["build-python", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=python --driver-type=both --preserve-mappings -s -v"]
+odbc-universal-local = ["build-odbc", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=odbc --driver-type=universal --preserve-mappings -s -v"]
+odbc-old-local = ["build-odbc", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=odbc --driver-type=old --preserve-mappings -s -v"]
+odbc-both-local = ["build-odbc", "build-wiremock", "PERF_LOCAL_COMPARE=1 python -m pytest {args:tests/} --driver=odbc --driver-type=both --preserve-mappings -s -v"]
 
 # CI
 core = "python -m pytest {args:tests/} --driver=core --upload-to-benchstore -s -v"

--- a/tests/performance/runner/container.py
+++ b/tests/performance/runner/container.py
@@ -4,7 +4,7 @@ import threading
 import time
 from pathlib import Path
 from testcontainers.core.container import DockerContainer
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def create_perf_container(
     results_dir: Path,
     driver_type: str = None,
     setup_queries: list[str] = None,
-    test_type: TestType = TestType.SELECT,
+    test_type: PerfTestType = PerfTestType.SELECT,
     s3_files_dir: Path = None,
     network_mode: str = "host",
 ) -> DockerContainer:
@@ -52,7 +52,7 @@ def create_perf_container(
         results_dir: Directory to mount for results
         driver_type: Driver type: 'universal' or 'old' (only 'universal' for core)
         setup_queries: Optional list of SQL queries to run before warmup/test iterations
-        test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
+        test_type: Type of test (PerfTestType.SELECT or PerfTestType.PUT_GET)
         s3_files_dir: Optional directory with S3-downloaded files to mount (for PUT/GET tests)
         network_mode: Docker network mode ("host" for direct host network, reduces jitter)
     

--- a/tests/performance/runner/local_compare.py
+++ b/tests/performance/runner/local_compare.py
@@ -1,0 +1,275 @@
+"""Local performance comparison: compare current results with previous local runs."""
+import csv
+import logging
+import re
+import statistics
+import sys
+from pathlib import Path
+from typing import Optional
+
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_RESET = "\033[0m"
+_USE_COLOR = sys.stdout.isatty()
+
+
+def _color(text: str, color: str) -> str:
+    return f"{color}{text}{_RESET}" if _USE_COLOR else text
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_metric_column(csv_path: Path) -> Optional[str]:
+    """Return 'fetch_s' for SELECT tests or 'query_s' for PUT/GET tests."""
+    try:
+        with open(csv_path, "r") as f:
+            header = f.readline()
+        if "fetch_s" in header:
+            return "fetch_s"
+        if "query_s" in header:
+            return "query_s"
+    except Exception:
+        pass
+    return None
+
+
+def _read_median(csv_path: Path, metric_col: str) -> Optional[float]:
+    """Read median of metric_col from a result CSV. Returns None on failure."""
+    try:
+        with open(csv_path, "r") as f:
+            reader = csv.DictReader(f)
+            values = [float(row[metric_col]) for row in reader if row.get(metric_col)]
+        return statistics.median(values) if values else None
+    except Exception as e:
+        logger.debug(f"Failed to read {metric_col} from {csv_path}: {e}")
+        return None
+
+
+def _is_main_result_file(path: Path) -> bool:
+    """Return True if file is a main result CSV (not a record/memory/wiremock file)."""
+    name = path.name
+    if name.startswith("memory_timeline_"):
+        return False
+    if name.startswith("wiremock_"):
+        return False
+    # Exclude recording-phase files: pattern is <test>_record_<driver>_...
+    # 'recorded' appears in test names (e.g. select_...recorded_http...) — that's fine.
+    # '_record_' appears as a separator between test name and driver name in record files.
+    if re.search(r"_record_[a-z]", name):
+        return False
+    return True
+
+
+def _pick_main_file(files: list[Path]) -> Optional[Path]:
+    return max(
+        (f for f in files if _is_main_result_file(f)),
+        key=lambda p: p.stat().st_mtime,
+        default=None,
+    )
+
+
+def _find_result_file(
+    run_dir: Path,
+    test_name: str,
+    driver: str,
+    driver_type: Optional[str],
+) -> Optional[Path]:
+    """Find the main result CSV for a test in a given run directory."""
+    if driver != "core" and driver_type:
+        pattern = f"{test_name}_{driver}_{driver_type}_*.csv"
+    else:
+        pattern = f"{test_name}_{driver}_*.csv"
+    candidates = [f for f in run_dir.glob(pattern) if _is_main_result_file(f)]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def get_file_median(files: list[Path]) -> Optional[tuple[str, float]]:
+    """
+    Return (metric_col, median) from a list of result files, or None if not possible.
+    Used to extract OLD driver median for UD vs OLD comparison.
+    """
+    f = _pick_main_file(files)
+    if f is None:
+        return None
+    metric_col = _detect_metric_column(f)
+    if not metric_col:
+        return None
+    avg = _read_median(f, metric_col)
+    if avg is None:
+        return None
+    return metric_col, avg
+
+
+def compare_with_history(
+    current_files: list[Path],
+    results_dir: Path,
+    test_name: str,
+    driver: str,
+    driver_type: Optional[str],
+    old_median: Optional[float] = None,
+) -> Optional[dict]:
+    """
+    Build comparison data for a test run against historical runs.
+
+    Args:
+        current_files: Result files from the current run
+        results_dir:   Current run directory (.../results/run_YYYYMMDD_HHMMSS/)
+        test_name:     Test name (without 'test_' prefix)
+        driver:        Driver name (core, python, odbc, jdbc)
+        driver_type:   Driver type (universal, old) or None for core
+        old_avg:       Optional OLD driver avg from the same run (for UD vs OLD display)
+
+    Returns:
+        Dict with comparison data, or None if the current avg cannot be determined.
+        History fields are empty when results_dir has no previous runs.
+    """
+    if not current_files:
+        return None
+
+    current_file = _pick_main_file(current_files)
+    if current_file is None:
+        return None
+
+    metric_col = _detect_metric_column(current_file)
+    if not metric_col:
+        return None
+
+    current_avg = _read_median(current_file, metric_col)
+    if current_avg is None:
+        return None
+
+    results_base = results_dir.parent
+    current_run_name = results_dir.name
+
+    history = []
+    if results_base.exists():
+        all_run_dirs = sorted(
+            [
+                d for d in results_base.iterdir()
+                if d.is_dir() and d.name.startswith("run_") and d.name != current_run_name
+            ],
+            key=lambda d: d.name,
+        )
+        for run_dir in all_run_dirs:
+            prev_file = _find_result_file(run_dir, test_name, driver, driver_type)
+            if prev_file is None:
+                continue
+            avg = _read_median(prev_file, metric_col)
+            if avg is not None:
+                history.append((run_dir.name, avg))
+
+    last_avg = history[-1][1] if history else None
+    all_median = statistics.median(v for _, v in history) if history else None
+
+    return {
+        "test_name": test_name,
+        "driver": driver,
+        "driver_type": driver_type,
+        "metric_col": metric_col,
+        "current_median": current_avg,
+        "old_median": old_median,
+        "history": history,
+        "last_median": last_avg,
+        "all_median": all_median,
+    }
+
+
+def _pct_diff(current: float, reference: float) -> str:
+    """Format percentage difference. Negative = faster (better)."""
+    if reference == 0:
+        return "N/A"
+    pct = (current - reference) / reference * 100
+    sign = "+" if pct > 0 else ""
+    return f"{sign}{pct:.1f}%"
+
+
+def _trend(current: float, reference: float) -> str:
+    """Return a brief trend indicator."""
+    if reference == 0:
+        return ""
+    pct = (current - reference) / reference * 100
+    if abs(pct) < 2.0:
+        return "~"
+    return "slower" if pct > 0 else "faster"
+
+
+def log_summary(comparisons: list[dict]) -> None:
+    """Log all comparison results at session end, grouped by test."""
+    if not comparisons:
+        return
+
+    logger.info("")
+    logger.info("=" * 80)
+    logger.info("SUMMARY")
+    logger.info("=" * 80)
+
+    for result in comparisons:
+        test_name = result["test_name"]
+        driver = result["driver"]
+        driver_type = result["driver_type"]
+        metric_col = result["metric_col"]
+        current_median = result["current_median"]
+        old_median = result.get("old_median")
+        history = result["history"]
+        last_median = result["last_median"]
+        all_median = result["all_median"]
+
+        label = f"{test_name}  ({driver}"
+        if driver_type:
+            label += f" {driver_type}"
+        label += ")"
+
+        logger.info("")
+        logger.info(f"  {label}")
+
+        # UD vs OLD (only when old_median is available)
+        if old_median is not None:
+            diff = _pct_diff(current_median, old_median)
+            trend = _trend(current_median, old_median)
+            if trend == "faster":
+                colored = _color(f"{diff} ({trend})", _GREEN)
+            elif trend == "slower":
+                colored = _color(f"{diff} ({trend})", _RED)
+            else:
+                colored = f"{diff} ({trend})"
+            logger.info(
+                f"    UD vs OLD:    {metric_col}  UD={current_median:.3f}s  OLD={old_median:.3f}s"
+                f"  UD is {colored} than OLD"
+            )
+
+        # History comparison
+        if history:
+            last_run_name = history[-1][0]
+            last_diff = _pct_diff(current_median, last_median)
+            last_trend = _trend(current_median, last_median)
+            if last_trend == "faster":
+                last_colored = _color(f"{last_diff}  {last_trend}", _GREEN)
+            elif last_trend == "slower":
+                last_colored = _color(f"{last_diff}  {last_trend}", _RED)
+            else:
+                last_colored = f"{last_diff}  {last_trend}"
+            logger.info(
+                f"    vs last run:  {metric_col}  {last_median:.3f}s -> {current_median:.3f}s"
+                f"  {last_colored}"
+                f"  ({last_run_name})"
+            )
+            if len(history) >= 2:
+                all_diff = _pct_diff(current_median, all_median)
+                all_trend = _trend(current_median, all_median)
+                if all_trend == "faster":
+                    all_colored = _color(f"{all_diff}  {all_trend}", _GREEN)
+                elif all_trend == "slower":
+                    all_colored = _color(f"{all_diff}  {all_trend}", _RED)
+                else:
+                    all_colored = f"{all_diff}  {all_trend}"
+                logger.info(
+                    f"    vs all prev:  {metric_col}  median {all_median:.3f}s -> {current_median:.3f}s"
+                    f"  {all_colored}"
+                    f"  [N={len(history)}]"
+                )
+
+    logger.info("")
+    logger.info("=" * 80)
+    logger.info("")

--- a/tests/performance/runner/local_compare.py
+++ b/tests/performance/runner/local_compare.py
@@ -28,8 +28,8 @@ def _detect_metric_column(csv_path: Path) -> Optional[str]:
             return "fetch_s"
         if "query_s" in header:
             return "query_s"
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Failed to detect metric column from {csv_path}: {e}")
     return None
 
 
@@ -96,11 +96,10 @@ def get_file_median(files: list[Path]) -> Optional[tuple[str, float]]:
     metric_col = _detect_metric_column(f)
     if not metric_col:
         return None
-    avg = _read_median(f, metric_col)
-    if avg is None:
+    median = _read_median(f, metric_col)
+    if median is None:
         return None
-    return metric_col, avg
-
+    return metric_col, median
 
 def compare_with_history(
     current_files: list[Path],
@@ -119,10 +118,10 @@ def compare_with_history(
         test_name:     Test name (without 'test_' prefix)
         driver:        Driver name (core, python, odbc, jdbc)
         driver_type:   Driver type (universal, old) or None for core
-        old_avg:       Optional OLD driver avg from the same run (for UD vs OLD display)
+        old_median:    Optional OLD driver median from the same run (for UD vs OLD display)
 
     Returns:
-        Dict with comparison data, or None if the current avg cannot be determined.
+        Dict with comparison data, or None if the current median cannot be determined.
         History fields are empty when results_dir has no previous runs.
     """
     if not current_files:
@@ -136,8 +135,8 @@ def compare_with_history(
     if not metric_col:
         return None
 
-    current_avg = _read_median(current_file, metric_col)
-    if current_avg is None:
+    current_median = _read_median(current_file, metric_col)
+    if current_median is None:
         return None
 
     results_base = results_dir.parent
@@ -156,11 +155,11 @@ def compare_with_history(
             prev_file = _find_result_file(run_dir, test_name, driver, driver_type)
             if prev_file is None:
                 continue
-            avg = _read_median(prev_file, metric_col)
-            if avg is not None:
-                history.append((run_dir.name, avg))
+            median = _read_median(prev_file, metric_col)
+            if median is not None:
+                history.append((run_dir.name, median))
 
-    last_avg = history[-1][1] if history else None
+    last_median = history[-1][1] if history else None
     all_median = statistics.median(v for _, v in history) if history else None
 
     return {
@@ -168,10 +167,10 @@ def compare_with_history(
         "driver": driver,
         "driver_type": driver_type,
         "metric_col": metric_col,
-        "current_median": current_avg,
+        "current_median": current_median,
         "old_median": old_median,
         "history": history,
-        "last_median": last_avg,
+        "last_median": last_median,
         "all_median": all_median,
     }
 
@@ -196,7 +195,7 @@ def _trend(current: float, reference: float) -> str:
 
 
 def log_summary(comparisons: list[dict]) -> None:
-    """Log all comparison results at session end, grouped by test."""
+    """Log all comparison results at session end, in test-run order."""
     if not comparisons:
         return
 
@@ -230,13 +229,16 @@ def log_summary(comparisons: list[dict]) -> None:
             trend = _trend(current_median, old_median)
             if trend == "faster":
                 colored = _color(f"{diff} ({trend})", _GREEN)
+                suffix = "than OLD"
             elif trend == "slower":
                 colored = _color(f"{diff} ({trend})", _RED)
+                suffix = "than OLD"
             else:
                 colored = f"{diff} ({trend})"
+                suffix = "vs OLD"
             logger.info(
                 f"    UD vs OLD:    {metric_col}  UD={current_median:.3f}s  OLD={old_median:.3f}s"
-                f"  UD is {colored} than OLD"
+                f"  UD is {colored} {suffix}"
             )
 
         # History comparison

--- a/tests/performance/runner/modes/common.py
+++ b/tests/performance/runner/modes/common.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from runner.container import create_perf_container, run_container
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 from runner.validation import verify_results
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ def execute_test(
     driver: str = "core",
     driver_type: str = None,
     setup_queries: list[str] = None,
-    test_type: TestType = TestType.SELECT,
+    test_type: PerfTestType = PerfTestType.SELECT,
     use_local_binary: bool = False,
     s3_files_dir: Path = None,
     env_vars: dict[str, str] = None,
@@ -39,7 +39,7 @@ def execute_test(
         driver: Driver to use (core, python, odbc, jdbc)
         driver_type: Driver type: 'universal' or 'old' (only 'universal' for core)
         setup_queries: Optional list of SQL queries to run before warmup/test iterations
-        test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
+        test_type: Type of test (PerfTestType.SELECT or PerfTestType.PUT_GET)
         use_local_binary: Use locally built binary instead of Docker (Core only)
         s3_files_dir: Optional directory with S3-downloaded files to mount (for PUT/GET tests)
         env_vars: Optional environment variables to pass to the test

--- a/tests/performance/runner/modes/e2e_runner.py
+++ b/tests/performance/runner/modes/e2e_runner.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from runner.modes.common import execute_test, verify_test_results
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def run_performance_test(
     driver: str = "core",
     driver_type: str = None,
     setup_queries: list[str] = None,
-    test_type: TestType = TestType.SELECT,
+    test_type: PerfTestType = PerfTestType.SELECT,
     use_local_binary: bool = False,
     s3_files_dir: Path = None,
 ) -> list[Path]:
@@ -35,7 +35,7 @@ def run_performance_test(
         driver: Driver to use (core, python, odbc, jdbc)
         driver_type: Driver type: 'universal' or 'old' (only 'universal' for core)
         setup_queries: Optional list of SQL queries to run before warmup/test iterations
-        test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
+        test_type: Type of test (PerfTestType.SELECT or PerfTestType.PUT_GET)
         use_local_binary: Use locally built binary instead of Docker (Core only)
         s3_files_dir: Optional directory with S3-downloaded files to mount (for PUT/GET tests)
     
@@ -84,7 +84,7 @@ def run_comparison_test(
     warmup_iterations: int,
     driver: str,
     setup_queries: list[str] = None,
-    test_type: TestType = TestType.SELECT,
+    test_type: PerfTestType = PerfTestType.SELECT,
     s3_files_dir: Path = None,
 ) -> dict[str, list[Path]]:
     """
@@ -99,7 +99,7 @@ def run_comparison_test(
         warmup_iterations: Number of warmup iterations
         driver: Driver to test (python, odbc, jdbc)
         setup_queries: Optional list of SQL queries to run before warmup/test iterations
-        test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
+        test_type: Type of test (PerfTestType.SELECT or PerfTestType.PUT_GET)
         s3_files_dir: Optional directory with S3-downloaded files to mount (for PUT/GET tests)
     
     Returns:

--- a/tests/performance/runner/modes/local_runner.py
+++ b/tests/performance/runner/modes/local_runner.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 from runner.utils import perf_tests_root
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ def run_local_core_binary(
     iterations: int,
     warmup_iterations: int,
     setup_queries: list[str] = None,
-    test_type: TestType = TestType.SELECT,
+    test_type: PerfTestType = PerfTestType.SELECT,
     s3_files_dir: Path = None,
 ) -> None:
     """
@@ -35,7 +35,7 @@ def run_local_core_binary(
         iterations: Number of test iterations
         warmup_iterations: Number of warmup iterations
         setup_queries: Optional list of SQL queries to run before warmup/test iterations
-        test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
+        test_type: Type of test (PerfTestType.SELECT or PerfTestType.PUT_GET)
         s3_files_dir: Optional directory with S3-downloaded files (for PUT/GET tests)
     """
     perf_root = perf_tests_root()
@@ -55,7 +55,7 @@ def run_local_core_binary(
         logger.error(build_result.stderr)
         raise RuntimeError(f"Cargo build failed with exit code {build_result.returncode}")
     
-    if test_type == TestType.PUT_GET and s3_files_dir:
+    if test_type == PerfTestType.PUT_GET and s3_files_dir:
         get_files_dir = perf_root / "get_files"
         
         global _get_files_cleaned

--- a/tests/performance/runner/modes/wiremock_runner.py
+++ b/tests/performance/runner/modes/wiremock_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from runner.docker_network import DockerNetworkManager
 from runner.modes.common import execute_test, verify_test_results
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 from runner.utils import perf_tests_root
 from wiremock.wiremock_manager import WiremockManager
 from wiremock.wiremock_monitor import WiremockMonitor, MonitorResult
@@ -598,7 +598,7 @@ def _run_test_with_proxy(
         driver=driver,
         driver_type=driver_type,
         setup_queries=setup_queries,
-        test_type=TestType.SELECT,  # WireMock tests are SELECT-based
+        test_type=PerfTestType.SELECT,  # WireMock tests are SELECT-based
         use_local_binary=use_local_binary,
         s3_files_dir=s3_files_dir,
         env_vars=env_vars,

--- a/tests/performance/runner/test_types.py
+++ b/tests/performance/runner/test_types.py
@@ -2,7 +2,7 @@
 from enum import Enum
 
 
-class TestType(str, Enum):
+class PerfTestType(str, Enum):
     """Enum for test types"""
     SELECT = "select"
     PUT_GET = "put_get"

--- a/tests/performance/tests/test_put_get.py
+++ b/tests/performance/tests/test_put_get.py
@@ -1,6 +1,6 @@
 import pytest
 
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 S3_TEST_DATA_12MX100 = "s3://sfc-eng-data/ecosystem/12Mx100/"
 S3_TEST_DATA_12MX1000 = "s3://sfc-eng-data/ecosystem/12Mx1000/"
@@ -13,7 +13,7 @@ def test_put_files_12mx100(perf_test):
     Total: 1.2GB across 100 files
     """
     perf_test(
-        test_type=TestType.PUT_GET,
+        test_type=PerfTestType.PUT_GET,
         s3_download_url=S3_TEST_DATA_12MX100,
         setup_queries=[
             "CREATE TEMPORARY STAGE put_test_stage"
@@ -32,7 +32,7 @@ def test_put_files_12mx1000(perf_test):
     Total: 12GB across 1000 files
     """
     perf_test(
-        test_type=TestType.PUT_GET,
+        test_type=PerfTestType.PUT_GET,
         s3_download_url=S3_TEST_DATA_12MX1000,
         setup_queries=[
             "CREATE TEMPORARY STAGE put_test_stage"
@@ -51,7 +51,7 @@ def test_put_files_1_2Gx10(perf_test):
     Total: 12GB across 10 files
     """
     perf_test(
-        test_type=TestType.PUT_GET,
+        test_type=PerfTestType.PUT_GET,
         s3_download_url=S3_TEST_DATA_1_2GX10,
         setup_queries=[
             "CREATE TEMPORARY STAGE put_test_stage"
@@ -69,7 +69,7 @@ def test_get_files_12mx100(perf_test):
     Total: 1.2GB across 100 files
     """
     perf_test(
-        test_type=TestType.PUT_GET,
+        test_type=PerfTestType.PUT_GET,
         s3_download_url=S3_TEST_DATA_12MX100,
         
         setup_queries=[

--- a/tests/performance/tests/test_select_1M_recorded_http.py
+++ b/tests/performance/tests/test_select_1M_recorded_http.py
@@ -1,6 +1,6 @@
 """Performance test for 1M rows with WireMock - for stability testing"""
 import pytest
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 ITERATIONS = 30
 WARMUP_ITERATIONS = 2
@@ -10,7 +10,7 @@ WARMUP_ITERATIONS = 2
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_string_1M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
     )
 
@@ -19,7 +19,7 @@ def test_select_string_1M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_number_1M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
     )
 
@@ -28,7 +28,7 @@ def test_select_number_1M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_date_1M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_SHIPDATE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
     )
 
@@ -37,7 +37,7 @@ def test_select_date_1M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_float_1M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
     )
 
@@ -46,7 +46,7 @@ def test_select_float_1M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_15columns_1M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="""
             SELECT 
                 L_ORDERKEY,
@@ -74,7 +74,7 @@ def test_select_15columns_1M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_string_1M_ordered_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000",
     )
 
@@ -83,7 +83,7 @@ def test_select_string_1M_ordered_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_number_1M_ordered_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000",
     )
 
@@ -92,7 +92,7 @@ def test_select_number_1M_ordered_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_15columns_1M_ordered_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="""
             SELECT 
                 L_ORDERKEY,

--- a/tests/performance/tests/test_select_50M_recorded_http.py
+++ b/tests/performance/tests/test_select_50M_recorded_http.py
@@ -1,5 +1,5 @@
 import pytest
-from runner.test_types import TestType
+from runner.test_types import PerfTestType
 
 ITERATIONS = 5
 WARMUP_ITERATIONS = 1
@@ -9,7 +9,7 @@ WARMUP_ITERATIONS = 1
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_string_50M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
     )
 
@@ -18,7 +18,7 @@ def test_select_string_50M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_number_50M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
     )
 
@@ -27,7 +27,7 @@ def test_select_number_50M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_date_50M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_SHIPDATE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
     )
 
@@ -36,7 +36,7 @@ def test_select_date_50M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_float_50M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
     )
 
@@ -45,7 +45,7 @@ def test_select_float_50M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_15columns_50M_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="""
             SELECT 
                 L_ORDERKEY,
@@ -73,7 +73,7 @@ def test_select_15columns_50M_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_string_50M_ordered_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
     )
 
@@ -82,6 +82,6 @@ def test_select_string_50M_ordered_arrow_recorded_http(perf_test):
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_number_50M_ordered_arrow_recorded_http(perf_test):
     perf_test(
-        test_type=TestType.SELECT_RECORDED_HTTP,
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
     )


### PR DESCRIPTION
What's new:

- runner/local_compare.py — new module handling all comparison logic: reads result CSVs from previous results/run_*/ directories, computes per-run medians, and builds comparison data
- Session-end summary logged after ✓ TESTS COMPLETED, grouped by test:
    - UD vs OLD — percentage difference between Universal and Old driver from the same run (shown whenever both drivers ran, including on CI)
    - vs last run — current median vs previous run median
    - vs all prev — current median vs median-of-medians across all previous runs
- Color output: green for faster (>2%), red for slower (>2%), plain for no significant change — colors suppressed when stdout is not a TTY
- Opt-in via PERF_LOCAL_COMPARE=1; all *-local hatch scripts set it automatically, CI scripts do not
- TestType renamed to PerfTestType to fix a PytestCollectionWarning (pytest was trying to collect it as a test class)
- Suppressed DeprecationWarning from testcontainers @wait_container_is_ready decorator via filterwarnings in pyproject.toml

Metric used: median of per-iteration values within each run; median-of-medians across runs. fetch_s for SELECT tests, query_s for PUT/GET tests.