### PR TITLE
Cache test dependencies

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .ccache
-          key: ${{ runner.os }}-ccache-odbc-${{ github.sha }}
+          key: ${{ runner.os }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
             ${{ runner.os }}-ccache-odbc-
 
@@ -276,7 +276,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .ccache
-          key: ${{ runner.os }}-ccache-odbc-${{ github.sha }}
+          key: ${{ runner.os }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
             ${{ runner.os }}-ccache-odbc-
 

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -16,6 +16,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_MAXSIZE: 200M
 
 jobs:
   detect-changes:
@@ -94,9 +97,17 @@ jobs:
         uses: actions/cache@v5
         with:
           path: odbc_tests/cmake-build/_deps
-          key: ${{ runner.os }}-catch2-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-catch2-deps-
+            ${{ runner.os }}-test-deps-
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-ccache-odbc-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-odbc-
 
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
@@ -110,6 +121,8 @@ jobs:
 
           Invoke-Checked "pip install cmake" { pip install cmake>=4.0.3 }
           cmake --version
+
+          Invoke-Checked "choco install ccache" { choco install ccache -y --no-progress }
 
           Invoke-Checked "vcpkg install zlib:x64-windows" { vcpkg install zlib:x64-windows }
 
@@ -126,7 +139,7 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y unixodbc unixodbc-dev curl odbcinst zlib1g-dev
+          sudo apt-get install -y unixodbc unixodbc-dev curl odbcinst zlib1g-dev ccache
 
           pip install cmake>=4.0.3
           cmake --version
@@ -160,6 +173,8 @@ jobs:
               -D ODBC_LIBRARY="/usr/lib/x86_64-linux-gnu/libodbc.so" \
               -D ODBC_INCLUDE_DIR="/usr/include" \
               -D DRIVER_TYPE=OLD \
+              -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -D CMAKE_C_COMPILER_LAUNCHER=ccache \
               .
           cmake --build cmake-build -- -j $(($(nproc) * 2))
           ctest -j $(($(nproc) * 4)) -C Debug --test-dir cmake-build --output-on-failure
@@ -253,16 +268,24 @@ jobs:
         uses: actions/cache@v5
         with:
           path: odbc_tests/cmake-build/_deps
-          key: ${{ runner.os }}-catch2-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-catch2-deps-
+            ${{ runner.os }}-test-deps-
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-ccache-odbc-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-odbc-
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y unixodbc-dev build-essential zlib1g-dev
+          sudo apt-get install -y unixodbc-dev build-essential zlib1g-dev ccache
           wget https://github.com/Kitware/CMake/releases/download/v4.0.3/cmake-4.0.3-linux-x86_64.sh
           sudo sh cmake-4.0.3-linux-x86_64.sh --skip-license --prefix=/usr/local
           sudo rm cmake-4.0.3-linux-x86_64.sh
@@ -273,7 +296,7 @@ jobs:
         run: |
           set -euxo pipefail
           # Go is required for building aws-lc-fips-sys (FIPS crypto)
-          brew install unixodbc cmake go
+          brew install unixodbc cmake go ccache
           cmake --version
           go version
           # Export ODBC paths dynamically (works for both ARM64 and Intel Macs)
@@ -291,6 +314,8 @@ jobs:
 
           Invoke-Checked "pip install cmake" { pip install cmake>=4.0.3 }
           cmake --version
+
+          Invoke-Checked "choco install ccache" { choco install ccache -y --no-progress }
 
           if (!(Test-Path "C:\Program Files\OpenSSL\lib\VC\x64\MD")) {
             Invoke-Checked "choco install openssl" { choco install openssl -y --no-progress }

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -90,6 +90,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache Test dependencies
+        uses: actions/cache@v5
+        with:
+          path: odbc_tests/cmake-build/_deps
+          key: ${{ runner.os }}-catch2-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-catch2-deps-
+
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -240,6 +248,14 @@ jobs:
           key: ${{ runner.os }}-rust-odbc-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-odbc-target-
+
+      - name: Cache Test dependencies
+        uses: actions/cache@v5
+        with:
+          path: odbc_tests/cmake-build/_deps
+          key: ${{ runner.os }}-catch2-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-catch2-deps-
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ build
 jdbc/.gradle
 jdbc/build
 odbc_tests/cmake-build
-odbc_tests/.ccache
 parameters*.json
 **/rsa_key.p8
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build
 jdbc/.gradle
 jdbc/build
 odbc_tests/cmake-build
+odbc_tests/.ccache
 parameters*.json
 **/rsa_key.p8
 .DS_Store

--- a/odbc/README.md
+++ b/odbc/README.md
@@ -11,6 +11,9 @@ Before running tests, ensure you have:
 - CMake 3.10 or later
 - C++17 compatible compiler
 - coreutils (for `nproc`), unixodbc (for `odbc_config`) from `brew`
+- (Optional) ccache for faster rebuilds: `brew install ccache`
+
+When ccache is installed, the build scripts automatically use it. The cache is stored in `odbc_tests/.ccache/` and persists across builds.
 
 ### Local Testing (macOS/Linux)
 

--- a/odbc/README.md
+++ b/odbc/README.md
@@ -13,7 +13,7 @@ Before running tests, ensure you have:
 - coreutils (for `nproc`), unixodbc (for `odbc_config`) from `brew`
 - (Optional) ccache for faster rebuilds: `brew install ccache`
 
-When ccache is installed, the build scripts automatically use it. The cache is stored in `odbc_tests/.ccache/` and persists across builds.
+When ccache is installed, the build scripts automatically use it as the compiler launcher.
 
 ### Local Testing (macOS/Linux)
 

--- a/odbc_tests/Dockerfile
+++ b/odbc_tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y unixodbc unixodbc-dev curl odbcinst wget build-essential git gdb \
-    zlib1g-dev libssl-dev jq
+    zlib1g-dev libssl-dev jq ccache
 
 # Install CMake (detect architecture automatically)
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/odbc_tests/run.ps1
+++ b/odbc_tests/run.ps1
@@ -36,6 +36,10 @@ try {
     New-Item -ItemType Directory -Force -Path cmake-build | Out-Null
 
     $cmakeArgs = @("-B", "cmake-build", "-D", "DRIVER_TYPE=NEW")
+    if (Get-Command ccache -ErrorAction SilentlyContinue) {
+        $cmakeArgs += @("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+        $env:CCACHE_DIR = Join-Path $PSScriptRoot ".ccache"
+    }
     $vcpkgRoot = if ($env:VCPKG_INSTALLATION_ROOT) { $env:VCPKG_INSTALLATION_ROOT } elseif ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $null }
     if ($vcpkgRoot) {
         $cmakeArgs += "-DCMAKE_TOOLCHAIN_FILE=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake"

--- a/odbc_tests/run.ps1
+++ b/odbc_tests/run.ps1
@@ -38,7 +38,6 @@ try {
     $cmakeArgs = @("-B", "cmake-build", "-D", "DRIVER_TYPE=NEW")
     if (Get-Command ccache -ErrorAction SilentlyContinue) {
         $cmakeArgs += @("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
-        $env:CCACHE_DIR = Join-Path $PSScriptRoot ".ccache"
     }
     $vcpkgRoot = if ($env:VCPKG_INSTALLATION_ROOT) { $env:VCPKG_INSTALLATION_ROOT } elseif ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $null }
     if ($vcpkgRoot) {

--- a/odbc_tests/run.sh
+++ b/odbc_tests/run.sh
@@ -16,6 +16,12 @@ fi
 export DRIVER_PATH=$(pwd)/target/debug/libsfodbc.${DYLIB_EXT}
 export PARAMETER_PATH=${PARAMETER_PATH:-$(pwd)/parameters.json}
 
+CCACHE_ARGS=""
+if command -v ccache &>/dev/null; then
+    CCACHE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache"
+    export CCACHE_DIR="$(pwd)/odbc_tests/.ccache"
+fi
+
 pushd odbc_tests
     if [ ! -d cmake-build ]; then
         mkdir -p cmake-build
@@ -25,6 +31,7 @@ pushd odbc_tests
             -D ODBC_LIBRARY="$(odbc_config --lib-prefix)/libodbc.${DYLIB_EXT}" \
             -D ODBC_INCLUDE_DIR="$(odbc_config --include-prefix)" \
             -D DRIVER_TYPE=NEW \
+            ${CCACHE_ARGS} \
             .
     fi
     cmake --build cmake-build -- -j 16

--- a/odbc_tests/run.sh
+++ b/odbc_tests/run.sh
@@ -19,7 +19,6 @@ export PARAMETER_PATH=${PARAMETER_PATH:-$(pwd)/parameters.json}
 CCACHE_ARGS=""
 if command -v ccache &>/dev/null; then
     CCACHE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache"
-    export CCACHE_DIR="$(pwd)/odbc_tests/.ccache"
 fi
 
 pushd odbc_tests

--- a/odbc_tests/run_reference.ps1
+++ b/odbc_tests/run_reference.ps1
@@ -99,6 +99,10 @@ try {
 
     New-Item -ItemType Directory -Force -Path cmake-build-reference | Out-Null
     $cmakeArgs = @("-B", "cmake-build-reference", "-D", "DRIVER_TYPE=OLD")
+    if (Get-Command ccache -ErrorAction SilentlyContinue) {
+        $cmakeArgs += @("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+        $env:CCACHE_DIR = Join-Path $ScriptDir ".ccache"
+    }
     $vcpkgRoot = if ($env:VCPKG_INSTALLATION_ROOT) { $env:VCPKG_INSTALLATION_ROOT } elseif ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $null }
     if ($vcpkgRoot) {
         $cmakeArgs += "-DCMAKE_TOOLCHAIN_FILE=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake"

--- a/odbc_tests/run_reference.ps1
+++ b/odbc_tests/run_reference.ps1
@@ -101,7 +101,6 @@ try {
     $cmakeArgs = @("-B", "cmake-build-reference", "-D", "DRIVER_TYPE=OLD")
     if (Get-Command ccache -ErrorAction SilentlyContinue) {
         $cmakeArgs += @("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
-        $env:CCACHE_DIR = Join-Path $ScriptDir ".ccache"
     }
     $vcpkgRoot = if ($env:VCPKG_INSTALLATION_ROOT) { $env:VCPKG_INSTALLATION_ROOT } elseif ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $null }
     if ($vcpkgRoot) {

--- a/odbc_tests/run_reference.sh
+++ b/odbc_tests/run_reference.sh
@@ -27,10 +27,8 @@ docker build \
     -t odbc-reference-tests "$SCRIPT_DIR"
 
 echo "Running ODBC reference tests in Docker container..."
-mkdir -p "$SCRIPT_DIR/.ccache"
 docker run --rm \
     -v "$PROJECT_ROOT":/workspace \
-    -v "$SCRIPT_DIR/.ccache:/root/.ccache" \
     -w /workspace \
     -e DRIVER_PATH="/usr/lib/snowflake/odbc/lib/libSnowflake.so" \
     -e PARAMETER_PATH="/workspace/parameters.json" \

--- a/odbc_tests/run_reference.sh
+++ b/odbc_tests/run_reference.sh
@@ -27,8 +27,10 @@ docker build \
     -t odbc-reference-tests "$SCRIPT_DIR"
 
 echo "Running ODBC reference tests in Docker container..."
+mkdir -p "$SCRIPT_DIR/.ccache"
 docker run --rm \
     -v "$PROJECT_ROOT":/workspace \
+    -v "$SCRIPT_DIR/.ccache:/root/.ccache" \
     -w /workspace \
     -e DRIVER_PATH="/usr/lib/snowflake/odbc/lib/libSnowflake.so" \
     -e PARAMETER_PATH="/workspace/parameters.json" \
@@ -59,6 +61,8 @@ docker run --rm \
             -D ODBC_LIBRARY=\"\$ODBC_LIB\" \\
             -D ODBC_INCLUDE_DIR='/usr/include' \\
             -D DRIVER_TYPE=OLD \\
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \\
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \\
             .
         
         # Build tests

--- a/scripts/odbc/run_tests_unix.sh
+++ b/scripts/odbc/run_tests_unix.sh
@@ -17,11 +17,17 @@ else
     NPROC=$(nproc)
 fi
 
+CCACHE_ARGS=""
+if command -v ccache &>/dev/null; then
+    CCACHE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache"
+fi
+
 mkdir -p cmake-build
 cmake -B cmake-build \
     -D ODBC_LIBRARY="${ODBC_LIBRARY}" \
     -D ODBC_INCLUDE_DIR="${ODBC_INCLUDE_DIR}" \
     -D DRIVER_TYPE="${DRIVER_TYPE}" \
+    ${CCACHE_ARGS} \
     .
 cmake --build cmake-build -- -j $((NPROC * 2))
 ctest -j $((NPROC * 4)) -C Debug --test-dir cmake-build --output-on-failure

--- a/scripts/odbc/run_tests_windows.ps1
+++ b/scripts/odbc/run_tests_windows.ps1
@@ -10,6 +10,9 @@ try {
     
     New-Item -ItemType Directory -Force -Path cmake-build | Out-Null
     $cmakeArgs = @("-B", "cmake-build", "-D", "DRIVER_TYPE=$env:DRIVER_TYPE")
+    if (Get-Command ccache -ErrorAction SilentlyContinue) {
+        $cmakeArgs += @("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+    }
     if ($env:VCPKG_INSTALLATION_ROOT) {
         $cmakeArgs += "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
     }


### PR DESCRIPTION
### TL;DR

Added ccache support to ODBC test workflows and build scripts to accelerate C++ compilation times.

### What changed?

- Added ccache installation and configuration to GitHub Actions workflows for Windows, Linux, and macOS
- Configured ccache environment variables with 200MB cache size and workspace-based directories
- Added ccache caching steps to preserve compilation cache between workflow runs
- Modified all build scripts (PowerShell and Bash) to automatically detect and use ccache as compiler launcher when available
- Updated Dockerfile to include ccache installation
- Added ccache documentation to the ODBC README with installation instructions

### How to test?

Run the ODBC tests locally or through CI:
- Install ccache on your system (`brew install ccache` on macOS, `apt-get install ccache` on Linux, `choco install ccache` on Windows)
- Execute any of the test scripts in `odbc_tests/` - they will automatically detect and use ccache
- Subsequent builds should show faster compilation times due to cached object files

### Why make this change?

C++ compilation in the ODBC tests can be time-consuming, especially in CI environments where builds happen frequently. Adding ccache reduces build times by caching compiled object files, leading to faster feedback cycles and reduced CI resource usage.