### PR TITLE
Add more caching

### DIFF
--- a/.github/workflows/test-jdbc.yml
+++ b/.github/workflows/test-jdbc.yml
@@ -65,8 +65,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-jdbc-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
           restore-keys: |
+            ${{ runner.os }}-gradle-jdbc-
             ${{ runner.os }}-gradle-
 
       - name: Decode secrets
@@ -114,8 +115,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-jdbc-reference-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
           restore-keys: |
+            ${{ runner.os }}-gradle-jdbc-reference-
             ${{ runner.os }}-gradle-
 
       - name: Decode secrets

--- a/.github/workflows/test-jdbc.yml
+++ b/.github/workflows/test-jdbc.yml
@@ -59,6 +59,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-jdbc-target-
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
         env:
@@ -97,6 +107,16 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -373,6 +373,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache Cargo registry (RPM build)
+        uses: actions/cache@v5
+        with:
+          path: .cargo-cache
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-registry-rpm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-registry-rpm-
+
+      - name: Cache Rust target (RPM build)
+        uses: actions/cache@v5
+        with:
+          path: .cargo-target-rpm
+          key: ${{ runner.os }}-${{ matrix.arch }}-rust-rpm-release-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-rust-rpm-release-target-
+
+      - name: Prepare cache directories
+        run: mkdir -p .cargo-cache/registry .cargo-cache/git .cargo-target-rpm
+
       - name: Build Docker image
         run: docker build -t rpm-build -f ci/Dockerfile.rocky-rpm-build .
 
@@ -380,6 +399,9 @@ jobs:
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
+            -v ${{ github.workspace }}/.cargo-cache/registry:/root/.cargo/registry \
+            -v ${{ github.workspace }}/.cargo-cache/git:/root/.cargo/git \
+            -v ${{ github.workspace }}/.cargo-target-rpm:/workspace/target \
             -w /workspace \
             -e PLATFORM=${{ matrix.platform }} \
             -e RUSTFLAGS="-C link-arg=-fuse-ld=lld -C link-arg=-Wl,--undefined-version" \

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -219,7 +219,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-arm64-nonfips-target-
 
+      - name: Capture vcpkg version for cache key
+        id: vcpkg-ver
+        shell: pwsh
+        run: |
+          $ver = & C:\vcpkg\vcpkg.exe version 2>$null |
+            Select-String 'version\s+(\S+)' |
+            ForEach-Object { $_.Matches[0].Groups[1].Value } |
+            Select-Object -First 1
+          if (-not $ver) { Write-Error "Could not determine vcpkg version"; exit 1 }
+          echo "VCPKG_VER=$ver" >> $env:GITHUB_ENV
+
+      - name: Cache vcpkg ARM64 OpenSSL
+        id: vcpkg-cache
+        uses: actions/cache@v5
+        with:
+          path: C:\vcpkg\installed\arm64-windows
+          key: windows-11-arm-vcpkg-openssl-${{ env.VCPKG_VER }}
+
       - name: Install ARM64 OpenSSL via vcpkg
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
         shell: cmd
         run: |
           :: Build native ARM64 OpenSSL from source. The pre-installed OpenSSL is


### PR DESCRIPTION
### TL;DR

Added caching for Gradle packages, Cargo registry/target directories, and vcpkg OpenSSL to improve CI build performance.

### What changed?

- Added Gradle package caching to both jobs in the JDBC test workflow, caching `~/.gradle/caches` and `~/.gradle/wrapper` directories
- Added Cargo registry and target directory caching to the RPM build job in the ODBC test workflow, with volume mounts to share cache with Docker containers
- Added vcpkg caching for ARM64 OpenSSL builds in the Rust core test workflow, including version detection and conditional installation

### How to test?

Run the affected CI workflows and verify that:
- Gradle dependencies are cached and restored between builds
- Cargo compilation artifacts are reused in RPM builds
- vcpkg OpenSSL installation is skipped when cache is available

### Why make this change?

These caching improvements reduce build times by avoiding repeated downloads and compilation of dependencies that don't change frequently between CI runs.