### PR TITLE
NO-SNOW: Add internal_application_name and internal_application_version connection kwargs

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -121,11 +121,18 @@ class Connection:
             self._application = application
         else:
             raise ProgrammingError(f"Invalid application parameter (must be a non-empty string): {application!r}")
-        # client_app_id → CLIENT_APP_ID in the login request; always the driver name.
+        # client_app_id → CLIENT_APP_ID in the login request.
+        # Defaults to the driver name, but can be overridden by internal_application_name
+        # (used by tools like SnowSQL to identify themselves to the server).
+        internal_app_name = kwargs.pop("internal_application_name", None)
+        kwargs["client_app_id"] = internal_app_name if isinstance(internal_app_name, str) and internal_app_name else CLIENT_NAME
+
+        # client_app_version → CLIENT_APP_VERSION; only sent when explicitly overridden.
+        internal_app_version = kwargs.pop("internal_application_version", None)
+        if isinstance(internal_app_version, str) and internal_app_version:
+            kwargs["client_app_version"] = internal_app_version
+
         # client_application → CLIENT_ENVIRONMENT.APPLICATION; the user-facing app name.
-        # This mirrors the old connector where internal_application_name and application
-        # were independent parameters.
-        kwargs["client_app_id"] = CLIENT_NAME
         kwargs["client_application"] = self._application
 
         self.db_api = database_driver_client()

--- a/python/tests/integ/test_application_login_payload.py
+++ b/python/tests/integ/test_application_login_payload.py
@@ -97,3 +97,59 @@ class TestApplicationLoginPayload:
                 assert conn.application == "PythonConnector"
             finally:
                 conn.close()
+
+
+class TestInternalApplicationNameLoginPayload:
+    """Verify internal_application_name and internal_application_version in the login request."""
+
+    def test_internal_application_name_overrides_client_app_id_in_payload(self, int_test_connection_factory):
+        """internal_application_name='SnowSQL' should override CLIENT_APP_ID
+        while CLIENT_ENVIRONMENT.APPLICATION stays at the default."""
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                internal_application_name="SnowSQL",
+            )
+            try:
+                body = _get_login_request_body(wiremock)
+                data = body["data"]
+
+                assert data["CLIENT_APP_ID"] == "SnowSQL"
+                assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "PythonConnector"
+            finally:
+                conn.close()
+
+    def test_internal_application_name_with_custom_application(self, int_test_connection_factory):
+        """Both internal_application_name and application set independently."""
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                internal_application_name="SnowSQL",
+                application="SNOWCLI.STAGE.COPY",
+            )
+            try:
+                body = _get_login_request_body(wiremock)
+                data = body["data"]
+
+                assert data["CLIENT_APP_ID"] == "SnowSQL"
+                assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
+            finally:
+                conn.close()
+
+    def test_internal_application_version_overrides_client_app_version_in_payload(self, int_test_connection_factory):
+        """internal_application_version='1.2.3' should appear as CLIENT_APP_VERSION."""
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                internal_application_version="1.2.3",
+            )
+            try:
+                body = _get_login_request_body(wiremock)
+                data = body["data"]
+
+                assert data["CLIENT_APP_VERSION"] == "1.2.3"
+            finally:
+                conn.close()

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -650,6 +650,83 @@ class TestApplicationProperty:
         )
 
 
+class TestInternalApplicationName:
+    """Unit tests for internal_application_name and internal_application_version kwargs."""
+
+    def test_internal_application_name_overrides_client_app_id(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(user="u", account="a", internal_application_name="SnowSQL")
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value="SnowSQL")
+
+    def test_internal_application_name_defaults_to_client_name(self, mock_db_api):
+        from snowflake.connector.connection import CLIENT_NAME, Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(user="u", account="a")
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value=CLIENT_NAME)
+
+    def test_internal_application_name_does_not_affect_application_property(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", internal_application_name="SnowSQL")
+        assert conn.application == "PythonConnector"
+
+    def test_internal_application_name_combined_with_application(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(
+                user="u",
+                account="a",
+                internal_application_name="SnowSQL",
+                application="SNOWCLI.STAGE.COPY",
+            )
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value="SnowSQL")
+        assert request.options["client_application"] == ConfigSetting(string_value="SNOWCLI.STAGE.COPY")
+        assert conn.application == "SNOWCLI.STAGE.COPY"
+
+    def test_internal_application_name_popped_from_kwargs(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", internal_application_name="SnowSQL")
+        assert "internal_application_name" not in conn.kwargs
+
+    def test_internal_application_version_overrides_client_app_version(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(user="u", account="a", internal_application_version="1.2.3")
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert request.options["client_app_version"] == ConfigSetting(string_value="1.2.3")
+
+    def test_internal_application_version_not_sent_when_omitted(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(user="u", account="a")
+
+        request = mock_db_api.connection_set_options.call_args[0][0]
+        assert "client_app_version" not in request.options
+
+    def test_internal_application_version_popped_from_kwargs(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a", internal_application_version="1.2.3")
+        assert "internal_application_version" not in conn.kwargs
+
+
 class TestConnectionArrowProperties:
     """Unit tests for Connection properties (getters/setters)."""
 

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -86,7 +86,9 @@ impl ClientInfo {
         let client_info = ClientInfo {
             application,
             client_application,
-            version: "3.15.0".to_string(),
+            version: settings
+                .get_string("client_app_version")
+                .unwrap_or_else(|| "3.15.0".to_string()),
             os: "Darwin".to_string(),
             os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
             ocsp_mode: Some("FAIL_OPEN".to_string()),


### PR DESCRIPTION
## Summary
- Add `internal_application_name` connection kwarg that overrides CLIENT_APP_ID (used by SnowSQL, Snow CLI to identify themselves)
- Add `internal_application_version` connection kwarg that overrides CLIENT_APP_VERSION
- Read `client_app_version` from settings in the Rust core instead of hardcoding it

## Context
The old connector supports `internal_application_name` and `internal_application_version` kwargs that tools like SnowSQL use to send their identity to the server. Without these, the new connector always reports "PythonConnector" and a hardcoded version. This PR restores parity so tools can properly identify themselves.

Stacked on #799 (CLIENT_APP_ID / CLIENT_ENVIRONMENT.APPLICATION separation).

## Test plan
- 8 unit tests in `TestInternalApplicationName` class in `test_connection.py`: override behavior, defaults, independence from `application`, combined usage, kwarg popping, version handling
- 3 Wiremock integration tests in `TestInternalApplicationNameLoginPayload` in `test_application_login_payload.py`: verify actual login request payload JSON
- All tests pass on both universal connector (Python 3.9-3.13) and reference connector (old snowflake-connector-python v4.3.0)