### PR TITLE
Use typed EncryptionData struct for GCS download metadata parsing

### DIFF
--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -113,8 +113,11 @@ async fn check_blob_exists(client: &reqwest::Client, url: &str, sas_token: &str)
                 false
             }
         },
-        Err(_) => {
-            tracing::warn!("Error checking Azure blob existence, proceeding with upload");
+        Err(e) => {
+            tracing::warn!(
+                "Error checking Azure blob existence, proceeding with upload: {}",
+                sanitize_sas(e.to_string())
+            );
             false
         }
     }
@@ -586,6 +589,19 @@ mod tests {
         assert_eq!(
             url,
             "https://mystorageaccount.blob.core.chinacloudapi.cn/my-container/prefix/file.csv.gz"
+        );
+    }
+
+    #[test]
+    fn url_endpoint_without_trailing_slash() {
+        let stage = make_stage_info(StageInfoOverrides {
+            end_point: Some("core.windows.net".to_string()),
+            ..Default::default()
+        });
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.windows.net/my-container/prefix/file.csv.gz"
         );
     }
 

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -1,9 +1,10 @@
 use super::types::{
-    CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
-    UploadStatus, build_encryption_metadata_json, percent_encode_path,
+    CloudCredentials, EncryptedFileMetadata, EncryptionData, EncryptionResult, MaterialDescription,
+    StageInfo, UploadStatus, build_encryption_metadata_json, percent_encode_path,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
+use crate::sensitive::SensitiveString;
 use reqwest::{Method, StatusCode};
 use snafu::{Location, OptionExt, ResultExt, Snafu};
 use std::time::Duration;
@@ -26,12 +27,12 @@ pub async fn upload_to_azure_or_skip(
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
 
-    if !overwrite && check_blob_exists(&client, &url, sas_token).await {
+    if !overwrite && check_blob_exists(&client, &url, sas_token.reveal()).await {
         tracing::info!("Blob already exists in Azure: {}", key);
         return Ok(UploadStatus::Skipped);
     }
 
-    upload_to_azure(&client, &url, sas_token, encryption_result).await?;
+    upload_to_azure(&client, &url, sas_token.reveal(), encryption_result).await?;
     Ok(UploadStatus::Uploaded)
 }
 
@@ -43,7 +44,7 @@ pub async fn download_from_azure(
     let client = create_azure_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
-    let full_url = build_sas_url(&url, sas_token);
+    let full_url = build_sas_url(&url, sas_token.reveal());
 
     let response = azure_request_with_retry(|| client.get(&full_url), Method::GET).await?;
 
@@ -54,29 +55,15 @@ pub async fn download_from_azure(
     let mat_desc_str = get_header(headers, AZURE_META_MATDESC)?;
 
     // Parse encryption data JSON to extract key and IV
-    let enc_data: serde_json::Value = serde_json::from_str(&encryption_data_str)
+    let enc_data: EncryptionData = serde_json::from_str(&encryption_data_str)
         .context(azure_download_error::DeserializationSnafu)?;
-
-    let encrypted_key = enc_data["WrappedContentKey"]["EncryptedKey"]
-        .as_str()
-        .context(azure_download_error::MissingMetadataSnafu {
-            field: "WrappedContentKey.EncryptedKey",
-        })?
-        .to_string();
-
-    let iv = enc_data["ContentEncryptionIV"]
-        .as_str()
-        .context(azure_download_error::MissingMetadataSnafu {
-            field: "ContentEncryptionIV",
-        })?
-        .to_string();
 
     let material_desc: MaterialDescription =
         serde_json::from_str(&mat_desc_str).context(azure_download_error::DeserializationSnafu)?;
 
     let file_metadata = EncryptedFileMetadata {
-        encrypted_key,
-        iv,
+        encrypted_key: enc_data.wrapped_content_key.encrypted_key,
+        iv: enc_data.content_encryption_iv,
         material_desc,
         digest,
     };
@@ -245,9 +232,9 @@ fn create_azure_client() -> Result<reqwest::Client, AzureRequestError> {
 fn resolve_url_and_token<'a>(
     stage_info: &'a StageInfo,
     key: &str,
-) -> Result<(String, &'a str), AzureRequestError> {
+) -> Result<(String, &'a SensitiveString), AzureRequestError> {
     let sas_token = match &stage_info.creds {
-        CloudCredentials::Azure { sas_token } => sas_token.reveal(),
+        CloudCredentials::Azure { sas_token } => sas_token,
         _ => return Err(AzureRequestError::MissingAzureCredentials),
     };
 
@@ -666,7 +653,7 @@ mod tests {
         let stage = make_stage_info(StageInfoOverrides::default());
         let (url, token) = resolve_url_and_token(&stage, "prefix/file.csv.gz").unwrap();
         assert!(url.starts_with("https://mystorageaccount.blob.core.windows.net/"));
-        assert_eq!(token, "fake-sas-token");
+        assert_eq!(token.reveal(), "fake-sas-token");
     }
 
     #[test]

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -26,12 +26,12 @@ pub async fn upload_to_azure_or_skip(
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
 
-    if !overwrite && check_blob_exists(&client, &url, &sas_token).await {
+    if !overwrite && check_blob_exists(&client, &url, sas_token).await {
         tracing::info!("Blob already exists in Azure: {}", key);
         return Ok(UploadStatus::Skipped);
     }
 
-    upload_to_azure(&client, &url, &sas_token, encryption_result).await?;
+    upload_to_azure(&client, &url, sas_token, encryption_result).await?;
     Ok(UploadStatus::Uploaded)
 }
 
@@ -43,7 +43,7 @@ pub async fn download_from_azure(
     let client = create_azure_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
-    let full_url = build_sas_url(&url, &sas_token);
+    let full_url = build_sas_url(&url, sas_token);
 
     let response = azure_request_with_retry(|| client.get(&full_url), Method::GET).await?;
 
@@ -84,7 +84,9 @@ pub async fn download_from_azure(
     let encrypted_data = response
         .bytes()
         .await
-        .map_err(|source| AzureRequestError::Http { source })?
+        .map_err(|e| AzureRequestError::Http {
+            detail: sanitize_sas(e.to_string()),
+        })?
         .to_vec();
     Ok((encrypted_data, file_metadata))
 }
@@ -111,11 +113,8 @@ async fn check_blob_exists(client: &reqwest::Client, url: &str, sas_token: &str)
                 false
             }
         },
-        Err(e) => {
-            tracing::warn!(
-                "Error checking Azure blob existence, proceeding with upload: {}",
-                e
-            );
+        Err(_) => {
+            tracing::warn!("Error checking Azure blob existence, proceeding with upload");
             false
         }
     }
@@ -213,9 +212,11 @@ where
 
 fn map_http_error(e: HttpError) -> AzureRequestError {
     match e {
-        HttpError::Transport { source, .. } => AzureRequestError::Http { source },
+        HttpError::Transport { source, .. } => AzureRequestError::Http {
+            detail: sanitize_sas(source.to_string()),
+        },
         other => AzureRequestError::RetryExhausted {
-            detail: other.to_string(),
+            detail: sanitize_sas(other.to_string()),
         },
     }
 }
@@ -226,7 +227,9 @@ fn create_azure_client() -> Result<reqwest::Client, AzureRequestError> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
         .build()
-        .map_err(|source| AzureRequestError::Http { source })
+        .map_err(|e| AzureRequestError::Http {
+            detail: e.to_string(),
+        })
 }
 
 /// Constructs the Azure Blob Storage URL and extracts the SAS token from stage info.
@@ -236,12 +239,12 @@ fn create_azure_client() -> Result<reqwest::Client, AzureRequestError> {
 /// The endpoint value comes from Snowflake and may vary by environment
 /// (commercial, government, China). It is used as-is from the server response,
 /// with a `blob.` prefix prepended only if absent.
-fn resolve_url_and_token(
-    stage_info: &StageInfo,
+fn resolve_url_and_token<'a>(
+    stage_info: &'a StageInfo,
     key: &str,
-) -> Result<(String, String), AzureRequestError> {
+) -> Result<(String, &'a str), AzureRequestError> {
     let sas_token = match &stage_info.creds {
-        CloudCredentials::Azure { sas_token } => sas_token.reveal().to_string(),
+        CloudCredentials::Azure { sas_token } => sas_token.reveal(),
         _ => return Err(AzureRequestError::MissingAzureCredentials),
     };
 
@@ -259,10 +262,23 @@ fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureReq
             field: "storage_account".to_string(),
         })?;
 
-    let endpoint = stage_info
+    let raw_endpoint = stage_info
         .end_point
         .as_deref()
         .unwrap_or("blob.core.windows.net");
+
+    // Normalize the endpoint to a bare hostname (strip any URL scheme or path).
+    let endpoint = {
+        let without_scheme = raw_endpoint
+            .split_once("://")
+            .map(|(_, rest)| rest)
+            .unwrap_or(raw_endpoint);
+        without_scheme
+            .trim_start_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or(without_scheme)
+    };
 
     // The Snowflake server may provide the endpoint with or without the "blob." prefix.
     // Azure Government uses "blob.core.usgovcloudapi.net", Azure China uses
@@ -339,8 +355,8 @@ fn sanitize_sas(input: String) -> String {
 /// Converted into `AzureUploadError` or `AzureDownloadError` via `From` impls.
 #[derive(Debug, Snafu)]
 enum AzureRequestError {
-    #[snafu(display("Azure HTTP error"))]
-    Http { source: reqwest::Error },
+    #[snafu(display("Azure HTTP error: {detail}"))]
+    Http { detail: String },
     #[snafu(display("Azure request failed: HTTP {status_code}: {body}"))]
     AzureHttp { status_code: u16, body: String },
     #[snafu(display("Missing Azure credentials"))]
@@ -354,8 +370,8 @@ enum AzureRequestError {
 impl From<AzureRequestError> for AzureUploadError {
     fn from(e: AzureRequestError) -> Self {
         match e {
-            AzureRequestError::Http { source } => AzureUploadError::Http {
-                source,
+            AzureRequestError::Http { detail } => AzureUploadError::Http {
+                detail,
                 location: Location::default(),
             },
             AzureRequestError::AzureHttp { status_code, body } => AzureUploadError::AzureHttp {
@@ -383,8 +399,8 @@ impl From<AzureRequestError> for AzureUploadError {
 impl From<AzureRequestError> for AzureDownloadError {
     fn from(e: AzureRequestError) -> Self {
         match e {
-            AzureRequestError::Http { source } => AzureDownloadError::Http {
-                source,
+            AzureRequestError::Http { detail } => AzureDownloadError::Http {
+                detail,
                 location: Location::default(),
             },
             AzureRequestError::AzureHttp { status_code, body } => AzureDownloadError::AzureHttp {
@@ -412,9 +428,9 @@ impl From<AzureRequestError> for AzureDownloadError {
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
 #[snafu(module)]
 pub enum AzureUploadError {
-    #[snafu(display("Azure HTTP error"))]
+    #[snafu(display("Azure HTTP error: {detail}"))]
     Http {
-        source: reqwest::Error,
+        detail: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -453,9 +469,9 @@ pub enum AzureUploadError {
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
 #[snafu(module)]
 pub enum AzureDownloadError {
-    #[snafu(display("Azure HTTP error"))]
+    #[snafu(display("Azure HTTP error: {detail}"))]
     Http {
-        source: reqwest::Error,
+        detail: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -713,6 +729,19 @@ mod tests {
         assert!(!result.contains("secret1"));
         assert!(!result.contains("secret2"));
         assert!(result.contains("sig=REDACTED"));
+    }
+
+    #[test]
+    fn url_endpoint_with_scheme_is_normalized() {
+        let stage = make_stage_info(StageInfoOverrides {
+            end_point: Some("https://blob.core.windows.net/".to_string()),
+            ..Default::default()
+        });
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.windows.net/my-container/prefix/file.csv.gz"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -1,0 +1,741 @@
+use super::types::{
+    CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
+    UploadStatus, build_encryption_metadata_json, percent_encode_path,
+};
+use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
+use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
+use reqwest::{Method, StatusCode};
+use snafu::{Location, OptionExt, ResultExt, Snafu};
+use std::time::Duration;
+
+const REQUEST_TIMEOUT_SECS: u64 = 300;
+
+// Azure metadata header names
+const AZURE_META_SFC_DIGEST: &str = "x-ms-meta-sfcdigest";
+const AZURE_META_ENCRYPTIONDATA: &str = "x-ms-meta-encryptiondata";
+const AZURE_META_MATDESC: &str = "x-ms-meta-matdesc";
+
+/// Uploads a file to Azure Blob Storage, skipping if it already exists and `overwrite` is false.
+pub async fn upload_to_azure_or_skip(
+    encryption_result: EncryptionResult,
+    stage_info: &StageInfo,
+    filename: &str,
+    overwrite: bool,
+) -> Result<UploadStatus, AzureUploadError> {
+    let client = create_azure_client()?;
+    let key = format!("{}{filename}", stage_info.key_prefix);
+    let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
+
+    if !overwrite && check_blob_exists(&client, &url, &sas_token).await {
+        tracing::info!("Blob already exists in Azure: {}", key);
+        return Ok(UploadStatus::Skipped);
+    }
+
+    upload_to_azure(&client, &url, &sas_token, encryption_result).await?;
+    Ok(UploadStatus::Uploaded)
+}
+
+/// Downloads a file from Azure Blob Storage and returns encrypted data with metadata.
+pub async fn download_from_azure(
+    stage_info: &StageInfo,
+    filename: &str,
+) -> Result<(Vec<u8>, EncryptedFileMetadata), AzureDownloadError> {
+    let client = create_azure_client()?;
+    let key = format!("{}{filename}", stage_info.key_prefix);
+    let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
+    let full_url = build_sas_url(&url, &sas_token);
+
+    let response = azure_request_with_retry(|| client.get(&full_url), Method::GET).await?;
+
+    // Extract metadata from response headers
+    let headers = response.headers();
+    let digest = get_header(headers, AZURE_META_SFC_DIGEST)?;
+    let encryption_data_str = get_header(headers, AZURE_META_ENCRYPTIONDATA)?;
+    let mat_desc_str = get_header(headers, AZURE_META_MATDESC)?;
+
+    // Parse encryption data JSON to extract key and IV
+    let enc_data: serde_json::Value = serde_json::from_str(&encryption_data_str)
+        .context(azure_download_error::DeserializationSnafu)?;
+
+    let encrypted_key = enc_data["WrappedContentKey"]["EncryptedKey"]
+        .as_str()
+        .context(azure_download_error::MissingMetadataSnafu {
+            field: "WrappedContentKey.EncryptedKey",
+        })?
+        .to_string();
+
+    let iv = enc_data["ContentEncryptionIV"]
+        .as_str()
+        .context(azure_download_error::MissingMetadataSnafu {
+            field: "ContentEncryptionIV",
+        })?
+        .to_string();
+
+    let material_desc: MaterialDescription =
+        serde_json::from_str(&mat_desc_str).context(azure_download_error::DeserializationSnafu)?;
+
+    let file_metadata = EncryptedFileMetadata {
+        encrypted_key,
+        iv,
+        material_desc,
+        digest,
+    };
+
+    let encrypted_data = response
+        .bytes()
+        .await
+        .map_err(|source| AzureRequestError::Http { source })?
+        .to_vec();
+    Ok((encrypted_data, file_metadata))
+}
+
+/// Check if a blob exists in Azure via HEAD request.
+/// Returns false on any error or non-200 status so the caller proceeds with upload.
+async fn check_blob_exists(client: &reqwest::Client, url: &str, sas_token: &str) -> bool {
+    let full_url = build_sas_url(url, sas_token);
+    match client.head(&full_url).send().await {
+        Ok(resp) => match resp.status() {
+            StatusCode::OK => true,
+            StatusCode::NOT_FOUND => false,
+            StatusCode::FORBIDDEN => {
+                tracing::warn!(
+                    "Access denied checking blob existence in Azure, proceeding with upload"
+                );
+                false
+            }
+            status => {
+                tracing::warn!(
+                    "Unexpected status {} checking Azure blob existence, proceeding with upload",
+                    status
+                );
+                false
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                "Error checking Azure blob existence, proceeding with upload: {}",
+                e
+            );
+            false
+        }
+    }
+}
+
+/// Upload encrypted data to Azure with retry logic.
+async fn upload_to_azure(
+    client: &reqwest::Client,
+    url: &str,
+    sas_token: &str,
+    encryption_result: EncryptionResult,
+) -> Result<(), AzureUploadError> {
+    let encryption_data = build_encryption_metadata_json(&encryption_result.metadata);
+    let encryption_data_str =
+        serde_json::to_string(&encryption_data).context(azure_upload_error::SerializationSnafu)?;
+
+    let mat_desc = serde_json::to_string(&encryption_result.metadata.material_desc)
+        .context(azure_upload_error::SerializationSnafu)?;
+
+    let data = encryption_result.data;
+    let digest = encryption_result.metadata.digest;
+    let full_url = build_sas_url(url, sas_token);
+
+    azure_request_with_retry(
+        || {
+            client
+                .put(&full_url)
+                .header("x-ms-blob-type", "BlockBlob")
+                // Empty content-encoding matches JDBC/ODBC behavior: explicitly clears
+                // any default encoding to ensure the blob is stored as-is.
+                .header("content-encoding", "")
+                .header(AZURE_META_SFC_DIGEST, &digest)
+                .header(AZURE_META_ENCRYPTIONDATA, &encryption_data_str)
+                .header(AZURE_META_MATDESC, &mat_desc)
+                .body(data.clone())
+        },
+        Method::PUT,
+    )
+    .await?;
+
+    tracing::debug!("Azure blob upload successful");
+    Ok(())
+}
+
+// --- Retry logic (delegates to http::retry) ---
+
+/// Returns a retry policy tuned for Azure file-transfer operations.
+///
+/// Azure treats 403 as retryable (SAS token clock skew / replication delays),
+/// matching JDBC/ODBC behavior.
+fn azure_retry_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 6,
+        backoff: BackoffConfig {
+            base: Duration::from_secs(1),
+            factor: 2.0,
+            cap: Duration::from_secs(16),
+            jitter: Jitter::None,
+        },
+        // Must exceed REQUEST_TIMEOUT_SECS (300s) to allow at least one full
+        // request + retries. 600s accommodates ~2 full-timeout attempts plus backoff.
+        max_elapsed: Duration::from_secs(600),
+        extra_retryable_statuses: vec![403],
+        ..RetryPolicy::default()
+    }
+}
+
+/// Executes an Azure HTTP request with retry, then checks for Azure-specific status codes.
+///
+/// Unlike GCS, Azure does not have a `TokenExpired` (401) fast-fail path.
+/// Azure SAS tokens are URL-embedded and produce 403 on expiry (which is already retried).
+/// SAS tokens cannot be refreshed mid-request — a new query execution is needed.
+async fn azure_request_with_retry<F>(
+    build_request: F,
+    method: Method,
+) -> Result<reqwest::Response, AzureRequestError>
+where
+    F: Fn() -> reqwest::RequestBuilder,
+{
+    let ctx = HttpContext::new(method, "azure-transfer");
+    let policy = azure_retry_policy();
+
+    let response = http_execute_with_retry(build_request, &ctx, &policy, |r| async move { Ok(r) })
+        .await
+        .map_err(map_http_error)?;
+
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status_code = response.status().as_u16();
+    let body = read_error_body(response).await;
+    Err(AzureRequestError::AzureHttp { status_code, body })
+}
+
+fn map_http_error(e: HttpError) -> AzureRequestError {
+    match e {
+        HttpError::Transport { source, .. } => AzureRequestError::Http { source },
+        other => AzureRequestError::RetryExhausted {
+            detail: other.to_string(),
+        },
+    }
+}
+
+// --- Helpers ---
+
+fn create_azure_client() -> Result<reqwest::Client, AzureRequestError> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|source| AzureRequestError::Http { source })
+}
+
+/// Constructs the Azure Blob Storage URL and extracts the SAS token from stage info.
+///
+/// URL format: `https://{storageAccount}.{blob_endpoint}/{container}/{blob_path}`
+///
+/// The endpoint value comes from Snowflake and may vary by environment
+/// (commercial, government, China). It is used as-is from the server response,
+/// with a `blob.` prefix prepended only if absent.
+fn resolve_url_and_token(
+    stage_info: &StageInfo,
+    key: &str,
+) -> Result<(String, String), AzureRequestError> {
+    let sas_token = match &stage_info.creds {
+        CloudCredentials::Azure { sas_token } => sas_token.reveal().to_string(),
+        _ => return Err(AzureRequestError::MissingAzureCredentials),
+    };
+
+    let url = build_azure_url(stage_info, key)?;
+    Ok((url, sas_token))
+}
+
+/// Builds the Azure Blob Storage URL for a given object key.
+fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureRequestError> {
+    let storage_account = stage_info
+        .storage_account
+        .as_ref()
+        .filter(|sa| !sa.is_empty())
+        .ok_or(AzureRequestError::MissingMetadata {
+            field: "storage_account".to_string(),
+        })?;
+
+    let endpoint = stage_info
+        .end_point
+        .as_deref()
+        .unwrap_or("blob.core.windows.net");
+
+    // The Snowflake server may provide the endpoint with or without the "blob." prefix.
+    // Azure Government uses "blob.core.usgovcloudapi.net", Azure China uses
+    // "blob.core.chinacloudapi.cn". We prepend "blob." only when it's missing.
+    let blob_endpoint = if endpoint.starts_with("blob.") {
+        endpoint.to_string()
+    } else {
+        format!("blob.{endpoint}")
+    };
+
+    let encoded_key = percent_encode_path(key);
+
+    Ok(format!(
+        "https://{storage_account}.{blob_endpoint}/{}/{encoded_key}",
+        stage_info.bucket
+    ))
+}
+
+/// Appends the SAS token to a URL as a query parameter.
+fn build_sas_url(base_url: &str, sas_token: &str) -> String {
+    let token = sas_token.strip_prefix('?').unwrap_or(sas_token);
+    let separator = if base_url.contains('?') { "&" } else { "?" };
+    format!("{base_url}{separator}{token}")
+}
+
+fn get_header(
+    headers: &reqwest::header::HeaderMap,
+    name: &str,
+) -> Result<String, AzureDownloadError> {
+    headers
+        .get(name)
+        .context(azure_download_error::MissingMetadataSnafu {
+            field: name.to_string(),
+        })?
+        .to_str()
+        .context(azure_download_error::InvalidHeaderValueSnafu)
+        .map(|s| s.to_string())
+}
+
+async fn read_error_body(response: reqwest::Response) -> String {
+    let body = match response.text().await {
+        Ok(text) => text,
+        Err(e) => {
+            tracing::warn!("Failed to read Azure error response body: {}", e);
+            return format!("<could not read body: {}>", e);
+        }
+    };
+    // Scrub SAS tokens (sig=…) from Azure error responses which may echo the request URL.
+    sanitize_sas(body)
+}
+
+/// Removes SAS token signature values from a string to prevent credential leakage in logs.
+/// Handles multiple `sig=` occurrences (e.g., when error bodies echo URLs more than once).
+fn sanitize_sas(input: String) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut remaining = input.as_str();
+    while let Some(start) = remaining.find("sig=") {
+        result.push_str(&remaining[..start]);
+        result.push_str("sig=REDACTED");
+        let value_start = start + 4;
+        let value_end = remaining[value_start..]
+            .find('&')
+            .map(|i| value_start + i)
+            .unwrap_or(remaining.len());
+        remaining = &remaining[value_end..];
+    }
+    result.push_str(remaining);
+    result
+}
+
+// --- Error types ---
+
+/// Internal error for shared helpers (retry, client creation, URL resolution).
+/// Converted into `AzureUploadError` or `AzureDownloadError` via `From` impls.
+#[derive(Debug, Snafu)]
+enum AzureRequestError {
+    #[snafu(display("Azure HTTP error"))]
+    Http { source: reqwest::Error },
+    #[snafu(display("Azure request failed: HTTP {status_code}: {body}"))]
+    AzureHttp { status_code: u16, body: String },
+    #[snafu(display("Missing Azure credentials"))]
+    MissingAzureCredentials,
+    #[snafu(display("Missing Azure metadata: {field}"))]
+    MissingMetadata { field: String },
+    #[snafu(display("Azure retry exhausted: {detail}"))]
+    RetryExhausted { detail: String },
+}
+
+impl From<AzureRequestError> for AzureUploadError {
+    fn from(e: AzureRequestError) -> Self {
+        match e {
+            AzureRequestError::Http { source } => AzureUploadError::Http {
+                source,
+                location: Location::default(),
+            },
+            AzureRequestError::AzureHttp { status_code, body } => AzureUploadError::AzureHttp {
+                status_code,
+                body,
+                location: Location::default(),
+            },
+            AzureRequestError::MissingAzureCredentials => {
+                AzureUploadError::MissingAzureCredentials {
+                    location: Location::default(),
+                }
+            }
+            AzureRequestError::MissingMetadata { field } => AzureUploadError::MissingMetadata {
+                field,
+                location: Location::default(),
+            },
+            AzureRequestError::RetryExhausted { detail } => AzureUploadError::RetryExhausted {
+                detail,
+                location: Location::default(),
+            },
+        }
+    }
+}
+
+impl From<AzureRequestError> for AzureDownloadError {
+    fn from(e: AzureRequestError) -> Self {
+        match e {
+            AzureRequestError::Http { source } => AzureDownloadError::Http {
+                source,
+                location: Location::default(),
+            },
+            AzureRequestError::AzureHttp { status_code, body } => AzureDownloadError::AzureHttp {
+                status_code,
+                body,
+                location: Location::default(),
+            },
+            AzureRequestError::MissingAzureCredentials => {
+                AzureDownloadError::MissingAzureCredentials {
+                    location: Location::default(),
+                }
+            }
+            AzureRequestError::MissingMetadata { field } => AzureDownloadError::MissingMetadata {
+                field,
+                location: Location::default(),
+            },
+            AzureRequestError::RetryExhausted { detail } => AzureDownloadError::RetryExhausted {
+                detail,
+                location: Location::default(),
+            },
+        }
+    }
+}
+
+#[derive(Snafu, Debug, error_trace::ErrorTrace)]
+#[snafu(module)]
+pub enum AzureUploadError {
+    #[snafu(display("Azure HTTP error"))]
+    Http {
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Azure request failed: HTTP {status_code}: {body}"))]
+    AzureHttp {
+        status_code: u16,
+        body: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to serialize Azure metadata"))]
+    Serialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Missing Azure credentials"))]
+    MissingAzureCredentials {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Missing Azure metadata: {field}"))]
+    MissingMetadata {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Azure retry exhausted: {detail}"))]
+    RetryExhausted {
+        detail: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+#[derive(Snafu, Debug, error_trace::ErrorTrace)]
+#[snafu(module)]
+pub enum AzureDownloadError {
+    #[snafu(display("Azure HTTP error"))]
+    Http {
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Azure request failed: HTTP {status_code}: {body}"))]
+    AzureHttp {
+        status_code: u16,
+        body: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to deserialize Azure metadata"))]
+    Deserialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Missing Azure metadata: {field}"))]
+    MissingMetadata {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Invalid Azure header value"))]
+    InvalidHeaderValue {
+        source: reqwest::header::ToStrError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Missing Azure credentials"))]
+    MissingAzureCredentials {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Azure retry exhausted: {detail}"))]
+    RetryExhausted {
+        detail: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+// --- Unit tests ---
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sensitive::SensitiveString;
+
+    fn make_stage_info(overrides: StageInfoOverrides) -> StageInfo {
+        StageInfo {
+            location_type: super::super::types::LocationType::Azure,
+            bucket: overrides.bucket.unwrap_or("my-container".to_string()),
+            key_prefix: overrides.key_prefix.unwrap_or("prefix/".to_string()),
+            region: overrides.region.unwrap_or("eastus2".to_string()),
+            creds: overrides.creds.unwrap_or(CloudCredentials::Azure {
+                sas_token: SensitiveString::from("fake-sas-token"),
+            }),
+            end_point: overrides.end_point,
+            presigned_url: None,
+            use_virtual_url: false,
+            use_regional_url: false,
+            storage_account: overrides
+                .storage_account
+                .or(Some("mystorageaccount".to_string())),
+        }
+    }
+
+    #[derive(Default)]
+    struct StageInfoOverrides {
+        bucket: Option<String>,
+        key_prefix: Option<String>,
+        region: Option<String>,
+        creds: Option<CloudCredentials>,
+        end_point: Option<String>,
+        storage_account: Option<String>,
+    }
+
+    // ---------------------------------------------------------------
+    // 1. URL construction
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn url_default_endpoint() {
+        let stage = make_stage_info(StageInfoOverrides::default());
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.windows.net/my-container/prefix/file.csv.gz"
+        );
+    }
+
+    #[test]
+    fn url_custom_endpoint_with_blob_prefix() {
+        let stage = make_stage_info(StageInfoOverrides {
+            end_point: Some("blob.core.usgovcloudapi.net".to_string()),
+            ..Default::default()
+        });
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.usgovcloudapi.net/my-container/prefix/file.csv.gz"
+        );
+    }
+
+    #[test]
+    fn url_custom_endpoint_without_blob_prefix() {
+        let stage = make_stage_info(StageInfoOverrides {
+            end_point: Some("core.chinacloudapi.cn".to_string()),
+            ..Default::default()
+        });
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.chinacloudapi.cn/my-container/prefix/file.csv.gz"
+        );
+    }
+
+    #[test]
+    fn url_missing_storage_account() {
+        let mut stage = make_stage_info(StageInfoOverrides::default());
+        stage.storage_account = None;
+        let result = build_azure_url(&stage, "prefix/file.csv.gz");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn url_with_nested_path() {
+        let stage = make_stage_info(StageInfoOverrides::default());
+        let url = build_azure_url(&stage, "deep/nested/path/file.csv.gz").unwrap();
+        assert!(url.contains("deep/nested/path/file.csv.gz"));
+    }
+
+    // ---------------------------------------------------------------
+    // 2. SAS token handling
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn sas_url_appends_token() {
+        let url = build_sas_url(
+            "https://example.blob.core.windows.net/c/f",
+            "sv=2021&sig=abc",
+        );
+        assert_eq!(
+            url,
+            "https://example.blob.core.windows.net/c/f?sv=2021&sig=abc"
+        );
+    }
+
+    #[test]
+    fn sas_url_strips_leading_question_mark() {
+        let url = build_sas_url(
+            "https://example.blob.core.windows.net/c/f",
+            "?sv=2021&sig=abc",
+        );
+        assert_eq!(
+            url,
+            "https://example.blob.core.windows.net/c/f?sv=2021&sig=abc"
+        );
+    }
+
+    #[test]
+    fn resolve_with_sas_token() {
+        let stage = make_stage_info(StageInfoOverrides::default());
+        let (url, token) = resolve_url_and_token(&stage, "prefix/file.csv.gz").unwrap();
+        assert!(url.starts_with("https://mystorageaccount.blob.core.windows.net/"));
+        assert_eq!(token, "fake-sas-token");
+    }
+
+    #[test]
+    fn resolve_with_s3_creds_returns_error() {
+        let stage = make_stage_info(StageInfoOverrides {
+            creds: Some(CloudCredentials::S3 {
+                aws_key_id: "key".to_string(),
+                aws_secret_key: SensitiveString::from("secret"),
+                aws_token: SensitiveString::from("token"),
+            }),
+            ..Default::default()
+        });
+        let result = resolve_url_and_token(&stage, "prefix/file.csv.gz");
+        assert!(matches!(
+            result,
+            Err(AzureRequestError::MissingAzureCredentials)
+        ));
+    }
+
+    // ---------------------------------------------------------------
+    // 3. Retry policy configuration
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn azure_retry_policy_includes_403() {
+        let policy = azure_retry_policy();
+        assert!(
+            policy.extra_retryable_statuses.contains(&403),
+            "403 should be retryable (SAS token clock skew / replication delays)"
+        );
+    }
+
+    #[test]
+    fn azure_retry_policy_max_elapsed_exceeds_request_timeout() {
+        let policy = azure_retry_policy();
+        assert_eq!(
+            policy.max_elapsed,
+            Duration::from_secs(600),
+            "max_elapsed must exceed REQUEST_TIMEOUT_SECS (300s)"
+        );
+        assert!(
+            policy.max_elapsed > Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            "retry budget must be larger than a single request timeout"
+        );
+    }
+
+    #[test]
+    fn azure_retry_policy_max_attempts() {
+        let policy = azure_retry_policy();
+        assert_eq!(policy.max_attempts, 6);
+    }
+
+    // ---------------------------------------------------------------
+    // 4. SAS token sanitization
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn sanitize_sas_redacts_signature() {
+        let input =
+            "https://acct.blob.core.windows.net/c/f?sv=2021&sig=secret123&se=2026".to_string();
+        let result = sanitize_sas(input);
+        assert_eq!(
+            result,
+            "https://acct.blob.core.windows.net/c/f?sv=2021&sig=REDACTED&se=2026"
+        );
+    }
+
+    #[test]
+    fn sanitize_sas_handles_sig_at_end() {
+        let input = "https://acct.blob.core.windows.net/c/f?sv=2021&sig=secret123".to_string();
+        let result = sanitize_sas(input);
+        assert_eq!(
+            result,
+            "https://acct.blob.core.windows.net/c/f?sv=2021&sig=REDACTED"
+        );
+    }
+
+    #[test]
+    fn sanitize_sas_no_sig_unchanged() {
+        let input = "no signature here".to_string();
+        let result = sanitize_sas(input);
+        assert_eq!(result, "no signature here");
+    }
+
+    #[test]
+    fn sanitize_sas_redacts_multiple_occurrences() {
+        let input = "url1?sig=secret1&se=2026 url2?sig=secret2&se=2027".to_string();
+        let result = sanitize_sas(input);
+        assert!(!result.contains("secret1"));
+        assert!(!result.contains("secret2"));
+        assert!(result.contains("sig=REDACTED"));
+    }
+
+    // ---------------------------------------------------------------
+    // 5. URL with special characters (uses shared percent_encode_path)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn url_encodes_special_chars_in_key() {
+        let stage = make_stage_info(StageInfoOverrides::default());
+        let url = build_azure_url(&stage, "dir/my file (1).csv").unwrap();
+        assert_eq!(
+            url,
+            "https://mystorageaccount.blob.core.windows.net/my-container/dir/my%20file%20%281%29.csv"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // 6. Upload status enum
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn upload_status_display() {
+        assert_eq!(UploadStatus::Uploaded.to_string(), "UPLOADED");
+        assert_eq!(UploadStatus::Skipped.to_string(), "SKIPPED");
+    }
+}

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -256,7 +256,22 @@ fn resolve_url_and_token<'a>(
 }
 
 /// Builds the Azure Blob Storage URL for a given object key.
+///
+/// When `end_point` contains a URL scheme (`http://` or `https://`), it is used directly
+/// as the base URL. This supports Azure-compatible local emulators (e.g. Azurite) and
+/// testing with mock servers. Otherwise, the standard Azure URL pattern
+/// `https://{storageAccount}.blob.{endpoint}/{container}/{key}` is used.
 fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureRequestError> {
+    let encoded_key = percent_encode_path(key);
+
+    // If endpoint contains a scheme, use it directly (e.g. Azurite or test servers).
+    if let Some(ref ep) = stage_info.end_point
+        && (ep.starts_with("http://") || ep.starts_with("https://"))
+    {
+        return Ok(format!("{ep}/{}/{encoded_key}", stage_info.bucket));
+    }
+
+    // Standard Azure URL: https://{account}.blob.{endpoint}/{bucket}/{key}
     let storage_account = stage_info
         .storage_account
         .as_ref()
@@ -291,8 +306,6 @@ fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureReq
     } else {
         format!("blob.{endpoint}")
     };
-
-    let encoded_key = percent_encode_path(key);
 
     Ok(format!(
         "https://{storage_account}.{blob_endpoint}/{}/{encoded_key}",
@@ -748,15 +761,28 @@ mod tests {
     }
 
     #[test]
-    fn url_endpoint_with_scheme_is_normalized() {
+    fn url_endpoint_with_scheme_is_used_directly() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("https://blob.core.windows.net/".to_string()),
+            end_point: Some("http://127.0.0.1:10000".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
         assert_eq!(
             url,
-            "https://mystorageaccount.blob.core.windows.net/my-container/prefix/file.csv.gz"
+            "http://127.0.0.1:10000/my-container/prefix/file.csv.gz"
+        );
+    }
+
+    #[test]
+    fn url_endpoint_with_https_scheme_is_used_directly() {
+        let stage = make_stage_info(StageInfoOverrides {
+            end_point: Some("https://azurite.local:10000".to_string()),
+            ..Default::default()
+        });
+        let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
+        assert_eq!(
+            url,
+            "https://azurite.local:10000/my-container/prefix/file.csv.gz"
         );
     }
 

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
-    UploadStatus, build_encryption_metadata_json, percent_encode_path,
+    CloudCredentials, EncryptedFileMetadata, EncryptionData, EncryptionResult, MaterialDescription,
+    StageInfo, UploadStatus, build_encryption_metadata_json, percent_encode_path,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
@@ -66,29 +66,15 @@ pub async fn download_from_gcs(
     let mat_desc_str = get_header(headers, GCS_META_MATDESC)?;
 
     // Parse encryption data JSON to extract key and IV
-    let enc_data: serde_json::Value = serde_json::from_str(&encryption_data_str)
+    let enc_data: EncryptionData = serde_json::from_str(&encryption_data_str)
         .context(gcs_download_error::DeserializationSnafu)?;
-
-    let encrypted_key = enc_data["WrappedContentKey"]["EncryptedKey"]
-        .as_str()
-        .context(gcs_download_error::MissingMetadataSnafu {
-            field: "WrappedContentKey.EncryptedKey",
-        })?
-        .to_string();
-
-    let iv = enc_data["ContentEncryptionIV"]
-        .as_str()
-        .context(gcs_download_error::MissingMetadataSnafu {
-            field: "ContentEncryptionIV",
-        })?
-        .to_string();
 
     let material_desc: MaterialDescription =
         serde_json::from_str(&mat_desc_str).context(gcs_download_error::DeserializationSnafu)?;
 
     let file_metadata = EncryptedFileMetadata {
-        encrypted_key,
-        iv,
+        encrypted_key: enc_data.wrapped_content_key.encrypted_key,
+        iv: enc_data.content_encryption_iv,
         material_desc,
         digest,
     };

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -1,6 +1,6 @@
 use super::types::{
     CloudCredentials, EncryptedFileMetadata, EncryptionResult, MaterialDescription, StageInfo,
-    UploadStatus,
+    UploadStatus, build_encryption_metadata_json, percent_encode_path,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
@@ -145,23 +145,7 @@ async fn upload_to_gcs(
     encryption_result: EncryptionResult,
     using_presigned_url: bool,
 ) -> Result<(), GcsUploadError> {
-    // Build encryption metadata JSON (matching JDBC/Python format)
-    let encryption_data = serde_json::json!({
-        "EncryptionMode": "FullBlob",
-        "WrappedContentKey": {
-            "KeyId": "symmKey1",
-            "EncryptedKey": encryption_result.metadata.encrypted_key,
-            "Algorithm": "AES_CBC_256"
-        },
-        "EncryptionAgent": {
-            "Protocol": "1.0",
-            "EncryptionAlgorithm": "AES_CBC_256"
-        },
-        "ContentEncryptionIV": encryption_result.metadata.iv,
-        "KeyWrappingMetadata": {
-            "EncryptionLibrary": "Rust(OpenSSL)"
-        }
-    });
+    let encryption_data = build_encryption_metadata_json(&encryption_result.metadata);
     let encryption_data_str =
         serde_json::to_string(&encryption_data).context(gcs_upload_error::SerializationSnafu)?;
 
@@ -341,25 +325,6 @@ fn build_gcs_url(stage_info: &StageInfo, key: &str) -> String {
         "https://storage.googleapis.com/{}/{encoded_key}",
         stage_info.bucket
     )
-}
-
-/// Percent-encode a URL path, preserving `/` separators.
-/// Matches Python `urllib.parse.quote()` / ODBC `encodeUrlName()` behavior:
-/// unreserved chars (RFC 3986) and `/` pass through, everything else is encoded.
-fn percent_encode_path(s: &str) -> String {
-    let mut encoded = String::with_capacity(s.len());
-    for byte in s.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
-                encoded.push(byte as char)
-            }
-            _ => {
-                use std::fmt::Write;
-                let _ = write!(encoded, "%{byte:02X}");
-            }
-        }
-    }
-    encoded
 }
 
 fn get_header(
@@ -568,6 +533,7 @@ mod tests {
             presigned_url: overrides.presigned_url,
             use_virtual_url: overrides.use_virtual_url,
             use_regional_url: overrides.use_regional_url,
+            storage_account: None,
         }
     }
 

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -7,13 +7,12 @@ mod path_expansion;
 pub mod types;
 
 pub use self::types::*;
+pub use azure_transfer::download_from_azure;
 pub use gcs_transfer::download_from_gcs;
 
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
-use azure_transfer::{
-    AzureDownloadError, AzureUploadError, download_from_azure, upload_to_azure_or_skip,
-};
+use azure_transfer::{AzureDownloadError, AzureUploadError, upload_to_azure_or_skip};
 use encryption::{EncryptionError, decrypt_file_data, encrypt_file_data};
 use gcs_transfer::{GcsDownloadError, GcsUploadError, upload_to_gcs_or_skip};
 use path_expansion::{PathExpansionError, expand_filenames};

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -1,3 +1,4 @@
+mod azure_transfer;
 mod encryption;
 mod gcs_transfer;
 mod s3_transfer;
@@ -10,6 +11,9 @@ pub use gcs_transfer::download_from_gcs;
 
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
+use azure_transfer::{
+    AzureDownloadError, AzureUploadError, download_from_azure, upload_to_azure_or_skip,
+};
 use encryption::{EncryptionError, decrypt_file_data, encrypt_file_data};
 use gcs_transfer::{GcsDownloadError, GcsUploadError, upload_to_gcs_or_skip};
 use path_expansion::{PathExpansionError, expand_filenames};
@@ -69,12 +73,14 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
         )
         .await
         .context(GcsUploadSnafu)?,
-        LocationType::Azure => {
-            return UnsupportedStorageTypeSnafu {
-                storage_type: "Azure",
-            }
-            .fail();
-        }
+        LocationType::Azure => upload_to_azure_or_skip(
+            encryption_result,
+            &data.stage_info,
+            file_metadata.target.as_str(),
+            data.overwrite,
+        )
+        .await
+        .context(AzureUploadSnafu)?,
     };
 
     // TODO: Right now empty message is hardcoded, because any error in the upload process will
@@ -196,12 +202,9 @@ pub async fn download_single_file(
         LocationType::Gcs => download_from_gcs(&data.stage_info, data.src_location.as_str())
             .await
             .context(GcsDownloadSnafu)?,
-        LocationType::Azure => {
-            return UnsupportedStorageTypeSnafu {
-                storage_type: "Azure",
-            }
-            .fail();
-        }
+        LocationType::Azure => download_from_azure(&data.stage_info, data.src_location.as_str())
+            .await
+            .context(AzureDownloadSnafu)?,
     };
 
     // Decrypt the data (this gives us the compressed data)
@@ -287,9 +290,15 @@ pub enum FileManagerError {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Unsupported storage type: {storage_type}"))]
-    UnsupportedStorageType {
-        storage_type: &'static str,
+    #[snafu(display("Failed to upload file to Azure"))]
+    AzureUpload {
+        source: AzureUploadError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to download file from Azure"))]
+    AzureDownload {
+        source: AzureDownloadError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -180,6 +180,22 @@ pub struct MaterialDescription {
     pub key_size: String,
 }
 
+/// Encryption metadata envelope returned by cloud storage providers.
+/// Matches the JSON format produced by `build_encryption_metadata_json`.
+#[derive(Debug, Deserialize)]
+pub(super) struct EncryptionData {
+    #[serde(rename = "WrappedContentKey")]
+    pub wrapped_content_key: WrappedContentKey,
+    #[serde(rename = "ContentEncryptionIV")]
+    pub content_encryption_iv: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct WrappedContentKey {
+    #[serde(rename = "EncryptedKey")]
+    pub encrypted_key: String,
+}
+
 /// Builds the Snowflake encryption metadata JSON envelope (shared across all cloud providers).
 /// Matches the format used by JDBC/Python/ODBC drivers.
 pub(super) fn build_encryption_metadata_json(

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -123,6 +123,8 @@ pub struct StageInfo {
     pub use_virtual_url: bool,
     /// Whether to use regional GCS endpoints.
     pub use_regional_url: bool,
+    /// Azure storage account name (required for Azure Blob Storage).
+    pub storage_account: Option<String>,
 }
 
 /// Cloud storage credentials.
@@ -139,6 +141,8 @@ pub enum CloudCredentials {
     Gcs {
         gcs_access_token: Option<SensitiveString>,
     },
+    /// Azure Blob Storage credentials (SAS token).
+    Azure { sas_token: SensitiveString },
 }
 
 /// Encryption material for file transfer.
@@ -174,4 +178,46 @@ pub struct MaterialDescription {
     pub smk_id: String,
     #[serde(rename = "keySize")]
     pub key_size: String,
+}
+
+/// Builds the Snowflake encryption metadata JSON envelope (shared across all cloud providers).
+/// Matches the format used by JDBC/Python/ODBC drivers.
+pub(super) fn build_encryption_metadata_json(
+    metadata: &EncryptedFileMetadata,
+) -> serde_json::Value {
+    serde_json::json!({
+        "EncryptionMode": "FullBlob",
+        "WrappedContentKey": {
+            "KeyId": "symmKey1",
+            "EncryptedKey": metadata.encrypted_key,
+            "Algorithm": "AES_CBC_256"
+        },
+        "EncryptionAgent": {
+            "Protocol": "1.0",
+            "EncryptionAlgorithm": "AES_CBC_256"
+        },
+        "ContentEncryptionIV": metadata.iv,
+        "KeyWrappingMetadata": {
+            "EncryptionLibrary": "Rust(OpenSSL)"
+        }
+    })
+}
+
+/// Percent-encode a URL path, preserving `/` separators.
+/// Matches Python `urllib.parse.quote()` / ODBC `encodeUrlName()` behavior:
+/// unreserved chars (RFC 3986) and `/` pass through, everything else is encoded.
+pub(super) fn percent_encode_path(s: &str) -> String {
+    let mut encoded = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                encoded.push(byte as char)
+            }
+            _ => {
+                use std::fmt::Write;
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    encoded
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -745,11 +745,23 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             value.use_regional_url.unwrap_or(false) || region.eq_ignore_ascii_case("me-central2");
         let use_virtual_url = value.use_virtual_url.unwrap_or(false);
 
-        let storage_account = value
-            .storage_account
-            .as_ref()
-            .filter(|sa| !sa.is_empty())
-            .cloned();
+        let storage_account = match location_type {
+            file_manager::LocationType::Azure => Some(
+                value
+                    .storage_account
+                    .as_ref()
+                    .filter(|sa| !sa.is_empty())
+                    .context(MissingParameterSnafu {
+                        parameter: "stage info -> storageAccount",
+                    })?
+                    .clone(),
+            ),
+            _ => value
+                .storage_account
+                .as_ref()
+                .filter(|sa| !sa.is_empty())
+                .cloned(),
+        };
 
         Ok(file_manager::StageInfo {
             location_type,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -232,11 +232,12 @@ pub struct StageInfo {
     #[serde(rename = "presignedUrl")]
     presigned_url: Option<String>,
 
+    #[serde(rename = "storageAccount")]
+    storage_account: Option<String>,
+
     // unused fields
     #[serde(rename = "path")]
     _path: Option<String>,
-    #[serde(rename = "storageAccount")]
-    _storage_account: Option<String>,
     #[serde(rename = "isClientSideEncrypted")]
     _is_client_side_encrypted: Option<bool>,
     #[serde(rename = "useS3RegionalUrl")]
@@ -259,13 +260,14 @@ pub struct Credentials {
     #[serde(rename = "GCS_ACCESS_TOKEN")]
     gcs_access_token: Option<String>,
 
+    #[serde(rename = "AZURE_SAS_TOKEN")]
+    azure_sas_token: Option<String>,
+
     // unused fields
     #[serde(rename = "AWS_ID")]
     _aws_id: Option<String>,
     #[serde(rename = "AWS_KEY")]
     _aws_key: Option<String>,
-    #[serde(rename = "AZURE_SAS_TOKEN")]
-    _azure_sas_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -640,12 +642,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
         // Determine location type (default to S3 for backward compatibility)
         let location_type = match value.location_type.as_deref() {
             Some("GCS") => file_manager::LocationType::Gcs,
-            Some("AZURE") => {
-                return UnsupportedStorageTypeSnafu {
-                    storage_type: "Azure",
-                }
-                .fail();
-            }
+            Some("AZURE") => file_manager::LocationType::Azure,
             Some("S3") | None => file_manager::LocationType::S3,
             Some(other) => {
                 return InvalidFormatSnafu {
@@ -719,7 +716,16 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
                     .filter(|t| !t.is_empty())
                     .map(|t| t.clone().into()),
             },
-            file_manager::LocationType::Azure => unreachable!("Azure rejected above"),
+            file_manager::LocationType::Azure => file_manager::CloudCredentials::Azure {
+                sas_token: creds_data
+                    .azure_sas_token
+                    .as_ref()
+                    .context(MissingParameterSnafu {
+                        parameter: "credentials -> AZURE_SAS_TOKEN",
+                    })?
+                    .clone()
+                    .into(),
+            },
         };
 
         let end_point = value
@@ -739,6 +745,12 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             value.use_regional_url.unwrap_or(false) || region.eq_ignore_ascii_case("me-central2");
         let use_virtual_url = value.use_virtual_url.unwrap_or(false);
 
+        let storage_account = value
+            .storage_account
+            .as_ref()
+            .filter(|sa| !sa.is_empty())
+            .cloned();
+
         Ok(file_manager::StageInfo {
             location_type,
             bucket,
@@ -749,6 +761,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             presigned_url,
             use_virtual_url,
             use_regional_url,
+            storage_account,
         })
     }
 }
@@ -799,12 +812,6 @@ pub enum QueryResponseError {
     #[snafu(display("Invalid Snowflake response: {message}"))]
     InvalidFormat {
         message: String,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-    #[snafu(display("Unsupported storage type: {storage_type}"))]
-    UnsupportedStorageType {
-        storage_type: &'static str,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -206,7 +206,13 @@ async fn azure_error_response_redacts_sas_token() {
 
 #[tokio::test]
 async fn azure_transport_error_does_not_leak_sas_token() {
-    // Use a non-scheme endpoint that resolves to a nonexistent host
+    // Bind a TCP listener, get its address, then drop it so the port is closed.
+    // Connecting to this port produces a deterministic "connection refused" transport
+    // error without any real DNS lookups.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
     let stage = StageInfo {
         location_type: LocationType::Azure,
         bucket: "test-container".to_string(),
@@ -215,11 +221,11 @@ async fn azure_transport_error_does_not_leak_sas_token() {
         creds: CloudCredentials::Azure {
             sas_token: SensitiveString::from("sv=2021-08-06&sig=test-secret-sig&se=2099-01-01"),
         },
-        end_point: Some("blob.core.windows.net".to_string()),
+        end_point: Some(format!("http://{addr}")),
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
-        storage_account: Some("nonexistentaccount".to_string()),
+        storage_account: Some("test".to_string()),
     };
 
     let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -1,0 +1,85 @@
+use sf_core::file_manager::{CloudCredentials, LocationType, StageInfo};
+use sf_core::sensitive::SensitiveString;
+
+/// Helper to build an Azure StageInfo.
+fn azure_stage() -> StageInfo {
+    StageInfo {
+        location_type: LocationType::Azure,
+        bucket: "test-container".to_string(),
+        key_prefix: "prefix/".to_string(),
+        region: "eastus2".to_string(),
+        creds: CloudCredentials::Azure {
+            sas_token: SensitiveString::from("sv=2021-08-06&sig=test-secret-sig&se=2099-01-01"),
+        },
+        end_point: Some("blob.core.windows.net".to_string()),
+        presigned_url: None,
+        use_virtual_url: false,
+        use_regional_url: false,
+        storage_account: Some("nonexistentaccount".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------
+// Transport errors do NOT leak SAS tokens
+// (Azure URLs embed SAS tokens as query parameters; reqwest::Error
+// includes the full URL, so we must sanitize before surfacing)
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_transport_error_does_not_leak_sas_token() {
+    let stage = azure_stage();
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    let err = result.unwrap_err();
+    let err_display = format!("{err}");
+    let err_debug = format!("{err:?}");
+
+    assert!(
+        !err_display.contains("test-secret-sig"),
+        "Display should not contain SAS signature, got: {err_display}"
+    );
+    assert!(
+        !err_debug.contains("test-secret-sig"),
+        "Debug should not contain SAS signature, got: {err_debug}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Missing credentials produce a clear error
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_with_wrong_creds_type_fails() {
+    let mut stage = azure_stage();
+    stage.creds = CloudCredentials::Gcs {
+        gcs_access_token: None,
+    };
+
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    let err = result.unwrap_err();
+    let err_str = format!("{err}");
+    assert!(
+        err_str.contains("Missing Azure credentials"),
+        "Should report missing credentials, got: {err_str}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Missing storage account produces a clear error
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_with_missing_storage_account_fails() {
+    let mut stage = azure_stage();
+    stage.storage_account = None;
+
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    let err = result.unwrap_err();
+    let err_str = format!("{err}");
+    assert!(
+        err_str.contains("storage_account"),
+        "Should report missing storage_account, got: {err_str}"
+    );
+}

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -1,9 +1,213 @@
 use sf_core::file_manager::{CloudCredentials, LocationType, StageInfo};
 use sf_core::sensitive::SensitiveString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
-/// Helper to build an Azure StageInfo.
-fn azure_stage() -> StageInfo {
+/// Helper to build a StageInfo pointing at the mock server.
+///
+/// Uses a scheme-based endpoint (`http://127.0.0.1:PORT`) so that
+/// `build_azure_url` uses the mock server URL directly, matching
+/// how GCS tests work with custom endpoints.
+fn azure_stage(mock_uri: &str) -> StageInfo {
     StageInfo {
+        location_type: LocationType::Azure,
+        bucket: "test-container".to_string(),
+        key_prefix: "prefix/".to_string(),
+        region: "eastus2".to_string(),
+        creds: CloudCredentials::Azure {
+            sas_token: SensitiveString::from("sv=2021-08-06&sig=test-secret-sig&se=2099-01-01"),
+        },
+        end_point: Some(mock_uri.to_string()),
+        presigned_url: None,
+        use_virtual_url: false,
+        use_regional_url: false,
+        storage_account: Some("test".to_string()),
+    }
+}
+
+fn azure_response_headers() -> ResponseTemplate {
+    let enc_data = serde_json::json!({
+        "EncryptionMode": "FullBlob",
+        "WrappedContentKey": {
+            "KeyId": "symmKey1",
+            "EncryptedKey": "dGVzdC1rZXk=",
+            "Algorithm": "AES_CBC_256"
+        },
+        "ContentEncryptionIV": "dGVzdC1pdg=="
+    });
+    let mat_desc = serde_json::json!({
+        "queryId": "test-query",
+        "smkId": "1",
+        "keySize": "256"
+    });
+    ResponseTemplate::new(200)
+        .set_body_bytes(b"encrypted-data".to_vec())
+        .insert_header("x-ms-meta-sfcdigest", "test-digest")
+        .insert_header("x-ms-meta-encryptiondata", enc_data.to_string().as_str())
+        .insert_header("x-ms-meta-matdesc", mat_desc.to_string().as_str())
+}
+
+// ---------------------------------------------------------------
+// Successful download returns encrypted data and metadata
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_success_returns_data_and_metadata() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(azure_response_headers())
+        .mount(&server)
+        .await;
+
+    let stage = azure_stage(&server.uri());
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    let (data, metadata) = result.expect("download should succeed");
+    assert_eq!(data, b"encrypted-data");
+    assert_eq!(metadata.digest, "test-digest");
+    assert_eq!(metadata.encrypted_key, "dGVzdC1rZXk=");
+    assert_eq!(metadata.iv, "dGVzdC1pdg==");
+    assert_eq!(metadata.material_desc.query_id, "test-query");
+    assert_eq!(metadata.material_desc.smk_id, "1");
+}
+
+// ---------------------------------------------------------------
+// 403 is retryable for Azure (SAS token clock skew / replication)
+// (matches JDBC/ODBC behavior)
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_403_is_retried_then_succeeds() {
+    let server = MockServer::start().await;
+    let attempt = Arc::new(AtomicU32::new(0));
+
+    let attempt_clone = attempt.clone();
+    Mock::given(method("GET"))
+        .respond_with(move |_: &Request| {
+            let n = attempt_clone.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                ResponseTemplate::new(403).set_body_string("Forbidden")
+            } else {
+                azure_response_headers()
+            }
+        })
+        .mount(&server)
+        .await;
+
+    let stage = azure_stage(&server.uri());
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    assert!(result.is_ok(), "403 should be retried and succeed");
+    assert_eq!(
+        attempt.load(Ordering::SeqCst),
+        2,
+        "should have retried once"
+    );
+}
+
+// ---------------------------------------------------------------
+// 404 is a hard failure (not retried)
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_404_is_not_retried() {
+    let server = MockServer::start().await;
+    let attempt = Arc::new(AtomicU32::new(0));
+
+    let attempt_clone = attempt.clone();
+    Mock::given(method("GET"))
+        .respond_with(move |_: &Request| {
+            attempt_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(404).set_body_string("Not Found")
+        })
+        .mount(&server)
+        .await;
+
+    let stage = azure_stage(&server.uri());
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    assert!(result.is_err(), "404 should be a hard failure");
+    assert_eq!(attempt.load(Ordering::SeqCst), 1, "should NOT retry 404");
+}
+
+// ---------------------------------------------------------------
+// Standard retryable codes (503) are retried
+// (matches all drivers)
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_download_503_is_retried_then_succeeds() {
+    let server = MockServer::start().await;
+    let attempt = Arc::new(AtomicU32::new(0));
+
+    let attempt_clone = attempt.clone();
+    Mock::given(method("GET"))
+        .respond_with(move |_: &Request| {
+            let n = attempt_clone.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                ResponseTemplate::new(503).set_body_string("Service Unavailable")
+            } else {
+                azure_response_headers()
+            }
+        })
+        .mount(&server)
+        .await;
+
+    let stage = azure_stage(&server.uri());
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    assert!(
+        result.is_ok(),
+        "503 should be retried and eventually succeed"
+    );
+    assert_eq!(
+        attempt.load(Ordering::SeqCst),
+        3,
+        "should have retried twice"
+    );
+}
+
+// ---------------------------------------------------------------
+// Error body is sanitized (SAS tokens redacted)
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_error_response_redacts_sas_token() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_string("Error: sig=secret123&se=2026 is invalid"),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = azure_stage(&server.uri());
+    let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
+
+    let err = result.unwrap_err();
+    let err_str = format!("{err}");
+    assert!(
+        !err_str.contains("secret123"),
+        "SAS signature should be redacted from error, got: {err_str}"
+    );
+    assert!(
+        err_str.contains("sig=REDACTED"),
+        "Should contain redacted marker, got: {err_str}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Transport errors do NOT leak SAS tokens
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn azure_transport_error_does_not_leak_sas_token() {
+    // Use a non-scheme endpoint that resolves to a nonexistent host
+    let stage = StageInfo {
         location_type: LocationType::Azure,
         bucket: "test-container".to_string(),
         key_prefix: "prefix/".to_string(),
@@ -16,18 +220,8 @@ fn azure_stage() -> StageInfo {
         use_virtual_url: false,
         use_regional_url: false,
         storage_account: Some("nonexistentaccount".to_string()),
-    }
-}
+    };
 
-// ---------------------------------------------------------------
-// Transport errors do NOT leak SAS tokens
-// (Azure URLs embed SAS tokens as query parameters; reqwest::Error
-// includes the full URL, so we must sanitize before surfacing)
-// ---------------------------------------------------------------
-
-#[tokio::test]
-async fn azure_download_transport_error_does_not_leak_sas_token() {
-    let stage = azure_stage();
     let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
 
     let err = result.unwrap_err();
@@ -45,12 +239,13 @@ async fn azure_download_transport_error_does_not_leak_sas_token() {
 }
 
 // ---------------------------------------------------------------
-// Missing credentials produce a clear error
+// Missing credentials / storage account produce clear errors
 // ---------------------------------------------------------------
 
 #[tokio::test]
 async fn azure_download_with_wrong_creds_type_fails() {
-    let mut stage = azure_stage();
+    let server = MockServer::start().await;
+    let mut stage = azure_stage(&server.uri());
     stage.creds = CloudCredentials::Gcs {
         gcs_access_token: None,
     };
@@ -65,14 +260,13 @@ async fn azure_download_with_wrong_creds_type_fails() {
     );
 }
 
-// ---------------------------------------------------------------
-// Missing storage account produces a clear error
-// ---------------------------------------------------------------
-
 #[tokio::test]
 async fn azure_download_with_missing_storage_account_fails() {
-    let mut stage = azure_stage();
+    let server = MockServer::start().await;
+    let mut stage = azure_stage(&server.uri());
     stage.storage_account = None;
+    // Remove scheme so it falls through to the standard URL path
+    stage.end_point = Some("blob.core.windows.net".to_string());
 
     let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
 

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -19,6 +19,7 @@ fn gcs_stage_with_presigned_url(presigned_url: &str) -> StageInfo {
         presigned_url: Some(presigned_url.to_string()),
         use_virtual_url: false,
         use_regional_url: false,
+        storage_account: None,
     }
 }
 
@@ -36,6 +37,7 @@ fn gcs_stage_with_token(endpoint: &str) -> StageInfo {
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
+        storage_account: None,
     }
 }
 

--- a/sf_core/tests/integration/http/mod.rs
+++ b/sf_core/tests/integration/http/mod.rs
@@ -1,3 +1,4 @@
+mod azure_retry;
 mod gcs_retry;
 mod retry;
 mod session_refresh;


### PR DESCRIPTION
## Summary
- Replace manual `serde_json::Value` navigation in GCS download with the typed `EncryptionData`/`WrappedContentKey` structs introduced in #732
- Gives compile-time field checking and clearer deserialization errors

## Stack
This is a follow-up to #732 (Azure Blob Storage file transfer support).

## Test plan
- [ ] `cargo test -p sf_core --lib` — all unit tests pass
- [ ] `cargo test -p sf_core --test integration_tests` — GCS integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)