### PR TITLE
NO-SNOW: decompose query_utils.py into focused modules and clean up cursor internals

### DIFF
--- a/python/src/snowflake/connector/_internal/arrow_stream_utils.py
+++ b/python/src/snowflake/connector/_internal/arrow_stream_utils.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from .arrow_context import ArrowConverterContext
+from .arrow_stream_iterator import ArrowStreamIterator, ArrowStreamTableIterator
+from .extras import pyarrow
+from .type_codes import FIXED
+
+
+if TYPE_CHECKING:
+    from pyarrow import Schema, Table
+
+    from ..cursor import ResultMetadata
+
+
+def release_arrow_stream(stream_ptr: int | None) -> None:
+    # Release the Arrow stream pointer to prevent memory leak
+    if stream_ptr:
+        # Create ArrowStreamIterator to take ownership of the stream pointer.
+        # The C++ destructor will handle cleanup when it goes out of scope.
+        _ = ArrowStreamIterator(stream_ptr, ArrowConverterContext())
+        # Iterator goes out of scope here, triggering C++ destructor
+
+
+def create_row_iterator(
+    stream_ptr: int,
+    use_dict_result: bool = False,
+    use_numpy: bool = False,
+) -> ArrowStreamIterator:
+    """Build an :class:`ArrowStreamIterator` that yields one row at a time."""
+    context = ArrowConverterContext()
+    return ArrowStreamIterator(
+        stream_ptr,
+        context,
+        use_dict_result=use_dict_result,
+        use_numpy=use_numpy,
+    )
+
+
+def create_table_iterator(
+    stream_ptr: int,
+    number_to_decimal: bool = False,
+    force_microsecond_precision: bool = False,
+) -> ArrowStreamTableIterator:
+    """Build an :class:`ArrowStreamTableIterator` that yields one RecordBatch at a time."""
+    context = ArrowConverterContext()
+    return ArrowStreamTableIterator(
+        stream_ptr,
+        context,
+        number_to_decimal=number_to_decimal,
+        force_microsecond_precision=force_microsecond_precision,
+    )
+
+
+def normalize_fixed_column_types(
+    schema: Schema,
+    description: Sequence[ResultMetadata],
+) -> Schema:
+    """Rewrite FIXED columns in an Arrow schema to int64 for backward compatibility.
+
+    When the result set has zero rows, sf-core may choose a narrower integer
+    type (e.g. int8) for NUMBER columns.  The old driver always exposed int64,
+    so we normalize here to keep behavior consistent.
+    """
+    new_fields = []
+    changed = False
+    for field, metadata in zip(schema, description):
+        if metadata.type_code == FIXED and field.type != pyarrow.int64():
+            new_fields.append(field.with_type(pyarrow.int64()))
+            changed = True
+        else:
+            new_fields.append(field)
+    return pyarrow.schema(new_fields) if changed else schema
+
+
+def collect_arrow_table(
+    table_iterator: ArrowStreamTableIterator,
+    columns_metadata: Sequence[ResultMetadata] | None = None,
+    force_return_table: bool = False,
+) -> Table | None:
+    """Collect all RecordBatches from *table_iterator* into a single Arrow Table.
+
+    When *force_return_table* is ``True`` an empty result set produces a
+    properly-typed empty table.  When ``False`` (the default), an empty result
+    set returns ``None``.
+
+    When *columns_metadata* is provided the empty-table schema is normalized via
+    :func:`normalize_fixed_column_types` so that FIXED columns are int64.
+    """
+    batches = list(table_iterator)
+    if batches:
+        return pyarrow.Table.from_batches(batches)
+
+    if not force_return_table:
+        return None
+
+    schema = table_iterator.get_converted_schema()
+    if columns_metadata:
+        schema = normalize_fixed_column_types(schema, columns_metadata)
+    return schema.empty_table()

--- a/python/src/snowflake/connector/_internal/statement_utils.py
+++ b/python/src/snowflake/connector/_internal/statement_utils.py
@@ -4,8 +4,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from .arrow_context import ArrowConverterContext
-from .arrow_stream_iterator import ArrowStreamIterator
 from .protobuf_gen.database_driver_v1_pb2 import (
     ExecuteResult,
     PrepareResult,
@@ -131,14 +129,3 @@ def get_stream_ptr(result: ExecuteResult | PrepareResult | None) -> int:
         raise RuntimeError("Stream pointer is null")
 
     return stream_ptr
-
-
-def release_arrow_stream(stream_ptr: int | None) -> None:
-    # Release the Arrow stream pointer to prevent memory leak
-    # The PrepareResult includes an ArrowArrayStreamPtr that must be released
-    # even though we won't consume any data from it.
-    if stream_ptr:
-        # Create ArrowStreamIterator to take ownership of the stream pointer.
-        # The C++ destructor will handle cleanup when it goes out of scope.
-        _ = ArrowStreamIterator(stream_ptr, ArrowConverterContext())
-        # Iterator goes out of scope here, triggering C++ destructor

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -16,16 +16,19 @@ import functools
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
-from snowflake.connector._internal.errorcode import ER_CONNECTION_IS_CLOSED, ER_CURSOR_IS_CLOSED
-
-from .._internal.arrow_context import ArrowConverterContext
-from .._internal.arrow_stream_iterator import ArrowStreamIterator, ArrowStreamTableIterator
+from .._internal.arrow_stream_utils import (
+    collect_arrow_table,
+    create_row_iterator,
+    create_table_iterator,
+    release_arrow_stream,
+)
 from .._internal.binding_converters import (
     ClientSideBindingConverter,
     JsonBindingConverter,
     ParamStyle,
 )
 from .._internal.decorators import pep249
+from .._internal.errorcode import ER_CURSOR_IS_CLOSED
 from .._internal.extras import check_dependency, pandas, pyarrow, requires_dependency
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     BinaryDataPtr,
@@ -37,21 +40,19 @@ from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     StatementHandle,
     StatementPrepareRequest,
 )
-from .._internal.query_utils import (
+from .._internal.statement_utils import (
     create_statement,
     extract_rowcount,
     extract_sqlstate,
     get_stream_ptr,
-    release_arrow_stream,
 )
-from .._internal.type_codes import FIXED
 from ..errors import InterfaceError, NotSupportedError, ProgrammingError
 from ._result_metadata import QueryResultStats, ResultMetadata
 
 
 if TYPE_CHECKING:
     from pandas import DataFrame
-    from pyarrow import Schema, Table
+    from pyarrow import Table
 
     from ..connection import Connection
 
@@ -72,25 +73,12 @@ class FetchMode(enum.Enum):
     ARROW = "arrow"
 
 
-def _requires_not_closed(func: F) -> F:
+def _requires_open(func: F) -> F:
 
     @functools.wraps(func)
     def wrapper(self: SnowflakeCursorBase, *args: Any, **kwargs: Any) -> Any:
-        if self._closed:
+        if self.is_closed():
             raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
-
-        return func(self, *args, **kwargs)
-
-    return cast(F, wrapper)
-
-
-def _requires_open_connection(func: F) -> F:
-    """Raise InterfaceError if the underlying connection is closed."""
-
-    @functools.wraps(func)
-    def wrapper(self: SnowflakeCursorBase, *args: Any, **kwargs: Any) -> Any:
-        if self.connection.is_closed():
-            raise InterfaceError("Connection is closed.", errno=ER_CONNECTION_IS_CLOSED)
 
         return func(self, *args, **kwargs)
 
@@ -135,23 +123,29 @@ class SnowflakeCursorBase(abc.ABC):
         Args:
             connection: Connection object that created this cursor
         """
+        # -- Core cursor state (identity, lifecycle, error handling) --
         self._connection = connection
-        self._description: list[ResultMetadata] | None = None
-        self._rowcount: int | None = None
+        self._closed = False
+        self._messages: list[tuple[type[Exception], dict[str, str | bool]]] = []
+        self._errorhandler: Callable
+
+        # -- PEP 249 cursor configuration (persists for cursor lifetime) --
         self._arraysize: int = 1
+
+        # -- Query result metadata (set on execute, preserved across reset) --
+        self._description: list[ResultMetadata] | None = None
         self._sqlstate: str | None = None
         self._sfqid: str | None = None
         self._query: str | None = None
-        self._closed = False
-        # Streaming state for Arrow results
-        self.execute_result: ExecuteResult | None = None
-        self._iterator: Iterator[Row] | None = None
+        self._rownumber: int = -1
+
+        # -- Active result state (cleared on reset) --
+        self._rowcount: int | None = None
+        self._execute_result: ExecuteResult | None = None
+        self._iterator: Iterator[Row | DictRow] | None = None
         self._fetch_mode: FetchMode | None = None
         # Query bindings - keep binding data reference to prevent garbage collection while Rust uses it
         self._binding_data: None | bytes = None
-        self._messages: list[tuple[type[Exception], dict[str, str | bool]]] = []
-        self._rownumber: int = -1
-        self._errorhandler: Callable
 
     # ------------------------------------------------------------------
     # PEP 249 attributes
@@ -250,9 +244,20 @@ class SnowflakeCursorBase(abc.ABC):
     @property
     def stats(self) -> QueryResultStats | None:
         """Returns detailed row-level statistics for DML operations."""
-        if self.execute_result is None or not self.execute_result.HasField("stats"):
+        if self._execute_result is None or not self._execute_result.HasField("stats"):
             return QueryResultStats()
-        return QueryResultStats.from_query_stats(self.execute_result.stats)
+        return QueryResultStats.from_query_stats(self._execute_result.stats)
+
+    @property
+    @pep249
+    def rownumber(self) -> int | None:
+        """The current 0-based index of the cursor in the result set, or ``None`` if indeterminate."""
+        return self._rownumber if self._rownumber >= 0 else None
+
+    @property
+    def sqlstate(self) -> str | None:
+        """The SQLSTATE code of the last executed operation."""
+        return self._sqlstate
 
     @pep249
     def callproc(self, procname: str, parameters: Sequence[Any] | None = None) -> Sequence[Any]:
@@ -271,21 +276,10 @@ class SnowflakeCursorBase(abc.ABC):
         """
         raise NotSupportedError("callproc is not implemented")
 
-    @pep249
-    def close(self) -> bool | None:
-        """Close the cursor now.
-
-        Returns whether the cursor was closed during this call.
-        """
-        try:
-            if self._closed:
-                return False
-            self.reset(closing=True)
-            self._closed = True
-            del self._messages[:]
-            return True
-        except Exception:
-            return None
+    @property
+    def is_file_transfer(self) -> bool:
+        """Whether the last executed command was a PUT or GET file transfer."""
+        raise NotImplementedError("is_file_transfer is not yet implemented")
 
     def _build_query_bindings(self, parameters: Sequence[Any]) -> QueryBindings | None:
         """Serialize parameters and build a QueryBindings protobuf message.
@@ -365,8 +359,7 @@ class SnowflakeCursorBase(abc.ABC):
             return operation, bindings
 
     @pep249
-    @_requires_not_closed
-    @_requires_open_connection
+    @_requires_open
     def execute(
         self,
         operation: str,
@@ -431,11 +424,10 @@ class SnowflakeCursorBase(abc.ABC):
         # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
         self._rownumber = -1
         # save execute result (holds arrow stream data needed for fetching)
-        self.execute_result = result
+        self._execute_result = result
 
     @pep249
-    @_requires_not_closed
-    @_requires_open_connection
+    @_requires_open
     def executemany(self, operation: str, seq_of_parameters: Sequence[Sequence[Any] | dict[str, Any]]) -> None:
         """
         Execute a database operation repeatedly for each element in seq_of_parameters.
@@ -498,8 +490,7 @@ class SnowflakeCursorBase(abc.ABC):
         # Execute using array binding (existing path handles list values)
         self.execute(operation, transposed)
 
-    @_requires_not_closed
-    @_requires_open_connection
+    @_requires_open
     def describe(
         self,
         operation: str,
@@ -530,8 +521,9 @@ class SnowflakeCursorBase(abc.ABC):
         with create_statement(self.connection, query) as stmt_handle:
             result = self._prepare(stmt_handle)
 
-        stream_ptr = get_stream_ptr(result)
-        release_arrow_stream(stream_ptr)
+        # The PrepareResult includes an ArrowArrayStreamPtr that must be released
+        # even though we won't consume any data from it.
+        release_arrow_stream(get_stream_ptr(result))
 
         result_metadata = ResultMetadata.create_description(result)
         if result_metadata:
@@ -544,38 +536,10 @@ class SnowflakeCursorBase(abc.ABC):
         return result_metadata
 
     # ------------------------------------------------------------------
-    # Arrow stream helpers
-    # ------------------------------------------------------------------
-
-    def _get_iterator(self) -> ArrowStreamIterator:
-        stream_ptr = get_stream_ptr(self.execute_result)
-        arrow_context = ArrowConverterContext()
-        return ArrowStreamIterator(
-            stream_ptr,
-            arrow_context,
-            use_dict_result=self._use_dict_result,
-            # TODO: SNOW-2997786, temporarily hardcoded
-            use_numpy=False,
-        )
-
-    def _get_table_iterator(
-        self,
-        force_microsecond_precision: bool = False,
-    ) -> ArrowStreamTableIterator:
-        stream_ptr = get_stream_ptr(self.execute_result)
-        arrow_context = ArrowConverterContext()
-        return ArrowStreamTableIterator(
-            stream_ptr,
-            arrow_context,
-            number_to_decimal=self._connection.arrow_number_to_decimal,
-            force_microsecond_precision=force_microsecond_precision,
-        )
-
-    # ------------------------------------------------------------------
     # Fetch – shared implementation
     # ------------------------------------------------------------------
 
-    @_requires_not_closed
+    @_requires_open
     @_requires_fetch_mode(FetchMode.ROW)
     def _fetchone(self) -> Row | DictRow | None:
         """Fetch the next row internally.
@@ -583,8 +547,8 @@ class SnowflakeCursorBase(abc.ABC):
         Return a dict if ``_use_dict_result`` is True, otherwise a tuple.
         Concrete subclasses expose this through a type-safe ``fetchone``.
         """
-        if self._iterator is None:
-            self._iterator = self._get_iterator()
+        if not self._iterator:
+            self._iterator = self._create_row_iterator()
         try:
             row = next(self._iterator)
             self._rownumber += 1
@@ -598,6 +562,7 @@ class SnowflakeCursorBase(abc.ABC):
         """Fetch the next row of a query result set."""
 
     @pep249
+    @_requires_open
     def fetchmany(self, size: int | None = None) -> list[Any]:
         """
         Fetch the next set of rows of a query result.
@@ -628,7 +593,7 @@ class SnowflakeCursorBase(abc.ABC):
         return ret
 
     @pep249
-    @_requires_not_closed
+    @_requires_open
     @_requires_fetch_mode(FetchMode.ROW)
     def fetchall(self) -> list[Any]:
         """
@@ -637,42 +602,24 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             sequence: List of all remaining rows
         """
-        if self._iterator is None:
-            self._iterator = self._get_iterator()
+        if not self._iterator:
+            self._iterator = self._create_row_iterator()
         rows = list(self._iterator)
         self._rownumber += len(rows)
         return rows
 
     # ------------------------------------------------------------------
-    # PEP 249 optional / no-op methods
-    # ------------------------------------------------------------------
-
-    @pep249
-    def nextset(self) -> None:
-        """
-        Skip to the next available set, discarding any remaining rows from current set.
-
-        Returns:
-            bool: True if next set is available, False/None otherwise
-
-        Raises:
-            NotSupportedError: If not implemented
-        """
-        raise NotSupportedError("nextset is not implemented")
-
-    @pep249
-    def setinputsizes(self, sizes: Sequence[Any]) -> None:
-        """Not supported."""
-        return None
-
-    @pep249
-    def setoutputsize(self, size: int, column: int | None = None) -> None:
-        """Not supported."""
-        return None
-
-    # ------------------------------------------------------------------
     # Iterator protocol
     # ------------------------------------------------------------------
+
+    def _create_row_iterator(self) -> Iterator[Row | DictRow]:
+        stream_ptr = get_stream_ptr(self._execute_result)
+        return create_row_iterator(
+            stream_ptr=stream_ptr,
+            use_dict_result=self._use_dict_result,
+            # TODO: SNOW-2997786, temporarily hardcoded
+            use_numpy=False,
+        )
 
     @pep249
     def __iter__(self) -> SnowflakeCursorBase:
@@ -705,6 +652,44 @@ class SnowflakeCursorBase(abc.ABC):
         return self.__next__()
 
     # ------------------------------------------------------------------
+    # PEP 249 optional / no-op methods
+    # ------------------------------------------------------------------
+
+    @pep249
+    def nextset(self) -> None:
+        """
+        Skip to the next available set, discarding any remaining rows from current set.
+
+        Returns:
+            bool: True if next set is available, False/None otherwise
+
+        Raises:
+            NotSupportedError: If not implemented
+        """
+        raise NotSupportedError("nextset is not implemented")
+
+    @pep249
+    def setinputsizes(self, sizes: Sequence[Any]) -> None:
+        """Not supported."""
+        return None
+
+    @pep249
+    def setoutputsize(self, size: int, column: int | None = None) -> None:
+        """Not supported."""
+        return None
+
+    @property
+    @pep249
+    def lastrowid(self) -> None:
+        """Snowflake does not support lastrowid; returns None per PEP 249."""
+        return None
+
+    @pep249
+    def scroll(self, value: int, mode: str = "relative") -> None:
+        """Scroll the cursor in the result set."""
+        raise NotSupportedError("scroll is not supported")
+
+    # ------------------------------------------------------------------
     # Context manager
     # ------------------------------------------------------------------
 
@@ -728,18 +713,46 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             bool: True if closed, False otherwise
         """
-        return self._closed
+        return self._closed or self._connection.is_closed()
 
-    @property
+    def reset(self, closing: bool = False) -> None:
+        """Reset the result set.
+
+        Frees heavy result data (arrow streams) while for backward compatibility
+        preserving metadata that the old driver also keeps across resets:
+        ``description``, ``rownumber``, ``sfqid``, ``query``, and ``sqlstate``.
+
+        Args:
+            closing: If True, do not reset rowcount,
+                     see: SNOW-647539: Do not erase the rowcount information when closing the cursor.
+                     If False, reset rowcount to None.
+        """
+        if not closing:
+            self._rowcount = None
+        self._execute_result = None
+        self._iterator = None
+        self._fetch_mode = None
+        self._binding_data = None
+
     @pep249
-    def rownumber(self) -> int | None:
-        """The current 0-based index of the cursor in the result set, or ``None`` if indeterminate."""
-        return self._rownumber if self._rownumber >= 0 else None
+    def close(self) -> bool | None:
+        """Close the cursor now.
 
-    @property
-    def sqlstate(self) -> str | None:
-        """The SQLSTATE code of the last executed operation."""
-        return self._sqlstate
+        Returns whether the cursor was closed during this call.
+        """
+        try:
+            if self._closed:
+                return False
+            self.reset(closing=True)
+            self._closed = True
+            del self._messages[:]
+            return True
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # Session parameter accessors
+    # ------------------------------------------------------------------
 
     @property
     def timestamp_output_format(self) -> str | None:
@@ -790,6 +803,10 @@ class SnowflakeCursorBase(abc.ABC):
         """The session's ``BINARY_OUTPUT_FORMAT`` parameter value (``HEX`` or ``BASE64``)."""
         return self._connection._get_session_parameter("BINARY_OUTPUT_FORMAT")
 
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
     @property
     @pep249
     def errorhandler(self) -> Callable:
@@ -802,67 +819,28 @@ class SnowflakeCursorBase(abc.ABC):
             raise ProgrammingError("Invalid errorhandler is specified")
         self._errorhandler = value
 
-    @property
-    def is_file_transfer(self) -> bool:
-        """Whether the last executed command was a PUT or GET file transfer."""
-        raise NotImplementedError("is_file_transfer is not yet implemented")
+    # ------------------------------------------------------------------
+    # Fetch – Arrow / Pandas
+    # ------------------------------------------------------------------
 
-    @property
-    @pep249
-    def lastrowid(self) -> None:
-        """Snowflake does not support lastrowid; returns None per PEP 249."""
-        return None
-
-    def execute_async(
-        self,
-        command: str,
-        params: Sequence[Any] | dict[str, Any] | None = None,
-        timeout: int | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Execute a query asynchronously without waiting for results."""
-        raise NotImplementedError("execute_async is not yet implemented")
-
-    @pep249
-    def scroll(self, value: int, mode: str = "relative") -> None:
-        """Scroll the cursor in the result set."""
-        raise NotSupportedError("scroll is not supported")
-
-    def reset(self, closing: bool = False) -> None:
-        """Reset the result set.
-
-        Frees heavy result data (arrow streams) while for backward compatibility
-        preserving metadata that the old driver also keeps across resets:
-        ``description``, ``rownumber``, ``sfqid``, ``query``, and ``sqlstate``.
-
-        Args:
-            closing: If True, do not reset rowcount,
-                     see: SNOW-647539: Do not erase the rowcount information when closing the cursor.
-                     If False, reset rowcount to None.
-        """
-        if not closing:
-            self._rowcount = None
-        self.execute_result = None
-        self._iterator = None
-        self._fetch_mode = None
-        self._binding_data = None
-
-    @_requires_not_closed
     @requires_dependency(pyarrow)
+    @_requires_open
     @_requires_fetch_mode(FetchMode.ARROW)
     def fetch_arrow_batches(
         self,
         force_microsecond_precision: bool = False,
     ) -> Iterator[Table]:
         """Fetch Arrow Tables in batches."""
-        iterator = self._get_table_iterator(
+        iterator = create_table_iterator(
+            stream_ptr=get_stream_ptr(self._execute_result),
+            number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
         )
         for batch in iterator:
             yield pyarrow.Table.from_batches([batch])
 
-    @_requires_not_closed
     @requires_dependency(pyarrow)
+    @_requires_open
     @_requires_fetch_mode(FetchMode.ARROW)
     def fetch_arrow_all(
         self,
@@ -870,47 +848,26 @@ class SnowflakeCursorBase(abc.ABC):
         force_microsecond_precision: bool = False,
     ) -> Table | None:
         """Fetch all results as a single Arrow Table."""
-        iterator = self._get_table_iterator(
+        iterator = create_table_iterator(
+            stream_ptr=get_stream_ptr(self._execute_result),
+            number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
         )
-        batches = list(iterator)
-        if not batches:
-            if force_return_table:
-                schema = iterator.get_converted_schema()
-                normalized_schema = self._normalize_fixed_column_types(schema)
-                return normalized_schema.empty_table()
-            return None
-        return pyarrow.Table.from_batches(batches)
+        return collect_arrow_table(
+            table_iterator=iterator,
+            columns_metadata=self._description,
+            force_return_table=force_return_table,
+        )
 
-    def _normalize_fixed_column_types(self, schema: Schema) -> Schema:
-        """Rewrite FIXED columns in an empty-result schema to int64 for backward compatibility.
-        When the result set has zero rows, the core chooses a narrower integer type
-        (i.e. int8) for NUMBER or float64 for SCALED NUMBER.
-        The old driver always exposed int64 in this case.
-        We use cursor.description (which is populated from query metadata) to identify FIXED columns and cast them.
-        """
-        if not self._description:
-            return schema
-
-        new_fields = []
-        changed = False
-        for field, metadata in zip(schema, self._description):
-            if metadata.type_code == FIXED and field.type != pyarrow.int64():
-                new_fields.append(field.with_type(pyarrow.int64()))
-                changed = True
-            else:
-                new_fields.append(field)
-        return pyarrow.schema(new_fields) if changed else schema
-
-    @_requires_not_closed
     @requires_dependency(pandas)
+    @_requires_open
     def fetch_pandas_batches(self, **kwargs: Any) -> Iterator[DataFrame]:
         """Fetch Pandas DataFrames in batches."""
         for table in self.fetch_arrow_batches(**kwargs):
             yield table.to_pandas()
 
-    @_requires_not_closed
     @requires_dependency(pandas)
+    @_requires_open
     def fetch_pandas_all(self, **kwargs: Any) -> DataFrame:
         """Fetch all results as a single Pandas DataFrame."""
         table: Table = self.fetch_arrow_all(force_return_table=True, **kwargs)
@@ -922,8 +879,19 @@ class SnowflakeCursorBase(abc.ABC):
     def check_can_use_pandas(self) -> None:
         check_dependency(pandas)
 
-    @_requires_not_closed
-    @_requires_open_connection
+    # ------------------------------------------------------------------
+    # Distributed fetch
+    # ------------------------------------------------------------------
+
+    def get_result_batches(self) -> list[Any] | None:
+        """Get the previously executed query's ResultBatches if available."""
+        raise NotImplementedError("get_result_batches is not yet implemented")
+
+    # ------------------------------------------------------------------
+    # Async query support
+    # ------------------------------------------------------------------
+
+    @_requires_open
     def query_result(self, qid: str) -> SnowflakeCursorBase:
         """Fetch the result of a previously executed query by its Snowflake Query ID.
 
@@ -953,14 +921,20 @@ class SnowflakeCursorBase(abc.ABC):
 
         return self
 
-    def abort_query(self, qid: str) -> bool:
-        """Abort a running query."""
-        raise NotImplementedError("abort_query is not yet implemented")
-
     def get_results_from_sfqid(self, sfqid: str) -> None:
         """Get results from a previously executed async query."""
         raise NotImplementedError("get_results_from_sfqid is not yet implemented")
 
-    def get_result_batches(self) -> list[Any] | None:
-        """Get the previously executed query's ResultBatches if available."""
-        raise NotImplementedError("get_result_batches is not yet implemented")
+    def execute_async(
+        self,
+        command: str,
+        params: Sequence[Any] | dict[str, Any] | None = None,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Execute a query asynchronously without waiting for results."""
+        raise NotImplementedError("execute_async is not yet implemented")
+
+    def abort_query(self, qid: str) -> bool:
+        """Abort a running query."""
+        raise NotImplementedError("abort_query is not yet implemented")

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -3,7 +3,7 @@ Unit tests for PEP 249 Cursor class.
 """
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -28,8 +28,9 @@ class TestFetchone:
 
     @pytest.fixture
     def mock_connection(self):
-        """Create a mock connection for testing."""
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -42,7 +43,7 @@ class TestFetchone:
         mock_iterator = iter(mock_rows)
         cursor._iterator = mock_iterator
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchone()
 
         assert result == (1,)
@@ -52,7 +53,7 @@ class TestFetchone:
         mock_iterator = iter([])
         cursor._iterator = mock_iterator
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchone()
 
         assert result is None
@@ -63,7 +64,7 @@ class TestFetchone:
         mock_iterator = iter(mock_rows)
         cursor._iterator = mock_iterator
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             first = cursor.fetchone()
             second = cursor.fetchone()
             third = cursor.fetchone()
@@ -74,11 +75,11 @@ class TestFetchone:
         assert third == (3,)
         assert fourth is None
 
-    def test_fetchone_calls_get_iterator_if_iterator_is_none(self, cursor):
-        """Test fetchone calls _get_iterator."""
+    def test_fetchone_calls_create_row_iterator_if_iterator_is_none(self, cursor):
+        """Test fetchone calls _create_row_iterator."""
         mock_ensure = MagicMock(return_value=iter([(1,)]))
 
-        with patch.object(cursor, "_get_iterator", mock_ensure):
+        with patch.object(cursor, "_create_row_iterator", mock_ensure):
             cursor.fetchone()
 
         mock_ensure.assert_called_once()
@@ -88,7 +89,7 @@ class TestFetchone:
         mock_rows = [(1, "hello", 3.14)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchone()
 
         assert result == (1, "hello", 3.14)
@@ -98,7 +99,7 @@ class TestFetchone:
         mock_rows = [(1, "text", Decimal("3.14"), None, True)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchone()
 
         assert result[0] == 1
@@ -113,7 +114,7 @@ class TestFetchone:
         mock_rows = [()]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchone()
 
         assert result == ()
@@ -123,7 +124,7 @@ class TestFetchone:
         mock_rows = [(1,)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()  # Consume the row
             result1 = cursor.fetchone()
             result2 = cursor.fetchone()
@@ -137,8 +138,9 @@ class TestFetchall:
 
     @pytest.fixture
     def mock_connection(self):
-        """Create a mock connection for testing."""
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -150,7 +152,7 @@ class TestFetchall:
         mock_rows = [(1,), (2,), (3,)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert result == [(1,), (2,), (3,)]
@@ -159,16 +161,16 @@ class TestFetchall:
         """Test fetchall returns empty list when no rows."""
         cursor._iterator = iter([])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert result == []
 
-    def test_fetchall_calls_get_iterator_if_iterator_is_none(self, cursor):
-        """Test fetchall calls _get_iterator."""
+    def test_fetchall_calls_create_row_iterator_if_iterator_is_none(self, cursor):
+        """Test fetchall calls _create_row_iterator."""
         mock_ensure = MagicMock()
 
-        with patch.object(cursor, "_get_iterator", mock_ensure):
+        with patch.object(cursor, "_create_row_iterator", mock_ensure):
             cursor.fetchall()
 
         mock_ensure.assert_called_once()
@@ -178,7 +180,7 @@ class TestFetchall:
         mock_rows = [(42,)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert result == [(42,)]
@@ -193,7 +195,7 @@ class TestFetchall:
         ]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert result == [(1, "a", 1.0), (2, "b", 2.0), (3, "c", 3.0)]
@@ -206,7 +208,7 @@ class TestFetchall:
         ]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert result[0] == (1, "text", Decimal("3.14"), None)
@@ -220,7 +222,7 @@ class TestFetchall:
         mock_iterator = iter(mock_rows)
         cursor._iterator = mock_iterator
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             # Fetch first two rows
             cursor.fetchone()
             cursor.fetchone()
@@ -235,7 +237,7 @@ class TestFetchall:
         mock_iterator = iter(mock_rows)
         cursor._iterator = mock_iterator
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchall()  # Consume all rows
             result = cursor.fetchall()
 
@@ -246,7 +248,7 @@ class TestFetchall:
         mock_rows = [(i,) for i in range(1000)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert len(result) == 1000
@@ -258,7 +260,7 @@ class TestFetchall:
         mock_rows = [(1,), (2,), (3,)]
         cursor._iterator = iter(mock_rows)
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             result = cursor.fetchall()
 
         assert isinstance(result, list)
@@ -270,7 +272,9 @@ class TestFetchmany:
     @pytest.fixture
     def mock_connection(self):
         """Create a mock connection for testing."""
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -728,7 +732,7 @@ class TestStats:
         """stats returns all-None when execute_result has no stats field."""
         mock_result = MagicMock()
         mock_result.HasField.return_value = False
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
 
         result = cursor.stats
 
@@ -747,7 +751,7 @@ class TestStats:
         mock_result = MagicMock()
         mock_result.HasField.return_value = True
         mock_result.stats = mock_stats
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
 
         result = cursor.stats
 
@@ -774,7 +778,7 @@ class TestStats:
         mock_result = MagicMock()
         mock_result.HasField.return_value = True
         mock_result.stats = mock_stats
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
 
         result = cursor.stats
 
@@ -795,7 +799,7 @@ class TestStats:
         mock_result = MagicMock()
         mock_result.HasField.return_value = True
         mock_result.stats = mock_stats
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
 
         result = cursor.stats
 
@@ -807,7 +811,7 @@ class TestStats:
 
         mock_result = MagicMock()
         mock_result.HasField.return_value = False
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
         assert isinstance(cursor.stats, QueryResultStats)
 
     def test_stats_updates_on_subsequent_execute(self, cursor):
@@ -819,7 +823,7 @@ class TestStats:
         first_result = MagicMock()
         first_result.HasField.return_value = True
         first_result.stats = first_stats
-        cursor.execute_result = first_result
+        cursor._execute_result = first_result
 
         assert cursor.stats.num_rows_inserted == 5
 
@@ -830,7 +834,7 @@ class TestStats:
         second_result = MagicMock()
         second_result.HasField.return_value = True
         second_result.stats = second_stats
-        cursor.execute_result = second_result
+        cursor._execute_result = second_result
 
         assert cursor.stats.num_rows_inserted == 20
 
@@ -847,7 +851,7 @@ class TestStats:
         mock_result = MagicMock()
         mock_result.HasField.return_value = True
         mock_result.stats = mock_stats
-        cursor.execute_result = mock_result
+        cursor._execute_result = mock_result
 
         result = cursor.stats
         assert result == QueryResultStats(
@@ -860,8 +864,9 @@ class TestFetchmanyArraysizeAttribute:
 
     @pytest.fixture
     def mock_connection(self):
-        """Create a mock connection for testing."""
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -899,7 +904,9 @@ class TestRownumber:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -913,7 +920,7 @@ class TestRownumber:
         """rownumber increments by 1 for each fetchone call."""
         cursor._iterator = iter([(1,), (2,), (3,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
             assert cursor.rownumber == 0
             cursor.fetchone()
@@ -925,7 +932,7 @@ class TestRownumber:
         """rownumber stays at last value when fetchone returns None."""
         cursor._iterator = iter([(1,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
             assert cursor.rownumber == 0
             cursor.fetchone()  # returns None
@@ -935,7 +942,7 @@ class TestRownumber:
         """rownumber reflects total rows fetched after fetchall."""
         cursor._iterator = iter([(1,), (2,), (3,), (4,), (5,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchall()
             assert cursor.rownumber == 4
 
@@ -943,7 +950,7 @@ class TestRownumber:
         """rownumber is correct when fetchall follows partial fetchone consumption."""
         cursor._iterator = iter([(1,), (2,), (3,), (4,), (5,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
             cursor.fetchone()
             assert cursor.rownumber == 1
@@ -954,7 +961,7 @@ class TestRownumber:
         """rownumber increments correctly through fetchmany calls."""
         cursor._iterator = iter([(1,), (2,), (3,), (4,), (5,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchmany(3)
             assert cursor.rownumber == 2
             cursor.fetchmany(2)
@@ -964,7 +971,7 @@ class TestRownumber:
         """rownumber stays None when fetchall returns no rows."""
         cursor._iterator = iter([])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchall()
             assert cursor.rownumber is None
 
@@ -972,7 +979,7 @@ class TestRownumber:
         """rownumber resets to None after a new execute call."""
         cursor._iterator = iter([(1,), (2,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
             assert cursor.rownumber == 0
 
@@ -1047,7 +1054,9 @@ class TestFetchArrowBatches:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -1068,7 +1077,10 @@ class TestFetchArrowBatches:
         table1, table2 = MagicMock(), MagicMock()
         self.pa.Table.from_batches.side_effect = [table1, table2]
 
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([batch1, batch2])):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])),
+        ):
             tables = list(cursor.fetch_arrow_batches())
 
         assert tables == [table1, table2]
@@ -1076,7 +1088,10 @@ class TestFetchArrowBatches:
         self.pa.Table.from_batches.assert_any_call([batch2])
 
     def test_yields_nothing_for_empty_stream(self, cursor):
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([])):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
+        ):
             tables = list(cursor.fetch_arrow_batches())
 
         assert tables == []
@@ -1091,10 +1106,13 @@ class TestFetchArrowBatches:
                 list(cursor.fetch_arrow_batches())
 
     def test_passes_force_microsecond_precision(self, cursor):
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([])) as mock_get:
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get,
+        ):
             list(cursor.fetch_arrow_batches(force_microsecond_precision=True))
 
-        mock_get.assert_called_once_with(force_microsecond_precision=True)
+        mock_get.assert_called_once_with(stream_ptr=42, force_microsecond_precision=True, number_to_decimal=ANY)
 
 
 class TestFetchArrowAll:
@@ -1102,7 +1120,9 @@ class TestFetchArrowAll:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -1114,6 +1134,7 @@ class TestFetchArrowAll:
         with (
             patch("snowflake.connector._internal.extras.check_dependency"),
             patch("snowflake.connector.cursor._base.pyarrow", new=mock_pa),
+            patch("snowflake.connector._internal.arrow_stream_utils.pyarrow", new=mock_pa),
         ):
             self.pa = mock_pa
             yield
@@ -1123,7 +1144,10 @@ class TestFetchArrowAll:
         mock_table = MagicMock()
         self.pa.Table.from_batches.return_value = mock_table
 
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([batch1, batch2])):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])),
+        ):
             result = cursor.fetch_arrow_all()
 
         assert result is mock_table
@@ -1133,7 +1157,10 @@ class TestFetchArrowAll:
         mock_iterator = MagicMock()
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
 
-        with patch.object(cursor, "_get_table_iterator", return_value=mock_iterator):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator),
+        ):
             result = cursor.fetch_arrow_all()
 
         assert result is None
@@ -1147,7 +1174,10 @@ class TestFetchArrowAll:
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
         mock_iterator.get_converted_schema.return_value = mock_schema
 
-        with patch.object(cursor, "_get_table_iterator", return_value=mock_iterator):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator),
+        ):
             result = cursor.fetch_arrow_all(force_return_table=True)
 
         assert result is mock_empty_table
@@ -1155,19 +1185,22 @@ class TestFetchArrowAll:
         mock_schema.empty_table.assert_called_once()
 
     def test_returns_none_without_force_return_table(self, cursor):
-        mock_iterator = MagicMock()
-        mock_iterator.__iter__ = MagicMock(return_value=iter([]))
-
-        with patch.object(cursor, "_get_table_iterator", return_value=mock_iterator):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
+        ):
             result = cursor.fetch_arrow_all(force_return_table=False)
 
         assert result is None
 
     def test_passes_force_microsecond_precision(self, cursor):
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([])) as mock_get:
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get,
+        ):
             cursor.fetch_arrow_all(force_microsecond_precision=True)
 
-        mock_get.assert_called_once_with(force_microsecond_precision=True)
+        mock_get.assert_called_once_with(stream_ptr=42, force_microsecond_precision=True, number_to_decimal=ANY)
 
 
 class TestFetchPandasBatches:
@@ -1175,7 +1208,9 @@ class TestFetchPandasBatches:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -1214,7 +1249,9 @@ class TestFetchPandasAll:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -1270,7 +1307,9 @@ class TestFetchModeValidation:
 
     @pytest.fixture
     def mock_connection(self):
-        return MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.is_closed.return_value = False
+        return mock_connection
 
     @pytest.fixture
     def cursor(self, mock_connection):
@@ -1288,14 +1327,17 @@ class TestFetchModeValidation:
     def test_row_then_arrow_raises(self, cursor):
         cursor._iterator = iter([(1,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
 
         with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
             list(cursor.fetch_arrow_batches())
 
     def test_arrow_then_row_raises(self, cursor):
-        with patch.object(cursor, "_get_table_iterator", return_value=iter([])):
+        with (
+            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
+            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
+        ):
             cursor.fetch_arrow_all()
 
         with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
@@ -1304,7 +1346,7 @@ class TestFetchModeValidation:
     def test_row_then_pandas_raises(self, cursor):
         cursor._iterator = iter([(1,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
 
         with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
@@ -1319,7 +1361,7 @@ class TestFetchModeValidation:
     def test_fetchall_then_arrow_raises(self, cursor):
         cursor._iterator = iter([(1,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchall()
 
         with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
@@ -1328,7 +1370,7 @@ class TestFetchModeValidation:
     def test_same_mode_is_fine(self, cursor):
         cursor._iterator = iter([(1,), (2,)])
 
-        with patch.object(cursor, "_get_iterator"):
+        with patch.object(cursor, "_create_row_iterator"):
             cursor.fetchone()
             cursor.fetchone()
 
@@ -1342,10 +1384,10 @@ class TestFetchModeValidation:
 
         cursor._fetch_mode = FetchMode.ARROW
         with (
-            patch("snowflake.connector._internal.query_utils.StatementNewRequest"),
-            patch("snowflake.connector._internal.query_utils.StatementSetSqlQueryRequest"),
+            patch("snowflake.connector._internal.statement_utils.StatementNewRequest"),
+            patch("snowflake.connector._internal.statement_utils.StatementSetSqlQueryRequest"),
             patch("snowflake.connector.cursor._base.StatementExecuteQueryRequest"),
-            patch("snowflake.connector._internal.query_utils.StatementReleaseRequest"),
+            patch("snowflake.connector._internal.statement_utils.StatementReleaseRequest"),
         ):
             cursor.execute("SELECT 1")
 
@@ -1365,7 +1407,7 @@ class TestReset:
 
     def test_reset_clears_all_state_together(self, cursor):
         """reset() frees heavy result data but preserves lightweight metadata."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
@@ -1380,7 +1422,7 @@ class TestReset:
         cursor.reset()
 
         # Cleared by reset
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
@@ -1394,7 +1436,7 @@ class TestReset:
 
     def test_reset_is_idempotent(self, cursor):
         """Calling reset() twice produces the same state as calling it once."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
         cursor._rowcount = 42
@@ -1402,7 +1444,7 @@ class TestReset:
         cursor.reset()
         cursor.reset()
 
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._fetch_mode is None
         assert cursor._rowcount is None
@@ -1412,7 +1454,7 @@ class TestReset:
         """reset() on a freshly created cursor doesn't break anything."""
         cursor.reset()
 
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._sqlstate is None
         assert cursor._fetch_mode is None
@@ -1422,7 +1464,7 @@ class TestReset:
 
     def test_reset_closing_true_clears_everything_except_rowcount(self, cursor):
         """reset(closing=True) preserves _rowcount in addition to the usual preserved fields."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
@@ -1437,7 +1479,7 @@ class TestReset:
         cursor.reset(closing=True)
 
         # Cleared by reset
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
@@ -1503,7 +1545,7 @@ class TestClose:
 
     def test_close_clears_result_state(self, cursor):
         """close() clears result-related state via reset (except description)."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         mock_desc = [MagicMock()]
         cursor._description = mock_desc
@@ -1511,7 +1553,7 @@ class TestClose:
 
         cursor.close()
 
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._description is mock_desc
         assert cursor._fetch_mode is None
@@ -1560,7 +1602,7 @@ class TestResetIntegration:
     def test_close_calls_reset_with_closing_true(self, cursor):
         """close() calls reset(closing=True) to preserve rowcount."""
         cursor._rowcount = 42
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
 
         cursor.close()
@@ -1568,13 +1610,13 @@ class TestResetIntegration:
         # Rowcount should be preserved
         assert cursor._rowcount == 42
         # Other state should be cleared
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor._iterator is None
         assert cursor._closed is True
 
     def test_execute_calls_reset_before_executing(self, cursor, mock_connection):
         """execute() calls reset() before executing to clear old state."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         cursor._description = [MagicMock()]
         cursor._rowcount = 100
@@ -1642,13 +1684,13 @@ class TestResetIntegration:
         """executemany() with empty seq_of_parameters returns early without calling reset."""
         cursor._fetch_mode = FetchMode.ARROW
         cursor._rowcount = 42
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
 
         cursor.executemany("INSERT INTO t VALUES (?)", [])
 
         assert cursor._fetch_mode == FetchMode.ARROW
         assert cursor._rowcount == 42
-        assert cursor.execute_result is not None
+        assert cursor._execute_result is not None
 
 
 class TestDescribe:
@@ -1704,7 +1746,7 @@ class TestDescribe:
         with patch("snowflake.connector.cursor._base.release_arrow_stream"):
             cursor.describe("SELECT 1")
 
-        assert cursor.execute_result is None
+        assert cursor._execute_result is None
         assert cursor.sfqid is None
         assert cursor.rowcount is None
         assert cursor._fetch_mode is None
@@ -1783,7 +1825,7 @@ class TestQueryResult:
         ret = cursor.query_result("01234567-abcd-ef01-0000-000000000001")
 
         assert ret is cursor
-        assert cursor.execute_result is result
+        assert cursor._execute_result is result
         assert cursor.description is not None
         assert len(cursor.description) == 1
         assert cursor.description[0].name == "ID"
@@ -1796,7 +1838,7 @@ class TestQueryResult:
 
     def test_query_result_resets_prior_state(self, cursor, mock_connection):
         """query_result clears iterator and fetch mode from a previous execute."""
-        cursor.execute_result = MagicMock()
+        cursor._execute_result = MagicMock()
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 


### PR DESCRIPTION
Split the monolithic query_utils.py into two single-responsibility modules:
- statement_utils.py: statement lifecycle (create, release) and result
  extraction (rowcount, sqlstate, stream pointer)
- arrow_stream_utils.py: Arrow stream construction, schema normalization,
  and table collection helpers

Refactor SnowflakeCursorBase alongside the split:
- Merge _requires_not_closed and _requires_open_connection into a single
  _requires_open decorator backed by is_closed() checking both cursor and
  connection state
- Make execute_result private (_execute_result)
- Extract _get_iterator/_get_table_iterator and _normalize_fixed_column_types
  out of the cursor into arrow_stream_utils as standalone functions
- Reorder class body into logical sections (lifecycle, PEP 249 config,
  query metadata, fetch, Arrow/Pandas, async, session params, errors)