### PR TITLE
SNOW-2314161: Wrapper identity registration and Python telemetry integration

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -711,6 +711,43 @@ message ConfigGetPathsResponse {
   string connections_file = 2;
 }
 
+// =============================================================================
+// TELEMETRY - In-band telemetry messages sent from wrappers via core
+// =============================================================================
+
+// Register wrapper identity (driver name, version, language info) with sf_core
+// so that subsequent telemetry events carry it automatically.
+// Call once BEFORE connection_init. The session_init telemetry event is emitted
+// by sf_core during connection_init using the stored identity.
+message TelemetryInitRequest {
+  ConnectionHandle conn_handle = 1;
+  string driver_name = 2;
+  string driver_version = 3;
+  string language_runtime = 4;
+  string language_version = 5;
+  optional string language_compiler = 6;
+}
+
+message TelemetryInitResponse {
+}
+
+message TelemetrySendApiUsageRequest {
+  ConnectionHandle conn_handle = 1;
+  string api_method = 2;
+}
+
+message TelemetrySendApiUsageResponse {
+}
+
+message TelemetrySendWrapperErrorRequest {
+  ConnectionHandle conn_handle = 1;
+  string exception_type = 2;
+  string error_source = 3;
+}
+
+message TelemetrySendWrapperErrorResponse {
+}
+
 // Database Driver service definition
 service DatabaseDriver {
   option (service_error) = "DriverException";
@@ -773,4 +810,9 @@ service DatabaseDriver {
   // Config operations
   rpc ConfigLoadAllSections(ConfigLoadAllSectionsRequest) returns (ConfigLoadAllSectionsResponse);
   rpc ConfigGetPaths(ConfigGetPathsRequest) returns (ConfigGetPathsResponse);
+
+  // Telemetry operations
+  rpc TelemetryInit(TelemetryInitRequest) returns (TelemetryInitResponse);
+  rpc TelemetrySendApiUsage(TelemetrySendApiUsageRequest) returns (TelemetrySendApiUsageResponse);
+  rpc TelemetrySendWrapperError(TelemetrySendWrapperErrorRequest) returns (TelemetrySendWrapperErrorResponse);
 }

--- a/python/src/snowflake/connector/_internal/telemetry.py
+++ b/python/src/snowflake/connector/_internal/telemetry.py
@@ -1,0 +1,63 @@
+"""In-band telemetry client that sends events to sf_core via protobuf RPC.
+
+All methods are fire-and-forget: failures are logged at DEBUG level and never
+propagate to the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import TYPE_CHECKING
+
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
+    TelemetrySendApiUsageRequest,
+    TelemetrySendWrapperErrorRequest,
+)
+
+
+if TYPE_CHECKING:
+    from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
+        ConnectionHandle,
+        DatabaseDriverClient,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryClient:
+    """Sends telemetry events to sf_core via protobuf RPC.
+
+    Wrapper identity is registered by the Connection constructor via
+    ``db_api.telemetry_init`` before connection_init. This client only sends
+    runtime events — sf_core attaches the stored identity automatically.
+    """
+
+    def __init__(self, db_api: DatabaseDriverClient, conn_handle: ConnectionHandle) -> None:
+        self._db_api = db_api
+        self._conn_handle = conn_handle
+
+    def send_api_usage(self, api_method: str) -> None:
+        """Record an API method call for telemetry."""
+        try:
+            self._db_api.telemetry_send_api_usage(
+                TelemetrySendApiUsageRequest(
+                    conn_handle=self._conn_handle,
+                    api_method=api_method,
+                )
+            )
+        except Exception:
+            logger.debug("Failed to send api_usage telemetry", exc_info=True)
+
+    def send_wrapper_error(self, exception_type: str, error_source: str) -> None:
+        """Record a wrapper error for telemetry."""
+        try:
+            self._db_api.telemetry_send_wrapper_error(
+                TelemetrySendWrapperErrorRequest(
+                    conn_handle=self._conn_handle,
+                    exception_type=exception_type,
+                    error_source=error_source,
+                )
+            )
+        except Exception:
+            logger.debug("Failed to send wrapper_error telemetry", exc_info=True)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -7,6 +7,7 @@ This module defines the Connection class as specified in PEP 249.
 from __future__ import annotations
 
 import logging
+import platform
 
 from collections.abc import Generator, Iterable
 from io import StringIO
@@ -26,6 +27,7 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_services impo
     ConnectionSetSessionParametersRequest,
     DatabaseInitRequest,
     DatabaseNewRequest,
+    TelemetryInitRequest,
 )
 from snowflake.connector._internal.snowflake_restful import SnowflakeRestful
 
@@ -33,11 +35,13 @@ from ._internal._private_key_helper import normalize_private_key
 from ._internal.api_client.client_api import database_driver_client
 from ._internal.binding_converters import ParamStyle
 from ._internal.decorators import backward_compatibility, internal_api, pep249
+from ._internal.telemetry import TelemetryClient as InternalTelemetryClient
 from ._internal.text_utils import split_statements
 from .constants import QueryStatus
 from .cursor import CursorInstance, CursorType, SnowflakeCursor
 from .errors import Error, InterfaceError, NotSupportedError, ProgrammingError
 from .telemetry import TelemetryClient
+from .version import __version__
 
 
 logger = logging.getLogger(__name__)
@@ -83,6 +87,18 @@ class Connection:
         self.db_handle = self.db_api.database_new(DatabaseNewRequest()).db_handle
         self.db_api.database_init(DatabaseInitRequest(db_handle=self.db_handle))
         self.conn_handle = self.db_api.connection_new(ConnectionNewRequest()).conn_handle
+
+        # Register wrapper identity so sf_core can attach it to telemetry events.
+        self.db_api.telemetry_init(
+            TelemetryInitRequest(
+                conn_handle=self.conn_handle,
+                driver_name="snowflake-connector-python",
+                driver_version=__version__,
+                language_runtime=platform.python_implementation(),
+                language_version=platform.python_version(),
+                language_compiler=platform.python_compiler(),
+            )
+        )
 
         # Extract session_parameters before processing other kwargs
         session_params: SessionParameters | None = kwargs.pop("session_parameters", None)  # type: ignore
@@ -134,6 +150,7 @@ class Connection:
             )
 
         self.db_api.connection_init(ConnectionInitRequest(conn_handle=self.conn_handle, db_handle=self.db_handle))
+        self._telemetry_client = InternalTelemetryClient(self.db_api, self.conn_handle)
         _sensitive_keys = {"password", "private_key"}
         self.kwargs = {k: ("***" if k in _sensitive_keys else v) for k, v in kwargs.items()}
         self._closed = False

--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -1,0 +1,77 @@
+import json
+
+from pathlib import Path
+
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, load_pem_private_key
+
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+from tests.private_key_helper import get_test_private_key_path
+from tests.wiremock_client import WiremockClient
+
+
+def test_session_init_telemetry_sent_on_connection_open(int_test_connection_factory):
+    """Verify that a session_init telemetry event is sent when a connection is opened.
+
+    This test uses Wiremock to intercept the POST to /telemetry/send and validates
+    the request path, headers, and top-level payload structure. It runs against both
+    the universal and old drivers for comparison.
+    """
+    with WiremockClient().start() as wiremock:
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("telemetry/telemetry_send_success.json")
+
+        # The old driver needs private_key as DER bytes; the universal driver uses private_key_file
+        extra_params = {}
+        if not IS_UNIVERSAL_DRIVER:
+            pem_data = Path(get_test_private_key_path()).read_bytes()
+            pk = load_pem_private_key(pem_data, password=None)
+            extra_params["private_key"] = pk.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+            extra_params["private_key_file"] = None
+
+        connection = int_test_connection_factory(server_url=wiremock.http_url(), **extra_params)
+        connection.close()
+
+        # Query Wiremock for captured telemetry requests
+        telemetry_requests = wiremock.get_requests("/telemetry/send")
+        assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after connection open"
+
+        request = telemetry_requests[0]
+
+        # Validate request path and method
+        assert request["method"] == "POST"
+        assert request["url"] == "/telemetry/send"
+
+        # Validate headers — only driver-set headers plus standard transport headers
+        headers = request["headers"]
+        expected_header_names = {
+            "Authorization",
+            "Accept",
+            "User-Agent",
+            "Content-Type",
+            "Host",
+            "Content-Length",
+            "Connection",
+            "Content-Encoding",
+            "Accept-Encoding",
+        }
+        assert set(headers.keys()) == expected_header_names, (
+            f"Unexpected headers: {set(headers.keys()) - expected_header_names}, "
+            f"Missing headers: {expected_header_names - set(headers.keys())}"
+        )
+        assert headers["Authorization"].startswith("Snowflake Token=")
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Accept"] == "application/json"
+        assert headers["User-Agent"] is not None
+
+        # Validate top-level payload structure
+        body = json.loads(request["body"])
+        assert "logs" in body, "Telemetry payload must contain 'logs' array"
+        assert isinstance(body["logs"], list)
+        assert len(body["logs"]) >= 1, "Expected at least one log entry"
+
+        # Each log entry must have 'message' and 'timestamp'
+        for entry in body["logs"]:
+            assert "message" in entry, "Log entry must contain 'message'"
+            assert "timestamp" in entry, "Log entry must contain 'timestamp'"
+            assert isinstance(entry["message"], dict)
+            assert isinstance(entry["timestamp"], str)

--- a/python/tests/unit/test_internal_telemetry.py
+++ b/python/tests/unit/test_internal_telemetry.py
@@ -1,0 +1,118 @@
+"""Unit tests for _internal.telemetry module and Connection telemetry integration."""
+
+import platform
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ConnectionHandle,
+    DatabaseHandle,
+)
+from snowflake.connector.version import __version__
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+
+
+pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
+
+
+@pytest.fixture
+def mock_db_api():
+    return MagicMock()
+
+
+@pytest.fixture
+def conn_handle():
+    return ConnectionHandle(id=42)
+
+
+@pytest.fixture
+def telemetry_client(mock_db_api, conn_handle):
+    from snowflake.connector._internal.telemetry import TelemetryClient
+
+    return TelemetryClient(mock_db_api, conn_handle)
+
+
+class TestTelemetryClientSendApiUsage:
+    """Tests for TelemetryClient.send_api_usage."""
+
+    def test_calls_rpc_with_correct_args(self, telemetry_client, mock_db_api, conn_handle):
+        telemetry_client.send_api_usage("cursor.execute")
+
+        mock_db_api.telemetry_send_api_usage.assert_called_once()
+        req = mock_db_api.telemetry_send_api_usage.call_args[0][0]
+        assert req.conn_handle == conn_handle
+        assert req.api_method == "cursor.execute"
+
+    def test_swallows_exceptions(self, telemetry_client, mock_db_api):
+        mock_db_api.telemetry_send_api_usage.side_effect = RuntimeError("rpc failed")
+
+        # Should not raise
+        telemetry_client.send_api_usage("cursor.execute")
+
+
+class TestTelemetryClientSendWrapperError:
+    """Tests for TelemetryClient.send_wrapper_error."""
+
+    def test_calls_rpc_with_correct_args(self, telemetry_client, mock_db_api, conn_handle):
+        telemetry_client.send_wrapper_error("ProgrammingError", "cursor.execute")
+
+        mock_db_api.telemetry_send_wrapper_error.assert_called_once()
+        req = mock_db_api.telemetry_send_wrapper_error.call_args[0][0]
+        assert req.conn_handle == conn_handle
+        assert req.exception_type == "ProgrammingError"
+        assert req.error_source == "cursor.execute"
+
+    def test_swallows_exceptions(self, telemetry_client, mock_db_api):
+        mock_db_api.telemetry_send_wrapper_error.side_effect = RuntimeError("rpc failed")
+
+        # Should not raise
+        telemetry_client.send_wrapper_error("Error", "source")
+
+
+class TestConnectionTelemetryInit:
+    """Tests for telemetry_init call in Connection constructor."""
+
+    @pytest.fixture
+    def full_mock_db_api(self):
+        db_api = MagicMock()
+        db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
+        db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
+        db_api.connection_get_parameter.return_value = MagicMock(value="")
+        return db_api
+
+    def test_telemetry_init_called_with_correct_identity(self, full_mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=full_mock_db_api):
+            Connection(user="test_user", account="test_account")
+
+        full_mock_db_api.telemetry_init.assert_called_once()
+        req = full_mock_db_api.telemetry_init.call_args[0][0]
+        assert req.driver_name == "snowflake-connector-python"
+        assert req.driver_version == __version__
+        assert req.language_runtime == platform.python_implementation()
+        assert req.language_version == platform.python_version()
+        assert req.language_compiler == platform.python_compiler()
+
+    def test_telemetry_init_called_before_connection_init(self, full_mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        call_order = []
+        full_mock_db_api.telemetry_init.side_effect = lambda *a, **kw: call_order.append("telemetry_init")
+        full_mock_db_api.connection_init.side_effect = lambda *a, **kw: call_order.append("connection_init")
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=full_mock_db_api):
+            Connection(user="test_user", account="test_account")
+
+        assert call_order.index("telemetry_init") < call_order.index("connection_init")
+
+    def test_telemetry_init_uses_correct_conn_handle(self, full_mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=full_mock_db_api):
+            conn = Connection(user="test_user", account="test_account")
+
+        req = full_mock_db_api.telemetry_init.call_args[0][0]
+        assert req.conn_handle == conn.conn_handle

--- a/python/tests/wiremock_client.py
+++ b/python/tests/wiremock_client.py
@@ -119,6 +119,24 @@ class WiremockClient:
             if response.status_code not in (200, 201):
                 raise RuntimeError(f"Failed to add mapping: {response.status_code} {response.text}")
 
+    def get_requests(self, url_path_pattern: str) -> list[dict]:
+        """Get all requests received by Wiremock matching a URL path pattern.
+
+        Args:
+            url_path_pattern: Regex pattern to match against request URL paths
+                             (e.g., "/telemetry/send")
+
+        Returns:
+            List of request objects captured by Wiremock.
+        """
+        response = requests.post(
+            f"{self.http_url()}/__admin/requests/find",
+            json={"urlPathPattern": url_path_pattern},
+        )
+        if response.status_code != 200:
+            raise RuntimeError(f"Failed to query requests: {response.status_code} {response.text}")
+        return response.json().get("requests", [])
+
     def stop(self) -> None:
         """Stop the Wiremock process.
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -113,16 +113,42 @@ impl DatabaseDriverV1 {
                 )
                 .await;
 
-                // Emit session_init telemetry using stored wrapper identity (if set).
+                // Emit session_init telemetry (best-effort, fire-and-forget).
                 if let Some(ref identity) = conn.wrapper_identity {
-                    tracing::info!(
-                        driver_name = %identity.driver_name,
-                        driver_version = %identity.driver_version,
-                        language_runtime = %identity.language_runtime,
-                        language_version = %identity.language_version,
-                        "Telemetry: session_init"
-                    );
-                    // TODO: emit OTel session_init span with wrapper identity + environment attributes
+                    let env_info =
+                        crate::telemetry::environment::EnvironmentInfo::with_wrapper(identity);
+                    let session_id = conn
+                        .tokens
+                        .read()
+                        .await
+                        .as_ref()
+                        .map(|t| t.session_id)
+                        .unwrap_or(0);
+                    let payload =
+                        crate::telemetry::build_session_init_payload(&env_info, session_id);
+                    if let (Some(client), Some(server_url), Some(client_info)) =
+                        (&conn.http_client, &conn.server_url, &conn.client_info)
+                    {
+                        let token = conn
+                            .tokens
+                            .read()
+                            .await
+                            .as_ref()
+                            .map(|t| t.session_token.clone());
+                        if let Some(token) = token
+                            && let Ok(url) = url::Url::parse(server_url)
+                            && let Err(e) = crate::rest::snowflake::telemetry::send_telemetry(
+                                client,
+                                &url,
+                                client_info,
+                                token.reveal(),
+                                &payload,
+                            )
+                            .await
+                        {
+                            tracing::warn!("Failed to send session_init telemetry: {e}");
+                        }
+                    }
                 }
 
                 Ok(())

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -99,21 +99,32 @@ impl DatabaseDriverV1 {
                     role: login_result.role_name,
                 };
 
-                conn_ptr
-                    .lock()
-                    .await
-                    .initialize(
-                        login_result.tokens,
-                        http_client,
-                        host,
-                        port,
-                        login_parameters.server_url.clone(),
-                        login_parameters.client_info.clone(),
-                        merged_params,
-                        login_final_names,
-                        resolved_snapshot,
-                    )
-                    .await;
+                let mut conn = conn_ptr.lock().await;
+                conn.initialize(
+                    login_result.tokens,
+                    http_client,
+                    host,
+                    port,
+                    login_parameters.server_url.clone(),
+                    login_parameters.client_info.clone(),
+                    merged_params,
+                    login_final_names,
+                    resolved_snapshot,
+                )
+                .await;
+
+                // Emit session_init telemetry using stored wrapper identity (if set).
+                if let Some(ref identity) = conn.wrapper_identity {
+                    tracing::info!(
+                        driver_name = %identity.driver_name,
+                        driver_version = %identity.driver_version,
+                        language_runtime = %identity.language_runtime,
+                        language_version = %identity.language_version,
+                        "Telemetry: session_init"
+                    );
+                    // TODO: emit OTel session_init span with wrapper identity + environment attributes
+                }
+
                 Ok(())
             }
             None => InvalidArgumentSnafu {
@@ -271,6 +282,58 @@ impl DatabaseDriverV1 {
             .fail(),
         }
     }
+
+    /// Store wrapper identity on a connection. Called once from `TelemetryInit`.
+    pub async fn set_wrapper_identity(
+        &self,
+        conn_handle: Handle,
+        identity: WrapperIdentity,
+    ) -> Result<(), ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let mut conn = conn_ptr.lock().await;
+                if conn.wrapper_identity.is_some() {
+                    tracing::warn!(
+                        "TelemetryInit called more than once on the same connection; overwriting previous wrapper identity"
+                    );
+                }
+                conn.wrapper_identity = Some(identity);
+                Ok(())
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Invalid connection handle".to_string(),
+            }
+            .fail(),
+        }
+    }
+
+    /// Read the stored wrapper identity for a connection, if `TelemetryInit` was called.
+    pub async fn get_wrapper_identity(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<Option<WrapperIdentity>, ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let conn = conn_ptr.lock().await;
+                Ok(conn.wrapper_identity.clone())
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Invalid connection handle".to_string(),
+            }
+            .fail(),
+        }
+    }
+}
+
+/// Wrapper identity set once via `TelemetryInit` and attached to all subsequent telemetry events.
+#[derive(Debug, Clone, Default)]
+pub struct WrapperIdentity {
+    pub driver_name: String,
+    pub driver_version: String,
+    pub language_runtime: String,
+    pub language_version: String,
+    /// `None` means compiler info is not applicable for this language.
+    pub language_compiler: Option<String>,
 }
 
 pub struct Connection {
@@ -299,6 +362,8 @@ pub struct Connection {
     /// Server-echoed final names from login and query responses (e.g. after USE DATABASE).
     /// Stored separately from session_parameters to keep concerns distinct.
     pub final_session_names: RwLock<FinalSessionNames>,
+    /// Wrapper identity for telemetry, set once via TelemetryInit.
+    pub wrapper_identity: Option<WrapperIdentity>,
 }
 
 impl Default for Connection {
@@ -323,6 +388,7 @@ impl Connection {
             session_parameters: Arc::new(AsyncRwLock::new(HashMap::new())),
             init_session_parameters: None,
             final_session_names: RwLock::new(FinalSessionNames::default()),
+            wrapper_identity: None,
         }
     }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1.rs
@@ -1472,6 +1472,130 @@ impl DatabaseDriver for DatabaseDriverImpl {
             connections_file: connections_file.to_string_lossy().into_owned(),
         })
     }
+
+    // -- Telemetry operations --
+
+    #[instrument(name = "DatabaseDriverV1::telemetry_init", skip(self, input))]
+    async fn telemetry_init(
+        &self,
+        input: TelemetryInitRequest,
+    ) -> Result<TelemetryInitResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        let handle = Handle::from(conn_handle);
+
+        // Validate that required identity fields are non-empty.
+        if input.driver_name.is_empty() {
+            return Err(DriverException {
+                message: "driver_name must not be empty".to_string(),
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            });
+        }
+        if input.driver_version.is_empty() {
+            return Err(DriverException {
+                message: "driver_version must not be empty".to_string(),
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            });
+        }
+        if input.language_runtime.is_empty() {
+            return Err(DriverException {
+                message: "language_runtime must not be empty".to_string(),
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            });
+        }
+        if input.language_version.is_empty() {
+            return Err(DriverException {
+                message: "language_version must not be empty".to_string(),
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            });
+        }
+
+        let identity = crate::apis::database_driver_v1::connection::WrapperIdentity {
+            driver_name: input.driver_name.clone(),
+            driver_version: input.driver_version.clone(),
+            language_runtime: input.language_runtime.clone(),
+            language_version: input.language_version.clone(),
+            language_compiler: input.language_compiler,
+        };
+
+        // Store wrapper identity on the connection. The session_init telemetry
+        // event is emitted by connection_init, not here.
+        self.driver
+            .set_wrapper_identity(handle, identity.clone())
+            .await
+            .to_protobuf()?;
+
+        tracing::debug!(
+            driver_name = %identity.driver_name,
+            driver_version = %identity.driver_version,
+            language_runtime = %identity.language_runtime,
+            language_version = %identity.language_version,
+            "Telemetry: wrapper identity stored"
+        );
+
+        Ok(TelemetryInitResponse {})
+    }
+
+    #[instrument(name = "DatabaseDriverV1::telemetry_send_api_usage", skip(self, input))]
+    async fn telemetry_send_api_usage(
+        &self,
+        input: TelemetrySendApiUsageRequest,
+    ) -> Result<TelemetrySendApiUsageResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        let handle = Handle::from(conn_handle);
+
+        let identity = self
+            .driver
+            .get_wrapper_identity(handle)
+            .await
+            .to_protobuf()?;
+        if identity.is_none() {
+            tracing::warn!(api_method = %input.api_method, "Telemetry: api_usage called before TelemetryInit; event will lack wrapper identity");
+        }
+
+        tracing::debug!(
+            api_method = %input.api_method,
+            driver_name = identity.as_ref().map_or("", |i| &i.driver_name),
+            "Telemetry: api_usage"
+        );
+
+        // TODO: increment OTel counter snowflake.driver.api.call with api_method + identity attributes
+        Ok(TelemetrySendApiUsageResponse {})
+    }
+
+    #[instrument(
+        name = "DatabaseDriverV1::telemetry_send_wrapper_error",
+        skip(self, input)
+    )]
+    async fn telemetry_send_wrapper_error(
+        &self,
+        input: TelemetrySendWrapperErrorRequest,
+    ) -> Result<TelemetrySendWrapperErrorResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        let handle = Handle::from(conn_handle);
+
+        let identity = self
+            .driver
+            .get_wrapper_identity(handle)
+            .await
+            .to_protobuf()?;
+        if identity.is_none() {
+            tracing::warn!(exception_type = %input.exception_type, "Telemetry: wrapper_error called before TelemetryInit; event will lack wrapper identity");
+        }
+
+        tracing::debug!(
+            exception_type = %input.exception_type,
+            error_source = %input.error_source,
+            driver_name = identity.as_ref().map_or("", |i| &i.driver_name),
+            "Telemetry: wrapper_error"
+        );
+
+        // TODO: create OTel span with exception event + identity attributes
+        Ok(TelemetrySendWrapperErrorResponse {})
+    }
 }
 
 impl DatabaseDriverServer for DatabaseDriverImpl {}

--- a/sf_core/src/rest/snowflake/telemetry.rs
+++ b/sf_core/src/rest/snowflake/telemetry.rs
@@ -1,5 +1,9 @@
+use std::io::Write;
 use std::time::Duration;
 
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use reqwest::header;
 use snafu::ResultExt;
 use url::Url;
 
@@ -35,12 +39,23 @@ pub async fn send_telemetry(
         path: TELEMETRY_SEND_PATH,
     })?;
 
+    // Serializing a serde_json::Value and gzip-compressing into a Vec are infallible.
+    let json_bytes = serde_json::to_vec(payload).expect("JSON Value serialization cannot fail");
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&json_bytes)
+        .expect("gzip write to Vec cannot fail");
+    let compressed = encoder.finish().expect("gzip finish on Vec cannot fail");
+
     let request = apply_json_content_type(apply_query_headers(
         client.post(url),
         client_info,
         session_token,
     ))
-    .json(payload)
+    .header(header::CONTENT_ENCODING, "gzip")
+    .header(header::ACCEPT_ENCODING, "gzip, deflate")
+    .header(header::CONNECTION, "keep-alive")
+    .body(compressed)
     .timeout(TELEMETRY_TIMEOUT)
     .build()
     .context(RequestConstructionSnafu {
@@ -66,7 +81,7 @@ pub async fn send_telemetry(
 mod tests {
     use super::*;
     use serde_json::json;
-    use wiremock::matchers::{body_json, header_regex, method, path};
+    use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client_info() -> ClientInfo {
@@ -96,8 +111,6 @@ mod tests {
 
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
-            .and(header_regex("Authorization", r#"^Snowflake Token=".+"$"#))
-            .and(body_json(&payload))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "success": true
             })))
@@ -116,7 +129,34 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "send_telemetry failed: {:?}", result.err());
+
+        // Verify headers and gzip body
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let req = &requests[0];
+
+        // Check all expected headers
+        let has_header = |name: &str, value: &str| {
+            req.headers
+                .get(name)
+                .map(|v| v.to_str().unwrap_or("") == value)
+                .unwrap_or(false)
+        };
+        assert!(has_header("content-encoding", "gzip"));
+        assert!(has_header("accept-encoding", "gzip, deflate"));
+        assert!(has_header("connection", "keep-alive"));
+        assert!(has_header("content-type", "application/json"));
+        assert!(has_header("accept", "application/json"));
+        assert!(req.headers.get("authorization").is_some());
+
+        // Verify the gzip body decompresses to the original payload
+        let body = &req.body;
+        let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+        let mut decompressed = String::new();
+        std::io::Read::read_to_string(&mut decoder, &mut decompressed).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&decompressed).unwrap();
+        assert_eq!(parsed, payload);
     }
 
     #[tokio::test]

--- a/sf_core/src/telemetry/environment.rs
+++ b/sf_core/src/telemetry/environment.rs
@@ -1,0 +1,123 @@
+use crate::apis::database_driver_v1::connection::WrapperIdentity;
+
+/// Auto-detected system environment information for telemetry.
+#[derive(Debug, Clone)]
+pub struct EnvironmentInfo {
+    pub os_name: String,
+    pub os_version: String,
+    pub os_architecture: String,
+    pub driver_name: String,
+    pub driver_version: String,
+    pub language_runtime: String,
+    pub language_version: String,
+    /// `None` means compiler info is not applicable for this language.
+    pub language_compiler: Option<String>,
+}
+
+impl EnvironmentInfo {
+    /// Detect OS-level fields and merge wrapper identity (from `TelemetryInit`).
+    pub fn with_wrapper(identity: &WrapperIdentity) -> Self {
+        Self {
+            os_name: std::env::consts::OS.to_string(),
+            os_version: detect_os_version(),
+            os_architecture: std::env::consts::ARCH.to_string(),
+            driver_name: identity.driver_name.clone(),
+            driver_version: identity.driver_version.clone(),
+            language_runtime: identity.language_runtime.clone(),
+            language_version: identity.language_version.clone(),
+            language_compiler: identity.language_compiler.clone(),
+        }
+    }
+
+    /// Detect OS-level fields only; wrapper fields remain empty.
+    pub fn detect() -> Self {
+        Self {
+            os_name: std::env::consts::OS.to_string(),
+            os_version: detect_os_version(),
+            os_architecture: std::env::consts::ARCH.to_string(),
+            driver_name: String::new(),
+            driver_version: String::new(),
+            language_runtime: String::new(),
+            language_version: String::new(),
+            language_compiler: None,
+        }
+    }
+}
+
+fn detect_os_version() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
+            for line in content.lines() {
+                if let Some(version) = line.strip_prefix("VERSION_ID=") {
+                    return version.trim_matches('"').to_string();
+                }
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(output) = std::process::Command::new("sw_vers")
+            .arg("-productVersion")
+            .output()
+        {
+            if output.status.success() {
+                return String::from_utf8_lossy(&output.stdout).trim().to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_non_empty_os_fields() {
+        let info = EnvironmentInfo::detect();
+        assert!(!info.os_name.is_empty());
+        assert!(!info.os_architecture.is_empty());
+    }
+
+    #[test]
+    fn wrapper_fields_are_empty_stubs() {
+        let info = EnvironmentInfo::detect();
+        assert!(info.driver_name.is_empty());
+        assert!(info.driver_version.is_empty());
+        assert!(info.language_runtime.is_empty());
+        assert!(info.language_version.is_empty());
+        assert!(info.language_compiler.is_none());
+    }
+
+    #[test]
+    fn with_wrapper_merges_identity_and_os_fields() {
+        let identity = WrapperIdentity {
+            driver_name: "snowflake-connector-python".to_string(),
+            driver_version: "3.0.0".to_string(),
+            language_runtime: "CPython".to_string(),
+            language_version: "3.12.0".to_string(),
+            language_compiler: Some("GCC 13.2.0".to_string()),
+        };
+        let info = EnvironmentInfo::with_wrapper(&identity);
+        assert!(!info.os_name.is_empty());
+        assert_eq!(info.driver_name, "snowflake-connector-python");
+        assert_eq!(info.driver_version, "3.0.0");
+        assert_eq!(info.language_runtime, "CPython");
+        assert_eq!(info.language_version, "3.12.0");
+        assert_eq!(info.language_compiler, Some("GCC 13.2.0".to_string()));
+    }
+
+    #[test]
+    fn with_wrapper_none_compiler() {
+        let identity = WrapperIdentity {
+            driver_name: "test".to_string(),
+            driver_version: "1.0".to_string(),
+            language_runtime: "node".to_string(),
+            language_version: "20.0".to_string(),
+            language_compiler: None,
+        };
+        let info = EnvironmentInfo::with_wrapper(&identity);
+        assert!(info.language_compiler.is_none());
+    }
+}

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -1,3 +1,4 @@
+pub mod environment;
 pub mod types;
 
 #[cfg(feature = "otlp_debug")]

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -4,7 +4,66 @@ pub mod types;
 #[cfg(feature = "otlp_debug")]
 pub mod otlp_debug;
 
+// These modules are public for integration tests but are not part of the stable API.
 #[doc(hidden)]
 pub mod serialization;
 #[doc(hidden)]
 pub mod snowflake_exporter;
+
+use environment::EnvironmentInfo;
+
+/// Build a `session_init` telemetry payload ready to POST to `/telemetry/send`.
+pub fn build_session_init_payload(env: &EnvironmentInfo, session_id: i64) -> serde_json::Value {
+    let now_millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    let mut message = serde_json::Map::new();
+    message.insert(
+        "type".to_string(),
+        serde_json::Value::String("session_init".to_string()),
+    );
+    message.insert(
+        "driver_name".to_string(),
+        serde_json::Value::String(env.driver_name.clone()),
+    );
+    message.insert(
+        "driver_version".to_string(),
+        serde_json::Value::String(env.driver_version.clone()),
+    );
+    message.insert(
+        "language_runtime".to_string(),
+        serde_json::Value::String(env.language_runtime.clone()),
+    );
+    message.insert(
+        "language_version".to_string(),
+        serde_json::Value::String(env.language_version.clone()),
+    );
+    if let Some(ref compiler) = env.language_compiler {
+        message.insert(
+            "language_compiler".to_string(),
+            serde_json::Value::String(compiler.clone()),
+        );
+    }
+    message.insert(
+        "os_name".to_string(),
+        serde_json::Value::String(env.os_name.clone()),
+    );
+    message.insert(
+        "os_version".to_string(),
+        serde_json::Value::String(env.os_version.clone()),
+    );
+    message.insert(
+        "os_architecture".to_string(),
+        serde_json::Value::String(env.os_architecture.clone()),
+    );
+    message.insert("session_id".to_string(), serde_json::json!(session_id));
+
+    serde_json::json!({
+        "logs": [{
+            "message": message,
+            "timestamp": now_millis.to_string()
+        }]
+    })
+}

--- a/sf_core/tests/integration/telemetry/mod.rs
+++ b/sf_core/tests/integration/telemetry/mod.rs
@@ -3,3 +3,4 @@ mod exporter_pipeline;
 mod otlp_debug;
 mod rest_endpoint;
 mod serialization;
+mod wrapper_identity;

--- a/sf_core/tests/integration/telemetry/wrapper_identity.rs
+++ b/sf_core/tests/integration/telemetry/wrapper_identity.rs
@@ -1,0 +1,161 @@
+use sf_core::apis::database_driver_v1::DatabaseDriverV1;
+use sf_core::apis::database_driver_v1::connection::WrapperIdentity;
+
+fn test_identity() -> WrapperIdentity {
+    WrapperIdentity {
+        driver_name: "snowflake-connector-python".to_string(),
+        driver_version: "3.5.0".to_string(),
+        language_runtime: "CPython".to_string(),
+        language_version: "3.12.1".to_string(),
+        language_compiler: Some("GCC 13.2.0".to_string()),
+    }
+}
+
+#[tokio::test]
+async fn set_then_get_roundtrips() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    driver
+        .set_wrapper_identity(handle, test_identity())
+        .await
+        .expect("set_wrapper_identity should succeed");
+
+    let identity = driver
+        .get_wrapper_identity(handle)
+        .await
+        .expect("get_wrapper_identity should succeed")
+        .expect("identity should be Some after set");
+
+    assert_eq!(identity.driver_name, "snowflake-connector-python");
+    assert_eq!(identity.driver_version, "3.5.0");
+    assert_eq!(identity.language_runtime, "CPython");
+    assert_eq!(identity.language_version, "3.12.1");
+    assert_eq!(identity.language_compiler, Some("GCC 13.2.0".to_string()));
+}
+
+#[tokio::test]
+async fn get_returns_none_before_set() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let identity = driver
+        .get_wrapper_identity(handle)
+        .await
+        .expect("get_wrapper_identity should succeed");
+
+    assert!(identity.is_none());
+}
+
+#[tokio::test]
+async fn set_with_none_compiler() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let identity = WrapperIdentity {
+        language_compiler: None,
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle, identity)
+        .await
+        .expect("set_wrapper_identity should succeed");
+
+    let stored = driver.get_wrapper_identity(handle).await.unwrap().unwrap();
+
+    assert!(stored.language_compiler.is_none());
+}
+
+#[tokio::test]
+async fn set_twice_overwrites() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let first = WrapperIdentity {
+        driver_version: "1.0.0".to_string(),
+        ..test_identity()
+    };
+    let second = WrapperIdentity {
+        driver_version: "2.0.0".to_string(),
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle, first)
+        .await
+        .expect("first set should succeed");
+    driver
+        .set_wrapper_identity(handle, second)
+        .await
+        .expect("second set should succeed (overwrite)");
+
+    let stored = driver.get_wrapper_identity(handle).await.unwrap().unwrap();
+
+    assert_eq!(stored.driver_version, "2.0.0");
+}
+
+#[tokio::test]
+async fn set_with_invalid_handle_returns_error() {
+    use sf_core::apis::database_driver_v1::Handle;
+
+    let driver = DatabaseDriverV1::new();
+    let bad_handle = Handle { id: 9999, magic: 0 };
+
+    let result = driver
+        .set_wrapper_identity(bad_handle, test_identity())
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn get_with_invalid_handle_returns_error() {
+    use sf_core::apis::database_driver_v1::Handle;
+
+    let driver = DatabaseDriverV1::new();
+    let bad_handle = Handle { id: 9999, magic: 0 };
+
+    let result = driver.get_wrapper_identity(bad_handle).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn identity_is_per_connection() {
+    let driver = DatabaseDriverV1::new();
+    let handle_a = driver.connection_new();
+    let handle_b = driver.connection_new();
+
+    let identity_a = WrapperIdentity {
+        driver_name: "python".to_string(),
+        ..test_identity()
+    };
+    let identity_b = WrapperIdentity {
+        driver_name: "nodejs".to_string(),
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle_a, identity_a)
+        .await
+        .unwrap();
+    driver
+        .set_wrapper_identity(handle_b, identity_b)
+        .await
+        .unwrap();
+
+    let stored_a = driver
+        .get_wrapper_identity(handle_a)
+        .await
+        .unwrap()
+        .unwrap();
+    let stored_b = driver
+        .get_wrapper_identity(handle_b)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(stored_a.driver_name, "python");
+    assert_eq!(stored_b.driver_name, "nodejs");
+}

--- a/tests/wiremock/mappings/auth/login_success_jwt.json
+++ b/tests/wiremock/mappings/auth/login_success_jwt.json
@@ -17,7 +17,10 @@
       "data": {
         "token": "mock_token",
         "masterToken": "mock_master_token",
-        "sessionId": 12345
+        "sessionId": 12345,
+        "parameters": [
+          {"name": "CLIENT_TELEMETRY_ENABLED", "value": true}
+        ]
       }
     }
   }

--- a/tests/wiremock/mappings/telemetry/telemetry_send_success.json
+++ b/tests/wiremock/mappings/telemetry/telemetry_send_success.json
@@ -1,0 +1,13 @@
+{
+  "name": "Telemetry send success",
+  "request": {
+    "urlPathPattern": "/telemetry/send",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "success": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Proto: `TelemetryInit`, `TelemetrySendApiUsage`, `TelemetrySendWrapperError` RPCs
- Rust: `WrapperIdentity` struct stored per-connection, `set/get_wrapper_identity` methods, input validation for required fields, idempotency warning on double-init, `session_init` event emitted in `connection_init`
- Python: `telemetry_init` called in `Connection.__init__` to register wrapper identity before login, `TelemetryClient` for fire-and-forget `api_usage`/`wrapper_error` events
- `EnvironmentInfo::with_wrapper()` constructor merging OS detection with wrapper identity

## Test plan
- [x] 7 Rust integration tests (roundtrip, invalid handle, per-connection isolation, overwrite)
- [x] 7 Python unit tests (RPC args, fire-and-forget, call ordering, conn_handle)
- [x] 4 Rust unit tests for `EnvironmentInfo` (`with_wrapper`, `None` compiler)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Stack: 3/3** — depends on #794 `telemetry/otlp-debug` ← #793 `telemetry/core-pipeline`