### PR TITLE
NO-SNOW: Retry transient SQLConnect failures in StmtFixture and preserve diagnostics

### DIFF
--- a/odbc_tests/common/include/ODBCFixtures.hpp
+++ b/odbc_tests/common/include/ODBCFixtures.hpp
@@ -4,8 +4,10 @@
 #include <sql.h>
 #include <sqlext.h>
 
+#include <chrono>
 #include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include <catch2/catch_test_macros.hpp>
@@ -14,6 +16,7 @@
 #include "ODBCConfig.hpp"
 #include "compatibility.hpp"
 #include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
 
 // ============================================================================
 // Base Fixtures (Parameterized via Constructor)
@@ -108,11 +111,29 @@ class StmtFixture : public DbcFixture {
  public:
   explicit StmtFixture(std::optional<DataSourceConfig> dsn_config = std::nullopt) : DbcFixture(std::move(dsn_config)) {
     const std::string dsn = dsn_name();
-    SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
-    REQUIRE(ret == SQL_SUCCESS);
+
+    constexpr int max_retries = 3;
+    SQLRETURN ret = SQL_ERROR;
+    std::string last_error;
+
+    for (int attempt = 1; attempt <= max_retries; ++attempt) {
+      ret = SQLConnect(dbc_handle(), sqlchar(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
+      if (SQL_SUCCEEDED(ret)) break;
+
+      last_error = Catch::StringMaker<OdbcResult>::convert(OdbcResult(ret, SQL_HANDLE_DBC, dbc_handle()));
+
+      if (attempt < max_retries) {
+        WARN("SQLConnect attempt " << attempt << "/" << max_retries << " failed: " << last_error << " — retrying");
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+      }
+    }
+
+    if (!SQL_SUCCEEDED(ret)) {
+      FAIL("SQLConnect failed after " << max_retries << " attempts: " << last_error);
+    }
 
     ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
-    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(SQL_SUCCEEDED(ret));
   }
 
   ~StmtFixture() {


### PR DESCRIPTION
## Summary

- Retry transient connection failures: `StmtFixture::SQLConnect` now retries up to 3 times with a 2-second delay between attempts. This addresses flaky test failures on macOS ARM64 GCP where transient auth/infra errors cause `SQLConnect` to fail sporadically, breaking unrelated tests.

- Preserve ODBC diagnostics on failure: Previously, the fixture used a bare `REQUIRE(ret == SQL_SUCCESS)` which only showed `-1 == 0` on failure — losing the SQLSTATE and error message entirely. Now extracts diagnostics via `SQLGetDiagRec` and reports them in the failure message, making CI failures actionable.

- Log intermediate retry failures: Each failed attempt emits a Catch2 `WARN` with the full diagnostic, so transient errors are visible in test output even when the retry succeeds.

## Context
The `SQLProcedureColumns: Can call multiple times on same statement after close cursor` test has been failing intermittently on macOS ARM64 GCP at `ODBCFixtures.hpp:112`. Investigation showed this is a transient `SQLConnect` failure (the test already uses `ReadOnlyDbStmtFixture`, so it's not a DDL/fixture issue). Other tests using the same fixture in the same CI run succeeded, confirming it's a one-off connection error. The actual SQLSTATE was never captured because the old code discarded it.