### PR TITLE
NO-SNOW: Implement callproc method on cursor and clean up stubs

### DIFF
--- a/python/src/snowflake/connector/_internal/binding_converters.py
+++ b/python/src/snowflake/connector/_internal/binding_converters.py
@@ -73,6 +73,23 @@ class ParamStyle(Enum):
         """Check if this style uses server-side binding."""
         return self in (ParamStyle.QMARK, ParamStyle.NUMERIC)
 
+    def placeholders(self, n: int) -> str:
+        """Build a comma-separated placeholder string for *n* parameters.
+
+        Examples:
+            >>> ParamStyle.QMARK.placeholders(3)
+            '?, ?, ?'
+            >>> ParamStyle.NUMERIC.placeholders(3)
+            ':1, :2, :3'
+            >>> ParamStyle.FORMAT.placeholders(2)
+            '%s, %s'
+        """
+        if self.is_client_side():
+            return ", ".join("%s" for _ in range(n))
+        if self is ParamStyle.NUMERIC:
+            return ", ".join(f":{i}" for i in range(1, n + 1))
+        return ", ".join("?" for _ in range(n))
+
 
 # Numeric types for IS_NUMERIC check (mirrors reference connector's compat.py)
 _NUM_DATA_TYPES: tuple[type, ...] = (int, float, Decimal)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -42,7 +42,7 @@ from ._internal.extras import numpy as np
 from ._internal.text_utils import split_statements
 from .constants import QueryStatus
 from .cursor import CursorInstance, CursorType, DictCursor, SnowflakeCursor
-from .errors import Error, InterfaceError, NotSupportedError, ProgrammingError
+from .errors import Error, InterfaceError, ProgrammingError
 from .telemetry import TelemetryClient
 
 
@@ -261,28 +261,6 @@ class Connection:
                         logger.warning("Rollback failed during exception handling", exc_info=True)
         finally:
             self.close()
-
-    # Optional methods that some databases might support
-    def cancel(self) -> None:
-        """
-        Cancel a long-running operation on the connection.
-
-        Raises:
-            NotSupportedError: If not implemented
-        """
-        raise NotSupportedError("cancel is not implemented")
-
-    def ping(self) -> bool:
-        """
-        Check if the connection to the server is still alive.
-
-        Returns:
-            bool: True if connection is alive, False otherwise
-
-        Raises:
-            NotSupportedError: If not implemented
-        """
-        raise NotSupportedError("ping is not implemented")
 
     @property
     def _autocommit(self) -> bool:

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -280,16 +280,19 @@ class SnowflakeCursorBase(abc.ABC):
 
     @pep249
     @_requires_open
-    def callproc(self, procname: str, args: Any = tuple()) -> Any:
+    def callproc(self, procname: str, args: Any = None) -> Any:
         """Call a stored procedure.
 
         Args:
             procname: The stored procedure to be called.
             args: Parameters to be passed into the stored procedure.
+                  ``None`` is treated as no arguments.
 
         Returns:
             The input parameters.
         """
+        if args is None:
+            args = ()
         marker = "%s" if self._connection.paramstyle.is_client_side() else "?"
         command = f"CALL {procname}({', '.join([marker for _ in range(len(args))])})"
         self.execute(command, args)

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -15,7 +15,7 @@ import functools
 import logging
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast, overload
 
 from .._internal.arrow_stream_utils import (
     collect_arrow_table,
@@ -62,6 +62,7 @@ Row = tuple[Any, ...]
 DictRow = dict[str, Any]
 
 F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T")
 
 
 class FetchMode(enum.Enum):
@@ -271,22 +272,28 @@ class SnowflakeCursorBase(abc.ABC):
         """The SQLSTATE code of the last executed operation."""
         return self._query_result.sqlstate
 
+    @overload
+    def callproc(self, procname: str) -> tuple: ...
+
+    @overload
+    def callproc(self, procname: str, args: T) -> T: ...
+
     @pep249
-    def callproc(self, procname: str, parameters: Sequence[Any] | None = None) -> Sequence[Any]:
-        """
-        Call a stored database procedure with the given name.
+    @_requires_open
+    def callproc(self, procname: str, args: Any = tuple()) -> Any:
+        """Call a stored procedure.
 
         Args:
-            procname (str): Name of the procedure to call
-            parameters (sequence): Input parameters for the procedure
+            procname: The stored procedure to be called.
+            args: Parameters to be passed into the stored procedure.
 
         Returns:
-            sequence: The result of the procedure call
-
-        Raises:
-            NotSupportedError: If not implemented
+            The input parameters.
         """
-        raise NotSupportedError("callproc is not implemented")
+        marker = "%s" if self._connection.paramstyle.is_client_side() else "?"
+        command = f"CALL {procname}({', '.join([marker for _ in range(len(args))])})"
+        self.execute(command, args)
+        return args
 
     @property
     def is_file_transfer(self) -> bool:
@@ -672,9 +679,9 @@ class SnowflakeCursorBase(abc.ABC):
             bool: True if next set is available, False/None otherwise
 
         Raises:
-            NotSupportedError: If not implemented
+            NotImplementedError: If not implemented
         """
-        raise NotSupportedError("nextset is not implemented")
+        raise NotImplementedError("nextset is not implemented")
 
     @pep249
     def setinputsizes(self, sizes: Sequence[Any]) -> None:

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -297,14 +297,7 @@ class SnowflakeCursorBase(abc.ABC):
             raise TypeError(f"callproc args must be a sequence (e.g. list or tuple), not {type(args).__name__}")
         if not isinstance(args, Sequence):
             raise TypeError(f"callproc args must be a sequence (e.g. list or tuple), not {type(args).__name__}")
-        paramstyle = self._connection.paramstyle
-        if paramstyle.is_client_side():
-            placeholders = ", ".join("%s" for _ in range(len(args)))
-        elif paramstyle == ParamStyle.NUMERIC:
-            placeholders = ", ".join(f":{i}" for i in range(1, len(args) + 1))
-        else:
-            placeholders = ", ".join("?" for _ in range(len(args)))
-        command = f"CALL {procname}({placeholders})"
+        command = f"CALL {procname}({self._connection.paramstyle.placeholders(len(args))})"
         self.execute(command, args)
         return args
 

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -62,7 +62,7 @@ Row = tuple[Any, ...]
 DictRow = dict[str, Any]
 
 F = TypeVar("F", bound=Callable[..., Any])
-T = TypeVar("T")
+T = TypeVar("T", bound=Sequence[Any])
 
 
 class FetchMode(enum.Enum):
@@ -293,8 +293,18 @@ class SnowflakeCursorBase(abc.ABC):
         """
         if args is None:
             args = ()
-        marker = "%s" if self._connection.paramstyle.is_client_side() else "?"
-        command = f"CALL {procname}({', '.join([marker for _ in range(len(args))])})"
+        if isinstance(args, (str, bytes)):
+            raise TypeError(f"callproc args must be a sequence (e.g. list or tuple), not {type(args).__name__}")
+        if not isinstance(args, Sequence):
+            raise TypeError(f"callproc args must be a sequence (e.g. list or tuple), not {type(args).__name__}")
+        paramstyle = self._connection.paramstyle
+        if paramstyle.is_client_side():
+            placeholders = ", ".join("%s" for _ in range(len(args)))
+        elif paramstyle == ParamStyle.NUMERIC:
+            placeholders = ", ".join(f":{i}" for i in range(1, len(args) + 1))
+        else:
+            placeholders = ", ".join("?" for _ in range(len(args)))
+        command = f"CALL {procname}({placeholders})"
         self.execute(command, args)
         return args
 

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock
 import pytest
 
 from snowflake.connector.cursor import DictCursor
-from snowflake.connector.errors import NotSupportedError
 
 
 class TestConnectionInfo:
@@ -94,20 +93,6 @@ class TestConnectionMethods:
 
 class TestConnectionOptionalMethods:
     """Test optional Connection methods."""
-
-    @pytest.mark.skip_reference(reason="Reference driver has no cancel method")
-    def test_cancel_not_implemented(self, connection):
-        """Test that cancel raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
-            connection.cancel()
-        assert "cancel is not implemented" in str(excinfo.value)
-
-    @pytest.mark.skip_reference(reason="Reference driver has no ping method")
-    def test_ping_not_implemented(self, connection):
-        """Test that ping raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
-            connection.ping()
-        assert "ping is not implemented" in str(excinfo.value)
 
     @pytest.mark.skip_reference(reason="Reference driver has no set_autocommit method")
     def test_set_autocommit(self, connection):

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -1063,14 +1063,51 @@ class TestCursorMethods:
         cursor.close()
         assert cursor.is_closed()
 
+    def test_callproc(self, cursor):
+        """Test that callproc calls a stored procedure and returns the input parameters."""
+        proc_name = "test_callproc_echo"
+        message = "hello_from_callproc"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}(msg VARCHAR)
+            RETURNS VARCHAR NOT NULL
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN msg;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, (message,))
+        assert ret == (message,)
+        assert cursor.fetchall() == [(message,)]
+
+    def test_callproc_no_args(self, cursor):
+        """Test callproc with a procedure that takes no arguments."""
+        proc_name = "test_callproc_no_args"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}()
+            RETURNS BOOLEAN
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN TRUE;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name)
+        assert ret == ()
+        assert cursor.fetchall() == [(True,)]
+
     @pytest.mark.skip_reference(
-        reason="Reference driver forwards callproc to server instead of raising NotSupportedError"
+        reason="Reference driver raises AttributeError instead of InterfaceError on closed cursor"
     )
-    def test_callproc_not_implemented(self, cursor):
-        """Test that callproc raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
-            cursor.callproc("test_proc", [1, 2, 3])
-        assert "callproc is not implemented" in str(excinfo.value)
+    def test_callproc_on_closed_cursor_raises(self, cursor):
+        """Test that callproc raises InterfaceError on a closed cursor."""
+        cursor.close()
+        with pytest.raises(InterfaceError):
+            cursor.callproc("any_proc")
 
     def test_executemany_is_callable(self, cursor):
         """Test that executemany is callable (basic smoke test)."""

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -7,7 +7,8 @@ from decimal import Decimal
 import pytest
 
 from snowflake.connector.cursor import QueryResultStats, SnowflakeCursor
-from snowflake.connector.errors import InterfaceError, NotSupportedError, ProgrammingError
+from snowflake.connector.errors import InterfaceError, ProgrammingError
+from tests.conftest import with_paramstyle
 from tests.e2e.types.utils import assert_sequential_values
 
 
@@ -1128,17 +1129,105 @@ class TestCursorMethods:
         with pytest.raises(InterfaceError):
             cursor.callproc("any_proc")
 
+    @pytest.mark.skip_reference(reason="Reference driver does not validate args type")
+    def test_callproc_rejects_string_args(self, cursor):
+        """Test that callproc rejects a string as args (would be treated as sequence of chars)."""
+        with pytest.raises(TypeError, match="must be a sequence"):
+            cursor.callproc("any_proc", "abc")
+
+    @pytest.mark.skip_reference(reason="Reference driver does not validate args type")
+    def test_callproc_rejects_non_sequence_args(self, cursor):
+        """Test that callproc rejects non-sequence types like int."""
+        with pytest.raises(TypeError, match="must be a sequence"):
+            cursor.callproc("any_proc", 42)
+
+    @with_paramstyle("qmark")
+    def test_callproc_qmark_paramstyle(self, cursor):
+        """Test callproc with qmark paramstyle uses ? placeholders."""
+        proc_name = "test_callproc_qmark"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}(p1 VARCHAR, p2 INT)
+            RETURNS VARCHAR NOT NULL
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN p1 || '_' || p2::VARCHAR;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, ("hello", 42))
+        assert ret == ("hello", 42)
+        assert cursor.fetchall() == [("hello_42",)]
+
+    @with_paramstyle("numeric")
+    def test_callproc_numeric_paramstyle(self, cursor):
+        """Test callproc with numeric paramstyle uses :1, :2 placeholders."""
+        proc_name = "test_callproc_numeric"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}(p1 VARCHAR, p2 INT)
+            RETURNS VARCHAR NOT NULL
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN p1 || '_' || p2::VARCHAR;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, ("hello", 42))
+        assert ret == ("hello", 42)
+        assert cursor.fetchall() == [("hello_42",)]
+
+    @with_paramstyle("pyformat")
+    def test_callproc_pyformat_paramstyle(self, cursor):
+        """Test callproc with pyformat paramstyle uses %s placeholders."""
+        proc_name = "test_callproc_pyformat"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}(p1 VARCHAR, p2 INT)
+            RETURNS VARCHAR NOT NULL
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN p1 || '_' || p2::VARCHAR;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, ("hello", 42))
+        assert ret == ("hello", 42)
+        assert cursor.fetchall() == [("hello_42",)]
+
+    @with_paramstyle("format")
+    def test_callproc_format_paramstyle(self, cursor):
+        """Test callproc with format paramstyle uses %s placeholders."""
+        proc_name = "test_callproc_format"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}(p1 VARCHAR, p2 INT)
+            RETURNS VARCHAR NOT NULL
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN p1 || '_' || p2::VARCHAR;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, ("hello", 42))
+        assert ret == ("hello", 42)
+        assert cursor.fetchall() == [("hello_42",)]
+
     def test_executemany_is_callable(self, cursor):
         """Test that executemany is callable (basic smoke test)."""
         # Just verify it's callable and accepts empty sequence without error
         cursor.executemany("INSERT INTO test VALUES (?)", [])
 
     @pytest.mark.skip_reference(
-        reason="Reference driver returns None from nextset instead of raising NotSupportedError"
+        reason="Reference driver returns None from nextset instead of raising NotImplementedError"
     )
     def test_nextset_not_implemented(self, cursor):
-        """Test that nextset raises NotSupportedError."""
-        with pytest.raises(NotSupportedError) as excinfo:
+        """Test that nextset raises NotImplementedError."""
+        with pytest.raises(NotImplementedError) as excinfo:
             cursor.nextset()
         assert "nextset is not implemented" in str(excinfo.value)
 

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -1100,6 +1100,25 @@ class TestCursorMethods:
         assert ret == ()
         assert cursor.fetchall() == [(True,)]
 
+    @pytest.mark.skip_reference(reason="Reference driver raises TypeError when args=None")
+    def test_callproc_none_args(self, cursor):
+        """Test callproc treats None args the same as no arguments."""
+        proc_name = "test_callproc_none_args"
+        cursor.execute(
+            f"""
+            CREATE OR REPLACE TEMPORARY PROCEDURE {proc_name}()
+            RETURNS BOOLEAN
+            LANGUAGE SQL
+            AS
+            BEGIN
+              RETURN TRUE;
+            END;
+            """
+        )
+        ret = cursor.callproc(proc_name, None)
+        assert ret == ()
+        assert cursor.fetchall() == [(True,)]
+
     @pytest.mark.skip_reference(
         reason="Reference driver raises AttributeError instead of InterfaceError on closed cursor"
     )

--- a/scripts/python_api_compare.py
+++ b/scripts/python_api_compare.py
@@ -58,8 +58,6 @@ EXCLUDED_FROM_PUPR = {
     "build_location_helper",
     "chunk_helper",
     "make_pd_writer",
-    # helper
-    "ResultMetadataV2",
     # internal, but missing "_" prefix - should not be exposed
     "get_query_context",
     "set_query_context",


### PR DESCRIPTION
Implement the PEP 249 callproc method following the reference driver's approach: build a CALL statement with paramstyle-aware placeholders and delegate to execute(). Also remove unused cancel/ping stubs from connection, switch nextset to NotImplementedError, and remove ResultMetadataV2 from the API comparison exclusion list.

Made-with: Cursor