### PR TITLE
SNOW-3253116: Fix Python wheel tags to include platform-specific metadata

### DIFF
--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -120,6 +120,8 @@ class BuildHook(BuildHookInterface):
         self._build_extensions()
         self._build_core()
 
+        build_data["pure_python"] = False
+
     def _generate_protobuf(self) -> None:
         """Generate Python protobuf code using the Rust proto_generator binary."""
         python_dir = Path(self.root)

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -121,6 +121,7 @@ class BuildHook(BuildHookInterface):
         self._build_core()
 
         build_data["pure_python"] = False
+        build_data["infer_tag"] = True
 
     def _generate_protobuf(self) -> None:
         """Generate Python protobuf code using the Rust proto_generator binary."""


### PR DESCRIPTION
## Summary
- Set `build_data["pure_python"] = False` and `build_data["infer_tag"] = True` in the Hatch build hook after compiling native extensions (Cython + sf_core)
- Without these flags, Hatchling defaults to `py3-none-any` wheel tags even though the wheel contains platform-specific binaries (`.so`/`.dylib`/`.dll`), which is incorrect metadata and would be rejected by PyPI

## Context
Hatchling (unlike setuptools) does not automatically infer platform-specific wheel tags from compiled extensions. The `artifacts` config in `pyproject.toml` controls which native files are *included* in the wheel, but the wheel *filename tag* and *metadata* must be set explicitly via `build_data` in the build hook. This is the canonical approach documented by Hatch ([ref](https://hatch.pypa.io/dev/plugins/builder/wheel/#build-data)).

Before: `snowflake_connector_python_ud-2026.0.0-py3-none-any.whl`
After: `snowflake_connector_python_ud-2026.0.0-cp312-cp312-linux_x86_64.whl`

## Test plan
- [x] CI passed: wheels built with correct platform-specific tags on both `ubuntu-latest` and `windows-11-arm`
<img width="609" height="229" alt="image" src="https://github.com/user-attachments/assets/281db7e7-886d-4b51-9d87-6130c65cd41a" />

- [x] All existing Python tests pass
- [x] (sanity check) Uploaded wheels to Internal PyPI repository and confirmed on Linux that  `pip install` inside a Docker container selects the correct wheel for the running Python version and platform

```
user@host ~ % export PIP_EXTRA_INDEX_URL=<INTERNAL_PYPI_REPOSITORY>
user@host ~ % for v in 3.9 3.10 3.11 3.12 3.13 3.14; do
  echo -n "Python $v: "
  docker run --rm \
    -e PIP_EXTRA_INDEX_URL \
    python:${v}-slim \
    pip install --dry-run snowflake-connector-python-ud 2>&1 | grep -oE 'snowflake_connector_python_ud-[^ ,]+'
done
Python 3.9: snowflake_connector_python_ud-2026.0.0-cp39-cp39-linux_x86_64.whl
Python 3.10: snowflake_connector_python_ud-2026.0.0-cp310-cp310-linux_x86_64.whl
Python 3.11: snowflake_connector_python_ud-2026.0.0-cp311-cp311-linux_x86_64.whl
Python 3.12: snowflake_connector_python_ud-2026.0.0-cp312-cp312-linux_x86_64.whl
Python 3.13: snowflake_connector_python_ud-2026.0.0-cp313-cp313-linux_x86_64.whl
Python 3.14: snowflake_connector_python_ud-2026.0.0-cp314-cp314-linux_x86_64.whl
user@host ~ %
```
