### PR TITLE
SNOW-2433865 validate returned rows in perf tests, improve error propagation

### DIFF
--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -89,7 +89,7 @@ pub fn run_test_iterations(
     iterations: usize,
 ) -> Result<Vec<IterationResult>> {
     let mut results = Vec::with_capacity(iterations);
-    let mut expected_row_count = get_expected_row_count();
+    let mut expected_row_count = get_expected_row_count()?;
 
     for i in 0..iterations {
         let (query_time, fetch_time, row_count, cpu_time_s, peak_rss_mb) =
@@ -114,7 +114,7 @@ pub fn run_test_iterations(
     Ok(results)
 }
 
-fn get_expected_row_count() -> Option<usize> {
+fn get_expected_row_count() -> Result<Option<usize>> {
     let expected_from_recording = std::env::var("EXPECTED_ROW_COUNT")
         .ok()
         .and_then(|s| s.parse::<usize>().ok());
@@ -124,9 +124,10 @@ fn get_expected_row_count() -> Option<usize> {
             "Row count baseline: {} rows (from recording phase)",
             expected
         );
-        Some(expected)
+        assert_nonzero_row_count(expected)?;
+        Ok(Some(expected))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -148,8 +149,20 @@ fn validate_row_count(
             "Row count baseline: {} rows (from first iteration)",
             row_count
         );
+        assert_nonzero_row_count(row_count)?;
         Ok(Some(row_count))
     }
+}
+
+fn assert_nonzero_row_count(count: usize) -> Result<()> {
+    if count == 0 {
+        return Err(
+            "Row count baseline is 0 — this likely indicates a silent \
+             query failure (e.g. async execution timeout). Refusing to use 0 as baseline."
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 fn execute_iteration(
@@ -175,7 +188,11 @@ fn execute_iteration(
     let row_count = if let Some(result) = response.result {
         fetch_result_rows(result).map_err(|e| format!("Failed to fetch results: {e:?}"))?
     } else {
-        0
+        return Err(
+            "Query returned no result set (response.result is None). \
+             This may indicate a silent async execution timeout or server error."
+                .to_string(),
+        );
     };
     let fetch_time = start_fetch.elapsed().as_secs_f64();
     let cpu_time_s = process_cpu_seconds() - cpu_before;

--- a/tests/performance/drivers/odbc/app/query_execution.cpp
+++ b/tests/performance/drivers/odbc/app/query_execution.cpp
@@ -21,6 +21,7 @@ void validate_row_counts(const std::vector<TestResult>& results);
 void print_statistics(const std::vector<TestResult>& results);
 TestResult run_query(SQLHDBC dbc, const std::string& sql, int iteration);
 std::pair<std::size_t, std::size_t> get_expected_row_count(const std::vector<TestResult>& results);
+void assert_nonzero_row_count(std::size_t count);
 void check_row_count_match(std::size_t actual_count, std::size_t expected_count, std::size_t iteration);
 void bind_columns_for_bulk_fetch(SQLHSTMT stmt, SQLSMALLINT column_count, std::vector<std::vector<char>>& char_bufs,
                                  std::vector<std::vector<SQLLEN>>& indicators);
@@ -112,14 +113,24 @@ std::pair<std::size_t, std::size_t> get_expected_row_count(const std::vector<Tes
   if (expected_from_recording) {
     expected_count = std::stoull(expected_from_recording);
     std::cout << "Row count baseline: " << expected_count << " rows (from recording phase)\n";
+    assert_nonzero_row_count(expected_count);
     start_idx = 0;
   } else {
     expected_count = results[0].row_count;
     std::cout << "Row count baseline: " << expected_count << " rows (from first iteration)\n";
+    assert_nonzero_row_count(expected_count);
     start_idx = 1;
   }
 
   return {expected_count, start_idx};
+}
+
+void assert_nonzero_row_count(std::size_t count) {
+  if (count == 0) {
+    std::cerr << "ERROR: Row count baseline is 0 — this likely indicates a silent query failure "
+              << "(e.g. async execution timeout). Refusing to use 0 as baseline.\n";
+    exit(1);
+  }
 }
 
 void check_row_count_match(std::size_t actual_count, std::size_t expected_count, std::size_t iteration) {

--- a/tests/performance/drivers/python/app/main.py
+++ b/tests/performance/drivers/python/app/main.py
@@ -38,18 +38,25 @@ def main():
     
     try:
         execute_setup_queries(cursor, setup_queries)
-    except Exception:
+    except Exception as e:
+        print(f"❌ Setup query failed: {e}")
         cursor.close()
         conn.close()
         sys.exit(1)
     
-    results, memory_timeline = execute_test(
-        config.test_type, 
-        cursor, 
-        config.sql_command, 
-        config.warmup_iterations, 
-        config.iterations
-    )
+    try:
+        results, memory_timeline = execute_test(
+            config.test_type, 
+            cursor, 
+            config.sql_command, 
+            config.warmup_iterations, 
+            config.iterations
+        )
+    except Exception as e:
+        print(f"❌ Test execution failed: {e}")
+        cursor.close()
+        conn.close()
+        sys.exit(1)
     
     # In replay mode, skip server version query and use N/A
     if os.getenv("WIREMOCK_REPLAY") == "true":

--- a/tests/performance/drivers/python/app/query_execution.py
+++ b/tests/performance/drivers/python/app/query_execution.py
@@ -63,17 +63,30 @@ def _get_expected_row_count(results):
     
     Returns:
         tuple: (expected_count, start_idx) where start_idx is the first index to validate
+    
+    Raises:
+        RuntimeError: If the expected row count is 0 (indicates a silent query failure)
     """
     expected_from_recording = os.getenv("EXPECTED_ROW_COUNT")
     if expected_from_recording:
         expected_count = int(expected_from_recording)
         print(f"Row count baseline: {expected_count} rows (from recording phase)")
+        _assert_nonzero_row_count(expected_count)
         return expected_count, 0  # Validate all iterations including first
     else:
-        # Use first iteration as baseline
         expected_count = results[0]['row_count']
         print(f"Row count baseline: {expected_count} rows (from first iteration)")
+        _assert_nonzero_row_count(expected_count)
         return expected_count, 1  # Skip first iteration since it's the baseline
+
+
+def _assert_nonzero_row_count(count):
+    """Reject 0-row baselines that indicate silent query failures."""
+    if count == 0:
+        raise RuntimeError(
+            "Row count baseline is 0 — this likely indicates a silent "
+            "query failure (e.g. async execution timeout). Refusing to use 0 as baseline."
+        )
 
 
 def _check_row_count_match(actual_count, expected_count, iteration):

--- a/tests/performance/runner/container.py
+++ b/tests/performance/runner/container.py
@@ -157,7 +157,6 @@ def run_container(container: DockerContainer) -> str:
         
         if exit_code != 0:
             logger.error(f"\nContainer exited with code {exit_code}")
-            # If streaming failed, show all logs now
             if stream_error or not logs_buffer:
                 logger.error("="*80)
                 logger.error("FULL CONTAINER OUTPUT:")
@@ -166,6 +165,12 @@ def run_container(container: DockerContainer) -> str:
                     if line.strip():
                         logger.error(line)
                 logger.error("="*80)
+
+            tail_lines = [l for l in logs_combined.splitlines() if l.strip()][-20:]
+            raise RuntimeError(
+                f"Container exited with code {exit_code}. "
+                f"Last output:\n" + "\n".join(tail_lines)
+            )
         
     return logs_combined
 

--- a/tests/performance/runner/modes/common.py
+++ b/tests/performance/runner/modes/common.py
@@ -1,6 +1,7 @@
 """Common test execution utilities for performance tests."""
 import logging
 import os
+import re
 from pathlib import Path
 
 from runner.container import create_perf_container, run_container
@@ -8,6 +9,12 @@ from runner.test_types import PerfTestType
 from runner.validation import verify_results
 
 logger = logging.getLogger(__name__)
+
+
+def extract_limit_from_sql(sql: str) -> int | None:
+    """Extract the LIMIT value from a SQL command, if present."""
+    match = re.search(r'\bLIMIT\s+(\d+)', sql, re.IGNORECASE)
+    return int(match.group(1)) if match else None
 
 
 def execute_test(

--- a/tests/performance/runner/modes/e2e_runner.py
+++ b/tests/performance/runner/modes/e2e_runner.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from runner.modes.common import execute_test, verify_test_results
+from runner.modes.common import execute_test, extract_limit_from_sql, verify_test_results
 from runner.test_types import PerfTestType
 
 logger = logging.getLogger(__name__)
@@ -51,6 +51,11 @@ def run_performance_test(
     
     logger.info(f"Running {test_name} ({driver_label}): {iterations} iterations [type={test_type}]")
     
+    env_vars = {}
+    expected = extract_limit_from_sql(sql_command)
+    if expected:
+        env_vars["EXPECTED_ROW_COUNT"] = str(expected)
+    
     execute_test(
         test_name=test_name,
         sql_command=sql_command,
@@ -64,6 +69,7 @@ def run_performance_test(
         test_type=test_type,
         use_local_binary=use_local_binary,
         s3_files_dir=s3_files_dir,
+        env_vars=env_vars,
     )
     
     return verify_test_results(

--- a/tests/performance/runner/modes/wiremock_runner.py
+++ b/tests/performance/runner/modes/wiremock_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from runner.docker_network import DockerNetworkManager
-from runner.modes.common import execute_test, verify_test_results
+from runner.modes.common import execute_test, extract_limit_from_sql, verify_test_results
 from runner.test_types import PerfTestType
 from runner.utils import perf_tests_root
 from wiremock.wiremock_manager import WiremockManager
@@ -574,6 +574,10 @@ def _run_test_with_proxy(
         if expected_row_count is not None:
             logger.info(f"Setting EXPECTED_ROW_COUNT={expected_row_count} for replay validation")
             env_vars["EXPECTED_ROW_COUNT"] = str(expected_row_count)
+    else:
+        expected = extract_limit_from_sql(sql_command)
+        if expected:
+            env_vars["EXPECTED_ROW_COUNT"] = str(expected)
     
     # Export the WireMock CA cert so the driver trusts the dynamically generated
     # MITM certificates. Each Dockerfile appends this to the appropriate CA bundle.
@@ -584,11 +588,10 @@ def _run_test_with_proxy(
             if driver == "odbc" and driver_type == "old":
                 env_vars["WIREMOCK_PROXY_URL"] = proxy_url
         except Exception as e:
-            logger.error(
-                "Failed to export WireMock CA cert; skipping this test execution.",
-                exc_info=True,
-            )
-            return
+            raise RuntimeError(
+                f"Failed to export WireMock CA cert: {e}. "
+                f"The driver container cannot trust WireMock's MITM certificates without it."
+            ) from e
     
     # Execute test with common function
     execute_test(


### PR DESCRIPTION
Row count validation (all drivers):
Auto-extract LIMIT N from SQL commands and pass as EXPECTED_ROW_COUNT to driver containers, so every SELECT test validates it fetched exactly the expected number of rows
Applies to both E2E and recorded HTTP tests with zero changes to test definitions
Reject 0-row baselines immediately with a clear error message pointing to likely causes (async timeout, server error)

Error propagation fixes:
run_container now raises RuntimeError with the last 20 lines of container output on non-zero exit, instead of silently continuing to verify_results which would report a generic "No result files found"
Rust core fails explicitly when response.result is None instead of silently returning 0 rows
Python driver now logs the actual exception for setup query and test execution failures before sys.exit(1)
WireMock CA cert export failure raises instead of silently returning, which caused misleading downstream errors