### PR TITLE
SNOW-2872401: Make authenticator matching case-insensitive for old driver compatibility

### DIFF
--- a/odbc_tests/tests/e2e/authentication/pat.cpp
+++ b/odbc_tests/tests/e2e/authentication/pat.cpp
@@ -210,6 +210,43 @@ TEST_CASE("should authenticate using PAT as token", "[pat]") {
   }
 }
 
+TEST_CASE("should authenticate using PAT as token with lowercase authenticator", "[pat]") {
+  // Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
+  PatSetup pat_setup;
+  PatResult pat = pat_setup.acquire();
+
+  OLD_DRIVER_ONLY("BD#7") {
+    CHECK(pat.fetch_ret == SQL_ERROR);
+    REQUIRE(pat.diag_records.size() == 1);
+    CHECK(pat.diag_records[0].sqlState == "24000");
+    CHECK(pat.diag_records[0].nativeError == 10510);
+    CHECK_THAT(pat.diag_records[0].messageText, ContainsSubstring("Invalid cursor state"));
+  }
+
+  NEW_DRIVER_ONLY("BD#7") {
+    REQUIRE(pat.fetch_ret == SQL_SUCCESS);
+
+    std::string connection_string = get_pat_as_token_connection_string(pat.token_secret);
+    const std::string upper_auth = "AUTHENTICATOR=PROGRAMMATIC_ACCESS_TOKEN;";
+    const std::string lower_auth = "AUTHENTICATOR=programmatic_access_token;";
+    auto auth_pos = connection_string.find(upper_auth);
+    if (auth_pos != std::string::npos) {
+      connection_string.replace(auth_pos, upper_auth.size(), lower_auth);
+    }
+
+    auto env = setup_pat_environment();
+    auto dbc = get_pat_connection_handle(env);
+
+    // When Trying to Connect
+    attempt_pat_connection(dbc, connection_string);
+
+    // Then Login is successful and simple query can be executed
+    verify_pat_simple_query_execution(dbc);
+
+    SQLDisconnect(dbc.getHandle());
+  }
+}
+
 TEST_CASE("should fail PAT authentication when invalid token provided", "[pat]") {
   // Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
   std::string connection_string = get_pat_as_token_connection_string("invalid_token_12345");

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -315,8 +315,9 @@ fn build_tls_config(settings: &ParamStore) -> TlsConfig {
 
 fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
     let authenticator = settings.get_string(AUTHENTICATOR).unwrap_or_default();
+    let auth_upper = authenticator.to_ascii_uppercase();
 
-    let use_jwt = authenticator == "SNOWFLAKE_JWT"
+    let use_jwt = auth_upper == "SNOWFLAKE_JWT"
         || (authenticator.is_empty() && has_private_key_params(settings));
 
     if use_jwt {
@@ -329,8 +330,8 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
         });
     }
 
-    match authenticator.as_str() {
-        "SNOWFLAKE_PASSWORD" | "" => Ok(AuthConfig::Password {
+    match auth_upper.as_str() {
+        "SNOWFLAKE" | "SNOWFLAKE_PASSWORD" | "" => Ok(AuthConfig::Password {
             user: non_empty_string(settings, USER).context(MissingParameterSnafu {
                 parameter: String::from(USER),
             })?,
@@ -366,7 +367,7 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                     parameter: String::from(TOKEN),
                 })?,
         }),
-        _ if authenticator.to_ascii_lowercase().starts_with("https://") => {
+        _ if auth_upper.starts_with("HTTPS://") => {
             let okta_url = Url::parse(&authenticator).map_err(|_| {
                 InvalidParameterValueSnafu {
                     parameter: String::from(AUTHENTICATOR),
@@ -401,7 +402,7 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
         _ => InvalidParameterValueSnafu {
             parameter: String::from(AUTHENTICATOR),
             value: authenticator,
-            explanation: "Allowed values are SNOWFLAKE_JWT, SNOWFLAKE_PASSWORD, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, or an https:// URL for native Okta SSO".to_string(),
+            explanation: "Allowed values are snowflake, snowflake_jwt, snowflake_password, programmatic_access_token, username_password_mfa, or an https:// URL for native Okta SSO (case-insensitive)".to_string(),
         }
         .fail(),
     }
@@ -561,22 +562,23 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
 
     // --- Auth-specific checks based on authenticator ---
     let authenticator = settings.get_string(AUTHENTICATOR).unwrap_or_default();
-    match authenticator.as_str() {
+    let auth_upper = authenticator.to_ascii_uppercase();
+    match auth_upper.as_str() {
         "" if has_private_key_params(settings) => {
             // Empty authenticator + private key params → auto-JWT, no password needed
         }
-        "SNOWFLAKE_PASSWORD" if has_private_key_params(settings) => {
+        "SNOWFLAKE" | "SNOWFLAKE_PASSWORD" if has_private_key_params(settings) => {
             issues.push(ValidationIssue {
                 severity: ValidationSeverity::Error,
                 parameter: AUTHENTICATOR.into(),
-                message: "Cannot specify 'SNOWFLAKE_PASSWORD' authenticator together with \
+                message: "Cannot specify basic authenticator together with \
                           private key parameters; use 'SNOWFLAKE_JWT' or remove the private \
                           key parameters"
                     .into(),
                 code: ValidationCode::ConflictingParameters,
             });
         }
-        "SNOWFLAKE_PASSWORD" | "" => {
+        "SNOWFLAKE" | "SNOWFLAKE_PASSWORD" | "" => {
             if settings.get_string(PASSWORD).is_none_or(|s| s.is_empty()) {
                 issues.push(ValidationIssue {
                     severity: ValidationSeverity::Error,
@@ -618,12 +620,15 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
                 });
             }
         }
-        other if other.to_ascii_lowercase().starts_with("https://") => {
-            if Url::parse(other).is_err() {
+        _ if auth_upper.starts_with("HTTPS://") => {
+            if Url::parse(&authenticator).is_err() {
                 issues.push(ValidationIssue {
                     severity: ValidationSeverity::Error,
                     parameter: AUTHENTICATOR.into(),
-                    message: format!("The authenticator URL '{other}' is not a valid URL"),
+                    message: format!(
+                        "The authenticator URL '{}' is not a valid URL",
+                        authenticator
+                    ),
                     code: ValidationCode::InvalidValue,
                 });
             }
@@ -637,12 +642,12 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
                 });
             }
         }
-        other => {
+        _ => {
             issues.push(ValidationIssue {
                 severity: ValidationSeverity::Error,
                 parameter: AUTHENTICATOR.into(),
                 message: format!(
-                    "Invalid authenticator '{other}'. Allowed: SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, or an https:// URL for native Okta SSO"
+                    "Invalid authenticator '{}'. Allowed: snowflake, snowflake_password, snowflake_jwt, programmatic_access_token, username_password_mfa, or an https:// URL for native Okta SSO (case-insensitive)", authenticator
                 ),
                 code: ValidationCode::InvalidValue,
             });
@@ -884,6 +889,138 @@ mod tests {
             }
             _ => panic!("Expected Pat auth"),
         }
+    }
+
+    #[test]
+    fn build_password_auth_with_snowflake_lowercase() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("authenticator", Setting::String("snowflake".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Password { user, password } => {
+                assert_eq!(user, "u");
+                assert_eq!(password.reveal(), "p");
+            }
+            _ => panic!("Expected Password auth for 'snowflake' authenticator"),
+        }
+    }
+
+    #[test]
+    fn build_password_auth_with_snowflake_mixed_case() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("authenticator", Setting::String("Snowflake".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Password { .. } => {}
+            _ => panic!("Expected Password auth for 'Snowflake' authenticator"),
+        }
+    }
+
+    #[test]
+    fn build_password_auth_with_snowflake_password_lowercase() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            (
+                "authenticator",
+                Setting::String("snowflake_password".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Password { .. } => {}
+            _ => panic!("Expected Password auth for 'snowflake_password' authenticator"),
+        }
+    }
+
+    #[test]
+    fn build_pat_auth_case_insensitive() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("token", Setting::String("tok123".into())),
+            (
+                "authenticator",
+                Setting::String("programmatic_access_token".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Pat { user, token } => {
+                assert_eq!(user, "u");
+                assert_eq!(token.reveal(), "tok123");
+            }
+            _ => panic!("Expected Pat auth for lowercase 'programmatic_access_token'"),
+        }
+    }
+
+    #[test]
+    fn build_pat_auth_mixed_case() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("token", Setting::String("tok123".into())),
+            (
+                "authenticator",
+                Setting::String("Programmatic_Access_Token".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Pat { .. } => {}
+            _ => panic!("Expected Pat auth for mixed-case authenticator"),
+        }
+    }
+
+    #[test]
+    fn build_mfa_auth_case_insensitive() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            (
+                "authenticator",
+                Setting::String("username_password_mfa".into()),
+            ),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        match &config.auth {
+            AuthConfig::Mfa { .. } => {}
+            _ => panic!("Expected Mfa auth for lowercase 'username_password_mfa'"),
+        }
+    }
+
+    #[test]
+    fn build_jwt_auth_case_insensitive() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("authenticator", Setting::String("snowflake_jwt".into())),
+            ("private_key", Setting::String("some_key".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let result = ConnectionConfig::build(&settings);
+        // Will fail at key parsing, but should NOT fail at authenticator recognition
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            !err_msg.contains("Invalid authenticator"),
+            "Should recognize 'snowflake_jwt' (lowercase): {err_msg}"
+        );
     }
 
     #[test]
@@ -1247,7 +1384,7 @@ mod tests {
             .expect("expected invalid authenticator issue");
 
         assert!(
-            auth_issue.message.contains("USERNAME_PASSWORD_MFA"),
+            auth_issue.message.contains("username_password_mfa"),
             "Expected MFA authenticator in message, got: {}",
             auth_issue.message
         );

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -283,10 +283,11 @@ impl LoginMethod {
 
     pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         let authenticator = settings.get_string("authenticator").unwrap_or_default();
+        let auth_upper = authenticator.to_ascii_uppercase();
 
         // Auto-detect JWT authentication if private key params are present
         // and authenticator is not explicitly set to something else
-        let use_jwt = authenticator == "SNOWFLAKE_JWT"
+        let use_jwt = auth_upper == "SNOWFLAKE_JWT"
             || (authenticator.is_empty() && Self::has_private_key_params(settings));
 
         if use_jwt {
@@ -300,8 +301,8 @@ impl LoginMethod {
             });
         }
 
-        match authenticator.as_str() {
-            "SNOWFLAKE_PASSWORD" | "" => Ok(Self::Password {
+        match auth_upper.as_str() {
+            "SNOWFLAKE" | "SNOWFLAKE_PASSWORD" | "" => Ok(Self::Password {
                 username: Self::non_empty_string(settings, "user")
                     .context(MissingParameterSnafu { parameter: "user" })?,
                 password: Self::non_empty_string(settings, "password")
@@ -315,7 +316,7 @@ impl LoginMethod {
                     .context(MissingParameterSnafu { parameter: "token" })?
                     .into(),
             }),
-            _ if authenticator.to_ascii_lowercase().starts_with("https://") => {
+            _ if auth_upper.starts_with("HTTPS://") => {
                 // Native Okta SSO is configured by passing the Okta URL endpoint as `authenticator`.
                 // This is intentionally broad (vanity domains may not contain "okta").
                 // Validate the URL is well-formed early to provide a clear error message.
@@ -389,7 +390,7 @@ impl LoginMethod {
             _ => InvalidParameterValueSnafu {
                 parameter: "authenticator",
                 value: authenticator,
-                explanation: "Allowed values are SNOWFLAKE_JWT, SNOWFLAKE_PASSWORD, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, or an https:// URL for native Okta SSO",
+                explanation: "Allowed values are snowflake, snowflake_jwt, snowflake_password, programmatic_access_token, username_password_mfa, or an https:// URL for native Okta SSO (case-insensitive)",
             }
             .fail()?,
         }
@@ -543,6 +544,82 @@ mod tests {
                 assert_eq!(password.reveal(), "test_password");
             }
             _ => panic!("Expected Password login method"),
+        }
+    }
+
+    #[test]
+    fn test_snowflake_lowercase_resolves_to_password() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("test_user".to_string())),
+            ("password", Setting::String("test_password".to_string())),
+            ("authenticator", Setting::String("snowflake".to_string())),
+        ]);
+
+        let result = LoginMethod::from_settings(&settings);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            LoginMethod::Password { username, password } => {
+                assert_eq!(username, "test_user");
+                assert_eq!(password.reveal(), "test_password");
+            }
+            _ => panic!("Expected Password login method for 'snowflake'"),
+        }
+    }
+
+    #[test]
+    fn test_snowflake_mixed_case_resolves_to_password() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("test_user".to_string())),
+            ("password", Setting::String("test_password".to_string())),
+            ("authenticator", Setting::String("Snowflake".to_string())),
+        ]);
+
+        let result = LoginMethod::from_settings(&settings);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            LoginMethod::Password { .. } => {}
+            _ => panic!("Expected Password login method for 'Snowflake'"),
+        }
+    }
+
+    #[test]
+    fn test_pat_lowercase_resolves_to_pat() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("test_user".to_string())),
+            ("token", Setting::String("test_token".to_string())),
+            (
+                "authenticator",
+                Setting::String("programmatic_access_token".to_string()),
+            ),
+        ]);
+
+        let result = LoginMethod::from_settings(&settings);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            LoginMethod::Pat { username, token } => {
+                assert_eq!(username, "test_user");
+                assert_eq!(token.reveal(), "test_token");
+            }
+            _ => panic!("Expected Pat login method for lowercase 'programmatic_access_token'"),
+        }
+    }
+
+    #[test]
+    fn test_mfa_lowercase_resolves_to_mfa() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("test_user".to_string())),
+            ("password", Setting::String("test_password".to_string())),
+            (
+                "authenticator",
+                Setting::String("username_password_mfa".to_string()),
+            ),
+        ]);
+
+        let result = LoginMethod::from_settings(&settings);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            LoginMethod::UserPasswordMfa { .. } => {}
+            _ => panic!("Expected UserPasswordMfa login method"),
         }
     }
 

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -267,7 +267,6 @@ pub async fn auth_request_data(
             Credentials::Password { username, password } => {
                 data.login_name = Some(username);
                 data.password = Some(password);
-                data.authenticator = Some("SNOWFLAKE".to_string());
             }
             Credentials::Jwt { username, token } => {
                 data.login_name = Some(username);
@@ -1815,5 +1814,77 @@ mod tests {
         assert!(!response.success);
         assert!(response.data.is_none());
         assert_eq!(response.message.as_deref(), Some("Unauthorized"));
+    }
+
+    fn test_client_info() -> ClientInfo {
+        ClientInfo {
+            application: "TestApp".to_string(),
+            version: "1.0.0".to_string(),
+            os: "Linux".to_string(),
+            os_version: "5.15".to_string(),
+            ocsp_mode: None,
+            crl_config: Default::default(),
+            tls_config: Default::default(),
+        }
+    }
+
+    #[test]
+    fn password_auth_payload_does_not_include_authenticator() {
+        let login_params = LoginParameters {
+            account_name: "testaccount".to_string(),
+            login_method: LoginMethod::Password {
+                username: "testuser".to_string(),
+                password: "testpass".into(),
+            },
+            server_url: "https://testaccount.snowflakecomputing.com".to_string(),
+            database: None,
+            schema: None,
+            warehouse: None,
+            role: None,
+            client_info: test_client_info(),
+            session_parameters: None,
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = reqwest::Client::new();
+        let data = rt
+            .block_on(auth_request_data(&client, &login_params, None, None))
+            .unwrap();
+
+        assert_eq!(data.login_name.as_deref(), Some("testuser"));
+        assert_eq!(data.password.as_ref().unwrap().reveal(), "testpass");
+        assert!(
+            data.authenticator.is_none(),
+            "Password auth should NOT include AUTHENTICATOR field (matching old driver behavior)"
+        );
+    }
+
+    #[test]
+    fn pat_auth_payload_includes_authenticator() {
+        let login_params = LoginParameters {
+            account_name: "testaccount".to_string(),
+            login_method: LoginMethod::Pat {
+                username: "testuser".to_string(),
+                token: "pat_secret".into(),
+            },
+            server_url: "https://testaccount.snowflakecomputing.com".to_string(),
+            database: None,
+            schema: None,
+            warehouse: None,
+            role: None,
+            client_info: test_client_info(),
+            session_parameters: None,
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = reqwest::Client::new();
+        let data = rt
+            .block_on(auth_request_data(&client, &login_params, None, None))
+            .unwrap();
+
+        assert_eq!(data.login_name.as_deref(), Some("testuser"));
+        assert_eq!(data.token.as_ref().unwrap().reveal(), "pat_secret");
+        assert_eq!(
+            data.authenticator.as_deref(),
+            Some("PROGRAMMATIC_ACCESS_TOKEN")
+        );
     }
 }

--- a/sf_core/tests/e2e/authentication/pat.rs
+++ b/sf_core/tests/e2e/authentication/pat.rs
@@ -31,6 +31,21 @@ fn should_authenticate_using_pat_as_token() {
 }
 
 #[test]
+fn should_authenticate_using_pat_as_token_with_lowercase_authenticator() {
+    //Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
+    let pat = Pat::acquire();
+    let client = SnowflakeTestClient::with_default_params();
+    client.set_connection_option("authenticator", "programmatic_access_token");
+    set_pat_token(&client, &pat.token_secret);
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then Login is successful and simple query can be executed
+    client.verify_simple_query(result);
+}
+
+#[test]
 fn should_fail_pat_authentication_when_invalid_token_provided() {
     //Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
     let client = SnowflakeTestClient::with_default_params();

--- a/tests/definitions/shared/authentication/PAT.feature
+++ b/tests/definitions/shared/authentication/PAT.feature
@@ -13,6 +13,12 @@ Feature: Personal Access Token Authentication
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
+  @core_e2e @odbc_e2e
+  Scenario: should authenticate using PAT as token with lowercase authenticator
+    Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
   @core_e2e @python_e2e @odbc_e2e
   Scenario: should fail PAT authentication when invalid token provided
     Given Authentication is set to Programmatic Access Token and invalid PAT token is provided


### PR DESCRIPTION
The old ODBC driver (snowflake-odbc) uses strcasecmp for all authenticator value comparisons, accepting any casing. The universal-driver used exact string matching, which broke backward compatibility for users passing lowercase values like "snowflake" or "programmatic_access_token".

Changes:
- Normalize authenticator values to uppercase before matching in both connection_config.rs (typed config path) and rest_parameters.rs (legacy path)
- Accept "snowflake" as an alias for password auth (in addition to "snowflake_password" and empty), matching the old driver constant S_AUTHENTICATOR_SNOWFLAKE = "snowflake"
- Stop sending AUTHENTICATOR field in the login JSON payload for plain password auth, matching old driver behavior where only PASSWORD is set
- Add unit tests for case-insensitive authenticator matching across all auth methods (password, PAT, MFA, JWT)
- Add e2e tests for lowercase PAT authenticator in core and ODBC
- Add Gherkin scenario for lowercase PAT authenticator compatibility
