### PR TITLE
Odbc trace tool: new IR, split and compare traces, better test generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,7 +3138,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "regex",
+ "serde",
+ "serde_yaml",
  "snafu 0.8.9",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4352,6 +4355,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sf_core"
 version = "0.0.0"
 dependencies = [
@@ -5244,6 +5260,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/odbc_trace_tool/Cargo.toml
+++ b/odbc_trace_tool/Cargo.toml
@@ -10,6 +10,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 snafu = { version = "0.8", features = ["rust_1_65"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/odbc_trace_tool/src/compare.rs
+++ b/odbc_trace_tool/src/compare.rs
@@ -1,0 +1,273 @@
+use crate::model::OdbcCall;
+
+/// Cost of inserting or deleting a call in the edit distance.
+const INDEL_COST: f64 = 1.0;
+
+/// Filter out diagnostic noise that varies across driver managers.
+pub fn filter_for_comparison(calls: &[OdbcCall]) -> Vec<&OdbcCall> {
+    calls
+        .iter()
+        .filter(|c| !matches!(c, OdbcCall::GetDiagRec(_) | OdbcCall::GetFunctions(_)))
+        .collect()
+}
+
+/// Substitution cost between two calls.
+///
+/// - Different function name: 1.0
+/// - Same function: sum of per-field penalties (capped at 1.0)
+pub fn call_distance(a: &OdbcCall, b: &OdbcCall) -> f64 {
+    if std::mem::discriminant(a) != std::mem::discriminant(b) {
+        return 1.0;
+    }
+
+    let penalty = match (a, b) {
+        (OdbcCall::AllocHandle(a), OdbcCall::AllocHandle(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.handle_type, &b.handle_type, 1.0)
+        }
+        (OdbcCall::FreeHandle(a), OdbcCall::FreeHandle(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.handle_type, &b.handle_type, 1.0)
+        }
+        (OdbcCall::SetEnvAttr(a), OdbcCall::SetEnvAttr(b)) => {
+            diff_rc(a.return_code, b.return_code)
+                + diff_opt(&a.attribute, &b.attribute, 0.3)
+                + diff_opt(&a.value, &b.value, 0.1)
+        }
+        (OdbcCall::SetConnectAttr(a), OdbcCall::SetConnectAttr(b)) => {
+            diff_rc(a.return_code, b.return_code)
+                + diff_opt(&a.attribute, &b.attribute, 0.3)
+                + diff_opt(&a.value, &b.value, 0.1)
+        }
+        (OdbcCall::Prepare(a), OdbcCall::Prepare(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.sql, &b.sql, 0.4)
+        }
+        (OdbcCall::ExecDirect(a), OdbcCall::ExecDirect(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.sql, &b.sql, 0.4)
+        }
+        (OdbcCall::DescribeCol(a), OdbcCall::DescribeCol(b)) => {
+            diff_rc(a.return_code, b.return_code)
+                + diff_opt(&a.column_number, &b.column_number, 0.2)
+                + diff_opt(&a.data_type, &b.data_type, 0.1)
+        }
+        (OdbcCall::GetData(a), OdbcCall::GetData(b)) => {
+            diff_rc(a.return_code, b.return_code)
+                + diff_opt(&a.column_number, &b.column_number, 0.2)
+                + diff_opt(&a.target_type_name, &b.target_type_name, 1.0)
+        }
+        (OdbcCall::FetchScroll(a), OdbcCall::FetchScroll(b)) => {
+            diff_rc(a.return_code, b.return_code)
+                + diff_opt(&a.orientation_name, &b.orientation_name, 0.2)
+        }
+        (OdbcCall::GetInfo(a), OdbcCall::GetInfo(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.info_type, &b.info_type, 1.0)
+        }
+        (OdbcCall::NumResultCols(a), OdbcCall::NumResultCols(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.count, &b.count, 0.1)
+        }
+        (OdbcCall::RowCount(a), OdbcCall::RowCount(b)) => {
+            diff_rc(a.return_code, b.return_code) + diff_opt(&a.count, &b.count, 0.1)
+        }
+        // Calls with no distinguishing args beyond return_code.
+        _ => diff_rc(a.return_code(), b.return_code()),
+    };
+
+    penalty.min(1.0)
+}
+
+fn diff_rc(a: crate::model::ReturnCode, b: crate::model::ReturnCode) -> f64 {
+    if a == b {
+        0.0
+    } else {
+        1.0
+    }
+}
+
+fn diff_opt<T: PartialEq>(a: &Option<T>, b: &Option<T>, weight: f64) -> f64 {
+    match (a, b) {
+        (Some(a), Some(b)) if a == b => 0.0,
+        (None, None) => 0.0,
+        _ => weight,
+    }
+}
+
+/// Weighted Levenshtein edit distance on two call sequences, normalized to [0.0, 1.0].
+pub fn compare_traces(a: &[&OdbcCall], b: &[&OdbcCall]) -> f64 {
+    let n = a.len();
+    let m = b.len();
+    if n == 0 && m == 0 {
+        return 0.0;
+    }
+
+    // Two-row DP. prev = row i-1, curr = row i.
+    let mut prev: Vec<f64> = (0..=m).map(|j| j as f64 * INDEL_COST).collect();
+    let mut curr = vec![0.0; m + 1];
+
+    for i in 1..=n {
+        curr[0] = i as f64 * INDEL_COST;
+        for j in 1..=m {
+            let sub = prev[j - 1] + call_distance(a[i - 1], b[j - 1]);
+            let del = prev[j] + INDEL_COST;
+            let ins = curr[j - 1] + INDEL_COST;
+            curr[j] = sub.min(del).min(ins);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    let raw = prev[m];
+    let max_len = n.max(m) as f64;
+    raw / max_len
+}
+
+pub struct CompareResult {
+    pub name_a: String,
+    pub name_b: String,
+    pub distance: f64,
+    pub len_b: usize,
+}
+
+pub fn print_report(reference_label: &str, results: &mut [CompareResult]) {
+    results.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+    let multi_ref = results.windows(2).any(|w| w[0].name_a != w[1].name_a);
+    println!("Reference: {reference_label}");
+    for r in results.iter() {
+        let identical = if r.distance == 0.0 {
+            " (identical)"
+        } else {
+            ""
+        };
+        let best_ref = if multi_ref {
+            format!(" [closest: {}]", r.name_a)
+        } else {
+            String::new()
+        };
+        println!(
+            "  vs {} ({} calls): distance {:.3}{identical}{best_ref}",
+            r.name_b, r.len_b, r.distance
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::*;
+
+    fn prep(sql: &str) -> OdbcCall {
+        OdbcCall::Prepare(Prepare {
+            return_code: ReturnCode::Success,
+            handle: None,
+            sql: Some(sql.to_string()),
+            sql_truncated: false,
+        })
+    }
+
+    fn exec() -> OdbcCall {
+        OdbcCall::Execute(Execute {
+            return_code: ReturnCode::Success,
+            handle: None,
+        })
+    }
+
+    fn fetch_ok() -> OdbcCall {
+        OdbcCall::Fetch(Fetch {
+            return_code: ReturnCode::Success,
+            handle: None,
+        })
+    }
+
+    fn fetch_no_data() -> OdbcCall {
+        OdbcCall::Fetch(Fetch {
+            return_code: ReturnCode::NoData,
+            handle: None,
+        })
+    }
+
+    #[test]
+    fn test_identical_traces() {
+        let a = vec![prep("SELECT 1"), exec(), fetch_ok()];
+        let b = vec![prep("SELECT 1"), exec(), fetch_ok()];
+        let fa: Vec<_> = a.iter().collect();
+        let fb: Vec<_> = b.iter().collect();
+        assert_eq!(compare_traces(&fa, &fb), 0.0);
+    }
+
+    #[test]
+    fn test_completely_different() {
+        let a = [prep("SELECT 1")];
+        let b = [exec()];
+        let fa: Vec<_> = a.iter().collect();
+        let fb: Vec<_> = b.iter().collect();
+        assert_eq!(compare_traces(&fa, &fb), 1.0);
+    }
+
+    #[test]
+    fn test_same_function_different_sql() {
+        let d = call_distance(&prep("SELECT 1"), &prep("SELECT 2"));
+        assert!((d - 0.4).abs() < 1e-9, "expected 0.4, got {d}");
+    }
+
+    #[test]
+    fn test_same_function_different_return_code() {
+        let d = call_distance(&fetch_ok(), &fetch_no_data());
+        assert!((d - 1.0).abs() < 1e-9, "expected 1.0, got {d}");
+    }
+
+    #[test]
+    fn test_same_function_same_args() {
+        let d = call_distance(&exec(), &exec());
+        assert_eq!(d, 0.0);
+    }
+
+    #[test]
+    fn test_different_function() {
+        let d = call_distance(&prep("SELECT 1"), &exec());
+        assert_eq!(d, 1.0);
+    }
+
+    #[test]
+    fn test_insertion_deletion() {
+        let a = vec![prep("SELECT 1"), exec(), fetch_ok()];
+        let b = vec![prep("SELECT 1"), exec()];
+        let fa: Vec<_> = a.iter().collect();
+        let fb: Vec<_> = b.iter().collect();
+        let d = compare_traces(&fa, &fb);
+        assert!((d - 1.0 / 3.0).abs() < 1e-9, "expected ~0.333, got {d}");
+    }
+
+    #[test]
+    fn test_empty_vs_nonempty() {
+        let a: Vec<OdbcCall> = vec![];
+        let b = [exec()];
+        let fa: Vec<_> = a.iter().collect();
+        let fb: Vec<_> = b.iter().collect();
+        assert_eq!(compare_traces(&fa, &fb), 1.0);
+    }
+
+    #[test]
+    fn test_both_empty() {
+        let a: Vec<OdbcCall> = vec![];
+        let b: Vec<OdbcCall> = vec![];
+        let fa: Vec<_> = a.iter().collect();
+        let fb: Vec<_> = b.iter().collect();
+        assert_eq!(compare_traces(&fa, &fb), 0.0);
+    }
+
+    #[test]
+    fn test_penalty_caps_at_one() {
+        let a = OdbcCall::SetEnvAttr(SetEnvAttr {
+            return_code: ReturnCode::Success,
+            handle: None,
+            attribute: Some("SQL_ATTR_ODBC_VERSION".to_string()),
+            value: Some(3),
+            str_len: None,
+        });
+        let b = OdbcCall::SetEnvAttr(SetEnvAttr {
+            return_code: ReturnCode::Error,
+            handle: None,
+            attribute: Some("SQL_ATTR_AUTOCOMMIT".to_string()),
+            value: Some(1),
+            str_len: None,
+        });
+        let d = call_distance(&a, &b);
+        assert!((d - 1.0).abs() < 1e-9, "should cap at 1.0, got {d}");
+    }
+}

--- a/odbc_trace_tool/src/generator/cpp.rs
+++ b/odbc_trace_tool/src/generator/cpp.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::Write as FmtWrite;
 
-use crate::model::{HandleType, OdbcCall, ParamValue, TraceLog};
+use crate::model::{HandleType, OdbcCall, ReturnCode};
+use crate::query_map::QueryMap;
 
 pub struct GeneratorConfig {
     pub test_name: String,
     pub tag: String,
+    pub query_map: Option<QueryMap>,
 }
 
 impl Default for GeneratorConfig {
@@ -13,12 +16,13 @@ impl Default for GeneratorConfig {
         Self {
             test_name: "Replay trace".to_string(),
             tag: "replay".to_string(),
+            query_map: None,
         }
     }
 }
 
-pub fn generate(trace: &TraceLog, config: &GeneratorConfig) -> String {
-    let mut ctx = GenContext::new(trace, config);
+pub fn generate(calls: &[OdbcCall], config: &GeneratorConfig) -> String {
+    let mut ctx = GenContext::new(calls, config);
     ctx.generate()
 }
 
@@ -41,12 +45,6 @@ fn escape_cpp_string_literal(s: &str) -> String {
     out
 }
 
-// SQLGetDiagRec calls are diagnostic-only and not part of the functional replay.
-// We can add them back later if we need to assert on diagnostics.
-// SQLGetFunctions queries driver manager which vary across managers and are
-// not meaningful to assert in replay tests.
-const SKIPPED_FUNCTIONS: &[&str] = &["SQLGetDiagRec", "SQLGetFunctions"];
-
 const DRIVER_SPECIFIC_INFO_TYPES: &[&str] = &[
     "SQL_DRIVER_VER",
     "SQL_DRIVER_NAME",
@@ -55,38 +53,42 @@ const DRIVER_SPECIFIC_INFO_TYPES: &[&str] = &[
 ];
 
 struct GenContext<'a> {
-    trace: &'a TraceLog,
+    calls: &'a [OdbcCall],
     config: &'a GeneratorConfig,
     output: String,
     indent: usize,
     handle_vars: HashMap<String, String>,
-    dbc_address: Option<String>,
+    env_counter: usize,
+    dbc_counter: usize,
     stmt_counter: usize,
-    declared_stmts: Vec<String>,
+    declared_handles: HashSet<String>,
+    query_counter: usize,
 }
 
 impl<'a> GenContext<'a> {
-    fn new(trace: &'a TraceLog, config: &'a GeneratorConfig) -> Self {
+    fn new(calls: &'a [OdbcCall], config: &'a GeneratorConfig) -> Self {
         Self {
-            trace,
+            calls,
             config,
             output: String::new(),
             indent: 1,
             handle_vars: HashMap::new(),
-            dbc_address: None,
+            env_counter: 0,
+            dbc_counter: 0,
             stmt_counter: 0,
-            declared_stmts: Vec::new(),
+            declared_handles: HashSet::new(),
+            query_counter: 0,
         }
     }
 
     fn generate(&mut self) -> String {
-        self.identify_dbc_handle();
         self.emit_header();
         self.emit_test_open();
+        self.emit_config_install();
+        self.emit_synthetic_handles();
 
-        for i in 0..self.trace.calls.len() {
-            let call = &self.trace.calls[i];
-            if SKIPPED_FUNCTIONS.iter().any(|&f| f == call.function_name) {
+        for call in self.calls {
+            if matches!(call, OdbcCall::GetDiagRec(_) | OdbcCall::GetFunctions(_)) {
                 continue;
             }
             self.emit_call(call);
@@ -96,17 +98,155 @@ impl<'a> GenContext<'a> {
         self.output.clone()
     }
 
-    fn identify_dbc_handle(&mut self) {
-        for call in &self.trace.calls {
-            if call.function_name == "SQLDriverConnect" {
-                if let Some(param) = call.output_params.first() {
-                    if let ParamValue::Address(addr) = &param.value {
-                        self.dbc_address = Some(addr.clone());
-                        self.handle_vars
-                            .insert(addr.clone(), "dbc_handle()".to_string());
+    /// Find env/dbc handle addresses that are referenced by calls but never
+    /// explicitly allocated via SQLAllocHandle in this call list. For each one,
+    /// synthesize a variable declaration and allocation block at the top.
+    fn emit_synthetic_handles(&mut self) {
+        let explicitly_allocated: HashSet<String> = self
+            .calls
+            .iter()
+            .filter_map(|c| {
+                if let OdbcCall::AllocHandle(a) = c {
+                    a.child_handle.clone()
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut implicit_envs: Vec<String> = Vec::new();
+        let mut implicit_dbcs: Vec<String> = Vec::new();
+
+        let mut record_implicit = |addr: &str, ht: HandleType| {
+            if explicitly_allocated.contains(addr) {
+                return;
+            }
+            match ht {
+                HandleType::Env => {
+                    if !implicit_envs.contains(&addr.to_string()) {
+                        implicit_envs.push(addr.to_string());
                     }
                 }
+                HandleType::Dbc => {
+                    if !implicit_dbcs.contains(&addr.to_string()) {
+                        implicit_dbcs.push(addr.to_string());
+                    }
+                }
+                _ => {}
             }
+        };
+
+        for call in self.calls {
+            match call {
+                OdbcCall::SetEnvAttr(c) => {
+                    if let Some(a) = &c.handle {
+                        record_implicit(a, HandleType::Env);
+                    }
+                }
+                OdbcCall::DriverConnect(c) => {
+                    if let Some(a) = &c.handle {
+                        record_implicit(a, HandleType::Dbc);
+                    }
+                }
+                OdbcCall::Disconnect(c) => {
+                    if let Some(a) = &c.handle {
+                        record_implicit(a, HandleType::Dbc);
+                    }
+                }
+                OdbcCall::SetConnectAttr(c) => {
+                    if let Some(a) = &c.handle {
+                        record_implicit(a, HandleType::Dbc);
+                    }
+                }
+                OdbcCall::GetInfo(c) => {
+                    if let Some(a) = &c.handle {
+                        record_implicit(a, HandleType::Dbc);
+                    }
+                }
+                OdbcCall::FreeHandle(c) => {
+                    if let (Some(a), Some(ht)) = (&c.handle, c.handle_type) {
+                        if matches!(ht, HandleType::Env | HandleType::Dbc) {
+                            record_implicit(a, ht);
+                        }
+                    }
+                }
+                OdbcCall::AllocHandle(c) => {
+                    if let Some(parent) = &c.parent_handle {
+                        if !explicitly_allocated.contains(parent) {
+                            let parent_ht = match c.handle_type {
+                                Some(HandleType::Dbc) => Some(HandleType::Env),
+                                Some(HandleType::Stmt) => Some(HandleType::Dbc),
+                                _ => None,
+                            };
+                            if let Some(ht) = parent_ht {
+                                record_implicit(parent, ht);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for env_addr in &implicit_envs {
+            let var = self.next_env_var();
+            self.declare_handle(&var, HandleType::Env);
+            self.writeln("// SQLAllocHandle - SQLHENV (implicit)");
+            self.writeln("{");
+            self.indent += 1;
+            self.writeln(&format!(
+                "SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &{var});"
+            ));
+            self.writeln("REQUIRE(ret == SQL_SUCCESS);");
+            self.writeln(&format!("REQUIRE({var} != SQL_NULL_HENV);"));
+            self.indent -= 1;
+            self.writeln("}");
+            self.writeln("");
+            self.handle_vars.insert(env_addr.clone(), var.clone());
+
+            self.writeln("// SQLSetEnvAttr - SQL_ATTR_ODBC_VERSION (implicit)");
+            self.writeln("{");
+            self.indent += 1;
+            self.writeln(&format!(
+                "SQLRETURN ret = SQLSetEnvAttr({var}, SQL_ATTR_ODBC_VERSION,"
+            ));
+            self.writeln("    (SQLPOINTER)SQL_OV_ODBC3, 0);");
+            self.writeln(&format!(
+                "REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_ENV, {var}),"
+            ));
+            self.writeln("           OdbcMatchers::IsSuccess());");
+            self.indent -= 1;
+            self.writeln("}");
+            self.writeln("");
+        }
+
+        let env_var_for_implicit_dbc = if !implicit_envs.is_empty() {
+            self.handle_vars
+                .get(&implicit_envs[0])
+                .cloned()
+                .unwrap_or_else(|| "env0".to_string())
+        } else {
+            self.first_env_var()
+        };
+
+        for dbc_addr in &implicit_dbcs {
+            let var = self.next_dbc_var();
+            self.declare_handle(&var, HandleType::Dbc);
+            self.writeln("// SQLAllocHandle - SQLHDBC (implicit)");
+            self.writeln("{");
+            self.indent += 1;
+            self.writeln(&format!(
+                "SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, {env_var_for_implicit_dbc}, &{var});"
+            ));
+            self.writeln(&format!(
+                "REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_ENV, {env_var_for_implicit_dbc}),"
+            ));
+            self.writeln("           OdbcMatchers::IsSuccess());");
+            self.writeln(&format!("REQUIRE({var} != SQL_NULL_HDBC);"));
+            self.indent -= 1;
+            self.writeln("}");
+            self.writeln("");
+            self.handle_vars.insert(dbc_addr.clone(), var);
         }
     }
 
@@ -114,7 +254,8 @@ impl<'a> GenContext<'a> {
         let saved = self.indent;
         self.indent = 0;
         self.writeln("#include <catch2/catch_test_macros.hpp>");
-        self.writeln("#include \"ODBCFixtures.hpp\"");
+        self.writeln("#include <vector>");
+        self.writeln("#include \"ODBCConfig.hpp\"");
         self.writeln("#include \"odbc_cast.hpp\"");
         self.writeln("#include \"odbc_matchers.hpp\"");
         self.writeln("");
@@ -126,10 +267,13 @@ impl<'a> GenContext<'a> {
         let tag = escape_cpp_string_literal(&self.config.tag);
         let saved = self.indent;
         self.indent = 0;
-        self.writeln(&format!(
-            "TEST_CASE_METHOD(DbcDefaultDSNFixture, \"Replay: {name}\", \"[{tag}]\") {{"
-        ));
+        self.writeln(&format!("TEST_CASE(\"Replay: {name}\", \"[{tag}]\") {{"));
         self.indent = saved;
+    }
+
+    fn emit_config_install(&mut self) {
+        self.writeln("auto config = DataSourceConfig::Snowflake().install();");
+        self.writeln("");
     }
 
     fn emit_test_close(&mut self) {
@@ -140,83 +284,109 @@ impl<'a> GenContext<'a> {
     }
 
     fn emit_call(&mut self, call: &OdbcCall) {
-        match call.function_name.as_str() {
-            "SQLDriverConnect" => self.emit_driver_connect(call),
-            "SQLAllocHandle" => self.emit_alloc_handle(call),
-            "SQLPrepare" => self.emit_prepare(call),
-            "SQLExecute" => self.emit_execute(call),
-            "SQLExecDirect" => self.emit_exec_direct(call),
-            "SQLNumResultCols" => self.emit_num_result_cols(call),
-            "SQLDescribeCol" => self.emit_describe_col(call),
-            "SQLFetchScroll" => self.emit_fetch_scroll(call),
-            "SQLFetch" => self.emit_fetch(call),
-            "SQLGetData" => self.emit_get_data(call),
-            "SQLMoreResults" => self.emit_more_results(call),
-            "SQLCloseCursor" => self.emit_close_cursor(call),
-            "SQLGetInfo" => self.emit_get_info(call),
-            "SQLFreeHandle" => self.emit_free_handle(call),
-            "SQLDisconnect" => self.emit_disconnect(call),
-            _ => self.emit_generic_comment(call),
+        match call {
+            OdbcCall::DriverConnect(c) => self.emit_driver_connect(c),
+            OdbcCall::AllocHandle(c) => self.emit_alloc_handle(c),
+            OdbcCall::SetEnvAttr(c) => self.emit_set_env_attr(c),
+            OdbcCall::SetConnectAttr(c) => self.emit_set_connect_attr(c),
+            OdbcCall::Prepare(c) => self.emit_prepare(c),
+            OdbcCall::Execute(c) => self.emit_execute(c),
+            OdbcCall::ExecDirect(c) => self.emit_exec_direct(c),
+            OdbcCall::NumResultCols(c) => self.emit_num_result_cols(c),
+            OdbcCall::DescribeCol(c) => self.emit_describe_col(c),
+            OdbcCall::FetchScroll(c) => self.emit_fetch_scroll(c),
+            OdbcCall::Fetch(c) => self.emit_fetch(c),
+            OdbcCall::GetData(c) => self.emit_get_data(c),
+            OdbcCall::RowCount(c) => self.emit_row_count(c),
+            OdbcCall::MoreResults(c) => self.emit_more_results(c),
+            OdbcCall::CloseCursor(c) => self.emit_close_cursor(c),
+            OdbcCall::GetInfo(c) => self.emit_get_info(c),
+            OdbcCall::FreeHandle(c) => self.emit_free_handle(c),
+            OdbcCall::Disconnect(c) => self.emit_disconnect(c),
+            _ => {}
         }
     }
 
-    fn emit_driver_connect(&mut self, call: &OdbcCall) {
+    fn emit_driver_connect(&mut self, call: &crate::model::DriverConnect) {
+        let dbc_var = self.dbc_var_for(&call.handle);
+
         self.writeln("// SQLDriverConnect");
         self.writeln("{");
         self.indent += 1;
-        self.writeln("SQLRETURN ret = SQLDriverConnect(dbc_handle(), nullptr,");
-        self.writeln("    sqlchar(connection_string().c_str()), SQL_NTS,");
+        self.writeln(&format!(
+            "SQLRETURN ret = SQLDriverConnect({dbc_var}, nullptr,"
+        ));
+        self.writeln("    sqlchar(config.connection_string().c_str()), SQL_NTS,");
         self.writeln("    nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);");
-        self.emit_return_assertion(call, "SQL_HANDLE_DBC", "dbc_handle()", true, true);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_DBC", &dbc_var, true, true);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_alloc_handle(&mut self, call: &OdbcCall) {
-        let handle_type_value = extract_integer_or_named(&call.output_params, 0);
-        let handle_type = handle_type_value.and_then(HandleType::from_value);
-        let parent_addr = extract_address(&call.output_params, 1);
-        let child_addr = extract_output_address(&call.output_params, 2);
+    fn emit_alloc_handle(&mut self, call: &crate::model::AllocHandle) {
+        let Some(ht) = call.handle_type else { return };
+        let Some(child) = &call.child_handle else {
+            return;
+        };
 
-        if let (Some(ht), Some(child)) = (handle_type, &child_addr) {
-            if ht == HandleType::Stmt {
-                let var_name = format!("stmt{}", self.stmt_counter);
-                self.stmt_counter += 1;
-
-                if !self.declared_stmts.contains(&var_name) {
-                    self.writeln(&format!("SQLHSTMT {var_name} = SQL_NULL_HSTMT;"));
-                    self.declared_stmts.push(var_name.clone());
-                }
-
-                self.handle_vars.insert(child.clone(), var_name.clone());
-
-                let parent_var = parent_addr
-                    .as_ref()
-                    .and_then(|a| self.handle_vars.get(a))
-                    .cloned()
-                    .unwrap_or_else(|| "dbc_handle()".to_string());
-
-                self.writeln(&format!("// SQLAllocHandle - {}", ht.c_type_name()));
-                self.writeln("{");
-                self.indent += 1;
-                self.writeln(&format!(
-                    "SQLRETURN ret = SQLAllocHandle({}, {parent_var}, &{var_name});",
-                    ht.sql_handle_type_constant()
-                ));
-                self.emit_return_assertion(call, "SQL_HANDLE_DBC", &parent_var, true, false);
-                self.indent -= 1;
-                self.writeln("}");
-                self.writeln("");
-            }
+        if self.handle_vars.contains_key(child) {
+            return;
         }
+
+        let var_name = match ht {
+            HandleType::Env => self.next_env_var(),
+            HandleType::Dbc => self.next_dbc_var(),
+            HandleType::Stmt => self.next_stmt_var(),
+            HandleType::Desc => return,
+        };
+
+        self.declare_handle(&var_name, ht);
+        self.handle_vars.insert(child.clone(), var_name.clone());
+
+        let parent_var = match ht {
+            HandleType::Env => "SQL_NULL_HANDLE".to_string(),
+            _ => call
+                .parent_handle
+                .as_ref()
+                .and_then(|a| self.handle_vars.get(a))
+                .cloned()
+                .unwrap_or_else(|| self.default_parent_var(ht)),
+        };
+
+        let diag_handle_type = match ht {
+            HandleType::Env => None,
+            HandleType::Dbc => Some("SQL_HANDLE_ENV"),
+            HandleType::Stmt => Some("SQL_HANDLE_DBC"),
+            HandleType::Desc => Some("SQL_HANDLE_DBC"),
+        };
+
+        self.writeln(&format!("// SQLAllocHandle - {}", ht.c_type_name()));
+        self.writeln("{");
+        self.indent += 1;
+        self.writeln(&format!(
+            "SQLRETURN ret = SQLAllocHandle({}, {parent_var}, &{var_name});",
+            ht.sql_handle_type_constant()
+        ));
+
+        if let Some(dht) = diag_handle_type {
+            self.emit_return_assertion(call.return_code, dht, &parent_var, true, false);
+        } else {
+            self.writeln("REQUIRE(ret == SQL_SUCCESS);");
+        }
+        self.writeln(&format!(
+            "REQUIRE({var_name} != {});",
+            ht.sql_null_constant()
+        ));
+        self.indent -= 1;
+        self.writeln("}");
+        self.writeln("");
     }
 
-    fn emit_prepare(&mut self, call: &OdbcCall) {
-        let sql = escape_cpp_string_literal(
-            &extract_string_value(&call.input_params).unwrap_or_default(),
-        );
-        let stmt_var = self.find_stmt_var(&call.input_params);
+    fn emit_prepare(&mut self, call: &crate::model::Prepare) {
+        let raw_sql = call.sql.as_deref().unwrap_or_default();
+        let sql = escape_cpp_string_literal(&self.resolve_query(raw_sql));
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLPrepare");
         self.writeln("{");
@@ -224,30 +394,29 @@ impl<'a> GenContext<'a> {
         self.writeln(&format!(
             "SQLRETURN ret = SQLPrepare({stmt_var}, sqlchar(\"{sql}\"), SQL_NTS);"
         ));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, true, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, true, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_execute(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.input_params);
+    fn emit_execute(&mut self, call: &crate::model::Execute) {
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLExecute");
         self.writeln("{");
         self.indent += 1;
         self.writeln(&format!("SQLRETURN ret = SQLExecute({stmt_var});"));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, true, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, true, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_exec_direct(&mut self, call: &OdbcCall) {
-        let sql = escape_cpp_string_literal(
-            &extract_string_value(&call.input_params).unwrap_or_default(),
-        );
-        let stmt_var = self.find_stmt_var(&call.input_params);
+    fn emit_exec_direct(&mut self, call: &crate::model::ExecDirect) {
+        let raw_sql = call.sql.as_deref().unwrap_or_default();
+        let sql = escape_cpp_string_literal(&self.resolve_query(raw_sql));
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLExecDirect");
         self.writeln("{");
@@ -255,15 +424,14 @@ impl<'a> GenContext<'a> {
         self.writeln(&format!(
             "SQLRETURN ret = SQLExecDirect({stmt_var}, sqlchar(\"{sql}\"), SQL_NTS);"
         ));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, true, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, true, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_num_result_cols(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
-        let num_cols = extract_output_integer(&call.output_params, 1);
+    fn emit_num_result_cols(&mut self, call: &crate::model::NumResultCols) {
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLNumResultCols");
         self.writeln("{");
@@ -272,8 +440,8 @@ impl<'a> GenContext<'a> {
         self.writeln(&format!(
             "SQLRETURN ret = SQLNumResultCols({stmt_var}, &numCols);"
         ));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
-        if let Some(n) = num_cols {
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        if let Some(n) = call.count {
             self.writeln(&format!("CHECK(numCols == {n});"));
         }
         self.indent -= 1;
@@ -281,15 +449,29 @@ impl<'a> GenContext<'a> {
         self.writeln("");
     }
 
-    fn emit_describe_col(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
-        let col_num = extract_integer_or_named(&call.output_params, 1).unwrap_or(1);
-        let col_name = extract_string_value(&call.output_params);
-        let buf_len = extract_integer_or_named(&call.output_params, 3).unwrap_or(50);
-        let data_type = extract_output_named_constant(&call.output_params, 5);
-        let col_size = extract_output_integer(&call.output_params, 6);
-        let scale = extract_output_integer(&call.output_params, 7);
-        let nullable = extract_output_named_constant(&call.output_params, 8);
+    fn emit_row_count(&mut self, call: &crate::model::RowCount) {
+        let stmt_var = self.stmt_var_for(&call.handle);
+
+        self.writeln("// SQLRowCount");
+        self.writeln("{");
+        self.indent += 1;
+        self.writeln("SQLLEN rowCount = 0;");
+        self.writeln(&format!(
+            "SQLRETURN ret = SQLRowCount({stmt_var}, &rowCount);"
+        ));
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        if let Some(n) = call.count {
+            self.writeln(&format!("CHECK(rowCount == {n});"));
+        }
+        self.indent -= 1;
+        self.writeln("}");
+        self.writeln("");
+    }
+
+    fn emit_describe_col(&mut self, call: &crate::model::DescribeCol) {
+        let stmt_var = self.stmt_var_for(&call.handle);
+        let col_num = call.column_number.unwrap_or(1);
+        let buf_len = call.buffer_length.unwrap_or(50);
 
         self.writeln(&format!("// SQLDescribeCol col {col_num}"));
         self.writeln("{");
@@ -304,22 +486,22 @@ impl<'a> GenContext<'a> {
             "    reinterpret_cast<SQLCHAR*>(colName), {buf_len}, nullptr,"
         ));
         self.writeln("    &dataType, &colSize, &scale, &nullable);");
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
 
-        if let Some(name) = &col_name {
+        if let Some(name) = &call.column_name {
             let escaped = escape_cpp_string_literal(name);
             self.writeln(&format!("CHECK(std::string(colName) == \"{escaped}\");"));
         }
-        if let Some(dt) = &data_type {
+        if let Some(dt) = &call.data_type {
             self.writeln(&format!("CHECK(dataType == {dt});"));
         }
-        if let Some(cs) = col_size {
+        if let Some(cs) = call.column_size {
             self.writeln(&format!("CHECK(colSize == {cs});"));
         }
-        if let Some(s) = scale {
+        if let Some(s) = call.decimal_digits {
             self.writeln(&format!("CHECK(scale == {s});"));
         }
-        if let Some(n) = &nullable {
+        if let Some(n) = &call.nullable {
             self.writeln(&format!("CHECK(nullable == {n});"));
         }
 
@@ -328,11 +510,10 @@ impl<'a> GenContext<'a> {
         self.writeln("");
     }
 
-    fn emit_fetch_scroll(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
-        let fetch_orientation = extract_named_constant_name(&call.output_params, 1)
-            .unwrap_or("SQL_FETCH_NEXT".to_string());
-        let offset = extract_integer_or_named(&call.output_params, 2).unwrap_or(1);
+    fn emit_fetch_scroll(&mut self, call: &crate::model::FetchScroll) {
+        let stmt_var = self.stmt_var_for(&call.handle);
+        let fetch_orientation = call.orientation_name.as_deref().unwrap_or("SQL_FETCH_NEXT");
+        let offset = call.offset.unwrap_or(1);
 
         self.writeln("// SQLFetchScroll");
         self.writeln("{");
@@ -340,60 +521,84 @@ impl<'a> GenContext<'a> {
         self.writeln(&format!(
             "SQLRETURN ret = SQLFetchScroll({stmt_var}, {fetch_orientation}, {offset});"
         ));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_fetch(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
+    fn emit_fetch(&mut self, call: &crate::model::Fetch) {
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLFetch");
         self.writeln("{");
         self.indent += 1;
         self.writeln(&format!("SQLRETURN ret = SQLFetch({stmt_var});"));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_get_data(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
-        let col_num = extract_integer_or_named(&call.output_params, 1).unwrap_or(1);
-        let target_type =
-            extract_named_constant_name(&call.output_params, 2).unwrap_or("SQL_C_CHAR".to_string());
-        let buf_len = extract_integer_or_named(&call.output_params, 4).unwrap_or(1024);
-        let string_val = extract_string_value(&call.output_params);
-        let indicator = extract_output_integer(&call.output_params, 5);
+    fn emit_get_data(&mut self, call: &crate::model::GetData) {
+        let stmt_var = self.stmt_var_for(&call.handle);
+        let col_num = call.column_number.unwrap_or(1);
+        let target_type = call.target_type_name.as_deref().unwrap_or("SQL_C_CHAR");
+        let buf_len = call.buffer_length.unwrap_or(1024).min(4096);
 
         self.writeln(&format!("// SQLGetData col {col_num}"));
         self.writeln("{");
         self.indent += 1;
 
-        if target_type == "SQL_C_CHAR" {
-            self.writeln(&format!("char buf[{}] = {{}};", buf_len + 1));
+        if target_type == "SQL_C_CHAR" || target_type == "SQL_CHAR" {
+            self.writeln(&format!("std::vector<char> buf({}, 0);", buf_len + 1));
             self.writeln("SQLLEN ind = 0;");
             self.writeln(&format!(
-                "SQLRETURN ret = SQLGetData({stmt_var}, {col_num}, {target_type}, buf, {buf_len}, &ind);"
+                "SQLRETURN ret = SQLGetData({stmt_var}, {col_num}, {target_type}, buf.data(), {buf_len}, &ind);"
             ));
-            self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+            self.emit_return_assertion(
+                call.return_code,
+                "SQL_HANDLE_STMT",
+                &stmt_var,
+                false,
+                false,
+            );
 
-            if let Some(val) = &string_val {
+            if let Some(ind_val) = call.indicator {
+                if ind_val == -1 {
+                    self.writeln("CHECK(ind == SQL_NULL_DATA);");
+                } else {
+                    if let Some(val) = &call.value {
+                        let escaped = escape_cpp_string_literal(val);
+                        self.writeln(&format!("CHECK(std::string(buf.data()) == \"{escaped}\");"));
+                    }
+                    self.writeln(&format!("CHECK(ind == {ind_val});"));
+                }
+            } else if let Some(val) = &call.value {
                 let escaped = escape_cpp_string_literal(val);
-                self.writeln(&format!("CHECK(std::string(buf) == \"{escaped}\");"));
-            }
-            if let Some(ind_val) = indicator {
-                self.writeln(&format!("CHECK(ind == {ind_val});"));
+                self.writeln(&format!("CHECK(std::string(buf.data()) == \"{escaped}\");"));
             }
         } else {
             self.writeln("SQLLEN ind = 0;");
-            self.writeln(&format!("char buf[{buf_len}] = {{}};"));
+            self.writeln(&format!("std::vector<char> buf({buf_len}, 0);"));
             self.writeln(&format!(
-                "SQLRETURN ret = SQLGetData({stmt_var}, {col_num}, {target_type}, buf, {buf_len}, &ind);"
+                "SQLRETURN ret = SQLGetData({stmt_var}, {col_num}, {target_type}, buf.data(), {buf_len}, &ind);"
             ));
-            self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+            self.emit_return_assertion(
+                call.return_code,
+                "SQL_HANDLE_STMT",
+                &stmt_var,
+                false,
+                false,
+            );
+
+            if let Some(ind_val) = call.indicator {
+                if ind_val == -1 {
+                    self.writeln("CHECK(ind == SQL_NULL_DATA);");
+                } else {
+                    self.writeln(&format!("CHECK(ind == {ind_val});"));
+                }
+            }
         }
 
         self.indent -= 1;
@@ -401,41 +606,37 @@ impl<'a> GenContext<'a> {
         self.writeln("");
     }
 
-    fn emit_more_results(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
+    fn emit_more_results(&mut self, call: &crate::model::MoreResults) {
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLMoreResults");
         self.writeln("{");
         self.indent += 1;
         self.writeln(&format!("SQLRETURN ret = SQLMoreResults({stmt_var});"));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_close_cursor(&mut self, call: &OdbcCall) {
-        let stmt_var = self.find_stmt_var(&call.output_params);
+    fn emit_close_cursor(&mut self, call: &crate::model::CloseCursor) {
+        let stmt_var = self.stmt_var_for(&call.handle);
 
         self.writeln("// SQLCloseCursor");
         self.writeln("{");
         self.indent += 1;
         self.writeln(&format!("SQLRETURN ret = SQLCloseCursor({stmt_var});"));
-        self.emit_return_assertion(call, "SQL_HANDLE_STMT", &stmt_var, false, false);
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_STMT", &stmt_var, false, false);
         self.indent -= 1;
         self.writeln("}");
         self.writeln("");
     }
 
-    fn emit_get_info(&mut self, call: &OdbcCall) {
-        let info_type_name =
-            extract_named_constant_name(&call.output_params, 1).unwrap_or("0".to_string());
+    fn emit_get_info(&mut self, call: &crate::model::GetInfo) {
+        let info_type_name = call.info_type.as_deref().unwrap_or("0");
+        let dbc_var = self.dbc_var_for(&call.handle);
 
-        let is_driver_specific = DRIVER_SPECIFIC_INFO_TYPES
-            .iter()
-            .any(|&t| t == info_type_name);
-
-        let string_val = extract_string_value(&call.output_params);
+        let is_driver_specific = DRIVER_SPECIFIC_INFO_TYPES.contains(&info_type_name);
 
         self.writeln(&format!("// SQLGetInfo - {info_type_name}"));
         self.writeln("{");
@@ -443,14 +644,14 @@ impl<'a> GenContext<'a> {
         self.writeln("char buf[256] = {};");
         self.writeln("SQLSMALLINT len = 0;");
         self.writeln(&format!(
-            "SQLRETURN ret = SQLGetInfo(dbc_handle(), {info_type_name}, buf, 255, &len);"
+            "SQLRETURN ret = SQLGetInfo({dbc_var}, {info_type_name}, buf, 255, &len);"
         ));
 
         if is_driver_specific {
-            self.emit_return_assertion_relaxed("SQL_HANDLE_DBC", "dbc_handle()");
+            self.emit_return_assertion_relaxed("SQL_HANDLE_DBC", &dbc_var);
         } else {
-            self.emit_return_assertion(call, "SQL_HANDLE_DBC", "dbc_handle()", false, false);
-            if let Some(val) = &string_val {
+            self.emit_return_assertion(call.return_code, "SQL_HANDLE_DBC", &dbc_var, false, false);
+            if let Some(val) = &call.info_value {
                 let escaped = escape_cpp_string_literal(val);
                 self.writeln(&format!("CHECK(std::string(buf) == \"{escaped}\");"));
             }
@@ -461,44 +662,104 @@ impl<'a> GenContext<'a> {
         self.writeln("");
     }
 
-    fn emit_free_handle(&mut self, call: &OdbcCall) {
-        let handle_type_value = extract_integer_or_named(&call.output_params, 0);
-        let handle_type = handle_type_value.and_then(HandleType::from_value);
-
-        let Some(ht) = handle_type else { return };
-
-        if matches!(ht, HandleType::Env | HandleType::Dbc) {
+    fn emit_free_handle(&mut self, call: &crate::model::FreeHandle) {
+        let Some(ht) = call.handle_type else { return };
+        if ht == HandleType::Desc {
             return;
         }
 
-        let handle_addr = extract_address(&call.output_params, 1);
-        let var_name = handle_addr
+        let var_name = call
+            .handle
             .as_ref()
             .and_then(|a| self.handle_vars.get(a))
             .cloned()
-            .unwrap_or_else(|| "stmt0".to_string());
+            .unwrap_or_else(|| self.default_var_for(ht));
 
+        if let Some(addr) = &call.handle {
+            self.handle_vars.remove(addr);
+        }
+
+        self.writeln(&format!("// SQLFreeHandle - {}", ht.c_type_name()));
+        self.writeln("{");
+        self.indent += 1;
         self.writeln(&format!(
-            "SQLFreeHandle({}, {var_name});",
+            "SQLRETURN ret = SQLFreeHandle({}, {var_name});",
             ht.sql_handle_type_constant()
         ));
+        self.emit_return_assertion(
+            call.return_code,
+            ht.sql_handle_type_constant(),
+            &var_name,
+            false,
+            false,
+        );
+        self.indent -= 1;
+        self.writeln("}");
+        self.writeln("");
     }
 
-    fn emit_disconnect(&mut self, _call: &OdbcCall) {
-        self.writeln("SQLDisconnect(dbc_handle());");
+    fn emit_disconnect(&mut self, call: &crate::model::Disconnect) {
+        let dbc_var = self.dbc_var_for(&call.handle);
+
+        self.writeln("// SQLDisconnect");
+        self.writeln("{");
+        self.indent += 1;
+        self.writeln(&format!("SQLRETURN ret = SQLDisconnect({dbc_var});"));
+        self.emit_return_assertion_relaxed("SQL_HANDLE_DBC", &dbc_var);
+        self.indent -= 1;
+        self.writeln("}");
+        self.writeln("");
     }
 
-    fn emit_generic_comment(&mut self, call: &OdbcCall) {
+    fn emit_set_env_attr(&mut self, call: &crate::model::SetEnvAttr) {
+        let attr_name = call.attribute.as_deref().unwrap_or_default();
+        let env_var = self.env_var_for(&call.handle);
+
+        if attr_name == "SQL_ATTR_ODBC_VERSION" && self.was_synthetically_set(&env_var) {
+            return;
+        }
+
+        let value = call.value.unwrap_or(0);
+        let value_expr = attr_value_cpp_expr(attr_name, value);
+        let str_len = call.str_len.unwrap_or(0);
+
+        self.writeln(&format!("// SQLSetEnvAttr - {attr_name}"));
+        self.writeln("{");
+        self.indent += 1;
         self.writeln(&format!(
-            "// TODO: {} (return code: {})",
-            call.function_name, call.return_code
+            "SQLRETURN ret = SQLSetEnvAttr({env_var}, {attr_name},"
         ));
+        self.writeln(&format!("    {value_expr}, {str_len});"));
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_ENV", &env_var, false, false);
+        self.indent -= 1;
+        self.writeln("}");
+        self.writeln("");
+    }
+
+    fn emit_set_connect_attr(&mut self, call: &crate::model::SetConnectAttr) {
+        let attr_name = call.attribute.as_deref().unwrap_or_default();
+        let value = call.value.unwrap_or(0);
+        let value_expr = attr_value_cpp_expr(attr_name, value);
+        let str_len = call.str_len.unwrap_or(0);
+
+        let conn_var = self.dbc_var_for(&call.handle);
+
+        self.writeln(&format!("// SQLSetConnectAttr - {attr_name}"));
+        self.writeln("{");
+        self.indent += 1;
+        self.writeln(&format!(
+            "SQLRETURN ret = SQLSetConnectAttr({conn_var}, {attr_name},"
+        ));
+        self.writeln(&format!("    {value_expr}, {str_len});"));
+        self.emit_return_assertion(call.return_code, "SQL_HANDLE_DBC", &conn_var, false, false);
+        self.indent -= 1;
+        self.writeln("}");
         self.writeln("");
     }
 
     fn emit_return_assertion(
         &mut self,
-        call: &OdbcCall,
+        return_code: ReturnCode,
         handle_type: &str,
         handle_var: &str,
         is_setup: bool,
@@ -512,7 +773,7 @@ impl<'a> GenContext<'a> {
         let matcher = if relaxed_connect {
             "OdbcMatchers::Succeeded()".to_string()
         } else {
-            format!("OdbcMatchers::{}()", call.return_code.matcher_name())
+            format!("OdbcMatchers::{}()", return_code.matcher_name())
         };
 
         self.writeln(&format!(
@@ -528,17 +789,112 @@ impl<'a> GenContext<'a> {
         self.writeln("           OdbcMatchers::Succeeded());");
     }
 
-    fn find_stmt_var(&self, params: &[crate::model::Parameter]) -> String {
-        for param in params {
-            if let ParamValue::Address(addr) = &param.value {
-                if let Some(var) = self.handle_vars.get(addr) {
-                    if var.starts_with("stmt") {
-                        return var.clone();
-                    }
-                }
-            }
+    fn resolve_query(&mut self, raw_sql: &str) -> String {
+        let idx = self.query_counter;
+        self.query_counter += 1;
+
+        self.config
+            .query_map
+            .as_ref()
+            .and_then(|qm| qm.get(idx))
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| raw_sql.to_string())
+    }
+
+    fn next_env_var(&mut self) -> String {
+        let name = format!("env{}", self.env_counter);
+        self.env_counter += 1;
+        name
+    }
+
+    fn next_dbc_var(&mut self) -> String {
+        let name = format!("dbc{}", self.dbc_counter);
+        self.dbc_counter += 1;
+        name
+    }
+
+    fn next_stmt_var(&mut self) -> String {
+        let name = format!("stmt{}", self.stmt_counter);
+        self.stmt_counter += 1;
+        name
+    }
+
+    fn declare_handle(&mut self, var_name: &str, ht: HandleType) {
+        if !self.declared_handles.contains(var_name) {
+            self.writeln(&format!(
+                "{} {var_name} = {};",
+                ht.c_type_name(),
+                ht.sql_null_constant()
+            ));
+            self.declared_handles.insert(var_name.to_string());
         }
-        "stmt0".to_string()
+    }
+
+    fn env_var_for(&self, handle: &Option<String>) -> String {
+        handle
+            .as_ref()
+            .and_then(|addr| self.handle_vars.get(addr))
+            .cloned()
+            .unwrap_or_else(|| self.first_env_var())
+    }
+
+    fn dbc_var_for(&self, handle: &Option<String>) -> String {
+        handle
+            .as_ref()
+            .and_then(|addr| self.handle_vars.get(addr))
+            .cloned()
+            .unwrap_or_else(|| self.first_dbc_var())
+    }
+
+    fn stmt_var_for(&self, handle: &Option<String>) -> String {
+        handle
+            .as_ref()
+            .and_then(|addr| self.handle_vars.get(addr))
+            .filter(|v| v.starts_with("stmt"))
+            .cloned()
+            .unwrap_or_else(|| "stmt0".to_string())
+    }
+
+    fn first_env_var(&self) -> String {
+        self.handle_vars
+            .values()
+            .find(|v| v.starts_with("env"))
+            .cloned()
+            .unwrap_or_else(|| "env0".to_string())
+    }
+
+    fn first_dbc_var(&self) -> String {
+        self.handle_vars
+            .values()
+            .find(|v| v.starts_with("dbc"))
+            .cloned()
+            .unwrap_or_else(|| "dbc0".to_string())
+    }
+
+    fn default_parent_var(&self, ht: HandleType) -> String {
+        match ht {
+            HandleType::Env => "SQL_NULL_HANDLE".to_string(),
+            HandleType::Dbc => self.first_env_var(),
+            HandleType::Stmt | HandleType::Desc => self.first_dbc_var(),
+        }
+    }
+
+    fn default_var_for(&self, ht: HandleType) -> String {
+        match ht {
+            HandleType::Env => self.first_env_var(),
+            HandleType::Dbc => self.first_dbc_var(),
+            HandleType::Stmt | HandleType::Desc => "stmt0".to_string(),
+        }
+    }
+
+    /// Returns true if the given env variable was created via synthetic
+    /// (implicit) allocation, which already emits its own SetEnvAttr for
+    /// SQL_ATTR_ODBC_VERSION. Used to avoid duplicating the call when the
+    /// trace also contains one.
+    fn was_synthetically_set(&self, env_var: &str) -> bool {
+        self.output.contains(&format!(
+            "SQLRETURN ret = SQLSetEnvAttr({env_var}, SQL_ATTR_ODBC_VERSION,"
+        ))
     }
 
     fn writeln(&mut self, line: &str) {
@@ -551,60 +907,33 @@ impl<'a> GenContext<'a> {
     }
 }
 
-fn extract_integer_or_named(params: &[crate::model::Parameter], idx: usize) -> Option<i64> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::Integer(v) => Some(*v),
-        ParamValue::NamedConstant { value, .. } => Some(*value),
+fn attr_value_cpp_expr(attr_name: &str, value: i64) -> String {
+    let symbolic = match (attr_name, value) {
+        ("SQL_ATTR_AUTOCOMMIT", 0) => Some("SQL_AUTOCOMMIT_OFF"),
+        ("SQL_ATTR_AUTOCOMMIT", 1) => Some("SQL_AUTOCOMMIT_ON"),
+        ("SQL_ATTR_ODBC_VERSION", 2) => Some("SQL_OV_ODBC2"),
+        ("SQL_ATTR_ODBC_VERSION", 3) => Some("SQL_OV_ODBC3"),
+        ("SQL_ATTR_ODBC_VERSION", 380) => Some("SQL_OV_ODBC3_80"),
+        ("SQL_ATTR_ACCESS_MODE", 0) => Some("SQL_MODE_DEFAULT"),
+        ("SQL_ATTR_ACCESS_MODE", 1) => Some("SQL_MODE_READ_ONLY"),
+        ("SQL_ATTR_ACCESS_MODE", 2) => Some("SQL_MODE_READ_WRITE"),
         _ => None,
-    })
-}
+    };
 
-fn extract_named_constant_name(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::NamedConstant { name, .. } => Some(name.clone()),
-        _ => None,
-    })
-}
-
-fn extract_address(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::Address(addr) => Some(addr.clone()),
-        _ => None,
-    })
-}
-
-fn extract_output_address(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::OutputAddress { output_address, .. } => Some(output_address.clone()),
-        _ => None,
-    })
-}
-
-fn extract_output_integer(params: &[crate::model::Parameter], idx: usize) -> Option<i64> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::OutputInteger { value, .. } => Some(*value),
-        _ => None,
-    })
-}
-
-fn extract_output_named_constant(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::OutputNamedConstant { name, .. } => Some(name.clone()),
-        _ => None,
-    })
-}
-
-fn extract_string_value(params: &[crate::model::Parameter]) -> Option<String> {
-    params.iter().find_map(|p| match &p.value {
-        ParamValue::StringValue(s) => Some(s.clone()),
-        _ => None,
-    })
+    if let Some(name) = symbolic {
+        format!("(SQLPOINTER){name}")
+    } else if value == 0 {
+        "nullptr".to_string()
+    } else {
+        format!("(SQLPOINTER){value}")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::parser::iodbc;
+    use crate::query_map::{QueryMap, QueryMapEntry};
 
     const SAMPLE_TRACE: &str =
         include_str!("../../../odbc_tests/tests/replay/iodbctest/select_1.log");
@@ -615,11 +944,23 @@ mod tests {
         let config = GeneratorConfig {
             test_name: "SELECT 1".to_string(),
             tag: "replay".to_string(),
+            query_map: None,
         };
 
-        let output = generate(&trace, &config);
+        let calls: Vec<_> = trace.calls.iter().map(|tc| tc.call.clone()).collect();
+        let output = generate(&calls, &config);
 
-        assert!(output.contains("TEST_CASE_METHOD(DbcDefaultDSNFixture"));
+        assert!(
+            output.contains("TEST_CASE(\"Replay: SELECT 1\""),
+            "plain TEST_CASE, no fixture"
+        );
+        assert!(
+            !output.contains("TEST_CASE_METHOD"),
+            "no fixture-based test"
+        );
+        assert!(output.contains("DataSourceConfig::Snowflake().install()"));
+        assert!(output.contains("ODBCConfig.hpp"));
+        assert!(!output.contains("ODBCFixtures.hpp"));
         assert!(output.contains("SQLDriverConnect"));
         assert!(output.contains("OdbcMatchers::"));
         assert!(output.contains("SQLPrepare"));
@@ -630,7 +971,6 @@ mod tests {
         assert!(output.contains("SQLGetData"));
         assert!(output.contains("SQLMoreResults"));
         assert!(!output.contains("SQLGetDiagRec"));
-        assert!(output.contains("ODBCFixtures.hpp"));
         assert!(output.contains("odbc_matchers.hpp"));
     }
 
@@ -640,16 +980,86 @@ mod tests {
         let config = GeneratorConfig {
             test_name: "SELECT 1".to_string(),
             tag: "replay".to_string(),
+            query_map: None,
         };
 
-        let output = generate(&trace, &config);
+        let calls: Vec<_> = trace.calls.iter().map(|tc| tc.call.clone()).collect();
+        let output = generate(&calls, &config);
 
+        assert!(
+            output.contains("SQLHENV env0 = SQL_NULL_HENV"),
+            "explicit env allocation"
+        );
+        assert!(
+            output.contains("SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env0)"),
+            "env alloc"
+        );
+        assert!(
+            output.contains("SQLHDBC dbc0 = SQL_NULL_HDBC"),
+            "explicit dbc allocation"
+        );
+        assert!(
+            output.contains("SQLAllocHandle(SQL_HANDLE_DBC, env0, &dbc0)"),
+            "dbc alloc"
+        );
+        assert!(
+            output.contains("SQLHSTMT stmt0 = SQL_NULL_HSTMT"),
+            "stmt declaration"
+        );
+        assert!(
+            output.contains("REQUIRE(stmt0 != SQL_NULL_HSTMT)"),
+            "stmt non-null check"
+        );
+        assert!(
+            output.contains("config.connection_string()"),
+            "connection string from config"
+        );
         assert!(output.contains("CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0),"));
         assert!(output.contains("OdbcMatchers::IsNoData()"));
         assert!(output.contains("OdbcMatchers::IsSuccess()"));
-        assert!(output.contains("connection_string()"));
-        assert!(output.contains("SQLHSTMT stmt0 = SQL_NULL_HSTMT"));
-        assert!(output.contains("SQLDisconnect(dbc_handle())"));
-        assert!(output.contains("SQLFreeHandle(SQL_HANDLE_STMT, stmt0)"));
+        assert!(
+            output.contains("SQLRETURN ret = SQLDisconnect(dbc0)"),
+            "disconnect uses var"
+        );
+        assert!(output.contains("SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt0)"));
+        assert!(
+            output.contains("SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc0)"),
+            "dbc freed"
+        );
+        assert!(
+            output.contains("SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_ENV, env0)"),
+            "env freed"
+        );
+    }
+
+    #[test]
+    fn test_generate_with_query_map() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("Failed to parse sample trace");
+
+        let qm = QueryMap {
+            queries: vec![QueryMapEntry {
+                index: 0,
+                original: "SELECT 1".to_string(),
+                mapped: "SELECT 42 AS answer".to_string(),
+            }],
+        };
+
+        let config = GeneratorConfig {
+            test_name: "mapped query".to_string(),
+            tag: "replay".to_string(),
+            query_map: Some(qm),
+        };
+
+        let calls: Vec<_> = trace.calls.iter().map(|tc| tc.call.clone()).collect();
+        let output = generate(&calls, &config);
+
+        assert!(
+            output.contains("SELECT 42 AS answer"),
+            "mapped query should appear in output"
+        );
+        assert!(
+            !output.contains("sqlchar(\"SELECT 1\")"),
+            "original query should be replaced"
+        );
     }
 }

--- a/odbc_trace_tool/src/ir.rs
+++ b/odbc_trace_tool/src/ir.rs
@@ -1,0 +1,1052 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{HandleType, OdbcCall, TraceHeader, TraceLog, TracedCall};
+
+pub type SeqNum = u64;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Operation {
+    pub seq: SeqNum,
+    pub call: OdbcCall,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry_line: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_line: Option<String>,
+}
+
+/// A handle's lifetime from allocation to deallocation.
+///
+/// Each node represents a `SQLAllocHandle` call (or a pre-existing handle discovered
+/// from the trace). It contains all operations performed on the resulting handle,
+/// plus child handle allocations as nested nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandleNode {
+    pub handle_type: HandleType,
+    pub address: String,
+    pub logical_name: String,
+    /// The `SQLAllocHandle` call that created this handle.
+    /// `None` for handles that existed before the trace started (implicit).
+    pub alloc: Option<Operation>,
+    /// The `SQLFreeHandle` call that destroyed this handle.
+    /// `None` if the handle was never freed (e.g. truncated trace).
+    pub free: Option<Operation>,
+    /// Work operations performed on this handle, ordered by `seq`.
+    pub operations: Vec<Operation>,
+    /// Child handles allocated from this handle, ordered by alloc seq.
+    pub children: Vec<HandleNode>,
+}
+
+/// The complete intermediate representation of an ODBC trace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceIr {
+    pub header: TraceHeader,
+    pub roots: Vec<HandleNode>,
+    pub unscoped_operations: Vec<Operation>,
+    pub total_operations: SeqNum,
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+pub fn build_ir(trace: &TraceLog) -> TraceIr {
+    let source = trace.header.source_file.as_deref();
+    let mut builder = IrBuilder::new(source);
+    for tc in &trace.calls {
+        builder.process_call(tc.clone());
+    }
+    builder.finish(trace.header.clone())
+}
+
+fn make_op(seq: SeqNum, tc: TracedCall, source: Option<&str>) -> Operation {
+    let fmt_line = |line: Option<usize>| -> Option<String> {
+        let l = line?;
+        match source {
+            Some(path) => Some(format!("{path}:{l}")),
+            None => Some(l.to_string()),
+        }
+    };
+    Operation {
+        seq,
+        entry_line: fmt_line(tc.entry_line),
+        exit_line: fmt_line(tc.exit_line),
+        call: tc.call,
+    }
+}
+
+struct BuilderNode {
+    handle_type: HandleType,
+    address: String,
+    logical_name: String,
+    alloc: Option<Operation>,
+    free: Option<Operation>,
+    operations: Vec<Operation>,
+}
+
+struct IrBuilder {
+    nodes: HashMap<String, BuilderNode>,
+    parent_of: HashMap<String, String>,
+    /// Maps raw handle address → versioned key in `nodes`.
+    active_handles: HashMap<String, String>,
+    addr_generation: HashMap<String, usize>,
+    unscoped: Vec<Operation>,
+    seq: SeqNum,
+    counters: HashMap<HandleType, usize>,
+    source_file: Option<String>,
+}
+
+impl IrBuilder {
+    fn new(source_file: Option<&str>) -> Self {
+        Self {
+            nodes: HashMap::new(),
+            parent_of: HashMap::new(),
+            active_handles: HashMap::new(),
+            addr_generation: HashMap::new(),
+            unscoped: Vec::new(),
+            seq: 0,
+            counters: HashMap::new(),
+            source_file: source_file.map(|s| s.to_string()),
+        }
+    }
+
+    fn next_seq(&mut self) -> SeqNum {
+        let s = self.seq;
+        self.seq += 1;
+        s
+    }
+
+    fn next_logical_name(&mut self, handle_type: HandleType) -> String {
+        let counter = self.counters.entry(handle_type).or_insert(0);
+        let prefix = match handle_type {
+            HandleType::Env => "env",
+            HandleType::Dbc => "dbc",
+            HandleType::Stmt => "stmt",
+            HandleType::Desc => "desc",
+        };
+        let name = format!("{prefix}{counter}");
+        *counter += 1;
+        name
+    }
+
+    fn to_op(&self, seq: SeqNum, tc: TracedCall) -> Operation {
+        make_op(seq, tc, self.source_file.as_deref())
+    }
+
+    fn process_call(&mut self, tc: TracedCall) {
+        let seq = self.next_seq();
+        match &tc.call {
+            OdbcCall::AllocHandle(_) => self.process_alloc(seq, tc),
+            OdbcCall::FreeHandle(_) => self.process_free(seq, tc),
+            _ => self.process_regular(seq, tc),
+        }
+    }
+
+    fn process_alloc(&mut self, seq: SeqNum, tc: TracedCall) {
+        let (handle_type, parent_addr, child_addr, is_success) = match &tc.call {
+            OdbcCall::AllocHandle(a) => (
+                a.handle_type,
+                a.parent_handle.clone(),
+                a.child_handle.clone(),
+                a.return_code.is_success(),
+            ),
+            _ => unreachable!(),
+        };
+
+        if !is_success {
+            self.unscoped.push(self.to_op(seq, tc));
+            return;
+        }
+
+        match (handle_type, child_addr) {
+            (Some(ht), Some(raw_child)) => {
+                if self.active_handles.contains_key(&raw_child) {
+                    self.active_handles.remove(&raw_child);
+                }
+
+                let gen = self.addr_generation.entry(raw_child.clone()).or_insert(0);
+                let vkey = versioned_key(&raw_child, *gen);
+                if self.nodes.contains_key(&vkey) {
+                    *gen += 1;
+                }
+                let vkey = versioned_key(&raw_child, *gen);
+
+                let logical_name = self.next_logical_name(ht);
+                self.nodes.insert(
+                    vkey.clone(),
+                    BuilderNode {
+                        handle_type: ht,
+                        address: raw_child.clone(),
+                        logical_name,
+                        alloc: Some(self.to_op(seq, tc)),
+                        free: None,
+                        operations: Vec::new(),
+                    },
+                );
+                self.active_handles.insert(raw_child.clone(), vkey.clone());
+
+                if let Some(raw_parent) = parent_addr {
+                    if !is_null_handle(&raw_parent) {
+                        let parent_vkey = self
+                            .active_handles
+                            .get(&raw_parent)
+                            .cloned()
+                            .unwrap_or(raw_parent);
+                        self.parent_of.insert(vkey, parent_vkey);
+                    }
+                }
+            }
+            _ => {
+                self.unscoped.push(self.to_op(seq, tc));
+            }
+        }
+    }
+
+    fn process_free(&mut self, seq: SeqNum, tc: TracedCall) {
+        let source = self.source_file.as_deref().map(|s| s.to_string());
+        let raw_addr = tc.call.handle_addr().map(|s| s.to_string());
+        if let Some(raw_addr) = raw_addr {
+            if let Some(vkey) = self.active_handles.remove(&raw_addr) {
+                if let Some(node) = self.nodes.get_mut(&vkey) {
+                    node.free = Some(make_op(seq, tc, source.as_deref()));
+                    return;
+                }
+            }
+        }
+        self.unscoped.push(make_op(seq, tc, source.as_deref()));
+    }
+
+    fn process_regular(&mut self, seq: SeqNum, tc: TracedCall) {
+        let source = self.source_file.as_deref().map(|s| s.to_string());
+        if let Some(vkey) = find_owning_handle(&tc.call, &self.active_handles) {
+            self.nodes
+                .get_mut(&vkey)
+                .expect("active handle must have a node")
+                .operations
+                .push(make_op(seq, tc, source.as_deref()));
+            return;
+        }
+
+        if let Some((raw_addr, ht)) = find_implicit_handle(&tc.call) {
+            let logical_name = self.next_logical_name(ht);
+            let vkey = raw_addr.clone();
+            self.nodes.insert(
+                vkey.clone(),
+                BuilderNode {
+                    handle_type: ht,
+                    address: raw_addr.clone(),
+                    logical_name,
+                    alloc: None,
+                    free: None,
+                    operations: vec![make_op(seq, tc, source.as_deref())],
+                },
+            );
+            self.active_handles.insert(raw_addr, vkey);
+            return;
+        }
+
+        self.unscoped.push(make_op(seq, tc, source.as_deref()));
+    }
+
+    fn finish(mut self, header: TraceHeader) -> TraceIr {
+        let total = self.seq;
+        self.infer_implicit_parents();
+
+        let mut children_of: HashMap<String, Vec<String>> = HashMap::new();
+        let mut root_addrs: Vec<String> = Vec::new();
+
+        let all_addrs: Vec<String> = self.nodes.keys().cloned().collect();
+        for addr in &all_addrs {
+            match self.parent_of.get(addr) {
+                Some(parent) if self.nodes.contains_key(parent) => {
+                    children_of
+                        .entry(parent.clone())
+                        .or_default()
+                        .push(addr.clone());
+                }
+                _ => {
+                    root_addrs.push(addr.clone());
+                }
+            }
+        }
+
+        root_addrs.sort_by_key(|a| {
+            let node = &self.nodes[a];
+            node.alloc
+                .as_ref()
+                .map(|op| op.seq)
+                .or_else(|| node.operations.first().map(|op| op.seq))
+                .unwrap_or(SeqNum::MAX)
+        });
+
+        let roots: Vec<HandleNode> = root_addrs
+            .iter()
+            .filter_map(|a| build_subtree(a, &mut self.nodes, &children_of))
+            .collect();
+
+        let mut ir = TraceIr {
+            header,
+            roots,
+            unscoped_operations: self.unscoped,
+            total_operations: total,
+        };
+        ir.resolve_all_handles();
+        ir
+    }
+
+    /// When there is exactly one Env, parent any orphan Dbc nodes to it.
+    /// When there is exactly one Dbc, parent any orphan Stmt nodes to it.
+    fn infer_implicit_parents(&mut self) {
+        let env_addrs: Vec<String> = self
+            .nodes
+            .iter()
+            .filter(|(_, n)| n.handle_type == HandleType::Env)
+            .map(|(a, _)| a.clone())
+            .collect();
+
+        if env_addrs.len() == 1 {
+            let orphan_dbcs: Vec<String> = self
+                .nodes
+                .iter()
+                .filter(|(addr, n)| {
+                    n.handle_type == HandleType::Dbc && !self.parent_of.contains_key(*addr)
+                })
+                .map(|(a, _)| a.clone())
+                .collect();
+            for dbc in orphan_dbcs {
+                self.parent_of.insert(dbc, env_addrs[0].clone());
+            }
+        }
+
+        let dbc_addrs: Vec<String> = self
+            .nodes
+            .iter()
+            .filter(|(_, n)| n.handle_type == HandleType::Dbc)
+            .map(|(a, _)| a.clone())
+            .collect();
+
+        if dbc_addrs.len() == 1 {
+            let orphan_stmts: Vec<String> = self
+                .nodes
+                .iter()
+                .filter(|(addr, n)| {
+                    n.handle_type == HandleType::Stmt && !self.parent_of.contains_key(*addr)
+                })
+                .map(|(a, _)| a.clone())
+                .collect();
+            for stmt in orphan_stmts {
+                self.parent_of.insert(stmt, dbc_addrs[0].clone());
+            }
+        }
+    }
+}
+
+fn build_subtree(
+    addr: &str,
+    nodes: &mut HashMap<String, BuilderNode>,
+    children_of: &HashMap<String, Vec<String>>,
+) -> Option<HandleNode> {
+    let node = nodes.remove(addr)?;
+    let child_addrs = children_of.get(addr).cloned().unwrap_or_default();
+    let mut children: Vec<HandleNode> = child_addrs
+        .iter()
+        .filter_map(|a| build_subtree(a, nodes, children_of))
+        .collect();
+    children.sort_by_key(|c| {
+        c.alloc
+            .as_ref()
+            .map(|op| op.seq)
+            .or_else(|| c.operations.first().map(|op| op.seq))
+            .unwrap_or(SeqNum::MAX)
+    });
+
+    Some(HandleNode {
+        handle_type: node.handle_type,
+        address: node.address,
+        logical_name: node.logical_name,
+        alloc: node.alloc,
+        free: node.free,
+        operations: node.operations,
+        children,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Handle attribution helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the versioned key of the node that owns this call, using the
+/// typed `handle_addr()` accessor on `OdbcCall`.
+fn find_owning_handle(call: &OdbcCall, active: &HashMap<String, String>) -> Option<String> {
+    call.handle_addr()
+        .and_then(|addr| active.get(addr).cloned())
+}
+
+/// For a call whose handle is not yet tracked, infer the handle type from
+/// the enum variant and return the address + type for implicit node creation.
+fn find_implicit_handle(call: &OdbcCall) -> Option<(String, HandleType)> {
+    let addr = call.handle_addr()?;
+    let ht = match call {
+        OdbcCall::SetEnvAttr(_) => HandleType::Env,
+        OdbcCall::DriverConnect(_)
+        | OdbcCall::Disconnect(_)
+        | OdbcCall::SetConnectAttr(_)
+        | OdbcCall::GetInfo(_)
+        | OdbcCall::GetFunctions(_) => HandleType::Dbc,
+        OdbcCall::Prepare(_)
+        | OdbcCall::Execute(_)
+        | OdbcCall::ExecDirect(_)
+        | OdbcCall::NumResultCols(_)
+        | OdbcCall::DescribeCol(_)
+        | OdbcCall::Fetch(_)
+        | OdbcCall::FetchScroll(_)
+        | OdbcCall::GetData(_)
+        | OdbcCall::RowCount(_)
+        | OdbcCall::MoreResults(_)
+        | OdbcCall::CloseCursor(_) => HandleType::Stmt,
+        OdbcCall::GetDiagRec(c) => c.handle_type?,
+        _ => return None,
+    };
+    Some((addr.to_string(), ht))
+}
+
+fn versioned_key(addr: &str, gen: usize) -> String {
+    if gen == 0 {
+        addr.to_string()
+    } else {
+        format!("{addr}#{gen}")
+    }
+}
+
+fn is_null_handle(addr: &str) -> bool {
+    matches!(
+        addr,
+        "SQL_NULL_HANDLE" | "(nil)" | "0x0" | "0x00" | "0" | "NULL"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Traversal helpers
+// ---------------------------------------------------------------------------
+
+impl TraceIr {
+    /// Flatten all operations (including alloc/free) across the entire tree,
+    /// sorted by global sequence number.
+    pub fn all_operations_sorted(&self) -> Vec<&Operation> {
+        let mut ops: Vec<&Operation> = Vec::new();
+        for op in &self.unscoped_operations {
+            ops.push(op);
+        }
+        for root in &self.roots {
+            root.collect_all_operations(&mut ops);
+        }
+        ops.sort_by_key(|op| op.seq);
+        ops
+    }
+
+    pub fn handle_count(&self) -> usize {
+        self.roots.iter().map(|r| r.subtree_handle_count()).sum()
+    }
+
+    pub fn all_handles(&self) -> Vec<&HandleNode> {
+        let mut handles = Vec::new();
+        for root in &self.roots {
+            root.collect_handles(&mut handles);
+        }
+        handles
+    }
+
+    /// Build an address→logical_name map from all handles and replace raw
+    /// addresses with logical names in every operation's call fields.
+    fn resolve_all_handles(&mut self) {
+        let map: HashMap<String, String> = self
+            .all_handles()
+            .into_iter()
+            .map(|h| (h.address.clone(), h.logical_name.clone()))
+            .collect();
+        for root in &mut self.roots {
+            root.resolve_handles(&map);
+        }
+        for op in &mut self.unscoped_operations {
+            op.call.resolve_handles(&map);
+        }
+    }
+
+    /// Flatten all calls in sequence order (for consumers that need a linear list).
+    pub fn flatten_calls(&self) -> Vec<OdbcCall> {
+        self.all_operations_sorted()
+            .into_iter()
+            .map(|op| op.call.clone())
+            .collect()
+    }
+
+    /// Split the IR by handle type. Each returned pair is (logical_name, sub-IR).
+    pub fn split(&self, mode: SplitMode) -> Vec<(String, TraceIr)> {
+        match mode {
+            SplitMode::Env => self
+                .roots
+                .iter()
+                .map(|env| {
+                    let name = env.logical_name.clone();
+                    let total = env.all_operations_recursive().len() as SeqNum;
+                    (
+                        name,
+                        TraceIr {
+                            header: self.header.clone(),
+                            roots: vec![env.clone()],
+                            unscoped_operations: vec![],
+                            total_operations: total,
+                        },
+                    )
+                })
+                .collect(),
+            SplitMode::Connection => {
+                let mut result = Vec::new();
+                for env in &self.roots {
+                    for dbc in &env.children {
+                        if dbc.handle_type != HandleType::Dbc {
+                            continue;
+                        }
+                        let wrapped = wrap_in_parent(env, dbc.clone());
+                        let total = wrapped.all_operations_recursive().len() as SeqNum;
+                        result.push((
+                            dbc.logical_name.clone(),
+                            TraceIr {
+                                header: self.header.clone(),
+                                roots: vec![wrapped],
+                                unscoped_operations: vec![],
+                                total_operations: total,
+                            },
+                        ));
+                    }
+                }
+                result
+            }
+            SplitMode::Statement => {
+                let mut result = Vec::new();
+                for env in &self.roots {
+                    for dbc in &env.children {
+                        if dbc.handle_type != HandleType::Dbc {
+                            continue;
+                        }
+                        for stmt in &dbc.children {
+                            if stmt.handle_type != HandleType::Stmt {
+                                continue;
+                            }
+                            let dbc_wrapped = wrap_in_parent(dbc, stmt.clone());
+                            let env_wrapped = wrap_in_parent(env, dbc_wrapped);
+                            let total = env_wrapped.all_operations_recursive().len() as SeqNum;
+                            result.push((
+                                stmt.logical_name.clone(),
+                                TraceIr {
+                                    header: self.header.clone(),
+                                    roots: vec![env_wrapped],
+                                    unscoped_operations: vec![],
+                                    total_operations: total,
+                                },
+                            ));
+                        }
+                    }
+                }
+                result
+            }
+        }
+    }
+}
+
+/// Clone a parent node's metadata and operations, replacing its children
+/// with a single child node.
+fn wrap_in_parent(parent: &HandleNode, child: HandleNode) -> HandleNode {
+    HandleNode {
+        handle_type: parent.handle_type,
+        address: parent.address.clone(),
+        logical_name: parent.logical_name.clone(),
+        alloc: parent.alloc.clone(),
+        free: parent.free.clone(),
+        operations: parent.operations.clone(),
+        children: vec![child],
+    }
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum SplitMode {
+    Env,
+    Connection,
+    Statement,
+}
+
+pub fn load_ir_yaml(path: &std::path::Path) -> std::io::Result<TraceIr> {
+    let content = std::fs::read_to_string(path)?;
+    serde_yaml::from_str(&content)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e}")))
+}
+
+impl HandleNode {
+    pub fn is_implicit(&self) -> bool {
+        self.alloc.is_none()
+    }
+
+    /// Whether any SQL query in this subtree was truncated by the trace.
+    pub fn has_truncated_sql(&self) -> bool {
+        self.operations.iter().any(|op| op.call.has_truncated_sql())
+            || self.children.iter().any(|c| c.has_truncated_sql())
+    }
+
+    /// Replace raw handle addresses with logical names in all operations.
+    fn resolve_handles(&mut self, map: &HashMap<String, String>) {
+        if let Some(alloc) = &mut self.alloc {
+            alloc.call.resolve_handles(map);
+        }
+        if let Some(free) = &mut self.free {
+            free.call.resolve_handles(map);
+        }
+        for op in &mut self.operations {
+            op.call.resolve_handles(map);
+        }
+        for child in &mut self.children {
+            child.resolve_handles(map);
+        }
+    }
+
+    /// All operations in this subtree (including alloc, free, and children),
+    /// sorted by global sequence number.
+    pub fn all_operations_recursive(&self) -> Vec<&Operation> {
+        let mut ops = Vec::new();
+        self.collect_all_operations(&mut ops);
+        ops.sort_by_key(|op| op.seq);
+        ops
+    }
+
+    pub fn handles_by_type(&self, ht: HandleType) -> Vec<&HandleNode> {
+        let mut result = Vec::new();
+        self.collect_handles_by_type(ht, &mut result);
+        result
+    }
+
+    fn collect_all_operations<'a>(&'a self, ops: &mut Vec<&'a Operation>) {
+        if let Some(alloc) = &self.alloc {
+            ops.push(alloc);
+        }
+        for op in &self.operations {
+            ops.push(op);
+        }
+        if let Some(free) = &self.free {
+            ops.push(free);
+        }
+        for child in &self.children {
+            child.collect_all_operations(ops);
+        }
+    }
+
+    fn collect_handles_by_type<'a>(&'a self, ht: HandleType, out: &mut Vec<&'a HandleNode>) {
+        if self.handle_type == ht {
+            out.push(self);
+        }
+        for child in &self.children {
+            child.collect_handles_by_type(ht, out);
+        }
+    }
+
+    fn collect_handles<'a>(&'a self, out: &mut Vec<&'a HandleNode>) {
+        out.push(self);
+        for child in &self.children {
+            child.collect_handles(out);
+        }
+    }
+
+    fn subtree_handle_count(&self) -> usize {
+        1 + self
+            .children
+            .iter()
+            .map(|c| c.subtree_handle_count())
+            .sum::<usize>()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+fn handle_type_label(ht: HandleType) -> &'static str {
+    match ht {
+        HandleType::Env => "Env",
+        HandleType::Dbc => "Dbc",
+        HandleType::Stmt => "Stmt",
+        HandleType::Desc => "Desc",
+    }
+}
+
+impl fmt::Display for TraceIr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "TraceIr: {} operations, {} handles",
+            self.total_operations,
+            self.handle_count()
+        )?;
+
+        if !self.unscoped_operations.is_empty() {
+            writeln!(f, "  unscoped ({}):", self.unscoped_operations.len())?;
+            for op in &self.unscoped_operations {
+                writeln!(f, "    [{:>4}] {}", op.seq, op.call)?;
+            }
+        }
+
+        for root in &self.roots {
+            write_node(f, root, 1)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn write_node(f: &mut fmt::Formatter<'_>, node: &HandleNode, depth: usize) -> fmt::Result {
+    let indent = "  ".repeat(depth);
+    let inner = "  ".repeat(depth + 1);
+
+    if let Some(alloc) = &node.alloc {
+        writeln!(
+            f,
+            "{}{} ({}, {}) [alloc: {}]",
+            indent,
+            node.logical_name,
+            handle_type_label(node.handle_type),
+            node.address,
+            alloc.seq
+        )?;
+    } else {
+        writeln!(
+            f,
+            "{}{} ({}, {}) [implicit]",
+            indent,
+            node.logical_name,
+            handle_type_label(node.handle_type),
+            node.address
+        )?;
+    }
+
+    for op in &node.operations {
+        writeln!(f, "{}[{:>4}] {}", inner, op.seq, op.call)?;
+    }
+
+    if let Some(free) = &node.free {
+        writeln!(f, "{}free: [{}] {}", inner, free.seq, free.call)?;
+    }
+
+    for child in &node.children {
+        write_node(f, child, depth + 1)?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::iodbc;
+
+    const SAMPLE_TRACE: &str = include_str!("../../odbc_tests/tests/replay/iodbctest/select_1.log");
+
+    #[test]
+    fn test_build_ir_basic_structure() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+
+        assert_eq!(ir.roots.len(), 1, "single env root");
+
+        let env = &ir.roots[0];
+        assert_eq!(env.handle_type, HandleType::Env);
+        assert!(
+            env.is_implicit(),
+            "env was not explicitly allocated in trace"
+        );
+        assert!(env.free.is_some(), "env was freed");
+
+        assert_eq!(env.children.len(), 1, "one dbc under env");
+        let dbc = &env.children[0];
+        assert_eq!(dbc.handle_type, HandleType::Dbc);
+        assert!(
+            dbc.is_implicit(),
+            "dbc was not explicitly allocated in trace"
+        );
+        assert!(dbc.free.is_some(), "dbc was freed");
+
+        assert_eq!(dbc.children.len(), 1, "one stmt under dbc");
+        let stmt = &dbc.children[0];
+        assert_eq!(stmt.handle_type, HandleType::Stmt);
+        assert!(!stmt.is_implicit(), "stmt was explicitly allocated");
+        assert!(stmt.free.is_some(), "stmt was freed");
+    }
+
+    #[test]
+    fn test_handle_count() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+        assert_eq!(ir.handle_count(), 3);
+    }
+
+    #[test]
+    fn test_operations_attributed_correctly() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+
+        let env = &ir.roots[0];
+        let dbc = &env.children[0];
+        let stmt = &dbc.children[0];
+
+        let env_fn_names: Vec<&str> = env
+            .operations
+            .iter()
+            .map(|o| o.call.function_name())
+            .collect();
+        assert!(
+            env_fn_names.contains(&"SQLGetDiagRec"),
+            "env should have GetDiagRec, got {env_fn_names:?}"
+        );
+
+        let dbc_fn_names: Vec<&str> = dbc
+            .operations
+            .iter()
+            .map(|o| o.call.function_name())
+            .collect();
+        assert!(dbc_fn_names.contains(&"SQLDriverConnect"));
+        assert!(dbc_fn_names.contains(&"SQLGetInfo"));
+        assert!(dbc_fn_names.contains(&"SQLDisconnect"));
+
+        let stmt_fn_names: Vec<&str> = stmt
+            .operations
+            .iter()
+            .map(|o| o.call.function_name())
+            .collect();
+        assert!(stmt_fn_names.contains(&"SQLPrepare"));
+        assert!(stmt_fn_names.contains(&"SQLExecute"));
+        assert!(stmt_fn_names.contains(&"SQLFetchScroll"));
+        assert!(stmt_fn_names.contains(&"SQLGetData"));
+    }
+
+    #[test]
+    fn test_global_sequence_is_monotonic() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+        let all_ops = ir.all_operations_sorted();
+
+        for window in all_ops.windows(2) {
+            assert!(
+                window[0].seq < window[1].seq,
+                "sequence must be strictly increasing: {} >= {}",
+                window[0].seq,
+                window[1].seq
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_operations_accounted_for() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let num_calls = trace.calls.len() as SeqNum;
+        let ir = build_ir(&trace);
+
+        assert_eq!(ir.total_operations, num_calls);
+
+        let all_ops = ir.all_operations_sorted();
+        assert_eq!(
+            all_ops.len(),
+            num_calls as usize,
+            "every call must appear somewhere in the IR"
+        );
+    }
+
+    #[test]
+    fn test_no_unscoped_operations() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+
+        assert!(
+            ir.unscoped_operations.is_empty(),
+            "all operations should be attributed, got {} unscoped: {:?}",
+            ir.unscoped_operations.len(),
+            ir.unscoped_operations
+                .iter()
+                .map(|o| o.call.function_name())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_handles_by_type() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+
+        let all_handles = ir.all_handles();
+        let envs: Vec<_> = all_handles
+            .iter()
+            .filter(|h| h.handle_type == HandleType::Env)
+            .collect();
+        let stmts: Vec<_> = all_handles
+            .iter()
+            .filter(|h| h.handle_type == HandleType::Stmt)
+            .collect();
+
+        assert_eq!(envs.len(), 1);
+        assert_eq!(stmts.len(), 1);
+    }
+
+    #[test]
+    fn test_display_does_not_panic() {
+        let trace = iodbc::parse_str(SAMPLE_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+        let output = format!("{ir}");
+        assert!(output.contains("TraceIr:"));
+        assert!(output.contains("[implicit]"));
+        assert!(output.contains("SQLPrepare"));
+    }
+
+    // -- unixODBC format tests --
+
+    const UNIXODBC_TRACE: &str = "\
+[ODBC][118][1774615098.017111][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0x2e91620
+[ODBC][118][1774615098.017167][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0x2e91620
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][118][1774615098.017193][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.017216][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0x2e91620
+\t\tUNICODE Using encoding ASCII 'UTF-8' and UNICODE 'UTF16LE'
+
+[ODBC][118][1774615098.017363][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0x2e92330
+[ODBC][118][1774615098.017499][SQLDriverConnect.c][751]
+\t\tEntry:
+\t\t\tConnection = 0x2e92330
+\t\t\tWindow Hdl = (nil)
+\t\t\tStr In = [Driver=TestDriver;SERVER=test.snowflakecomputing.com][length = 52]
+\t\t\tStr Out = 0x7ffc81545ea0
+\t\t\tStr Out Max = 1024
+\t\t\tStr Out Ptr = 0x7ffc81545e8a
+\t\t\tCompletion = 0
+[ODBC][118][1774615098.123288][SQLDriverConnect.c][1809]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.163786][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0x2e92330
+[ODBC][118][1774615098.163973][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0x3086810
+[ODBC][118][1774615098.164003][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0x3086810
+\t\t\tSQL = [SELECT 1][length = 8 (SQL_NTS)]
+[ODBC][118][1774615098.237948][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.238178][SQLFetch.c][162]
+\t\tEntry:
+\t\t\tStatement = 0x3086810
+[ODBC][118][1774615098.238253][SQLFetch.c][352]
+\t\tExit:[SQL_NO_DATA]
+[ODBC][118][1774615098.238366][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0x3086810
+[ODBC][118][1774615098.238473][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.509432][SQLDisconnect.c][208]
+\t\tEntry:
+\t\t\tConnection = 0x2e92330
+[ODBC][118][1774615098.511068][SQLDisconnect.c][358]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.511124][SQLFreeHandle.c][290]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0x2e92330
+[ODBC][118][1774615098.511160][SQLFreeHandle.c][339]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.511189][SQLFreeHandle.c][220]
+\t\tEntry:
+\t\t\tHandle Type = 1
+\t\t\tInput Handle = 0x2e91620
+[ODBC][118][1774615098.511200][SQLFreeHandle.c][250]
+\t\tExit:[SQL_SUCCESS]
+";
+
+    use crate::parser::unixodbc;
+
+    #[test]
+    fn test_unixodbc_tree_structure() {
+        let trace = unixodbc::parse_str(UNIXODBC_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+
+        assert_eq!(ir.roots.len(), 1, "single env root");
+        assert_eq!(ir.handle_count(), 3);
+        assert!(ir.unscoped_operations.is_empty(), "no unscoped ops");
+
+        let env = &ir.roots[0];
+        assert_eq!(env.handle_type, HandleType::Env);
+        assert!(!env.is_implicit(), "env explicitly allocated via __handles");
+        assert!(env.free.is_some());
+        assert_eq!(env.operations.len(), 1, "SetEnvAttr");
+
+        let dbc = &env.children[0];
+        assert_eq!(dbc.handle_type, HandleType::Dbc);
+        assert!(!dbc.is_implicit());
+        assert!(dbc.free.is_some());
+
+        let dbc_fns: Vec<&str> = dbc
+            .operations
+            .iter()
+            .map(|o| o.call.function_name())
+            .collect();
+        assert!(dbc_fns.contains(&"SQLDriverConnect"));
+        assert!(dbc_fns.contains(&"SQLDisconnect"));
+
+        let stmt = &dbc.children[0];
+        assert_eq!(stmt.handle_type, HandleType::Stmt);
+        assert!(!stmt.is_implicit());
+        assert!(stmt.free.is_some());
+
+        let stmt_fns: Vec<&str> = stmt
+            .operations
+            .iter()
+            .map(|o| o.call.function_name())
+            .collect();
+        assert!(stmt_fns.contains(&"SQLExecDirect"));
+        assert!(stmt_fns.contains(&"SQLFetch"));
+    }
+
+    #[test]
+    fn test_unixodbc_all_operations_accounted_for() {
+        let trace = unixodbc::parse_str(UNIXODBC_TRACE).expect("parse failed");
+        let num_calls = trace.calls.len() as SeqNum;
+        let ir = build_ir(&trace);
+
+        assert_eq!(ir.total_operations, num_calls);
+        assert_eq!(ir.all_operations_sorted().len(), num_calls as usize);
+    }
+
+    #[test]
+    fn test_unixodbc_global_sequence_monotonic() {
+        let trace = unixodbc::parse_str(UNIXODBC_TRACE).expect("parse failed");
+        let ir = build_ir(&trace);
+        let all_ops = ir.all_operations_sorted();
+        for window in all_ops.windows(2) {
+            assert!(window[0].seq < window[1].seq);
+        }
+    }
+}

--- a/odbc_trace_tool/src/lib.rs
+++ b/odbc_trace_tool/src/lib.rs
@@ -1,4 +1,8 @@
+pub mod compare;
 pub mod generator;
+pub mod ir;
 pub mod model;
 pub mod parser;
+pub mod query_map;
 pub mod replayer;
+pub mod splitter;

--- a/odbc_trace_tool/src/main.rs
+++ b/odbc_trace_tool/src/main.rs
@@ -1,9 +1,14 @@
+mod compare;
 mod generator;
+mod ir;
 mod model;
 mod parser;
+mod query_map;
 mod replayer;
+#[allow(dead_code)]
+mod splitter;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -19,17 +24,22 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Generate a C++ Catch2 test file from an ODBC trace log.
+    /// Generate a C++ Catch2 test file from a trace log or IR YAML.
     Generate {
-        /// Path to the ODBC trace log file.
+        /// Path to an ODBC trace log or IR YAML file (.yaml/.yml).
         #[arg(short, long)]
         input: PathBuf,
 
-        /// Path for the generated C++ test file.
+        /// Path for the generated C++ test file (default: <input_dir>/test.cpp).
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Trace log format (auto-detected if omitted).
+        /// Path to a YAML query mapping file (default: <input_dir>/queries.yaml).
+        /// Auto-created with DTM-stripped defaults if it does not exist.
+        #[arg(short = 'q', long)]
+        query_map: Option<PathBuf>,
+
+        /// Trace log format (auto-detected if omitted; ignored for IR YAML input).
         #[arg(short, long, value_enum, default_value = "auto")]
         format: FormatArg,
 
@@ -40,6 +50,75 @@ enum Commands {
         /// Tag used in the Catch2 test (e.g. "[replay]").
         #[arg(short, long, default_value = "replay")]
         tag: String,
+    },
+
+    /// Extract SQL queries from a trace and write a YAML mapping file.
+    QueryMap {
+        /// Path to the ODBC trace log file.
+        #[arg(short, long)]
+        input: PathBuf,
+
+        /// Path for the generated query mapping file (default: <input_dir>/queries.yaml).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Trace log format (auto-detected if omitted).
+        #[arg(short, long, value_enum, default_value = "auto")]
+        format: FormatArg,
+    },
+
+    /// Split an ODBC trace into per-handle IR YAML files.
+    Split {
+        /// Path to an ODBC trace log or IR YAML file.
+        #[arg(short, long)]
+        input: PathBuf,
+
+        /// Output directory for split IR YAML files.
+        #[arg(short, long)]
+        output_dir: PathBuf,
+
+        /// Split granularity.
+        #[arg(short, long, value_enum)]
+        mode: ir::SplitMode,
+
+        /// Skip traces that contain truncated SQL strings.
+        #[arg(long, default_value = "false")]
+        require_complete_sql: bool,
+
+        /// Trace log format (auto-detected if omitted; ignored for IR YAML input).
+        #[arg(short, long, value_enum, default_value = "auto")]
+        format: FormatArg,
+    },
+
+    /// Dump the handle-tree intermediate representation for debugging.
+    DumpIr {
+        /// Path to the ODBC trace log file.
+        #[arg(short, long)]
+        input: PathBuf,
+
+        /// Write YAML to a file instead of human-readable text to stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Trace log format (auto-detected if omitted).
+        #[arg(short, long, value_enum, default_value = "auto")]
+        format: FormatArg,
+    },
+
+    /// Compare traces by edit distance on their flattened call sequences.
+    Compare {
+        /// One or more reference traces. Each input is compared against all
+        /// references and the minimum distance is reported.
+        #[arg(short, long, num_args = 1..)]
+        reference: Vec<PathBuf>,
+
+        /// Traces to compare against the references.
+        #[arg(short, long, num_args = 1..)]
+        inputs: Vec<PathBuf>,
+
+        /// Trace log format (auto-detected if omitted; ignored for IR YAML input).
+        #[arg(short, long, value_enum, default_value = "auto")]
+        format: FormatArg,
     },
 
     /// Replay an ODBC trace log against the driver, comparing results.
@@ -80,26 +159,175 @@ fn main() {
         Commands::Generate {
             input,
             output,
+            query_map: query_map_path,
             format,
             test_name,
             tag,
         } => {
-            let trace = parse_trace(&input, &format);
-            let config = generator::cpp::GeneratorConfig { test_name, tag };
-            let cpp_output = generator::cpp::generate(&trace, &config);
+            let calls = load_calls(&input, &format);
 
-            match output {
-                Some(path) => {
-                    if let Err(e) = std::fs::write(&path, &cpp_output) {
-                        eprintln!("Error writing output file: {e}");
-                        process::exit(1);
-                    }
-                    println!("Generated test written to {}", path.display());
+            let qm_path =
+                query_map_path.unwrap_or_else(|| default_sibling_path(&input, "queries.yaml"));
+
+            let qm = load_or_create_query_map(&qm_path, &calls);
+
+            let config = generator::cpp::GeneratorConfig {
+                test_name,
+                tag,
+                query_map: Some(qm),
+            };
+            let cpp_output = generator::cpp::generate(&calls, &config);
+
+            let out_path = output.unwrap_or_else(|| default_sibling_path(&input, "test.cpp"));
+
+            if let Err(e) = std::fs::write(&out_path, &cpp_output) {
+                eprintln!("Error writing output file: {e}");
+                process::exit(1);
+            }
+            println!("Generated test written to {}", out_path.display());
+        }
+        Commands::Split {
+            input,
+            output_dir,
+            mode,
+            require_complete_sql,
+            format,
+        } => {
+            let trace_ir = load_ir(&input, &format);
+            let all_parts = trace_ir.split(mode);
+
+            let parts: Vec<_> = if require_complete_sql {
+                all_parts
+                    .into_iter()
+                    .filter(|(_, sub)| !sub.roots.iter().any(|r| r.has_truncated_sql()))
+                    .collect()
+            } else {
+                all_parts
+            };
+
+            if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                eprintln!("Error creating output directory: {e}");
+                process::exit(1);
+            }
+
+            for (name, sub_ir) in &parts {
+                let dir = output_dir.join(name);
+                if let Err(e) = std::fs::create_dir_all(&dir) {
+                    eprintln!("Error creating directory {}: {e}", dir.display());
+                    process::exit(1);
                 }
-                None => {
-                    print!("{cpp_output}");
+                let path = dir.join("ir.yaml");
+                let yaml = serde_yaml::to_string(sub_ir).unwrap_or_else(|e| {
+                    eprintln!("Error serializing IR for {name}: {e}");
+                    process::exit(1);
+                });
+                if let Err(e) = std::fs::write(&path, &yaml) {
+                    eprintln!("Error writing {}: {e}", path.display());
+                    process::exit(1);
                 }
             }
+
+            println!(
+                "Split complete: {} IR files written to {}",
+                parts.len(),
+                output_dir.display()
+            );
+        }
+        Commands::QueryMap {
+            input,
+            output,
+            format,
+        } => {
+            let calls = load_calls(&input, &format);
+            let qm = query_map::generate_query_map(&calls);
+            let out_path = output.unwrap_or_else(|| default_sibling_path(&input, "queries.yaml"));
+
+            let yaml = serde_yaml::to_string(&qm).unwrap_or_else(|e| {
+                eprintln!("Error serializing query map: {e}");
+                process::exit(1);
+            });
+
+            if let Err(e) = std::fs::write(&out_path, &yaml) {
+                eprintln!("Error writing query map: {e}");
+                process::exit(1);
+            }
+            println!(
+                "Query map written to {} ({} queries)",
+                out_path.display(),
+                qm.queries.len()
+            );
+        }
+        Commands::DumpIr {
+            input,
+            output,
+            format,
+        } => {
+            let trace_ir = load_ir(&input, &format);
+
+            if let Some(out_path) = output {
+                let yaml = serde_yaml::to_string(&trace_ir).unwrap_or_else(|e| {
+                    eprintln!("Error serializing IR: {e}");
+                    process::exit(1);
+                });
+                if let Err(e) = std::fs::write(&out_path, &yaml) {
+                    eprintln!("Error writing IR: {e}");
+                    process::exit(1);
+                }
+                println!(
+                    "IR written to {} ({} operations, {} handles)",
+                    out_path.display(),
+                    trace_ir.total_operations,
+                    trace_ir.handle_count()
+                );
+            } else {
+                print!("{trace_ir}");
+            }
+        }
+        Commands::Compare {
+            reference,
+            inputs,
+            format,
+        } => {
+            let ref_data: Vec<_> = reference
+                .iter()
+                .map(|p| {
+                    let ir = load_ir(p, &format);
+                    let calls = ir.flatten_calls();
+                    let name = p.display().to_string();
+                    (name, calls)
+                })
+                .collect();
+
+            let mut results = Vec::new();
+            for path in &inputs {
+                let ir = load_ir(path, &format);
+                let calls = ir.flatten_calls();
+                let filtered = compare::filter_for_comparison(&calls);
+
+                let best = ref_data
+                    .iter()
+                    .map(|(name, ref_calls)| {
+                        let ref_filtered = compare::filter_for_comparison(ref_calls);
+                        let d = compare::compare_traces(&ref_filtered, &filtered);
+                        (name.as_str(), d, ref_filtered.len())
+                    })
+                    .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+                    .unwrap();
+
+                results.push(compare::CompareResult {
+                    name_a: best.0.to_string(),
+                    name_b: path.display().to_string(),
+                    distance: best.1,
+                    len_b: filtered.len(),
+                });
+            }
+
+            let ref_label = if ref_data.len() == 1 {
+                ref_data[0].0.clone()
+            } else {
+                format!("{} references", ref_data.len())
+            };
+            compare::print_report(&ref_label, &mut results);
         }
         Commands::Replay {
             input,
@@ -129,6 +357,81 @@ fn main() {
     }
 }
 
+fn is_yaml_file(path: &Path) -> bool {
+    path.extension()
+        .map(|e| e == "yaml" || e == "yml")
+        .unwrap_or(false)
+}
+
+/// Load an IR, either from a YAML file or by parsing a trace log and building it.
+fn load_ir(input: &Path, format: &FormatArg) -> ir::TraceIr {
+    if is_yaml_file(input) {
+        ir::load_ir_yaml(input).unwrap_or_else(|e| {
+            eprintln!("Error loading IR YAML {}: {e}", input.display());
+            process::exit(1);
+        })
+    } else {
+        let trace = parse_trace(input, format);
+        ir::build_ir(&trace)
+    }
+}
+
+/// Load a flat call list, either from IR YAML or by parsing a trace log.
+fn load_calls(input: &Path, format: &FormatArg) -> Vec<model::OdbcCall> {
+    if is_yaml_file(input) {
+        let trace_ir = ir::load_ir_yaml(input).unwrap_or_else(|e| {
+            eprintln!("Error loading IR YAML {}: {e}", input.display());
+            process::exit(1);
+        });
+        trace_ir.flatten_calls()
+    } else {
+        let trace = parse_trace(input, format);
+        trace.calls.into_iter().map(|tc| tc.call).collect()
+    }
+}
+
+fn default_sibling_path(input: &Path, filename: &str) -> PathBuf {
+    input
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(filename)
+}
+
+fn load_or_create_query_map(path: &Path, calls: &[model::OdbcCall]) -> query_map::QueryMap {
+    if path.exists() {
+        let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
+            eprintln!("Error reading query map {}: {e}", path.display());
+            process::exit(1);
+        });
+        let qm: query_map::QueryMap = serde_yaml::from_str(&content).unwrap_or_else(|e| {
+            eprintln!("Error parsing query map {}: {e}", path.display());
+            process::exit(1);
+        });
+        println!(
+            "Loaded query map from {} ({} queries)",
+            path.display(),
+            qm.queries.len()
+        );
+        qm
+    } else {
+        let qm = query_map::generate_query_map(calls);
+        let yaml = serde_yaml::to_string(&qm).unwrap_or_else(|e| {
+            eprintln!("Error serializing query map: {e}");
+            process::exit(1);
+        });
+        if let Err(e) = std::fs::write(path, &yaml) {
+            eprintln!("Error writing query map {}: {e}", path.display());
+            process::exit(1);
+        }
+        println!(
+            "Created query map at {} ({} queries)",
+            path.display(),
+            qm.queries.len()
+        );
+        qm
+    }
+}
+
 fn parse_trace(input: &std::path::Path, format: &FormatArg) -> model::TraceLog {
     let result = match format {
         FormatArg::Auto => parser::parse_file_auto(input),
@@ -137,7 +440,10 @@ fn parse_trace(input: &std::path::Path, format: &FormatArg) -> model::TraceLog {
     };
 
     match result {
-        Ok(trace) => trace,
+        Ok(mut trace) => {
+            trace.header.source_file = Some(input.display().to_string());
+            trace
+        }
         Err(e) => {
             eprintln!("Error parsing trace file: {e}");
             process::exit(1);

--- a/odbc_trace_tool/src/model.rs
+++ b/odbc_trace_tool/src/model.rs
@@ -302,6 +302,13 @@ pub struct GetFunctions {
     pub function_id: Option<i64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Unsupported {
+    pub return_code: ReturnCode,
+    pub function_name: String,
+    pub handle: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // OdbcCall enum
 // ---------------------------------------------------------------------------
@@ -349,6 +356,8 @@ pub enum OdbcCall {
     GetDiagRec(GetDiagRec),
     #[serde(rename = "SQLGetFunctions")]
     GetFunctions(GetFunctions),
+    #[serde(rename = "Unsupported")]
+    Unsupported(Unsupported),
 }
 
 impl OdbcCall {
@@ -374,6 +383,7 @@ impl OdbcCall {
             Self::GetInfo(c) => c.return_code,
             Self::GetDiagRec(c) => c.return_code,
             Self::GetFunctions(c) => c.return_code,
+            Self::Unsupported(c) => c.return_code,
         }
     }
 
@@ -399,6 +409,7 @@ impl OdbcCall {
             Self::GetInfo(_) => "SQLGetInfo",
             Self::GetDiagRec(_) => "SQLGetDiagRec",
             Self::GetFunctions(_) => "SQLGetFunctions",
+            Self::Unsupported(c) => &c.function_name,
         }
     }
 
@@ -433,6 +444,7 @@ impl OdbcCall {
             Self::GetInfo(c) => c.handle.as_deref(),
             Self::GetDiagRec(c) => c.handle.as_deref(),
             Self::GetFunctions(c) => c.handle.as_deref(),
+            Self::Unsupported(c) => c.handle.as_deref(),
         }
     }
 
@@ -469,6 +481,7 @@ impl OdbcCall {
             Self::GetInfo(c) => resolve(&mut c.handle, map),
             Self::GetDiagRec(c) => resolve(&mut c.handle, map),
             Self::GetFunctions(c) => resolve(&mut c.handle, map),
+            Self::Unsupported(c) => resolve(&mut c.handle, map),
         }
     }
 
@@ -569,7 +582,15 @@ impl OdbcCall {
             "SQLGetInfo" => raw::build_get_info(input_params, output_params, return_code),
             "SQLGetDiagRec" => raw::build_get_diag_rec(input_params, output_params, return_code),
             "SQLGetFunctions" => raw::build_get_functions(input_params, output_params, return_code),
-            _ => panic!("unsupported ODBC function: {function_name}"),
+            _ => {
+                let handle =
+                    raw::first_addr(&input_params).or_else(|| raw::first_addr(&output_params));
+                Self::Unsupported(Unsupported {
+                    return_code,
+                    function_name: function_name.to_string(),
+                    handle,
+                })
+            }
         }
     }
 }
@@ -745,12 +766,16 @@ mod raw {
             buffer_length: int_or_named(&output, 3)
                 .or_else(|| int_by_name(&input, "Buffer Length")),
             data_type: output_named_at(&output, 5)
+                .or_else(|| named_const_at(&output, 5))
+                .or_else(|| named_const_by_name(&output, "Data Type"))
                 .or_else(|| output_int_by_name(&output, "Data Type").map(|v| v.to_string())),
             column_size: output_int_at(&output, 6)
                 .or_else(|| output_int_by_name(&output, "Column Size")),
             decimal_digits: output_int_at(&output, 7)
                 .or_else(|| output_int_by_name(&output, "Decimal Digits")),
             nullable: output_named_at(&output, 8)
+                .or_else(|| named_const_at(&output, 8))
+                .or_else(|| named_const_by_name(&output, "Nullable"))
                 .or_else(|| output_int_by_name(&output, "Nullable").map(|v| v.to_string())),
         })
     }
@@ -897,7 +922,7 @@ mod raw {
             })
     }
 
-    fn first_addr(params: &[Parameter]) -> Option<String> {
+    pub(super) fn first_addr(params: &[Parameter]) -> Option<String> {
         params.iter().find_map(|p| match &p.value {
             ParamValue::Address(a) => Some(a.clone()),
             _ => None,

--- a/odbc_trace_tool/src/model.rs
+++ b/odbc_trace_tool/src/model.rs
@@ -3,15 +3,24 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// ODBC return code as recorded in the trace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReturnCode {
+    #[serde(rename = "SQL_SUCCESS")]
     Success,
+    #[serde(rename = "SQL_SUCCESS_WITH_INFO")]
     SuccessWithInfo,
+    #[serde(rename = "SQL_ERROR")]
     Error,
+    #[serde(rename = "SQL_INVALID_HANDLE")]
     InvalidHandle,
+    #[serde(rename = "SQL_NO_DATA")]
     NoData,
+    #[serde(rename = "SQL_NEED_DATA")]
     NeedData,
+    #[serde(rename = "SQL_STILL_EXECUTING")]
     StillExecuting,
 }
 
@@ -25,6 +34,19 @@ impl ReturnCode {
             100 => Some(Self::NoData),
             99 => Some(Self::NeedData),
             2 => Some(Self::StillExecuting),
+            _ => None,
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "SQL_SUCCESS" => Some(Self::Success),
+            "SQL_SUCCESS_WITH_INFO" => Some(Self::SuccessWithInfo),
+            "SQL_ERROR" => Some(Self::Error),
+            "SQL_INVALID_HANDLE" => Some(Self::InvalidHandle),
+            "SQL_NO_DATA" => Some(Self::NoData),
+            "SQL_NEED_DATA" => Some(Self::NeedData),
+            "SQL_STILL_EXECUTING" => Some(Self::StillExecuting),
             _ => None,
         }
     }
@@ -61,7 +83,7 @@ impl fmt::Display for ReturnCode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ParamValue {
     Integer(i64),
     NamedConstant {
@@ -82,10 +104,13 @@ pub enum ParamValue {
         address: String,
         output_address: String,
     },
-    StringValue(String),
+    StringValue {
+        value: String,
+        truncated: bool,
+    },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Parameter {
     pub type_name: String,
     pub value: ParamValue,
@@ -100,22 +125,904 @@ pub enum Direction {
 #[derive(Debug, Clone)]
 pub struct TraceEntry {
     pub timestamp: String,
+    pub thread_id: Option<String>,
     pub direction: Direction,
     pub function_name: String,
     pub return_code: Option<ReturnCode>,
     pub return_code_raw: Option<i32>,
     pub parameters: Vec<Parameter>,
+    pub line_number: Option<usize>,
 }
 
-#[derive(Debug, Clone)]
-pub struct OdbcCall {
-    pub function_name: String,
-    pub input_params: Vec<Parameter>,
-    pub output_params: Vec<Parameter>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TracedCall {
+    pub call: OdbcCall,
+    pub entry_line: Option<usize>,
+    pub exit_line: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Typed ODBC call structs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllocHandle {
     pub return_code: ReturnCode,
+    pub handle_type: Option<HandleType>,
+    pub parent_handle: Option<String>,
+    pub child_handle: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FreeHandle {
+    pub return_code: ReturnCode,
+    pub handle_type: Option<HandleType>,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetEnvAttr {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub attribute: Option<String>,
+    pub value: Option<i64>,
+    pub str_len: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetConnectAttr {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub attribute: Option<String>,
+    pub value: Option<i64>,
+    pub str_len: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriverConnect {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Disconnect {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Prepare {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub sql: Option<String>,
+    pub sql_truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Execute {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecDirect {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub sql: Option<String>,
+    pub sql_truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NumResultCols {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub count: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DescribeCol {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub column_number: Option<i64>,
+    pub column_name: Option<String>,
+    pub buffer_length: Option<i64>,
+    pub data_type: Option<String>,
+    pub column_size: Option<i64>,
+    pub decimal_digits: Option<i64>,
+    pub nullable: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fetch {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FetchScroll {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub orientation: Option<i64>,
+    pub orientation_name: Option<String>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetData {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub column_number: Option<i64>,
+    pub target_type: Option<i64>,
+    pub target_type_name: Option<String>,
+    pub buffer_length: Option<i64>,
+    pub value: Option<String>,
+    pub indicator: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RowCount {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub count: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoreResults {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloseCursor {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetInfo {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub info_type: Option<String>,
+    pub info_type_value: Option<i64>,
+    pub info_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetDiagRec {
+    pub return_code: ReturnCode,
+    pub handle_type: Option<HandleType>,
+    pub handle: Option<String>,
+    pub rec_number: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetFunctions {
+    pub return_code: ReturnCode,
+    pub handle: Option<String>,
+    pub function_id: Option<i64>,
+}
+
+// ---------------------------------------------------------------------------
+// OdbcCall enum
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "function")]
+pub enum OdbcCall {
+    #[serde(rename = "SQLAllocHandle")]
+    AllocHandle(AllocHandle),
+    #[serde(rename = "SQLFreeHandle")]
+    FreeHandle(FreeHandle),
+    #[serde(rename = "SQLSetEnvAttr")]
+    SetEnvAttr(SetEnvAttr),
+    #[serde(rename = "SQLSetConnectAttr")]
+    SetConnectAttr(SetConnectAttr),
+    #[serde(rename = "SQLDriverConnect")]
+    DriverConnect(DriverConnect),
+    #[serde(rename = "SQLDisconnect")]
+    Disconnect(Disconnect),
+    #[serde(rename = "SQLPrepare")]
+    Prepare(Prepare),
+    #[serde(rename = "SQLExecute")]
+    Execute(Execute),
+    #[serde(rename = "SQLExecDirect")]
+    ExecDirect(ExecDirect),
+    #[serde(rename = "SQLNumResultCols")]
+    NumResultCols(NumResultCols),
+    #[serde(rename = "SQLDescribeCol")]
+    DescribeCol(DescribeCol),
+    #[serde(rename = "SQLFetch")]
+    Fetch(Fetch),
+    #[serde(rename = "SQLFetchScroll")]
+    FetchScroll(FetchScroll),
+    #[serde(rename = "SQLGetData")]
+    GetData(GetData),
+    #[serde(rename = "SQLRowCount")]
+    RowCount(RowCount),
+    #[serde(rename = "SQLMoreResults")]
+    MoreResults(MoreResults),
+    #[serde(rename = "SQLCloseCursor")]
+    CloseCursor(CloseCursor),
+    #[serde(rename = "SQLGetInfo")]
+    GetInfo(GetInfo),
+    #[serde(rename = "SQLGetDiagRec")]
+    GetDiagRec(GetDiagRec),
+    #[serde(rename = "SQLGetFunctions")]
+    GetFunctions(GetFunctions),
+}
+
+impl OdbcCall {
+    pub fn return_code(&self) -> ReturnCode {
+        match self {
+            Self::AllocHandle(c) => c.return_code,
+            Self::FreeHandle(c) => c.return_code,
+            Self::SetEnvAttr(c) => c.return_code,
+            Self::SetConnectAttr(c) => c.return_code,
+            Self::DriverConnect(c) => c.return_code,
+            Self::Disconnect(c) => c.return_code,
+            Self::Prepare(c) => c.return_code,
+            Self::Execute(c) => c.return_code,
+            Self::ExecDirect(c) => c.return_code,
+            Self::NumResultCols(c) => c.return_code,
+            Self::DescribeCol(c) => c.return_code,
+            Self::Fetch(c) => c.return_code,
+            Self::FetchScroll(c) => c.return_code,
+            Self::GetData(c) => c.return_code,
+            Self::RowCount(c) => c.return_code,
+            Self::MoreResults(c) => c.return_code,
+            Self::CloseCursor(c) => c.return_code,
+            Self::GetInfo(c) => c.return_code,
+            Self::GetDiagRec(c) => c.return_code,
+            Self::GetFunctions(c) => c.return_code,
+        }
+    }
+
+    pub fn function_name(&self) -> &str {
+        match self {
+            Self::AllocHandle(_) => "SQLAllocHandle",
+            Self::FreeHandle(_) => "SQLFreeHandle",
+            Self::SetEnvAttr(_) => "SQLSetEnvAttr",
+            Self::SetConnectAttr(_) => "SQLSetConnectAttr",
+            Self::DriverConnect(_) => "SQLDriverConnect",
+            Self::Disconnect(_) => "SQLDisconnect",
+            Self::Prepare(_) => "SQLPrepare",
+            Self::Execute(_) => "SQLExecute",
+            Self::ExecDirect(_) => "SQLExecDirect",
+            Self::NumResultCols(_) => "SQLNumResultCols",
+            Self::DescribeCol(_) => "SQLDescribeCol",
+            Self::Fetch(_) => "SQLFetch",
+            Self::FetchScroll(_) => "SQLFetchScroll",
+            Self::GetData(_) => "SQLGetData",
+            Self::RowCount(_) => "SQLRowCount",
+            Self::MoreResults(_) => "SQLMoreResults",
+            Self::CloseCursor(_) => "SQLCloseCursor",
+            Self::GetInfo(_) => "SQLGetInfo",
+            Self::GetDiagRec(_) => "SQLGetDiagRec",
+            Self::GetFunctions(_) => "SQLGetFunctions",
+        }
+    }
+
+    pub fn has_truncated_sql(&self) -> bool {
+        match self {
+            Self::Prepare(c) => c.sql_truncated,
+            Self::ExecDirect(c) => c.sql_truncated,
+            _ => false,
+        }
+    }
+
+    /// The primary handle address this call operates on.
+    pub fn handle_addr(&self) -> Option<&str> {
+        match self {
+            Self::AllocHandle(c) => c.parent_handle.as_deref(),
+            Self::FreeHandle(c) => c.handle.as_deref(),
+            Self::SetEnvAttr(c) => c.handle.as_deref(),
+            Self::SetConnectAttr(c) => c.handle.as_deref(),
+            Self::DriverConnect(c) => c.handle.as_deref(),
+            Self::Disconnect(c) => c.handle.as_deref(),
+            Self::Prepare(c) => c.handle.as_deref(),
+            Self::Execute(c) => c.handle.as_deref(),
+            Self::ExecDirect(c) => c.handle.as_deref(),
+            Self::NumResultCols(c) => c.handle.as_deref(),
+            Self::DescribeCol(c) => c.handle.as_deref(),
+            Self::Fetch(c) => c.handle.as_deref(),
+            Self::FetchScroll(c) => c.handle.as_deref(),
+            Self::GetData(c) => c.handle.as_deref(),
+            Self::RowCount(c) => c.handle.as_deref(),
+            Self::MoreResults(c) => c.handle.as_deref(),
+            Self::CloseCursor(c) => c.handle.as_deref(),
+            Self::GetInfo(c) => c.handle.as_deref(),
+            Self::GetDiagRec(c) => c.handle.as_deref(),
+            Self::GetFunctions(c) => c.handle.as_deref(),
+        }
+    }
+
+    /// Replace raw handle addresses with logical names where a mapping exists.
+    pub fn resolve_handles(&mut self, map: &HashMap<String, String>) {
+        fn resolve(field: &mut Option<String>, map: &HashMap<String, String>) {
+            if let Some(addr) = field.as_ref() {
+                if let Some(name) = map.get(addr) {
+                    *field = Some(name.clone());
+                }
+            }
+        }
+        match self {
+            Self::AllocHandle(c) => {
+                resolve(&mut c.parent_handle, map);
+                resolve(&mut c.child_handle, map);
+            }
+            Self::FreeHandle(c) => resolve(&mut c.handle, map),
+            Self::SetEnvAttr(c) => resolve(&mut c.handle, map),
+            Self::SetConnectAttr(c) => resolve(&mut c.handle, map),
+            Self::DriverConnect(c) => resolve(&mut c.handle, map),
+            Self::Disconnect(c) => resolve(&mut c.handle, map),
+            Self::Prepare(c) => resolve(&mut c.handle, map),
+            Self::Execute(c) => resolve(&mut c.handle, map),
+            Self::ExecDirect(c) => resolve(&mut c.handle, map),
+            Self::NumResultCols(c) => resolve(&mut c.handle, map),
+            Self::DescribeCol(c) => resolve(&mut c.handle, map),
+            Self::Fetch(c) => resolve(&mut c.handle, map),
+            Self::FetchScroll(c) => resolve(&mut c.handle, map),
+            Self::GetData(c) => resolve(&mut c.handle, map),
+            Self::RowCount(c) => resolve(&mut c.handle, map),
+            Self::MoreResults(c) => resolve(&mut c.handle, map),
+            Self::CloseCursor(c) => resolve(&mut c.handle, map),
+            Self::GetInfo(c) => resolve(&mut c.handle, map),
+            Self::GetDiagRec(c) => resolve(&mut c.handle, map),
+            Self::GetFunctions(c) => resolve(&mut c.handle, map),
+        }
+    }
+
+    pub fn from_raw(
+        function_name: &str,
+        input_params: Vec<Parameter>,
+        output_params: Vec<Parameter>,
+        return_code: ReturnCode,
+    ) -> Self {
+        match function_name {
+            "SQLAllocHandle" => raw::build_alloc_handle(input_params, output_params, return_code),
+            "SQLFreeHandle" => raw::build_free_handle(input_params, output_params, return_code),
+            "SQLSetEnvAttr" => raw::build_set_env_attr(input_params, output_params, return_code),
+            "SQLSetConnectAttr" => {
+                raw::build_set_connect_attr(input_params, output_params, return_code)
+            }
+            "SQLDriverConnect" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::DriverConnect(DriverConnect {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLDisconnect" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::Disconnect(Disconnect {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLPrepare" => raw::build_sql_call(
+                input_params,
+                output_params,
+                return_code,
+                |h, sql, trunc, rc| {
+                    Self::Prepare(Prepare {
+                        return_code: rc,
+                        handle: h,
+                        sql,
+                        sql_truncated: trunc,
+                    })
+                },
+            ),
+            "SQLExecute" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::Execute(Execute {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLExecDirect" => raw::build_sql_call(
+                input_params,
+                output_params,
+                return_code,
+                |h, sql, trunc, rc| {
+                    Self::ExecDirect(ExecDirect {
+                        return_code: rc,
+                        handle: h,
+                        sql,
+                        sql_truncated: trunc,
+                    })
+                },
+            ),
+            "SQLNumResultCols" => {
+                raw::build_num_result_cols(input_params, output_params, return_code)
+            }
+            "SQLDescribeCol" => raw::build_describe_col(input_params, output_params, return_code),
+            "SQLFetch" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::Fetch(Fetch {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLFetchScroll" => raw::build_fetch_scroll(input_params, output_params, return_code),
+            "SQLGetData" => raw::build_get_data(input_params, output_params, return_code),
+            "SQLRowCount" => raw::build_row_count(input_params, output_params, return_code),
+            "SQLMoreResults" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::MoreResults(MoreResults {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLCloseCursor" => {
+                raw::build_simple_handle_call(input_params, output_params, return_code, |h, rc| {
+                    Self::CloseCursor(CloseCursor {
+                        return_code: rc,
+                        handle: h,
+                    })
+                })
+            }
+            "SQLGetInfo" => raw::build_get_info(input_params, output_params, return_code),
+            "SQLGetDiagRec" => raw::build_get_diag_rec(input_params, output_params, return_code),
+            "SQLGetFunctions" => raw::build_get_functions(input_params, output_params, return_code),
+            _ => panic!("unsupported ODBC function: {function_name}"),
+        }
+    }
+}
+
+impl fmt::Display for OdbcCall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}", self.function_name(), self.return_code())
+    }
+}
+
+/// Raw-parameter extraction used by `OdbcCall::from_raw`.
+mod raw {
+    use super::*;
+
+    pub fn build_alloc_handle(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let mut handle_type = int_or_named(&output, 0)
+            .or_else(|| int_by_name(&input, "Handle Type"))
+            .and_then(HandleType::from_value);
+        let mut parent = addr_at(&output, 1).or_else(|| addr_by_name(&input, "Input Handle"));
+        let mut child =
+            output_addr_at(&output, 2).or_else(|| addr_by_name(&output, "Output Handle"));
+
+        if handle_type.is_none() && input.is_empty() {
+            if let Some(env_addr) = addr_by_name(&output, "Environment") {
+                handle_type = Some(HandleType::Env);
+                parent = None;
+                child = Some(env_addr);
+            }
+        }
+
+        OdbcCall::AllocHandle(AllocHandle {
+            return_code: rc,
+            handle_type,
+            parent_handle: parent,
+            child_handle: child,
+        })
+    }
+
+    pub fn build_free_handle(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle_type = int_or_named(&output, 0)
+            .or_else(|| int_by_name(&input, "Handle Type"))
+            .and_then(HandleType::from_value);
+        let handle = addr_at(&output, 1)
+            .or_else(|| addr_by_name(&input, "Input Handle"))
+            .or_else(|| first_handle_addr(&input))
+            .or_else(|| first_handle_addr(&output));
+        OdbcCall::FreeHandle(FreeHandle {
+            return_code: rc,
+            handle_type,
+            handle,
+        })
+    }
+
+    pub fn build_set_env_attr(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Environment")
+            .or_else(|| first_addr(&input))
+            .or_else(|| first_addr(&output));
+        let attribute = attr_name(&input).or_else(|| attr_name(&output));
+        let value = pointer_as_int(&input).or_else(|| pointer_as_int(&output));
+        let str_len = int_by_name(&input, "StrLen").or_else(|| int_by_name(&output, "StrLen"));
+        OdbcCall::SetEnvAttr(SetEnvAttr {
+            return_code: rc,
+            handle,
+            attribute,
+            value,
+            str_len,
+        })
+    }
+
+    pub fn build_set_connect_attr(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Connection")
+            .or_else(|| first_addr(&input))
+            .or_else(|| first_addr(&output));
+        let attribute = attr_name(&input).or_else(|| attr_name(&output));
+        let value = pointer_as_int(&input).or_else(|| pointer_as_int(&output));
+        let str_len = int_by_name(&input, "StrLen").or_else(|| int_by_name(&output, "StrLen"));
+        OdbcCall::SetConnectAttr(SetConnectAttr {
+            return_code: rc,
+            handle,
+            attribute,
+            value,
+            str_len,
+        })
+    }
+
+    pub fn build_simple_handle_call(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+        make: impl FnOnce(Option<String>, ReturnCode) -> OdbcCall,
+    ) -> OdbcCall {
+        let handle = first_addr(&input).or_else(|| first_addr(&output));
+        make(handle, rc)
+    }
+
+    pub fn build_sql_call(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+        make: impl FnOnce(Option<String>, Option<String>, bool, ReturnCode) -> OdbcCall,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&input))
+            .or_else(|| first_addr(&output));
+        let (sql, truncated) = first_string_truncated(&input)
+            .or_else(|| first_string_truncated(&output))
+            .unwrap_or((None, false));
+        make(handle, sql, truncated, rc)
+    }
+
+    pub fn build_num_result_cols(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        let count = output_int_at(&output, 1).or_else(|| output_int_by_name(&output, "Count"));
+        OdbcCall::NumResultCols(NumResultCols {
+            return_code: rc,
+            handle,
+            count,
+        })
+    }
+
+    pub fn build_row_count(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        let count = output_int_at(&output, 1).or_else(|| output_int_by_name(&output, "Row Count"));
+        OdbcCall::RowCount(RowCount {
+            return_code: rc,
+            handle,
+            count,
+        })
+    }
+
+    pub fn build_describe_col(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        OdbcCall::DescribeCol(DescribeCol {
+            return_code: rc,
+            handle,
+            column_number: int_or_named(&output, 1)
+                .or_else(|| int_by_name(&input, "Column Number")),
+            column_name: first_string(&output).or_else(|| string_by_name(&output, "Column Name")),
+            buffer_length: int_or_named(&output, 3)
+                .or_else(|| int_by_name(&input, "Buffer Length")),
+            data_type: output_named_at(&output, 5)
+                .or_else(|| output_int_by_name(&output, "Data Type").map(|v| v.to_string())),
+            column_size: output_int_at(&output, 6)
+                .or_else(|| output_int_by_name(&output, "Column Size")),
+            decimal_digits: output_int_at(&output, 7)
+                .or_else(|| output_int_by_name(&output, "Decimal Digits")),
+            nullable: output_named_at(&output, 8)
+                .or_else(|| output_int_by_name(&output, "Nullable").map(|v| v.to_string())),
+        })
+    }
+
+    pub fn build_fetch_scroll(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        OdbcCall::FetchScroll(FetchScroll {
+            return_code: rc,
+            handle,
+            orientation: int_or_named(&output, 1)
+                .or_else(|| int_by_name(&input, "Fetch Orientation")),
+            orientation_name: named_const_at(&output, 1)
+                .or_else(|| named_const_by_name(&input, "Fetch Orientation")),
+            offset: int_or_named(&output, 2).or_else(|| int_by_name(&input, "Fetch Offset")),
+        })
+    }
+
+    pub fn build_get_data(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Statement")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        OdbcCall::GetData(GetData {
+            return_code: rc,
+            handle,
+            column_number: int_or_named(&output, 1)
+                .or_else(|| int_by_name(&input, "Column Number")),
+            target_type: int_or_named(&output, 2).or_else(|| int_by_name(&input, "Target Type")),
+            target_type_name: named_const_at(&output, 2)
+                .or_else(|| named_const_by_name(&input, "Target Type")),
+            buffer_length: int_or_named(&output, 4)
+                .or_else(|| int_by_name(&input, "Buffer Length")),
+            value: first_string(&output).or_else(|| string_by_name(&output, "Buffer")),
+            indicator: output_int_at(&output, 5)
+                .or_else(|| output_int_by_name(&output, "Strlen Or Ind")),
+        })
+    }
+
+    pub fn build_get_info(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = addr_by_name(&input, "Connection")
+            .or_else(|| first_addr(&output))
+            .or_else(|| first_addr(&input));
+        OdbcCall::GetInfo(GetInfo {
+            return_code: rc,
+            handle,
+            info_type: named_const_at(&output, 1)
+                .or_else(|| named_const_by_name(&input, "Info Type")),
+            info_type_value: int_or_named(&output, 1).or_else(|| int_by_name(&input, "Info Type")),
+            info_value: first_string(&output),
+        })
+    }
+
+    pub fn build_get_diag_rec(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle_type = int_or_named(&output, 0)
+            .or_else(|| int_or_named(&input, 0))
+            .and_then(HandleType::from_value);
+        let handle = addr_at(&output, 1)
+            .or_else(|| addr_at(&input, 1))
+            .or_else(|| first_addr(&input))
+            .or_else(|| first_addr(&output));
+        let rec_number = int_or_named(&output, 2).or_else(|| int_or_named(&input, 2));
+        OdbcCall::GetDiagRec(GetDiagRec {
+            return_code: rc,
+            handle_type,
+            handle,
+            rec_number,
+        })
+    }
+
+    pub fn build_get_functions(
+        input: Vec<Parameter>,
+        output: Vec<Parameter>,
+        rc: ReturnCode,
+    ) -> OdbcCall {
+        let handle = first_addr(&input).or_else(|| first_addr(&output));
+        let function_id = int_or_named(&output, 1).or_else(|| int_or_named(&input, 1));
+        OdbcCall::GetFunctions(GetFunctions {
+            return_code: rc,
+            handle,
+            function_id,
+        })
+    }
+
+    // -- extraction helpers --
+
+    fn int_or_named(params: &[Parameter], idx: usize) -> Option<i64> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::Integer(v) => Some(*v),
+            ParamValue::NamedConstant { value, .. } => Some(*value),
+            _ => None,
+        })
+    }
+
+    fn int_by_name(params: &[Parameter], name: &str) -> Option<i64> {
+        params
+            .iter()
+            .find(|p| p.type_name == name)
+            .and_then(|p| match &p.value {
+                ParamValue::Integer(v) => Some(*v),
+                ParamValue::NamedConstant { value, .. } => Some(*value),
+                _ => None,
+            })
+    }
+
+    fn addr_at(params: &[Parameter], idx: usize) -> Option<String> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::Address(a) => Some(a.clone()),
+            _ => None,
+        })
+    }
+
+    fn output_addr_at(params: &[Parameter], idx: usize) -> Option<String> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::OutputAddress { output_address, .. } => Some(output_address.clone()),
+            _ => None,
+        })
+    }
+
+    fn addr_by_name(params: &[Parameter], name: &str) -> Option<String> {
+        params
+            .iter()
+            .find(|p| p.type_name == name)
+            .and_then(|p| match &p.value {
+                ParamValue::Address(a) => Some(a.clone()),
+                ParamValue::OutputAddress { output_address, .. } => Some(output_address.clone()),
+                _ => None,
+            })
+    }
+
+    fn first_addr(params: &[Parameter]) -> Option<String> {
+        params.iter().find_map(|p| match &p.value {
+            ParamValue::Address(a) => Some(a.clone()),
+            _ => None,
+        })
+    }
+
+    fn first_handle_addr(params: &[Parameter]) -> Option<String> {
+        params.iter().find_map(|p| {
+            if let ParamValue::Address(a) = &p.value {
+                let ht = matches!(
+                    p.type_name.as_str(),
+                    "SQLHENV"
+                        | "SQLHDBC"
+                        | "SQLHSTMT"
+                        | "SQLHDESC"
+                        | "Environment"
+                        | "Connection"
+                        | "Statement"
+                );
+                if ht {
+                    Some(a.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+    }
+
+    fn first_string(params: &[Parameter]) -> Option<String> {
+        params.iter().find_map(|p| match &p.value {
+            ParamValue::StringValue { value, .. } => Some(value.clone()),
+            _ => None,
+        })
+    }
+
+    fn first_string_truncated(params: &[Parameter]) -> Option<(Option<String>, bool)> {
+        params.iter().find_map(|p| match &p.value {
+            ParamValue::StringValue { value, truncated } => Some((Some(value.clone()), *truncated)),
+            _ => None,
+        })
+    }
+
+    fn named_const_at(params: &[Parameter], idx: usize) -> Option<String> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::NamedConstant { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+    }
+
+    fn output_int_by_name(params: &[Parameter], name: &str) -> Option<i64> {
+        params
+            .iter()
+            .find(|p| p.type_name == name)
+            .and_then(|p| match &p.value {
+                ParamValue::OutputInteger { value, .. } => Some(*value),
+                ParamValue::Integer(v) => Some(*v),
+                _ => None,
+            })
+    }
+
+    fn named_const_by_name(params: &[Parameter], name: &str) -> Option<String> {
+        params
+            .iter()
+            .find(|p| p.type_name == name)
+            .and_then(|p| match &p.value {
+                ParamValue::NamedConstant { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+    }
+
+    fn string_by_name(params: &[Parameter], name: &str) -> Option<String> {
+        params
+            .iter()
+            .find(|p| p.type_name == name)
+            .and_then(|p| match &p.value {
+                ParamValue::StringValue { value, .. } => Some(value.clone()),
+                _ => None,
+            })
+    }
+
+    fn output_int_at(params: &[Parameter], idx: usize) -> Option<i64> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::OutputInteger { value, .. } => Some(*value),
+            _ => None,
+        })
+    }
+
+    fn output_named_at(params: &[Parameter], idx: usize) -> Option<String> {
+        params.get(idx).and_then(|p| match &p.value {
+            ParamValue::OutputNamedConstant { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+    }
+
+    fn attr_name(params: &[Parameter]) -> Option<String> {
+        params
+            .iter()
+            .find(|p| p.type_name == "Attribute")
+            .and_then(|p| match &p.value {
+                ParamValue::NamedConstant { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+    }
+
+    fn pointer_as_int(params: &[Parameter]) -> Option<i64> {
+        params
+            .iter()
+            .find(|p| p.type_name == "Value")
+            .map(|p| match &p.value {
+                ParamValue::NullPointer => 0,
+                ParamValue::Integer(v) => *v,
+                ParamValue::Address(addr) => addr
+                    .strip_prefix("0x")
+                    .or_else(|| addr.strip_prefix("0X"))
+                    .and_then(|h| i64::from_str_radix(h, 16).ok())
+                    .unwrap_or(0),
+                _ => 0,
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum HandleType {
     Env,
     Dbc,
@@ -149,6 +1056,15 @@ impl HandleType {
             Self::Dbc => "SQLHDBC",
             Self::Stmt => "SQLHSTMT",
             Self::Desc => "SQLHDESC",
+        }
+    }
+
+    pub fn sql_null_constant(&self) -> &'static str {
+        match self {
+            Self::Env => "SQL_NULL_HENV",
+            Self::Dbc => "SQL_NULL_HDBC",
+            Self::Stmt => "SQL_NULL_HSTMT",
+            Self::Desc => "SQL_NULL_HDESC",
         }
     }
 }
@@ -199,6 +1115,10 @@ impl HandleGraph {
         );
     }
 
+    pub fn register_free(&mut self, address: &str) {
+        self.handles.remove(address);
+    }
+
     pub fn logical_name(&self, address: &str) -> Option<&str> {
         self.handles.get(address).map(|h| h.logical_name.as_str())
     }
@@ -208,23 +1128,27 @@ impl HandleGraph {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TraceHeader {
     pub format: TraceFormat,
     pub started: Option<String>,
     pub driver_manager_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum TraceFormat {
     #[default]
+    #[serde(rename = "iodbc")]
     IOdbc,
+    #[serde(rename = "unixodbc")]
     UnixOdbc,
 }
 
 #[derive(Debug)]
 pub struct TraceLog {
     pub header: TraceHeader,
-    pub calls: Vec<OdbcCall>,
+    pub calls: Vec<TracedCall>,
     pub handle_graph: HandleGraph,
 }

--- a/odbc_trace_tool/src/parser/iodbc.rs
+++ b/odbc_trace_tool/src/parser/iodbc.rs
@@ -6,7 +6,7 @@ use snafu::Location;
 
 use crate::model::{
     Direction, HandleGraph, HandleType, OdbcCall, ParamValue, Parameter, ReturnCode, TraceEntry,
-    TraceFormat, TraceHeader, TraceLog,
+    TraceFormat, TraceHeader, TraceLog, TracedCall,
 };
 
 #[derive(Snafu, Debug)]
@@ -76,6 +76,7 @@ struct RawBlock {
     timestamp: String,
     header_line: String,
     param_lines: Vec<String>,
+    line_number: usize,
 }
 
 static TIMESTAMP_RE: LazyLock<Regex> =
@@ -84,30 +85,42 @@ static TIMESTAMP_RE: LazyLock<Regex> =
 fn split_into_blocks(content: &str) -> Vec<RawBlock> {
     let timestamp_re = &*TIMESTAMP_RE;
     let mut blocks = Vec::new();
-    let mut lines = content.lines().peekable();
+    let all_lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
 
-    while let Some(line) = lines.next() {
+    while i < all_lines.len() {
+        let line = all_lines[i];
         if let Some(caps) = timestamp_re.captures(line) {
+            let block_line = i + 1;
             let timestamp = caps[1].to_string();
+            i += 1;
 
-            let header_line = match lines.next() {
-                Some(h) => h.to_string(),
-                None => continue,
+            let header_line = if i < all_lines.len() {
+                let h = all_lines[i].to_string();
+                i += 1;
+                h
+            } else {
+                continue;
             };
 
             let mut param_lines = Vec::new();
-            while let Some(peeked) = lines.peek() {
+            while i < all_lines.len() {
+                let peeked = all_lines[i];
                 if peeked.is_empty() || timestamp_re.is_match(peeked) || peeked.starts_with("**") {
                     break;
                 }
-                param_lines.push(lines.next().unwrap().to_string());
+                param_lines.push(peeked.to_string());
+                i += 1;
             }
 
             blocks.push(RawBlock {
                 timestamp,
                 header_line,
                 param_lines,
+                line_number: block_line,
             });
+        } else {
+            i += 1;
         }
     }
 
@@ -244,7 +257,10 @@ fn parse_parameters(param_lines: &[String]) -> Vec<Parameter> {
                 let string_val = str_caps[1].trim().to_string();
                 params.push(Parameter {
                     type_name,
-                    value: ParamValue::StringValue(string_val),
+                    value: ParamValue::StringValue {
+                        truncated: string_val.ends_with("..."),
+                        value: string_val,
+                    },
                 });
                 i += 2;
                 continue;
@@ -280,18 +296,20 @@ fn parse_entries(content: &str) -> Vec<TraceEntry> {
 
         entries.push(TraceEntry {
             timestamp: block.timestamp,
+            thread_id: None,
             direction: header.direction,
             function_name: header.function_name,
             return_code,
             return_code_raw,
             parameters,
+            line_number: Some(block.line_number),
         });
     }
 
     entries
 }
 
-fn pair_entries(entries: Vec<TraceEntry>) -> (Vec<OdbcCall>, HandleGraph) {
+fn pair_entries(entries: Vec<TraceEntry>) -> (Vec<TracedCall>, HandleGraph) {
     let mut calls = Vec::new();
     let mut handle_graph = HandleGraph::new();
     let mut pending_enters: Vec<TraceEntry> = Vec::new();
@@ -306,24 +324,30 @@ fn pair_entries(entries: Vec<TraceEntry>) -> (Vec<OdbcCall>, HandleGraph) {
                     .iter()
                     .rposition(|e| e.function_name == entry.function_name);
 
-                let input_params = if let Some(idx) = enter_idx {
+                let (input_params, entry_line) = if let Some(idx) = enter_idx {
                     let enter = pending_enters.remove(idx);
-                    enter.parameters
+                    (enter.parameters, enter.line_number)
                 } else {
-                    Vec::new()
+                    (Vec::new(), None)
                 };
 
                 let return_code = entry.return_code.unwrap_or(ReturnCode::Success);
+                let exit_line = entry.line_number;
 
+                let output_params = entry.parameters;
                 if entry.function_name == "SQLAllocHandle" && return_code.is_success() {
-                    register_alloc_from_params(&entry.parameters, &mut handle_graph);
+                    register_alloc_from_params(&output_params, &mut handle_graph);
                 }
 
-                calls.push(OdbcCall {
-                    function_name: entry.function_name,
-                    input_params,
-                    output_params: entry.parameters,
-                    return_code,
+                calls.push(TracedCall {
+                    call: OdbcCall::from_raw(
+                        &entry.function_name,
+                        input_params,
+                        output_params,
+                        return_code,
+                    ),
+                    entry_line,
+                    exit_line,
                 });
             }
         }
@@ -363,6 +387,7 @@ fn register_alloc_from_params(params: &[Parameter], graph: &mut HandleGraph) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{AllocHandle, DescribeCol, GetData, NumResultCols, Prepare};
 
     const SAMPLE_TRACE: &str =
         include_str!("../../../odbc_tests/tests/replay/iodbctest/select_1.log");
@@ -477,11 +502,7 @@ mod tests {
     #[test]
     fn test_parse_full_trace_function_names() {
         let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse sample trace");
-        let names: Vec<&str> = trace
-            .calls
-            .iter()
-            .map(|c| c.function_name.as_str())
-            .collect();
+        let names: Vec<&str> = trace.calls.iter().map(|c| c.call.function_name()).collect();
 
         assert_eq!(names[0], "SQLDriverConnect");
         assert!(names.contains(&"SQLGetDiagRec"));
@@ -503,30 +524,33 @@ mod tests {
     fn test_parse_full_trace_return_codes() {
         let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse sample trace");
 
-        assert_eq!(trace.calls[0].return_code, ReturnCode::SuccessWithInfo);
+        assert_eq!(
+            trace.calls[0].call.return_code(),
+            ReturnCode::SuccessWithInfo
+        );
 
         let prepare = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLPrepare")
+            .find(|c| c.call.function_name() == "SQLPrepare")
             .unwrap();
-        assert_eq!(prepare.return_code, ReturnCode::Success);
+        assert_eq!(prepare.call.return_code(), ReturnCode::Success);
 
         let fetch_scrolls: Vec<_> = trace
             .calls
             .iter()
-            .filter(|c| c.function_name == "SQLFetchScroll")
+            .filter(|c| c.call.function_name() == "SQLFetchScroll")
             .collect();
         assert_eq!(fetch_scrolls.len(), 2);
-        assert_eq!(fetch_scrolls[0].return_code, ReturnCode::Success);
-        assert_eq!(fetch_scrolls[1].return_code, ReturnCode::NoData);
+        assert_eq!(fetch_scrolls[0].call.return_code(), ReturnCode::Success);
+        assert_eq!(fetch_scrolls[1].call.return_code(), ReturnCode::NoData);
 
         let close = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLCloseCursor")
+            .find(|c| c.call.function_name() == "SQLCloseCursor")
             .unwrap();
-        assert_eq!(close.return_code, ReturnCode::Error);
+        assert_eq!(close.call.return_code(), ReturnCode::Error);
     }
 
     #[test]
@@ -536,23 +560,23 @@ mod tests {
         let prepare = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLPrepare")
+            .find(|c| c.call.function_name() == "SQLPrepare")
             .unwrap();
-        let sql = prepare.input_params.iter().find_map(|p| match &p.value {
-            ParamValue::StringValue(s) => Some(s.as_str()),
+        let sql = match &prepare.call {
+            OdbcCall::Prepare(Prepare { sql, .. }) => sql.as_deref(),
             _ => None,
-        });
+        };
         assert_eq!(sql, Some("SELECT 1"));
 
         let get_data = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLGetData")
+            .find(|c| c.call.function_name() == "SQLGetData")
             .unwrap();
-        let data = get_data.output_params.iter().find_map(|p| match &p.value {
-            ParamValue::StringValue(s) => Some(s.as_str()),
+        let data = match &get_data.call {
+            OdbcCall::GetData(GetData { value, .. }) => value.as_deref(),
             _ => None,
-        });
+        };
         assert_eq!(data, Some("1"));
     }
 
@@ -579,25 +603,23 @@ mod tests {
         let num_cols = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLNumResultCols")
+            .find(|c| c.call.function_name() == "SQLNumResultCols")
             .unwrap();
-        let count = num_cols.output_params.iter().find_map(|p| match &p.value {
-            ParamValue::OutputInteger { value, .. } => Some(*value),
+        let count = match &num_cols.call {
+            OdbcCall::NumResultCols(NumResultCols { count, .. }) => *count,
             _ => None,
-        });
+        };
         assert_eq!(count, Some(1));
 
         let desc = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLDescribeCol")
+            .find(|c| c.call.function_name() == "SQLDescribeCol")
             .unwrap();
-        let data_type = desc.output_params.iter().find_map(|p| match &p.value {
-            ParamValue::OutputNamedConstant { name, .. } if name == "SQL_DECIMAL" => {
-                Some(name.as_str())
-            }
+        let data_type = match &desc.call {
+            OdbcCall::DescribeCol(DescribeCol { data_type, .. }) => data_type.as_deref(),
             _ => None,
-        });
+        };
         assert_eq!(data_type, Some("SQL_DECIMAL"));
     }
 
@@ -608,20 +630,17 @@ mod tests {
         let alloc = trace
             .calls
             .iter()
-            .find(|c| c.function_name == "SQLAllocHandle")
+            .find(|c| c.call.function_name() == "SQLAllocHandle")
             .unwrap();
 
-        let ht = &alloc.output_params[0].value;
-        assert!(
-            matches!(ht, ParamValue::NamedConstant { value: 3, name } if name == "SQL_HANDLE_STMT")
-        );
-
-        let out = &alloc.output_params[2].value;
-        assert!(matches!(
-            out,
-            ParamValue::OutputAddress {
-                output_address, ..
-            } if output_address == "0x104956bc0"
-        ));
+        let OdbcCall::AllocHandle(AllocHandle {
+            handle_type: Some(HandleType::Stmt),
+            child_handle,
+            ..
+        }) = &alloc.call
+        else {
+            panic!("expected SQLAllocHandle for STMT with child handle");
+        };
+        assert_eq!(child_handle.as_deref(), Some("0x104956bc0"));
     }
 }

--- a/odbc_trace_tool/src/parser/unixodbc.rs
+++ b/odbc_trace_tool/src/parser/unixodbc.rs
@@ -1,11 +1,25 @@
-use snafu::{prelude::*, Location};
+use std::sync::LazyLock;
 
-use crate::model::TraceLog;
+use regex::Regex;
+use snafu::prelude::*;
+use snafu::Location;
+
+use crate::model::{
+    Direction, HandleGraph, HandleType, OdbcCall, ParamValue, Parameter, ReturnCode, TraceEntry,
+    TraceFormat, TraceHeader, TraceLog, TracedCall,
+};
 
 #[derive(Snafu, Debug)]
 pub enum UnixOdbcParserError {
-    #[snafu(display("unixODBC trace parser is not yet implemented"))]
-    NotImplemented {
+    #[snafu(display("Failed to read trace file"))]
+    FileRead {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid trace format: not a unixODBC trace file"))]
+    InvalidFormat {
         #[snafu(implicit)]
         location: Location,
     },
@@ -13,10 +27,728 @@ pub enum UnixOdbcParserError {
 
 type Result<T> = std::result::Result<T, UnixOdbcParserError>;
 
-pub fn parse_file(_path: &std::path::Path) -> Result<TraceLog> {
-    NotImplementedSnafu.fail()
+pub fn parse_file(path: &std::path::Path) -> Result<TraceLog> {
+    let content = std::fs::read_to_string(path).context(FileReadSnafu)?;
+    parse_str(&content)
 }
 
-pub fn parse_str(_content: &str) -> Result<TraceLog> {
-    NotImplementedSnafu.fail()
+pub fn parse_str(content: &str) -> Result<TraceLog> {
+    if !content.starts_with("[ODBC]") {
+        return Err(UnixOdbcParserError::InvalidFormat {
+            location: Location::default(),
+        });
+    }
+
+    let entries = parse_entries(content);
+    let (calls, handle_graph) = pair_entries(entries);
+
+    let header = TraceHeader {
+        format: TraceFormat::UnixOdbc,
+        ..Default::default()
+    };
+
+    Ok(TraceLog {
+        header,
+        calls,
+        handle_graph,
+    })
+}
+
+struct RawBlock {
+    thread_id: String,
+    timestamp: String,
+    source_file: String,
+    body_lines: Vec<String>,
+    line_number: usize,
+}
+
+static HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\[ODBC\]\[(\d+)\]\[([^\]]+)\]\[([^\]]+)\]\[(\d+)\]").unwrap());
+
+static EXIT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"Exit:\[(\w+)\]").unwrap());
+
+static KV_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s+([\w][\w\s]*?)\s*=\s*(.+)$").unwrap());
+
+static OUTPUT_PTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(0x[0-9a-fA-F]+)\s*->\s*(-?\d+)(?:\s*\(\d+\s*bits?\))?$").unwrap()
+});
+
+static NAMED_CONST_PARENS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([A-Z_][A-Z_0-9]+)\s+\((-?\d+)\)$").unwrap());
+
+static NAMED_CONST_PREFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(-?\d+)\s+([A-Z_][A-Z_0-9]+)$").unwrap());
+
+static HEX_ADDR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^0x[0-9a-fA-F]+$").unwrap());
+
+static STRING_WITH_LEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)^\[(.*)\]\[length\s*=\s*\d+.*\]$").unwrap());
+
+static STRING_BARE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)^\[(.*)\]$").unwrap());
+
+fn split_into_blocks(content: &str) -> Vec<RawBlock> {
+    let header_re = &*HEADER_RE;
+    let mut blocks = Vec::new();
+    let mut current: Option<RawBlock> = None;
+
+    for (idx, line) in content.lines().enumerate() {
+        if let Some(caps) = header_re.captures(line) {
+            if let Some(block) = current.take() {
+                blocks.push(block);
+            }
+            current = Some(RawBlock {
+                thread_id: caps[1].to_string(),
+                timestamp: caps[2].to_string(),
+                source_file: caps[3].to_string(),
+                body_lines: Vec::new(),
+                line_number: idx + 1,
+            });
+        } else if let Some(ref mut block) = current {
+            block.body_lines.push(line.to_string());
+        }
+    }
+
+    if let Some(block) = current {
+        blocks.push(block);
+    }
+
+    blocks
+}
+
+fn function_name_from_source(source_file: &str) -> String {
+    let name = source_file.strip_suffix(".c").unwrap_or(source_file);
+    if name == "__handles" {
+        "SQLAllocHandle".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn parse_param_value(raw: &str) -> ParamValue {
+    let trimmed = raw.trim();
+
+    if trimmed == "(nil)" || trimmed == "0x0" {
+        return ParamValue::NullPointer;
+    }
+
+    if let Some(caps) = OUTPUT_PTR_RE.captures(trimmed) {
+        return ParamValue::OutputInteger {
+            address: caps[1].to_string(),
+            value: caps[2].parse().unwrap_or(0),
+        };
+    }
+
+    if let Some(caps) = STRING_WITH_LEN_RE.captures(trimmed) {
+        let text = caps[1].to_string();
+        let truncated = text.ends_with("...");
+        return ParamValue::StringValue {
+            value: text,
+            truncated,
+        };
+    }
+
+    if let Some(caps) = STRING_BARE_RE.captures(trimmed) {
+        let text = caps[1].to_string();
+        let truncated = text.ends_with("...");
+        return ParamValue::StringValue {
+            value: text,
+            truncated,
+        };
+    }
+
+    if let Some(caps) = NAMED_CONST_PARENS_RE.captures(trimmed) {
+        return ParamValue::NamedConstant {
+            name: caps[1].to_string(),
+            value: caps[2].parse().unwrap_or(0),
+        };
+    }
+
+    if let Some(caps) = NAMED_CONST_PREFIX_RE.captures(trimmed) {
+        return ParamValue::NamedConstant {
+            value: caps[1].parse().unwrap_or(0),
+            name: caps[2].to_string(),
+        };
+    }
+
+    if HEX_ADDR_RE.is_match(trimmed) {
+        return ParamValue::Address(trimmed.to_string());
+    }
+
+    if let Ok(v) = trimmed.parse::<i64>() {
+        return ParamValue::Integer(v);
+    }
+
+    if is_constant_name(trimmed) {
+        return ParamValue::NamedConstant {
+            name: trimmed.to_string(),
+            value: 0,
+        };
+    }
+
+    ParamValue::Address(trimmed.to_string())
+}
+
+fn is_constant_name(s: &str) -> bool {
+    s.len() > 2
+        && s.contains('_')
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+}
+
+fn has_closing_bracket(s: &str) -> bool {
+    let mut depth = 0i32;
+    for ch in s.chars() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn parse_body(body_lines: &[String]) -> (Direction, Option<ReturnCode>, Vec<Parameter>) {
+    let exit_re = &*EXIT_RE;
+    let kv_re = &*KV_RE;
+
+    let mut direction = Direction::Enter;
+    let mut return_code = None;
+    let mut params = Vec::new();
+
+    let mut i = 0;
+    while i < body_lines.len() {
+        let line = body_lines[i].trim();
+
+        if line.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        if line == "Entry:" {
+            direction = Direction::Enter;
+            i += 1;
+            continue;
+        }
+
+        if let Some(caps) = exit_re.captures(line) {
+            direction = Direction::Exit;
+            return_code = ReturnCode::from_name(&caps[1]);
+            i += 1;
+            continue;
+        }
+
+        if let Some(caps) = kv_re.captures(&body_lines[i]) {
+            let key = caps[1].trim().to_string();
+            let raw_value = caps[2].trim().to_string();
+
+            if raw_value.starts_with('[') && !has_closing_bracket(&raw_value) {
+                let mut full_value = raw_value.clone();
+                while i + 1 < body_lines.len() {
+                    i += 1;
+                    let next = &body_lines[i];
+                    full_value.push('\n');
+                    full_value.push_str(next);
+                    if has_closing_bracket(&full_value) {
+                        break;
+                    }
+                }
+                params.push(Parameter {
+                    type_name: key,
+                    value: parse_param_value(&full_value),
+                });
+            } else {
+                params.push(Parameter {
+                    type_name: key,
+                    value: parse_param_value(&raw_value),
+                });
+            }
+        }
+
+        i += 1;
+    }
+
+    (direction, return_code, params)
+}
+
+fn parse_entries(content: &str) -> Vec<TraceEntry> {
+    let blocks = split_into_blocks(content);
+    let mut entries = Vec::with_capacity(blocks.len());
+
+    for block in blocks {
+        let function_name = function_name_from_source(&block.source_file);
+        let (direction, return_code, parameters) = parse_body(&block.body_lines);
+
+        entries.push(TraceEntry {
+            timestamp: block.timestamp,
+            thread_id: Some(block.thread_id),
+            direction,
+            function_name,
+            return_code,
+            return_code_raw: None,
+            parameters,
+            line_number: Some(block.line_number),
+        });
+    }
+
+    entries
+}
+
+fn pair_entries(entries: Vec<TraceEntry>) -> (Vec<TracedCall>, HandleGraph) {
+    let mut calls = Vec::new();
+    let mut handle_graph = HandleGraph::new();
+    let mut pending_enters: Vec<TraceEntry> = Vec::new();
+
+    for entry in entries {
+        match entry.direction {
+            Direction::Enter => {
+                pending_enters.push(entry);
+            }
+            Direction::Exit => {
+                let enter_idx = pending_enters.iter().rposition(|e| {
+                    e.function_name == entry.function_name && e.thread_id == entry.thread_id
+                });
+
+                let (input_params, entry_line) = if let Some(idx) = enter_idx {
+                    let enter = pending_enters.remove(idx);
+                    (enter.parameters, enter.line_number)
+                } else {
+                    (Vec::new(), None)
+                };
+
+                let return_code = entry.return_code.unwrap_or(ReturnCode::Success);
+                let exit_line = entry.line_number;
+
+                let output_params = entry.parameters;
+                if entry.function_name == "SQLAllocHandle" && return_code.is_success() {
+                    register_alloc(&input_params, &output_params, &mut handle_graph);
+                }
+
+                calls.push(TracedCall {
+                    call: OdbcCall::from_raw(
+                        &entry.function_name,
+                        input_params,
+                        output_params,
+                        return_code,
+                    ),
+                    entry_line,
+                    exit_line,
+                });
+            }
+        }
+    }
+
+    (calls, handle_graph)
+}
+
+fn register_alloc(
+    input_params: &[Parameter],
+    output_params: &[Parameter],
+    graph: &mut HandleGraph,
+) {
+    if input_params.is_empty() {
+        // Implicit env creation from __handles.c (Exit-only, no Entry).
+        if let Some(addr) = find_param_addr(output_params, "Environment") {
+            graph.register_alloc(HandleType::Env, "SQL_NULL_HANDLE", &addr);
+        }
+        return;
+    }
+
+    let Some(handle_type_int) = find_param_int(input_params, "Handle Type") else {
+        return;
+    };
+    let Some(handle_type) = HandleType::from_value(handle_type_int) else {
+        return;
+    };
+    let Some(parent_addr) = find_param_addr(input_params, "Input Handle") else {
+        return;
+    };
+    let Some(child_addr) = find_param_addr(output_params, "Output Handle") else {
+        return;
+    };
+
+    graph.register_alloc(handle_type, &parent_addr, &child_addr);
+}
+
+fn find_param_int(params: &[Parameter], key: &str) -> Option<i64> {
+    params
+        .iter()
+        .find(|p| p.type_name == key)
+        .and_then(|p| match &p.value {
+            ParamValue::Integer(v) => Some(*v),
+            _ => None,
+        })
+}
+
+fn find_param_addr(params: &[Parameter], key: &str) -> Option<String> {
+    params
+        .iter()
+        .find(|p| p.type_name == key)
+        .and_then(|p| match &p.value {
+            ParamValue::Address(a) => Some(a.clone()),
+            _ => None,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ExecDirect, SetEnvAttr};
+
+    const SAMPLE_TRACE: &str = "\
+[ODBC][118][1774615098.017111][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0x2e91620
+[ODBC][118][1774615098.017167][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0x2e91620
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][118][1774615098.017193][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.017216][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0x2e91620
+\t\tUNICODE Using encoding ASCII 'UTF-8' and UNICODE 'UTF16LE'
+
+[ODBC][118][1774615098.017363][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0x2e92330
+[ODBC][118][1774615098.017499][SQLDriverConnect.c][751]
+\t\tEntry:
+\t\t\tConnection = 0x2e92330
+\t\t\tWindow Hdl = (nil)
+\t\t\tStr In = [Driver=TestDriver;SERVER=test.snowflakecomputing.com][length = 52]
+\t\t\tStr Out = 0x7ffc81545ea0
+\t\t\tStr Out Max = 1024
+\t\t\tStr Out Ptr = 0x7ffc81545e8a
+\t\t\tCompletion = 0
+[ODBC][118][1774615098.123288][SQLDriverConnect.c][1809]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.163786][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0x2e92330
+[ODBC][118][1774615098.163973][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0x3086810
+[ODBC][118][1774615098.164003][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0x3086810
+\t\t\tSQL = [SELECT 1][length = 8 (SQL_NTS)]
+[ODBC][118][1774615098.237948][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.238178][SQLFetch.c][162]
+\t\tEntry:
+\t\t\tStatement = 0x3086810
+[ODBC][118][1774615098.238253][SQLFetch.c][352]
+\t\tExit:[SQL_NO_DATA]
+[ODBC][118][1774615098.238366][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0x3086810
+[ODBC][118][1774615098.238473][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.509432][SQLDisconnect.c][208]
+\t\tEntry:
+\t\t\tConnection = 0x2e92330
+[ODBC][118][1774615098.511068][SQLDisconnect.c][358]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.511124][SQLFreeHandle.c][290]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0x2e92330
+[ODBC][118][1774615098.511160][SQLFreeHandle.c][339]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][118][1774615098.511189][SQLFreeHandle.c][220]
+\t\tEntry:
+\t\t\tHandle Type = 1
+\t\t\tInput Handle = 0x2e91620
+[ODBC][118][1774615098.511200][SQLFreeHandle.c][250]
+\t\tExit:[SQL_SUCCESS]
+";
+
+    #[test]
+    fn test_split_into_blocks() {
+        let blocks = split_into_blocks(SAMPLE_TRACE);
+        assert!(
+            blocks.len() >= 20,
+            "Expected >=20 blocks, got {}",
+            blocks.len()
+        );
+        assert_eq!(blocks[0].thread_id, "118");
+        assert_eq!(blocks[0].source_file, "__handles.c");
+    }
+
+    #[test]
+    fn test_function_name_from_source() {
+        assert_eq!(
+            function_name_from_source("SQLAllocHandle.c"),
+            "SQLAllocHandle"
+        );
+        assert_eq!(function_name_from_source("__handles.c"), "SQLAllocHandle");
+        assert_eq!(
+            function_name_from_source("SQLDriverConnect.c"),
+            "SQLDriverConnect"
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_nil() {
+        assert_eq!(parse_param_value("(nil)"), ParamValue::NullPointer);
+        assert_eq!(parse_param_value("0x0"), ParamValue::NullPointer);
+    }
+
+    #[test]
+    fn test_parse_param_value_output_ptr() {
+        assert_eq!(
+            parse_param_value("0x7ffc8154786e -> 2"),
+            ParamValue::OutputInteger {
+                address: "0x7ffc8154786e".to_string(),
+                value: 2,
+            }
+        );
+        assert_eq!(
+            parse_param_value("0x7ffc815476e8 -> 256 (64 bits)"),
+            ParamValue::OutputInteger {
+                address: "0x7ffc815476e8".to_string(),
+                value: 256,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_string_with_length() {
+        assert_eq!(
+            parse_param_value("[SELECT 1][length = 8 (SQL_NTS)]"),
+            ParamValue::StringValue {
+                value: "SELECT 1".to_string(),
+                truncated: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_string_bare() {
+        assert_eq!(
+            parse_param_value("[SCHEMANAME]"),
+            ParamValue::StringValue {
+                value: "SCHEMANAME".to_string(),
+                truncated: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_named_const_parens() {
+        assert_eq!(
+            parse_param_value("SQL_DBMS_NAME (17)"),
+            ParamValue::NamedConstant {
+                name: "SQL_DBMS_NAME".to_string(),
+                value: 17,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_named_const_prefix() {
+        assert_eq!(
+            parse_param_value("1 SQL_CHAR"),
+            ParamValue::NamedConstant {
+                value: 1,
+                name: "SQL_CHAR".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_address() {
+        assert_eq!(
+            parse_param_value("0x2e91620"),
+            ParamValue::Address("0x2e91620".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_param_value_integer() {
+        assert_eq!(parse_param_value("256"), ParamValue::Integer(256));
+        assert_eq!(parse_param_value("0"), ParamValue::Integer(0));
+    }
+
+    #[test]
+    fn test_parse_param_value_named_const_bare() {
+        assert_eq!(
+            parse_param_value("SQL_ATTR_ODBC_VERSION"),
+            ParamValue::NamedConstant {
+                name: "SQL_ATTR_ODBC_VERSION".to_string(),
+                value: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_full_trace() {
+        let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse sample trace");
+        assert_eq!(trace.header.format, TraceFormat::UnixOdbc);
+
+        let names: Vec<&str> = trace.calls.iter().map(|c| c.call.function_name()).collect();
+        assert!(names.contains(&"SQLAllocHandle"), "missing SQLAllocHandle");
+        assert!(names.contains(&"SQLSetEnvAttr"), "missing SQLSetEnvAttr");
+        assert!(
+            names.contains(&"SQLDriverConnect"),
+            "missing SQLDriverConnect"
+        );
+        assert!(names.contains(&"SQLExecDirect"), "missing SQLExecDirect");
+        assert!(names.contains(&"SQLFetch"), "missing SQLFetch");
+        assert!(names.contains(&"SQLFreeHandle"), "missing SQLFreeHandle");
+        assert!(names.contains(&"SQLDisconnect"), "missing SQLDisconnect");
+    }
+
+    #[test]
+    fn test_parse_full_trace_return_codes() {
+        let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse");
+
+        let fetch = trace
+            .calls
+            .iter()
+            .find(|c| c.call.function_name() == "SQLFetch")
+            .unwrap();
+        assert_eq!(fetch.call.return_code(), ReturnCode::NoData);
+
+        let exec = trace
+            .calls
+            .iter()
+            .find(|c| c.call.function_name() == "SQLExecDirect")
+            .unwrap();
+        assert_eq!(exec.call.return_code(), ReturnCode::Success);
+    }
+
+    #[test]
+    fn test_parse_full_trace_handle_graph() {
+        let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse");
+
+        let env = trace.handle_graph.get("0x2e91620");
+        assert!(env.is_some(), "env handle should be registered");
+        assert_eq!(env.unwrap().handle_type, HandleType::Env);
+        assert_eq!(env.unwrap().logical_name, "env0");
+
+        let dbc = trace.handle_graph.get("0x2e92330");
+        assert!(dbc.is_some(), "dbc handle should be registered");
+        assert_eq!(dbc.unwrap().handle_type, HandleType::Dbc);
+        assert_eq!(dbc.unwrap().parent_address.as_deref(), Some("0x2e91620"));
+
+        let stmt = trace.handle_graph.get("0x3086810");
+        assert!(stmt.is_some(), "stmt handle should be registered");
+        assert_eq!(stmt.unwrap().handle_type, HandleType::Stmt);
+        assert_eq!(stmt.unwrap().parent_address.as_deref(), Some("0x2e92330"));
+    }
+
+    #[test]
+    fn test_parse_full_trace_string_values() {
+        let trace = parse_str(SAMPLE_TRACE).expect("Failed to parse");
+
+        let exec = trace
+            .calls
+            .iter()
+            .find(|c| c.call.function_name() == "SQLExecDirect")
+            .unwrap();
+        let sql = match &exec.call {
+            OdbcCall::ExecDirect(ExecDirect { sql, .. }) => sql.as_deref(),
+            _ => None,
+        };
+        assert_eq!(sql, Some("SELECT 1"));
+    }
+
+    #[test]
+    fn test_parse_multiline_string() {
+        let trace_with_multiline = "\
+[ODBC][100][1774615098.100000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xaaa
+[ODBC][100][1774615098.200000][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xaaa
+[ODBC][100][1774615098.200001][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xbbb
+[ODBC][100][1774615098.300000][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xbbb
+[ODBC][100][1774615098.300001][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xccc
+[ODBC][100][1774615098.400000][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xccc
+\t\t\tSQL = [SELECT
+  1
+  FROM dual][length = 22 (SQL_NTS)]
+[ODBC][100][1774615098.500000][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+";
+        let trace = parse_str(trace_with_multiline).expect("Failed to parse");
+        let exec = trace
+            .calls
+            .iter()
+            .find(|c| c.call.function_name() == "SQLExecDirect")
+            .unwrap();
+        let sql = match &exec.call {
+            OdbcCall::ExecDirect(ExecDirect { sql, .. }) => sql.as_deref(),
+            _ => None,
+        };
+        assert_eq!(sql, Some("SELECT\n  1\n  FROM dual"));
+    }
+
+    #[test]
+    fn test_parse_multithreaded_pairing() {
+        let trace = "\
+[ODBC][100][1774615098.100000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xaaa
+[ODBC][200][1774615098.100001][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xbbb
+[ODBC][100][1774615098.200000][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0xaaa
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][200][1774615098.200001][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0xbbb
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][200][1774615098.300000][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1774615098.300001][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+";
+        let trace = parse_str(trace).expect("Failed to parse");
+
+        let set_attrs: Vec<_> = trace
+            .calls
+            .iter()
+            .filter(|c| c.call.function_name() == "SQLSetEnvAttr")
+            .collect();
+        assert_eq!(set_attrs.len(), 2);
+
+        // Thread 200's Exit came first, so it should pair with thread 200's Enter (env 0xbbb)
+        let first = &set_attrs[0];
+        let env_addr = match &first.call {
+            OdbcCall::SetEnvAttr(SetEnvAttr { handle, .. }) => handle.as_deref(),
+            _ => None,
+        };
+        assert_eq!(env_addr, Some("0xbbb"));
+    }
 }

--- a/odbc_trace_tool/src/query_map.rs
+++ b/odbc_trace_tool/src/query_map.rs
@@ -1,0 +1,183 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::model::OdbcCall;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryMapEntry {
+    pub index: usize,
+    pub original: String,
+    pub mapped: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryMap {
+    pub queries: Vec<QueryMapEntry>,
+}
+
+impl QueryMap {
+    pub fn get(&self, index: usize) -> Option<&str> {
+        self.queries
+            .iter()
+            .find(|e| e.index == index)
+            .map(|e| e.mapped.as_str())
+    }
+}
+
+static DTM_COMMENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^-- DTM_\w+:.*\n?").unwrap());
+
+pub fn strip_dtm_comments(sql: &str) -> String {
+    let result = DTM_COMMENT_RE.replace_all(sql, "");
+    let trimmed = result.trim_start_matches('\n');
+    trimmed.trim_end().to_string()
+}
+
+pub fn generate_query_map(calls: &[OdbcCall]) -> QueryMap {
+    let mut entries = Vec::new();
+    let mut index = 0;
+
+    for call in calls {
+        let original = match call {
+            OdbcCall::Prepare(c) => c.sql.clone().unwrap_or_default(),
+            OdbcCall::ExecDirect(c) => c.sql.clone().unwrap_or_default(),
+            _ => continue,
+        };
+
+        let mapped = strip_dtm_comments(&original);
+
+        entries.push(QueryMapEntry {
+            index,
+            original,
+            mapped,
+        });
+        index += 1;
+    }
+
+    QueryMap { queries: entries }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_dtm_comments_all_three_tags() {
+        let sql = "-- DTM_BRID: 652649af-6392-434e-9227-7d5ff972d577\n\
+                    -- DTM_QRY:\n\
+                    -- DTM_BSID: 652649af-6392-434e-9227-7d5ff972d577.0001 \n\
+                    SELECT\n   ...";
+        assert_eq!(strip_dtm_comments(sql), "SELECT\n   ...");
+    }
+
+    #[test]
+    fn test_strip_dtm_comments_brid_and_qry_only() {
+        let sql = "-- DTM_BRID: abc-123\n\
+                    -- DTM_QRY:\n\
+                    SHOW SCHEMAS LIKE 'PUBLIC'";
+        assert_eq!(strip_dtm_comments(sql), "SHOW SCHEMAS LIKE 'PUBLIC'");
+    }
+
+    #[test]
+    fn test_strip_dtm_comments_no_dtm() {
+        let sql = "SELECT 1";
+        assert_eq!(strip_dtm_comments(sql), "SELECT 1");
+    }
+
+    #[test]
+    fn test_strip_dtm_comments_preserves_non_dtm_comments() {
+        let sql = "-- DTM_BRID: abc\n-- regular comment\nSELECT 1";
+        assert_eq!(strip_dtm_comments(sql), "-- regular comment\nSELECT 1");
+    }
+
+    #[test]
+    fn test_strip_dtm_comments_empty() {
+        assert_eq!(strip_dtm_comments(""), "");
+    }
+
+    #[test]
+    fn test_query_map_get() {
+        let qm = QueryMap {
+            queries: vec![
+                QueryMapEntry {
+                    index: 0,
+                    original: "orig0".to_string(),
+                    mapped: "mapped0".to_string(),
+                },
+                QueryMapEntry {
+                    index: 1,
+                    original: "orig1".to_string(),
+                    mapped: "mapped1".to_string(),
+                },
+            ],
+        };
+        assert_eq!(qm.get(0), Some("mapped0"));
+        assert_eq!(qm.get(1), Some("mapped1"));
+        assert_eq!(qm.get(2), None);
+    }
+
+    #[test]
+    fn test_query_map_yaml_roundtrip() {
+        let qm = QueryMap {
+            queries: vec![
+                QueryMapEntry {
+                    index: 0,
+                    original: "-- DTM_BRID: abc\nSELECT 1".to_string(),
+                    mapped: "SELECT 1".to_string(),
+                },
+                QueryMapEntry {
+                    index: 1,
+                    original: "SHOW SCHEMAS LIKE 'PUBLIC'".to_string(),
+                    mapped: "SHOW SCHEMAS LIKE 'PUBLIC'".to_string(),
+                },
+            ],
+        };
+
+        let yaml = serde_yaml::to_string(&qm).expect("serialize");
+        let loaded: QueryMap = serde_yaml::from_str(&yaml).expect("deserialize");
+
+        assert_eq!(loaded.queries.len(), 2);
+        assert_eq!(loaded.get(0), Some("SELECT 1"));
+        assert_eq!(loaded.get(1), Some("SHOW SCHEMAS LIKE 'PUBLIC'"));
+    }
+
+    #[test]
+    fn test_generate_query_map_from_trace() {
+        let trace = crate::parser::unixodbc::parse_str(SAMPLE_TRACE).expect("parse");
+        let calls: Vec<_> = trace.calls.iter().map(|tc| tc.call.clone()).collect();
+        let qm = generate_query_map(&calls);
+
+        assert_eq!(qm.queries.len(), 1);
+        assert_eq!(qm.queries[0].index, 0);
+        assert_eq!(qm.queries[0].original, "SELECT 1");
+        assert_eq!(qm.queries[0].mapped, "SELECT 1");
+    }
+
+    const SAMPLE_TRACE: &str = "\
+[ODBC][100][1774615098.100000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xaaa
+[ODBC][100][1774615098.200000][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xaaa
+[ODBC][100][1774615098.200001][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xbbb
+[ODBC][100][1774615098.300000][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xbbb
+[ODBC][100][1774615098.300001][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xccc
+[ODBC][100][1774615098.400000][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xccc
+\t\t\tSQL = [SELECT 1][length = 8 (SQL_NTS)]
+[ODBC][100][1774615098.500000][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+";
+}

--- a/odbc_trace_tool/src/replayer/mod.rs
+++ b/odbc_trace_tool/src/replayer/mod.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use snafu::prelude::*;
 use snafu::Location;
 
-use crate::model::{HandleType, OdbcCall, ParamValue, ReturnCode, TraceLog};
+use crate::model::{HandleType, OdbcCall, ReturnCode, TraceLog};
 
 #[derive(Snafu, Debug)]
 pub enum ReplayerError {
@@ -53,8 +53,6 @@ const SQL_C_CHAR: SqlSmallInt = 1;
 const SQL_SUCCESS: SqlReturn = 0;
 const SQL_SUCCESS_WITH_INFO: SqlReturn = 1;
 const SQL_NO_DATA: SqlReturn = 100;
-
-const SKIPPED_FUNCTIONS: &[&str] = &["SQLGetDiagRec", "SQLGetFunctions"];
 
 pub struct ReplayConfig {
     pub connection_string: String,
@@ -128,6 +126,8 @@ extern "C" {
     ) -> SqlReturn;
 
     fn SQLNumResultCols(stmt: SqlHandle, column_count: *mut SqlSmallInt) -> SqlReturn;
+
+    fn SQLRowCount(stmt: SqlHandle, row_count: *mut SqlLen) -> SqlReturn;
 
     fn SQLDescribeCol(
         stmt: SqlHandle,
@@ -231,23 +231,24 @@ impl<'a> ReplayContext<'a> {
             h
         };
 
-        for call in &trace.calls {
-            if call.function_name == "SQLDriverConnect" {
-                if let Some(param) = call.output_params.first() {
-                    if let ParamValue::Address(addr) = &param.value {
-                        self.handle_map.insert(addr.clone(), dbc);
-                    }
+        for tc in &trace.calls {
+            if let OdbcCall::DriverConnect(c) = &tc.call {
+                if let Some(addr) = &c.handle {
+                    self.handle_map.insert(addr.clone(), dbc);
                 }
                 break;
             }
         }
 
-        for call in &trace.calls {
-            if SKIPPED_FUNCTIONS.iter().any(|&f| f == call.function_name) {
+        for tc in &trace.calls {
+            if matches!(
+                &tc.call,
+                OdbcCall::GetDiagRec(_) | OdbcCall::GetFunctions(_)
+            ) {
                 self.skipped += 1;
                 continue;
             }
-            self.replay_call(call, env, dbc)?;
+            self.replay_call(&tc.call, env, dbc)?;
         }
 
         unsafe {
@@ -270,22 +271,23 @@ impl<'a> ReplayContext<'a> {
     }
 
     fn replay_call(&mut self, call: &OdbcCall, _env: SqlHandle, dbc: SqlHandle) -> Result<()> {
-        match call.function_name.as_str() {
-            "SQLDriverConnect" => self.replay_driver_connect(call, dbc)?,
-            "SQLAllocHandle" => self.replay_alloc_handle(call, dbc),
-            "SQLPrepare" => self.replay_prepare(call)?,
-            "SQLExecute" => self.replay_execute(call),
-            "SQLExecDirect" => self.replay_exec_direct(call)?,
-            "SQLNumResultCols" => self.replay_num_result_cols(call),
-            "SQLDescribeCol" => self.replay_describe_col(call),
-            "SQLFetchScroll" => self.replay_fetch_scroll(call),
-            "SQLFetch" => self.replay_fetch(call),
-            "SQLGetData" => self.replay_get_data(call),
-            "SQLMoreResults" => self.replay_more_results(call),
-            "SQLCloseCursor" => self.replay_close_cursor(call),
-            "SQLGetInfo" => self.replay_get_info(call, dbc),
-            "SQLFreeHandle" => self.replay_free_handle(call),
-            "SQLDisconnect" => {}
+        match call {
+            OdbcCall::DriverConnect(c) => self.replay_driver_connect(c, dbc)?,
+            OdbcCall::AllocHandle(c) => self.replay_alloc_handle(c, dbc),
+            OdbcCall::Prepare(c) => self.replay_prepare(c)?,
+            OdbcCall::Execute(c) => self.replay_execute(c),
+            OdbcCall::ExecDirect(c) => self.replay_exec_direct(c)?,
+            OdbcCall::NumResultCols(c) => self.replay_num_result_cols(c),
+            OdbcCall::DescribeCol(c) => self.replay_describe_col(c),
+            OdbcCall::FetchScroll(c) => self.replay_fetch_scroll(c),
+            OdbcCall::Fetch(c) => self.replay_fetch(c),
+            OdbcCall::GetData(c) => self.replay_get_data(c),
+            OdbcCall::RowCount(c) => self.replay_row_count(c),
+            OdbcCall::MoreResults(c) => self.replay_more_results(c),
+            OdbcCall::CloseCursor(c) => self.replay_close_cursor(c),
+            OdbcCall::GetInfo(c) => self.replay_get_info(c, dbc),
+            OdbcCall::FreeHandle(c) => self.replay_free_handle(c),
+            OdbcCall::Disconnect(_) => {}
             _ => {
                 self.skipped += 1;
             }
@@ -293,7 +295,11 @@ impl<'a> ReplayContext<'a> {
         Ok(())
     }
 
-    fn replay_driver_connect(&mut self, call: &OdbcCall, dbc: SqlHandle) -> Result<()> {
+    fn replay_driver_connect(
+        &mut self,
+        call: &crate::model::DriverConnect,
+        dbc: SqlHandle,
+    ) -> Result<()> {
         let conn_str = CString::new(self.config.connection_string.as_str()).map_err(|e| {
             ReplayerError::InvalidString {
                 detail: format!("connection string: {e}"),
@@ -312,13 +318,12 @@ impl<'a> ReplayContext<'a> {
                 SQL_DRIVER_NOPROMPT,
             )
         };
-        self.record_result(call, ret, true);
+        self.record(call.return_code, "SQLDriverConnect", ret, true);
         Ok(())
     }
 
-    fn replay_alloc_handle(&mut self, call: &OdbcCall, dbc: SqlHandle) {
-        let handle_type_value = extract_int(&call.output_params, 0);
-        let Some(ht) = handle_type_value.and_then(HandleType::from_value) else {
+    fn replay_alloc_handle(&mut self, call: &crate::model::AllocHandle, dbc: SqlHandle) {
+        let Some(ht) = call.handle_type else {
             self.skipped += 1;
             return;
         };
@@ -326,62 +331,75 @@ impl<'a> ReplayContext<'a> {
             self.skipped += 1;
             return;
         }
-        let child_addr = extract_output_addr(&call.output_params, 2);
         let mut new_handle: SqlHandle = ptr::null_mut();
         let ret = unsafe { SQLAllocHandle(SQL_HANDLE_STMT, dbc, &mut new_handle) };
-        if let Some(addr) = child_addr {
-            self.handle_map.insert(addr, new_handle);
+        if let Some(addr) = &call.child_handle {
+            self.handle_map.insert(addr.clone(), new_handle);
         }
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLAllocHandle", ret, false);
     }
 
-    fn replay_prepare(&mut self, call: &OdbcCall) -> Result<()> {
-        let stmt = self.resolve_stmt(&call.input_params);
-        let sql = extract_string(&call.input_params).unwrap_or_default();
+    fn replay_prepare(&mut self, call: &crate::model::Prepare) -> Result<()> {
+        let stmt = self.resolve_handle(&call.handle);
+        let sql = call.sql.as_deref().unwrap_or_default();
         let sql_c = CString::new(sql).map_err(|e| ReplayerError::InvalidString {
             detail: format!("SQL statement: {e}"),
             location: Location::default(),
         })?;
         let ret = unsafe { SQLPrepare(stmt, sql_c.as_ptr() as *const SqlChar, SQL_NTS) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLPrepare", ret, false);
         Ok(())
     }
 
-    fn replay_execute(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.input_params);
+    fn replay_execute(&mut self, call: &crate::model::Execute) {
+        let stmt = self.resolve_handle(&call.handle);
         let ret = unsafe { SQLExecute(stmt) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLExecute", ret, false);
     }
 
-    fn replay_exec_direct(&mut self, call: &OdbcCall) -> Result<()> {
-        let stmt = self.resolve_stmt(&call.input_params);
-        let sql = extract_string(&call.input_params).unwrap_or_default();
+    fn replay_exec_direct(&mut self, call: &crate::model::ExecDirect) -> Result<()> {
+        let stmt = self.resolve_handle(&call.handle);
+        let sql = call.sql.as_deref().unwrap_or_default();
         let sql_c = CString::new(sql).map_err(|e| ReplayerError::InvalidString {
             detail: format!("SQL statement: {e}"),
             location: Location::default(),
         })?;
         let ret = unsafe { SQLExecDirect(stmt, sql_c.as_ptr() as *const SqlChar, SQL_NTS) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLExecDirect", ret, false);
         Ok(())
     }
 
-    fn replay_num_result_cols(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
-        let expected_count = extract_output_int(&call.output_params, 1);
+    fn replay_num_result_cols(&mut self, call: &crate::model::NumResultCols) {
+        let stmt = self.resolve_handle(&call.handle);
         let mut count: SqlSmallInt = 0;
         let ret = unsafe { SQLNumResultCols(stmt, &mut count) };
-        let mut details = None;
-        if let Some(expected) = expected_count {
+        let details = call.count.and_then(|expected| {
             if i64::from(count) != expected {
-                details = Some(format!("Column count: expected {expected}, got {count}"));
+                Some(format!("Column count: expected {expected}, got {count}"))
+            } else {
+                None
             }
-        }
-        self.record_result_with_details(call, ret, false, details);
+        });
+        self.record_with_details(call.return_code, "SQLNumResultCols", ret, false, details);
     }
 
-    fn replay_describe_col(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
-        let col_num = extract_int(&call.output_params, 1).unwrap_or(1) as SqlUSmallInt;
+    fn replay_row_count(&mut self, call: &crate::model::RowCount) {
+        let stmt = self.resolve_handle(&call.handle);
+        let mut count: SqlLen = 0;
+        let ret = unsafe { SQLRowCount(stmt, &mut count) };
+        let details = call.count.and_then(|expected| {
+            if count as i64 != expected {
+                Some(format!("Row count: expected {expected}, got {count}"))
+            } else {
+                None
+            }
+        });
+        self.record_with_details(call.return_code, "SQLRowCount", ret, false, details);
+    }
+
+    fn replay_describe_col(&mut self, call: &crate::model::DescribeCol) {
+        let stmt = self.resolve_handle(&call.handle);
+        let col_num = call.column_number.unwrap_or(1) as SqlUSmallInt;
         let mut col_name = [0u8; 256];
         let mut name_len: SqlSmallInt = 0;
         let mut data_type: SqlSmallInt = 0;
@@ -402,11 +420,11 @@ impl<'a> ReplayContext<'a> {
             )
         };
         let mut mismatches = Vec::new();
-        if let Some(expected_name) = extract_string(&call.output_params) {
+        if let Some(expected_name) = &call.column_name {
             let actual = unsafe { CStr::from_ptr(col_name.as_ptr() as *const _) }
                 .to_string_lossy()
                 .to_string();
-            if actual != expected_name {
+            if actual != *expected_name {
                 mismatches.push(format!(
                     "Column name: expected '{expected_name}', got '{actual}'"
                 ));
@@ -417,29 +435,28 @@ impl<'a> ReplayContext<'a> {
         } else {
             Some(mismatches.join("; "))
         };
-        self.record_result_with_details(call, ret, false, details);
+        self.record_with_details(call.return_code, "SQLDescribeCol", ret, false, details);
     }
 
-    fn replay_fetch_scroll(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
-        let orientation = extract_int(&call.output_params, 1).unwrap_or(1) as SqlSmallInt;
-        let offset = extract_int(&call.output_params, 2).unwrap_or(1) as SqlLen;
+    fn replay_fetch_scroll(&mut self, call: &crate::model::FetchScroll) {
+        let stmt = self.resolve_handle(&call.handle);
+        let orientation = call.orientation.unwrap_or(1) as SqlSmallInt;
+        let offset = call.offset.unwrap_or(1) as SqlLen;
         let ret = unsafe { SQLFetchScroll(stmt, orientation, offset) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLFetchScroll", ret, false);
     }
 
-    fn replay_fetch(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
+    fn replay_fetch(&mut self, call: &crate::model::Fetch) {
+        let stmt = self.resolve_handle(&call.handle);
         let ret = unsafe { SQLFetch(stmt) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLFetch", ret, false);
     }
 
-    fn replay_get_data(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
-        let col_num = extract_int(&call.output_params, 1).unwrap_or(1) as SqlUSmallInt;
-        let target_type =
-            extract_int(&call.output_params, 2).unwrap_or(i64::from(SQL_C_CHAR)) as SqlSmallInt;
-        let buf_len = extract_int(&call.output_params, 4).unwrap_or(1024) as SqlLen;
+    fn replay_get_data(&mut self, call: &crate::model::GetData) {
+        let stmt = self.resolve_handle(&call.handle);
+        let col_num = call.column_number.unwrap_or(1) as SqlUSmallInt;
+        let target_type = call.target_type.unwrap_or(i64::from(SQL_C_CHAR)) as SqlSmallInt;
+        let buf_len = call.buffer_length.unwrap_or(1024) as SqlLen;
         let mut buffer = vec![0u8; buf_len as usize + 1];
         let mut indicator: SqlLen = 0;
         let ret = unsafe {
@@ -454,34 +471,34 @@ impl<'a> ReplayContext<'a> {
         };
         let mut details = None;
         if ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO {
-            if let Some(expected_str) = extract_string(&call.output_params) {
+            if let Some(expected_str) = &call.value {
                 let actual = unsafe { CStr::from_ptr(buffer.as_ptr() as *const _) }
                     .to_string_lossy()
                     .to_string();
-                if actual != expected_str {
+                if actual != *expected_str {
                     details = Some(format!(
                         "Data value: expected '{expected_str}', got '{actual}'"
                     ));
                 }
             }
         }
-        self.record_result_with_details(call, ret, false, details);
+        self.record_with_details(call.return_code, "SQLGetData", ret, false, details);
     }
 
-    fn replay_more_results(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
+    fn replay_more_results(&mut self, call: &crate::model::MoreResults) {
+        let stmt = self.resolve_handle(&call.handle);
         let ret = unsafe { SQLMoreResults(stmt) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLMoreResults", ret, false);
     }
 
-    fn replay_close_cursor(&mut self, call: &OdbcCall) {
-        let stmt = self.resolve_stmt(&call.output_params);
+    fn replay_close_cursor(&mut self, call: &crate::model::CloseCursor) {
+        let stmt = self.resolve_handle(&call.handle);
         let ret = unsafe { SQLCloseCursor(stmt) };
-        self.record_result(call, ret, false);
+        self.record(call.return_code, "SQLCloseCursor", ret, false);
     }
 
-    fn replay_get_info(&mut self, call: &OdbcCall, dbc: SqlHandle) {
-        let info_type = extract_int(&call.output_params, 1).unwrap_or(0) as SqlUSmallInt;
+    fn replay_get_info(&mut self, call: &crate::model::GetInfo, dbc: SqlHandle) {
+        let info_type = call.info_type_value.unwrap_or(0) as SqlUSmallInt;
         let mut buffer = [0u8; 256];
         let mut len: SqlSmallInt = 0;
         let ret = unsafe {
@@ -493,52 +510,52 @@ impl<'a> ReplayContext<'a> {
                 &mut len,
             )
         };
-        self.record_result(call, ret, true);
+        self.record(call.return_code, "SQLGetInfo", ret, true);
     }
 
-    fn replay_free_handle(&mut self, call: &OdbcCall) {
-        let handle_type_value = extract_int(&call.output_params, 0);
-        let Some(ht) = handle_type_value.and_then(HandleType::from_value) else {
+    fn replay_free_handle(&mut self, call: &crate::model::FreeHandle) {
+        let Some(ht) = call.handle_type else {
             return;
         };
         if matches!(ht, HandleType::Env | HandleType::Dbc) {
             return;
         }
-        let addr = extract_addr(&call.output_params, 1);
-        if let Some(handle) = addr.and_then(|a| self.handle_map.remove(&a)) {
+        if let Some(handle) = call.handle.as_ref().and_then(|a| self.handle_map.remove(a)) {
             unsafe {
                 SQLFreeHandle(SQL_HANDLE_STMT, handle);
             }
         }
     }
 
-    fn resolve_stmt(&self, params: &[crate::model::Parameter]) -> SqlHandle {
-        for param in params {
-            if let ParamValue::Address(addr) = &param.value {
-                if let Some(&handle) = self.handle_map.get(addr) {
-                    return handle;
-                }
-            }
-        }
-        ptr::null_mut()
+    fn resolve_handle(&self, addr: &Option<String>) -> SqlHandle {
+        addr.as_ref()
+            .and_then(|a| self.handle_map.get(a))
+            .copied()
+            .unwrap_or(ptr::null_mut())
     }
 
-    fn record_result(&mut self, call: &OdbcCall, actual: SqlReturn, relaxed_success: bool) {
-        self.record_result_with_details(call, actual, relaxed_success, None);
-    }
-
-    fn record_result_with_details(
+    fn record(
         &mut self,
-        call: &OdbcCall,
+        expected: ReturnCode,
+        function_name: &str,
+        actual: SqlReturn,
+        relaxed_success: bool,
+    ) {
+        self.record_with_details(expected, function_name, actual, relaxed_success, None);
+    }
+
+    fn record_with_details(
+        &mut self,
+        expected: ReturnCode,
+        function_name: &str,
         actual: SqlReturn,
         relaxed_success: bool,
         details: Option<String>,
     ) {
-        let expected = call.return_code;
         let passed =
             self.return_codes_match(expected, actual, relaxed_success) && details.is_none();
         self.results.push(CallResult {
-            function_name: call.function_name.clone(),
+            function_name: function_name.to_string(),
             expected_return_code: expected,
             actual_return_code: actual,
             passed,
@@ -574,42 +591,6 @@ fn expected_code(rc: ReturnCode) -> SqlReturn {
         ReturnCode::NeedData => 99,
         ReturnCode::StillExecuting => 2,
     }
-}
-
-fn extract_int(params: &[crate::model::Parameter], idx: usize) -> Option<i64> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::Integer(v) => Some(*v),
-        ParamValue::NamedConstant { value, .. } => Some(*value),
-        _ => None,
-    })
-}
-
-fn extract_output_int(params: &[crate::model::Parameter], idx: usize) -> Option<i64> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::OutputInteger { value, .. } => Some(*value),
-        _ => None,
-    })
-}
-
-fn extract_addr(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::Address(a) => Some(a.clone()),
-        _ => None,
-    })
-}
-
-fn extract_output_addr(params: &[crate::model::Parameter], idx: usize) -> Option<String> {
-    params.get(idx).and_then(|p| match &p.value {
-        ParamValue::OutputAddress { output_address, .. } => Some(output_address.clone()),
-        _ => None,
-    })
-}
-
-fn extract_string(params: &[crate::model::Parameter]) -> Option<String> {
-    params.iter().find_map(|p| match &p.value {
-        ParamValue::StringValue(s) => Some(s.clone()),
-        _ => None,
-    })
 }
 
 pub fn print_report(summary: &ReplaySummary) {

--- a/odbc_trace_tool/src/splitter.rs
+++ b/odbc_trace_tool/src/splitter.rs
@@ -1,0 +1,1041 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::model::{Direction, HandleType};
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum SplitMode {
+    Env,
+    Connection,
+    Statement,
+}
+
+pub struct SplitStats {
+    pub files_written: usize,
+    pub blocks_processed: usize,
+    pub envs_found: usize,
+    pub connections_found: usize,
+    pub statements_found: usize,
+}
+
+pub fn split_trace(
+    input: &Path,
+    output_dir: &Path,
+    mode: SplitMode,
+    require_statements: bool,
+) -> io::Result<SplitStats> {
+    let content = fs::read_to_string(input)?;
+    let mut raw_blocks = extract_raw_blocks(&content);
+    let hierarchy = build_hierarchy_and_assign_scopes(&mut raw_blocks);
+    write_split_output(
+        &raw_blocks,
+        &hierarchy,
+        output_dir,
+        mode,
+        require_statements,
+    )
+}
+
+// -- Raw block extraction --
+
+#[derive(Debug, Clone)]
+enum HandleScope {
+    Env(String),
+    Connection(String),
+    Statement(String),
+    Unknown,
+}
+
+#[derive(Debug)]
+struct RawBlock {
+    raw_text: String,
+    thread_id: String,
+    function_name: String,
+    direction: Direction,
+    scope: HandleScope,
+    env_addr: Option<String>,
+    conn_addr: Option<String>,
+    stmt_addr: Option<String>,
+    handle_type: Option<i64>,
+    input_handle: Option<String>,
+    output_handle: Option<String>,
+}
+
+static HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\[ODBC\]\[(\d+)\]\[([^\]]+)\]\[([^\]]+)\]\[(\d+)\]").unwrap());
+
+static EXIT_DIR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"Exit:\[(\w+)\]").unwrap());
+
+fn extract_raw_blocks(content: &str) -> Vec<RawBlock> {
+    let header_re = &*HEADER_RE;
+    let mut blocks = Vec::new();
+    let mut cur_raw = String::new();
+    let mut cur_meta: Option<(String, String)> = None;
+    let mut cur_body: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        if let Some(caps) = header_re.captures(line) {
+            if let Some((thread_id, source_file)) = cur_meta.take() {
+                blocks.push(finalize_block(
+                    std::mem::take(&mut cur_raw),
+                    thread_id,
+                    source_file,
+                    std::mem::take(&mut cur_body),
+                ));
+            }
+            cur_raw.push_str(line);
+            cur_raw.push('\n');
+            cur_meta = Some((caps[1].to_string(), caps[3].to_string()));
+        } else if cur_meta.is_some() {
+            cur_raw.push_str(line);
+            cur_raw.push('\n');
+            cur_body.push(line.to_string());
+        }
+    }
+
+    if let Some((thread_id, source_file)) = cur_meta.take() {
+        blocks.push(finalize_block(cur_raw, thread_id, source_file, cur_body));
+    }
+
+    blocks
+}
+
+fn finalize_block(
+    raw_text: String,
+    thread_id: String,
+    source_file: String,
+    body_lines: Vec<String>,
+) -> RawBlock {
+    let function_name = {
+        let name = source_file.strip_suffix(".c").unwrap_or(&source_file);
+        if name == "__handles" {
+            "SQLAllocHandle".to_string()
+        } else {
+            name.to_string()
+        }
+    };
+
+    let exit_dir_re = &*EXIT_DIR_RE;
+    let mut direction = Direction::Enter;
+    let mut env_addr = None;
+    let mut conn_addr = None;
+    let mut stmt_addr = None;
+    let mut handle_type = None;
+    let mut input_handle = None;
+    let mut output_handle = None;
+
+    for line in &body_lines {
+        let trimmed = line.trim();
+        if trimmed == "Entry:" {
+            direction = Direction::Enter;
+        } else if exit_dir_re.is_match(trimmed) {
+            direction = Direction::Exit;
+        } else if let Some(rest) = trimmed.strip_prefix("Environment = ") {
+            env_addr = extract_addr(rest);
+        } else if let Some(rest) = trimmed.strip_prefix("Connection = ") {
+            conn_addr = extract_addr(rest);
+        } else if let Some(rest) = trimmed.strip_prefix("Statement = ") {
+            stmt_addr = extract_addr(rest);
+        } else if let Some(rest) = trimmed.strip_prefix("Handle Type = ") {
+            handle_type = rest.trim().parse::<i64>().ok();
+        } else if let Some(rest) = trimmed.strip_prefix("Input Handle = ") {
+            input_handle = extract_addr(rest);
+        } else if let Some(rest) = trimmed.strip_prefix("Output Handle = ") {
+            output_handle = extract_addr(rest);
+        }
+    }
+
+    RawBlock {
+        raw_text,
+        thread_id,
+        function_name,
+        direction,
+        scope: HandleScope::Unknown,
+        env_addr,
+        conn_addr,
+        stmt_addr,
+        handle_type,
+        input_handle,
+        output_handle,
+    }
+}
+
+fn extract_addr(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    Some(trimmed.to_string())
+}
+
+// -- Handle hierarchy --
+
+struct HandleHierarchy {
+    parent_of: HashMap<String, String>,
+    type_of: HashMap<String, HandleType>,
+    name_of: HashMap<String, String>,
+    env_counter: usize,
+    conn_counter: usize,
+    stmt_counter: usize,
+}
+
+impl HandleHierarchy {
+    fn new() -> Self {
+        Self {
+            parent_of: HashMap::new(),
+            type_of: HashMap::new(),
+            name_of: HashMap::new(),
+            env_counter: 0,
+            conn_counter: 0,
+            stmt_counter: 0,
+        }
+    }
+
+    fn register(&mut self, handle_type: HandleType, parent_key: &str, child_key: &str) {
+        if self.type_of.contains_key(child_key) {
+            return;
+        }
+        self.parent_of
+            .insert(child_key.to_string(), parent_key.to_string());
+        self.type_of.insert(child_key.to_string(), handle_type);
+
+        let name = match handle_type {
+            HandleType::Env => {
+                let n = format!("env_{}", self.env_counter);
+                self.env_counter += 1;
+                n
+            }
+            HandleType::Dbc => {
+                let n = format!("conn_{}", self.conn_counter);
+                self.conn_counter += 1;
+                n
+            }
+            HandleType::Stmt => {
+                let n = format!("stmt_{}", self.stmt_counter);
+                self.stmt_counter += 1;
+                n
+            }
+            HandleType::Desc => {
+                format!("desc_{child_key}")
+            }
+        };
+        self.name_of.insert(child_key.to_string(), name);
+    }
+
+    fn env_of<'a>(&'a self, addr: &'a str) -> Option<&'a str> {
+        match self.type_of.get(addr)? {
+            HandleType::Env => Some(addr),
+            HandleType::Dbc => self.parent_of.get(addr).map(|s| s.as_str()),
+            HandleType::Stmt => {
+                let conn = self.parent_of.get(addr)?;
+                self.parent_of.get(conn.as_str()).map(|s| s.as_str())
+            }
+            HandleType::Desc => None,
+        }
+    }
+
+    fn conn_of<'a>(&'a self, addr: &'a str) -> Option<&'a str> {
+        match self.type_of.get(addr)? {
+            HandleType::Dbc => Some(addr),
+            HandleType::Stmt => self.parent_of.get(addr).map(|s| s.as_str()),
+            _ => None,
+        }
+    }
+
+    fn name<'a>(&'a self, addr: &'a str) -> &'a str {
+        self.name_of.get(addr).map(|s| s.as_str()).unwrap_or(addr)
+    }
+
+    fn all_envs(&self) -> Vec<String> {
+        self.type_of
+            .iter()
+            .filter(|(_, t)| **t == HandleType::Env)
+            .map(|(a, _)| a.clone())
+            .collect()
+    }
+
+    fn all_conns(&self) -> Vec<String> {
+        self.type_of
+            .iter()
+            .filter(|(_, t)| **t == HandleType::Dbc)
+            .map(|(a, _)| a.clone())
+            .collect()
+    }
+
+    fn all_stmts(&self) -> Vec<String> {
+        self.type_of
+            .iter()
+            .filter(|(_, t)| **t == HandleType::Stmt)
+            .map(|(a, _)| a.clone())
+            .collect()
+    }
+
+    fn conn_has_stmts(&self, conn_addr: &str) -> bool {
+        self.type_of.iter().any(|(addr, t)| {
+            *t == HandleType::Stmt
+                && self.parent_of.get(addr).map(|s| s.as_str()) == Some(conn_addr)
+        })
+    }
+
+    fn env_has_stmts(&self, env_addr: &str) -> bool {
+        self.all_conns().iter().any(|conn_addr| {
+            self.env_of(conn_addr) == Some(env_addr) && self.conn_has_stmts(conn_addr)
+        })
+    }
+}
+
+fn versioned_key(addr: &str, generation: usize) -> String {
+    if generation == 0 {
+        addr.to_string()
+    } else {
+        format!("{addr}#{generation}")
+    }
+}
+
+fn build_hierarchy_and_assign_scopes(blocks: &mut [RawBlock]) -> HandleHierarchy {
+    let mut hierarchy = HandleHierarchy::new();
+    let mut addr_generation: HashMap<String, usize> = HashMap::new();
+    let mut active_handles: HashMap<String, String> = HashMap::new();
+    let mut pending_scopes: HashMap<(String, String), Vec<HandleScope>> = HashMap::new();
+
+    struct PendingAlloc {
+        handle_type: i64,
+        input_handle: String,
+    }
+    let mut pending_allocs: HashMap<String, Vec<PendingAlloc>> = HashMap::new();
+
+    for block in blocks.iter_mut() {
+        // Step 1: Process alloc events to register handles before scope determination.
+        if block.function_name == "SQLAllocHandle" {
+            match block.direction {
+                Direction::Enter => {
+                    if let (Some(ht), Some(ref ih)) = (block.handle_type, &block.input_handle) {
+                        pending_allocs
+                            .entry(block.thread_id.clone())
+                            .or_default()
+                            .push(PendingAlloc {
+                                handle_type: ht,
+                                input_handle: ih.clone(),
+                            });
+                    }
+                }
+                Direction::Exit => {
+                    if let Some(ref env_addr) = block.env_addr {
+                        let gen = addr_generation.entry(env_addr.clone()).or_insert(0);
+                        let key = versioned_key(env_addr, *gen);
+                        if !hierarchy.type_of.contains_key(&key) {
+                            hierarchy.register(HandleType::Env, "SQL_NULL_HANDLE", &key);
+                        }
+                        active_handles.insert(env_addr.clone(), key);
+                    } else if let Some(ref out_addr) = block.output_handle {
+                        let alloc = pending_allocs
+                            .get_mut(&block.thread_id)
+                            .and_then(|stack| stack.pop());
+                        if let Some(alloc) = alloc {
+                            if let Some(ht) = HandleType::from_value(alloc.handle_type) {
+                                let gen = addr_generation.entry(out_addr.clone()).or_insert(0);
+                                let key = versioned_key(out_addr, *gen);
+                                let parent_key = active_handles
+                                    .get(&alloc.input_handle)
+                                    .cloned()
+                                    .unwrap_or_else(|| alloc.input_handle.clone());
+                                hierarchy.register(ht, &parent_key, &key);
+                                active_handles.insert(out_addr.clone(), key);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step 2: Determine scope using current active_handles mapping.
+        let scope = determine_scope(block, &hierarchy, &active_handles);
+
+        // Step 3: Assign scope (with pending-scope inheritance for Exit blocks).
+        match block.direction {
+            Direction::Enter => {
+                block.scope = scope.clone();
+                pending_scopes
+                    .entry((block.thread_id.clone(), block.function_name.clone()))
+                    .or_default()
+                    .push(scope);
+            }
+            Direction::Exit => {
+                if matches!(scope, HandleScope::Unknown) {
+                    let inherited = pending_scopes
+                        .get_mut(&(block.thread_id.clone(), block.function_name.clone()))
+                        .and_then(|stack| stack.pop());
+                    block.scope = inherited.unwrap_or(HandleScope::Unknown);
+                } else {
+                    pending_scopes
+                        .get_mut(&(block.thread_id.clone(), block.function_name.clone()))
+                        .and_then(|stack| stack.pop());
+                    block.scope = scope;
+                }
+            }
+        }
+
+        // Step 4: Process free events AFTER scope determination so the handle
+        // is still resolvable during scope lookup for the free block itself.
+        if block.function_name == "SQLFreeHandle" && block.direction == Direction::Enter {
+            if let Some(ref ih) = block.input_handle {
+                active_handles.remove(ih);
+                let gen = addr_generation.entry(ih.clone()).or_insert(0);
+                *gen += 1;
+            }
+        }
+    }
+
+    hierarchy
+}
+
+fn determine_scope(
+    block: &RawBlock,
+    hierarchy: &HandleHierarchy,
+    active_handles: &HashMap<String, String>,
+) -> HandleScope {
+    if let Some(ref addr) = block.stmt_addr {
+        let key = active_handles
+            .get(addr)
+            .cloned()
+            .unwrap_or_else(|| addr.clone());
+        return HandleScope::Statement(key);
+    }
+    if let Some(ref addr) = block.conn_addr {
+        let key = active_handles
+            .get(addr)
+            .cloned()
+            .unwrap_or_else(|| addr.clone());
+        return HandleScope::Connection(key);
+    }
+    if let Some(ref addr) = block.env_addr {
+        let key = active_handles
+            .get(addr)
+            .cloned()
+            .unwrap_or_else(|| addr.clone());
+        return HandleScope::Env(key);
+    }
+
+    let is_alloc_or_free =
+        block.function_name == "SQLAllocHandle" || block.function_name == "SQLFreeHandle";
+
+    if !is_alloc_or_free {
+        return HandleScope::Unknown;
+    }
+
+    if let Some(ref out_addr) = block.output_handle {
+        let key = active_handles
+            .get(out_addr)
+            .cloned()
+            .unwrap_or_else(|| out_addr.clone());
+        if let Some(ht) = hierarchy.type_of.get(&key) {
+            return match ht {
+                HandleType::Env => HandleScope::Env(key),
+                HandleType::Dbc => HandleScope::Connection(key),
+                HandleType::Stmt => HandleScope::Statement(key),
+                HandleType::Desc => HandleScope::Unknown,
+            };
+        }
+    }
+
+    if let (Some(ht_val), Some(ref ih)) = (block.handle_type, &block.input_handle) {
+        let key = active_handles
+            .get(ih)
+            .cloned()
+            .unwrap_or_else(|| ih.clone());
+        if block.function_name == "SQLFreeHandle" {
+            return match HandleType::from_value(ht_val) {
+                Some(HandleType::Env) => HandleScope::Env(key),
+                Some(HandleType::Dbc) => HandleScope::Connection(key),
+                Some(HandleType::Stmt) => HandleScope::Statement(key),
+                _ => HandleScope::Unknown,
+            };
+        }
+
+        return match HandleType::from_value(ht_val) {
+            Some(HandleType::Dbc) => HandleScope::Env(key),
+            Some(HandleType::Stmt) => HandleScope::Connection(key),
+            _ => HandleScope::Unknown,
+        };
+    }
+
+    HandleScope::Unknown
+}
+
+// -- Output writing --
+
+fn write_split_output(
+    blocks: &[RawBlock],
+    hierarchy: &HandleHierarchy,
+    output_dir: &Path,
+    mode: SplitMode,
+    require_statements: bool,
+) -> io::Result<SplitStats> {
+    // Group block indices by scope addr (env/conn/stmt)
+    let mut env_block_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut conn_block_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut stmt_block_indices: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for (i, block) in blocks.iter().enumerate() {
+        match &block.scope {
+            HandleScope::Env(addr) => {
+                env_block_indices.entry(addr.clone()).or_default().push(i);
+            }
+            HandleScope::Connection(addr) => {
+                conn_block_indices.entry(addr.clone()).or_default().push(i);
+            }
+            HandleScope::Statement(addr) => {
+                stmt_block_indices.entry(addr.clone()).or_default().push(i);
+            }
+            HandleScope::Unknown => {}
+        }
+    }
+
+    let mut files_written = 0;
+
+    match mode {
+        SplitMode::Env => {
+            for env_addr in hierarchy.all_envs() {
+                if require_statements && !hierarchy.env_has_stmts(&env_addr) {
+                    continue;
+                }
+                let env_name = hierarchy.name(&env_addr);
+                let dir = output_dir.join(env_name);
+                fs::create_dir_all(&dir)?;
+
+                let mut indices: Vec<usize> = Vec::new();
+
+                if let Some(ei) = env_block_indices.get(&env_addr) {
+                    indices.extend(ei);
+                }
+                for conn_addr in hierarchy.all_conns() {
+                    if hierarchy.env_of(&conn_addr) == Some(env_addr.as_str()) {
+                        if let Some(ci) = conn_block_indices.get(&conn_addr) {
+                            indices.extend(ci);
+                        }
+                        for stmt_addr in hierarchy.all_stmts() {
+                            if hierarchy.conn_of(&stmt_addr) == Some(conn_addr.as_str()) {
+                                if let Some(si) = stmt_block_indices.get(&stmt_addr) {
+                                    indices.extend(si);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                indices.sort_unstable();
+                write_blocks_to_file(&dir.join("trace.txt"), blocks, &indices)?;
+                files_written += 1;
+            }
+        }
+
+        SplitMode::Connection => {
+            for conn_addr in hierarchy.all_conns() {
+                if require_statements && !hierarchy.conn_has_stmts(&conn_addr) {
+                    continue;
+                }
+                let conn_name = hierarchy.name(&conn_addr);
+                let env_addr = hierarchy.env_of(&conn_addr).unwrap_or("unknown_env");
+                let env_name = hierarchy.name(env_addr);
+                let dir = output_dir.join(env_name).join(conn_name);
+                fs::create_dir_all(&dir)?;
+
+                let mut indices: Vec<usize> = Vec::new();
+
+                // Repeat env blocks
+                if let Some(ei) = env_block_indices.get(env_addr) {
+                    indices.extend(ei);
+                }
+                // Connection blocks
+                if let Some(ci) = conn_block_indices.get(&conn_addr) {
+                    indices.extend(ci);
+                }
+                // Child statement blocks
+                for stmt_addr in hierarchy.all_stmts() {
+                    if hierarchy.conn_of(&stmt_addr) == Some(conn_addr.as_str()) {
+                        if let Some(si) = stmt_block_indices.get(&stmt_addr) {
+                            indices.extend(si);
+                        }
+                    }
+                }
+
+                indices.sort_unstable();
+                write_blocks_to_file(&dir.join("trace.txt"), blocks, &indices)?;
+                files_written += 1;
+            }
+        }
+
+        SplitMode::Statement => {
+            for stmt_addr in hierarchy.all_stmts() {
+                let stmt_name = hierarchy.name(&stmt_addr);
+                let conn_addr_str = hierarchy.conn_of(&stmt_addr).unwrap_or("unknown_conn");
+                let conn_name = hierarchy.name(conn_addr_str);
+                let env_addr_str = hierarchy.env_of(&stmt_addr).unwrap_or("unknown_env");
+                let env_name = hierarchy.name(env_addr_str);
+
+                let dir = output_dir.join(env_name).join(conn_name);
+                fs::create_dir_all(&dir)?;
+
+                let mut indices: Vec<usize> = Vec::new();
+
+                // Repeat env blocks
+                if let Some(ei) = env_block_indices.get(env_addr_str) {
+                    indices.extend(ei);
+                }
+                // Repeat conn blocks
+                if let Some(ci) = conn_block_indices.get(conn_addr_str) {
+                    indices.extend(ci);
+                }
+                // Statement blocks
+                if let Some(si) = stmt_block_indices.get(&stmt_addr) {
+                    indices.extend(si);
+                }
+
+                indices.sort_unstable();
+                let filename = format!("{}_trace.txt", stmt_name);
+                write_blocks_to_file(&dir.join(filename), blocks, &indices)?;
+                files_written += 1;
+            }
+        }
+    }
+
+    Ok(SplitStats {
+        files_written,
+        blocks_processed: blocks.len(),
+        envs_found: hierarchy.all_envs().len(),
+        connections_found: hierarchy.all_conns().len(),
+        statements_found: hierarchy.all_stmts().len(),
+    })
+}
+
+fn write_blocks_to_file(path: &Path, blocks: &[RawBlock], indices: &[usize]) -> io::Result<()> {
+    use std::io::Write;
+    let file = fs::File::create(path)?;
+    let mut writer = io::BufWriter::new(file);
+    for &idx in indices {
+        writer.write_all(blocks[idx].raw_text.as_bytes())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn sample_trace() -> &'static str {
+        "\
+[ODBC][100][1000.000000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xenv1
+[ODBC][100][1000.000001][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0xenv1
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][100][1000.000002][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000003][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][1000.000004][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xconn1
+[ODBC][100][1000.000005][SQLDriverConnect.c][751]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+\t\t\tStr In = [DSN=test][length = 8]
+[ODBC][100][1000.000006][SQLDriverConnect.c][1809]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000007][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][1000.000008][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xstmt1
+[ODBC][100][1000.000009][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xstmt1
+\t\t\tSQL = [SELECT 1][length = 8 (SQL_NTS)]
+[ODBC][100][1000.000010][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000011][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][1000.000012][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xstmt2
+[ODBC][100][1000.000013][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xstmt2
+\t\t\tSQL = [SELECT 2][length = 8 (SQL_NTS)]
+[ODBC][100][1000.000014][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000015][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xstmt1
+[ODBC][100][1000.000016][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000017][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xstmt2
+[ODBC][100][1000.000018][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000019][SQLDisconnect.c][208]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+[ODBC][100][1000.000020][SQLDisconnect.c][358]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000021][SQLFreeHandle.c][290]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][1000.000022][SQLFreeHandle.c][339]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000023][SQLFreeHandle.c][220]
+\t\tEntry:
+\t\t\tHandle Type = 1
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][1000.000024][SQLFreeHandle.c][250]
+\t\tExit:[SQL_SUCCESS]
+"
+    }
+
+    #[test]
+    fn test_extract_raw_blocks() {
+        let blocks = extract_raw_blocks(sample_trace());
+        assert!(!blocks.is_empty());
+        assert_eq!(blocks[0].function_name, "SQLAllocHandle");
+        assert_eq!(blocks[0].direction, Direction::Exit);
+        assert_eq!(blocks[0].env_addr, Some("0xenv1".to_string()));
+    }
+
+    #[test]
+    fn test_build_hierarchy() {
+        let mut blocks = extract_raw_blocks(sample_trace());
+        let h = build_hierarchy_and_assign_scopes(&mut blocks);
+
+        assert!(h.type_of.contains_key("0xenv1"));
+        assert_eq!(h.type_of["0xenv1"], HandleType::Env);
+
+        assert!(h.type_of.contains_key("0xconn1"));
+        assert_eq!(h.type_of["0xconn1"], HandleType::Dbc);
+        assert_eq!(h.parent_of["0xconn1"], "0xenv1");
+
+        assert!(h.type_of.contains_key("0xstmt1"));
+        assert_eq!(h.type_of["0xstmt1"], HandleType::Stmt);
+        assert_eq!(h.parent_of["0xstmt1"], "0xconn1");
+
+        assert!(h.type_of.contains_key("0xstmt2"));
+    }
+
+    #[test]
+    fn test_scope_assignment() {
+        let mut blocks = extract_raw_blocks(sample_trace());
+        let _h = build_hierarchy_and_assign_scopes(&mut blocks);
+
+        // __handles.c Exit → env scope
+        assert!(matches!(&blocks[0].scope, HandleScope::Env(a) if a == "0xenv1"));
+
+        // SQLSetEnvAttr Entry → env scope
+        assert!(matches!(&blocks[1].scope, HandleScope::Env(a) if a == "0xenv1"));
+
+        // SQLSetEnvAttr Exit → env scope (inherited from Entry)
+        assert!(matches!(&blocks[2].scope, HandleScope::Env(a) if a == "0xenv1"));
+
+        // SQLDriverConnect Entry → conn scope
+        let dc_entry = blocks
+            .iter()
+            .find(|b| b.function_name == "SQLDriverConnect" && b.direction == Direction::Enter)
+            .unwrap();
+        assert!(matches!(&dc_entry.scope, HandleScope::Connection(a) if a == "0xconn1"));
+
+        // SQLExecDirect Entry for stmt1 → stmt scope
+        let exec1 = blocks
+            .iter()
+            .find(|b| {
+                b.function_name == "SQLExecDirect"
+                    && b.direction == Direction::Enter
+                    && b.stmt_addr.as_deref() == Some("0xstmt1")
+            })
+            .unwrap();
+        assert!(matches!(&exec1.scope, HandleScope::Statement(a) if a == "0xstmt1"));
+    }
+
+    #[test]
+    fn test_split_by_env() {
+        let tmp = TempDir::new().unwrap();
+        let input = write_temp_trace(tmp.path(), sample_trace());
+
+        let stats = split_trace(&input, &tmp.path().join("out"), SplitMode::Env, false).unwrap();
+
+        assert_eq!(stats.envs_found, 1);
+        assert_eq!(stats.files_written, 1);
+
+        let trace = fs::read_to_string(tmp.path().join("out/env_0/trace.txt")).unwrap();
+        assert!(trace.contains("0xenv1"));
+        assert!(trace.contains("0xconn1"));
+        assert!(trace.contains("0xstmt1"));
+    }
+
+    #[test]
+    fn test_split_by_connection() {
+        let tmp = TempDir::new().unwrap();
+        let input = write_temp_trace(tmp.path(), sample_trace());
+
+        let stats = split_trace(
+            &input,
+            &tmp.path().join("out"),
+            SplitMode::Connection,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(stats.connections_found, 1);
+        assert_eq!(stats.files_written, 1);
+
+        let trace = fs::read_to_string(tmp.path().join("out/env_0/conn_0/trace.txt")).unwrap();
+        // Should include env blocks (repeated) + conn blocks + stmt blocks
+        assert!(trace.contains("0xenv1"));
+        assert!(trace.contains("0xconn1"));
+        assert!(trace.contains("0xstmt1"));
+        assert!(trace.contains("0xstmt2"));
+    }
+
+    #[test]
+    fn test_split_by_statement() {
+        let tmp = TempDir::new().unwrap();
+        let input = write_temp_trace(tmp.path(), sample_trace());
+
+        let stats =
+            split_trace(&input, &tmp.path().join("out"), SplitMode::Statement, false).unwrap();
+
+        assert_eq!(stats.statements_found, 2);
+        assert_eq!(stats.files_written, 2);
+
+        let trace1 =
+            fs::read_to_string(tmp.path().join("out/env_0/conn_0/stmt_0_trace.txt")).unwrap();
+        let trace2 =
+            fs::read_to_string(tmp.path().join("out/env_0/conn_0/stmt_1_trace.txt")).unwrap();
+
+        // Both should include env and conn blocks (repeated)
+        assert!(trace1.contains("0xenv1"));
+        assert!(trace1.contains("0xconn1"));
+        assert!(trace2.contains("0xenv1"));
+        assert!(trace2.contains("0xconn1"));
+
+        // Each should include only its own stmt blocks
+        assert!(trace1.contains("0xstmt1"));
+        assert!(!trace1.contains("0xstmt2"));
+        assert!(trace2.contains("0xstmt2"));
+        assert!(!trace2.contains("0xstmt1"));
+    }
+
+    fn sample_trace_address_reuse() -> &'static str {
+        "\
+[ODBC][100][1000.000000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xenv1
+[ODBC][100][1000.000001][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0xenv1
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][100][1000.000002][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000003][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][1000.000004][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xconn1
+[ODBC][100][1000.000005][SQLDriverConnect.c][751]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+\t\t\tStr In = [DSN=test][length = 8]
+[ODBC][100][1000.000006][SQLDriverConnect.c][1809]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000007][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][1000.000008][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xstmt1
+[ODBC][100][1000.000009][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xstmt1
+\t\t\tSQL = [SELECT 1][length = 8 (SQL_NTS)]
+[ODBC][100][1000.000010][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000011][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xstmt1
+[ODBC][100][1000.000012][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000013][SQLDisconnect.c][208]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+[ODBC][100][1000.000014][SQLDisconnect.c][358]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000015][SQLFreeHandle.c][290]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][1000.000016][SQLFreeHandle.c][339]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][1000.000017][SQLFreeHandle.c][220]
+\t\tEntry:
+\t\t\tHandle Type = 1
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][1000.000018][SQLFreeHandle.c][250]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000000][__handles.c][499]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tEnvironment = 0xenv1
+[ODBC][100][2000.000001][SQLSetEnvAttr.c][189]
+\t\tEntry:
+\t\t\tEnvironment = 0xenv1
+\t\t\tAttribute = SQL_ATTR_ODBC_VERSION
+\t\t\tValue = 0x17c
+\t\t\tStrLen = 0
+[ODBC][100][2000.000002][SQLSetEnvAttr.c][381]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000003][SQLAllocHandle.c][395]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][2000.000004][SQLAllocHandle.c][531]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xconn1
+[ODBC][100][2000.000005][SQLDriverConnect.c][751]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+\t\t\tStr In = [DSN=test][length = 8]
+[ODBC][100][2000.000006][SQLDriverConnect.c][1809]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000007][SQLAllocHandle.c][578]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][2000.000008][SQLAllocHandle.c][1123]
+\t\tExit:[SQL_SUCCESS]
+\t\t\tOutput Handle = 0xstmt1
+[ODBC][100][2000.000009][SQLExecDirect.c][240]
+\t\tEntry:
+\t\t\tStatement = 0xstmt1
+\t\t\tSQL = [SELECT 2][length = 8 (SQL_NTS)]
+[ODBC][100][2000.000010][SQLExecDirect.c][521]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000011][SQLFreeHandle.c][387]
+\t\tEntry:
+\t\t\tHandle Type = 3
+\t\t\tInput Handle = 0xstmt1
+[ODBC][100][2000.000012][SQLFreeHandle.c][490]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000013][SQLDisconnect.c][208]
+\t\tEntry:
+\t\t\tConnection = 0xconn1
+[ODBC][100][2000.000014][SQLDisconnect.c][358]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000015][SQLFreeHandle.c][290]
+\t\tEntry:
+\t\t\tHandle Type = 2
+\t\t\tInput Handle = 0xconn1
+[ODBC][100][2000.000016][SQLFreeHandle.c][339]
+\t\tExit:[SQL_SUCCESS]
+[ODBC][100][2000.000017][SQLFreeHandle.c][220]
+\t\tEntry:
+\t\t\tHandle Type = 1
+\t\t\tInput Handle = 0xenv1
+[ODBC][100][2000.000018][SQLFreeHandle.c][250]
+\t\tExit:[SQL_SUCCESS]
+"
+    }
+
+    #[test]
+    fn test_address_reuse_hierarchy() {
+        let mut blocks = extract_raw_blocks(sample_trace_address_reuse());
+        let h = build_hierarchy_and_assign_scopes(&mut blocks);
+
+        assert_eq!(h.all_envs().len(), 2, "Should find 2 envs");
+        assert_eq!(h.all_conns().len(), 2, "Should find 2 connections");
+        assert_eq!(h.all_stmts().len(), 2, "Should find 2 statements");
+
+        assert_eq!(h.type_of["0xenv1"], HandleType::Env);
+        assert_eq!(h.type_of["0xenv1#1"], HandleType::Env);
+        assert_eq!(h.type_of["0xconn1"], HandleType::Dbc);
+        assert_eq!(h.type_of["0xconn1#1"], HandleType::Dbc);
+        assert_eq!(h.type_of["0xstmt1"], HandleType::Stmt);
+        assert_eq!(h.type_of["0xstmt1#1"], HandleType::Stmt);
+
+        assert_eq!(h.parent_of["0xconn1"], "0xenv1");
+        assert_eq!(h.parent_of["0xconn1#1"], "0xenv1#1");
+        assert_eq!(h.parent_of["0xstmt1"], "0xconn1");
+        assert_eq!(h.parent_of["0xstmt1#1"], "0xconn1#1");
+    }
+
+    #[test]
+    fn test_address_reuse_split_by_env() {
+        let tmp = TempDir::new().unwrap();
+        let input = write_temp_trace(tmp.path(), sample_trace_address_reuse());
+
+        let stats = split_trace(&input, &tmp.path().join("out"), SplitMode::Env, false).unwrap();
+
+        assert_eq!(
+            stats.envs_found, 2,
+            "Should find 2 envs (same address, different lifetimes)"
+        );
+        assert_eq!(stats.files_written, 2);
+
+        let trace0 = fs::read_to_string(tmp.path().join("out/env_0/trace.txt")).unwrap();
+        let trace1 = fs::read_to_string(tmp.path().join("out/env_1/trace.txt")).unwrap();
+
+        assert!(
+            trace0.contains("SELECT 1"),
+            "First env should contain SELECT 1"
+        );
+        assert!(
+            !trace0.contains("SELECT 2"),
+            "First env should not contain SELECT 2"
+        );
+        assert!(
+            trace1.contains("SELECT 2"),
+            "Second env should contain SELECT 2"
+        );
+        assert!(
+            !trace1.contains("SELECT 1"),
+            "Second env should not contain SELECT 1"
+        );
+    }
+
+    #[test]
+    fn test_address_reuse_split_by_stmt() {
+        let tmp = TempDir::new().unwrap();
+        let input = write_temp_trace(tmp.path(), sample_trace_address_reuse());
+
+        let stats =
+            split_trace(&input, &tmp.path().join("out"), SplitMode::Statement, false).unwrap();
+
+        assert_eq!(stats.statements_found, 2, "Should find 2 statements");
+        assert_eq!(stats.files_written, 2);
+    }
+
+    fn write_temp_trace(dir: &Path, content: &str) -> PathBuf {
+        let path = dir.join("input_trace.txt");
+        fs::write(&path, content).unwrap();
+        path
+    }
+}


### PR DESCRIPTION
Major upgrade to the ODBC trace tool — adds a structured pipeline for turning raw traces into replay tests:

- Typed model & IR: Replaced untyped OdbcCall with a strongly-typed enum + a handle-tree intermediate representation, both serializable to YAML
- Trace splitting: Split large traces into isolated per-env/connection/statement IR files (split command)
- Trace comparison: Edit-distance-based deduplication across trace files (compare command)
- Query mapping: Extract and remap SQL queries (with DTM comment stripping) via editable YAML (query-map command)
- unixODBC parser: Fully implemented (was a stub)
- Better generation: generate now accepts IR YAML input, auto-creates query maps, and defaults output paths
