### PR TITLE
NO-SNOW: Add api_usage and wrapper_error telemetry RPCs

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -185,6 +185,18 @@ jobs:
           python scripts/cleanup_test_pats.py \
             --parameter-path $(pwd)/parameters.json
 
+      - name: Trim tarpaulin artifacts before cache save
+        if: always()
+        shell: bash
+        run: |
+          # Tarpaulin instruments every build artifact which roughly doubles
+          # the target/ size (~14 GB).  These instrumented binaries are not
+          # reusable across runs, so strip them to keep the cache under the
+          # GitHub Actions runner disk budget (~14 GB free).
+          rm -rf target/tarpaulin || true
+          # Also remove profraw files left by coverage runs
+          find target -name '*.profraw' -delete 2>/dev/null || true
+
       - name: Save Rust cache
         if: always()
         uses: ./.github/actions/cargo-cache

--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -1,10 +1,14 @@
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use jni::JNIEnv;
 use jni::objects::{JByteArray, JClass, JObject, JString, JValue};
 use jni::sys::{jint, jobject};
 use proto_utils::{ProtoError, Transport};
 use sf_core::protobuf::apis::RustTransport;
+use sf_core::telemetry::TelemetryInit;
+use sf_core::telemetry::snowflake_exporter::SessionRegistry;
+
+static JDBC_TELEMETRY: OnceLock<TelemetryInit> = OnceLock::new();
 
 struct JdbcBridge {
     runtime: tokio::runtime::Runtime,
@@ -13,6 +17,10 @@ struct JdbcBridge {
 
 impl JdbcBridge {
     pub fn new() -> Self {
+        let providers = match JDBC_TELEMETRY.get() {
+            Some(init) => init.to_providers(),
+            None => Default::default(),
+        };
         Self {
             // Single worker thread is intentional: keeps contention minimal and
             // makes deadlocks easier to detect. Will be increased during
@@ -22,7 +30,7 @@ impl JdbcBridge {
                 .enable_all()
                 .build()
                 .expect("Failed to create tokio runtime"),
-            transport: RustTransport::new(),
+            transport: RustTransport::new_with(providers),
         }
     }
 
@@ -49,8 +57,14 @@ mod sflogger_layer;
 pub extern "system" fn JNI_OnLoad(jvm: *mut jni::sys::JavaVM, _: *mut u8) -> jint {
     let config = sf_core::logging::LoggingConfig::new(None, false, false);
     let layer = sflogger_layer::SFLoggerLayer::new(jvm);
-    match sf_core::logging::init_logging(config, Some(layer)) {
-        Ok(_) => jni::sys::JNI_VERSION_1_2,
+    let sessions = SessionRegistry::default();
+    match sf_core::logging::init_logging(config, Some(layer), sessions.clone()) {
+        Ok(provider) => {
+            JDBC_TELEMETRY
+                .set(TelemetryInit { provider, sessions })
+                .ok();
+            jni::sys::JNI_VERSION_1_2
+        }
         Err(e) => {
             eprintln!("Failed to initialize logging: {e:?}");
             -1

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -717,6 +717,24 @@ message ConfigGetPathsResponse {
   string connections_file = 2;
 }
 
+// =============================================================================
+// TELEMETRY - In-band telemetry messages sent from wrappers via core
+// =============================================================================
+
+
+message TelemetrySendApiUsageRequest {
+  ConnectionHandle conn_handle = 1;
+  string api_method = 2;
+}
+
+message TelemetrySendWrapperErrorRequest {
+  ConnectionHandle conn_handle = 1;
+  string exception_type = 2;
+  string error_source = 3;
+}
+
+message TelemetrySendResponse {
+}
 
 // Database Driver service definition
 service DatabaseDriver {
@@ -778,4 +796,7 @@ service DatabaseDriver {
   rpc ConfigLoadAllSections(ConfigLoadAllSectionsRequest) returns (ConfigLoadAllSectionsResponse);
   rpc ConfigGetPaths(ConfigGetPathsRequest) returns (ConfigGetPathsResponse);
 
+  // Telemetry operations
+  rpc TelemetrySendApiUsage(TelemetrySendApiUsageRequest) returns (TelemetrySendResponse);
+  rpc TelemetrySendWrapperError(TelemetrySendWrapperErrorRequest) returns (TelemetrySendResponse);
 }

--- a/python/src/snowflake/connector/_internal/telemetry.py
+++ b/python/src/snowflake/connector/_internal/telemetry.py
@@ -1,0 +1,62 @@
+"""In-band telemetry client that sends events to sf_core via protobuf RPC.
+
+All methods are fire-and-forget: failures are logged at DEBUG level and never
+propagate to the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import TYPE_CHECKING
+
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
+    TelemetrySendApiUsageRequest,
+    TelemetrySendWrapperErrorRequest,
+)
+
+
+if TYPE_CHECKING:
+    from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
+        ConnectionHandle,
+        DatabaseDriverClient,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryClient:
+    """Sends telemetry events to sf_core via protobuf RPC.
+
+    Wrapper identity is passed as part of ``connection_init``. This client only
+    sends runtime events — sf_core attaches the stored identity automatically.
+    """
+
+    def __init__(self, db_api: DatabaseDriverClient, conn_handle: ConnectionHandle) -> None:
+        self._db_api = db_api
+        self._conn_handle = conn_handle
+
+    def send_api_usage(self, api_method: str) -> None:
+        """Record an API method call for telemetry."""
+        try:
+            self._db_api.telemetry_send_api_usage(
+                TelemetrySendApiUsageRequest(
+                    conn_handle=self._conn_handle,
+                    api_method=api_method,
+                )
+            )
+        except Exception:
+            logger.debug("Failed to send api_usage telemetry", exc_info=True)
+
+    def send_wrapper_error(self, exception_type: str, error_source: str) -> None:
+        """Record a wrapper error for telemetry."""
+        try:
+            self._db_api.telemetry_send_wrapper_error(
+                TelemetrySendWrapperErrorRequest(
+                    conn_handle=self._conn_handle,
+                    exception_type=exception_type,
+                    error_source=error_source,
+                )
+            )
+        except Exception:
+            logger.debug("Failed to send wrapper_error telemetry", exc_info=True)

--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -32,8 +32,9 @@ def test_session_init_telemetry_sent_on_connection_open(int_test_connection_fact
         connection = int_test_connection_factory(server_url=wiremock.http_url(), **extra_params)
         connection.close()
 
-        # Telemetry is sent asynchronously via a background task, so poll until it arrives.
-        telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=2.0)
+        # Telemetry is exported synchronously on connection release via
+        # SimpleSpanProcessor. Poll briefly in case of timing variability.
+        telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
         assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after connection open"
 
         request = telemetry_requests[0]

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -258,6 +258,7 @@ impl DatabaseDriverV1 {
                     role: login_result.role_name,
                 };
 
+                let session_id = login_result.tokens.session_id;
                 let mut conn = conn_ptr.lock().await;
                 conn.initialize(
                     login_result.tokens,
@@ -272,25 +273,65 @@ impl DatabaseDriverV1 {
                 )
                 .await;
 
-                // Snowflake server defaults CLIENT_TELEMETRY_ENABLED to true; it only
-                // sends "false" when the account or user has opted out. If the parameter
-                // is absent (e.g. older server), we default to enabled to match server behavior.
-                let telemetry_enabled = conn
-                    .session_parameters
-                    .read()
-                    .await
-                    .get(param_names::CLIENT_TELEMETRY_ENABLED.as_str())
-                    .map(|v| v.eq_ignore_ascii_case("true"))
-                    .unwrap_or(true);
-                drop(conn);
+                // Telemetry setup: check if the server has opted this session
+                // into in-band telemetry and a session registry is configured,
+                // then register the session so spans tagged with this
+                // session_id are routed to /telemetry/send.
+                let telemetry_enabled = self.telemetry_sessions().is_some()
+                    && conn
+                        .session_parameters
+                        .read()
+                        .await
+                        .get(param_names::CLIENT_TELEMETRY_ENABLED.as_str())
+                        .map(|v| v.eq_ignore_ascii_case("true"))
+                        .unwrap_or(true);
 
-                // Best-effort session_init telemetry — spawned as a background task
-                // so connection open never blocks on telemetry latency.
                 if telemetry_enabled {
-                    let conn_ptr_clone = conn_ptr.clone();
-                    tokio::spawn(async move {
-                        Self::send_session_init_telemetry(&conn_ptr_clone).await;
+                    use crate::telemetry::snowflake_exporter::ExporterSession;
+
+                    let Some(http_client) = conn.http_client.clone() else {
+                        tracing::warn!(
+                            "Skipping telemetry: http_client not set after connection init"
+                        );
+                        drop(conn);
+                        return Ok(());
+                    };
+
+                    let query_parameters = conn.query_transport_parameters()?;
+                    let exporter_session = Arc::new(ExporterSession {
+                        client: http_client,
+                        query_parameters,
+                        session_token: conn.tokens.clone(),
                     });
+
+                    // unwrap is safe: telemetry_enabled is only true when
+                    // telemetry_sessions() is Some.
+                    self.telemetry_sessions()
+                        .unwrap()
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .insert(session_id, exporter_session);
+
+                    let env_info = conn
+                        .wrapper_identity
+                        .as_ref()
+                        .map(crate::telemetry::environment::EnvironmentInfo::with_wrapper)
+                        .unwrap_or_else(crate::telemetry::environment::EnvironmentInfo::detect);
+                    // Long-lived connection span carries all telemetry events
+                    // (session_init, api_usage, wrapper_error) for this session.
+                    // Events are exported when the span ends on connection release.
+                    let conn_span =
+                        tracing::info_span!("connection", "snowflake.session.id" = session_id,);
+
+                    // Record session_init as an event on the connection span.
+                    // We enter the span so the OpenTelemetryLayer captures the
+                    // tracing event as an OTel span event.
+                    {
+                        let _guard = conn_span.enter();
+                        crate::telemetry::record_session_init(&env_info);
+                    }
+
+                    conn.telemetry_span = Some(conn_span);
                 }
 
                 Ok(())
@@ -302,54 +343,46 @@ impl DatabaseDriverV1 {
         }
     }
 
-    /// Send session_init telemetry for the given connection (best-effort, fire-and-forget).
+    /// Return the per-connection telemetry span if available.
     ///
-    /// Acquires the connection Mutex briefly to extract identity, tokens Arc,
-    /// and transport parameters, then drops the Mutex before reading the tokens
-    /// RwLock or making any network call. This avoids holding the Mutex across
-    /// an RwLock await (which could deadlock if a concurrent token refresh holds
-    /// the write lock).
-    async fn send_session_init_telemetry(conn_ptr: &Arc<Mutex<Connection>>) {
-        use crate::telemetry::snowflake_exporter::{ExporterSession, SnowflakeInBandExporter};
-        use opentelemetry_sdk::trace::SpanExporter;
+    /// Callers enter this span and record OTel events (via
+    /// `telemetry::record_api_call` / `record_exception`). The span
+    /// carries `snowflake.session.id` for routing by the shared exporter.
+    pub async fn telemetry_span(&self, handle: Handle) -> Option<tracing::Span> {
+        let conn_ptr = self.connections.get_obj(handle)?;
+        let conn = conn_ptr.lock().await;
+        conn.telemetry_span.clone()
+    }
 
-        // Step 1: Hold the connection Mutex only to clone what we need.
-        let (env_info, tokens_arc, query_parameters, http_client) = {
-            let conn = conn_ptr.lock().await;
-            let Some(ref identity) = conn.wrapper_identity else {
-                return;
+    /// End the connection span and deregister from the shared telemetry
+    /// session registry, then release the connection handle.
+    pub async fn flush_telemetry_on_release(&self, conn_handle: Handle) -> Result<(), ApiError> {
+        if let Some(conn_ptr) = self.connections.get_obj(conn_handle) {
+            let (span, tokens_arc) = {
+                let mut conn = conn_ptr.lock().await;
+                (conn.telemetry_span.take(), conn.tokens.clone())
             };
-            let env_info = crate::telemetry::environment::EnvironmentInfo::with_wrapper(identity);
-            let Ok(query_parameters) = conn.query_transport_parameters() else {
-                return;
-            };
-            let Some(http_client) = conn.http_client.clone() else {
-                return;
-            };
-            (env_info, conn.tokens.clone(), query_parameters, http_client)
-        };
-        // Mutex is now dropped.
+            // Mutex dropped before reading the tokens RwLock to avoid deadlock.
+            let session_id = tokens_arc.read().await.as_ref().map(|t| t.session_id);
 
-        // Step 2: Read session_id from the tokens RwLock without holding the Mutex.
-        // After a successful login, tokens are always present. The unwrap_or(0)
-        // is a defensive fallback — session_id 0 acts as a "no session" sentinel
-        // in the telemetry payload and is harmless if it somehow occurs.
-        let session_id = tokens_arc
-            .read()
-            .await
-            .as_ref()
-            .map(|t| t.session_id)
-            .unwrap_or(0);
+            // Drop the tracing span — this ends the underlying OTel span.
+            // SimpleSpanProcessor calls the exporter synchronously, which
+            // spawns the HTTP POST on the tokio runtime (fire-and-forget).
+            drop(span);
+            // Yield to let the spawned export task run before we deregister
+            // the session from the registry.
+            tokio::task::yield_now().await;
+            if let Some(id) = session_id
+                && let Some(sessions) = self.telemetry_sessions()
+            {
+                sessions
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&id);
+            }
+        }
 
-        let span = crate::telemetry::build_session_init_span(&env_info, session_id);
-        let session = Arc::new(ExporterSession {
-            client: http_client,
-            query_parameters,
-            session_token: tokens_arc,
-        });
-
-        let exporter = SnowflakeInBandExporter::new(session);
-        let _ = exporter.export(vec![span]).await;
+        self.connection_release(conn_handle)
     }
 
     pub async fn connection_set_option(
@@ -524,6 +557,23 @@ impl DatabaseDriverV1 {
             .fail(),
         }
     }
+
+    /// Read the stored wrapper identity for a connection, if set during `ConnectionInit`.
+    pub async fn get_wrapper_identity(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<Option<WrapperIdentity>, ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let conn = conn_ptr.lock().await;
+                Ok(conn.wrapper_identity.clone())
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Invalid connection handle".to_string(),
+            }
+            .fail(),
+        }
+    }
 }
 
 /// Wrapper identity set once via `ConnectionInit` and attached to all subsequent telemetry events.
@@ -565,6 +615,10 @@ pub struct Connection {
     pub final_session_names: RwLock<FinalSessionNames>,
     /// Wrapper identity for telemetry, set once via ConnectionInit.
     pub wrapper_identity: Option<WrapperIdentity>,
+    /// Long-lived connection span carrying `snowflake.session.id`.
+    /// Telemetry events (session_init, api_usage, wrapper_error) are
+    /// recorded as OTel events on this span; it is ended on release.
+    pub(crate) telemetry_span: Option<tracing::Span>,
 }
 
 impl Default for Connection {
@@ -590,6 +644,7 @@ impl Connection {
             init_session_parameters: None,
             final_session_names: RwLock::new(FinalSessionNames::default()),
             wrapper_identity: None,
+            telemetry_span: None,
         }
     }
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -366,12 +366,11 @@ impl DatabaseDriverV1 {
             let session_id = tokens_arc.read().await.as_ref().map(|t| t.session_id);
 
             // Drop the tracing span — this ends the underlying OTel span.
-            // SimpleSpanProcessor calls the exporter synchronously, which
-            // spawns the HTTP POST on the tokio runtime (fire-and-forget).
+            // SimpleSpanProcessor calls the exporter synchronously via
+            // futures_executor::block_on.  The exporter spawns the HTTP
+            // POST on the tokio runtime and awaits the JoinHandle, so by
+            // the time drop() returns the telemetry has been sent.
             drop(span);
-            // Yield to let the spawned export task run before we deregister
-            // the session from the registry.
-            tokio::task::yield_now().await;
             if let Some(id) = session_id
                 && let Some(sessions) = self.telemetry_sessions()
             {

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -70,17 +70,9 @@ impl DatabaseDriverV1 {
         }
     }
 
-    /// Returns the session registry, checking DriverProviders first then
-    /// falling back to the C API telemetry init state (which may be populated
-    /// after CApiState initialization).
+    /// Returns the session registry if telemetry was configured via `DriverProviders`.
     pub(super) fn telemetry_sessions(&self) -> Option<&SessionRegistry> {
-        self.telemetry_sessions
-            .as_ref()
-            .or_else(|| {
-                crate::logging::c_api::TELEMETRY_INIT
-                    .get()
-                    .map(|init| &init.sessions)
-            })
+        self.telemetry_sessions.as_ref()
     }
 
     pub fn token_cache(&self) -> Result<&KeyringTokenCache, TokenCacheError> {

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -10,6 +10,7 @@ use crate::fs_adapter::{FsAdapter, RealFs};
 use crate::handle_manager::HandleManager;
 use crate::telemetry::os_details::detect_os_details;
 use crate::telemetry::platform_detection::{DetectionConfig, detect_platforms};
+use crate::telemetry::snowflake_exporter::SessionRegistry;
 use crate::token_cache::{KeyringTokenCache, TokenCacheError};
 
 /// Injection points for `DatabaseDriverV1`.
@@ -21,6 +22,13 @@ use crate::token_cache::{KeyringTokenCache, TokenCacheError};
 #[derive(Default)]
 pub struct DriverProviders {
     pub fs: Option<Arc<dyn FsAdapter>>,
+    /// Session registry shared with the Snowflake telemetry exporter layer.
+    /// Created by the initialization code that calls `init_logging` and passed
+    /// here so `DatabaseDriverV1` can register/deregister sessions.
+    pub telemetry_sessions: Option<SessionRegistry>,
+    /// The `SdkTracerProvider` returned by `init_logging`. Must be kept alive
+    /// for the process lifetime to prevent the exporter from shutting down.
+    pub telemetry_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
 }
 
 pub struct DatabaseDriverV1 {
@@ -30,6 +38,10 @@ pub struct DatabaseDriverV1 {
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
+    telemetry_sessions: Option<SessionRegistry>,
+    /// Kept alive so the Snowflake exporter is not shut down.
+    #[allow(dead_code)]
+    telemetry_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
     os_details: once_cell::sync::OnceCell<Option<HashMap<String, String>>>,
 }
 
@@ -52,8 +64,23 @@ impl DatabaseDriverV1 {
             token_cache: once_cell::sync::OnceCell::new(),
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),
+            telemetry_sessions: providers.telemetry_sessions,
+            telemetry_provider: providers.telemetry_provider,
             os_details: once_cell::sync::OnceCell::new(),
         }
+    }
+
+    /// Returns the session registry, checking DriverProviders first then
+    /// falling back to the C API telemetry init state (which may be populated
+    /// after CApiState initialization).
+    pub(super) fn telemetry_sessions(&self) -> Option<&SessionRegistry> {
+        self.telemetry_sessions
+            .as_ref()
+            .or_else(|| {
+                crate::logging::c_api::TELEMETRY_INIT
+                    .get()
+                    .map(|init| &init.sessions)
+            })
     }
 
     pub fn token_cache(&self) -> Result<&KeyringTokenCache, TokenCacheError> {

--- a/sf_core/src/logging/c_api.rs
+++ b/sf_core/src/logging/c_api.rs
@@ -1,23 +1,30 @@
-use std::sync::OnceLock;
-
 use crate::logging;
-use crate::telemetry::TelemetryInit;
-use crate::telemetry::snowflake_exporter::SessionRegistry;
 
-/// Telemetry state created during logging initialization.
-/// Read by `protobuf::c_api::CApiState` to pass context to `DatabaseDriverV1`.
-pub(crate) static TELEMETRY_INIT: OnceLock<TelemetryInit> = OnceLock::new();
+#[cfg(not(feature = "protobuf"))]
+use crate::telemetry::snowflake_exporter::SessionRegistry;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn sf_core_init_logger(callback: logging::CLogCallback) -> u32 {
     let config = logging::LoggingConfig::new(None, false, false);
     let layer = logging::CallbackLayer::new(callback);
+
+    // When the protobuf feature is enabled the SessionRegistry is owned by
+    // CApiState (protobuf::c_api) — no process-global OnceLock needed.
+    // Without protobuf we create a local registry that lives only in the
+    // tracing subscriber (telemetry will be a no-op without a driver).
+    #[cfg(feature = "protobuf")]
+    let sessions = crate::protobuf::c_api::telemetry_sessions();
+    #[cfg(not(feature = "protobuf"))]
     let sessions = SessionRegistry::default();
-    match logging::init_logging(config, Some(layer), sessions.clone()) {
+
+    match logging::init_logging(config, Some(layer), sessions) {
         Ok(provider) => {
-            TELEMETRY_INIT
-                .set(TelemetryInit { provider, sessions })
-                .ok();
+            #[cfg(feature = "protobuf")]
+            crate::protobuf::c_api::set_telemetry_provider(provider);
+            // Without protobuf the provider is dropped here, which is fine
+            // because there is no exporter to keep alive.
+            #[cfg(not(feature = "protobuf"))]
+            drop(provider);
             0
         }
         Err(e) => {

--- a/sf_core/src/logging/c_api.rs
+++ b/sf_core/src/logging/c_api.rs
@@ -1,11 +1,25 @@
+use std::sync::OnceLock;
+
 use crate::logging;
+use crate::telemetry::TelemetryInit;
+use crate::telemetry::snowflake_exporter::SessionRegistry;
+
+/// Telemetry state created during logging initialization.
+/// Read by `protobuf::c_api::CApiState` to pass context to `DatabaseDriverV1`.
+pub(crate) static TELEMETRY_INIT: OnceLock<TelemetryInit> = OnceLock::new();
 
 #[unsafe(no_mangle)]
 pub extern "C" fn sf_core_init_logger(callback: logging::CLogCallback) -> u32 {
     let config = logging::LoggingConfig::new(None, false, false);
     let layer = logging::CallbackLayer::new(callback);
-    match logging::init_logging(config, Some(layer)) {
-        Ok(_) => 0,
+    let sessions = SessionRegistry::default();
+    match logging::init_logging(config, Some(layer), sessions.clone()) {
+        Ok(provider) => {
+            TELEMETRY_INIT
+                .set(TelemetryInit { provider, sessions })
+                .ok();
+            0
+        }
         Err(e) => {
             eprintln!("Failed to initialize logging: {e:?}");
             1

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -4,6 +4,8 @@ pub use crate::logging::callback_layer::CLogCallback;
 pub use crate::logging::callback_layer::CallbackLayer;
 pub use crate::logging::error::LogError;
 use crate::logging::opentelemetry::init_tracer;
+use crate::telemetry::snowflake_exporter::SessionRegistry;
+use ::opentelemetry::trace::TracerProvider;
 use tracing::Subscriber;
 use tracing::level_filters::LevelFilter;
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -36,11 +38,37 @@ struct EmptyLayer;
 
 impl<S: Subscriber> Layer<S> for EmptyLayer {}
 
+/// Initialize logging without a telemetry session registry.
+///
+/// The Snowflake in-band telemetry layer is not installed. Callers that
+/// need telemetry should use [`init_logging`] instead.
 pub fn init(config: LoggingConfig) -> Result<(), LogError> {
-    init_logging::<EmptyLayer>(config, None)
+    init_logging_inner::<EmptyLayer>(config, None, None).map(|_provider| ())
 }
 
-pub fn init_logging<L>(config: LoggingConfig, extra_layer: Option<L>) -> Result<(), LogError>
+/// Initialize logging and return the Snowflake telemetry provider.
+///
+/// The caller is responsible for keeping the returned `SdkTracerProvider`
+/// alive for the process lifetime (typically by storing it in the
+/// `DatabaseDriverV1` via `DriverProviders`). Dropping the provider will
+/// shut down the exporter.
+pub fn init_logging<L>(
+    config: LoggingConfig,
+    extra_layer: Option<L>,
+    telemetry_sessions: SessionRegistry,
+) -> Result<opentelemetry_sdk::trace::SdkTracerProvider, LogError>
+where
+    L: Layer<Registry> + Send + Sync,
+{
+    init_logging_inner(config, extra_layer, Some(telemetry_sessions))
+        .map(|provider| provider.expect("provider is always Some when sessions are provided"))
+}
+
+fn init_logging_inner<L>(
+    config: LoggingConfig,
+    extra_layer: Option<L>,
+    telemetry_sessions: Option<SessionRegistry>,
+) -> Result<Option<opentelemetry_sdk::trace::SdkTracerProvider>, LogError>
 where
     L: Layer<Registry> + Send + Sync,
 {
@@ -69,6 +97,26 @@ where
     };
     let subscriber = subscriber.with(opentelemetry_layer);
 
+    let (snowflake_layer, provider) = if let Some(sessions) = telemetry_sessions {
+        let exporter = crate::telemetry::snowflake_exporter::SnowflakeInBandExporter::new(sessions);
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("snowflake.telemetry");
+        // Only process "connection" spans (which carry snowflake.session.id)
+        // and events within them, so the extra provider does minimal work for
+        // non-telemetry code paths.
+        let layer = OpenTelemetryLayer::new(tracer).with_filter(
+            tracing_subscriber::filter::filter_fn(|metadata| {
+                metadata.name() == "connection" || metadata.is_event()
+            }),
+        );
+        (Some(layer), Some(provider))
+    } else {
+        (None, None)
+    };
+    let subscriber = subscriber.with(snowflake_layer);
+
     let stderr_layer = if config.stderr {
         Some(
             tracing_subscriber::fmt::layer()
@@ -87,5 +135,5 @@ where
 
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|e| LogError::InitError(e.to_string()))?;
-    Ok(())
+    Ok(provider)
 }

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -106,11 +106,10 @@ where
         // Only process "connection" spans (which carry snowflake.session.id)
         // and events within them, so the extra provider does minimal work for
         // non-telemetry code paths.
-        let layer = OpenTelemetryLayer::new(tracer).with_filter(
-            tracing_subscriber::filter::filter_fn(|metadata| {
-                metadata.name() == "connection" || metadata.is_event()
-            }),
-        );
+        let layer =
+            OpenTelemetryLayer::new(tracer).with_filter(tracing_subscriber::filter::filter_fn(
+                |metadata| metadata.name() == "connection" || metadata.is_event(),
+            ));
         (Some(layer), Some(provider))
     } else {
         (None, None)

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -221,7 +221,8 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         self.driver
-            .connection_release(conn_handle.into())
+            .flush_telemetry_on_release(conn_handle.into())
+            .await
             .to_protobuf()?;
         Ok(ConnectionReleaseResponse {})
     }
@@ -833,6 +834,43 @@ impl DatabaseDriver for DatabaseDriverImpl {
             config_file: config_file.to_string_lossy().into_owned(),
             connections_file: connections_file.to_string_lossy().into_owned(),
         })
+    }
+
+    // -- Telemetry operations --
+
+    #[instrument(name = "DatabaseDriverV1::telemetry_send_api_usage", skip(self, input))]
+    async fn telemetry_send_api_usage(
+        &self,
+        input: TelemetrySendApiUsageRequest,
+    ) -> Result<TelemetrySendResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        let handle = Handle::from(conn_handle);
+
+        if let Some(conn_span) = self.driver.telemetry_span(handle).await {
+            let _guard = conn_span.enter();
+            crate::telemetry::record_api_call(&input.api_method);
+        }
+
+        Ok(TelemetrySendResponse {})
+    }
+
+    #[instrument(
+        name = "DatabaseDriverV1::telemetry_send_wrapper_error",
+        skip(self, input)
+    )]
+    async fn telemetry_send_wrapper_error(
+        &self,
+        input: TelemetrySendWrapperErrorRequest,
+    ) -> Result<TelemetrySendResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        let handle = Handle::from(conn_handle);
+
+        if let Some(conn_span) = self.driver.telemetry_span(handle).await {
+            let _guard = conn_span.enter();
+            crate::telemetry::record_exception(&input.exception_type, &input.error_source);
+        }
+
+        Ok(TelemetrySendResponse {})
     }
 }
 

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -1,21 +1,28 @@
 use std::ffi::c_char;
 use std::sync::LazyLock;
 
+use crate::apis::database_driver_v1::DriverProviders;
 use crate::protobuf::apis::RustTransport;
+use crate::telemetry::snowflake_exporter::SessionRegistry;
 use proto_utils::{ProtoError, Transport};
 
 struct CApiState {
     runtime: tokio::runtime::Runtime,
     transport: RustTransport,
+    /// Shared with the Snowflake telemetry exporter layer installed by
+    /// `sf_core_init_logger`. Created here so there is no process-global
+    /// `OnceLock` that survives DLL unload/reload (important for ODBC).
+    telemetry_sessions: SessionRegistry,
+    /// Keeps the `SdkTracerProvider` alive for the process lifetime.
+    /// Set by `sf_core_init_logger` after the tracing subscriber is installed.
+    telemetry_provider: std::sync::Mutex<Option<opentelemetry_sdk::trace::SdkTracerProvider>>,
 }
 
 static STATE: LazyLock<CApiState> = LazyLock::new(|| {
-    // Telemetry state may not be available yet (sf_core_init_logger may be
-    // called after CApiState initialization). DatabaseDriverV1 falls back to
-    // reading TELEMETRY_INIT lazily when telemetry is first needed.
-    let providers = match crate::logging::c_api::TELEMETRY_INIT.get() {
-        Some(init) => init.to_providers(),
-        None => Default::default(),
+    let sessions = SessionRegistry::default();
+    let providers = DriverProviders {
+        telemetry_sessions: Some(sessions.clone()),
+        ..Default::default()
     };
 
     CApiState {
@@ -28,8 +35,26 @@ static STATE: LazyLock<CApiState> = LazyLock::new(|| {
             .build()
             .expect("Failed to create tokio runtime"),
         transport: RustTransport::new_with(providers),
+        telemetry_sessions: sessions,
+        telemetry_provider: std::sync::Mutex::new(None),
     }
 });
+
+/// Returns the shared `SessionRegistry` owned by the C API state.
+/// Called by `sf_core_init_logger` so the tracing subscriber and
+/// `DatabaseDriverV1` share the same registry.
+pub(crate) fn telemetry_sessions() -> SessionRegistry {
+    STATE.telemetry_sessions.clone()
+}
+
+/// Store the `SdkTracerProvider` so it is kept alive for the process lifetime.
+/// Called by `sf_core_init_logger` after successfully installing the subscriber.
+pub(crate) fn set_telemetry_provider(provider: opentelemetry_sdk::trace::SdkTracerProvider) {
+    *STATE
+        .telemetry_provider
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Some(provider);
+}
 
 fn write_buffer(vec: Vec<u8>, buffer: *mut *const u8, len: *mut usize) {
     let boxed = vec.into_boxed_slice();

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -9,16 +9,26 @@ struct CApiState {
     transport: RustTransport,
 }
 
-static STATE: LazyLock<CApiState> = LazyLock::new(|| CApiState {
-    // Single worker thread is intentional: keeps contention minimal and
-    // makes deadlocks easier to detect. Will be increased during
-    // performance optimization.
-    runtime: tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
-        .enable_all()
-        .build()
-        .expect("Failed to create tokio runtime"),
-    transport: RustTransport::new(),
+static STATE: LazyLock<CApiState> = LazyLock::new(|| {
+    // Telemetry state may not be available yet (sf_core_init_logger may be
+    // called after CApiState initialization). DatabaseDriverV1 falls back to
+    // reading TELEMETRY_INIT lazily when telemetry is first needed.
+    let providers = match crate::logging::c_api::TELEMETRY_INIT.get() {
+        Some(init) => init.to_providers(),
+        None => Default::default(),
+    };
+
+    CApiState {
+        // Single worker thread is intentional: keeps contention minimal and
+        // makes deadlocks easier to detect. Will be increased during
+        // performance optimization.
+        runtime: tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime"),
+        transport: RustTransport::new_with(providers),
+    }
 });
 
 fn write_buffer(vec: Vec<u8>, buffer: *mut *const u8, len: *mut usize) {

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -11,57 +11,92 @@ pub(crate) mod aws_identity;
 pub mod os_details;
 pub mod platform_detection;
 
-use environment::EnvironmentInfo;
-use opentelemetry::InstrumentationScope;
-use opentelemetry::KeyValue;
-use opentelemetry::trace::{
-    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
-};
-use opentelemetry_sdk::trace::SpanData;
-use rand::Rng;
+use crate::apis::database_driver_v1::DriverProviders;
 
-/// Build a `session_init` OTel span carrying environment and session metadata.
+/// Telemetry state created during logging initialization.
 ///
-/// The span is serialized by [`serialization::spans_to_snowflake_payload`] and
-/// exported via [`snowflake_exporter::SnowflakeInBandExporter`] to the
-/// `/telemetry/send` endpoint.
-pub fn build_session_init_span(env: &EnvironmentInfo, session_id: i64) -> SpanData {
-    let now = std::time::SystemTime::now();
-    let mut rng = rand::rng();
+/// Bridges (C API, JDBC, ODBC) should store this between `init_logging` and
+/// `DatabaseDriverV1` creation, then pass it to [`DriverProviders`] via
+/// [`into_providers`](TelemetryInit::into_providers).
+pub struct TelemetryInit {
+    pub provider: opentelemetry_sdk::trace::SdkTracerProvider,
+    pub sessions: snowflake_exporter::SessionRegistry,
+}
 
-    let mut attributes = vec![
-        KeyValue::new("service.name", env.driver_name.clone()),
-        KeyValue::new("service.version", env.driver_version.clone()),
-        KeyValue::new("process.runtime.name", env.language_runtime.clone()),
-        KeyValue::new("process.runtime.version", env.language_version.clone()),
-        KeyValue::new("os.type", env.os_name.clone()),
-        KeyValue::new("os.version", env.os_version.clone()),
-        KeyValue::new("host.arch", env.os_architecture.clone()),
-        KeyValue::new("snowflake.session.id", session_id),
+impl TelemetryInit {
+    /// Convert into `DriverProviders` fields for `DatabaseDriverV1`.
+    pub fn into_providers(self) -> DriverProviders {
+        DriverProviders {
+            telemetry_sessions: Some(self.sessions),
+            telemetry_provider: Some(self.provider),
+            ..Default::default()
+        }
+    }
+
+    /// Create `DriverProviders` by cloning (provider uses `Arc` internally).
+    pub fn to_providers(&self) -> DriverProviders {
+        DriverProviders {
+            telemetry_sessions: Some(self.sessions.clone()),
+            telemetry_provider: Some(self.provider.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+use opentelemetry::trace::TraceContextExt;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Record a session_init event on the **current** tracing span.
+///
+/// The caller must have entered the connection span before calling this.
+/// Uses the OTel API directly because `tracing::event!` does not support
+/// dotted field names (e.g. `service.name`).
+pub fn record_session_init(env: &environment::EnvironmentInfo) {
+    let span = tracing::Span::current();
+    let otel_ctx = span.context();
+    let otel_span = otel_ctx.span();
+    let mut attrs = vec![
+        opentelemetry::KeyValue::new("service.name", env.driver_name.clone()),
+        opentelemetry::KeyValue::new("service.version", env.driver_version.clone()),
+        opentelemetry::KeyValue::new("process.runtime.name", env.language_runtime.clone()),
+        opentelemetry::KeyValue::new("process.runtime.version", env.language_version.clone()),
+        opentelemetry::KeyValue::new("os.type", env.os_name.clone()),
+        opentelemetry::KeyValue::new("os.version", env.os_version.clone()),
+        opentelemetry::KeyValue::new("host.arch", env.os_architecture.clone()),
     ];
-
     if let Some(ref compiler) = env.language_compiler {
-        attributes.push(KeyValue::new("process.runtime.compiler", compiler.clone()));
+        attrs.push(opentelemetry::KeyValue::new(
+            "process.runtime.compiler",
+            compiler.clone(),
+        ));
     }
+    otel_span.add_event("session_init", attrs);
+}
 
-    SpanData {
-        span_context: SpanContext::new(
-            TraceId::from_bytes(rng.random()),
-            SpanId::from_bytes(rng.random()),
-            TraceFlags::default(),
-            false,
-            TraceState::default(),
-        ),
-        parent_span_id: SpanId::INVALID,
-        span_kind: SpanKind::Internal,
-        name: "session_init".into(),
-        start_time: now,
-        end_time: now,
-        attributes,
-        dropped_attributes_count: 0,
-        events: Default::default(),
-        links: Default::default(),
-        status: Status::Ok,
-        instrumentation_scope: InstrumentationScope::builder("snowflake.telemetry").build(),
-    }
+/// Record an api_call event on the **current** tracing span.
+pub fn record_api_call(api_method: &str) {
+    let span = tracing::Span::current();
+    let otel_ctx = span.context();
+    let otel_span = otel_ctx.span();
+    otel_span.add_event(
+        "api_call",
+        vec![opentelemetry::KeyValue::new(
+            "api_method",
+            api_method.to_string(),
+        )],
+    );
+}
+
+/// Record an exception event on the **current** tracing span.
+pub fn record_exception(exception_type: &str, error_source: &str) {
+    let span = tracing::Span::current();
+    let otel_ctx = span.context();
+    let otel_span = otel_ctx.span();
+    otel_span.add_event(
+        "exception",
+        vec![
+            opentelemetry::KeyValue::new("exception.type", exception_type.to_string()),
+            opentelemetry::KeyValue::new("exception.source", error_source.to_string()),
+        ],
+    );
 }

--- a/sf_core/src/telemetry/serialization.rs
+++ b/sf_core/src/telemetry/serialization.rs
@@ -8,45 +8,56 @@ use serde_json::{Value, json};
 ///
 /// Format: `{"logs": [{"message": {...}, "timestamp": "..."}]}`
 pub fn spans_to_snowflake_payload(spans: &[SpanData]) -> Value {
-    let logs: Vec<Value> = spans.iter().map(span_to_log_entry).collect();
+    let logs: Vec<Value> = spans.iter().flat_map(span_to_log_entries).collect();
     json!({ "logs": logs })
 }
 
-fn span_to_log_entry(span: &SpanData) -> Value {
+fn span_to_log_entries(span: &SpanData) -> Vec<Value> {
+    let mut entries = Vec::new();
+
+    if span.events.is_empty() {
+        // No events — emit the span itself as a single log entry (e.g. session_init
+        // when emitted as a standalone span for backward compatibility).
+        entries.push(attrs_to_log_entry(
+            &span.name,
+            &span.attributes,
+            span.start_time,
+        ));
+    } else {
+        // Each event on the span becomes its own log entry. The span's
+        // attributes are inherited so every entry carries session_id etc.
+        for event in span.events.iter() {
+            let mut attrs: Vec<opentelemetry::KeyValue> = span.attributes.clone();
+            for kv in &event.attributes {
+                attrs.push(kv.clone());
+            }
+            entries.push(attrs_to_log_entry(&event.name, &attrs, event.timestamp));
+        }
+    }
+
+    entries
+}
+
+fn attrs_to_log_entry(
+    name: &str,
+    attributes: &[opentelemetry::KeyValue],
+    timestamp: SystemTime,
+) -> Value {
     let mut message = serde_json::Map::new();
+    message.insert("type".to_string(), Value::String(name.to_string()));
 
-    message.insert("type".to_string(), Value::String(span.name.to_string()));
-
-    for kv in &span.attributes {
+    for kv in attributes {
         let key = kv.key.as_str();
         if key == "type" {
-            tracing::warn!("Span attribute key 'type' conflicts with span name field, skipping");
             continue;
         }
         message.insert(key.to_string(), otel_value_to_json(&kv.value));
     }
 
-    // Flatten span events (e.g., exception events) into the message.
-    // Event attributes are prefixed with "exception." to avoid overwriting span attributes.
-    for event in span.events.iter() {
-        if event.name.as_ref() == "exception" {
-            for kv in &event.attributes {
-                let key = kv.key.as_str();
-                let prefixed = if key.starts_with("exception.") {
-                    key.to_string()
-                } else {
-                    format!("exception.{key}")
-                };
-                message.insert(prefixed, otel_value_to_json(&kv.value));
-            }
-        }
-    }
-
-    let timestamp = system_time_to_epoch_millis(span.start_time);
-
+    let ts = system_time_to_epoch_millis(timestamp);
     json!({
         "message": message,
-        "timestamp": timestamp.to_string()
+        "timestamp": ts.to_string()
     })
 }
 

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::metrics::Temporality;
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
-use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
 use tokio::sync::RwLock as AsyncRwLock;
 
@@ -13,6 +13,13 @@ use crate::rest::snowflake::SessionTokens;
 use crate::rest::snowflake::telemetry as rest;
 
 use super::serialization;
+
+/// Span attribute key used to route telemetry to the correct session.
+const SESSION_ID_ATTR: &str = "snowflake.session.id";
+
+/// Shared registry mapping session IDs to their exporter sessions.
+/// Connections register on init, deregister on release.
+pub type SessionRegistry = Arc<RwLock<HashMap<i64, Arc<ExporterSession>>>>;
 
 /// Shared session context that the exporter uses to POST telemetry.
 pub struct ExporterSession {
@@ -31,15 +38,20 @@ impl std::fmt::Debug for ExporterSession {
 
 /// Custom OTel exporter that sends telemetry to Snowflake's in-band `/telemetry/send` endpoint.
 ///
+/// Uses a shared session registry to route spans to the correct connection based on
+/// the `snowflake.session.id` span attribute. Spans without this attribute are silently
+/// dropped — this is the security/privacy boundary ensuring only explicitly tagged spans
+/// are sent to Snowflake.
+///
 /// All errors are treated as non-fatal — telemetry must never break the user's workflow.
 #[derive(Debug, Clone)]
 pub struct SnowflakeInBandExporter {
-    session: Arc<ExporterSession>,
+    sessions: SessionRegistry,
 }
 
 impl SnowflakeInBandExporter {
-    pub fn new(session: Arc<ExporterSession>) -> Self {
-        Self { session }
+    pub fn new(sessions: SessionRegistry) -> Self {
+        Self { sessions }
     }
 }
 
@@ -72,61 +84,87 @@ async fn send_with_token(session: &ExporterSession, payload: &serde_json::Value)
     Ok(())
 }
 
+/// Extract the `snowflake.session.id` attribute value from a span's attributes.
+/// Handles both I64 (from tracing i64 fields) and String representations.
+fn extract_session_id(attrs: &[KeyValue]) -> Option<i64> {
+    use opentelemetry::Value;
+    attrs.iter().find_map(|kv| {
+        if kv.key.as_str() == SESSION_ID_ATTR {
+            match &kv.value {
+                Value::I64(id) => Some(*id),
+                Value::String(s) => s.as_str().parse::<i64>().ok(),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    })
+}
+
 impl SpanExporter for SnowflakeInBandExporter {
     fn export(
         &self,
         batch: Vec<SpanData>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
-        let session = self.session.clone();
+        let sessions = self.sessions.clone();
+        // SimpleSpanProcessor drives this future with futures_executor::block_on,
+        // which lacks tokio I/O drivers. We spawn the actual export on the tokio
+        // runtime (if available) so reqwest can perform async HTTP I/O.
+        let rt_handle = tokio::runtime::Handle::try_current().ok();
         async move {
             if batch.is_empty() {
                 return Ok(());
             }
 
-            let payload = serialization::spans_to_snowflake_payload(&batch);
-            send_with_token(&session, &payload).await
+            let do_export = move || async move {
+                // Group spans by session_id. Spans without the attribute are dropped.
+                let mut by_session: HashMap<i64, Vec<SpanData>> = HashMap::new();
+                for span in batch {
+                    if let Some(session_id) = extract_session_id(&span.attributes) {
+                        by_session.entry(session_id).or_default().push(span);
+                    }
+                }
+
+                if by_session.is_empty() {
+                    return;
+                }
+
+                // Snapshot the sessions we need under a short-lived read lock.
+                let session_map: HashMap<i64, Arc<ExporterSession>> = {
+                    let guard = sessions.read().unwrap_or_else(|e| e.into_inner());
+                    by_session
+                        .keys()
+                        .filter_map(|id| guard.get(id).map(|s| (*id, s.clone())))
+                        .collect()
+                };
+
+                // Send each session's spans independently.
+                for (session_id, spans) in &by_session {
+                    let Some(session) = session_map.get(session_id) else {
+                        tracing::debug!(
+                            session_id,
+                            "No registered session for telemetry spans, dropping"
+                        );
+                        continue;
+                    };
+                    let payload = serialization::spans_to_snowflake_payload(spans.as_slice());
+                    let _ = send_with_token(session, &payload).await;
+                }
+            };
+
+            // Spawn on the tokio runtime so reqwest I/O works. Best-effort:
+            // we don't block on completion since that would deadlock with
+            // the single-worker runtime used by the C API bridge.
+            if let Some(handle) = rt_handle {
+                handle.spawn(do_export());
+            }
+
+            Ok(())
         }
     }
 
     fn shutdown_with_timeout(&mut self, _timeout: Duration) -> OTelSdkResult {
         Ok(())
-    }
-}
-
-impl PushMetricExporter for SnowflakeInBandExporter {
-    fn export(
-        &self,
-        metrics: &ResourceMetrics,
-    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
-        let session = self.session.clone();
-        // Check if there are any metrics worth serializing before doing work.
-        let has_metrics = metrics
-            .scope_metrics()
-            .any(|sm| sm.metrics().next().is_some());
-        async move {
-            if !has_metrics {
-                return Ok(());
-            }
-
-            let payload = serialization::metrics_to_snowflake_payload(metrics);
-            if payload["logs"].as_array().is_some_and(|a| a.is_empty()) {
-                return Ok(());
-            }
-
-            send_with_token(&session, &payload).await
-        }
-    }
-
-    fn force_flush(&self) -> OTelSdkResult {
-        Ok(())
-    }
-
-    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
-        Ok(())
-    }
-
-    fn temporality(&self) -> Temporality {
-        Temporality::Delta
     }
 }
 
@@ -151,6 +189,15 @@ mod tests {
         }
     }
 
+    fn make_registry_with_session(
+        session_id: i64,
+        session: Arc<ExporterSession>,
+    ) -> SessionRegistry {
+        let mut map = HashMap::new();
+        map.insert(session_id, session);
+        Arc::new(RwLock::new(map))
+    }
+
     fn make_exporter_session(server_url: &str) -> Arc<ExporterSession> {
         use crate::sensitive::SensitiveString;
 
@@ -169,7 +216,20 @@ mod tests {
         })
     }
 
-    fn make_test_span() -> SpanData {
+    fn make_exporter_session_no_token(server_url: &str) -> Arc<ExporterSession> {
+        Arc::new(ExporterSession {
+            client: reqwest::Client::new(),
+            query_parameters: test_query_parameters(server_url),
+            session_token: Arc::new(AsyncRwLock::new(None)),
+        })
+    }
+
+    fn make_test_span(session_id: Option<i64>) -> SpanData {
+        let mut attributes = vec![];
+        if let Some(id) = session_id {
+            attributes.push(KeyValue::new(SESSION_ID_ATTR, id.to_string()));
+        }
+
         SpanData {
             span_context: SpanContext::new(
                 TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
@@ -183,7 +243,7 @@ mod tests {
             name: "test_span".into(),
             start_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000000000),
             end_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000001000),
-            attributes: vec![],
+            attributes,
             dropped_attributes_count: 0,
             events: Default::default(),
             links: Default::default(),
@@ -196,6 +256,7 @@ mod tests {
     async fn span_exporter_posts_to_telemetry_endpoint() {
         let server = MockServer::start().await;
         let session = make_exporter_session(&server.uri());
+        let registry = make_registry_with_session(1, session);
 
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
@@ -204,16 +265,29 @@ mod tests {
             .mount(&server)
             .await;
 
-        let exporter = SnowflakeInBandExporter::new(session);
-        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![make_test_span(Some(1))]).await;
         assert!(result.is_ok());
+        // Export is fire-and-forget via tokio::spawn; yield to let it complete.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
     #[tokio::test]
     async fn span_exporter_empty_batch_skips_post() {
+        let registry: SessionRegistry = Arc::new(RwLock::new(HashMap::new()));
+
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn span_exporter_drops_spans_without_session_id() {
         let server = MockServer::start().await;
         let session = make_exporter_session(&server.uri());
+        let registry = make_registry_with_session(1, session);
 
+        // No POST expected — span has no session_id attribute
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
@@ -221,8 +295,27 @@ mod tests {
             .mount(&server)
             .await;
 
-        let exporter = SnowflakeInBandExporter::new(session);
-        let result = SpanExporter::export(&exporter, vec![]).await;
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![make_test_span(None)]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn span_exporter_drops_spans_for_unknown_session() {
+        let server = MockServer::start().await;
+        let session = make_exporter_session(&server.uri());
+        let registry = make_registry_with_session(1, session);
+
+        // Span has session_id=999, but only session 1 is registered
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![make_test_span(Some(999))]).await;
         assert!(result.is_ok());
     }
 
@@ -230,6 +323,7 @@ mod tests {
     async fn span_exporter_no_session_token_drops_silently() {
         let server = MockServer::start().await;
         let session = make_exporter_session_no_token(&server.uri());
+        let registry = make_registry_with_session(1, session);
 
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
@@ -238,8 +332,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let exporter = SnowflakeInBandExporter::new(session);
-        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![make_test_span(Some(1))]).await;
         assert!(result.is_ok());
     }
 
@@ -247,6 +341,7 @@ mod tests {
     async fn span_exporter_server_error_returns_ok() {
         let server = MockServer::start().await;
         let session = make_exporter_session(&server.uri());
+        let registry = make_registry_with_session(1, session);
 
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
@@ -254,157 +349,62 @@ mod tests {
             .mount(&server)
             .await;
 
-        let exporter = SnowflakeInBandExporter::new(session);
-        let result = SpanExporter::export(&exporter, vec![make_test_span()]).await;
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(&exporter, vec![make_test_span(Some(1))]).await;
         assert!(result.is_ok());
     }
 
-    // -- PushMetricExporter unit tests --
-
-    use opentelemetry::KeyValue;
-    use opentelemetry::metrics::MeterProvider;
-    use opentelemetry_sdk::metrics::ManualReader;
-    use opentelemetry_sdk::metrics::Pipeline;
-    use opentelemetry_sdk::metrics::reader::MetricReader;
-    use std::sync::Weak;
-
-    /// Wrapper around `Arc<ManualReader>` that implements `MetricReader`,
-    /// allowing the reader to be shared between the `SdkMeterProvider` and
-    /// test code that calls `collect()`.
-    #[derive(Debug, Clone)]
-    struct SharedManualReader(Arc<ManualReader>);
-
-    impl MetricReader for SharedManualReader {
-        fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
-            self.0.register_pipeline(pipeline);
-        }
-        fn collect(
-            &self,
-            rm: &mut opentelemetry_sdk::metrics::data::ResourceMetrics,
-        ) -> opentelemetry_sdk::error::OTelSdkResult {
-            self.0.collect(rm)
-        }
-        fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
-            self.0.force_flush()
-        }
-        fn shutdown_with_timeout(
-            &self,
-            timeout: Duration,
-        ) -> opentelemetry_sdk::error::OTelSdkResult {
-            self.0.shutdown_with_timeout(timeout)
-        }
-        fn temporality(&self, kind: opentelemetry_sdk::metrics::InstrumentKind) -> Temporality {
-            self.0.temporality(kind)
-        }
+    #[test]
+    fn extract_session_id_handles_i64_value() {
+        let attrs = vec![KeyValue::new(SESSION_ID_ATTR, 42i64)];
+        assert_eq!(extract_session_id(&attrs), Some(42));
     }
 
-    fn make_exporter_session_no_token(server_url: &str) -> Arc<ExporterSession> {
-        Arc::new(ExporterSession {
-            client: reqwest::Client::new(),
-            query_parameters: test_query_parameters(server_url),
-            session_token: Arc::new(AsyncRwLock::new(None)),
-        })
+    #[test]
+    fn extract_session_id_handles_string_value() {
+        let attrs = vec![KeyValue::new(SESSION_ID_ATTR, "99")];
+        assert_eq!(extract_session_id(&attrs), Some(99));
     }
 
-    fn collect_test_metrics(
-        counter_name: &'static str,
-        attrs: &[KeyValue],
-    ) -> opentelemetry_sdk::metrics::data::ResourceMetrics {
-        let reader = SharedManualReader(Arc::new(
-            ManualReader::builder()
-                .with_temporality(Temporality::Delta)
-                .build(),
-        ));
-        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-            .with_reader(reader.clone())
-            .build();
-        let meter = provider.meter("test");
-        let counter = meter.u64_counter(counter_name).build();
-        counter.add(1, attrs);
-
-        let mut rm = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
-        reader.collect(&mut rm).unwrap();
-        rm
+    #[test]
+    fn extract_session_id_returns_none_when_missing() {
+        let attrs = vec![KeyValue::new("other.attr", "value")];
+        assert_eq!(extract_session_id(&attrs), None);
     }
 
     #[tokio::test]
-    async fn metric_exporter_posts_to_telemetry_endpoint() {
-        let server = MockServer::start().await;
-        let session = make_exporter_session(&server.uri());
+    async fn span_exporter_routes_to_multiple_sessions() {
+        let server1 = MockServer::start().await;
+        let server2 = MockServer::start().await;
+
+        let session1 = make_exporter_session(&server1.uri());
+        let session2 = make_exporter_session(&server2.uri());
+
+        let registry: SessionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        registry.write().unwrap().insert(1, session1);
+        registry.write().unwrap().insert(2, session2);
 
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
             .expect(1)
-            .mount(&server)
+            .mount(&server1)
             .await;
-
-        let exporter = SnowflakeInBandExporter::new(session);
-        let rm = collect_test_metrics(
-            "snowflake.driver.api.call",
-            &[KeyValue::new("api_method", "execute")],
-        );
-        let result = PushMetricExporter::export(&exporter, &rm).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn metric_exporter_empty_metrics_skips_post() {
-        let server = MockServer::start().await;
-        let session = make_exporter_session(&server.uri());
-
         Mock::given(method("POST"))
             .and(path("/telemetry/send"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
-            .expect(0)
-            .mount(&server)
+            .expect(1)
+            .mount(&server2)
             .await;
 
-        let exporter = SnowflakeInBandExporter::new(session);
-        let empty = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
-        let result = PushMetricExporter::export(&exporter, &empty).await;
+        let exporter = SnowflakeInBandExporter::new(registry);
+        let result = SpanExporter::export(
+            &exporter,
+            vec![make_test_span(Some(1)), make_test_span(Some(2))],
+        )
+        .await;
         assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn metric_exporter_no_token_drops_silently() {
-        let server = MockServer::start().await;
-        let session = make_exporter_session_no_token(&server.uri());
-
-        Mock::given(method("POST"))
-            .and(path("/telemetry/send"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let exporter = SnowflakeInBandExporter::new(session);
-        let rm = collect_test_metrics("test.counter", &[]);
-        let result = PushMetricExporter::export(&exporter, &rm).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn metric_exporter_server_error_returns_ok() {
-        let server = MockServer::start().await;
-        let session = make_exporter_session(&server.uri());
-
-        Mock::given(method("POST"))
-            .and(path("/telemetry/send"))
-            .respond_with(ResponseTemplate::new(500).set_body_string("error"))
-            .mount(&server)
-            .await;
-
-        let exporter = SnowflakeInBandExporter::new(session);
-        let rm = collect_test_metrics("test.counter", &[]);
-        let result = PushMetricExporter::export(&exporter, &rm).await;
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn metric_exporter_temporality_is_delta() {
-        let session = make_exporter_session("http://localhost:1");
-        let exporter = SnowflakeInBandExporter::new(session);
-        assert_eq!(exporter.temporality(), Temporality::Delta);
+        // Export is fire-and-forget via tokio::spawn; yield to let it complete.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -152,11 +152,14 @@ impl SpanExporter for SnowflakeInBandExporter {
                 }
             };
 
-            // Spawn on the tokio runtime so reqwest I/O works. Best-effort:
-            // we don't block on completion since that would deadlock with
-            // the single-worker runtime used by the C API bridge.
+            // Spawn on the tokio runtime so reqwest can perform async HTTP
+            // I/O (futures_executor::block_on, used by SimpleSpanProcessor,
+            // lacks tokio I/O drivers).  We await the JoinHandle so the
+            // export completes before on_end returns — this is safe because
+            // Runtime::block_on drives the handler on the calling thread
+            // while the spawned task runs on a separate worker thread.
             if let Some(handle) = rt_handle {
-                handle.spawn(do_export());
+                let _ = handle.spawn(do_export()).await;
             }
 
             Ok(())
@@ -268,8 +271,6 @@ mod tests {
         let exporter = SnowflakeInBandExporter::new(registry);
         let result = SpanExporter::export(&exporter, vec![make_test_span(Some(1))]).await;
         assert!(result.is_ok());
-        // Export is fire-and-forget via tokio::spawn; yield to let it complete.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
     #[tokio::test]
@@ -404,7 +405,5 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
-        // Export is fire-and-forget via tokio::spawn; yield to let it complete.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/sf_core/tests/integration/authentication/os_details.rs
+++ b/sf_core/tests/integration/authentication/os_details.rs
@@ -28,7 +28,10 @@ fn should_include_os_details_on_linux() {
     let mock = MockServerWithTls::start();
     let client = SnowflakeTestClient::with_int_tests_params_using(
         Some(&mock.http_url()),
-        DriverProviders { fs: Some(fs) },
+        DriverProviders {
+            fs: Some(fs),
+            ..Default::default()
+        },
     );
     client.set_connection_option("password", "test_password"); // pragma: allowlist secret
 

--- a/sf_core/tests/integration/authentication/spcs_token.rs
+++ b/sf_core/tests/integration/authentication/spcs_token.rs
@@ -60,7 +60,10 @@ fn should_not_include_spcs_token_when_env_var_is_not_set() {
 #[test]
 fn should_include_spcs_token_when_env_var_is_set_and_file_exists() {
     let fs = Arc::new(MockFs::new().with_file("/snowflake/session/spcs_token", "my-spcs-token"));
-    let context = SpcsTokenTestContext::with_providers(DriverProviders { fs: Some(fs) });
+    let context = SpcsTokenTestContext::with_providers(DriverProviders {
+        fs: Some(fs),
+        ..Default::default()
+    });
     context.mock.mount(
         Mock::given(method("POST"))
             .and(path_regex(r"/session/v1/login-request"))

--- a/sf_core/tests/integration/telemetry/exporter_pipeline.rs
+++ b/sf_core/tests/integration/telemetry/exporter_pipeline.rs
@@ -115,8 +115,6 @@ async fn span_exporter_sends_span_attributes_in_snowflake_format() {
     let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, vec![span]).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -147,8 +145,6 @@ async fn span_exporter_sends_multiple_spans_in_single_batch() {
     let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, spans).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -180,7 +176,6 @@ async fn span_exporter_handles_token_revoked_between_calls() {
     let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, vec![make_tagged_span("span1", vec![])]).await;
     assert!(result.is_ok());
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Clear the token — simulating session expiry
     *token_store.write().await = None;
@@ -188,8 +183,6 @@ async fn span_exporter_handles_token_revoked_between_calls() {
     // Second export should silently succeed (no POST, no error)
     let result = SpanExporter::export(&exporter, vec![make_tagged_span("span2", vec![])]).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -231,8 +224,6 @@ async fn span_exporter_uses_refreshed_token() {
     let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, vec![make_tagged_span("test", vec![])]).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -273,8 +264,6 @@ async fn span_exporter_shutdown_is_clean() {
     let mut exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::shutdown(&mut exporter);
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -293,8 +282,6 @@ async fn span_exporter_drops_spans_without_session_id() {
     let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -316,7 +303,6 @@ async fn span_exporter_drops_spans_after_session_deregistered() {
     let result =
         SpanExporter::export(&exporter, vec![make_tagged_span("before_close", vec![])]).await;
     assert!(result.is_ok());
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Simulate connection close: remove the session from the registry.
     registry.write().unwrap().remove(&SESSION_ID);
@@ -325,8 +311,6 @@ async fn span_exporter_drops_spans_after_session_deregistered() {
     let result =
         SpanExporter::export(&exporter, vec![make_tagged_span("after_close", vec![])]).await;
     assert!(result.is_ok());
-    // Export is fire-and-forget; yield to let it complete.
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 fn server_url_placeholder() -> String {

--- a/sf_core/tests/integration/telemetry/exporter_pipeline.rs
+++ b/sf_core/tests/integration/telemetry/exporter_pipeline.rs
@@ -1,22 +1,25 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, UNIX_EPOCH};
 
 use opentelemetry::trace::{
     SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
 };
 use opentelemetry::{InstrumentationScope, KeyValue};
-use opentelemetry_sdk::metrics::Temporality;
-use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
 use serde_json::json;
 use sf_core::config::rest_parameters::QueryParameters;
 use sf_core::config::rest_parameters::test_fixtures::test_client_info;
 use sf_core::rest::snowflake::SessionTokens;
 use sf_core::sensitive::SensitiveString;
-use sf_core::telemetry::snowflake_exporter::{ExporterSession, SnowflakeInBandExporter};
+use sf_core::telemetry::snowflake_exporter::{
+    ExporterSession, SessionRegistry, SnowflakeInBandExporter,
+};
 use tokio::sync::RwLock as AsyncRwLock;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SESSION_ID: i64 = 42;
 
 fn test_query_parameters(server_url: &str) -> QueryParameters {
     QueryParameters {
@@ -38,11 +41,17 @@ fn make_active_session(server_url: &str) -> Arc<ExporterSession> {
     let tokens = SessionTokens {
         session_token: SensitiveString::from("test_token"),
         master_token: SensitiveString::from("master_token"),
-        session_id: 42,
+        session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
     };
     make_session(server_url, Some(tokens))
+}
+
+fn make_registry(session_id: i64, session: Arc<ExporterSession>) -> SessionRegistry {
+    let mut map = HashMap::new();
+    map.insert(session_id, session);
+    Arc::new(RwLock::new(map))
 }
 
 fn make_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
@@ -68,6 +77,16 @@ fn make_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
     }
 }
 
+/// Helper: create a span with the `snowflake.session.id` attribute set.
+fn make_tagged_span(name: &'static str, extra_attrs: Vec<KeyValue>) -> SpanData {
+    let mut attrs = vec![KeyValue::new(
+        "snowflake.session.id",
+        SESSION_ID.to_string(),
+    )];
+    attrs.extend(extra_attrs);
+    make_span(name, attrs)
+}
+
 // ---------------------------------------------------------------------------
 // SpanExporter tests
 // ---------------------------------------------------------------------------
@@ -76,6 +95,7 @@ fn make_span(name: &'static str, attributes: Vec<KeyValue>) -> SpanData {
 async fn span_exporter_sends_span_attributes_in_snowflake_format() {
     let server = MockServer::start().await;
     let session = make_active_session(&server.uri());
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
@@ -84,7 +104,7 @@ async fn span_exporter_sends_span_attributes_in_snowflake_format() {
         .mount(&server)
         .await;
 
-    let span = make_span(
+    let span = make_tagged_span(
         "session_init",
         vec![
             KeyValue::new("service.name", "snowflake-python"),
@@ -92,15 +112,18 @@ async fn span_exporter_sends_span_attributes_in_snowflake_format() {
         ],
     );
 
-    let exporter = SnowflakeInBandExporter::new(session);
+    let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, vec![span]).await;
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
 async fn span_exporter_sends_multiple_spans_in_single_batch() {
     let server = MockServer::start().await;
     let session = make_active_session(&server.uri());
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
@@ -110,20 +133,22 @@ async fn span_exporter_sends_multiple_spans_in_single_batch() {
         .await;
 
     let spans = vec![
-        make_span(
+        make_tagged_span(
             "session_init",
             vec![KeyValue::new("service.name", "python")],
         ),
-        make_span(
+        make_tagged_span(
             "driver_exception",
             vec![KeyValue::new("exception.type", "RuntimeError")],
         ),
-        make_span("session_init", vec![KeyValue::new("service.name", "odbc")]),
+        make_tagged_span("session_init", vec![KeyValue::new("service.name", "odbc")]),
     ];
 
-    let exporter = SnowflakeInBandExporter::new(session);
+    let exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::export(&exporter, spans).await;
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -132,7 +157,7 @@ async fn span_exporter_handles_token_revoked_between_calls() {
     let tokens = SessionTokens {
         session_token: SensitiveString::from("valid_token"),
         master_token: SensitiveString::from("master"),
-        session_id: 1,
+        session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
     };
@@ -143,6 +168,7 @@ async fn span_exporter_handles_token_revoked_between_calls() {
         query_parameters: test_query_parameters(&server.uri()),
         session_token: token_store.clone(),
     });
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
@@ -151,16 +177,19 @@ async fn span_exporter_handles_token_revoked_between_calls() {
         .mount(&server)
         .await;
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    let result = SpanExporter::export(&exporter, vec![make_span("span1", vec![])]).await;
+    let exporter = SnowflakeInBandExporter::new(registry);
+    let result = SpanExporter::export(&exporter, vec![make_tagged_span("span1", vec![])]).await;
     assert!(result.is_ok());
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Clear the token — simulating session expiry
     *token_store.write().await = None;
 
     // Second export should silently succeed (no POST, no error)
-    let result = SpanExporter::export(&exporter, vec![make_span("span2", vec![])]).await;
+    let result = SpanExporter::export(&exporter, vec![make_tagged_span("span2", vec![])]).await;
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
@@ -169,7 +198,7 @@ async fn span_exporter_uses_refreshed_token() {
     let initial_tokens = SessionTokens {
         session_token: SensitiveString::from("old_token"),
         master_token: SensitiveString::from("master"),
-        session_id: 1,
+        session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
     };
@@ -180,6 +209,7 @@ async fn span_exporter_uses_refreshed_token() {
         query_parameters: test_query_parameters(&server.uri()),
         session_token: token_store.clone(),
     });
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
@@ -192,21 +222,24 @@ async fn span_exporter_uses_refreshed_token() {
     let new_tokens = SessionTokens {
         session_token: SensitiveString::from("new_refreshed_token"),
         master_token: SensitiveString::from("master"),
-        session_id: 1,
+        session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
     };
     *token_store.write().await = Some(new_tokens);
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    let exporter = SnowflakeInBandExporter::new(registry);
+    let result = SpanExporter::export(&exporter, vec![make_tagged_span("test", vec![])]).await;
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
 async fn span_exporter_swallows_all_server_errors() {
     let server = MockServer::start().await;
     let session = make_active_session(&server.uri());
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
@@ -214,17 +247,18 @@ async fn span_exporter_swallows_all_server_errors() {
         .mount(&server)
         .await;
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    let exporter = SnowflakeInBandExporter::new(registry);
+    let result = SpanExporter::export(&exporter, vec![make_tagged_span("test", vec![])]).await;
     assert!(result.is_ok(), "Exporter must not propagate server errors");
 }
 
 #[tokio::test]
 async fn span_exporter_swallows_connection_errors() {
     let session = make_active_session("http://127.0.0.1:1");
+    let registry = make_registry(SESSION_ID, session);
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
+    let exporter = SnowflakeInBandExporter::new(registry);
+    let result = SpanExporter::export(&exporter, vec![make_tagged_span("test", vec![])]).await;
     assert!(
         result.is_ok(),
         "Exporter must not propagate connection errors"
@@ -233,72 +267,68 @@ async fn span_exporter_swallows_connection_errors() {
 
 #[tokio::test]
 async fn span_exporter_shutdown_is_clean() {
-    let server = MockServer::start().await;
-    let session = make_active_session(&server.uri());
+    let session = make_active_session(&server_url_placeholder());
+    let registry = make_registry(SESSION_ID, session);
 
-    let mut exporter = SnowflakeInBandExporter::new(session);
+    let mut exporter = SnowflakeInBandExporter::new(registry);
     let result = SpanExporter::shutdown(&mut exporter);
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
-// ---------------------------------------------------------------------------
-// PushMetricExporter tests
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
-async fn metric_exporter_empty_metrics_skips_post() {
+async fn span_exporter_drops_spans_without_session_id() {
     let server = MockServer::start().await;
     let session = make_active_session(&server.uri());
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
-        .expect(0) // No call expected for empty metrics
+        .expect(0) // No POST — spans lack session_id
         .mount(&server)
         .await;
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    let empty_metrics = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
-    let result = PushMetricExporter::export(&exporter, &empty_metrics).await;
+    let exporter = SnowflakeInBandExporter::new(registry);
+    let result = SpanExporter::export(&exporter, vec![make_span("test", vec![])]).await;
     assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 #[tokio::test]
-async fn metric_exporter_no_token_drops_silently() {
+async fn span_exporter_drops_spans_after_session_deregistered() {
     let server = MockServer::start().await;
-    let session = make_session(&server.uri(), None);
+    let session = make_active_session(&server.uri());
+    let registry = make_registry(SESSION_ID, session);
 
     Mock::given(method("POST"))
         .and(path("/telemetry/send"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
-        .expect(0) // No call expected when no token
+        .expect(1) // Only the first export should POST
         .mount(&server)
         .await;
 
-    let exporter = SnowflakeInBandExporter::new(session);
-    // Even with default (empty) metrics, the code path for no-token should be tested
-    let empty_metrics = opentelemetry_sdk::metrics::data::ResourceMetrics::default();
-    let result = PushMetricExporter::export(&exporter, &empty_metrics).await;
+    let exporter = SnowflakeInBandExporter::new(registry.clone());
+
+    // First export succeeds — session is registered.
+    let result =
+        SpanExporter::export(&exporter, vec![make_tagged_span("before_close", vec![])]).await;
     assert!(result.is_ok());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Simulate connection close: remove the session from the registry.
+    registry.write().unwrap().remove(&SESSION_ID);
+
+    // Second export should silently drop — no POST, no error.
+    let result =
+        SpanExporter::export(&exporter, vec![make_tagged_span("after_close", vec![])]).await;
+    assert!(result.is_ok());
+    // Export is fire-and-forget; yield to let it complete.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
-#[test]
-fn metric_exporter_temporality_is_delta() {
-    let session = make_session("http://localhost:1", None);
-    let exporter = SnowflakeInBandExporter::new(session);
-    assert_eq!(exporter.temporality(), Temporality::Delta);
-}
-
-#[test]
-fn metric_exporter_force_flush_is_ok() {
-    let session = make_session("http://localhost:1", None);
-    let exporter = SnowflakeInBandExporter::new(session);
-    assert!(exporter.force_flush().is_ok());
-}
-
-#[test]
-fn metric_exporter_shutdown_is_ok() {
-    let session = make_session("http://localhost:1", None);
-    let exporter = SnowflakeInBandExporter::new(session);
-    assert!(PushMetricExporter::shutdown(&exporter).is_ok());
+fn server_url_placeholder() -> String {
+    "http://127.0.0.1:1".to_string()
 }

--- a/sf_core/tests/integration/telemetry/mod.rs
+++ b/sf_core/tests/integration/telemetry/mod.rs
@@ -2,3 +2,4 @@ mod exporter_pipeline;
 pub mod platform_detection;
 mod rest_endpoint;
 mod serialization;
+mod wrapper_identity;

--- a/sf_core/tests/integration/telemetry/serialization.rs
+++ b/sf_core/tests/integration/telemetry/serialization.rs
@@ -87,17 +87,19 @@ fn multiple_spans_produce_multiple_log_entries() {
 }
 
 #[test]
-fn exception_span_event_attributes_are_flattened_into_message() {
+fn span_events_produce_separate_log_entries() {
     use opentelemetry::trace::Event;
 
-    let mut span = make_span("driver_exception", vec![]);
+    let mut span = make_span(
+        "connection",
+        vec![KeyValue::new("snowflake.session.id", 42i64)],
+    );
     let event = Event::new(
         "exception",
         UNIX_EPOCH + Duration::from_millis(1700000000500),
         vec![
             KeyValue::new("exception.type", "ConnectionError"),
             KeyValue::new("exception.message", "timeout after 30s"),
-            KeyValue::new("exception.stacktrace", "at line 42"),
         ],
         0,
     );
@@ -106,33 +108,49 @@ fn exception_span_event_attributes_are_flattened_into_message() {
     span.events = events;
 
     let payload = spans_to_snowflake_payload(&[span]);
-    let msg = &payload["logs"][0]["message"];
+    let logs = payload["logs"].as_array().unwrap();
 
-    assert_eq!(msg["type"], "driver_exception");
+    // Event becomes its own log entry, inheriting span attributes.
+    assert_eq!(logs.len(), 1);
+    let msg = &logs[0]["message"];
+    assert_eq!(msg["type"], "exception");
     assert_eq!(msg["exception.type"], "ConnectionError");
     assert_eq!(msg["exception.message"], "timeout after 30s");
-    assert_eq!(msg["exception.stacktrace"], "at line 42");
+    assert_eq!(msg["snowflake.session.id"], 42);
+    assert_eq!(logs[0]["timestamp"], "1700000000500");
 }
 
 #[test]
-fn non_exception_span_events_are_not_flattened() {
+fn span_with_multiple_events_produces_multiple_entries() {
     use opentelemetry::trace::Event;
 
-    let mut span = make_span("some_span", vec![]);
-    let event = Event::new(
-        "custom_event",
-        UNIX_EPOCH + Duration::from_millis(1700000000500),
-        vec![KeyValue::new("custom.key", "custom_value")],
-        0,
+    let mut span = make_span(
+        "connection",
+        vec![KeyValue::new("snowflake.session.id", 1i64)],
     );
     let mut events = opentelemetry_sdk::trace::SpanEvents::default();
-    events.events.push(event);
+    events.events.push(Event::new(
+        "session_init",
+        UNIX_EPOCH + Duration::from_millis(1700000000000),
+        vec![KeyValue::new("service.name", "python")],
+        0,
+    ));
+    events.events.push(Event::new(
+        "api_call",
+        UNIX_EPOCH + Duration::from_millis(1700000000100),
+        vec![KeyValue::new("api_method", "cursor.execute")],
+        0,
+    ));
     span.events = events;
 
     let payload = spans_to_snowflake_payload(&[span]);
-    let msg = &payload["logs"][0]["message"];
+    let logs = payload["logs"].as_array().unwrap();
 
-    // Only "type" should be present — custom event attrs should NOT be flattened
-    assert_eq!(msg["type"], "some_span");
-    assert!(msg.get("custom.key").is_none());
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0]["message"]["type"], "session_init");
+    assert_eq!(logs[0]["message"]["service.name"], "python");
+    assert_eq!(logs[0]["message"]["snowflake.session.id"], 1);
+    assert_eq!(logs[1]["message"]["type"], "api_call");
+    assert_eq!(logs[1]["message"]["api_method"], "cursor.execute");
+    assert_eq!(logs[1]["message"]["snowflake.session.id"], 1);
 }

--- a/sf_core/tests/integration/telemetry/wrapper_identity.rs
+++ b/sf_core/tests/integration/telemetry/wrapper_identity.rs
@@ -1,0 +1,161 @@
+use sf_core::apis::database_driver_v1::DatabaseDriverV1;
+use sf_core::apis::database_driver_v1::connection::WrapperIdentity;
+
+fn test_identity() -> WrapperIdentity {
+    WrapperIdentity {
+        driver_name: "snowflake-connector-python".to_string(),
+        driver_version: "3.5.0".to_string(),
+        language_runtime: "CPython".to_string(),
+        language_version: "3.12.1".to_string(),
+        language_compiler: Some("GCC 13.2.0".to_string()),
+    }
+}
+
+#[tokio::test]
+async fn set_then_get_roundtrips() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    driver
+        .set_wrapper_identity(handle, test_identity())
+        .await
+        .expect("set_wrapper_identity should succeed");
+
+    let identity = driver
+        .get_wrapper_identity(handle)
+        .await
+        .expect("get_wrapper_identity should succeed")
+        .expect("identity should be Some after set");
+
+    assert_eq!(identity.driver_name, "snowflake-connector-python");
+    assert_eq!(identity.driver_version, "3.5.0");
+    assert_eq!(identity.language_runtime, "CPython");
+    assert_eq!(identity.language_version, "3.12.1");
+    assert_eq!(identity.language_compiler, Some("GCC 13.2.0".to_string()));
+}
+
+#[tokio::test]
+async fn get_returns_none_before_set() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let identity = driver
+        .get_wrapper_identity(handle)
+        .await
+        .expect("get_wrapper_identity should succeed");
+
+    assert!(identity.is_none());
+}
+
+#[tokio::test]
+async fn set_with_none_compiler() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let identity = WrapperIdentity {
+        language_compiler: None,
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle, identity)
+        .await
+        .expect("set_wrapper_identity should succeed");
+
+    let stored = driver.get_wrapper_identity(handle).await.unwrap().unwrap();
+
+    assert!(stored.language_compiler.is_none());
+}
+
+#[tokio::test]
+async fn set_twice_overwrites() {
+    let driver = DatabaseDriverV1::new();
+    let handle = driver.connection_new();
+
+    let first = WrapperIdentity {
+        driver_version: "1.0.0".to_string(),
+        ..test_identity()
+    };
+    let second = WrapperIdentity {
+        driver_version: "2.0.0".to_string(),
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle, first)
+        .await
+        .expect("first set should succeed");
+    driver
+        .set_wrapper_identity(handle, second)
+        .await
+        .expect("second set should succeed (overwrite)");
+
+    let stored = driver.get_wrapper_identity(handle).await.unwrap().unwrap();
+
+    assert_eq!(stored.driver_version, "2.0.0");
+}
+
+#[tokio::test]
+async fn set_with_invalid_handle_returns_error() {
+    use sf_core::apis::database_driver_v1::Handle;
+
+    let driver = DatabaseDriverV1::new();
+    let bad_handle = Handle { id: 9999, magic: 0 };
+
+    let result = driver
+        .set_wrapper_identity(bad_handle, test_identity())
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn get_with_invalid_handle_returns_error() {
+    use sf_core::apis::database_driver_v1::Handle;
+
+    let driver = DatabaseDriverV1::new();
+    let bad_handle = Handle { id: 9999, magic: 0 };
+
+    let result = driver.get_wrapper_identity(bad_handle).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn identity_is_per_connection() {
+    let driver = DatabaseDriverV1::new();
+    let handle_a = driver.connection_new();
+    let handle_b = driver.connection_new();
+
+    let identity_a = WrapperIdentity {
+        driver_name: "python".to_string(),
+        ..test_identity()
+    };
+    let identity_b = WrapperIdentity {
+        driver_name: "nodejs".to_string(),
+        ..test_identity()
+    };
+
+    driver
+        .set_wrapper_identity(handle_a, identity_a)
+        .await
+        .unwrap();
+    driver
+        .set_wrapper_identity(handle_b, identity_b)
+        .await
+        .unwrap();
+
+    let stored_a = driver
+        .get_wrapper_identity(handle_a)
+        .await
+        .unwrap()
+        .unwrap();
+    let stored_b = driver
+        .get_wrapper_identity(handle_b)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(stored_a.driver_name, "python");
+    assert_eq!(stored_b.driver_name, "nodejs");
+}


### PR DESCRIPTION
## Summary

Builds on the in-band telemetry foundation (PR #806) to add **api_usage and wrapper_error telemetry** and rework the exporter architecture for multi-session correctness.

### What changed from #806

PR #806 shipped `session_init` telemetry via a fire-and-forget HTTP POST per connection. That worked for a single event but doesn't scale. This PR replaces it with a `tracing`-native pipeline where all telemetry flows through OTel span events on a single long-lived connection span.

### Architecture

Each connection gets a long-lived `tracing::info_span!("connection")` carrying `snowflake.session.id`. Telemetry events (`session_init`, `api_call`, `exception`) are recorded as OTel events on this span via `Span::add_event()`. When the connection is released, the span ends and the batch exporter serializes each event into its own log entry for `POST /telemetry/send`.

```
Python wrapper                    sf_core (Rust)
─────────────                     ──────────────
TelemetryClient.send_api_usage()
  → protobuf RPC ──────────────→ telemetry_send_api_usage()
                                    → Span::add_event("api_call", [...])
                                      on connection span
                                         ↓ (on connection release)
                                  tracing subscriber
                                    → OpenTelemetryLayer
                                    → BatchSpanProcessor
                                    → SnowflakeInBandExporter
                                      routes by snowflake.session.id
                                      each event → log entry
                                    → POST /telemetry/send
```

### Key design decisions

- **Events, not child spans**: `session_init`, `api_call`, and `exception` are OTel events on the connection span. This batches all telemetry into one export per session and avoids span-per-call overhead.
- **Global shared `SessionRegistry`**: A process-global `Arc<RwLock<HashMap>>` shared between the exporter layer (installed at logging init with an empty registry) and `DatabaseDriverV1` (populated when connections open). This decouples initialization timing — logging init happens at module import, driver state arrives later.
- **Force-flush before deregister**: On connection release, the span is ended and the batch processor is force-flushed before the session is removed from the registry, preventing silent telemetry loss.
- **Serialization**: Each event on a span becomes its own `{"message": {...}, "timestamp": "..."}` log entry. Span attributes (`snowflake.session.id`) are inherited into every entry.

### Changes

**Protobuf** — new `TelemetrySendApiUsage` / `TelemetrySendWrapperError` RPCs

**Rust core**
- `snowflake_exporter.rs` — global `SessionRegistry`, session-id-based span routing
- `logging/mod.rs` — always install exporter layer via global registry, `OnceLock` for provider lifetime, `flush_telemetry()` helper
- `connection.rs` — register session on init, record `session_init` event, `telemetry_span()` accessor, flush + deregister on release
- `database_driver_v1.rs` — RPC handlers add events to connection span via OTel API
- `serialization.rs` — span events → individual log entries with inherited attributes

**Python**
- `_internal/telemetry.py` — fire-and-forget `TelemetryClient` for api_usage / wrapper_error
- `connection.py` — TODO for wiring `TelemetryClient`

**Tests** — wrapper identity integration tests, `extract_session_id` unit tests, updated serialization tests for event-based model

## Test plan

- [x] `cargo test -p sf_core -- telemetry` (46 tests pass)
- [x] `cargo build -p jdbc_bridge` (compiles)
- [x] Python unit tests `test_internal_telemetry.py` (5 tests pass)
- [ ] CI: `test_session_init_telemetry_sent_on_connection_open` (e2e with Wiremock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)