### PR TITLE
fix(python): support Cython compilation in editable installs

### DIFF
--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -100,7 +100,7 @@ class BuildHook(BuildHookInterface):
         """Initialize the build hook: generate protobuf code and compile extensions."""
         self._generate_protobuf()
 
-        if self.target_name != "wheel":
+        if self.target_name not in ("wheel", "editable"):
             return
 
         if os.environ.get(self.DISABLE_COMPILE_ENV_VAR, "false").lower() in self.POSITIVE_VALUES:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "Cython", "setuptools", "mypy-protobuf~=5.0"]
+requires = ["hatchling", "editables", "Cython", "setuptools", "mypy-protobuf~=5.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -207,6 +207,10 @@ fix = [
 [tool.hatch.envs.dev]
 skip-install = false
 dev-mode = true
+dependencies = [
+    "Cython",
+    "setuptools",
+]
 
 [tool.hatch.envs.dev.env-vars]
 # IMPORTANT: PARAMETER_PATH must be explicitly set

--- a/python/tests/packaging/test_editable.py
+++ b/python/tests/packaging/test_editable.py
@@ -1,0 +1,134 @@
+"""E2E tests for editable (PEP 660) install packaging.
+
+These tests verify that a PEP 660 editable install compiles the native Cython
+extension (arrow_stream_iterator) and exports all expected symbols.  The Rust
+core build is skipped via SKIP_CORE_BUILD=1 to keep the test fast; sf_core
+loading is already covered by test_sdist.py.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import venv
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+
+def get_python_dir() -> Path:
+    """Return the python/ project root (parent of tests/)."""
+    # tests/packaging/test_editable.py -> python/
+    return Path(__file__).parent.parent.parent
+
+
+class TestEditableInstall:
+    """Tests for PEP 660 editable install."""
+
+    @pytest.fixture
+    def temp_env(self):
+        """Temporary directory for the test environment."""
+        with TemporaryDirectory(prefix="editable_test_") as tmpdir:
+            yield Path(tmpdir)
+
+    def _run_command(
+        self,
+        cmd: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int = 300,
+    ) -> subprocess.CompletedProcess:
+        full_env = os.environ.copy()
+        if env:
+            full_env.update(env)
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=full_env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def _create_venv(self, venv_path: Path) -> Path:
+        """Create a venv and return the path to its Python executable."""
+        venv.create(venv_path, with_pip=True)
+        python_exe = venv_path / "Scripts" / "python.exe" if sys.platform == "win32" else venv_path / "bin" / "python"
+        pip_exe = venv_path / "Scripts" / "pip.exe" if sys.platform == "win32" else venv_path / "bin" / "pip"
+        result = self._run_command([str(pip_exe), "install", "--upgrade", "pip"])
+        if result.returncode != 0:
+            pytest.fail(f"pip upgrade failed: {result.stderr}")
+        return python_exe
+
+    @pytest.mark.slow
+    def test_editable_install_compiles_arrow_extension(self, temp_env: Path) -> None:
+        """Editable install must compile arrow_stream_iterator and export ArrowStreamTableIterator.
+
+        Regression test for the BuildHook gap where target_name == 'editable'
+        caused an early return, leaving the Cython extension uncompiled.
+
+        Steps:
+        1. Create a fresh venv (no pre-built .so present).
+        2. pip install -e <python_dir> — exercises the PEP 660 editable path.
+        3. Assert ArrowStreamTableIterator is importable from the compiled module.
+        4. Assert the module is a native .so/.pyd (not a Python fallback).
+        """
+        python_dir = get_python_dir()
+        venv_path = temp_env / "venv"
+
+        python_exe = self._create_venv(venv_path)
+
+        # Install in editable mode.  SKIP_CORE_BUILD=1 skips the Rust release
+        # build — sf_core is covered by test_sdist.py.  Proto generation still
+        # runs (it uses cargo, but only the fast proto_generator binary).
+        result = self._run_command(
+            [str(python_exe), "-m", "pip", "install", "--editable", str(python_dir)],
+            env={"SKIP_CORE_BUILD": "1"},
+            timeout=300,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Editable install failed:\nstdout: {result.stdout}\nstderr: {result.stderr}")
+
+        # Verify ArrowStreamTableIterator is exported by the compiled extension.
+        result = self._run_command(
+            [
+                str(python_exe),
+                "-c",
+                (
+                    "from snowflake.connector._internal.arrow_stream_iterator"
+                    " import ArrowStreamTableIterator;"
+                    " print('ArrowStreamTableIterator imported successfully')"
+                ),
+            ]
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"ArrowStreamTableIterator import failed — Cython extension may not have been"
+                f" compiled during editable install:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+        assert "ArrowStreamTableIterator imported successfully" in result.stdout
+
+        # Confirm the module resolves to a compiled native extension (.so / .pyd),
+        # not a pure-Python fallback.
+        result = self._run_command(
+            [
+                str(python_exe),
+                "-c",
+                (
+                    "import snowflake.connector._internal.arrow_stream_iterator as m;"
+                    " import pathlib;"
+                    " f = pathlib.Path(m.__file__);"
+                    " assert f.suffix in ('.so', '.pyd'), f'Expected native extension, got {f}';"
+                    " print(f'Native extension confirmed: {f.name}')"
+                ),
+            ]
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"arrow_stream_iterator is not a compiled native extension:"
+                f"\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+        assert "Native extension confirmed" in result.stdout


### PR DESCRIPTION
## Summary

- `BuildHook.initialize()` now compiles Cython extensions for the `editable` target (used by `hatch run dev.*`) in addition to `wheel`. Previously, editable installs silently skipped Cython compilation, leaving dev environments with a stale `.so` missing symbols added after the last wheel build (e.g. `ArrowStreamTableIterator`).
- Added `editables` to `build-system.requires` for PEP 660 editable install support in hatchling.
- Explicitly declared `Cython` and `setuptools` in `[tool.hatch.envs.dev].dependencies` — `build-system.requires` runs in an isolated build virtualenv and is not inherited by hatch environments.

## Why this is needed

`dev-mode = true` in `pyproject.toml` implies editable installs should produce a fully functional environment. Without this fix, any developer running `hatch run dev.py3.X:integ` on a fresh env would get an incomplete `.so` that silently misses recently-added C++ symbols.

## Test plan

- [ ] `hatch env remove dev.py3.9 && hatch env create dev.py3.9` — verify env creates cleanly and `from snowflake.connector._internal.arrow_stream_iterator import ArrowStreamTableIterator` succeeds
- [ ] `hatch run dev.py3.9:unit` — passes
- [ ] `hatch run precommit:check` — passes (ruff + mypy)
- [ ] Wheel build unaffected: `hatch build --target wheel`

> **Note for reviewers:** existing dev environments must be recreated to pick up the new `Cython`/`setuptools` deps: `hatch env remove dev.py3.X && hatch env create dev.py3.X`

🤖 Generated with [Claude Code](https://claude.com/claude-code)