### PR TITLE
SNOW-2314161: Feature-gated OTLP exporter for local Jaeger debugging

### DIFF
--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -11,12 +11,16 @@ default = ["protobuf"]
 fips = ["rustls/fips"]
 protobuf = ["prost", "proto_utils"]
 auth_mfa_e2e = []
+# Enables a secondary OTLP exporter for local debugging with Jaeger or any
+# OTLP-compatible collector. Start Jaeger via ./scripts/run_jaeger.sh, then
+# build with `--features otlp_debug`. See telemetry::otlp_debug module docs.
+otlp_debug = ["opentelemetry-otlp"]
 
 [dependencies]
 tracing-opentelemetry = "0.31.0"
 opentelemetry = { version = "0.30.0", default-features = false, features = ["trace", "metrics"] }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.30.0" }
+opentelemetry-otlp = { version = "0.30.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.30.0" }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -14,8 +14,8 @@ auth_mfa_e2e = []
 
 [dependencies]
 tracing-opentelemetry = "0.31.0"
-opentelemetry = { version = "0.30.0", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.30.0", default-features = false, features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.30.0" }
 opentelemetry-semantic-conventions = { version = "0.30.0" }
 tracing = "0.1.41"
@@ -91,6 +91,7 @@ proto_generator = { path = "../proto_generator" }
 libc = "0.2"
 
 [dev-dependencies]
+opentelemetry_sdk = { version = "0.30.0", features = ["experimental_metrics_custom_reader"] }
 tempfile = "3.21.0"
 arrow_deserialize_macro = { path = "tests/common/arrow_deserialize_macro" }
 bzip2 = "0.6.0"

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod logging;
 pub mod query_types;
 pub mod rest;
 pub mod sensitive;
+pub mod telemetry;
 pub mod tls;
 pub mod token_cache;
 

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -3,8 +3,10 @@ use std::path::PathBuf;
 pub use crate::logging::callback_layer::CLogCallback;
 pub use crate::logging::callback_layer::CallbackLayer;
 pub use crate::logging::error::LogError;
+#[cfg(feature = "otlp_debug")]
 use crate::logging::opentelemetry::init_tracer;
 use tracing::level_filters::LevelFilter;
+#[cfg(feature = "otlp_debug")]
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
@@ -13,6 +15,7 @@ use tracing_subscriber::layer::SubscriberExt;
 pub mod c_api;
 mod callback_layer;
 mod error;
+#[cfg(feature = "otlp_debug")]
 mod opentelemetry;
 
 pub struct LoggingConfig {
@@ -60,13 +63,25 @@ where
     };
     let subscriber = subscriber.with(file_layer);
 
-    let opentelemetry_layer = if config.opentelemetry {
-        let tracer_layer = init_tracer()?;
-        Some(OpenTelemetryLayer::new(tracer_layer))
-    } else {
-        None
+    #[cfg(feature = "otlp_debug")]
+    let subscriber = {
+        let opentelemetry_layer = if config.opentelemetry {
+            let tracer_layer = init_tracer()?;
+            Some(OpenTelemetryLayer::new(tracer_layer))
+        } else {
+            None
+        };
+        subscriber.with(opentelemetry_layer)
     };
-    let subscriber = subscriber.with(opentelemetry_layer);
+    #[cfg(not(feature = "otlp_debug"))]
+    let subscriber = {
+        if config.opentelemetry {
+            tracing::warn!(
+                "OpenTelemetry tracing requested but sf_core was built without the `otlp_debug` feature"
+            );
+        }
+        subscriber.with(None::<tracing_subscriber::layer::Identity>)
+    };
 
     let stderr_layer = if config.stderr {
         Some(

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -6,6 +6,7 @@ pub mod heartbeat;
 mod native_okta;
 pub mod query_request;
 pub mod query_response;
+pub mod telemetry;
 
 use std::collections::HashMap;
 

--- a/sf_core/src/rest/snowflake/telemetry.rs
+++ b/sf_core/src/rest/snowflake/telemetry.rs
@@ -1,0 +1,169 @@
+use std::time::Duration;
+
+use snafu::ResultExt;
+use url::Url;
+
+use crate::config::rest_parameters::ClientInfo;
+use crate::rest::snowflake::{
+    CommunicationSnafu, InvalidSnowflakeResponseSnafu, RequestConstructionSnafu, RestError,
+    UrlJoinSnafu, apply_json_content_type, apply_query_headers, read_response_json,
+};
+
+const TELEMETRY_SEND_PATH: &str = "/telemetry/send";
+const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, serde::Deserialize)]
+struct TelemetryResponse {
+    success: bool,
+}
+
+/// POST a batch of telemetry events to the Snowflake in-band endpoint.
+///
+/// The `payload` must conform to Snowflake's expected format:
+/// `{"logs": [{"message": {...}, "timestamp": "..."}]}`
+///
+/// Telemetry is best-effort: callers should handle errors gracefully.
+#[tracing::instrument(skip(client, client_info, session_token, payload))]
+pub async fn send_telemetry(
+    client: &reqwest::Client,
+    server_url: &Url,
+    client_info: &ClientInfo,
+    session_token: &str,
+    payload: &serde_json::Value,
+) -> Result<(), RestError> {
+    let url = server_url.join(TELEMETRY_SEND_PATH).context(UrlJoinSnafu {
+        path: TELEMETRY_SEND_PATH,
+    })?;
+
+    let request = apply_json_content_type(apply_query_headers(
+        client.post(url),
+        client_info,
+        session_token,
+    ))
+    .json(payload)
+    .timeout(TELEMETRY_TIMEOUT)
+    .build()
+    .context(RequestConstructionSnafu {
+        request: "telemetry",
+    })?;
+
+    let response = client.execute(request).await.context(CommunicationSnafu {
+        context: "Failed to execute telemetry request",
+    })?;
+
+    let parsed: TelemetryResponse = read_response_json(response)
+        .await
+        .context(InvalidSnowflakeResponseSnafu)?;
+
+    if !parsed.success {
+        tracing::warn!("Telemetry endpoint returned success=false");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header_regex, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client_info() -> ClientInfo {
+        use crate::crl::config::CrlConfig;
+        use crate::tls::config::TlsConfig;
+        ClientInfo {
+            application: "TestApp".to_string(),
+            version: "1.0.0".to_string(),
+            os: "Linux".to_string(),
+            os_version: "5.15".to_string(),
+            ocsp_mode: None,
+            crl_config: CrlConfig::default(),
+            tls_config: TlsConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_telemetry_success() {
+        let server = MockServer::start().await;
+
+        let payload = json!({
+            "logs": [{
+                "message": {"type": "test"},
+                "timestamp": "1234567890123"
+            }]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .and(header_regex("Authorization", r#"^Snowflake Token=".+"$"#))
+            .and(body_json(&payload))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let server_url = Url::parse(&server.uri()).unwrap();
+        let result = send_telemetry(
+            &client,
+            &server_url,
+            &test_client_info(),
+            "test_session_token",
+            &payload,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_telemetry_server_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let server_url = Url::parse(&server.uri()).unwrap();
+        let result = send_telemetry(
+            &client,
+            &server_url,
+            &test_client_info(),
+            "test_session_token",
+            &json!({"logs": []}),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_telemetry_session_expired() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let server_url = Url::parse(&server.uri()).unwrap();
+        let result = send_telemetry(
+            &client,
+            &server_url,
+            &test_client_info(),
+            "test_session_token",
+            &json!({"logs": []}),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+}

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -1,0 +1,6 @@
+pub mod types;
+
+#[doc(hidden)]
+pub mod serialization;
+#[doc(hidden)]
+pub mod snowflake_exporter;

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -1,5 +1,8 @@
 pub mod types;
 
+#[cfg(feature = "otlp_debug")]
+pub mod otlp_debug;
+
 #[doc(hidden)]
 pub mod serialization;
 #[doc(hidden)]

--- a/sf_core/src/telemetry/otlp_debug.rs
+++ b/sf_core/src/telemetry/otlp_debug.rs
@@ -1,0 +1,59 @@
+//! Optional OTLP exporters for local debugging with Jaeger or any OTLP-compatible collector.
+//!
+//! Gated behind the `otlp_debug` feature flag. When enabled, the telemetry pipeline
+//! can add these exporters alongside the Snowflake in-band exporter so that spans
+//! and metrics are also sent to a local collector for real-time inspection.
+//!
+//! # Usage
+//!
+//! 1. Start Jaeger locally:
+//!    ```sh
+//!    ./scripts/run_jaeger.sh
+//!    ```
+//!
+//! 2. Build with the feature enabled:
+//!    ```sh
+//!    cargo build -p sf_core --features otlp_debug
+//!    ```
+//!
+//! 3. Open Jaeger UI at `http://localhost:16686`
+
+use opentelemetry_otlp::WithExportConfig;
+
+const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:8318";
+
+/// Create an OTLP span exporter targeting a local collector.
+///
+/// Uses `SF_OTLP_ENDPOINT` env var if set, otherwise defaults to
+/// `http://localhost:8318` (Jaeger's OTLP HTTP port as mapped in `scripts/run_jaeger.sh`).
+pub fn otlp_span_exporter()
+-> Result<opentelemetry_otlp::SpanExporter, opentelemetry_otlp::ExporterBuildError> {
+    let endpoint = endpoint();
+    tracing::info!("OTLP debug span exporter → {endpoint}/v1/traces");
+
+    opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{endpoint}/v1/traces"))
+        .with_protocol(opentelemetry_otlp::Protocol::HttpJson)
+        .build()
+}
+
+/// Create an OTLP metric exporter targeting a local collector.
+///
+/// Uses `SF_OTLP_ENDPOINT` env var if set, otherwise defaults to
+/// `http://localhost:8318`.
+pub fn otlp_metric_exporter()
+-> Result<opentelemetry_otlp::MetricExporter, opentelemetry_otlp::ExporterBuildError> {
+    let endpoint = endpoint();
+    tracing::info!("OTLP debug metric exporter → {endpoint}");
+
+    opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
+        .with_endpoint(&endpoint)
+        .build()
+}
+
+fn endpoint() -> String {
+    std::env::var("SF_OTLP_ENDPOINT").unwrap_or_else(|_| DEFAULT_OTLP_HTTP_ENDPOINT.to_string())
+}

--- a/sf_core/src/telemetry/serialization.rs
+++ b/sf_core/src/telemetry/serialization.rs
@@ -1,0 +1,183 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+use opentelemetry_sdk::trace::SpanData;
+use serde_json::{Value, json};
+
+/// Convert a batch of OTel spans into Snowflake's `/telemetry/send` JSON payload.
+///
+/// Format: `{"logs": [{"message": {...}, "timestamp": "..."}]}`
+pub fn spans_to_snowflake_payload(spans: &[SpanData]) -> Value {
+    let logs: Vec<Value> = spans.iter().map(span_to_log_entry).collect();
+    json!({ "logs": logs })
+}
+
+fn span_to_log_entry(span: &SpanData) -> Value {
+    let mut message = serde_json::Map::new();
+
+    message.insert("type".to_string(), Value::String(span.name.to_string()));
+
+    for kv in &span.attributes {
+        message.insert(kv.key.as_str().to_string(), otel_value_to_json(&kv.value));
+    }
+
+    // Flatten span events (e.g., exception events) into the message
+    for event in span.events.iter() {
+        if event.name.as_ref() == "exception" {
+            for kv in &event.attributes {
+                message.insert(kv.key.as_str().to_string(), otel_value_to_json(&kv.value));
+            }
+        }
+    }
+
+    let timestamp = system_time_to_epoch_millis(span.start_time);
+
+    json!({
+        "message": message,
+        "timestamp": timestamp.to_string()
+    })
+}
+
+/// Convert aggregated metric data into Snowflake's `/telemetry/send` JSON payload.
+pub fn metrics_to_snowflake_payload(metrics: &ResourceMetrics) -> Value {
+    let mut logs = Vec::new();
+
+    for scope_metrics in metrics.scope_metrics() {
+        for metric in scope_metrics.metrics() {
+            let metric_name = metric.name();
+            match metric.data() {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                    collect_sum_data_points!(logs, metric_name, sum, u64);
+                }
+                AggregatedMetrics::I64(MetricData::Sum(sum)) => {
+                    collect_sum_data_points!(logs, metric_name, sum, i64);
+                }
+                AggregatedMetrics::F64(MetricData::Sum(sum)) => {
+                    collect_sum_data_points!(logs, metric_name, sum, f64);
+                }
+                _ => {
+                    tracing::debug!("Skipping non-Sum metric type for telemetry: {metric_name}");
+                }
+            }
+        }
+    }
+
+    json!({ "logs": logs })
+}
+
+macro_rules! collect_sum_data_points {
+    ($logs:expr, $metric_name:expr, $sum:expr, $ty:ty) => {{
+        let timestamp = system_time_to_epoch_millis($sum.time());
+        for dp in $sum.data_points() {
+            let mut message = serde_json::Map::new();
+            message.insert("type".to_string(), Value::String($metric_name.to_string()));
+            message.insert("value".to_string(), json!(dp.value()));
+            for kv in dp.attributes() {
+                message.insert(kv.key.as_str().to_string(), otel_value_to_json(&kv.value));
+            }
+            $logs.push(json!({
+                "message": message,
+                "timestamp": timestamp.to_string()
+            }));
+        }
+    }};
+}
+use collect_sum_data_points;
+
+fn otel_value_to_json(value: &opentelemetry::Value) -> Value {
+    use opentelemetry::Value as OtelValue;
+    match value {
+        OtelValue::Bool(b) => Value::Bool(*b),
+        OtelValue::I64(i) => json!(*i),
+        OtelValue::F64(f) => json!(*f),
+        OtelValue::String(s) => Value::String(s.to_string()),
+        OtelValue::Array(_) => Value::String(format!("{value}")),
+        _ => Value::String(format!("{value}")),
+    }
+}
+
+fn system_time_to_epoch_millis(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::InstrumentationScope;
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::{
+        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    };
+
+    fn make_test_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
+                SpanId::from_hex("0102030405060708").unwrap(),
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            span_kind: SpanKind::Internal,
+            name: name.into(),
+            start_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000000000),
+            end_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000001000),
+            attributes,
+            dropped_attributes_count: 0,
+            events: Default::default(),
+            links: Default::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    #[test]
+    fn spans_to_payload_basic_structure() {
+        let span = make_test_span(
+            "session_init",
+            vec![KeyValue::new("service.name", "snowflake-python")],
+        );
+
+        let payload = spans_to_snowflake_payload(&[span]);
+
+        let logs = payload["logs"].as_array().unwrap();
+        assert_eq!(logs.len(), 1);
+
+        let entry = &logs[0];
+        assert_eq!(entry["message"]["type"], "session_init");
+        assert_eq!(entry["message"]["service.name"], "snowflake-python");
+        assert_eq!(entry["timestamp"], "1700000000000");
+    }
+
+    #[test]
+    fn spans_to_payload_empty_batch() {
+        let payload = spans_to_snowflake_payload(&[]);
+        let logs = payload["logs"].as_array().unwrap();
+        assert!(logs.is_empty());
+    }
+
+    #[test]
+    fn span_boolean_attribute() {
+        let span = make_test_span(
+            "session_init",
+            vec![KeyValue::new("snowflake.driver.is_ci_cd", true)],
+        );
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        assert_eq!(
+            payload["logs"][0]["message"]["snowflake.driver.is_ci_cd"],
+            true
+        );
+    }
+
+    #[test]
+    fn span_numeric_attribute() {
+        let span = make_test_span("session_init", vec![KeyValue::new("login_timeout", 30_i64)]);
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        assert_eq!(payload["logs"][0]["message"]["login_timeout"], 30);
+    }
+}

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -1,0 +1,445 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+use tokio::sync::RwLock as AsyncRwLock;
+use url::Url;
+
+use crate::config::rest_parameters::ClientInfo;
+use crate::rest::snowflake::SessionTokens;
+use crate::rest::snowflake::telemetry as rest;
+
+use super::serialization;
+
+/// Shared session context that the exporter uses to POST telemetry.
+pub struct ExporterSession {
+    pub client: reqwest::Client,
+    pub server_url: Url,
+    pub client_info: ClientInfo,
+    pub session_token: Arc<AsyncRwLock<Option<SessionTokens>>>,
+}
+
+impl std::fmt::Debug for ExporterSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExporterSession")
+            .field("server_url", &self.server_url)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Custom OTel exporter that sends telemetry to Snowflake's in-band `/telemetry/send` endpoint.
+///
+/// All errors are treated as non-fatal — telemetry must never break the user's workflow.
+#[derive(Debug, Clone)]
+pub struct SnowflakeInBandExporter {
+    session: Arc<ExporterSession>,
+}
+
+impl SnowflakeInBandExporter {
+    pub fn new(session: Arc<ExporterSession>) -> Self {
+        Self { session }
+    }
+}
+
+/// Acquire the read guard and send telemetry while the guard is held.
+/// This avoids cloning the session token into a plain String, preserving
+/// the SensitiveString zeroization guarantees.
+async fn send_with_token(session: &ExporterSession, payload: &serde_json::Value) -> OTelSdkResult {
+    let guard = session.session_token.read().await;
+    let Some(tokens) = guard.as_ref() else {
+        tracing::debug!("No active session token, dropping telemetry");
+        return Ok(());
+    };
+
+    if let Err(e) = rest::send_telemetry(
+        &session.client,
+        &session.server_url,
+        &session.client_info,
+        tokens.session_token.reveal(),
+        payload,
+    )
+    .await
+    {
+        tracing::warn!("Failed to export telemetry: {e}");
+    }
+
+    // Best-effort: always return Ok
+    Ok(())
+}
+
+impl SpanExporter for SnowflakeInBandExporter {
+    fn export(
+        &self,
+        batch: Vec<SpanData>,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        let session = self.session.clone();
+        async move {
+            if batch.is_empty() {
+                return Ok(());
+            }
+
+            let payload = serialization::spans_to_snowflake_payload(&batch);
+            send_with_token(&session, &payload).await
+        }
+    }
+
+    fn shutdown_with_timeout(&mut self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+}
+
+impl PushMetricExporter for SnowflakeInBandExporter {
+    fn export(
+        &self,
+        metrics: &ResourceMetrics,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        let session = self.session.clone();
+        // Check if there are any metrics worth serializing before doing work.
+        let has_metrics = metrics
+            .scope_metrics()
+            .any(|sm| sm.metrics().next().is_some());
+        async move {
+            if !has_metrics {
+                return Ok(());
+            }
+
+            // Check token availability before serializing to avoid wasted work.
+            {
+                let guard = session.session_token.read().await;
+                if guard.is_none() {
+                    tracing::debug!("No active session token, dropping telemetry metrics");
+                    return Ok(());
+                }
+            }
+
+            let payload = serialization::metrics_to_snowflake_payload(metrics);
+            if payload["logs"].as_array().is_some_and(|a| a.is_empty()) {
+                return Ok(());
+            }
+
+            send_with_token(&session, &payload).await
+        }
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        Temporality::Delta
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::InstrumentationScope;
+    use opentelemetry::trace::{
+        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    };
+    use serde_json::json;
+    use std::time::UNIX_EPOCH;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_exporter_session(server_url: Url) -> Arc<ExporterSession> {
+        use crate::crl::config::CrlConfig;
+        use crate::tls::config::TlsConfig;
+
+        use crate::sensitive::SensitiveString;
+
+        let tokens = SessionTokens {
+            session_token: SensitiveString::from("test_token"),
+            master_token: SensitiveString::from("master_token"),
+            session_id: 1,
+            session_expires_at: None,
+            master_expires_at: None,
+        };
+
+        Arc::new(ExporterSession {
+            client: reqwest::Client::new(),
+            server_url,
+            client_info: ClientInfo {
+                application: "TestApp".to_string(),
+                version: "1.0.0".to_string(),
+                os: "Linux".to_string(),
+                os_version: "5.15".to_string(),
+                ocsp_mode: None,
+                crl_config: CrlConfig::default(),
+                tls_config: TlsConfig::default(),
+            },
+            session_token: Arc::new(AsyncRwLock::new(Some(tokens))),
+        })
+    }
+
+    fn make_test_span() -> SpanData {
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
+                SpanId::from_hex("0102030405060708").unwrap(),
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            span_kind: SpanKind::Internal,
+            name: "test_span".into(),
+            start_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000000000),
+            end_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000001000),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            events: Default::default(),
+            links: Default::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    #[tokio::test]
+    async fn span_exporter_posts_to_telemetry_endpoint() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn span_exporter_empty_batch_skips_post() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let result = SpanExporter::export(&exporter, vec![]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn span_exporter_no_session_token_drops_silently() {
+        let server = MockServer::start().await;
+        let session = Arc::new(ExporterSession {
+            client: reqwest::Client::new(),
+            server_url: Url::parse(&server.uri()).unwrap(),
+            client_info: ClientInfo {
+                application: "TestApp".to_string(),
+                version: "1.0.0".to_string(),
+                os: "Linux".to_string(),
+                os_version: "5.15".to_string(),
+                ocsp_mode: None,
+                crl_config: crate::crl::config::CrlConfig::default(),
+                tls_config: crate::tls::config::TlsConfig::default(),
+            },
+            session_token: Arc::new(AsyncRwLock::new(None)),
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn span_exporter_server_error_returns_ok() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("error"))
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        assert!(result.is_ok());
+    }
+
+    // -- PushMetricExporter unit tests --
+
+    use opentelemetry::KeyValue;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::ManualReader;
+    use opentelemetry_sdk::metrics::Pipeline;
+    use opentelemetry_sdk::metrics::reader::MetricReader;
+    use std::sync::Weak;
+
+    /// Wrapper around `Arc<ManualReader>` that implements `MetricReader`,
+    /// allowing the reader to be shared between the `SdkMeterProvider` and
+    /// test code that calls `collect()`.
+    #[derive(Debug, Clone)]
+    struct SharedManualReader(Arc<ManualReader>);
+
+    impl MetricReader for SharedManualReader {
+        fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
+            self.0.register_pipeline(pipeline);
+        }
+        fn collect(
+            &self,
+            rm: &mut opentelemetry_sdk::metrics::data::ResourceMetrics,
+        ) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.0.collect(rm)
+        }
+        fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.0.force_flush()
+        }
+        fn shutdown_with_timeout(
+            &self,
+            timeout: Duration,
+        ) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.0.shutdown_with_timeout(timeout)
+        }
+        fn temporality(&self, kind: opentelemetry_sdk::metrics::InstrumentKind) -> Temporality {
+            self.0.temporality(kind)
+        }
+    }
+
+    fn make_exporter_session_no_token(server_url: Url) -> Arc<ExporterSession> {
+        use crate::crl::config::CrlConfig;
+        use crate::tls::config::TlsConfig;
+        Arc::new(ExporterSession {
+            client: reqwest::Client::new(),
+            server_url,
+            client_info: ClientInfo {
+                application: "TestApp".to_string(),
+                version: "1.0.0".to_string(),
+                os: "Linux".to_string(),
+                os_version: "5.15".to_string(),
+                ocsp_mode: None,
+                crl_config: CrlConfig::default(),
+                tls_config: TlsConfig::default(),
+            },
+            session_token: Arc::new(AsyncRwLock::new(None)),
+        })
+    }
+
+    fn collect_test_metrics(
+        counter_name: &'static str,
+        attrs: &[KeyValue],
+    ) -> opentelemetry_sdk::metrics::data::ResourceMetrics {
+        let reader = SharedManualReader(Arc::new(
+            ManualReader::builder()
+                .with_temporality(Temporality::Delta)
+                .build(),
+        ));
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_reader(reader.clone())
+            .build();
+        let meter = provider.meter("test");
+        let counter = meter.u64_counter(counter_name).build();
+        counter.add(1, attrs);
+
+        let mut rm = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
+        reader.collect(&mut rm).unwrap();
+        rm
+    }
+
+    #[tokio::test]
+    async fn metric_exporter_posts_to_telemetry_endpoint() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let rm = collect_test_metrics(
+            "snowflake.driver.api.call",
+            &[KeyValue::new("api_method", "execute")],
+        );
+        let result = PushMetricExporter::export(&exporter, &rm).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn metric_exporter_empty_metrics_skips_post() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let empty = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
+        let result = PushMetricExporter::export(&exporter, &empty).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn metric_exporter_no_token_drops_silently() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session_no_token(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let rm = collect_test_metrics("test.counter", &[]);
+        let result = PushMetricExporter::export(&exporter, &rm).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn metric_exporter_server_error_returns_ok() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(Url::parse(&server.uri()).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("error"))
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(session);
+        let rm = collect_test_metrics("test.counter", &[]);
+        let result = PushMetricExporter::export(&exporter, &rm).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn metric_exporter_temporality_is_delta() {
+        let session = make_exporter_session(Url::parse("http://localhost:1").unwrap());
+        let exporter = SnowflakeInBandExporter::new(session);
+        assert_eq!(exporter.temporality(), Temporality::Delta);
+    }
+}

--- a/sf_core/src/telemetry/types.rs
+++ b/sf_core/src/telemetry/types.rs
@@ -1,0 +1,52 @@
+/// Where the error originated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorOrigin {
+    Core,
+    Wrapper,
+}
+
+impl ErrorOrigin {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorOrigin::Core => "core",
+            ErrorOrigin::Wrapper => "wrapper",
+        }
+    }
+}
+
+/// Data provided by wrappers for session_init.
+#[derive(Debug, Clone)]
+pub struct SessionInitData {
+    pub driver_name: String,
+    pub driver_version: String,
+    pub language_runtime: String,
+    pub language_version: String,
+    pub language_compiler: Option<String>,
+    //pub release_date: Option<String>,
+    //pub is_lts: Option<bool>,
+    pub svn_revision: Option<String>,
+    pub application: Option<String>,
+    pub application_path: Option<String>,
+    pub tracing_level: Option<i32>,
+    pub login_timeout: Option<i32>,
+    pub network_timeout: Option<i32>,
+    pub socket_timeout: Option<i32>,
+}
+
+/// Data for driver_exception events reported by wrappers.
+#[derive(Debug, Clone)]
+pub struct WrapperErrorData {
+    pub exception_type: String,
+    pub error_source: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_origin_as_str() {
+        assert_eq!(ErrorOrigin::Core.as_str(), "core");
+        assert_eq!(ErrorOrigin::Wrapper.as_str(), "wrapper");
+    }
+}

--- a/sf_core/tests/integration/mod.rs
+++ b/sf_core/tests/integration/mod.rs
@@ -7,3 +7,4 @@ pub mod http;
 pub mod put_get;
 pub mod query;
 pub mod session;
+pub mod telemetry;

--- a/sf_core/tests/integration/telemetry/exporter_pipeline.rs
+++ b/sf_core/tests/integration/telemetry/exporter_pipeline.rs
@@ -1,0 +1,313 @@
+use std::sync::Arc;
+use std::time::{Duration, UNIX_EPOCH};
+
+use opentelemetry::trace::{
+    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+};
+use opentelemetry::{InstrumentationScope, KeyValue};
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+use serde_json::json;
+use sf_core::config::rest_parameters::ClientInfo;
+use sf_core::crl::config::CrlConfig;
+use sf_core::rest::snowflake::SessionTokens;
+use sf_core::sensitive::SensitiveString;
+use sf_core::telemetry::snowflake_exporter::{ExporterSession, SnowflakeInBandExporter};
+use sf_core::tls::config::TlsConfig;
+use tokio::sync::RwLock as AsyncRwLock;
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn test_client_info() -> ClientInfo {
+    ClientInfo {
+        application: "TestApp".to_string(),
+        version: "1.0.0".to_string(),
+        os: "Linux".to_string(),
+        os_version: "5.15".to_string(),
+        ocsp_mode: None,
+        crl_config: CrlConfig::default(),
+        tls_config: TlsConfig::default(),
+    }
+}
+
+fn make_session(server_url: Url, token: Option<SessionTokens>) -> Arc<ExporterSession> {
+    Arc::new(ExporterSession {
+        client: reqwest::Client::new(),
+        server_url,
+        client_info: test_client_info(),
+        session_token: Arc::new(AsyncRwLock::new(token)),
+    })
+}
+
+fn make_active_session(server_url: Url) -> Arc<ExporterSession> {
+    let tokens = SessionTokens {
+        session_token: SensitiveString::from("test_token"),
+        master_token: SensitiveString::from("master_token"),
+        session_id: 42,
+        session_expires_at: None,
+        master_expires_at: None,
+    };
+    make_session(server_url, Some(tokens))
+}
+
+fn make_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
+    SpanData {
+        span_context: SpanContext::new(
+            TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
+            SpanId::from_hex("0102030405060708").unwrap(),
+            TraceFlags::default(),
+            false,
+            TraceState::default(),
+        ),
+        parent_span_id: SpanId::INVALID,
+        span_kind: SpanKind::Internal,
+        name: name.into(),
+        start_time: UNIX_EPOCH + Duration::from_millis(1700000000000),
+        end_time: UNIX_EPOCH + Duration::from_millis(1700000001000),
+        attributes,
+        dropped_attributes_count: 0,
+        events: Default::default(),
+        links: Default::default(),
+        status: Status::Ok,
+        instrumentation_scope: InstrumentationScope::builder("test").build(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpanExporter tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn span_exporter_sends_span_attributes_in_snowflake_format() {
+    let server = MockServer::start().await;
+    let session = make_active_session(Url::parse(&server.uri()).unwrap());
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let span = make_span(
+        "session_init",
+        vec![
+            KeyValue::new("service.name", "snowflake-python"),
+            KeyValue::new("os.type", "linux"),
+        ],
+    );
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, vec![span]).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn span_exporter_sends_multiple_spans_in_single_batch() {
+    let server = MockServer::start().await;
+    let session = make_active_session(Url::parse(&server.uri()).unwrap());
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1) // Single POST for the entire batch
+        .mount(&server)
+        .await;
+
+    let spans = vec![
+        make_span(
+            "session_init",
+            vec![KeyValue::new("service.name", "python")],
+        ),
+        make_span(
+            "driver_exception",
+            vec![KeyValue::new("exception.type", "RuntimeError")],
+        ),
+        make_span("session_init", vec![KeyValue::new("service.name", "odbc")]),
+    ];
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, spans).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn span_exporter_handles_token_revoked_between_calls() {
+    let server = MockServer::start().await;
+    let tokens = SessionTokens {
+        session_token: SensitiveString::from("valid_token"),
+        master_token: SensitiveString::from("master"),
+        session_id: 1,
+        session_expires_at: None,
+        master_expires_at: None,
+    };
+    let token_store = Arc::new(AsyncRwLock::new(Some(tokens)));
+
+    let session = Arc::new(ExporterSession {
+        client: reqwest::Client::new(),
+        server_url: Url::parse(&server.uri()).unwrap(),
+        client_info: test_client_info(),
+        session_token: token_store.clone(),
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, vec![make_span("span1", vec![])]).await;
+    assert!(result.is_ok());
+
+    // Clear the token — simulating session expiry
+    *token_store.write().await = None;
+
+    // Second export should silently succeed (no POST, no error)
+    let result = SpanExporter::export(&exporter, vec![make_span("span2", vec![])]).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn span_exporter_uses_refreshed_token() {
+    let server = MockServer::start().await;
+    let initial_tokens = SessionTokens {
+        session_token: SensitiveString::from("old_token"),
+        master_token: SensitiveString::from("master"),
+        session_id: 1,
+        session_expires_at: None,
+        master_expires_at: None,
+    };
+    let token_store = Arc::new(AsyncRwLock::new(Some(initial_tokens)));
+
+    let session = Arc::new(ExporterSession {
+        client: reqwest::Client::new(),
+        server_url: Url::parse(&server.uri()).unwrap(),
+        client_info: test_client_info(),
+        session_token: token_store.clone(),
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Refresh the token before exporting
+    let new_tokens = SessionTokens {
+        session_token: SensitiveString::from("new_refreshed_token"),
+        master_token: SensitiveString::from("master"),
+        session_id: 1,
+        session_expires_at: None,
+        master_expires_at: None,
+    };
+    *token_store.write().await = Some(new_tokens);
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn span_exporter_swallows_all_server_errors() {
+    let server = MockServer::start().await;
+    let session = make_active_session(Url::parse(&server.uri()).unwrap());
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+        .mount(&server)
+        .await;
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    assert!(result.is_ok(), "Exporter must not propagate server errors");
+}
+
+#[tokio::test]
+async fn span_exporter_swallows_connection_errors() {
+    let session = make_active_session(Url::parse("http://127.0.0.1:1").unwrap());
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    assert!(
+        result.is_ok(),
+        "Exporter must not propagate connection errors"
+    );
+}
+
+#[tokio::test]
+async fn span_exporter_shutdown_is_clean() {
+    let server = MockServer::start().await;
+    let session = make_active_session(Url::parse(&server.uri()).unwrap());
+
+    let mut exporter = SnowflakeInBandExporter::new(session);
+    let result = SpanExporter::shutdown(&mut exporter);
+    assert!(result.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// PushMetricExporter tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn metric_exporter_empty_metrics_skips_post() {
+    let server = MockServer::start().await;
+    let session = make_active_session(Url::parse(&server.uri()).unwrap());
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(0) // No call expected for empty metrics
+        .mount(&server)
+        .await;
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    let empty_metrics = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
+    let result = PushMetricExporter::export(&exporter, &empty_metrics).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn metric_exporter_no_token_drops_silently() {
+    let server = MockServer::start().await;
+    let session = make_session(Url::parse(&server.uri()).unwrap(), None);
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(0) // No call expected when no token
+        .mount(&server)
+        .await;
+
+    let exporter = SnowflakeInBandExporter::new(session);
+    // Even with default (empty) metrics, the code path for no-token should be tested
+    let empty_metrics = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
+    let result = PushMetricExporter::export(&exporter, &empty_metrics).await;
+    assert!(result.is_ok());
+}
+
+#[test]
+fn metric_exporter_temporality_is_delta() {
+    let session = make_session(Url::parse("http://localhost:1").unwrap(), None);
+    let exporter = SnowflakeInBandExporter::new(session);
+    assert_eq!(exporter.temporality(), Temporality::Delta);
+}
+
+#[test]
+fn metric_exporter_force_flush_is_ok() {
+    let session = make_session(Url::parse("http://localhost:1").unwrap(), None);
+    let exporter = SnowflakeInBandExporter::new(session);
+    assert!(exporter.force_flush().is_ok());
+}
+
+#[test]
+fn metric_exporter_shutdown_is_ok() {
+    let session = make_session(Url::parse("http://localhost:1").unwrap(), None);
+    let exporter = SnowflakeInBandExporter::new(session);
+    assert!(PushMetricExporter::shutdown(&exporter).is_ok());
+}

--- a/sf_core/tests/integration/telemetry/mod.rs
+++ b/sf_core/tests/integration/telemetry/mod.rs
@@ -1,3 +1,5 @@
 mod exporter_pipeline;
+#[cfg(feature = "otlp_debug")]
+mod otlp_debug;
 mod rest_endpoint;
 mod serialization;

--- a/sf_core/tests/integration/telemetry/mod.rs
+++ b/sf_core/tests/integration/telemetry/mod.rs
@@ -1,0 +1,3 @@
+mod exporter_pipeline;
+mod rest_endpoint;
+mod serialization;

--- a/sf_core/tests/integration/telemetry/otlp_debug.rs
+++ b/sf_core/tests/integration/telemetry/otlp_debug.rs
@@ -1,0 +1,111 @@
+//! Smoke test: creates real OTel spans and metrics via a TracerProvider /
+//! MeterProvider wired to the OTLP debug exporter, then flushes them.
+//!
+//! Run with Jaeger to see the events:
+//!
+//! ```sh
+//! ./scripts/run_jaeger.sh                             # terminal 1
+//! cargo test -p sf_core --test integration_tests      \
+//!   --features otlp_debug                             \
+//!   telemetry::otlp_debug                             \
+//!   -- --ignored                                      # terminal 2
+//! ```
+//!
+//! Then open http://localhost:16686 and look for service "sf_core_test".
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::trace::{Tracer, TracerProvider};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use sf_core::telemetry::otlp_debug;
+use std::time::Duration;
+
+fn test_resource() -> Resource {
+    Resource::builder()
+        .with_service_name("sf_core_test")
+        .build()
+}
+
+#[tokio::test]
+#[ignore] // requires a running Jaeger instance
+async fn spans_appear_in_jaeger() {
+    let span_exporter =
+        otlp_debug::otlp_span_exporter().expect("failed to build OTLP span exporter");
+
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_resource(test_resource())
+        .with_batch_exporter(span_exporter)
+        .build();
+
+    let tracer = tracer_provider.tracer("sf_core_test");
+
+    // Simulate a session_init span
+    {
+        use opentelemetry::trace::SpanKind;
+        let mut span = tracer
+            .span_builder("session_init")
+            .with_kind(SpanKind::Internal)
+            .with_attributes(vec![
+                KeyValue::new("snowflake.driver.name", "universal-driver"),
+                KeyValue::new("snowflake.driver.version", env!("CARGO_PKG_VERSION")),
+                KeyValue::new("os.type", std::env::consts::OS),
+                KeyValue::new("os.arch", std::env::consts::ARCH),
+            ])
+            .start(&tracer);
+
+        // Add an exception event
+        use opentelemetry::trace::Span;
+        span.add_event(
+            "exception",
+            vec![
+                KeyValue::new("exception.type", "RuntimeError"),
+                KeyValue::new("exception.message", "test error for Jaeger"),
+            ],
+        );
+    } // span ends here
+
+    // Simulate a driver_exception span
+    {
+        let _span = tracer
+            .span_builder("driver_exception")
+            .with_attributes(vec![
+                KeyValue::new("exception.type", "NetworkError"),
+                KeyValue::new("error.source", "connection timeout"),
+            ])
+            .start(&tracer);
+    }
+
+    // Flush is best-effort — collector may not be running in all environments.
+    let _ = tracer_provider.force_flush();
+    let _ = tracer_provider.shutdown();
+}
+
+#[tokio::test]
+#[ignore] // requires a running Jaeger instance
+async fn metrics_appear_in_jaeger() {
+    let metric_exporter =
+        otlp_debug::otlp_metric_exporter().expect("failed to build OTLP metric exporter");
+
+    let reader = PeriodicReader::builder(metric_exporter)
+        .with_interval(Duration::from_secs(1))
+        .build();
+
+    let meter_provider = SdkMeterProvider::builder()
+        .with_resource(test_resource())
+        .with_reader(reader)
+        .build();
+
+    let meter = meter_provider.meter("sf_core_test");
+
+    // Simulate API call counters
+    let counter = meter.u64_counter("snowflake.driver.api.call").build();
+    counter.add(3, &[KeyValue::new("api_method", "execute")]);
+    counter.add(1, &[KeyValue::new("api_method", "fetch")]);
+    counter.add(2, &[KeyValue::new("api_method", "close_session")]);
+
+    // Flush is best-effort — collector may not be running in all environments.
+    let _ = meter_provider.force_flush();
+    let _ = meter_provider.shutdown();
+}

--- a/sf_core/tests/integration/telemetry/rest_endpoint.rs
+++ b/sf_core/tests/integration/telemetry/rest_endpoint.rs
@@ -1,0 +1,129 @@
+use serde_json::json;
+use sf_core::config::rest_parameters::ClientInfo;
+use sf_core::crl::config::CrlConfig;
+use sf_core::rest::snowflake::telemetry::send_telemetry;
+use sf_core::tls::config::TlsConfig;
+use url::Url;
+use wiremock::matchers::{body_json, header, header_regex, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn test_client_info() -> ClientInfo {
+    ClientInfo {
+        application: "TestApp".to_string(),
+        version: "1.0.0".to_string(),
+        os: "Linux".to_string(),
+        os_version: "5.15".to_string(),
+        ocsp_mode: None,
+        crl_config: CrlConfig::default(),
+        tls_config: TlsConfig::default(),
+    }
+}
+
+#[tokio::test]
+async fn telemetry_post_includes_auth_and_content_type_headers() {
+    let server = MockServer::start().await;
+
+    let payload = json!({
+        "logs": [{
+            "message": {"type": "session_init", "service.name": "snowflake-python"},
+            "timestamp": "1700000000000"
+        }]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .and(header_regex("Authorization", r#"^Snowflake Token=".+"$"#))
+        .and(header("Content-Type", "application/json"))
+        .and(header("Accept", "application/json"))
+        .and(body_json(&payload))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = reqwest::Client::new();
+    let server_url = Url::parse(&server.uri()).unwrap();
+    let result = send_telemetry(
+        &client,
+        &server_url,
+        &test_client_info(),
+        "my_session_token",
+        &payload,
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn telemetry_post_sends_multiple_log_entries() {
+    let server = MockServer::start().await;
+
+    let payload = json!({
+        "logs": [
+            {
+                "message": {"type": "session_init"},
+                "timestamp": "1700000000000"
+            },
+            {
+                "message": {"type": "driver_exception", "exception.type": "ValueError"},
+                "timestamp": "1700000001000"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .and(body_json(&payload))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = reqwest::Client::new();
+    let server_url = Url::parse(&server.uri()).unwrap();
+    let result = send_telemetry(&client, &server_url, &test_client_info(), "token", &payload).await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn telemetry_post_handles_401_as_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/telemetry/send"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let client = reqwest::Client::new();
+    let server_url = Url::parse(&server.uri()).unwrap();
+    let result = send_telemetry(
+        &client,
+        &server_url,
+        &test_client_info(),
+        "expired_token",
+        &json!({"logs": []}),
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn telemetry_post_handles_connection_refused() {
+    let client = reqwest::Client::new();
+    // Port 1 is almost certainly not listening
+    let server_url = Url::parse("http://127.0.0.1:1").unwrap();
+    let result = send_telemetry(
+        &client,
+        &server_url,
+        &test_client_info(),
+        "token",
+        &json!({"logs": []}),
+    )
+    .await;
+
+    assert!(result.is_err());
+}

--- a/sf_core/tests/integration/telemetry/serialization.rs
+++ b/sf_core/tests/integration/telemetry/serialization.rs
@@ -1,0 +1,138 @@
+use opentelemetry::trace::{
+    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+};
+use opentelemetry::{InstrumentationScope, KeyValue};
+use opentelemetry_sdk::trace::SpanData;
+use sf_core::telemetry::serialization::spans_to_snowflake_payload;
+use std::time::{Duration, UNIX_EPOCH};
+
+fn make_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
+    SpanData {
+        span_context: SpanContext::new(
+            TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
+            SpanId::from_hex("0102030405060708").unwrap(),
+            TraceFlags::default(),
+            false,
+            TraceState::default(),
+        ),
+        parent_span_id: SpanId::INVALID,
+        span_kind: SpanKind::Internal,
+        name: name.into(),
+        start_time: UNIX_EPOCH + Duration::from_millis(1700000000000),
+        end_time: UNIX_EPOCH + Duration::from_millis(1700000001000),
+        attributes,
+        dropped_attributes_count: 0,
+        events: Default::default(),
+        links: Default::default(),
+        status: Status::Ok,
+        instrumentation_scope: InstrumentationScope::builder("test").build(),
+    }
+}
+
+#[test]
+fn session_init_span_produces_correct_snowflake_json() {
+    let span = make_span(
+        "session_init",
+        vec![
+            KeyValue::new("service.name", "snowflake-python"),
+            KeyValue::new("service.version", "3.5.0"),
+            KeyValue::new("os.type", "linux"),
+            KeyValue::new("os.version", "6.1"),
+            KeyValue::new("host.arch", "aarch64"),
+            KeyValue::new("process.runtime.name", "CPython"),
+            KeyValue::new("process.runtime.version", "3.11.6"),
+            KeyValue::new("snowflake.driver.core_version", "0.1.0"),
+            KeyValue::new("snowflake.driver.is_ci_cd", false),
+            KeyValue::new("snowflake.driver.is_interactive", true),
+        ],
+    );
+
+    let payload = spans_to_snowflake_payload(&[span]);
+
+    let logs = payload["logs"].as_array().unwrap();
+    assert_eq!(logs.len(), 1);
+
+    let msg = &logs[0]["message"];
+    assert_eq!(msg["type"], "session_init");
+    assert_eq!(msg["service.name"], "snowflake-python");
+    assert_eq!(msg["service.version"], "3.5.0");
+    assert_eq!(msg["os.type"], "linux");
+    assert_eq!(msg["host.arch"], "aarch64");
+    assert_eq!(msg["process.runtime.name"], "CPython");
+    assert_eq!(msg["snowflake.driver.core_version"], "0.1.0");
+    assert_eq!(msg["snowflake.driver.is_ci_cd"], false);
+    assert_eq!(msg["snowflake.driver.is_interactive"], true);
+
+    assert_eq!(logs[0]["timestamp"], "1700000000000");
+}
+
+#[test]
+fn multiple_spans_produce_multiple_log_entries() {
+    let spans = vec![
+        make_span(
+            "session_init",
+            vec![KeyValue::new("service.name", "python")],
+        ),
+        make_span(
+            "driver_exception",
+            vec![KeyValue::new("exception.type", "RuntimeError")],
+        ),
+    ];
+
+    let payload = spans_to_snowflake_payload(&spans);
+    let logs = payload["logs"].as_array().unwrap();
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0]["message"]["type"], "session_init");
+    assert_eq!(logs[1]["message"]["type"], "driver_exception");
+}
+
+#[test]
+fn exception_span_event_attributes_are_flattened_into_message() {
+    use opentelemetry::trace::Event;
+
+    let mut span = make_span("driver_exception", vec![]);
+    let event = Event::new(
+        "exception",
+        UNIX_EPOCH + Duration::from_millis(1700000000500),
+        vec![
+            KeyValue::new("exception.type", "ConnectionError"),
+            KeyValue::new("exception.message", "timeout after 30s"),
+            KeyValue::new("exception.stacktrace", "at line 42"),
+        ],
+        0,
+    );
+    let mut events = opentelemetry_sdk::trace::SpanEvents::default();
+    events.events.push(event);
+    span.events = events;
+
+    let payload = spans_to_snowflake_payload(&[span]);
+    let msg = &payload["logs"][0]["message"];
+
+    assert_eq!(msg["type"], "driver_exception");
+    assert_eq!(msg["exception.type"], "ConnectionError");
+    assert_eq!(msg["exception.message"], "timeout after 30s");
+    assert_eq!(msg["exception.stacktrace"], "at line 42");
+}
+
+#[test]
+fn non_exception_span_events_are_not_flattened() {
+    use opentelemetry::trace::Event;
+
+    let mut span = make_span("some_span", vec![]);
+    let event = Event::new(
+        "custom_event",
+        UNIX_EPOCH + Duration::from_millis(1700000000500),
+        vec![KeyValue::new("custom.key", "custom_value")],
+        0,
+    );
+    let mut events = opentelemetry_sdk::trace::SpanEvents::default();
+    events.events.push(event);
+    span.events = events;
+
+    let payload = spans_to_snowflake_payload(&[span]);
+    let msg = &payload["logs"][0]["message"];
+
+    // Only "type" should be present — custom event attrs should NOT be flattened
+    assert_eq!(msg["type"], "some_span");
+    assert!(msg.get("custom.key").is_none());
+}


### PR DESCRIPTION
## Summary
- Add `otlp_debug` Cargo feature that enables a secondary OTLP exporter for local Jaeger or any OTLP-compatible collector
- Make `opentelemetry-otlp` optional (only compiled with the feature)
- Gate the OpenTelemetry tracing bridge in `logging/mod.rs` behind the same feature
- Factory functions for OTLP span/metric exporters targeting `http://localhost:8318`

## Test plan
- [x] Smoke tests for Jaeger integration (`#[ignore]` — require local Jaeger via `scripts/run_jaeger.sh`)
- [x] Default build (without feature) still compiles and passes all tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Stack: 2/3** — depends on #793 `telemetry/core-pipeline` → #3 `telemetry/wrapper-identity`