### PR TITLE
Fix read_wchar_str to handle SQL_NTS and null indicator

### DIFF
--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -359,11 +359,33 @@ pub(crate) fn read_char_str(binding: &ParameterBinding) -> Result<String, JsonBi
 }
 
 /// Read a SQL_C_WCHAR (UTF-16) value and convert to a UTF-8 string.
+///
+/// When `StrLen_or_IndPtr` is NULL or points to `SQL_NTS`, the buffer is
+/// treated as null-terminated (scans for the first `0x0000` code unit).
+/// Otherwise the indicated byte length is used (clamped to `buffer_length`).
 pub(crate) fn read_wchar_str(binding: &ParameterBinding) -> Result<String, JsonBindingError> {
-    let byte_len = buffer_data_len(binding);
-    let unit_len = byte_len / mem::size_of::<u16>();
-    let units =
-        unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u16, unit_len) };
+    let null_terminated =
+        binding.str_len_or_ind_ptr.is_null() || unsafe { *binding.str_len_or_ind_ptr } == sql::NTS;
+
+    let units = if null_terminated {
+        let ptr = binding.parameter_value_ptr as *const u16;
+        let max_units = if binding.buffer_length > 0 {
+            binding.buffer_length as usize / mem::size_of::<u16>()
+        } else {
+            usize::MAX
+        };
+        let mut len = 0;
+        unsafe {
+            while len < max_units && *ptr.add(len) != 0 {
+                len += 1;
+            }
+            slice::from_raw_parts(ptr, len)
+        }
+    } else {
+        let byte_len = buffer_data_len(binding);
+        let unit_len = byte_len / mem::size_of::<u16>();
+        unsafe { slice::from_raw_parts(binding.parameter_value_ptr as *const u16, unit_len) }
+    };
     String::from_utf16(units).map_err(|_| WCharConversionSnafu.build())
 }
 
@@ -433,6 +455,67 @@ mod tests {
     ) -> Result<(SnowflakeLogicalType, Value), JsonBindingError> {
         let converter = make_converter(&binding.sql_data_type)?;
         converter.convert(binding)
+    }
+
+    // -- read_wchar_str tests -------------------------------------------------
+
+    #[test]
+    fn read_wchar_str_with_explicit_length() -> TestResult {
+        let data: [u16; 4] = ['h' as u16, 'i' as u16, '!' as u16, 0];
+        let mut ind: sql::Len = 3 * mem::size_of::<u16>() as sql::Len;
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::VARCHAR,
+            data.as_ptr() as sql::Pointer,
+            (4 * mem::size_of::<u16>()) as sql::Len,
+            &mut ind,
+        );
+        assert_eq!(read_wchar_str(&binding)?, "hi!");
+        Ok(())
+    }
+
+    #[test]
+    fn read_wchar_str_with_sql_nts() -> TestResult {
+        let data: [u16; 4] = ['h' as u16, 'i' as u16, '!' as u16, 0];
+        let mut ind: sql::Len = sql::NTS;
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::VARCHAR,
+            data.as_ptr() as sql::Pointer,
+            (4 * mem::size_of::<u16>()) as sql::Len,
+            &mut ind,
+        );
+        assert_eq!(read_wchar_str(&binding)?, "hi!");
+        Ok(())
+    }
+
+    #[test]
+    fn read_wchar_str_with_null_indicator() -> TestResult {
+        let data: [u16; 4] = ['h' as u16, 'i' as u16, '!' as u16, 0];
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::VARCHAR,
+            data.as_ptr() as sql::Pointer,
+            (4 * mem::size_of::<u16>()) as sql::Len,
+            std::ptr::null_mut(),
+        );
+        assert_eq!(read_wchar_str(&binding)?, "hi!");
+        Ok(())
+    }
+
+    #[test]
+    fn read_wchar_str_sql_nts_zero_buffer_length() -> TestResult {
+        let data: [u16; 4] = ['h' as u16, 'i' as u16, '!' as u16, 0];
+        let mut ind: sql::Len = sql::NTS;
+        let binding = make_binding(
+            CDataType::WChar,
+            sql::SqlDataType::VARCHAR,
+            data.as_ptr() as sql::Pointer,
+            0,
+            &mut ind,
+        );
+        assert_eq!(read_wchar_str(&binding)?, "hi!");
+        Ok(())
     }
 
     // -- ParamConverter tests per type ----------------------------------------

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -371,10 +371,8 @@ pub(crate) fn read_wchar_str(binding: &ParameterBinding) -> Result<String, JsonB
         let ptr = binding.parameter_value_ptr as *const u16;
         let max_units = if binding.buffer_length > 0 {
             binding.buffer_length as usize / mem::size_of::<u16>()
-        } else if binding.buffer_length == 0 {
-            usize::MAX
         } else {
-            0
+            usize::MAX
         };
         let mut len = 0;
         unsafe {

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -371,8 +371,10 @@ pub(crate) fn read_wchar_str(binding: &ParameterBinding) -> Result<String, JsonB
         let ptr = binding.parameter_value_ptr as *const u16;
         let max_units = if binding.buffer_length > 0 {
             binding.buffer_length as usize / mem::size_of::<u16>()
-        } else {
+        } else if binding.buffer_length == 0 {
             usize::MAX
+        } else {
+            0
         };
         let mut len = 0;
         unsafe {

--- a/odbc_tests/tests/e2e/query/c_char_to_varchar.cpp
+++ b/odbc_tests/tests/e2e/query/c_char_to_varchar.cpp
@@ -42,6 +42,24 @@ TEST_CASE("should bind SQL_C_WCHAR to SQL_VARCHAR.", "[query][bind_parameter][c_
   CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "hello");
 }
 
+TEST_CASE("should bind SQL_C_WCHAR with SQL_NTS to SQL_VARCHAR.", "[query][bind_parameter][c_char_to_varchar]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLWCHAR param[] = {'h', 'e', 'l', 'l', 'o', 0};
+  SQLLEN indicator = SQL_NTS;
+  // When the C type value is bound with SQL_NTS indicator and SELECT ? is executed
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR, 100, 0, param,
+                                   sizeof(param), &indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  // Then the result should be the expected string
+  CHECK(get_data<SQL_C_CHAR>(stmt, 1) == "hello");
+}
+
 TEST_CASE("should bind SQL_C_DEFAULT to SQL_VARCHAR.", "[query][bind_parameter][c_char_to_varchar]") {
   // Given Snowflake client is logged in
   Connection conn;

--- a/tests/definitions/odbc/query/c_char_to_varchar.feature
+++ b/tests/definitions/odbc/query/c_char_to_varchar.feature
@@ -17,6 +17,12 @@ Feature: ODBC SQLBindParameter C char/default types to VARCHAR conversion
     Then the result should be the expected string
 
   @odbc_e2e
+  Scenario: should bind SQL_C_WCHAR with SQL_NTS to SQL_VARCHAR.
+    Given Snowflake client is logged in
+    When the C type value is bound with SQL_NTS indicator and SELECT ? is executed
+    Then the result should be the expected string
+
+  @odbc_e2e
   Scenario: should bind SQL_C_DEFAULT to SQL_VARCHAR.
     Given Snowflake client is logged in
     When the C type value is bound as a string SQL type and SELECT ? is executed


### PR DESCRIPTION
read_wchar_str previously always used buffer_data_len, which does not
understand SQL_NTS (-1). When an application binds SQL_C_WCHAR with
SQL_NTS indicator (or a null indicator pointer), the function would
either read zero code units (empty string) or include the null
terminator in the data, causing downstream parse failures.

Mirror read_char_str behavior: when str_len_or_ind_ptr is NULL or
SQL_NTS, scan for the first 0x0000 code unit to determine string
length. This affects all 7 callers (varchar, number, boolean, real,
date, time, timestamp).

Made-with: Cursor