### PR TITLE
Python - ease application name check

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -47,7 +47,11 @@ from .telemetry import TelemetryClient
 logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "PythonConnector"
-APPLICATION_RE = re.compile(r"^[\w\d_]+$")
+# The old connector used re.match(r"[\w\d_]+") without anchors, so any string
+# starting with a word character was accepted (dots, hyphens, etc. in the tail
+# were silently ignored).  We keep a start-anchored pattern without $ so that
+# callers like Snow CLI can pass dotted names such as "SNOWCLI.STAGE.COPY".
+APPLICATION_RE = re.compile(r"^[\w\d_]+")
 
 SessionParameters = dict[str, Any]
 ConnectionParamValue = Union[int, str, float, bytes, bool, SessionParameters]

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -611,12 +611,12 @@ class TestApplicationProperty:
             with pytest.raises(ProgrammingError, match="Invalid application parameter"):
                 Connection(user="u", account="a", application=123)
 
-    def test_application_rejects_invalid_characters(self, mock_db_api):
+    def test_application_rejects_name_starting_with_non_word_char(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
             with pytest.raises(ProgrammingError, match="Invalid application name"):
-                Connection(user="u", account="a", application="My App!")
+                Connection(user="u", account="a", application="!invalid")
 
     def test_application_not_in_stored_kwargs(self, mock_db_api):
         """application should be popped from kwargs so it doesn't leak into stored kwargs."""

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -596,6 +596,14 @@ class TestApplicationProperty:
             conn = Connection(user="u", account="a", application="")
         assert conn.application == "PythonConnector"
 
+    def test_application_accepts_dotted_name(self, mock_db_api):
+        """Snow CLI passes dotted names like 'SNOWCLI.STAGE.COPY'."""
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", application="SNOWCLI.STAGE.COPY")
+        assert conn.application == "SNOWCLI.STAGE.COPY"
+
     def test_application_rejects_non_string(self, mock_db_api):
         from snowflake.connector.connection import Connection
 


### PR DESCRIPTION
Old connector matched the application name field using `"[\w\d_]+"` regex which were missing start and end anchors (probably a bug), which matched whether the name **contained** a word. New connector added anchors, which made the check more strict (**a whole name must be a word**).

This caused error in SnowflakeCLI, which was using dots (`'.'`) in application name for it's telemetry purposes.

This PR eases the check, removing the end anchor, so now the name **must start** with a word.