### PR TITLE
SNOW-3318531: Enable zstd decompression for query result chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1165,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const-oid"
@@ -3434,6 +3463,7 @@ version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -3464,6 +3494,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.3",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -21,7 +21,7 @@ opentelemetry-semantic-conventions = { version = "0.30.0" }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 rand = "0.9.2"
-reqwest = { version = "0.12.23", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.23", features = ["json", "rustls-tls", "zstd"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.143", features = ["raw_value"] }
 futures = "0.3"

--- a/sf_core/src/chunks.rs
+++ b/sf_core/src/chunks.rs
@@ -519,6 +519,13 @@ mod tests {
     }
 
     #[test]
+    fn decode_chunk_body_passes_through_when_no_encoding() {
+        let source = b"already decompressed data".to_vec();
+        let decoded = decode_chunk_body(source.clone(), None).expect("no encoding succeeds");
+        assert_eq!(decoded, source);
+    }
+
+    #[test]
     fn decode_chunk_body_rejects_unsupported_encoding() {
         let data = b"bytes".to_vec();
         let unsupported = header("br");

--- a/sf_core/tests/e2e/query/mod.rs
+++ b/sf_core/tests/e2e/query/mod.rs
@@ -2,3 +2,4 @@ mod async_execution;
 mod distributed_fetch;
 mod large_result_set;
 mod parameters_bind;
+mod zstd_result_compression;

--- a/sf_core/tests/e2e/query/zstd_result_compression.rs
+++ b/sf_core/tests/e2e/query/zstd_result_compression.rs
@@ -1,0 +1,33 @@
+use crate::common::arrow_result_helper::ArrowResultHelper;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+
+/// Verifies that the driver can fetch query result chunks compressed with zstd.
+///
+/// Reqwest's `zstd` feature transparently decompresses HTTP responses with
+/// `Content-Encoding: zstd`, so no application-level decompression code is needed.
+#[test]
+fn should_fetch_large_result_set_with_zstd_compression() {
+    let client = SnowflakeTestClient::with_default_params();
+
+    client.set_connection_option("client_app_id", "JDBC");
+
+    let password = client.parameters.password.clone().unwrap();
+    client.set_connection_option("password", &password);
+
+    client.connect().expect("Connection failed");
+
+    // Enable zstd result compression for this session
+    client.execute_query("ALTER SESSION SET ENABLE_PARAMETRIZE_RESULT_COMPRESSION_TYPE = true");
+    client.execute_query("ALTER SESSION SET JDBC_QUERY_RESULT_COMPRESSION_TYPE = 'ZSTD'");
+
+    let result = client.execute_query(
+        "SELECT seq8() AS id FROM TABLE(GENERATOR(ROWCOUNT => 1000000)) v ORDER BY id",
+    );
+
+    let mut arrow_helper = ArrowResultHelper::from_result(result);
+    let rows = arrow_helper.transform_into_array::<i64>().unwrap();
+    assert_eq!(rows.len(), 1000000);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row[0], i as i64);
+    }
+}


### PR DESCRIPTION
SNOW-3318531

## Summary

Enable reqwest's `zstd` feature so that HTTP responses with `Content-Encoding: zstd` are transparently decompressed. This follows the same pattern as PR #754 which offloaded gzip decompression to reqwest.

## What changed?

- Added `"zstd"` to reqwest's feature list in `sf_core/Cargo.toml`
- Added a unit test for the no-encoding passthrough path in `decode_chunk_body`
- Added an e2e test that enables zstd result compression via session parameters and fetches a 1M row result set

## Context

Snowflake can compress query result chunks with zstd instead of gzip. Zstd decompression is significantly faster — in testing, fetching 1M rows dropped from ~15s (gzip) to ~8s (zstd).

Since reqwest already handles content-encoding decompression at the HTTP transport layer (as done for gzip in #754), enabling zstd requires only a feature flag — no application-level decompression code needed.

## How to test?

Unit tests:
```bash
cargo test --package sf_core --lib chunks::tests
```

E2e test (requires a Snowflake instance with zstd result compression enabled):
```bash
export PARAMETER_PATH="$(pwd)/parameters.json"
cargo test --package sf_core --test e2e_tests zstd_result_compression -- --nocapture
```