### PR TITLE
SNOW-3311747: Remove unnecessary stderr printing

### DIFF
--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -133,7 +133,7 @@ pub fn init_logging() {
     static LOGGING_RESULT: LazyLock<Result<(), sf_core::logging::LogError>> = LazyLock::new(|| {
         sf_core::logging::init(sf_core::logging::LoggingConfig::new(
             Some("odbc.log".into()),
-            true,
+            false,
             false,
         ))
     });

--- a/sf_core/src/config/toml_loader.rs
+++ b/sf_core/src/config/toml_loader.rs
@@ -58,8 +58,8 @@ pub fn check_file_permissions(path: &Path) -> Result<(), ConfigError> {
         if mode & 0o044 != 0
             && std::env::var("SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE").is_err()
         {
-            eprintln!(
-                "Warning: Config file {} is readable by group or others",
+            tracing::warn!(
+                "Config file {} is readable by group or others",
                 path.display()
             );
         }

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -36,7 +36,6 @@ struct EmptyLayer;
 impl Layer<Registry> for EmptyLayer {}
 
 pub fn init(config: LoggingConfig) -> Result<(), LogError> {
-    eprintln!("Initializing logging");
     init_logging::<EmptyLayer>(config, None)
 }
 


### PR DESCRIPTION
### TL;DR

Disabled console logging in ODBC initialization and replaced direct console output with proper tracing calls.

### What changed?

- Changed the second parameter in `LoggingConfig::new()` from `true` to `false` in the ODBC handle allocation module
- Replaced `eprintln!` with `tracing::warn!` for the config file permissions warning
- Removed the debug `eprintln!` statement from the logging initialization function

### How to test?

- Run the ODBC driver and verify that console logging is no longer enabled by default
- Test config file permission warnings to ensure they now use the tracing system
- Verify that the "Initializing logging" debug message no longer appears on startup

### Why make this change?

This change standardizes logging behavior by using the proper tracing infrastructure instead of direct console output, and disables verbose console logging in the ODBC driver to reduce noise during normal operation.