### PR TITLE
SNOW-3240589: Transaction support

### DIFF
--- a/odbc/exports.def
+++ b/odbc/exports.def
@@ -10,6 +10,7 @@ EXPORTS
     SQLBindCol
     SQLBindParameter
     SQLCancel
+    SQLCancelHandle
     SQLCloseCursor
     SQLColAttributeW
     SQLConnectW

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -154,6 +154,54 @@ pub unsafe extern "C" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCod
 
 /// # Safety
 /// This function is called by the ODBC driver manager.
+///
+/// `SQLCancelHandle` is the ODBC 3.8 generalization of `SQLCancel` that
+/// accepts both statement and connection handles.
+///
+/// For **SQL_HANDLE_STMT** the behavior is identical to `SQLCancel`:
+/// the cancel token is triggered through the global registry without
+/// dereferencing the statement, so it is safe for cross-thread use.
+/// Diagnostics are not touched (same reasoning as `SQLCancel`).
+///
+/// For **SQL_HANDLE_DBC** this is currently a no-op returning SUCCESS.
+/// Connection-level cancel (async connect, cross-thread
+/// `SQLDriverConnect`) will be implemented after the connection state
+/// machine is hardened (SNOW-3307201).
+///
+/// **SQL_HANDLE_ENV** and **SQL_HANDLE_DESC** return `SQL_ERROR` with
+/// SQLSTATE HY092 per the ODBC 3.8 spec. Any truly unknown handle
+/// type returns `SQL_INVALID_HANDLE`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SQLCancelHandle(
+    handle_type: sql::HandleType,
+    handle: sql::Handle,
+) -> sql::RetCode {
+    if handle.is_null() {
+        return sql::SqlReturn::INVALID_HANDLE.0;
+    }
+    match handle_type {
+        sql::HandleType::Stmt => {
+            let result = api::statement::cancel(handle);
+            result.to_sql_code()
+        }
+        // TODO(SNOW-3307201): implement connection-level cancel after
+        // the connection state machine is hardened.
+        sql::HandleType::Dbc => sql::SqlReturn::SUCCESS.0,
+        sql::HandleType::Env => {
+            api::diagnostic::clear_diag_info(sql::HandleType::Env, handle);
+            let result: api::OdbcResult<()> = api::error::UnknownAttributeSnafu {
+                attribute: handle_type as i32,
+            }
+            .fail();
+            api::diagnostic::set_diag_info_from_result(sql::HandleType::Env, handle, &result);
+            result.to_sql_code()
+        }
+        _ => sql::SqlReturn::INVALID_HANDLE.0,
+    }
+}
+
+/// # Safety
+/// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLConnect(
     connection_handle: sql::Handle,

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -398,3 +398,18 @@ behavior_differences:
       the behavior of other numeric C types bound to SQL_BIT.
       Impact: Applications binding SQL_C_NUMERIC values to BOOLEAN columns
       will succeed on the new driver for any nonzero value.
+
+  38:
+    name: "SQLGetFunctions does not report SQLCancelHandle as supported"
+    description: |
+      OLD driver: SQLGetFunctions returns SQL_FALSE for SQL_API_SQLCANCELHANDLE
+      even though the reference driver exports and handles the function.
+      The internal supported-functions bitmap does not include the ODBC 3.8
+      SQLCancelHandle entry, so the function works at runtime but the
+      SQLGetFunctions report is missing.
+      NEW driver: Will report SQL_API_SQLCANCELHANDLE as supported once
+      SQLGetFunctions is implemented.
+      Impact: Applications that probe SQLGetFunctions before calling
+      SQLCancelHandle will incorrectly believe the old driver does not
+      support it. The function works regardless of what SQLGetFunctions
+      reports.

--- a/odbc_tests/common/include/cross_thread_cancel.hpp
+++ b/odbc_tests/common/include/cross_thread_cancel.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <sql.h>
-#include <sqlext.h>
 
 #include <atomic>
 #include <chrono>
@@ -26,15 +25,20 @@ struct CrossThreadCancel {
   std::atomic<SQLRETURN> exec_result{SQL_NO_DATA};
   SQLRETURN cancel_result = SQL_ERROR;
 
-  void run(SQLHSTMT stmt, const char* query, std::chrono::seconds pre_cancel_delay) {
+  void run(const SQLHSTMT stmt, const char* query, const std::chrono::seconds pre_cancel_delay) {
+    run(stmt, query, pre_cancel_delay, [](const SQLHSTMT s) { return SQLCancel(s); });
+  }
+
+  template <typename CancelFn>
+  void run(SQLHSTMT stmt, const char* query, const std::chrono::seconds pre_cancel_delay, CancelFn cancel_fn) {
     std::mutex mtx;
     std::condition_variable cv;
-    bool executing = false;
+    std::atomic executing{false};  // NOLINT: read by cv.wait predicate on another thread
 
     std::thread executor([&]() {
       {
         std::lock_guard lk(mtx);
-        executing = true;
+        executing.store(true);
       }
       cv.notify_one();
       exec_result.store(SQLExecDirect(stmt, sqlchar(query), SQL_NTS));
@@ -43,14 +47,14 @@ struct CrossThreadCancel {
 
     {
       std::unique_lock lk(mtx);
-      cv.wait(lk, [&] { return executing; });
+      cv.wait(lk, [&] { return executing.load(); });
     }
 
     if (pre_cancel_delay.count() > 0) {
       std::this_thread::sleep_for(pre_cancel_delay);
     }
 
-    cancel_result = SQLCancel(stmt);
+    cancel_result = cancel_fn(stmt);
   }
 };
 

--- a/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_functions_tests.cpp
@@ -98,6 +98,7 @@ static const FunctionTest ALL_ODBC_FUNCTIONS[] = {
 
     // Statement Termination Functions
     {SQL_API_SQLCANCEL, "SQLCancel", true},
+    {SQL_API_SQLCANCELHANDLE, "SQLCancelHandle", false},
     {SQL_API_SQLCLOSECURSOR, "SQLCloseCursor", false},
     {SQL_API_SQLENDTRAN, "SQLEndTran", false},
     {SQL_API_SQLFREESTMT, "SQLFreeStmt", true},
@@ -125,6 +126,11 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture,
     // Windows DM does not report deprecated SQLSetScrollOptions
     WINDOWS_ONLY {
       if (func.functionId == SQL_API_SQLSETSCROLLOPTIONS) continue;
+    }
+    // BD#38: Reference driver's SQLGetFunctions bitmap omits SQL_API_SQLCANCELHANDLE
+    // even though the reference driver exports and handles the function.
+    OLD_DRIVER_ONLY("BD#38") {
+      if (func.functionId == SQL_API_SQLCANCELHANDLE) continue;
     }
     INFO("Function: " << func.name << " (ID=" << func.functionId << ")");
     REQUIRE(SQL_FUNC_EXISTS(supported, func.functionId));
@@ -277,6 +283,10 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetFunctions: All known supported fun
   for (const auto& func : ALL_ODBC_FUNCTIONS) {
     WINDOWS_ONLY {
       if (func.functionId == SQL_API_SQLSETSCROLLOPTIONS) continue;
+    }
+    // BD#38: Reference driver's SQLGetFunctions bitmap omits SQL_API_SQLCANCELHANDLE
+    OLD_DRIVER_ONLY("BD#38") {
+      if (func.functionId == SQL_API_SQLCANCELHANDLE) continue;
     }
     SQLUSMALLINT supported = SQL_FALSE;
     ret = SQLGetFunctions(dbc_handle(), func.functionId, &supported);

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
@@ -2,15 +2,29 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
+#include <chrono>
+#include <thread>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
+#include "Schema.hpp"
 #include "compatibility.hpp"
+#include "cross_thread_cancel.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "test_macros.hpp"
+#include "odbc_matchers.hpp"
 #include "test_setup.hpp"
+
+// NOTE: SQLCancelHandle(SQL_HANDLE_STMT, ...) behaves identically to SQLCancel
+// per the ODBC 3.8 spec. The Driver Manager maps it to SQLCancel when the
+// driver does not export SQLCancelHandle. The same Unix DM cursor-closing
+// behavior described in cancel_tests.cpp applies here.
+
+namespace {
+constexpr int kMaxPollIterations = 300;
+}  // namespace
 
 // ============================================================================
 // SQLCancelHandle - Statement Handle: Basic Functionality
@@ -21,16 +35,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on idle stateme
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -39,20 +54,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after query exe
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open and usable
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: Per ODBC 3.5 spec, cancel when no async processing is in progress
-    // should have no effect keeping the cursor open and usable. The reference
-    // driver unconditionally closes cursors during cancel.
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -66,21 +77,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after fetch",
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_NO_DATA);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
   }
   UNIX_ONLY {
-    // Note: Same reference driver bug as above
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -94,19 +103,20 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on prepared but
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -119,21 +129,19 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: After cancel on execut
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open
     ret = SQLFetch(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: Same reference driver bug
     ret = SQLFetch(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 
@@ -147,25 +155,26 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Statement recoverable 
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -174,22 +183,84 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: SQLCloseCursor fails a
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   WINDOWS_ONLY {
-    // Windows DM: synchronous cancel is a no-op, cursor remains open and closeable
     ret = SQLCloseCursor(stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
   UNIX_ONLY {
-    // Note: SQLCloseCursor fails because the reference driver already invalidated
-    // the cursor during cancel.
     ret = SQLCloseCursor(stmt_handle());
     REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
   }
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after error recovery and re-execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM nonexistent_table_xyz_999"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 99);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on never-executed statement then use and free",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT fresh_stmt = SQL_NULL_HSTMT;
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(fresh_stmt, sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(fresh_stmt, 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, fresh_stmt);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, fresh_stmt), OdbcMatchers::Succeeded());
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on idle statement",
@@ -198,17 +269,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on id
 
   for (int i = 0; i < 3; i++) {
     const SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   }
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 99);
 }
 
@@ -223,22 +295,22 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves bound column
   SQLINTEGER col_val = 0;
   SQLLEN indicator = 0;
   SQLRETURN ret = SQLBindCol(stmt_handle(), 1, SQL_C_SLONG, &col_val, 0, &indicator);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(col_val == 99);
 }
 
@@ -247,32 +319,75 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves bound parame
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER param = 55;
   SQLLEN ind = 0;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   param = 88;
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 88);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Parameter bindings preserved after cancel with open cursor",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER param = 55;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param, 0, &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 55);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  param = 123;
+  ret = SQLExecute(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 123);
 }
 
 // ============================================================================
@@ -284,36 +399,241 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancels data-at-execut
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_indicator = SQL_DATA_AT_EXEC;
   SQLINTEGER param_id = 1;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
                          reinterpret_cast<SQLPOINTER>(static_cast<SQLLEN>(param_id)), 0, &dae_indicator);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFreeStmt(stmt_handle(), SQL_RESET_PARAMS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 77"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 77);
 }
 
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Re-execute immediately after canceling data-at-execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_indicator = SQL_DATA_AT_EXEC;
+  SQLINTEGER param_id = 1;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
+                         reinterpret_cast<SQLPOINTER>(static_cast<SQLLEN>(param_id)), 0, &dae_indicator);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
 // ============================================================================
-// SQLCancelHandle - Statement Handle: Diagnostic Information
+// SQLCancelHandle - Statement Handle: State Coverage
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after all rows fetched",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 42);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel after DDL execution",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret =
+      SQLExecDirect(stmt_handle(), sqlchar("CREATE OR REPLACE TABLE cancel_handle_test_tmp (id INT)"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFreeStmt(stmt_handle(), SQL_CLOSE);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 1);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on statement in Error state",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  auto schema = Schema::use_random_schema(dbc_handle());
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT * FROM nonexistent_table"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Cursor Preservation
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cursor remains usable after cancel on multi-row result",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT column1 FROM VALUES (1),(2),(3) ORDER BY 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 1);
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  WINDOWS_ONLY {
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    REQUIRE(val == 2);
+
+    ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+    REQUIRE(val == 3);
+
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+  }
+  UNIX_ONLY {
+    ret = SQLFetch(stmt_handle());
+    REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
+  }
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Isolation
+// ============================================================================
+
+TEST_CASE_METHOD(TwoStmtDefaultDSNFixture, "SQLCancelHandle: Does not affect other statements on same connection",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt2_handle(), sqlchar("SELECT 2"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt2_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+
+  SQLINTEGER val = 0;
+  ret = SQLGetData(stmt2_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt2_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(val == 2);
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Attribute Preservation
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Preserves statement attributes after cancel",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLULEN max_length = 1024;
+  SQLRETURN ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_MAX_LENGTH, reinterpret_cast<SQLPOINTER>(max_length), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLULEN retrieved_max_length = 0;
+  ret = SQLGetStmtAttr(stmt_handle(), SQL_ATTR_MAX_LENGTH, &retrieved_max_length, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(retrieved_max_length == max_length);
+
+  SQLULEN cursor_type = 0;
+  ret = SQLGetStmtAttr(stmt_handle(), SQL_ATTR_CURSOR_TYPE, &cursor_type, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(cursor_type == SQL_CURSOR_FORWARD_ONLY);
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Diagnostic Behavior
 // ============================================================================
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Diagnostics after cancel error state",
@@ -321,42 +641,148 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Diagnostics after canc
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
-  // Note: 24000 because of the reference driver bug, re-execution should succeed.
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 2"), SQL_NTS);
   REQUIRE_EXPECTED_ERROR(ret, "24000", stmt_handle(), SQL_HANDLE_STMT);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Does not post diagnostic records on no-op cancel",
+                 "[odbc-api][cancelhandle][terminating_statement]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLCHAR sql_state[6] = {};
+  SQLINTEGER native_error = 0;
+  SQLCHAR message[256] = {};
+  SQLSMALLINT msg_len = 0;
+  ret = SQLGetDiagRec(SQL_HANDLE_STMT, stmt_handle(), 1, sql_state, &native_error, message, sizeof(message), &msg_len);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsNoData());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Async Cancel
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Async cancel interrupts execution with HY008",
+                 "[odbc-api][cancelhandle][terminating_statement][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  SKIP_OLD_DRIVER("BD#32", "Async cancel does not interrupt in-progress operations on reference driver");
+
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  SQLRETURN cancel_ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(cancel_ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  int polls = 0;
+  SQLRETURN poll_ret = SQL_STILL_EXECUTING;
+  while (poll_ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    poll_ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  }
+  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
+
+  REQUIRE_EXPECTED_ERROR(poll_ret, "HY008", stmt_handle(), SQL_HANDLE_STMT);
+
+  ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Async cancel clears diagnostics and posts its own",
+                 "[odbc-api][cancelhandle][terminating_statement][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  SKIP_OLD_DRIVER("BD#32", "Async cancel does not interrupt in-progress operations on reference driver");
+
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  SQLRETURN cancel_ret = SQLCancelHandle(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE_THAT(OdbcResult(cancel_ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  int polls = 0;
+  SQLRETURN poll_ret = SQL_STILL_EXECUTING;
+  while (poll_ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    poll_ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))"), SQL_NTS);
+  }
+  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
+
+  REQUIRE_EXPECTED_ERROR(poll_ret, "HY008", stmt_handle(), SQL_HANDLE_STMT);
+
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt_handle());
+  REQUIRE(!records.empty());
+  REQUIRE(records.size() == 1);
+  REQUIRE(records[0].sqlState == "HY008");
+
+  ret = SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+}
+
+// ============================================================================
+// SQLCancelHandle - Statement Handle: Cross-Thread Cancel
+// ============================================================================
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cross-thread cancel interrupts execution with HY008",
+                 "[odbc-api][cancelhandle][terminating_statement][cross_thread]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLHSTMT stmt = stmt_handle();
+  odbc_test::CrossThreadCancel ctx;
+  ctx.run(stmt, "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 60))", std::chrono::seconds(5),
+          [](SQLHSTMT s) { return SQLCancelHandle(SQL_HANDLE_STMT, s); });
+
+  REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+
+  SQLRETURN exec_ret = ctx.exec_result.load();
+  REQUIRE_EXPECTED_ERROR(exec_ret, "HY008", stmt, SQL_HANDLE_STMT);
+
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt);
+  REQUIRE(records.size() == 1);
+  REQUIRE(records[0].sqlState == "HY008");
 }
 
 // ============================================================================
 // SQLCancelHandle - Connection Handle
 // ============================================================================
 
-// Note: The reference driver does not support connection-level cancel
-// (SFConnection::OnCancel is a no-op that only reports unsupported telemetry).
 // The ODBC 3.8 spec intends SQLCancelHandle(SQL_HANDLE_DBC) to cancel
 // in-progress connection operations (e.g. a blocking SQLDriverConnect from
-// another thread). Since this is unsupported, all connection-handle cancel
-// calls silently succeed without any observable effect.
+// another thread). Connection-level cancel is a no-op for now because no
+// async or cross-thread connection operations are supported.
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel on idle connection",
                  "[odbc-api][cancelhandle][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 123"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 123);
 }
 
@@ -365,16 +791,17 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel connection with
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -382,21 +809,21 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cancel connection betw
                  "[odbc-api][cancelhandle][terminating_statement]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  // Issuing a connection-level cancel between prepare and execute has no effect
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT 42"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 42);
 }
 
@@ -406,17 +833,18 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Multiple cancels on id
 
   for (int i = 0; i < 3; i++) {
     const SQLRETURN ret = SQLCancelHandle(SQL_HANDLE_DBC, dbc_handle());
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()), OdbcMatchers::Succeeded());
   }
 
   SQLRETURN ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT 99"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 0;
-  SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  ret = SQLGetData(stmt_handle(), 1, SQL_C_SLONG, &val, 0, nullptr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(val == 99);
 }
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -470,6 +470,19 @@ impl Connection {
         })
     }
 
+    /// Snapshot of everything needed to issue a query against the server.
+    pub(crate) fn query_transport(
+        &self,
+    ) -> Result<(QueryParameters, reqwest::Client, RetryPolicy), ApiError> {
+        Ok((
+            self.query_transport_parameters()?,
+            self.http_client
+                .clone()
+                .context(ConnectionNotInitializedSnafu)?,
+            self.retry_policy.clone(),
+        ))
+    }
+
     /// Convenience setter for tests and direct call sites.
     pub fn set_option(&mut self, key: String, value: Setting) {
         self.connection_seed.insert(key, value);

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod error;
 mod global_state;
 mod query;
 pub(crate) mod statement;
+pub(crate) mod transaction;
 pub(crate) mod validation;
 
 pub use crate::config::settings::Setting;

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -1,4 +1,4 @@
-use snafu::{OptionExt, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu};
 use tokio::sync::Mutex;
 
 use super::connection::{Connection, RefreshContext};
@@ -338,13 +338,7 @@ impl DatabaseDriverV1 {
 
         let (query_parameters, http_client, retry_policy) = {
             let conn = stmt.conn.lock().await;
-            (
-                conn.query_transport_parameters()?,
-                conn.http_client
-                    .clone()
-                    .context(ConnectionNotInitializedSnafu)?,
-                conn.retry_policy.clone(),
-            )
+            conn.query_transport()?
         };
 
         let execution_mode = stmt.execution_mode(Some(&query));
@@ -458,13 +452,7 @@ impl DatabaseDriverV1 {
 
         let (query_parameters, http_client, retry_policy) = {
             let conn = conn_ptr.lock().await;
-            (
-                conn.query_transport_parameters()?,
-                conn.http_client
-                    .clone()
-                    .context(ConnectionNotInitializedSnafu)?,
-                conn.retry_policy.clone(),
-            )
+            conn.query_transport()?
         };
 
         let response = {

--- a/sf_core/src/apis/database_driver_v1/transaction.rs
+++ b/sf_core/src/apis/database_driver_v1/transaction.rs
@@ -1,0 +1,134 @@
+use super::connection::RefreshContext;
+use super::error::*;
+use super::global_state::DatabaseDriverV1;
+use crate::handle_manager::Handle;
+use crate::rest::snowflake::{QueryExecutionMode, QueryInput, snowflake_query_with_client};
+
+impl DatabaseDriverV1 {
+    pub async fn connection_commit(&self, conn_handle: Handle) -> Result<(), ApiError> {
+        self.execute_transaction_internal(conn_handle, "commit")
+            .await
+    }
+
+    pub async fn connection_rollback(&self, conn_handle: Handle) -> Result<(), ApiError> {
+        self.execute_transaction_internal(conn_handle, "rollback")
+            .await
+    }
+
+    async fn execute_transaction_internal(
+        &self,
+        conn_handle: Handle,
+        sql: &str,
+    ) -> Result<(), ApiError> {
+        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
+            InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .build()
+        })?;
+
+        let (query_parameters, http_client, retry_policy) = {
+            let conn = conn_ptr.lock().await;
+            conn.query_transport()?
+        };
+
+        let query_input = QueryInput {
+            sql: sql.to_string(),
+            bindings: None,
+            describe_only: None,
+        };
+
+        let response = {
+            let mut ctx = RefreshContext::from_arc(&conn_ptr).await?;
+            let mut last_error = None;
+            loop {
+                let session_token = ctx.refresh_token(last_error).await?;
+                match snowflake_query_with_client(
+                    &http_client,
+                    query_parameters.clone(),
+                    session_token.reveal(),
+                    query_input.clone(),
+                    &retry_policy,
+                    QueryExecutionMode::Blocking,
+                )
+                .await
+                {
+                    Ok(result) => break Ok(result),
+                    Err(e) => last_error = Some(e),
+                }
+            }
+        }?;
+
+        if response.success {
+            let conn = conn_ptr.lock().await;
+            conn.update_session_params_cache(
+                sql,
+                response.data.parameters.as_ref(),
+                &super::connection::FinalSessionNames {
+                    database: response.data.final_database_name.clone(),
+                    schema: response.data.final_schema_name.clone(),
+                    warehouse: response.data.final_warehouse_name.clone(),
+                    role: response.data.final_role_name.clone(),
+                },
+            )
+            .await;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bogus_handle() -> Handle {
+        Handle { id: 999, magic: 0 }
+    }
+
+    #[tokio::test]
+    async fn commit_with_invalid_handle_returns_error() {
+        let driver = DatabaseDriverV1::new();
+        let err = driver.connection_commit(bogus_handle()).await;
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("Connection handle not found"),
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_with_invalid_handle_returns_error() {
+        let driver = DatabaseDriverV1::new();
+        let err = driver.connection_rollback(bogus_handle()).await;
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("Connection handle not found"),
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_without_initialized_connection_returns_error() {
+        let driver = DatabaseDriverV1::new();
+        let conn_handle = driver.connection_new();
+        let err = driver.connection_commit(conn_handle).await;
+        assert!(
+            err.is_err(),
+            "commit on uninitialized connection should fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_without_initialized_connection_returns_error() {
+        let driver = DatabaseDriverV1::new();
+        let conn_handle = driver.connection_new();
+        let err = driver.connection_rollback(conn_handle).await;
+        assert!(
+            err.is_err(),
+            "rollback on uninitialized connection should fail"
+        );
+    }
+}

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -1087,22 +1087,34 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_commit", skip(self, _input))]
+    #[instrument(name = "DatabaseDriverV1::connection_commit", skip(self, input))]
     async fn connection_commit(
         &self,
-        _input: ConnectionCommitRequest,
+        input: ConnectionCommitRequest,
     ) -> Result<ConnectionCommitResponse, DriverException> {
-        Err(not_implemented("connection_commit is not yet implemented"))
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        self.driver
+            .connection_commit(conn_handle.into())
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionCommitResponse {})
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_rollback", skip(self, _input))]
+    #[instrument(name = "DatabaseDriverV1::connection_rollback", skip(self, input))]
     async fn connection_rollback(
         &self,
-        _input: ConnectionRollbackRequest,
+        input: ConnectionRollbackRequest,
     ) -> Result<ConnectionRollbackResponse, DriverException> {
-        Err(not_implemented(
-            "connection_rollback is not yet implemented",
-        ))
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        self.driver
+            .connection_rollback(conn_handle.into())
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionRollbackResponse {})
     }
 
     #[instrument(
@@ -1738,6 +1750,14 @@ pub trait DatabaseDriverClientBlockingExt {
         &self,
         input: StatementSetOptionBoolRequest,
     ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_commit_blocking(
+        &self,
+        input: ConnectionCommitRequest,
+    ) -> Result<ConnectionCommitResponse, proto_utils::ProtoError<DriverException>>;
+    fn connection_rollback_blocking(
+        &self,
+        input: ConnectionRollbackRequest,
+    ) -> Result<ConnectionRollbackResponse, proto_utils::ProtoError<DriverException>>;
     fn connection_release_blocking(
         &self,
         input: ConnectionReleaseRequest,
@@ -1846,6 +1866,20 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
         input: StatementSetOptionBoolRequest,
     ) -> Result<StatementSetOptionBoolResponse, proto_utils::ProtoError<DriverException>> {
         BLOCKING_CLIENT_RUNTIME.block_on(self.statement_set_option_bool(input))
+    }
+
+    fn connection_commit_blocking(
+        &self,
+        input: ConnectionCommitRequest,
+    ) -> Result<ConnectionCommitResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_commit(input))
+    }
+
+    fn connection_rollback_blocking(
+        &self,
+        input: ConnectionRollbackRequest,
+    ) -> Result<ConnectionRollbackResponse, proto_utils::ProtoError<DriverException>> {
+        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_rollback(input))
     }
 
     fn connection_release_blocking(

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -287,6 +287,22 @@ impl SnowflakeTestClient {
         }
     }
 
+    pub fn commit(&self) {
+        self.client
+            .connection_commit_blocking(ConnectionCommitRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+            .unwrap();
+    }
+
+    pub fn rollback(&self) {
+        self.client
+            .connection_rollback_blocking(ConnectionRollbackRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+            .unwrap();
+    }
+
     pub fn create_temporary_stage(&self, stage_name: &str) {
         self.execute_query(&format!(
             "create temporary stage if not exists {stage_name}"

--- a/sf_core/tests/e2e/query/mod.rs
+++ b/sf_core/tests/e2e/query/mod.rs
@@ -2,3 +2,4 @@ mod async_execution;
 mod distributed_fetch;
 mod large_result_set;
 mod parameters_bind;
+mod transaction;

--- a/sf_core/tests/e2e/query/transaction.rs
+++ b/sf_core/tests/e2e/query/transaction.rs
@@ -1,0 +1,137 @@
+use crate::common::arrow_result_helper::ArrowResultHelper;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+
+#[test]
+fn should_commit_transaction() {
+    // Given a connected Snowflake client with autocommit disabled
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_commit_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query("ALTER SESSION SET AUTOCOMMIT=FALSE");
+
+    // When a row is inserted and committed
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (1)"));
+    client.commit();
+
+    // Then the row is visible after commit
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 1);
+}
+
+#[test]
+fn should_rollback_transaction() {
+    // Given a connected Snowflake client with autocommit disabled and a committed row
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_rollback_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query("ALTER SESSION SET AUTOCOMMIT=FALSE");
+
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (1)"));
+    client.commit();
+
+    // When a second row is inserted and rolled back
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (2)"));
+    client.rollback();
+
+    // Then only the first committed row remains
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 1);
+}
+
+#[test]
+fn should_commit_with_no_pending_changes() {
+    // Given a connected Snowflake client with autocommit disabled and an empty table
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_commit_noop_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query("ALTER SESSION SET AUTOCOMMIT=FALSE");
+
+    // When commit is called with no pending changes
+    client.commit();
+
+    // Then the table remains empty and no error occurs
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 0);
+}
+
+#[test]
+fn should_rollback_with_no_pending_changes() {
+    // Given a connected Snowflake client with autocommit disabled and an empty table
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_rollback_noop_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query("ALTER SESSION SET AUTOCOMMIT=FALSE");
+
+    // When rollback is called with no pending changes
+    client.rollback();
+
+    // Then the table remains empty and no error occurs
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 0);
+}
+
+#[test]
+fn should_commit_multiple_inserts_in_single_transaction() {
+    // Given a connected Snowflake client with autocommit disabled
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_multi_insert_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query("ALTER SESSION SET AUTOCOMMIT=FALSE");
+
+    // When multiple rows are inserted and committed in a single transaction
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (1)"));
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (2)"));
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (3)"));
+    client.commit();
+
+    // Then all rows are visible after commit
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 3);
+}
+
+#[test]
+fn should_commit_and_rollback_with_autocommit_enabled() {
+    // Given a connected Snowflake client with autocommit enabled
+    let client = SnowflakeTestClient::connect_with_default_auth();
+    let table_name = format!("test_autocommit_{}", std::process::id());
+    client.execute_query(&format!(
+        "CREATE OR REPLACE TEMPORARY TABLE {table_name} (id INT)"
+    ));
+    client.execute_query(&format!("INSERT INTO {table_name} VALUES (1)"));
+
+    // When commit and rollback are called with autocommit enabled
+    client.commit();
+    client.rollback();
+
+    // Then the auto-committed row is still visible
+    let result = client.execute_query(&format!("SELECT COUNT(*) FROM {table_name}"));
+    let mut helper = ArrowResultHelper::from_result(result);
+    let rows = helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], 1);
+}

--- a/tests/definitions/core/query/transaction.feature
+++ b/tests/definitions/core/query/transaction.feature
@@ -1,0 +1,38 @@
+@core
+Feature: Transaction
+
+  @core_e2e
+  Scenario: should commit transaction
+    Given a connected Snowflake client with autocommit disabled
+    When a row is inserted and committed
+    Then the row is visible after commit
+
+  @core_e2e
+  Scenario: should rollback transaction
+    Given a connected Snowflake client with autocommit disabled and a committed row
+    When a second row is inserted and rolled back
+    Then only the first committed row remains
+
+  @core_e2e
+  Scenario: should commit with no pending changes
+    Given a connected Snowflake client with autocommit disabled and an empty table
+    When commit is called with no pending changes
+    Then the table remains empty and no error occurs
+
+  @core_e2e
+  Scenario: should rollback with no pending changes
+    Given a connected Snowflake client with autocommit disabled and an empty table
+    When rollback is called with no pending changes
+    Then the table remains empty and no error occurs
+
+  @core_e2e
+  Scenario: should commit multiple inserts in single transaction
+    Given a connected Snowflake client with autocommit disabled
+    When multiple rows are inserted and committed in a single transaction
+    Then all rows are visible after commit
+
+  @core_e2e
+  Scenario: should commit and rollback with autocommit enabled
+    Given a connected Snowflake client with autocommit enabled
+    When commit and rollback are called with autocommit enabled
+    Then the auto-committed row is still visible


### PR DESCRIPTION
## Add transaction support with commit and rollback operations

This change implements transaction control functionality for database connections by adding commit and rollback operations.

### Changes

- Added `query_transport()` method to `Connection` to encapsulate query transport parameters, HTTP client, and retry policy
- Created new `transaction.rs` module with `connection_commit()` and `connection_rollback()` methods
- Refactored statement execution to use the new `query_transport()` helper method
- Implemented protobuf handlers for `connection_commit` and `connection_rollback` requests
- Added blocking client extensions for commit and rollback operations
- Extended test client with `commit()` and `rollback()` helper methods
- Added comprehensive end-to-end tests covering transaction scenarios including multiple inserts, no-op operations, and autocommit behavior