### PR TITLE
SNOW-3243354: Implement Connection.application property

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -7,6 +7,7 @@ This module defines the Connection class as specified in PEP 249.
 from __future__ import annotations
 
 import logging
+import re
 
 from collections.abc import Generator, Iterable
 from io import StringIO
@@ -43,6 +44,9 @@ from .telemetry import TelemetryClient
 
 
 logger = logging.getLogger(__name__)
+
+CLIENT_NAME = "PythonConnector"
+APPLICATION_RE = re.compile(r"^[\w\d_]+$")
 
 SessionParameters = dict[str, Any]
 ConnectionParamValue = Union[int, str, float, bytes, bool, SessionParameters]
@@ -102,6 +106,17 @@ class Connection:
 
         kwargs = self._rewrite_private_key_password(kwargs)
         kwargs = self._rewrite_mfa_params(kwargs)
+
+        application = kwargs.pop("application", None)
+        if application is None or (isinstance(application, str) and not application):
+            self._application = CLIENT_NAME
+        elif isinstance(application, str):
+            if not APPLICATION_RE.match(application):
+                raise ProgrammingError(f"Invalid application name: {application!r}")
+            self._application = application
+        else:
+            raise ProgrammingError(f"Invalid application parameter (must be a non-empty string): {application!r}")
+        kwargs["client_app_id"] = self._application
 
         self.db_api = database_driver_client()
         self.db_handle = self.db_api.database_new(DatabaseNewRequest()).db_handle
@@ -514,7 +529,7 @@ class Connection:
     @property
     def application(self) -> str:
         """The name of the client application connecting to Snowflake."""
-        raise NotImplementedError("application is not yet implemented")
+        return self._application
 
     @property
     @pep249

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -260,7 +260,7 @@ class TestConnectionSetOptions:
 
         assert mock_db_api.connection_set_options.call_count == 1
         request = mock_db_api.connection_set_options.call_args[0][0]
-        assert set(request.options.keys()) == {"user", "account", "port", "insecure_mode", "timeout"}
+        assert set(request.options.keys()) == {"user", "account", "port", "insecure_mode", "timeout", "client_app_id"}
 
     def test_validation_warnings_forwarded_via_warnings_warn(self, mock_db_api):
         """ValidationIssue warnings from the response should be surfaced via warnings.warn."""
@@ -284,14 +284,17 @@ class TestConnectionSetOptions:
         assert "param 'x' is deprecated" in str(caught[0].message)
         assert "param 'y' has no effect" in str(caught[1].message)
 
-    def test_no_options_skips_rpc(self, mock_db_api):
-        """When there are no typed kwargs, connection_set_options should not be called."""
+    def test_no_user_options_sends_only_client_app_id(self, mock_db_api):
+        """When there are no user-supplied kwargs, only the injected client_app_id is sent."""
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
             Connection(session_parameters={"AUTOCOMMIT": "true"})
 
-        mock_db_api.connection_set_options.assert_not_called()
+        assert mock_db_api.connection_set_options.call_count == 1
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert set(request.options.keys()) == {"client_app_id"}
+        assert request.options["client_app_id"] == ConfigSetting(string_value="PythonConnector")
 
 
 class TestContextManagerUnit:
@@ -517,6 +520,67 @@ class TestIsAnError:
         from snowflake.connector.connection import Connection
 
         assert Connection.is_an_error(status) == expected
+
+
+class TestApplicationProperty:
+    """Unit tests for the Connection.application property."""
+
+    def test_application_defaults_to_python_connector(self, connection):
+        assert connection.application == "PythonConnector"
+
+    def test_application_custom_value(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", application="MyApp")
+        assert conn.application == "MyApp"
+
+    def test_application_maps_to_client_app_id_option(self, mock_db_api):
+        """The application value should be forwarded to sf_core as client_app_id."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(user="u", account="a", application="CustomApp")
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value="CustomApp")
+        assert "application" not in request.options
+
+    def test_application_none_defaults_to_client_name(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", application=None)
+        assert conn.application == "PythonConnector"
+
+    def test_application_empty_string_defaults_to_client_name(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", application="")
+        assert conn.application == "PythonConnector"
+
+    def test_application_rejects_non_string(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            with pytest.raises(ProgrammingError, match="Invalid application parameter"):
+                Connection(user="u", account="a", application=123)
+
+    def test_application_rejects_invalid_characters(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            with pytest.raises(ProgrammingError, match="Invalid application name"):
+                Connection(user="u", account="a", application="My App!")
+
+    def test_application_not_in_stored_kwargs(self, mock_db_api):
+        """application should be popped from kwargs so it doesn't leak into stored kwargs."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", application="MyApp")
+        assert "application" not in conn.kwargs
 
 
 class TestConnectionArrowProperties:


### PR DESCRIPTION
### TL;DR

Implemented the `application` property for Snowflake connections with a default value of "PythonConnector" and proper mapping to the underlying client configuration.

### What changed?

- Replaced the `NotImplementedError` in the `application` property getter with actual implementation
- Added logic to extract the `application` parameter from connection kwargs with "PythonConnector" as the default value
- The `application` value is now mapped to `client_app_id` in the connection options sent to the database driver
- The `application` parameter is removed from stored kwargs after processing

### How to test?

- Verify that `connection.application` returns "PythonConnector" by default
- Test setting a custom application name via the `application` parameter in connection initialization
- Confirm that the `client_app_id` option is properly set in the database driver configuration
- Ensure that `application` does not appear in the connection's stored kwargs

### Why make this change?

This implements a previously unimplemented feature that allows users to identify their applications when connecting to Snowflake, which is useful for monitoring and debugging purposes. The implementation ensures proper integration with the underlying database driver while maintaining clean separation of concerns.