### PR TITLE
NO-SNOW: Fix TOCTOU race in directory-based file lock

### DIFF
--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -10,7 +10,7 @@ use keyring::credential::{CredentialApi, CredentialBuilderApi, CredentialPersist
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, ensure};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::{
     CacheDirectoryResolutionSnafu, LockAcquisitionSnafu, LockExhaustedSnafu, TokenCacheError,
@@ -123,6 +123,13 @@ impl FileLock {
                     return Ok(FileLock { lock_path });
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // TOCTOU: another thread could acquire the lock between
+                    // is_stale returning true and remove_dir. This only matters
+                    // when the lock is genuinely stale (>60s, i.e. holder
+                    // crashed), which is rare. The proper fix is replacing
+                    // mkdir-based locking with flock(2) / LockFileEx, which
+                    // lets the OS release locks on process crash and removes
+                    // the need for stale detection entirely.
                     if Self::is_stale(&lock_path, stale_timeout) {
                         let _ = fs::remove_dir(&lock_path);
                         continue;
@@ -181,12 +188,33 @@ impl FileLock {
     }
 
     fn is_stale(lock_path: &Path, stale_timeout: Duration) -> bool {
-        fs::metadata(lock_path)
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-            .map(|age| age > stale_timeout)
-            .unwrap_or(true)
+        let metadata = match fs::metadata(lock_path) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return false,
+            Err(e) => {
+                warn!(
+                    path = ?lock_path,
+                    error = %e,
+                    "failed to read lock metadata while checking staleness"
+                );
+                return false;
+            }
+        };
+        let modified = match metadata.modified() {
+            Ok(t) => t,
+            Err(e) => {
+                debug!(
+                    path = ?lock_path,
+                    error = %e,
+                    "filesystem does not support modification times, cannot determine lock staleness"
+                );
+                return false;
+            }
+        };
+        match SystemTime::now().duration_since(modified) {
+            Ok(age) => age > stale_timeout,
+            Err(_) => false,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix a TOCTOU race condition in the directory-based file lock used by `FileTokenCache` that could allow two threads into the critical section simultaneously, causing `get_secret` to return `Ok(None)` for keys that should always exist.

The `is_stale` function used a chained `unwrap_or(true)` that collapsed four distinct failure modes into "assume stale." When the lock directory was removed by another thread between `create_dir` (returning `AlreadyExists`) and `fs::metadata`, it assumed "stale" and called `remove_dir` — which could delete a *third* thread's freshly-acquired lock.

Fix: split `is_stale` into explicit match arms with correct semantics for each failure:

- `fs::metadata` → `NotFound`: lock dir removed by another thread's `Drop`; not stale, just retry (closes the TOCTOU window)
- `fs::metadata` → other errors: log a warning, return not-stale to avoid removing a potentially live lock
- `modified()` fails: can't determine staleness; not stale
- `duration_since` fails (clock skew): lock is very recent; not stale

Stale lock recovery for crashed processes still works because it relies on the age check (`age > stale_timeout`), not the failure fallbacks.

Verified locally with a stress test (200 rounds, 20 threads each): **17/200 rounds had lock violations before the fix, 0/200 after.**

This fixes the flaky `concurrent_reads_during_writes` test that was intermittently failing on CI (confirmed on run [24069116498](https://github.com/snowflakedb/universal-driver/actions/runs/24069116498)).