### PR TITLE
SNOW-2399387 split perf PR builds and smoke tests to separate nodes to decrease check time

### DIFF
--- a/tests/performance/Jenkinsfile.pr-check
+++ b/tests/performance/Jenkinsfile.pr-check
@@ -1,9 +1,19 @@
 #!/usr/bin/env groovy
 
-pipeline {
-    agent {
-        label 'regular-memory-node-snowos'
+def setupVenv() {
+    dir('tests/performance') {
+        sh '''
+            python3.11 --version
+            python3.11 -m venv .venv
+            source .venv/bin/activate
+            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install hatch "virtualenv<21.0.0"
+        '''
     }
+}
+
+pipeline {
+    agent none
 
     options {
         timestamps()
@@ -20,106 +30,98 @@ pipeline {
     }
 
     stages {
-        stage('Install Dependencies') {
-            steps {
-                dir('tests/performance') {
-                    sh '''
-                        python3.11 --version
-                        python3.11 -m venv .venv
-                        source .venv/bin/activate
-                        python -m pip install --upgrade pip setuptools wheel
-                        python -m pip install hatch "virtualenv<21.0.0"
-                    '''
-                }
-            }
-        }
-
-        stage('Build Docker Images') {
+        stage('PR Check') {
+            failFast true
             parallel {
-                stage('Core + WireMock') {
-                    steps {
-                        withCredentials([
-                            usernamePassword(
-                                credentialsId: '063fc85b-62a6-4181-9d72-873b43488411',
-                                usernameVariable: 'AWS_ACCESS_KEY_ID',
-                                passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                            )
-                        ]) {
-                            sh 'tests/performance/drivers/core/build.sh'
-                            sh 'tests/performance/wiremock/build.sh'
+                stage('Core') {
+                    agent { label 'regular-memory-node-snowos' }
+                    stages {
+                        stage('Setup - Core') {
+                            steps {
+                                setupVenv()
+                            }
+                        }
+                        stage('Build - Core + WireMock') {
+                            steps {
+                                withCredentials([
+                                    usernamePassword(
+                                        credentialsId: '063fc85b-62a6-4181-9d72-873b43488411',
+                                        usernameVariable: 'AWS_ACCESS_KEY_ID',
+                                        passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+                                    )
+                                ]) {
+                                    sh 'tests/performance/drivers/core/build.sh'
+                                    sh 'tests/performance/wiremock/build.sh'
+                                }
+                            }
+                        }
+                        stage('Smoke Test - Core') {
+                            steps {
+                                withCredentials([
+                                    string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')
+                                ]) {
+                                    sh './scripts/decode_secrets.sh'
+                                }
+                                dir('tests/performance') {
+                                    withCredentials([
+                                        file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
+                                    ]) {
+                                        sh '''
+                                            source .venv/bin/activate
+                                            export CLOUD=aws
+                                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=core --iterations=1 --warmup-iterations=0 -s -v
+                                        '''
+                                    }
+                                }
+                            }
                         }
                     }
                 }
+
                 stage('Python + ODBC') {
-                    steps {
-                        withCredentials([
-                            usernamePassword(
-                                credentialsId: '063fc85b-62a6-4181-9d72-873b43488411',
-                                usernameVariable: 'AWS_ACCESS_KEY_ID',
-                                passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                            )
-                        ]) {
-                            sh 'tests/performance/drivers/python/build.sh'
-                            sh 'tests/performance/drivers/odbc/build.sh'
+                    agent { label 'regular-memory-node-snowos' }
+                    stages {
+                        stage('Setup - Python/ODBC') {
+                            steps {
+                                setupVenv()
+                            }
                         }
-                    }
-                }
-            }
-        }
-
-        stage('Decrypt Secrets') {
-            steps {
-                withCredentials([
-                    string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')
-                ]) {
-                    sh './scripts/decode_secrets.sh'
-                }
-            }
-        }
-
-        stage('Smoke Test - Core') {
-            steps {
-                dir('tests/performance') {
-                    withCredentials([
-                        file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
-                    ]) {
-                        sh '''
-                            source .venv/bin/activate
-                            export CLOUD=aws
-                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=core --iterations=1 --warmup-iterations=0 -s -v
-                        '''
-                    }
-                }
-            }
-        }
-
-        stage('Smoke Test - Python (both)') {
-            steps {
-                dir('tests/performance') {
-                    withCredentials([
-                        file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
-                    ]) {
-                        sh '''
-                            source .venv/bin/activate
-                            export CLOUD=aws
-                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=python --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
-                        '''
-                    }
-                }
-            }
-        }
-
-        stage('Smoke Test - ODBC (both)') {
-            steps {
-                dir('tests/performance') {
-                    withCredentials([
-                        file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
-                    ]) {
-                        sh '''
-                            source .venv/bin/activate
-                            export CLOUD=aws
-                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=odbc --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
-                        '''
+                        stage('Build - Python + ODBC') {
+                            steps {
+                                withCredentials([
+                                    usernamePassword(
+                                        credentialsId: '063fc85b-62a6-4181-9d72-873b43488411',
+                                        usernameVariable: 'AWS_ACCESS_KEY_ID',
+                                        passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+                                    )
+                                ]) {
+                                    sh 'tests/performance/drivers/python/build.sh'
+                                    sh 'tests/performance/drivers/odbc/build.sh'
+                                    sh 'tests/performance/wiremock/build.sh'
+                                }
+                            }
+                        }
+                        stage('Smoke Test - Python + ODBC') {
+                            steps {
+                                withCredentials([
+                                    string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')
+                                ]) {
+                                    sh './scripts/decode_secrets.sh'
+                                }
+                                dir('tests/performance') {
+                                    withCredentials([
+                                        file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
+                                    ]) {
+                                        sh '''
+                                            source .venv/bin/activate
+                                            export CLOUD=aws
+                                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=python --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
+                                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=odbc --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
+                                        '''
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/performance/drivers/python/Dockerfile
+++ b/tests/performance/drivers/python/Dockerfile
@@ -28,11 +28,11 @@ COPY tests/performance/drivers/python/app/ /workdir/
 ENV PYTHONUNBUFFERED=1
 
 # ============================================================================
-# Universal driver: builds Rust core + Cython extensions
+# Universal driver: Cython extensions + pre-built Rust core
 # ============================================================================
 FROM base AS universal
 
-# Install Rust toolchain
+# Install Rust toolchain (needed for proto_generator during pip install)
 COPY rust-toolchain.toml ./rust-toolchain.toml
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -68,9 +68,13 @@ RUN cd python && \
     ln -s ../error_trace error_trace && \
     ln -s ../error_trace_derive error_trace_derive
 
-RUN rustc --version | awk '{print $2}' | cut -d. -f1,2 > /etc/rust_version
+# Use pre-built libsf_core.so from sf-core-builder.
+COPY tests/performance/.tmp/libsf_core.so /workdir/python/src/snowflake/connector/_core/libsf_core.so
+COPY tests/performance/.tmp/rust_version /etc/rust_version
 
-# Install the driver — builds Rust core and Cython extensions via hatch_build.py
+# Install the driver — builds Cython extensions via hatch_build.py.
+# SKIP_CORE_BUILD tells hatch to skip cargo build of sf_core (we use the pre-built one above).
+ENV SKIP_CORE_BUILD=1
 RUN pip install --no-cache-dir /workdir/python/
 
 ENV DRIVER_TYPE=universal

--- a/tests/performance/drivers/python/build.sh
+++ b/tests/performance/drivers/python/build.sh
@@ -12,6 +12,45 @@ echo "Building Python performance drivers..."
 echo "Platform: ${BUILDPLATFORM}"
 echo ""
 
+# Cleanup function
+cleanup() {
+  rm -rf tests/performance/.tmp
+}
+trap cleanup EXIT INT TERM
+
+# Create temp directory
+mkdir -p tests/performance/.tmp
+
+# Step 1: Build sf-core-builder (shared with ODBC — builds libsf_core.so)
+echo "→ Building sf-core-builder..."
+docker build -f tests/performance/drivers/Dockerfile.sf_core_builder \
+  --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
+  -t sf-core-builder:latest .
+
+echo ""
+echo "✓ sf-core-builder ready"
+echo ""
+
+# Step 2: Extract libsf_core.so from the builder image
+echo "→ Extracting libsf_core.so from sf-core-builder..."
+docker rm -f sf-core-extract >/dev/null 2>&1 || true
+docker create --name sf-core-extract sf-core-builder:latest >/dev/null 2>&1
+if docker cp sf-core-extract:/workdir/libsf_core.so tests/performance/.tmp/libsf_core.so 2>/dev/null; then
+    echo "✓ Extracted libsf_core.so"
+else
+    echo "Error: Could not extract libsf_core.so"
+    docker rm -f sf-core-extract >/dev/null 2>&1
+    exit 1
+fi
+docker rm -f sf-core-extract >/dev/null 2>&1
+
+# Get Rust version from sf-core-builder (the version that actually built libsf_core.so)
+RUST_VERSION=$(docker run --rm sf-core-builder:latest rustc --version 2>/dev/null | awk '{print $2}' | cut -d. -f1,2 || echo "NA")
+echo "${RUST_VERSION}" > tests/performance/.tmp/rust_version
+echo "✓ Rust version: ${RUST_VERSION}"
+echo ""
+
+# Step 3: Build universal driver image (uses pre-built libsf_core.so, skips cargo build)
 echo "→ Building universal driver image..."
 docker build -f tests/performance/drivers/python/Dockerfile \
   --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \
@@ -22,6 +61,7 @@ echo ""
 echo "✓ Built: python-perf-driver-universal:latest"
 echo ""
 
+# Step 4: Build old driver image
 echo "→ Building old driver image..."
 docker build -f tests/performance/drivers/python/Dockerfile \
   --build-arg BUILDPLATFORM="${BUILDPLATFORM}" \


### PR DESCRIPTION
Changes
Parallel nodes: Split the single-node pipeline into two parallel Jenkins nodes — Core and Python + ODBC — so builds and smoke tests run concurrently
Python reuses sf-core-builder: python/build.sh now builds sf-core-builder first and extracts the pre-built libsf_core.so, skipping the redundant cargo build --release --package sf_core inside pip install (via SKIP_CORE_BUILD=1). When ODBC builds next on the same node, Docker layer cache makes its sf-core-builder build near-instant
failFast: Parallel branches abort immediately on first failure