### PR TITLE
SNOW-2872401: Add dedicated username+password authentication tests

### DIFF
--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -5,6 +5,7 @@ add_odbc_test(e2e_authentication_native_okta authentication/native_okta.cpp)
 add_odbc_test(e2e_authentication_pat authentication/pat.cpp)
 add_odbc_test(e2e_authentication_private_key_auth authentication/private_key_auth.cpp)
 add_odbc_test(e2e_authentication_mfa_auth authentication/user_password_mfa.cpp)
+add_odbc_test(e2e_authentication_user_password authentication/user_password.cpp)
 
 # put_get
 add_odbc_test(e2e_put_get_put_get_auto_compress put_get/put_get_auto_compress.cpp)

--- a/odbc_tests/tests/e2e/authentication/user_password.cpp
+++ b/odbc_tests/tests/e2e/authentication/user_password.cpp
@@ -1,0 +1,137 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <sstream>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "Connection.hpp"
+#include "HandleWrapper.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_matchers.hpp"
+#include "require.hpp"
+#include "test_setup.hpp"
+
+using namespace Catch::Matchers;
+
+// Some test accounts (notably GCP) enforce MFA at the account level, which
+// causes plain username+password login to fail with:
+//   "Multi-factor authentication is required for this account."
+// This is a server-side policy, not a driver bug.  We detect this at runtime
+// and SKIP the happy-path tests so they don't produce false failures.
+
+std::string get_password_connection_string() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_USER", "UID");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_PASSWORD", "PWD");
+  return ss.str();
+}
+
+std::string get_password_connection_string_with_explicit_authenticator() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_USER", "UID");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_PASSWORD", "PWD");
+  ss << "AUTHENTICATOR=snowflake;";
+  return ss.str();
+}
+
+std::string get_wrong_password_connection_string() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_USER", "UID");
+  ss << "PWD=definitely_not_a_valid_password_12345;";
+  return ss.str();
+}
+
+void verify_simple_query(ConnectionHandleWrapper& dbc) {
+  StatementHandleWrapper stmt = dbc.createStatementHandle();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER result = 0;
+  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &result, sizeof(result), NULL);
+  REQUIRE_ODBC(ret, stmt);
+  REQUIRE(result == 1);
+}
+
+bool try_password_connect(const std::string& connection_string, ConnectionHandleWrapper& dbc) {
+  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,
+                                   SQL_DRIVER_NOPROMPT);
+  if (ret == SQL_ERROR) {
+    auto records = get_diag_rec(dbc);
+    for (const auto& record : records) {
+      if (record.messageText.find("Multi-factor authentication is required") != std::string::npos) {
+        SKIP("Account has MFA enforcement enabled — plain password auth is not possible on this account");
+        return false;
+      }
+    }
+    REQUIRE_ODBC(ret, dbc);
+  }
+  return true;
+}
+
+TEST_CASE("should authenticate using username and password", "[user_password]") {
+  // Given Authentication is set to default (snowflake) with valid username and password
+  std::string connection_string = get_password_connection_string();
+
+  // When Trying to Connect
+  EnvironmentHandleWrapper env;
+  SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+  REQUIRE_ODBC(ret, env);
+
+  auto dbc = env.createConnectionHandle();
+  if (!try_password_connect(connection_string, dbc)) return;
+
+  // Then Login is successful and simple query can be executed
+  verify_simple_query(dbc);
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("should authenticate using explicit snowflake authenticator", "[user_password]") {
+  SKIP_OLD_DRIVER("N/A", "Old driver already accepts 'snowflake' — test verifies new driver does too");
+
+  // Given Authentication is explicitly set to snowflake with valid username and password
+  std::string connection_string = get_password_connection_string_with_explicit_authenticator();
+
+  // When Trying to Connect
+  EnvironmentHandleWrapper env;
+  SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+  REQUIRE_ODBC(ret, env);
+
+  auto dbc = env.createConnectionHandle();
+  if (!try_password_connect(connection_string, dbc)) return;
+
+  // Then Login is successful and simple query can be executed
+  verify_simple_query(dbc);
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("should fail authentication when wrong password is provided", "[user_password]") {
+  // Given Authentication is set to default with valid username and wrong password
+  std::string connection_string = get_wrong_password_connection_string();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then There is error returned
+  REQUIRE(records.size() >= 1);
+  CHECK(records[0].sqlState == "28000");
+}

--- a/odbc_tests/tests/e2e/authentication/user_password.cpp
+++ b/odbc_tests/tests/e2e/authentication/user_password.cpp
@@ -106,7 +106,7 @@ TEST_CASE("should authenticate using username and password", "[user_password]") 
 }
 
 TEST_CASE("should authenticate using explicit snowflake authenticator", "[user_password]") {
-  SKIP_OLD_DRIVER("N/A", "Old driver already accepts 'snowflake' — test verifies new driver does too");
+  SKIP_OLD_DRIVER("", "Old driver already accepts 'snowflake' — test verifies new driver does too");
 
   // Given Authentication is explicitly set to snowflake with valid username and password
   std::string connection_string = get_password_connection_string_with_explicit_authenticator();

--- a/python/tests/e2e/authentication/test_user_password.py
+++ b/python/tests/e2e/authentication/test_user_password.py
@@ -1,5 +1,7 @@
 import pytest
 
+from snowflake.connector.errors import DatabaseError
+
 from ...config import get_test_parameters
 from .auth_helpers import verify_simple_query_execution
 
@@ -48,7 +50,6 @@ class TestUserPasswordAuthentication:
             connection_factory(**params)
 
         # Then There is error returned
-        error_msg = str(exception.value).lower()
-        assert "incorrect" in error_msg or "password" in error_msg or "multi-factor" in error_msg, (
-            f"Expected authentication error, got: {exception.value}"
+        assert isinstance(exception.value, DatabaseError), (
+            f"Expected DatabaseError, got: {type(exception.value).__name__}: {exception.value}"
         )

--- a/python/tests/e2e/authentication/test_user_password.py
+++ b/python/tests/e2e/authentication/test_user_password.py
@@ -1,0 +1,54 @@
+import pytest
+
+from ...config import get_test_parameters
+from .auth_helpers import verify_simple_query_execution
+
+
+# Some test accounts (notably GCP) enforce MFA at the account level, which
+# causes plain username+password login to fail with:
+#   "Multi-factor authentication is required for this account."
+# This is a server-side policy, not a driver bug.  We detect this at runtime
+# and skip the happy-path tests so they don't produce false failures.
+MFA_ENFORCED_MESSAGE = "multi-factor authentication is required"
+
+
+def get_password_auth_params():
+    """Build connection params for plain password auth, overriding the default JWT."""
+    test_params = get_test_parameters()
+    return {
+        "authenticator": "snowflake",
+        "password": test_params.get("SNOWFLAKE_TEST_PASSWORD"),
+    }
+
+
+class TestUserPasswordAuthentication:
+    def test_should_authenticate_using_username_and_password(self, connection_factory):
+        # Given Authentication is set to default (snowflake) with valid username and password
+        params = get_password_auth_params()
+
+        # When Trying to Connect
+        try:
+            connection = connection_factory(**params)
+        except Exception as e:
+            if MFA_ENFORCED_MESSAGE in str(e).lower():
+                pytest.skip("Account has MFA enforcement enabled — plain password auth is not possible")
+            raise
+
+        # Then Login is successful and simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    def test_should_fail_authentication_when_wrong_password_is_provided(self, connection_factory):
+        # Given Authentication is set to default with valid username and wrong password
+        params = get_password_auth_params()
+        params["password"] = "definitely_not_a_valid_password_12345"
+
+        # When Trying to Connect
+        with pytest.raises(Exception) as exception:
+            connection_factory(**params)
+
+        # Then There is error returned
+        error_msg = str(exception.value).lower()
+        assert "incorrect" in error_msg or "password" in error_msg or "multi-factor" in error_msg, (
+            f"Expected authentication error, got: {exception.value}"
+        )

--- a/python/tests/e2e/authentication/test_user_password.py
+++ b/python/tests/e2e/authentication/test_user_password.py
@@ -6,20 +6,18 @@ from ...config import get_test_parameters
 from .auth_helpers import verify_simple_query_execution
 
 
-# Some test accounts (notably GCP) enforce MFA at the account level, which
-# causes plain username+password login to fail with:
-#   "Multi-factor authentication is required for this account."
-# This is a server-side policy, not a driver bug.  We detect this at runtime
-# and skip the happy-path tests so they don't produce false failures.
 MFA_ENFORCED_MESSAGE = "multi-factor authentication is required"
 
 
 def get_password_auth_params():
     """Build connection params for plain password auth, overriding the default JWT."""
     test_params = get_test_parameters()
+    password = test_params.get("SNOWFLAKE_TEST_PASSWORD")
+    if not password:
+        pytest.skip("SNOWFLAKE_TEST_PASSWORD not configured (JWT-only environment)")
     return {
         "authenticator": "snowflake",
-        "password": test_params.get("SNOWFLAKE_TEST_PASSWORD"),
+        "password": password,
     }
 
 
@@ -31,7 +29,7 @@ class TestUserPasswordAuthentication:
         # When Trying to Connect
         try:
             connection = connection_factory(**params)
-        except Exception as e:
+        except DatabaseError as e:
             if MFA_ENFORCED_MESSAGE in str(e).lower():
                 pytest.skip("Account has MFA enforcement enabled — plain password auth is not possible")
             raise
@@ -46,10 +44,6 @@ class TestUserPasswordAuthentication:
         params["password"] = "definitely_not_a_valid_password_12345"
 
         # When Trying to Connect
-        with pytest.raises(Exception) as exception:
-            connection_factory(**params)
-
         # Then There is error returned
-        assert isinstance(exception.value, DatabaseError), (
-            f"Expected DatabaseError, got: {type(exception.value).__name__}: {exception.value}"
-        )
+        with pytest.raises(DatabaseError):
+            connection_factory(**params)

--- a/python/tests/e2e/authentication/test_user_password.py
+++ b/python/tests/e2e/authentication/test_user_password.py
@@ -44,6 +44,6 @@ class TestUserPasswordAuthentication:
         params["password"] = "definitely_not_a_valid_password_12345"
 
         # When Trying to Connect
-        # Then There is error returned
         with pytest.raises(DatabaseError):
+            # Then There is error returned
             connection_factory(**params)

--- a/sf_core/tests/common/mocks/mod.rs
+++ b/sf_core/tests/common/mocks/mod.rs
@@ -6,4 +6,5 @@
 pub mod auth;
 pub mod mfa;
 pub mod okta;
+pub mod password;
 pub mod put_get;

--- a/sf_core/tests/common/mocks/password.rs
+++ b/sf_core/tests/common/mocks/password.rs
@@ -4,12 +4,26 @@
 //! The caller mounts them via `MockServerWithTls::mount`.
 
 use serde_json::json;
-use wiremock::Mock;
-use wiremock::ResponseTemplate;
 use wiremock::matchers::{body_partial_json, method, path_regex};
+use wiremock::{Match, Mock, Request, ResponseTemplate};
+
+/// Rejects requests whose JSON body contains `data.AUTHENTICATOR`.
+/// Plain password auth must NOT send this field (matching old driver behavior).
+struct AuthenticatorFieldAbsent;
+
+impl Match for AuthenticatorFieldAbsent {
+    fn matches(&self, request: &Request) -> bool {
+        let Ok(body) = serde_json::from_slice::<serde_json::Value>(&request.body) else {
+            return false;
+        };
+        body.get("data")
+            .and_then(|d| d.get("AUTHENTICATOR"))
+            .is_none()
+    }
+}
 
 /// Successful password login — matches a POST to login-request with LOGIN_NAME and PASSWORD
-/// but WITHOUT the AUTHENTICATOR field (matching old driver behavior).
+/// and verifies the AUTHENTICATOR field is absent (matching old driver behavior).
 pub fn login_success() -> Mock {
     Mock::given(method("POST"))
         .and(path_regex(r"/session/v1/login-request"))
@@ -19,6 +33,7 @@ pub fn login_success() -> Mock {
                 "PASSWORD": "test_password"
             }
         })))
+        .and(AuthenticatorFieldAbsent)
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "success": true,
             "data": {

--- a/sf_core/tests/common/mocks/password.rs
+++ b/sf_core/tests/common/mocks/password.rs
@@ -63,6 +63,7 @@ pub fn login_failure_wrong_credentials() -> Mock {
                 "PASSWORD": "wrong_password"
             }
         })))
+        .and(AuthenticatorFieldAbsent)
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "success": false,
             "code": "390100",

--- a/sf_core/tests/common/mocks/password.rs
+++ b/sf_core/tests/common/mocks/password.rs
@@ -1,0 +1,56 @@
+//! Password (SNOWFLAKE) authentication mock helpers.
+//!
+//! Each function returns a `wiremock::Mock` for a specific password login scenario.
+//! The caller mounts them via `MockServerWithTls::mount`.
+
+use serde_json::json;
+use wiremock::Mock;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::{body_partial_json, method, path_regex};
+
+/// Successful password login — matches a POST to login-request with LOGIN_NAME and PASSWORD
+/// but WITHOUT the AUTHENTICATOR field (matching old driver behavior).
+pub fn login_success() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "LOGIN_NAME": "test_user",
+                "PASSWORD": "test_password"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token",
+                "masterToken": "mock_master_token",
+                "sessionId": 12345,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400,
+                "parameters": [],
+                "sessionInfo": {
+                    "databaseName": "test_database",
+                    "schemaName": "test_schema",
+                    "warehouseName": "test_warehouse",
+                    "roleName": "test_role"
+                }
+            }
+        })))
+}
+
+/// Failed password login — wrong credentials.
+pub fn login_failure_wrong_credentials() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "LOGIN_NAME": "test_user",
+                "PASSWORD": "wrong_password"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": false,
+            "code": "390100",
+            "message": "Incorrect username or password was specified."
+        })))
+}

--- a/sf_core/tests/e2e/authentication/mod.rs
+++ b/sf_core/tests/e2e/authentication/mod.rs
@@ -1,5 +1,6 @@
 mod native_okta;
 mod pat;
 mod private_key_auth;
+mod user_password;
 #[cfg(feature = "auth_mfa_e2e")]
 mod user_password_mfa;

--- a/sf_core/tests/e2e/authentication/user_password.rs
+++ b/sf_core/tests/e2e/authentication/user_password.rs
@@ -13,7 +13,10 @@ fn is_mfa_enforced(err: &str) -> bool {
 fn should_authenticate_using_username_and_password() {
     //Given Authentication is set to default (snowflake) with valid username and password
     let client = SnowflakeTestClient::with_default_params();
-    let password = client.parameters.password.clone().unwrap();
+    let Some(password) = client.parameters.password.clone() else {
+        eprintln!("SKIPPED: no password configured (environment uses JWT-only auth)");
+        return;
+    };
     client.set_connection_option("password", &password);
 
     //When Trying to Connect
@@ -33,7 +36,10 @@ fn should_authenticate_using_username_and_password() {
 fn should_authenticate_using_explicit_snowflake_authenticator() {
     //Given Authentication is explicitly set to snowflake with valid username and password
     let client = SnowflakeTestClient::with_default_params();
-    let password = client.parameters.password.clone().unwrap();
+    let Some(password) = client.parameters.password.clone() else {
+        eprintln!("SKIPPED: no password configured (environment uses JWT-only auth)");
+        return;
+    };
     client.set_connection_option("password", &password);
     client.set_connection_option("authenticator", "snowflake");
 

--- a/sf_core/tests/e2e/authentication/user_password.rs
+++ b/sf_core/tests/e2e/authentication/user_password.rs
@@ -23,13 +23,13 @@ fn should_authenticate_using_username_and_password() {
     let result = client.connect();
 
     //Then Login is successful and simple query can be executed
-    match result {
-        Ok(()) => client.verify_simple_query(Ok(())),
-        Err(ref e) if is_mfa_enforced(e) => {
+    if let Err(ref e) = result {
+        if is_mfa_enforced(e) {
             eprintln!("SKIPPED: account has MFA enforcement enabled");
+            return;
         }
-        Err(e) => panic!("Expected login to succeed, got: {e}"),
     }
+    client.verify_simple_query(result);
 }
 
 #[test]
@@ -47,13 +47,13 @@ fn should_authenticate_using_explicit_snowflake_authenticator() {
     let result = client.connect();
 
     //Then Login is successful and simple query can be executed
-    match result {
-        Ok(()) => client.verify_simple_query(Ok(())),
-        Err(ref e) if is_mfa_enforced(e) => {
+    if let Err(ref e) = result {
+        if is_mfa_enforced(e) {
             eprintln!("SKIPPED: account has MFA enforcement enabled");
+            return;
         }
-        Err(e) => panic!("Expected login to succeed, got: {e}"),
     }
+    client.verify_simple_query(result);
 }
 
 #[test]

--- a/sf_core/tests/e2e/authentication/user_password.rs
+++ b/sf_core/tests/e2e/authentication/user_password.rs
@@ -1,0 +1,64 @@
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+
+// Some test accounts (notably GCP) enforce MFA at the account level, which
+// causes plain username+password login to fail with "Multi-factor authentication
+// is required for this account." This is a server-side policy, not a driver bug.
+// We detect this and skip instead of failing.
+
+fn is_mfa_enforced(err: &str) -> bool {
+    err.contains("Multi-factor authentication is required")
+}
+
+#[test]
+fn should_authenticate_using_username_and_password() {
+    //Given Authentication is set to default (snowflake) with valid username and password
+    let client = SnowflakeTestClient::with_default_params();
+    let password = client.parameters.password.clone().unwrap();
+    client.set_connection_option("password", &password);
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then Login is successful and simple query can be executed
+    match result {
+        Ok(()) => client.verify_simple_query(Ok(())),
+        Err(ref e) if is_mfa_enforced(e) => {
+            eprintln!("SKIPPED: account has MFA enforcement enabled");
+        }
+        Err(e) => panic!("Expected login to succeed, got: {e}"),
+    }
+}
+
+#[test]
+fn should_authenticate_using_explicit_snowflake_authenticator() {
+    //Given Authentication is explicitly set to snowflake with valid username and password
+    let client = SnowflakeTestClient::with_default_params();
+    let password = client.parameters.password.clone().unwrap();
+    client.set_connection_option("password", &password);
+    client.set_connection_option("authenticator", "snowflake");
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then Login is successful and simple query can be executed
+    match result {
+        Ok(()) => client.verify_simple_query(Ok(())),
+        Err(ref e) if is_mfa_enforced(e) => {
+            eprintln!("SKIPPED: account has MFA enforcement enabled");
+        }
+        Err(e) => panic!("Expected login to succeed, got: {e}"),
+    }
+}
+
+#[test]
+fn should_fail_authentication_when_wrong_password_is_provided() {
+    //Given Authentication is set to default with valid username and wrong password
+    let client = SnowflakeTestClient::with_default_params();
+    client.set_connection_option("password", "definitely_not_a_valid_password_12345");
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then There is error returned
+    client.assert_login_error(result);
+}

--- a/sf_core/tests/e2e/authentication/user_password.rs
+++ b/sf_core/tests/e2e/authentication/user_password.rs
@@ -23,11 +23,11 @@ fn should_authenticate_using_username_and_password() {
     let result = client.connect();
 
     //Then Login is successful and simple query can be executed
-    if let Err(ref e) = result {
-        if is_mfa_enforced(e) {
-            eprintln!("SKIPPED: account has MFA enforcement enabled");
-            return;
-        }
+    if let Err(ref e) = result
+        && is_mfa_enforced(e)
+    {
+        eprintln!("SKIPPED: account has MFA enforcement enabled");
+        return;
     }
     client.verify_simple_query(result);
 }
@@ -47,11 +47,11 @@ fn should_authenticate_using_explicit_snowflake_authenticator() {
     let result = client.connect();
 
     //Then Login is successful and simple query can be executed
-    if let Err(ref e) = result {
-        if is_mfa_enforced(e) {
-            eprintln!("SKIPPED: account has MFA enforcement enabled");
-            return;
-        }
+    if let Err(ref e) = result
+        && is_mfa_enforced(e)
+    {
+        eprintln!("SKIPPED: account has MFA enforcement enabled");
+        return;
     }
     client.verify_simple_query(result);
 }

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,3 +1,4 @@
 pub mod native_okta;
 pub mod private_key_auth;
+pub mod user_password;
 pub mod user_password_mfa;

--- a/sf_core/tests/integration/authentication/user_password.rs
+++ b/sf_core/tests/integration/authentication/user_password.rs
@@ -1,0 +1,105 @@
+use crate::common::mocks::password;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+
+struct PasswordTestFixture {
+    mock: MockServerWithTls,
+    client: SnowflakeTestClient,
+}
+
+impl PasswordTestFixture {
+    fn new() -> Self {
+        let mock = MockServerWithTls::start();
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("password", "test_password"); // pragma: allowlist secret
+        Self { mock, client }
+    }
+}
+
+#[test]
+fn should_authenticate_with_password_via_wiremock() {
+    //Given Wiremock is running and has password login success mapping
+    let fixture = PasswordTestFixture::new();
+    //And Snowflake client is configured for password authentication
+    fixture.mock.mount(password::login_success());
+
+    //When Trying to Connect
+    let result = fixture.client.connect();
+
+    //Then Login is successful
+    assert!(
+        result.is_ok(),
+        "Expected password login to succeed, got: {result:?}"
+    );
+}
+
+#[test]
+fn should_fail_authentication_when_server_returns_error() {
+    //Given Wiremock is running and has password login failure mapping
+    let fixture = PasswordTestFixture::new();
+    //And Snowflake client is configured for password authentication
+    fixture
+        .client
+        .set_connection_option("password", "wrong_password"); // pragma: allowlist secret
+    fixture
+        .mock
+        .mount(password::login_failure_wrong_credentials());
+
+    //When Trying to Connect
+    let result = fixture.client.connect();
+
+    //Then There is error returned
+    let error = result.expect_err("Expected login to fail with wrong password");
+    assert!(
+        error.contains("Incorrect username or password"),
+        "Expected credential error, got: {error}"
+    );
+}
+
+#[test]
+fn should_fail_authentication_when_user_is_not_provided() {
+    //Given Wiremock is running and has password login success mapping
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    //And Snowflake client is configured for password authentication without user
+    client.set_connection_option("user", "");
+    client.set_connection_option("password", "test_password"); // pragma: allowlist secret
+    mock.mount(password::login_success());
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then There is error returned with missing parameter
+    client.assert_missing_parameter_error(result);
+}
+
+#[test]
+fn should_fail_authentication_when_password_is_not_provided() {
+    //Given Wiremock is running and has password login success mapping
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    //And Snowflake client is configured for password authentication without password
+    mock.mount(password::login_success());
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then There is error returned with missing parameter
+    client.assert_missing_parameter_error(result);
+}
+
+#[test]
+fn should_fail_authentication_when_password_is_empty() {
+    //Given Wiremock is running and has password login success mapping
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    //And Snowflake client is configured for password authentication with empty password
+    client.set_connection_option("password", ""); // pragma: allowlist secret
+    mock.mount(password::login_success());
+
+    //When Trying to Connect
+    let result = client.connect();
+
+    //Then There is error returned with missing parameter
+    client.assert_missing_parameter_error(result);
+}

--- a/sf_core/tests/integration/authentication/user_password.rs
+++ b/sf_core/tests/integration/authentication/user_password.rs
@@ -34,10 +34,10 @@ fn should_authenticate_with_password_via_wiremock() {
 }
 
 #[test]
-fn should_fail_authentication_when_server_returns_error() {
-    //Given Wiremock is running and has password login failure mapping
+fn should_fail_authentication_when_wrong_credentials_are_provided() {
+    //Given Wiremock is running and has password login failure mapping for wrong credentials
     let fixture = PasswordTestFixture::new();
-    //And Snowflake client is configured for password authentication
+    //And Snowflake client is configured for password authentication with wrong password
     fixture
         .client
         .set_connection_option("password", "wrong_password"); // pragma: allowlist secret

--- a/tests/definitions/shared/authentication/user_password.feature
+++ b/tests/definitions/shared/authentication/user_password.feature
@@ -48,8 +48,8 @@ Feature: Username and Password Authentication
     Then There is error returned with missing parameter
 
   @core_int
-  Scenario: should fail authentication when server returns error
-    Given Wiremock is running and has password login failure mapping
-    And Snowflake client is configured for password authentication
+  Scenario: should fail authentication when wrong credentials are provided
+    Given Wiremock is running and has password login failure mapping for wrong credentials
+    And Snowflake client is configured for password authentication with wrong password
     When Trying to Connect
     Then There is error returned

--- a/tests/definitions/shared/authentication/user_password.feature
+++ b/tests/definitions/shared/authentication/user_password.feature
@@ -1,0 +1,55 @@
+@core @python @odbc
+Feature: Username and Password Authentication
+
+  @core_e2e @python_e2e @odbc_e2e
+  Scenario: should authenticate using username and password
+    Given Authentication is set to default (snowflake) with valid username and password
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @core_e2e @odbc_e2e
+  Scenario: should authenticate using explicit snowflake authenticator
+    Given Authentication is explicitly set to snowflake with valid username and password
+    When Trying to Connect
+    Then Login is successful and simple query can be executed
+
+  @core_e2e @python_e2e @odbc_e2e
+  Scenario: should fail authentication when wrong password is provided
+    Given Authentication is set to default with valid username and wrong password
+    When Trying to Connect
+    Then There is error returned
+
+  @core_int
+  Scenario: should authenticate with password via wiremock
+    Given Wiremock is running and has password login success mapping
+    And Snowflake client is configured for password authentication
+    When Trying to Connect
+    Then Login is successful
+
+  @core_int
+  Scenario: should fail authentication when user is not provided
+    Given Wiremock is running and has password login success mapping
+    And Snowflake client is configured for password authentication without user
+    When Trying to Connect
+    Then There is error returned with missing parameter
+
+  @core_int
+  Scenario: should fail authentication when password is not provided
+    Given Wiremock is running and has password login success mapping
+    And Snowflake client is configured for password authentication without password
+    When Trying to Connect
+    Then There is error returned with missing parameter
+
+  @core_int
+  Scenario: should fail authentication when password is empty
+    Given Wiremock is running and has password login success mapping
+    And Snowflake client is configured for password authentication with empty password
+    When Trying to Connect
+    Then There is error returned with missing parameter
+
+  @core_int
+  Scenario: should fail authentication when server returns error
+    Given Wiremock is running and has password login failure mapping
+    And Snowflake client is configured for password authentication
+    When Trying to Connect
+    Then There is error returned


### PR DESCRIPTION
## Summary

- Add a full test suite for plain username+password authentication (the default `SNOWFLAKE` authenticator) across all layers
- Every other auth type (PAT, JWT/key-pair, MFA, native Okta) had dedicated test files, but username+password had zero — it was only exercised implicitly as test infrastructure

## MFA-enforced accounts

Some test accounts (notably GCP) enforce MFA at the account level, causing plain username+password login to fail with "Multi-factor authentication is required for this account." This is a server-side policy, not a driver bug. The happy-path e2e tests detect this at runtime and **skip** instead of failing, so CI stays green on both AWS (no MFA enforcement) and GCP (MFA enforced) test accounts.

## Test matrix

| Scenario | Core e2e | Core int (wiremock) | ODBC e2e | Python e2e |
|----------|----------|---------------------|----------|------------|
| Happy path: default auth | x (skip if MFA enforced) | x | x (skip if MFA enforced) | x (skip if MFA enforced) |
| Happy path: explicit `snowflake` authenticator | x (skip if MFA enforced) | | x (skip if MFA enforced) | |
| Wrong password | x | x | x | x |
| Missing user | | x | | |
| Missing password | | x | | |
| Empty password | | x | | |
| Server returns error | | x | | |

## New files

- `sf_core/tests/e2e/authentication/user_password.rs` — 3 e2e tests
- `sf_core/tests/integration/authentication/user_password.rs` — 5 wiremock integration tests
- `sf_core/tests/common/mocks/password.rs` — password login success/failure mocks
- `odbc_tests/tests/e2e/authentication/user_password.cpp` — 3 ODBC e2e tests
- `python/tests/e2e/authentication/test_user_password.py` — 2 Python e2e tests
- `tests/definitions/shared/authentication/user_password.feature` — Gherkin scenarios

## Test plan

- [x] Core integration tests pass locally (22 auth tests, including 5 new password tests)
- [x] `cargo check -p sf_core --tests` compiles cleanly
- [x] E2e tests skip gracefully on MFA-enforced accounts (GCP)
- [ ] Run core e2e tests against real Snowflake (AWS)
- [ ] Run ODBC e2e tests against real Snowflake (AWS)
- [ ] Run Python e2e tests against real Snowflake