### PR TITLE
SNOW-2433865 orginize perf results directory

### DIFF
--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -384,8 +384,8 @@ The `PARAMETERS_JSON` environment variable must contain a JSON object with a `te
 
 Each driver container must generate:
 
-1. **CSV Results File**: `/results/<test_name>_<driver>_<type>_<timestamp>.csv`
-   
+1. **CSV Results File**: `/results/<driver_type>/<test_name>/<test_name>_<driver>_<type>_<timestamp>.csv`
+
    See [CSV Format](#csv-format) section for detailed format specification.
 
 2. **Metadata File**: `/results/run_metadata_<driver>_<type>.json`
@@ -409,16 +409,27 @@ Each driver container must generate:
 ```
 results/
 └── run_20251030_113045/
-    ├── select_string_1M_arrow_python_universal_1761734615.csv
-    ├── select_string_1M_arrow_python_old_1761734627.csv
-    ├── memory_timeline_select_string_1M_arrow_python_universal_1761734615.csv
-    ├── memory_timeline_select_string_1M_arrow_python_old_1761734627.csv
-    ├── select_number_1M_arrow_python_universal_1761734660.csv
-    ├── select_number_1M_arrow_python_old_1761734671.csv
-    ├── memory_timeline_select_number_1M_arrow_python_universal_1761734660.csv
-    ├── memory_timeline_select_number_1M_arrow_python_old_1761734671.csv
     ├── run_metadata_python_universal.json
-    └── run_metadata_python_old.json
+    ├── run_metadata_python_old.json
+    ├── wiremock/
+    │   ├── wiremock_stats_select_string_1M_arrow_recorded_http_record_universal_1761734600.csv
+    │   └── wiremock_logs_select_string_1M_arrow_recorded_http_replay_universal_1761734610.log
+    ├── universal/
+    │   ├── _record/
+    │   │   └── select_string_1M_arrow_recorded_http_record_python_universal_1761734605.csv
+    │   ├── select_string_1M_arrow/
+    │   │   ├── select_string_1M_arrow_python_universal_1761734615.csv
+    │   │   └── memory_timeline_select_string_1M_arrow_python_universal_1761734615.csv
+    │   └── select_number_1M_arrow/
+    │       ├── select_number_1M_arrow_python_universal_1761734660.csv
+    │       └── memory_timeline_select_number_1M_arrow_python_universal_1761734660.csv
+    └── old/
+        ├── select_string_1M_arrow/
+        │   ├── select_string_1M_arrow_python_old_1761734627.csv
+        │   └── memory_timeline_select_string_1M_arrow_python_old_1761734627.csv
+        └── select_number_1M_arrow/
+            ├── select_number_1M_arrow_python_old_1761734671.csv
+            └── memory_timeline_select_number_1M_arrow_python_old_1761734671.csv
 ```
 
 ### CSV Format
@@ -427,22 +438,22 @@ Results CSV files contain per-iteration timing, CPU, and memory data with actual
 
 **For SELECT tests:**
 ```csv
-timestamp,query_s,fetch_s,row_count,cpu_time_s,peak_rss_mb
-1762522370,0.005432,1.583121,1000000,1.571032,236.2
-1762522372,0.005118,1.812228,1000000,1.798445,237.4
-1762522374,0.004987,1.799454,1000000,1.785123,236.1
+timestamp_ms,query_s,fetch_s,row_count,cpu_time_s,peak_rss_mb
+1762522370000,0.005432,1.583121,1000000,1.571032,236.2
+1762522372000,0.005118,1.812228,1000000,1.798445,237.4
+1762522374000,0.004987,1.799454,1000000,1.785123,236.1
 ```
 
 **For PUT/GET tests:**
 ```csv
-timestamp,query_s,cpu_time_s,peak_rss_mb
-1762522254,6.595445,0.312456,85.3
-1762522271,4.385419,0.298234,85.1
-1762522288,5.123456,0.305678,85.2
+timestamp_ms,query_s,cpu_time_s,peak_rss_mb
+1762522254000,6.595445,0.312456,85.3
+1762522271000,4.385419,0.298234,85.1
+1762522288000,5.123456,0.305678,85.2
 ```
 
 **Columns**:
-- `timestamp`: Unix timestamp (seconds since epoch) when the iteration completed
+- `timestamp_ms`: Unix timestamp in milliseconds when the iteration completed
 - `query_s`: Wall-clock time to execute the query (`cursor.execute()`) and get initial response (seconds)
 - `fetch_s`: Wall-clock time to fetch all result rows via `fetchmany()` (seconds) — **SELECT tests only**
 - `row_count`: Number of rows fetched — **SELECT tests only**

--- a/tests/performance/drivers/core/app/src/results.rs
+++ b/tests/performance/drivers/core/app/src/results.rs
@@ -70,8 +70,14 @@ pub fn write_memory_timeline(samples: &[MemorySample], test_name: &str) {
 
     let timestamp = current_unix_timestamp_ms();
     let results_dir = std::env::var("RESULTS_DIR").unwrap_or_else(|_| "/results".to_string());
-    let results_path = PathBuf::from(&results_dir);
+    let subdir = if test_name.ends_with("_record") { "_record" } else { test_name };
+    let results_path = PathBuf::from(&results_dir).join("universal").join(subdir);
     let filename = results_path.join(format!("memory_timeline_{test_name}_core_{timestamp}.csv"));
+
+    if let Err(e) = fs::create_dir_all(&results_path) {
+        eprintln!("⚠️  Warning: Could not create results directory: {e}");
+        return;
+    }
 
     let Ok(mut file) = fs::File::create(&filename) else {
         eprintln!("⚠️  Warning: Could not create memory timeline file");
@@ -221,7 +227,8 @@ where
 
     // Use RESULTS_DIR env var if set (for local execution), otherwise use /results (Docker)
     let results_dir = std::env::var("RESULTS_DIR").unwrap_or_else(|_| "/results".to_string());
-    let results_path = PathBuf::from(&results_dir);
+    let subdir = if test_name.ends_with("_record") { "_record" } else { test_name };
+    let results_path = PathBuf::from(&results_dir).join("universal").join(subdir);
     let filename = results_path.join(format!("{}_core_{}.csv", test_name, timestamp));
 
     fs::create_dir_all(&results_path)

--- a/tests/performance/drivers/odbc/app/results.cpp
+++ b/tests/performance/drivers/odbc/app/results.cpp
@@ -48,7 +48,9 @@ void write_memory_timeline(const std::vector<MemorySample>& samples, const std::
                            const std::string& driver_type, time_t timestamp) {
   if (samples.empty()) return;
 
-  std::filesystem::path results_dir("/results");
+  std::string subdir =
+      (test_name.size() >= 7 && test_name.substr(test_name.size() - 7) == "_record") ? "_record" : test_name;
+  std::filesystem::path results_dir = std::filesystem::path("/results") / driver_type / subdir;
   std::stringstream filename_ss;
   filename_ss << "memory_timeline_" << test_name << "_odbc_" << driver_type << "_" << timestamp << ".csv";
   std::string filename = (results_dir / filename_ss.str()).string();
@@ -66,7 +68,9 @@ void write_memory_timeline(const std::vector<MemorySample>& samples, const std::
 }
 
 std::string generate_results_filename(const std::string& test_name, const std::string& driver_type, time_t timestamp) {
-  std::filesystem::path results_dir = std::filesystem::path("/results");
+  std::string subdir =
+      (test_name.size() >= 7 && test_name.substr(test_name.size() - 7) == "_record") ? "_record" : test_name;
+  std::filesystem::path results_dir = std::filesystem::path("/results") / driver_type / subdir;
   std::stringstream filename_ss;
   filename_ss << test_name << "_odbc_" << driver_type << "_" << timestamp << ".csv";
   return (results_dir / filename_ss.str()).string();

--- a/tests/performance/drivers/python/app/results.py
+++ b/tests/performance/drivers/python/app/results.py
@@ -11,19 +11,20 @@ from test_types import TestType
 
 def write_csv_results(results, test_name, driver_type, test_type: TestType = TestType.SELECT):
     """Write test results to CSV file.
-    
+
     Args:
         results: List of result dictionaries
         test_name: Name of the test
         driver_type: Driver type (universal or old)
         test_type: Type of test (TestType.SELECT or TestType.PUT_GET)
-    
+
     Returns:
         Path: Path to the created CSV file
     """
     timestamp = int(time.time())
-    results_dir = Path("/results")
-    results_dir.mkdir(exist_ok=True)
+    subdir = "_record" if test_name.endswith("_record") else test_name
+    results_dir = Path("/results") / driver_type / subdir
+    results_dir.mkdir(parents=True, exist_ok=True)
     
     filename = results_dir / f"{test_name}_python_{driver_type}_{timestamp}.csv"
     
@@ -73,8 +74,9 @@ def write_memory_timeline(memory_timeline, test_name, driver_type):
         return None
 
     timestamp = int(time.time())
-    results_dir = Path("/results")
-    results_dir.mkdir(exist_ok=True)
+    subdir = "_record" if test_name.endswith("_record") else test_name
+    results_dir = Path("/results") / driver_type / subdir
+    results_dir.mkdir(parents=True, exist_ok=True)
 
     filename = results_dir / f"memory_timeline_{test_name}_python_{driver_type}_{timestamp}.csv"
 

--- a/tests/performance/runner/benchstore_upload.py
+++ b/tests/performance/runner/benchstore_upload.py
@@ -427,7 +427,10 @@ def upload_metrics(results_dir: Optional[Path] = None, use_local_auth: bool = Fa
     if not results_dir.exists():
         raise Exception(f"Results directory does not exist: {results_dir}")
     
-    csv_files = list(results_dir.glob("*.csv"))
+    csv_files = (
+        list(results_dir.glob("universal/**/*.csv")) +
+        list(results_dir.glob("old/**/*.csv"))
+    )
     if not csv_files:
         raise Exception(f"No CSV files found in: {results_dir}")
     

--- a/tests/performance/runner/local_compare.py
+++ b/tests/performance/runner/local_compare.py
@@ -75,11 +75,13 @@ def _find_result_file(
     driver_type: Optional[str],
 ) -> Optional[Path]:
     """Find the main result CSV for a test in a given run directory."""
+    driver_type_dir = driver_type if (driver != "core" and driver_type) else "universal"
+    test_dir = run_dir / driver_type_dir / test_name
     if driver != "core" and driver_type:
         pattern = f"{test_name}_{driver}_{driver_type}_*.csv"
     else:
         pattern = f"{test_name}_{driver}_*.csv"
-    candidates = [f for f in run_dir.glob(pattern) if _is_main_result_file(f)]
+    candidates = [f for f in test_dir.glob(pattern) if _is_main_result_file(f)]
     if not candidates:
         return None
     return max(candidates, key=lambda p: p.stat().st_mtime)

--- a/tests/performance/runner/modes/wiremock_runner.py
+++ b/tests/performance/runner/modes/wiremock_runner.py
@@ -4,6 +4,7 @@ import shutil
 import statistics
 import time
 from pathlib import Path
+from typing import Optional
 
 from runner.docker_network import DockerNetworkManager
 from runner.modes.common import execute_test, verify_test_results
@@ -499,19 +500,21 @@ def _get_proxy_url_for_container(wiremock_url: str, wiremock_container_name: str
         return f"http://host.docker.internal:{wiremock_port}"
 
 
-def _extract_row_count_from_recording(results_dir: Path, test_name: str, driver: str, driver_type: str) -> int:
+def _extract_row_count_from_recording(results_dir: Path, test_name: str, driver: str, driver_type: str) -> Optional[int]:
     """Extract row count from recording phase CSV file."""
-    # Find the recording CSV file
-    # Core driver doesn't include driver_type in filename, others do
+    # Recording files are all written to {driver_type}/_record/
+    driver_type_dir = driver_type if driver != "core" else "universal"
+    recording_dir = results_dir / driver_type_dir / "_record"
+
     if driver == "core":
         pattern = f"{test_name}_record_{driver}_*.csv"
     else:
         pattern = f"{test_name}_record_{driver}_{driver_type}_*.csv"
-    
-    csv_files = list(results_dir.glob(pattern))
+
+    csv_files = list(recording_dir.glob(pattern))
     
     if not csv_files:
-        logger.warning(f"No recording CSV found matching pattern: {pattern}")
+        logger.warning(f"No recording CSV found matching pattern: {pattern} in {recording_dir}")
         return None
     
     csv_file = max(csv_files, key=lambda p: p.stat().st_mtime)
@@ -617,10 +620,13 @@ def _write_wiremock_monitor_results(
     timestamp = int(time.time())
     driver_suffix = f"_{driver_type}" if driver_type else ""
 
+    wiremock_dir = results_dir / "wiremock"
+    wiremock_dir.mkdir(exist_ok=True)
+
     # --- CSV stats ---
     if result.samples:
         csv_name = f"wiremock_stats_{test_name}_{phase}{driver_suffix}_{timestamp}.csv"
-        csv_path = results_dir / csv_name
+        csv_path = wiremock_dir / csv_name
         with open(csv_path, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(["timestamp_ms", "cpu_percent", "memory_usage_mb", "memory_limit_mb"])
@@ -631,7 +637,7 @@ def _write_wiremock_monitor_results(
     # --- Container logs ---
     if result.logs:
         log_name = f"wiremock_logs_{test_name}_{phase}{driver_suffix}_{timestamp}.log"
-        log_path = results_dir / log_name
+        log_path = wiremock_dir / log_name
         log_path.write_text(result.logs, encoding="utf-8")
         logger.info(f"Wrote WireMock logs: {log_path.name}")
 

--- a/tests/performance/runner/validation.py
+++ b/tests/performance/runner/validation.py
@@ -29,15 +29,18 @@ def verify_results(
     """
     # For drivers with type variants, include driver type in pattern
     # Core only has universal implementation
+    driver_type_dir = driver_type if (driver != "core" and driver_type) else "universal"
+    test_dir = results_dir / driver_type_dir / test_name
+
     if driver != "core" and driver_type:
         pattern = f"{test_name}_{driver}_{driver_type}_*.csv"
     else:
         pattern = f"{test_name}_{driver}_*.csv"
-    
-    result_files = list(results_dir.glob(pattern))
+
+    result_files = list(test_dir.glob(pattern))
     
     if len(result_files) == 0:
-        raise RuntimeError(f"No result files found matching pattern '{pattern}' in {results_dir}")
+        raise RuntimeError(f"No result files found matching pattern '{pattern}' in {test_dir}")
     
     # Verify CSV structure
     latest_file = max(result_files, key=lambda p: p.stat().st_mtime)


### PR DESCRIPTION
Reorganize the performance test results directory structure. Previously all CSV files were written flat into the run directory. Now they're nested:

- wiremock/ — WireMock stats and log files
- universal/{test_name}/ and old/{test_name}/ — per-driver, per-test result and memory timeline CSVs
- universal/_record/ — recording-phase CSVs consolidated in one place (instead of per-test subfolders)