### PR TITLE
Fix performance regression in python

### DIFF
--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -77,7 +77,7 @@ def _requires_open(func: F) -> F:
 
     @functools.wraps(func)
     def wrapper(self: SnowflakeCursorBase, *args: Any, **kwargs: Any) -> Any:
-        if self.is_closed():
+        if self._closed or self._connection.is_closed():
             raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
 
         return func(self, *args, **kwargs)
@@ -542,8 +542,6 @@ class SnowflakeCursorBase(abc.ABC):
     # Fetch – shared implementation
     # ------------------------------------------------------------------
 
-    @_requires_open
-    @_requires_fetch_mode(FetchMode.ROW)
     def _fetchone(self) -> Row | DictRow | None:
         """Fetch the next row internally.
 
@@ -566,6 +564,7 @@ class SnowflakeCursorBase(abc.ABC):
 
     @pep249
     @_requires_open
+    @_requires_fetch_mode(FetchMode.ROW)
     def fetchmany(self, size: int | None = None) -> list[Any]:
         """
         Fetch the next set of rows of a query result.
@@ -587,7 +586,7 @@ class SnowflakeCursorBase(abc.ABC):
 
         ret = []
         while size > 0:
-            row = self.fetchone()
+            row = self._fetchone()
             if row is None:
                 break
             ret.append(row)

--- a/python/src/snowflake/connector/cursor/_dict_cursor.py
+++ b/python/src/snowflake/connector/cursor/_dict_cursor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ._base import DictRow, SnowflakeCursorBase
+from ._base import DictRow, FetchMode, SnowflakeCursorBase, _requires_fetch_mode, _requires_open
 
 
 class DictCursor(SnowflakeCursorBase):
@@ -20,6 +20,8 @@ class DictCursor(SnowflakeCursorBase):
     def _use_dict_result(self) -> bool:
         return True
 
+    @_requires_open
+    @_requires_fetch_mode(FetchMode.ROW)
     def fetchone(self) -> DictRow | None:
         """
         Fetch the next row of a query result set as a dictionary.

--- a/python/src/snowflake/connector/cursor/_snowflake_cursor.py
+++ b/python/src/snowflake/connector/cursor/_snowflake_cursor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ._base import Row, SnowflakeCursorBase
+from ._base import FetchMode, Row, SnowflakeCursorBase, _requires_fetch_mode, _requires_open
 
 
 class SnowflakeCursor(SnowflakeCursorBase):
@@ -15,6 +15,8 @@ class SnowflakeCursor(SnowflakeCursorBase):
     def _use_dict_result(self) -> bool:
         return False
 
+    @_requires_open
+    @_requires_fetch_mode(FetchMode.ROW)
     def fetchone(self) -> Row | None:
         """
         Fetch the next row of a query result set.

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -287,7 +287,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,), (4,), (5,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany()
 
         assert result == [(1,), (2,), (3,)]
@@ -297,7 +297,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,), (4,), (5,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(2)
 
         assert result == [(1,), (2,)]
@@ -307,14 +307,14 @@ class TestFetchmany:
         mock_rows = [(1,), (2,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(5)
 
         assert result == [(1,), (2,)]
 
     def test_fetchmany_returns_empty_list_when_no_rows(self, cursor):
         """Test fetchmany returns empty list when no rows available."""
-        with patch.object(cursor, "fetchone", return_value=None):
+        with patch.object(cursor, "_fetchone", return_value=None):
             result = cursor.fetchmany(5)
 
         assert result == []
@@ -322,7 +322,7 @@ class TestFetchmany:
     def test_fetchmany_with_size_zero(self, cursor):
         """Test fetchmany(0) returns empty list."""
         mock_fetchone = MagicMock()
-        with patch.object(cursor, "fetchone", mock_fetchone):
+        with patch.object(cursor, "_fetchone", mock_fetchone):
             result = cursor.fetchmany(0)
 
         assert result == []
@@ -347,7 +347,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,), (4,), (5,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             first_batch = cursor.fetchmany(2)
             second_batch = cursor.fetchmany(2)
             third_batch = cursor.fetchmany(2)
@@ -361,7 +361,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             cursor.fetchmany(5)  # Consume all rows
             result = cursor.fetchmany(5)
 
@@ -372,7 +372,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             cursor.arraysize = 2
             first_batch = cursor.fetchmany()
 
@@ -387,7 +387,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(1)
 
         assert result == [(1,)]
@@ -397,7 +397,7 @@ class TestFetchmany:
         mock_rows = [(i,) for i in range(10)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(1000)
 
         assert result == [(i,) for i in range(10)]
@@ -409,7 +409,7 @@ class TestFetchmany:
         mock_rows = [(1,), (2,), (3,)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany()
 
         # Default arraysize is 1, so should fetch 1 row
@@ -424,7 +424,7 @@ class TestFetchmany:
         ]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(2)
 
         assert result == [(1, "a", 1.0), (2, "b", 2.0)]
@@ -437,7 +437,7 @@ class TestFetchmany:
         ]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany(2)
 
         assert result[0] == (1, "text", Decimal("3.14"), None)
@@ -927,7 +927,7 @@ class TestFetchmanyArraysizeAttribute:
         mock_rows = [(i,) for i in range(10)]
         row_iter = iter(mock_rows)
 
-        with patch.object(cursor, "fetchone", side_effect=lambda: next(row_iter, None)):
+        with patch.object(cursor, "_fetchone", side_effect=lambda: next(row_iter, None)):
             result = cursor.fetchmany()
 
         assert len(result) == 5


### PR DESCRIPTION

The _requires_open and _requires_fetch_mode decorators on _fetchone() were executing on every row (1M times for a 1M row fetch), but these checks only need to run once per fetch operation. Move them to the caller level: fetchmany(), fetchall(), and the concrete fetchone() overrides.

Also inline the is_closed() method call in _requires_open to avoid an extra method dispatch per decorated call.