### PR TITLE
NO-SNOW: Add mapping needed by dbt tests

### DIFF
--- a/python/src/snowflake/connector/__init__.py
+++ b/python/src/snowflake/connector/__init__.py
@@ -7,6 +7,7 @@ as defined in PEP 249.
 
 from typing import Any
 
+from . import util_text  # noqa: F401 - backward compatibility re-exports
 from ._internal.api_client.c_api import register_default_logger_callback
 from ._internal.decorators import pep249
 from .connection import Connection, SnowflakeConnection

--- a/python/src/snowflake/connector/_internal/type_codes.py
+++ b/python/src/snowflake/connector/_internal/type_codes.py
@@ -100,3 +100,27 @@ def get_type_code(snowflake_type: str) -> int:
     # Normalize type name: uppercase and strip leading/trailing whitespace (preserve internal spaces)
     normalized_type = snowflake_type.upper().strip()
     return SNOWFLAKE_TYPE_TO_CODE.get(normalized_type, TEXT)  # Default to TEXT if unknown
+
+
+# Reverse mapping: type code → canonical Snowflake type name.
+# Re-exported by snowflake.connector.constants for backward compatibility with
+# code written against the old snowflake-connector-python driver (e.g. dbt-snowflake).
+FIELD_ID_TO_NAME: dict[int, str] = {
+    FIXED: "FIXED",
+    REAL: "REAL",
+    TEXT: "TEXT",
+    DATE: "DATE",
+    TIMESTAMP: "TIMESTAMP",
+    VARIANT: "VARIANT",
+    TIMESTAMP_LTZ: "TIMESTAMP_LTZ",
+    TIMESTAMP_TZ: "TIMESTAMP_TZ",
+    TIMESTAMP_NTZ: "TIMESTAMP_NTZ",
+    OBJECT: "OBJECT",
+    ARRAY: "ARRAY",
+    BINARY: "BINARY",
+    TIME: "TIME",
+    BOOLEAN: "BOOLEAN",
+    GEOGRAPHY: "GEOGRAPHY",
+    GEOMETRY: "GEOMETRY",
+    VECTOR: "VECTOR",
+}

--- a/python/src/snowflake/connector/_internal/type_codes.py
+++ b/python/src/snowflake/connector/_internal/type_codes.py
@@ -4,6 +4,8 @@ Type code mappings for Snowflake data types to PEP 249 DB API 2.0.
 Maps Snowflake type names to integer type codes for cursor.description.
 """
 
+from ._internal.decorators import backward_compatibility
+
 # Type code constants for PEP 249 compliance
 # These match the indices from snowflake-connector-python for compatibility
 FIXED = 0
@@ -105,6 +107,7 @@ def get_type_code(snowflake_type: str) -> int:
 # Reverse mapping: type code → canonical Snowflake type name.
 # Re-exported by snowflake.connector.constants for backward compatibility with
 # code written against the old snowflake-connector-python driver (e.g. dbt-snowflake).
+@backward_compatibility
 FIELD_ID_TO_NAME: dict[int, str] = {
     FIXED: "FIXED",
     REAL: "REAL",

--- a/python/src/snowflake/connector/_internal/type_codes.py
+++ b/python/src/snowflake/connector/_internal/type_codes.py
@@ -4,8 +4,6 @@ Type code mappings for Snowflake data types to PEP 249 DB API 2.0.
 Maps Snowflake type names to integer type codes for cursor.description.
 """
 
-from ._internal.decorators import backward_compatibility
-
 # Type code constants for PEP 249 compliance
 # These match the indices from snowflake-connector-python for compatibility
 FIXED = 0
@@ -107,7 +105,6 @@ def get_type_code(snowflake_type: str) -> int:
 # Reverse mapping: type code → canonical Snowflake type name.
 # Re-exported by snowflake.connector.constants for backward compatibility with
 # code written against the old snowflake-connector-python driver (e.g. dbt-snowflake).
-@backward_compatibility
 FIELD_ID_TO_NAME: dict[int, str] = {
     FIXED: "FIXED",
     REAL: "REAL",

--- a/python/src/snowflake/connector/constants.py
+++ b/python/src/snowflake/connector/constants.py
@@ -2,6 +2,7 @@
 
 from enum import Enum, unique
 
+from ._internal.type_codes import FIELD_ID_TO_NAME  # noqa: F401 - backward compatibility re-exports
 from .config_manager import CONFIG_FILE, CONNECTIONS_FILE  # noqa: F401 - backward compatibility re-exports
 
 


### PR DESCRIPTION
## Summary
- Add missing mapping needed by dbt tests

## Context
Stacked on #788. Adds backward-compatibility mappings required for dbt-snowflake to work with the universal driver.

