### PR TITLE
SNOW-3254915: Replace MissingResponseFieldSnafu with dedicated InvalidUrl error variant

### DIFF
--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1110,14 +1110,12 @@ pub async fn get_query_status(
             path: MONITORING_QUERIES_PATH,
         })?;
 
-    url.path_segments_mut()
-        .map_err(|()| {
-            MissingResponseFieldSnafu {
-                field: "base URL for monitoring queries",
-            }
-            .build()
-        })?
-        .push(query_id);
+    {
+        let url_str = url.to_string();
+        url.path_segments_mut()
+            .map_err(|()| InvalidUrlSnafu { url: url_str }.build())?
+            .push(query_id);
+    }
 
     let token_str = session_token.reveal();
     let build_request = || {
@@ -1382,6 +1380,12 @@ pub enum RestError {
     HttpRetry {
         context: &'static str,
         source: crate::http::retry::HttpError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Invalid URL: {url}"))]
+    InvalidUrl {
+        url: String,
         #[snafu(implicit)]
         location: Location,
     },


### PR DESCRIPTION
## Summary
- Replace semantically incorrect `MissingResponseFieldSnafu` with a new `InvalidUrl` error variant in `RestError` for the `path_segments_mut()` failure in `get_query_status`
- This is a follow-up to PR #753 addressing a review comment about error variant semantics

## Context
During review of the query status Rust core implementation (#753), `MissingResponseFieldSnafu` was used as a catch-all for the `url.path_segments_mut()` error. This is semantically wrong since the failure is about URL construction, not a missing response field. This PR adds a proper `InvalidUrl` variant without a `source` field.

## Test plan
- `cargo check -p sf_core` passes
- `cargo clippy -p sf_core` passes with no warnings
- `cargo fmt -- --check` passes

Made with [Cursor](https://cursor.com)