### PR TITLE
NO-SNOW: Propagate query_id (sfqid) through error path on failed queries

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -123,6 +123,8 @@ message DriverException {
   // The deepest cause in the error chain (root cause).
   // More informative than the top-level message for end users.
   optional string root_cause = 7;
+  // Snowflake Query ID (sfqid) associated with the failed query, if available.
+  optional string query_id = 8;
 }
 
 // Column metadata for description

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -128,7 +128,9 @@ def _convert_application_error(proto_exc: ProtoApplicationException) -> Error:
     # Prefer the server-provided sql_state; fall back to a type-derived value.
     sqlstate = _get_optional_str(driver_exc, "sql_state") or _derive_sqlstate(driver_exc)
 
-    return exc_class(message, errno=errno, sqlstate=sqlstate)
+    sfqid = _get_optional_str(driver_exc, "query_id")
+
+    return exc_class(message, errno=errno, sqlstate=sqlstate, sfqid=sfqid)
 
 
 def _get_optional_int(msg: Any, field: str) -> int | None:

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -412,6 +412,7 @@ class SnowflakeCursorBase(abc.ABC):
             return self._connection.db_api.statement_execute_query(request).result
         except ProgrammingError as exc:
             self._sqlstate = exc.sqlstate or None
+            self._sfqid = exc.sfqid or None
             raise
 
     def _prepare(self, stmt_handle: StatementHandle) -> PrepareResult:

--- a/python/tests/e2e/query/test_query_status.py
+++ b/python/tests/e2e/query/test_query_status.py
@@ -38,7 +38,6 @@ class TestQueryStatus:
         # And the query should not be indicated as an error
         assert not connection.is_an_error(status)
 
-    @pytest.mark.skip(reason="cursor.sfqid is not populated on failed queries yet")
     def test_should_return_error_status_for_failed_query(self, connection, cursor):
         """Test that a failed query returns error status."""
         # Given Snowflake client is logged in

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -615,6 +615,40 @@ class TestSqlstate:
         assert cursor.sqlstate is None
 
 
+class TestSfqidOnFailedQuery:
+    """Unit tests for cursor.sfqid propagation when execute raises."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = MagicMock()
+        conn.conn_handle = ConnectionHandle(id=1)
+        conn.is_closed.return_value = False
+        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        return conn
+
+    @pytest.fixture
+    def cursor(self, mock_connection):
+        return SnowflakeCursor(mock_connection)
+
+    def test_sfqid_set_from_error_on_failed_execute(self, cursor, mock_connection):
+        """sfqid is captured from ProgrammingError when execute raises."""
+        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error", sfqid="01abc-def-12345")
+
+        with pytest.raises(ProgrammingError):
+            cursor.execute("INVALID SQL")
+
+        assert cursor.sfqid == "01abc-def-12345"
+
+    def test_sfqid_none_when_error_has_no_sfqid(self, cursor, mock_connection):
+        """sfqid is None when error carries no sfqid."""
+        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error")
+
+        with pytest.raises(ProgrammingError):
+            cursor.execute("INVALID SQL")
+
+        assert cursor.sfqid is None
+
+
 class TestQueryResultStats:
     """Unit tests for QueryResultStats NamedTuple."""
 

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -479,6 +479,16 @@ fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
     }
 }
 
+fn extract_query_id(error: &ApiError) -> Option<String> {
+    match error {
+        ApiError::Query {
+            source: RestError::QueryFailed { query_id, .. },
+            ..
+        } => query_id.clone(),
+        _ => None,
+    }
+}
+
 fn to_driver_exception(error: ApiError) -> DriverException {
     let status_code = match &error {
         ApiError::GenericError { .. } => StatusCode::GenericError,
@@ -552,6 +562,7 @@ fn to_driver_exception(error: ApiError) -> DriverException {
     };
 
     let (vendor_code, sql_state) = extract_vendor_info(&error);
+    let query_id = extract_query_id(&error);
     let message = error.to_string();
     let root_cause = extract_root_cause(&error);
     let driver_error = to_driver_error(&error);
@@ -574,6 +585,7 @@ fn to_driver_exception(error: ApiError) -> DriverException {
         vendor_code,
         sql_state,
         root_cause,
+        query_id,
     }
 }
 

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -935,7 +935,7 @@ async fn execute_sync_with_retry<'a>(
 
 /// Map a Snowflake query response into a `Result`, converting
 /// `response.success == false` into `RestError::QueryFailed` with
-/// the server's message, error code, and SQL state.
+/// the server's message, error code, SQL state, and query ID.
 fn into_query_result(
     response: query_response::Response,
 ) -> Result<query_response::Response, RestError> {
@@ -945,11 +945,13 @@ fn into_query_result(
             .unwrap_or_else(|| "Unknown error".to_owned());
         let code = response.code.as_deref().and_then(|c| c.parse::<i32>().ok());
         let sql_state = response.data.sql_state.clone();
+        let query_id = response.data.query_id.clone();
 
         return QueryFailedSnafu {
             message,
             code,
             sql_state,
+            query_id,
         }
         .fail();
     }
@@ -1143,6 +1145,7 @@ pub async fn get_query_status(
             message,
             code,
             sql_state: None::<String>,
+            query_id: Some(query_id.to_owned()),
         }
         .fail();
     }
@@ -1373,6 +1376,8 @@ pub enum RestError {
         code: Option<i32>,
         /// ANSI SQL state code (e.g. "42000" for syntax error).
         sql_state: Option<String>,
+        /// Snowflake Query ID associated with the failed query.
+        query_id: Option<String>,
         #[snafu(implicit)]
         location: Location,
     },
@@ -1627,7 +1632,8 @@ mod tests {
                 "data": {
                     "rowset": null,
                     "rowsetBase64": null,
-                    "sqlState": "42000"
+                    "sqlState": "42000",
+                    "queryId": "01abc-def-12345"
                 }
             }));
 
@@ -1636,11 +1642,13 @@ mod tests {
                     message,
                     code,
                     sql_state,
+                    query_id,
                     ..
                 }) => {
                     assert_eq!(message, "SQL compilation error");
                     assert_eq!(code, Some(1003));
                     assert_eq!(sql_state, Some("42000".to_owned()));
+                    assert_eq!(query_id, Some("01abc-def-12345".to_owned()));
                 }
                 Err(other) => panic!("expected QueryFailed, got {:?}", other),
                 Ok(_) => panic!("expected Err, got Ok"),
@@ -1662,11 +1670,13 @@ mod tests {
                     message,
                     code,
                     sql_state,
+                    query_id,
                     ..
                 }) => {
                     assert_eq!(message, "Unknown error");
                     assert_eq!(code, None);
                     assert_eq!(sql_state, None);
+                    assert_eq!(query_id, None);
                 }
                 Err(other) => panic!("expected QueryFailed, got {:?}", other),
                 Ok(_) => panic!("expected Err, got Ok"),


### PR DESCRIPTION
### TL;DR

Added Snowflake Query ID (sfqid) propagation to failed query exceptions, enabling better error tracking and debugging.

### What changed?

- Extended the `DriverException` protobuf message with an optional `query_id` field
- Modified error handling in the Python connector to extract and propagate the `sfqid` from `ProgrammingError` exceptions to the cursor
- Updated the Rust core to extract query IDs from `QueryFailed` errors and include them in driver exceptions
- Enhanced the REST error handling to capture query IDs from Snowflake API responses when queries fail

### How to test?

Run the existing end-to-end test `test_should_return_error_status_for_failed_query` which was previously skipped. Execute a query that will fail and verify that `cursor.sfqid` is populated with the Snowflake Query ID. The new unit tests in `TestSfqidOnFailedQuery` class demonstrate the expected behavior.

### Why make this change?

This enables developers to access Snowflake Query IDs when queries fail, which is essential for debugging and tracking failed operations in Snowflake's query history. Previously, this information was lost when exceptions were raised, making it difficult to correlate failed queries with Snowflake's internal tracking systems.