### PR TITLE
SNOW-2433865 add more data types performance tests, adjust test scope

### DIFF
--- a/tests/performance/tests/test_select_1M.py
+++ b/tests/performance/tests/test_select_1M.py
@@ -1,8 +1,7 @@
 import pytest
 
-# Match recorded_http iteration counts for fair CoV comparison
-ITERATIONS = 30
-WARMUP_ITERATIONS = 1
+ITERATIONS = 10
+WARMUP_ITERATIONS = 2
 
 
 @pytest.mark.iterations(ITERATIONS)
@@ -31,9 +30,9 @@ def test_select_date_1M_arrow(perf_test):
 
 @pytest.mark.iterations(ITERATIONS)
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_float_1M_arrow(perf_test):
+def test_select_timestamp_ntz_1M_arrow(perf_test):
     perf_test(
-        sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000"
+        sql_command="SELECT L_SHIPDATE::TIMESTAMP_NTZ FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000"
     )
 
 
@@ -62,48 +61,3 @@ def test_select_15columns_1M_arrow(perf_test):
             LIMIT 1000000
         """
     )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_string_1M_ordered_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000"
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_number_1M_ordered_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 1000000"
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_15columns_1M_ordered_arrow(perf_test):
-    perf_test(
-        sql_command="""
-            SELECT 
-                L_ORDERKEY,
-                L_PARTKEY,
-                L_SUPPKEY,
-                L_LINENUMBER,
-                L_QUANTITY,
-                L_EXTENDEDPRICE,
-                L_DISCOUNT,
-                L_TAX,
-                L_RETURNFLAG,
-                L_LINESTATUS,
-                L_SHIPDATE,
-                L_COMMITDATE,
-                L_RECEIPTDATE,
-                L_SHIPINSTRUCT,
-                L_COMMENT
-            FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM 
-            ORDER BY L_ORDERKEY
-            LIMIT 1000000
-        """
-    )
-

--- a/tests/performance/tests/test_select_1M_recorded_http.py
+++ b/tests/performance/tests/test_select_1M_recorded_http.py
@@ -2,7 +2,7 @@
 import pytest
 from runner.test_types import PerfTestType
 
-ITERATIONS = 30
+ITERATIONS = 10
 WARMUP_ITERATIONS = 2
 
 
@@ -39,6 +39,60 @@ def test_select_float_1M_arrow_recorded_http(perf_test):
     perf_test(
         test_type=PerfTestType.SELECT_RECORDED_HTTP,
         sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_double_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_EXTENDEDPRICE::DOUBLE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_boolean_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT (L_TAX > 0.04)::BOOLEAN FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_timestamp_ntz_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_SHIPDATE::TIMESTAMP_NTZ FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_timestamp_tz_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT L_SHIPDATE::TIMESTAMP_TZ FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_time_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT TIME_FROM_PARTS(MOD(L_ORDERKEY, 24), MOD(L_PARTKEY, 60), MOD(L_SUPPKEY, 60)) FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
+    )
+
+
+@pytest.mark.iterations(ITERATIONS)
+@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
+def test_select_binary_1M_arrow_recorded_http(perf_test):
+    perf_test(
+        test_type=PerfTestType.SELECT_RECORDED_HTTP,
+        sql_command="SELECT TO_BINARY(L_COMMENT, 'UTF-8') FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 1000000",
     )
 
 

--- a/tests/performance/tests/test_select_50M.py
+++ b/tests/performance/tests/test_select_50M.py
@@ -1,39 +1,7 @@
 import pytest
 
-ITERATIONS = 5
-WARMUP_ITERATIONS = 1
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_string_50M_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000"
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_number_50M_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000"
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_date_50M_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_SHIPDATE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000"
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_float_50M_arrow(perf_test):
-    perf_test(
-        sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000"
-    )
+ITERATIONS = 3
+WARMUP_ITERATIONS = 0
 
 
 @pytest.mark.iterations(ITERATIONS)

--- a/tests/performance/tests/test_select_50M_recorded_http.py
+++ b/tests/performance/tests/test_select_50M_recorded_http.py
@@ -1,8 +1,8 @@
 import pytest
 from runner.test_types import PerfTestType
 
-ITERATIONS = 5
-WARMUP_ITERATIONS = 1
+ITERATIONS = 3
+WARMUP_ITERATIONS = 0
 
 
 @pytest.mark.iterations(ITERATIONS)
@@ -31,16 +31,6 @@ def test_select_date_50M_arrow_recorded_http(perf_test):
         sql_command="SELECT L_SHIPDATE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
     )
 
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_float_50M_arrow_recorded_http(perf_test):
-    perf_test(
-        test_type=PerfTestType.SELECT_RECORDED_HTTP,
-        sql_command="SELECT L_EXTENDEDPRICE FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM LIMIT 50000000",
-    )
-
-
 @pytest.mark.iterations(ITERATIONS)
 @pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
 def test_select_15columns_50M_arrow_recorded_http(perf_test):
@@ -66,22 +56,4 @@ def test_select_15columns_50M_arrow_recorded_http(perf_test):
             FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM 
             LIMIT 50000000
         """,
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_string_50M_ordered_arrow_recorded_http(perf_test):
-    perf_test(
-        test_type=PerfTestType.SELECT_RECORDED_HTTP,
-        sql_command="SELECT L_COMMENT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
-    )
-
-
-@pytest.mark.iterations(ITERATIONS)
-@pytest.mark.warmup_iterations(WARMUP_ITERATIONS)
-def test_select_number_50M_ordered_arrow_recorded_http(perf_test):
-    perf_test(
-        test_type=PerfTestType.SELECT_RECORDED_HTTP,
-        sql_command="SELECT L_LINENUMBER::INT FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM ORDER BY L_ORDERKEY LIMIT 50000000",
     )


### PR DESCRIPTION
Restructures the performance test suite to improve type coverage while significantly reducing CI runtime, based on BenchDash CoV analysis and Jenkins failure investigation.

Key decisions:

-  1M recorded HTTP — added 6 new data types (double, boolean, timestamp_ntz, timestamp_tz, time, binary)

- 1M E2E is a focused smoke set —5 data types
- 50M E2E reduced to 15column test
- 50M recorded HTTP retains string, number, date, and 15col — dropped float (tracked number almost perfectly, r=0.95; number is faster and more prevalent)

Ordered variants: BenchDash analysis showed <1% difference from unordered results at 1M scale. A few ordered tests are retained in the suite for further investigation

Iteration reductions based on statistical analysis:
1M tests: 30 → 10 iterations (between-run variance dominates; extra iterations yield negligible improvement)
50M tests: 5 → 3 iterations, warmup removed (CoV <1.5% without warmup; each iteration is 18-65s, making JIT/cache effects negligible)