### PR TITLE
feat: support all C data types for boolean parameter binding

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -514,6 +514,9 @@ impl OdbcError {
                 JsonBindingError::InvalidBooleanValue { .. } => {
                     SqlState::InvalidCharacterValueForCast
                 }
+                JsonBindingError::BindingNumericOutOfRange { .. } => {
+                    SqlState::NumericValueOutOfRange
+                }
                 _ => SqlState::GeneralError,
             },
             OdbcError::CoreError { source, .. } => match source.as_ref() {

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -511,6 +511,9 @@ impl OdbcError {
                 JsonBindingError::UnsupportedCDataType { .. } => {
                     SqlState::RestrictedDataTypeAttributeViolation
                 }
+                JsonBindingError::InvalidBooleanValue { .. } => {
+                    SqlState::InvalidCharacterValueForCast
+                }
                 _ => SqlState::GeneralError,
             },
             OdbcError::CoreError { source, .. } => match source.as_ref() {

--- a/odbc/src/conversion/boolean.rs
+++ b/odbc/src/conversion/boolean.rs
@@ -190,8 +190,26 @@ impl ReadODBC for SnowflakeBoolean {
             CDataType::UShort => Ok(read_unaligned::<u16>(binding) != 0),
             CDataType::SBigInt => Ok(read_unaligned::<i64>(binding) != 0),
             CDataType::UBigInt => Ok(read_unaligned::<u64>(binding) != 0),
-            CDataType::Float => Ok(read_unaligned::<f32>(binding) != 0.0),
-            CDataType::Double => Ok(read_unaligned::<f64>(binding) != 0.0),
+            CDataType::Float => {
+                let v = read_unaligned::<f32>(binding);
+                if !v.is_finite() {
+                    return UnsupportedCDataTypeSnafu {
+                        c_type: binding.value_type,
+                    }
+                    .fail();
+                }
+                Ok(v != 0.0)
+            }
+            CDataType::Double => {
+                let v = read_unaligned::<f64>(binding);
+                if !v.is_finite() {
+                    return UnsupportedCDataTypeSnafu {
+                        c_type: binding.value_type,
+                    }
+                    .fail();
+                }
+                Ok(v != 0.0)
+            }
             CDataType::Char => {
                 let s = read_char_str(binding)?;
                 parse_str_to_bool(&s, binding.value_type)

--- a/odbc/src/conversion/boolean.rs
+++ b/odbc/src/conversion/boolean.rs
@@ -4,14 +4,14 @@ use serde_json::Value;
 
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
+use crate::conversion::error::JsonBindingError;
 use crate::conversion::error::UnsupportedCDataTypeSnafu;
-use crate::conversion::error::{JsonBindingError, NumericMagnitudeOverflowSnafu};
 use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
 use crate::conversion::numeric_helpers::{
     reject_multi_field_interval, write_interval_second, write_single_field_interval,
 };
 use crate::conversion::param_binding::{
-    read_char_str, read_numeric_struct, read_unaligned, read_wchar_str,
+    buffer_data_len, read_char_str, read_unaligned, read_wchar_str,
 };
 use crate::conversion::traits::Binding;
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
@@ -155,93 +155,67 @@ impl WriteODBCType for SnowflakeBoolean {
     }
 }
 
+/// Parse a string value to a boolean per ODBC spec: the string is first
+/// converted to a numeric value, then 0 → false, nonzero → true.
+fn parse_str_to_bool(s: &str) -> Result<bool, JsonBindingError> {
+    let trimmed = s.trim();
+    if let Ok(i) = trimmed.parse::<i64>() {
+        return Ok(i != 0);
+    }
+    if let Ok(f) = trimmed.parse::<f64>() {
+        return Ok(f != 0.0);
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => UnsupportedCDataTypeSnafu {
+            c_type: CDataType::Char,
+        }
+        .fail(),
+    }
+}
+
 impl ReadODBC for SnowflakeBoolean {
     fn read_odbc<'a>(
         &self,
         binding: &'a ParameterBinding,
     ) -> Result<Self::Representation<'a>, JsonBindingError> {
-        let result = match binding.value_type {
-            CDataType::Default | CDataType::Bit => read_unaligned::<u8>(binding) != 0,
-            CDataType::TinyInt | CDataType::STinyInt => read_unaligned::<i8>(binding) != 0,
-            CDataType::UTinyInt => read_unaligned::<u8>(binding) != 0,
-            CDataType::Short | CDataType::SShort => read_unaligned::<i16>(binding) != 0,
-            CDataType::UShort => read_unaligned::<u16>(binding) != 0,
-            CDataType::Long | CDataType::SLong => read_unaligned::<i32>(binding) != 0,
-            CDataType::ULong => read_unaligned::<u32>(binding) != 0,
-            CDataType::SBigInt => read_unaligned::<i64>(binding) != 0,
-            CDataType::UBigInt => read_unaligned::<u64>(binding) != 0,
-            CDataType::Float => {
-                let v = read_unaligned::<f32>(binding);
-                if !v.is_finite() {
-                    return NumericMagnitudeOverflowSnafu {
-                        reason: format!("non-finite f32 value {v} cannot be converted to boolean"),
-                    }
-                    .fail();
-                }
-                v != 0.0
-            }
-            CDataType::Double => {
-                let v = read_unaligned::<f64>(binding);
-                if !v.is_finite() {
-                    return NumericMagnitudeOverflowSnafu {
-                        reason: format!("non-finite f64 value {v} cannot be converted to boolean"),
-                    }
-                    .fail();
-                }
-                v != 0.0
-            }
-            CDataType::Numeric => {
-                let (mantissa, _scale) = read_numeric_struct(binding)?;
-                mantissa != 0
-            }
+        match binding.value_type {
+            CDataType::Bit | CDataType::UTinyInt => Ok(read_unaligned::<u8>(binding) != 0),
+            CDataType::TinyInt | CDataType::STinyInt => Ok(read_unaligned::<i8>(binding) != 0),
+            CDataType::Long | CDataType::SLong => Ok(read_unaligned::<i32>(binding) != 0),
+            CDataType::ULong => Ok(read_unaligned::<u32>(binding) != 0),
+            CDataType::Short | CDataType::SShort => Ok(read_unaligned::<i16>(binding) != 0),
+            CDataType::UShort => Ok(read_unaligned::<u16>(binding) != 0),
+            CDataType::SBigInt => Ok(read_unaligned::<i64>(binding) != 0),
+            CDataType::UBigInt => Ok(read_unaligned::<u64>(binding) != 0),
+            CDataType::Float => Ok(read_unaligned::<f32>(binding) != 0.0),
+            CDataType::Double => Ok(read_unaligned::<f64>(binding) != 0.0),
             CDataType::Char => {
                 let s = read_char_str(binding)?;
-                let trimmed = s.trim();
-                if let Ok(v) = trimmed.parse::<f64>() {
-                    if !v.is_finite() {
-                        return NumericMagnitudeOverflowSnafu {
-                            reason: format!(
-                                "non-finite f64 value {v} cannot be converted to boolean"
-                            ),
-                        }
-                        .fail();
-                    }
-                    v != 0.0
-                } else {
-                    return UnsupportedCDataTypeSnafu {
-                        c_type: binding.value_type,
-                    }
-                    .fail();
-                }
+                parse_str_to_bool(&s)
             }
             CDataType::WChar => {
                 let s = read_wchar_str(binding)?;
-                let trimmed = s.trim();
-                if let Ok(v) = trimmed.parse::<f64>() {
-                    if !v.is_finite() {
-                        return NumericMagnitudeOverflowSnafu {
-                            reason: format!(
-                                "non-finite f64 value {v} cannot be converted to boolean"
-                            ),
-                        }
-                        .fail();
-                    }
-                    v != 0.0
-                } else {
-                    return UnsupportedCDataTypeSnafu {
-                        c_type: binding.value_type,
-                    }
-                    .fail();
-                }
+                parse_str_to_bool(&s)
             }
-            _ => {
-                return UnsupportedCDataTypeSnafu {
-                    c_type: binding.value_type,
-                }
-                .fail();
+            CDataType::Numeric => {
+                let n = read_unaligned::<sql::Numeric>(binding);
+                Ok(u128::from_le_bytes(n.val) != 0)
             }
-        };
-        Ok(result)
+            CDataType::Binary => {
+                let len = buffer_data_len(binding);
+                if len == 0 {
+                    return Ok(false);
+                }
+                let first = unsafe { *(binding.parameter_value_ptr as *const u8) };
+                Ok(first != 0)
+            }
+            _ => UnsupportedCDataTypeSnafu {
+                c_type: binding.value_type,
+            }
+            .fail(),
+        }
     }
 }
 

--- a/odbc/src/conversion/boolean.rs
+++ b/odbc/src/conversion/boolean.rs
@@ -157,21 +157,22 @@ impl WriteODBCType for SnowflakeBoolean {
 
 /// Parse a string value to a boolean per ODBC spec: the string is first
 /// converted to a numeric value, then 0 → false, nonzero → true.
-fn parse_str_to_bool(s: &str) -> Result<bool, JsonBindingError> {
+/// Also accepts "true"/"false" literals for Snowflake compatibility.
+fn parse_str_to_bool(s: &str, c_type: CDataType) -> Result<bool, JsonBindingError> {
     let trimmed = s.trim();
     if let Ok(i) = trimmed.parse::<i64>() {
         return Ok(i != 0);
     }
     if let Ok(f) = trimmed.parse::<f64>() {
-        return Ok(f != 0.0);
+        return match f.is_finite() {
+            true => Ok(f != 0.0),
+            false => UnsupportedCDataTypeSnafu { c_type }.fail(),
+        };
     }
     match trimmed.to_ascii_lowercase().as_str() {
         "true" => Ok(true),
         "false" => Ok(false),
-        _ => UnsupportedCDataTypeSnafu {
-            c_type: CDataType::Char,
-        }
-        .fail(),
+        _ => UnsupportedCDataTypeSnafu { c_type }.fail(),
     }
 }
 
@@ -193,11 +194,11 @@ impl ReadODBC for SnowflakeBoolean {
             CDataType::Double => Ok(read_unaligned::<f64>(binding) != 0.0),
             CDataType::Char => {
                 let s = read_char_str(binding)?;
-                parse_str_to_bool(&s)
+                parse_str_to_bool(&s, binding.value_type)
             }
             CDataType::WChar => {
                 let s = read_wchar_str(binding)?;
-                parse_str_to_bool(&s)
+                parse_str_to_bool(&s, binding.value_type)
             }
             CDataType::Numeric => {
                 let n = read_unaligned::<sql::Numeric>(binding);

--- a/odbc/src/conversion/boolean.rs
+++ b/odbc/src/conversion/boolean.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::JsonBindingError;
-use crate::conversion::error::{InvalidBooleanValueSnafu, UnsupportedCDataTypeSnafu};
+use crate::conversion::error::{
+    BindingNumericOutOfRangeSnafu, InvalidBooleanValueSnafu, UnsupportedCDataTypeSnafu,
+};
 use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
 use crate::conversion::numeric_helpers::{
     reject_multi_field_interval, write_interval_second, write_single_field_interval,
@@ -232,13 +234,16 @@ impl ReadODBC for SnowflakeBoolean {
             }
             CDataType::Binary => {
                 let len = buffer_data_len(binding);
-                if len == 0 {
-                    return Ok(false);
+                if len != 1 {
+                    return BindingNumericOutOfRangeSnafu {
+                        reason: format!(
+                            "SQL_C_BINARY to SQL_BIT requires exactly 1 byte, got {len}"
+                        ),
+                    }
+                    .fail();
                 }
-                let slice = unsafe {
-                    std::slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len)
-                };
-                Ok(slice.iter().any(|&b| b != 0))
+                let byte = unsafe { *(binding.parameter_value_ptr as *const u8) };
+                Ok(byte != 0)
             }
             _ => UnsupportedCDataTypeSnafu {
                 c_type: binding.value_type,

--- a/odbc/src/conversion/boolean.rs
+++ b/odbc/src/conversion/boolean.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::JsonBindingError;
-use crate::conversion::error::UnsupportedCDataTypeSnafu;
+use crate::conversion::error::{InvalidBooleanValueSnafu, UnsupportedCDataTypeSnafu};
 use crate::conversion::error::{ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError};
 use crate::conversion::numeric_helpers::{
     reject_multi_field_interval, write_interval_second, write_single_field_interval,
@@ -158,7 +158,7 @@ impl WriteODBCType for SnowflakeBoolean {
 /// Parse a string value to a boolean per ODBC spec: the string is first
 /// converted to a numeric value, then 0 → false, nonzero → true.
 /// Also accepts "true"/"false" literals for Snowflake compatibility.
-fn parse_str_to_bool(s: &str, c_type: CDataType) -> Result<bool, JsonBindingError> {
+fn parse_str_to_bool(s: &str) -> Result<bool, JsonBindingError> {
     let trimmed = s.trim();
     if let Ok(i) = trimmed.parse::<i64>() {
         return Ok(i != 0);
@@ -166,13 +166,19 @@ fn parse_str_to_bool(s: &str, c_type: CDataType) -> Result<bool, JsonBindingErro
     if let Ok(f) = trimmed.parse::<f64>() {
         return match f.is_finite() {
             true => Ok(f != 0.0),
-            false => UnsupportedCDataTypeSnafu { c_type }.fail(),
+            false => InvalidBooleanValueSnafu {
+                value: trimmed.to_string(),
+            }
+            .fail(),
         };
     }
     match trimmed.to_ascii_lowercase().as_str() {
         "true" => Ok(true),
         "false" => Ok(false),
-        _ => UnsupportedCDataTypeSnafu { c_type }.fail(),
+        _ => InvalidBooleanValueSnafu {
+            value: trimmed.to_string(),
+        }
+        .fail(),
     }
 }
 
@@ -182,7 +188,9 @@ impl ReadODBC for SnowflakeBoolean {
         binding: &'a ParameterBinding,
     ) -> Result<Self::Representation<'a>, JsonBindingError> {
         match binding.value_type {
-            CDataType::Bit | CDataType::UTinyInt => Ok(read_unaligned::<u8>(binding) != 0),
+            CDataType::Default | CDataType::Bit | CDataType::UTinyInt => {
+                Ok(read_unaligned::<u8>(binding) != 0)
+            }
             CDataType::TinyInt | CDataType::STinyInt => Ok(read_unaligned::<i8>(binding) != 0),
             CDataType::Long | CDataType::SLong => Ok(read_unaligned::<i32>(binding) != 0),
             CDataType::ULong => Ok(read_unaligned::<u32>(binding) != 0),
@@ -193,8 +201,8 @@ impl ReadODBC for SnowflakeBoolean {
             CDataType::Float => {
                 let v = read_unaligned::<f32>(binding);
                 if !v.is_finite() {
-                    return UnsupportedCDataTypeSnafu {
-                        c_type: binding.value_type,
+                    return InvalidBooleanValueSnafu {
+                        value: v.to_string(),
                     }
                     .fail();
                 }
@@ -203,8 +211,8 @@ impl ReadODBC for SnowflakeBoolean {
             CDataType::Double => {
                 let v = read_unaligned::<f64>(binding);
                 if !v.is_finite() {
-                    return UnsupportedCDataTypeSnafu {
-                        c_type: binding.value_type,
+                    return InvalidBooleanValueSnafu {
+                        value: v.to_string(),
                     }
                     .fail();
                 }
@@ -212,11 +220,11 @@ impl ReadODBC for SnowflakeBoolean {
             }
             CDataType::Char => {
                 let s = read_char_str(binding)?;
-                parse_str_to_bool(&s, binding.value_type)
+                parse_str_to_bool(&s)
             }
             CDataType::WChar => {
                 let s = read_wchar_str(binding)?;
-                parse_str_to_bool(&s, binding.value_type)
+                parse_str_to_bool(&s)
             }
             CDataType::Numeric => {
                 let n = read_unaligned::<sql::Numeric>(binding);
@@ -227,8 +235,10 @@ impl ReadODBC for SnowflakeBoolean {
                 if len == 0 {
                     return Ok(false);
                 }
-                let first = unsafe { *(binding.parameter_value_ptr as *const u8) };
-                Ok(first != 0)
+                let slice = unsafe {
+                    std::slice::from_raw_parts(binding.parameter_value_ptr as *const u8, len)
+                };
+                Ok(slice.iter().any(|&b| b != 0))
             }
             _ => UnsupportedCDataTypeSnafu {
                 c_type: binding.value_type,

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -213,6 +213,13 @@ pub enum JsonBindingError {
         location: Location,
     },
 
+    #[snafu(display("Invalid boolean value: {value}"))]
+    InvalidBooleanValue {
+        value: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to serialize bindings to JSON: {source}"))]
     Serialization {
         source: serde_json::Error,

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -220,6 +220,13 @@ pub enum JsonBindingError {
         location: Location,
     },
 
+    #[snafu(display("Numeric value out of range: {reason}"))]
+    BindingNumericOutOfRange {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to serialize bindings to JSON: {source}"))]
     Serialization {
         source: serde_json::Error,

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1577,7 +1577,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_binary_multibyte_nonzero_second_byte_to_boolean_true() -> TestResult {
+    fn convert_binary_multibyte_to_boolean_fails() {
         let val: [u8; 3] = [0x00, 0x01, 0x00];
         let mut ind: sql::Len = 3;
         let binding = make_binding(
@@ -1587,27 +1587,27 @@ mod tests {
             3,
             &mut ind,
         );
-        let (ty, v) = convert_binding(&binding)?;
-        assert_eq!(ty, SnowflakeLogicalType::Boolean);
-        assert_eq!(v, Value::String("true".to_string()));
-        Ok(())
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Multi-byte binary should be rejected for SQL_BIT (ODBC spec: len must equal 1)"
+        );
     }
 
     #[test]
-    fn convert_binary_multibyte_all_zero_to_boolean_false() -> TestResult {
-        let val: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
-        let mut ind: sql::Len = 4;
+    fn convert_binary_empty_to_boolean_fails() {
+        let val: [u8; 0] = [];
+        let mut ind: sql::Len = 0;
         let binding = make_binding(
             CDataType::Binary,
             sql::SqlDataType::EXT_BIT,
             val.as_ptr() as sql::Pointer,
-            4,
+            0,
             &mut ind,
         );
-        let (ty, v) = convert_binding(&binding)?;
-        assert_eq!(ty, SnowflakeLogicalType::Boolean);
-        assert_eq!(v, Value::String("false".to_string()));
-        Ok(())
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Empty binary should be rejected for SQL_BIT (ODBC spec: len must equal 1)"
+        );
     }
 
     #[test]
@@ -2512,7 +2512,7 @@ mod tests {
         );
         assert!(matches!(
             convert_binding(&binding),
-            Err(JsonBindingError::NumericMagnitudeOverflow { .. })
+            Err(JsonBindingError::InvalidBooleanValue { .. })
         ));
     }
 
@@ -2528,7 +2528,7 @@ mod tests {
         );
         assert!(matches!(
             convert_binding(&binding),
-            Err(JsonBindingError::NumericMagnitudeOverflow { .. })
+            Err(JsonBindingError::InvalidBooleanValue { .. })
         ));
     }
 
@@ -2650,7 +2650,7 @@ mod tests {
         );
         assert!(matches!(
             convert_binding(&binding),
-            Err(JsonBindingError::NumericMagnitudeOverflow { .. })
+            Err(JsonBindingError::InvalidBooleanValue { .. })
         ));
     }
 
@@ -2666,7 +2666,7 @@ mod tests {
         );
         assert!(matches!(
             convert_binding(&binding),
-            Err(JsonBindingError::NumericMagnitudeOverflow { .. })
+            Err(JsonBindingError::InvalidBooleanValue { .. })
         ));
     }
 }

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1113,6 +1113,326 @@ mod tests {
     }
 
     #[test]
+    fn convert_stinyint_to_boolean_true() -> TestResult {
+        let val: i8 = -1;
+        let binding = make_binding(
+            CDataType::STinyInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i8 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_stinyint_to_boolean_false() -> TestResult {
+        let val: i8 = 0;
+        let binding = make_binding(
+            CDataType::STinyInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i8 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_utinyint_to_boolean_true() -> TestResult {
+        let val: u8 = 255;
+        let binding = make_binding(
+            CDataType::UTinyInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u8 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ulong_to_boolean_true() -> TestResult {
+        let val: u32 = 1;
+        let binding = make_binding(
+            CDataType::ULong,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ulong_to_boolean_false() -> TestResult {
+        let val: u32 = 0;
+        let binding = make_binding(
+            CDataType::ULong,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ushort_to_boolean_true() -> TestResult {
+        let val: u16 = 1;
+        let binding = make_binding(
+            CDataType::UShort,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u16 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ushort_to_boolean_false() -> TestResult {
+        let val: u16 = 0;
+        let binding = make_binding(
+            CDataType::UShort,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u16 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ubigint_to_boolean_true() -> TestResult {
+        let val: u64 = 1;
+        let binding = make_binding(
+            CDataType::UBigInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ubigint_to_boolean_false() -> TestResult {
+        let val: u64 = 0;
+        let binding = make_binding(
+            CDataType::UBigInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const u64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_float_to_boolean_false() -> TestResult {
+        let val: f32 = 0.0;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_slong_negative_to_boolean_true() -> TestResult {
+        let val: i32 = -99;
+        let binding = make_binding(
+            CDataType::SLong,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_nan_to_boolean_fails() {
+        let val = b"NaN\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "NaN should not be accepted as a boolean value"
+        );
+    }
+
+    #[test]
+    fn convert_char_inf_to_boolean_fails() {
+        let val = b"inf\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "inf should not be accepted as a boolean value"
+        );
+    }
+
+    #[test]
+    fn convert_char_garbage_to_boolean_fails() {
+        let val = b"hello\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Non-numeric non-boolean string should fail"
+        );
+    }
+
+    #[test]
+    fn convert_sshort_to_boolean_false() -> TestResult {
+        let val: i16 = 0;
+        let binding = make_binding(
+            CDataType::SShort,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i16 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_sbigint_to_boolean_false() -> TestResult {
+        let val: i64 = 0;
+        let binding = make_binding(
+            CDataType::SBigInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_numeric_nonzero_to_boolean() -> TestResult {
+        let val = b"42\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_negative_to_boolean() -> TestResult {
+        let val = b"-1\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_float_string_to_boolean() -> TestResult {
+        let val = b"0.5\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_float_zero_string_to_boolean() -> TestResult {
+        let val = b"0.0\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
     fn convert_binary() -> TestResult {
         let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
         let mut ind: sql::Len = 4;

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1513,6 +1513,104 @@ mod tests {
     }
 
     #[test]
+    fn convert_char_neg_zero_string_to_boolean() -> TestResult {
+        let val = b"-0.0\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_float_neg_zero_to_boolean_false() -> TestResult {
+        let val: f32 = -0.0;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_double_neg_zero_to_boolean_false() -> TestResult {
+        let val: f64 = -0.0;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_float_neg_inf_to_boolean_fails() {
+        let val: f32 = f32::NEG_INFINITY;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Float -infinity should not convert to boolean"
+        );
+    }
+
+    #[test]
+    fn convert_binary_multibyte_nonzero_second_byte_to_boolean_true() -> TestResult {
+        let val: [u8; 3] = [0x00, 0x01, 0x00];
+        let mut ind: sql::Len = 3;
+        let binding = make_binding(
+            CDataType::Binary,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            3,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_binary_multibyte_all_zero_to_boolean_false() -> TestResult {
+        let val: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+        let mut ind: sql::Len = 4;
+        let binding = make_binding(
+            CDataType::Binary,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            4,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
     fn convert_binary() -> TestResult {
         let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
         let mut ind: sql::Len = 4;

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -840,6 +840,278 @@ mod tests {
         Ok(())
     }
 
+    // -- C types → BOOLEAN (SQL_BIT) ------------------------------------------
+
+    #[test]
+    fn convert_char_to_boolean_true() -> TestResult {
+        let val = b"1\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_to_boolean_false() -> TestResult {
+        let val = b"0\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_true_string_to_boolean() -> TestResult {
+        let val = b"true\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_char_false_string_to_boolean() -> TestResult {
+        let val = b"false\0";
+        let binding = make_binding(
+            CDataType::Char,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            sql::NTS,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_wchar_to_boolean_true() -> TestResult {
+        let val: [u16; 1] = [b'1' as u16];
+        let mut ind: sql::Len = 2;
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            2,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_wchar_to_boolean_false() -> TestResult {
+        let val: [u16; 1] = [b'0' as u16];
+        let mut ind: sql::Len = 2;
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            2,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_slong_to_boolean_true() -> TestResult {
+        let val: i32 = 42;
+        let binding = make_binding(
+            CDataType::SLong,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_slong_to_boolean_false() -> TestResult {
+        let val: i32 = 0;
+        let binding = make_binding(
+            CDataType::SLong,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_sbigint_to_boolean_true() -> TestResult {
+        let val: i64 = -1;
+        let binding = make_binding(
+            CDataType::SBigInt,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const i64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_double_to_boolean_true() -> TestResult {
+        let val: f64 = 1.5;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_double_to_boolean_false() -> TestResult {
+        let val: f64 = 0.0;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_float_to_boolean_true() -> TestResult {
+        let val: f32 = 0.5;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_numeric_to_boolean_true() -> TestResult {
+        let n = sql::Numeric {
+            precision: 10,
+            scale: 0,
+            sign: 1,
+            val: 1u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::EXT_BIT,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_numeric_to_boolean_false() -> TestResult {
+        let n = sql::Numeric {
+            precision: 10,
+            scale: 0,
+            sign: 1,
+            val: 0u128.to_le_bytes(),
+        };
+        let binding = make_binding(
+            CDataType::Numeric,
+            sql::SqlDataType::EXT_BIT,
+            &n as *const sql::Numeric as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_binary_to_boolean_true() -> TestResult {
+        let val: [u8; 1] = [0x01];
+        let mut ind: sql::Len = 1;
+        let binding = make_binding(
+            CDataType::Binary,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            1,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_binary_to_boolean_false() -> TestResult {
+        let val: [u8; 1] = [0x00];
+        let mut ind: sql::Len = 1;
+        let binding = make_binding(
+            CDataType::Binary,
+            sql::SqlDataType::EXT_BIT,
+            val.as_ptr() as sql::Pointer,
+            1,
+            &mut ind,
+        );
+        let (ty, v) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::Boolean);
+        assert_eq!(v, Value::String("false".to_string()));
+        Ok(())
+    }
+
     #[test]
     fn convert_binary() -> TestResult {
         let val: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1273,6 +1273,86 @@ mod tests {
     }
 
     #[test]
+    fn convert_float_nan_to_boolean_fails() {
+        let val: f32 = f32::NAN;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Float NaN should not convert to boolean"
+        );
+    }
+
+    #[test]
+    fn convert_float_inf_to_boolean_fails() {
+        let val: f32 = f32::INFINITY;
+        let binding = make_binding(
+            CDataType::Float,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f32 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Float infinity should not convert to boolean"
+        );
+    }
+
+    #[test]
+    fn convert_double_nan_to_boolean_fails() {
+        let val: f64 = f64::NAN;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Double NaN should not convert to boolean"
+        );
+    }
+
+    #[test]
+    fn convert_double_inf_to_boolean_fails() {
+        let val: f64 = f64::INFINITY;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Double infinity should not convert to boolean"
+        );
+    }
+
+    #[test]
+    fn convert_double_neg_inf_to_boolean_fails() {
+        let val: f64 = f64::NEG_INFINITY;
+        let binding = make_binding(
+            CDataType::Double,
+            sql::SqlDataType::EXT_BIT,
+            &val as *const f64 as sql::Pointer,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert!(
+            convert_binding(&binding).is_err(),
+            "Double -infinity should not convert to boolean"
+        );
+    }
+
+    #[test]
     fn convert_slong_negative_to_boolean_true() -> TestResult {
         let val: i32 = -99;
         let binding = make_binding(


### PR DESCRIPTION
Previously, ReadODBC for SnowflakeBoolean only handled SQL_C_BIT
(raw u8). Per the ODBC spec, SQL_BIT should accept all numeric C
types, SQL_C_CHAR, SQL_C_WCHAR, SQL_C_NUMERIC, and SQL_C_BINARY.

Added matching on binding.value_type for all integer types (nonzero
= true), float/double (nonzero = true, non-finite values rejected),
char/wchar (parse numeric string or "true"/"false"), numeric struct
(check val != 0), and binary (rejecting buffers with lenght other than 1).

CDataType::Default is handled explicitly (maps to u8, same as Bit).

Invalid boolean values (non-finite floats, unparseable strings) return
SQLSTATE 22018 (InvalidCharacterValueForCast) via a new
InvalidBooleanValue error variant in JsonBindingError.

Includes unit tests for each conversion path through the full
make_converter -> ParamConverter -> ReadODBC + WriteJson pipeline,
including edge cases: -0.0, NaN, ±inf, multi-byte binary buffers.

SNOW-3031772

Made-with: Cursor