### PR TITLE
NO-SNOW: python - fix memory leak around releasing arrow stream, refactor query results

### DIFF
--- a/python/src/snowflake/connector/_internal/arrow_stream_utils.py
+++ b/python/src/snowflake/connector/_internal/arrow_stream_utils.py
@@ -16,12 +16,24 @@ if TYPE_CHECKING:
 
 
 def release_arrow_stream(stream_ptr: int | None) -> None:
-    # Release the Arrow stream pointer to prevent memory leak
-    if stream_ptr:
-        # Create ArrowStreamIterator to take ownership of the stream pointer.
-        # The C++ destructor will handle cleanup when it goes out of scope.
+    """Release an ArrowArrayStream pointer to prevent memory leaks.
+
+    Works by creating a throwaway ArrowStreamIterator whose C++ destructor
+    calls ``stream->release(stream)`` when it goes out of scope.  This is
+    indirect — the C++ from_stream() factory also reads the schema — but it
+    is the only release path currently exposed to Python.
+
+    If the stream is in a bad state (already released, corrupt), the
+    ArrowStreamIterator constructor will fail.  We catch that to avoid
+    propagating errors into callers that are doing best-effort cleanup
+    (e.g. _QueryResult.__del__ or reset()).
+    """
+    if not stream_ptr:
+        return
+    try:
         _ = ArrowStreamIterator(stream_ptr, ArrowConverterContext())
-        # Iterator goes out of scope here, triggering C++ destructor
+    except Exception:
+        pass
 
 
 def create_row_iterator(

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -21,7 +21,6 @@ from .._internal.arrow_stream_utils import (
     collect_arrow_table,
     create_row_iterator,
     create_table_iterator,
-    release_arrow_stream,
 )
 from .._internal.binding_converters import (
     ClientSideBindingConverter,
@@ -43,14 +42,10 @@ from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     StatementPrepareRequest,
     StatementResultChunksRequest,
 )
-from .._internal.statement_utils import (
-    create_statement,
-    extract_rowcount,
-    extract_sqlstate,
-    get_stream_ptr,
-)
+from .._internal.statement_utils import create_statement
 from ..errors import InterfaceError, NotSupportedError, ProgrammingError
 from ..result_batch import ResultBatch
+from ._query_result import _QueryResult
 from ._query_result_waiter import QueryResultWaiter
 from ._result_metadata import QueryResultStats, ResultMetadata
 
@@ -150,23 +145,18 @@ class SnowflakeCursorBase(abc.ABC):
         # -- PEP 249 cursor configuration (persists for cursor lifetime) --
         self._arraysize: int = 1
 
-        # -- Query result metadata (set on execute, preserved across reset) --
-        self._description: list[ResultMetadata] | None = None
-        self._sqlstate: str | None = None
-        self._sfqid: str | None = None
-        self._query: str | None = None
+        # -- Query result state (replaced on execute, mutated on reset/consume) --
+        self._query_result: _QueryResult = _QueryResult()
+
+        # Cursor navigation position — mutable to avoid allocation per fetchone
         self._rownumber: int = -1
 
-        # -- Active result state (cleared on reset) --
-        self._rowcount: int | None = None
-        # TODO: API will be changed to fetch execute_results or chunks in separate step
-        #   then statement should be stored in cursor field instead of ExecuteResult and ResultChunk
-        #   and those will be fetch on demand
-        self._execute_result: ExecuteResult | None = None
+        # -- Active iteration state (cleared on reset) --
         self._result_chunks: list[ResultChunk] | None = None
         self._iterator: Iterator[Row | DictRow] | None = None
         self._fetch_mode: FetchMode | None = None
-        # Query bindings - keep binding data reference to prevent garbage collection while Rust uses it
+
+        # Keep binding data reference to prevent garbage collection while Rust uses it
         self._binding_data: None | bytes = None
         # Deferred result loading (set by get_results_from_sfqid, invoked on first fetch)
         self._prefetch_hook: Callable[[], None] | None = None
@@ -198,7 +188,7 @@ class SnowflakeCursorBase(abc.ABC):
 
         Returns None if no query has been executed or if the query didn't produce a result set.
         """
-        return self._description
+        return self._query_result.description
 
     @property
     @pep249
@@ -210,7 +200,7 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             int: Number of rows affected, or None if not determined
         """
-        return self._rowcount
+        return self._query_result.rowcount
 
     @property
     @pep249
@@ -253,7 +243,7 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             str | None: The SQL query string, or None if no query has been executed or described
         """
-        return self._query
+        return self._query_result.query
 
     @property
     def sfqid(self) -> str | None:
@@ -263,14 +253,12 @@ class SnowflakeCursorBase(abc.ABC):
         Returns:
             str | None: Snowflake Query ID (UUID format), or None if no query has been executed or described
         """
-        return self._sfqid
+        return self._query_result.sfqid
 
     @property
-    def stats(self) -> QueryResultStats | None:
+    def stats(self) -> QueryResultStats:
         """Returns detailed row-level statistics for DML operations."""
-        if self._execute_result is None or not self._execute_result.HasField("stats"):
-            return QueryResultStats()
-        return QueryResultStats.from_query_stats(self._execute_result.stats)
+        return self._query_result.stats
 
     @property
     @pep249
@@ -281,7 +269,7 @@ class SnowflakeCursorBase(abc.ABC):
     @property
     def sqlstate(self) -> str | None:
         """The SQLSTATE code of the last executed operation."""
-        return self._sqlstate
+        return self._query_result.sqlstate
 
     @pep249
     def callproc(self, procname: str, parameters: Sequence[Any] | None = None) -> Sequence[Any]:
@@ -420,7 +408,8 @@ class SnowflakeCursorBase(abc.ABC):
             result = self._execute_query(stmt_handle, bindings)
             self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle)
 
-        self._populate_state_from_execute_result(result)
+        self._query_result = _QueryResult.from_execute_result(result)
+        self._rownumber = -1  # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
 
         return self
 
@@ -441,8 +430,7 @@ class SnowflakeCursorBase(abc.ABC):
             request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
             return self._connection.db_api.statement_execute_query(request).result
         except ProgrammingError as exc:
-            self._sqlstate = exc.sqlstate or None
-            self._sfqid = exc.sfqid or None
+            self._query_result = _QueryResult.from_programming_error(exc)
             raise
 
     def _prepare(self, stmt_handle: StatementHandle) -> PrepareResult:
@@ -450,19 +438,8 @@ class SnowflakeCursorBase(abc.ABC):
             request = StatementPrepareRequest(stmt_handle=stmt_handle)
             return self._connection.db_api.statement_prepare(request).result
         except ProgrammingError as exc:
-            self._sqlstate = exc.sqlstate or None
+            self._query_result = _QueryResult.from_programming_error(exc)
             raise
-
-    def _populate_state_from_execute_result(self, result: ExecuteResult | None) -> None:
-        self._description = ResultMetadata.create_description(result)
-        self._rowcount = extract_rowcount(result)
-        self._sqlstate = extract_sqlstate(result)
-        self._sfqid = (result.query_id if result.query_id else None) if result else None
-        self._query = (result.query if result.query else None) if result else None
-        # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
-        self._rownumber = -1
-        # save execute result (holds arrow stream data needed for fetching)
-        self._execute_result = result
 
     @pep249
     @_requires_open
@@ -496,14 +473,14 @@ class SnowflakeCursorBase(abc.ABC):
             unknown_rowcount = False
             for params in seq_of_parameters:
                 self._execute(operation, params)  # no reset between calls
-                rc = self._rowcount
+                rc = self._query_result.rowcount
                 if rc is None or rc == -1:
                     unknown_rowcount = True
                 elif not unknown_rowcount:
                     total_rowcount += rc
-            # Per PEP 249, -1 indicates that the number of rows is unknown
-            # but for backward compatibility we set it to None
-            self._rowcount = None if unknown_rowcount else total_rowcount
+            # Per PEP 249, -1 indicates that the number of rows is unknown,
+            # but for backward compatibility it's set to None.
+            self._query_result.rowcount = None if unknown_rowcount else total_rowcount
             return
 
         # Server-side binding: validate and use array binding
@@ -555,25 +532,16 @@ class SnowflakeCursorBase(abc.ABC):
         self.reset()
         query, bindings = self._prepare_query(operation, parameters)
 
-        result: PrepareResult | None = None
+        prepare_result: PrepareResult | None = None
         with create_statement(self.connection, query) as stmt_handle:
-            result = self._prepare(stmt_handle)
+            prepare_result = self._prepare(stmt_handle)
 
-        # The PrepareResult includes an ArrowArrayStreamPtr that must be released
-        # even though we won't consume any data from it.
-        release_arrow_stream(get_stream_ptr(result))
+        self._query_result = _QueryResult.from_prepare_result(prepare_result)
 
-        result_metadata = ResultMetadata.create_description(result)
-        self._sqlstate = extract_sqlstate(result)
-        self._sfqid = (result.query_id if result.query_id else None) if result else None
-        self._query = (result.query if result.query else None) if result else None
-        if result_metadata:
-            self._description = result_metadata  # shallow copy
-            self._rowcount = 0
-            # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
+        if self._query_result.description:
             self._rownumber = -1
 
-        return result_metadata
+        return self._query_result.description
 
     # ------------------------------------------------------------------
     # Fetch – shared implementation
@@ -655,9 +623,8 @@ class SnowflakeCursorBase(abc.ABC):
     # ------------------------------------------------------------------
 
     def _create_row_iterator(self) -> Iterator[Row | DictRow]:
-        stream_ptr = get_stream_ptr(self._execute_result)
         return create_row_iterator(
-            stream_ptr=stream_ptr,
+            stream_ptr=self._query_result.consume_stream(),
             use_dict_result=self._use_dict_result,
             use_numpy=self._connection._numpy,
         )
@@ -768,9 +735,7 @@ class SnowflakeCursorBase(abc.ABC):
                      see: SNOW-647539: Do not erase the rowcount information when closing the cursor.
                      If False, reset rowcount to None.
         """
-        if not closing:
-            self._rowcount = None
-        self._execute_result = None
+        self._query_result.reset(closing=closing)
         self._result_chunks = None
         self._iterator = None
         self._fetch_mode = None
@@ -876,7 +841,7 @@ class SnowflakeCursorBase(abc.ABC):
     ) -> Iterator[Table]:
         """Fetch Arrow Tables in batches."""
         iterator = create_table_iterator(
-            stream_ptr=get_stream_ptr(self._execute_result),
+            stream_ptr=self._query_result.consume_stream(),
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
         )
@@ -894,13 +859,13 @@ class SnowflakeCursorBase(abc.ABC):
     ) -> Table | None:
         """Fetch all results as a single Arrow Table."""
         iterator = create_table_iterator(
-            stream_ptr=get_stream_ptr(self._execute_result),
+            stream_ptr=self._query_result.consume_stream(),
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
         )
         return collect_arrow_table(
             table_iterator=iterator,
-            columns_metadata=self._description,
+            columns_metadata=self._query_result.description,
             force_return_table=force_return_table,
         )
 
@@ -931,7 +896,7 @@ class SnowflakeCursorBase(abc.ABC):
     @_requires_open
     def get_result_batches(self) -> list[ResultBatch] | None:
         """Get the previously executed query's ResultBatches if available."""
-        return ResultBatch.from_chunks(self._result_chunks, self._description, self._connection)
+        return ResultBatch.from_chunks(self._result_chunks, self._query_result.description, self._connection)
 
     # ------------------------------------------------------------------
     # Async query support
@@ -963,7 +928,8 @@ class SnowflakeCursorBase(abc.ABC):
         )
         response = self._connection.db_api.connection_get_query_result(request)
 
-        self._populate_state_from_execute_result(response.result)
+        self._query_result = _QueryResult.from_execute_result(response.result)
+        self._rownumber = -1
 
         return self
 
@@ -990,7 +956,7 @@ class SnowflakeCursorBase(abc.ABC):
         """
         self.reset()
         self.connection.get_query_status_throw_if_error(sfqid)
-        self._sfqid = sfqid
+        self._query_result.sfqid = sfqid
         waiter = QueryResultWaiter(self._connection, sfqid)
 
         def prefetch_hook() -> None:

--- a/python/src/snowflake/connector/cursor/_query_result.py
+++ b/python/src/snowflake/connector/cursor/_query_result.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from .._internal.arrow_stream_utils import release_arrow_stream
+from .._internal.protobuf_gen.database_driver_v1_pb2 import ExecuteResult, PrepareResult
+from .._internal.statement_utils import extract_rowcount, extract_sqlstate, get_stream_ptr
+from ..errors import ProgrammingError
+from ._result_metadata import QueryResultStats, ResultMetadata
+
+
+class _QueryResult:
+    __slots__ = ("description", "sqlstate", "sfqid", "query", "stats", "rowcount", "_stream_ptr")
+
+    def __init__(
+        self,
+        *,
+        description: list[ResultMetadata] | None = None,
+        sqlstate: str | None = None,
+        sfqid: str | None = None,
+        query: str | None = None,
+        stats: QueryResultStats | None = None,
+        rowcount: int | None = None,
+        _stream_ptr: int | None = None,
+    ) -> None:
+        self.description = description
+        self.sqlstate = sqlstate
+        self.sfqid = sfqid
+        self.query = query
+        self.stats = stats if stats is not None else QueryResultStats()
+        self.rowcount = rowcount
+        self._stream_ptr = _stream_ptr
+
+    def __del__(self) -> None:
+        # Safety net: release the native ArrowArrayStream if it was neither
+        # consumed (via consume_stream) nor explicitly freed (via reset).
+        # This guards against leaks when a _QueryResult is replaced on the
+        # cursor (e.g. executemany loop, error paths) without a prior reset().
+        # The try/except is intentional — during interpreter shutdown, modules
+        # and builtins referenced by release_arrow_stream may already be torn
+        # down, so any call here is best-effort only.
+        try:
+            if self._stream_ptr:
+                release_arrow_stream(self._stream_ptr)
+        except Exception:
+            pass
+
+    def consume_stream(self) -> int:
+        """Take ownership of the arrow stream pointer.
+
+        Returns the stream pointer and clears it from this result.
+        After this call the stream is the caller's responsibility;
+        reset() will not attempt to release it.
+
+        Raises:
+            ProgrammingError: If no stream is available (already consumed,
+                never present, or result was from a non-query statement).
+        """
+        ptr = self._stream_ptr
+        if not ptr:
+            raise ProgrammingError("No arrow stream available (already consumed or not produced by this query)")
+        self._stream_ptr = None
+        return ptr
+
+    def reset(self, closing: bool = False) -> None:
+        """Release the arrow stream and optionally clear rowcount.
+
+        Only stream and rowcount are reset — description, sqlstate, sfqid,
+        query, and stats are left intact for backward compatibility (callers
+        may read them after close/reset).  They are overwritten wholesale
+        when the cursor's _query_result is replaced on the next execute().
+        """
+        release_arrow_stream(self._stream_ptr)
+        self._stream_ptr = None
+
+        if not closing:
+            self.rowcount = None
+
+    @staticmethod
+    def from_execute_result(result: ExecuteResult | None) -> _QueryResult:
+        return _QueryResult(
+            description=ResultMetadata.create_description(result),
+            sqlstate=extract_sqlstate(result),
+            sfqid=(result.query_id if result.query_id else None) if result else None,
+            query=(result.query if result.query else None) if result else None,
+            rowcount=extract_rowcount(result),
+            _stream_ptr=get_stream_ptr(result),
+            stats=(
+                QueryResultStats.from_query_stats(result.stats)
+                if (result and result.HasField("stats"))
+                else QueryResultStats()
+            ),
+        )
+
+    @staticmethod
+    def from_prepare_result(result: PrepareResult | None) -> _QueryResult:
+        stream_ptr = get_stream_ptr(result)
+        release_arrow_stream(stream_ptr)
+
+        description = ResultMetadata.create_description(result)
+        return _QueryResult(
+            description=description,
+            sqlstate=extract_sqlstate(result),
+            sfqid=(result.query_id if result.query_id else None) if result else None,
+            query=(result.query if result.query else None) if result else None,
+            rowcount=0 if description else None,
+        )
+
+    @staticmethod
+    def from_programming_error(exc: ProgrammingError) -> _QueryResult:
+        return _QueryResult(
+            sqlstate=exc.sqlstate or None,
+            sfqid=exc.sfqid or None,
+            query=exc.query or None,
+        )

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -21,8 +21,19 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
 )
 from snowflake.connector.constants import QueryStatus
 from snowflake.connector.cursor import FetchMode, QueryResultStats, SnowflakeCursor, SnowflakeCursorBase
+from snowflake.connector.cursor._query_result import _QueryResult
 from snowflake.connector.cursor._query_result_waiter import QueryResultWaiter
 from snowflake.connector.errors import DatabaseError, InterfaceError, ProgrammingError
+
+
+@pytest.fixture(autouse=True)
+def _no_native_stream_ops():
+    """Prevent _QueryResult from touching real native memory in unit tests."""
+    with (
+        patch("snowflake.connector.cursor._query_result.get_stream_ptr", return_value=0),
+        patch("snowflake.connector.cursor._query_result.release_arrow_stream"),
+    ):
+        yield
 
 
 class TestFetchone:
@@ -765,33 +776,21 @@ class TestStats:
         assert result == QueryResultStats(None, None, None, None)
 
     def test_stats_returns_all_none_when_no_stats_field(self, cursor):
-        """stats returns all-None when execute_result has no stats field."""
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = False
-        cursor._execute_result = mock_result
-
+        """stats returns all-None when _query_result has default stats."""
         result = cursor.stats
 
         assert result == QueryResultStats(None, None, None, None)
-        mock_result.HasField.assert_called_with("stats")
 
     def test_stats_returns_all_fields_when_present(self, cursor):
-        """stats returns all populated fields from execute_result."""
-        mock_stats = MagicMock()
-        mock_stats.num_rows_inserted = 10
-        mock_stats.num_rows_deleted = 5
-        mock_stats.num_rows_updated = 3
-        mock_stats.num_dml_duplicates = 1
-        mock_stats.HasField.return_value = True
+        """stats returns all populated fields from _query_result."""
+        cursor._query_result.stats = QueryResultStats(
+            num_rows_inserted=10,
+            num_rows_deleted=5,
+            num_rows_updated=3,
+            num_dml_duplicates=1,
+        )
 
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = True
-        mock_result.stats = mock_stats
-        cursor._execute_result = mock_result
-
-        result = cursor.stats
-
-        assert result == QueryResultStats(
+        assert cursor.stats == QueryResultStats(
             num_rows_inserted=10,
             num_rows_deleted=5,
             num_rows_updated=3,
@@ -799,22 +798,8 @@ class TestStats:
         )
 
     def test_stats_returns_partial_fields(self, cursor):
-        """stats returns None for fields not present in the protobuf."""
-        mock_stats = MagicMock()
-        mock_stats.num_rows_inserted = 10
-        mock_stats.num_rows_deleted = 0
-        mock_stats.num_rows_updated = 0
-        mock_stats.num_dml_duplicates = 0
-
-        def has_field(name):
-            return name == "num_rows_inserted"
-
-        mock_stats.HasField.side_effect = has_field
-
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = True
-        mock_result.stats = mock_stats
-        cursor._execute_result = mock_result
+        """stats returns None for fields not present."""
+        cursor._query_result.stats = QueryResultStats(num_rows_inserted=10)
 
         result = cursor.stats
 
@@ -825,69 +810,28 @@ class TestStats:
 
     def test_stats_distinguishes_zero_from_absent(self, cursor):
         """A field present with value 0 is returned as 0, not None."""
-        mock_stats = MagicMock()
-        mock_stats.num_rows_inserted = 0
-        mock_stats.num_rows_deleted = 0
-        mock_stats.num_rows_updated = 0
-        mock_stats.num_dml_duplicates = 0
-        mock_stats.HasField.return_value = True
+        cursor._query_result.stats = QueryResultStats(0, 0, 0, 0)
 
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = True
-        mock_result.stats = mock_stats
-        cursor._execute_result = mock_result
-
-        result = cursor.stats
-
-        assert result == QueryResultStats(0, 0, 0, 0)
+        assert cursor.stats == QueryResultStats(0, 0, 0, 0)
 
     def test_stats_returns_query_result_stats_type(self, cursor):
         """stats always returns a QueryResultStats instance."""
         assert isinstance(cursor.stats, QueryResultStats)
 
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = False
-        cursor._execute_result = mock_result
+        cursor._query_result.stats = QueryResultStats(1, 2, 3, 4)
         assert isinstance(cursor.stats, QueryResultStats)
 
     def test_stats_updates_on_subsequent_execute(self, cursor):
-        """stats reflects the most recent execute_result."""
-        first_stats = MagicMock()
-        first_stats.num_rows_inserted = 5
-        first_stats.HasField.return_value = True
-
-        first_result = MagicMock()
-        first_result.HasField.return_value = True
-        first_result.stats = first_stats
-        cursor._execute_result = first_result
-
+        """stats reflects the most recent _query_result."""
+        cursor._query_result.stats = QueryResultStats(num_rows_inserted=5)
         assert cursor.stats.num_rows_inserted == 5
 
-        second_stats = MagicMock()
-        second_stats.num_rows_inserted = 20
-        second_stats.HasField.return_value = True
-
-        second_result = MagicMock()
-        second_result.HasField.return_value = True
-        second_result.stats = second_stats
-        cursor._execute_result = second_result
-
+        cursor._query_result.stats = QueryResultStats(num_rows_inserted=20)
         assert cursor.stats.num_rows_inserted == 20
 
     def test_stats_only_insert_field(self, cursor):
         """stats correctly returns only num_rows_inserted when only that field is present."""
-        mock_stats = MagicMock()
-        mock_stats.num_rows_inserted = 42
-
-        def has_field(name):
-            return name == "num_rows_inserted"
-
-        mock_stats.HasField.side_effect = has_field
-
-        mock_result = MagicMock()
-        mock_result.HasField.return_value = True
-        mock_result.stats = mock_stats
-        cursor._execute_result = mock_result
+        cursor._query_result.stats = QueryResultStats(num_rows_inserted=42)
 
         result = cursor.stats
         assert result == QueryResultStats(
@@ -1035,12 +979,9 @@ class TestCreateRowIteratorNumpyFlag:
     def test_passes_numpy_true_from_connection(self, mock_connection):
         mock_connection._numpy = True
         cursor = SnowflakeCursor(mock_connection)
-        cursor._execute_result = MagicMock()
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create,
-        ):
+        with patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create:
             mock_create.return_value = iter([])
             cursor._create_row_iterator()
 
@@ -1053,12 +994,9 @@ class TestCreateRowIteratorNumpyFlag:
     def test_passes_numpy_false_from_connection(self, mock_connection):
         mock_connection._numpy = False
         cursor = SnowflakeCursor(mock_connection)
-        cursor._execute_result = MagicMock()
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create,
-        ):
+        with patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create:
             mock_create.return_value = iter([])
             cursor._create_row_iterator()
 
@@ -1158,11 +1096,9 @@ class TestFetchArrowBatches:
         batch1, batch2 = MagicMock(), MagicMock()
         table1, table2 = MagicMock(), MagicMock()
         self.pa.Table.from_batches.side_effect = [table1, table2]
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])),
-        ):
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])):
             tables = list(cursor.fetch_arrow_batches())
 
         assert tables == [table1, table2]
@@ -1170,10 +1106,9 @@ class TestFetchArrowBatches:
         self.pa.Table.from_batches.assert_any_call([batch2])
 
     def test_yields_nothing_for_empty_stream(self, cursor):
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
-        ):
+        cursor._query_result._stream_ptr = 42
+
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             tables = list(cursor.fetch_arrow_batches())
 
         assert tables == []
@@ -1188,10 +1123,9 @@ class TestFetchArrowBatches:
                 list(cursor.fetch_arrow_batches())
 
     def test_passes_force_microsecond_precision(self, cursor):
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get,
-        ):
+        cursor._query_result._stream_ptr = 42
+
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get:
             list(cursor.fetch_arrow_batches(force_microsecond_precision=True))
 
         mock_get.assert_called_once_with(stream_ptr=42, force_microsecond_precision=True, number_to_decimal=ANY)
@@ -1225,11 +1159,9 @@ class TestFetchArrowAll:
         batch1, batch2 = MagicMock(), MagicMock()
         mock_table = MagicMock()
         self.pa.Table.from_batches.return_value = mock_table
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])),
-        ):
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])):
             result = cursor.fetch_arrow_all()
 
         assert result is mock_table
@@ -1238,11 +1170,9 @@ class TestFetchArrowAll:
     def test_returns_none_for_empty_stream(self, cursor):
         mock_iterator = MagicMock()
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator),
-        ):
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator):
             result = cursor.fetch_arrow_all()
 
         assert result is None
@@ -1255,11 +1185,9 @@ class TestFetchArrowAll:
         mock_iterator = MagicMock()
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
         mock_iterator.get_converted_schema.return_value = mock_schema
+        cursor._query_result._stream_ptr = 42
 
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator),
-        ):
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator):
             result = cursor.fetch_arrow_all(force_return_table=True)
 
         assert result is mock_empty_table
@@ -1267,19 +1195,17 @@ class TestFetchArrowAll:
         mock_schema.empty_table.assert_called_once()
 
     def test_returns_none_without_force_return_table(self, cursor):
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
-        ):
+        cursor._query_result._stream_ptr = 42
+
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             result = cursor.fetch_arrow_all(force_return_table=False)
 
         assert result is None
 
     def test_passes_force_microsecond_precision(self, cursor):
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get,
-        ):
+        cursor._query_result._stream_ptr = 42
+
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get:
             cursor.fetch_arrow_all(force_microsecond_precision=True)
 
         mock_get.assert_called_once_with(stream_ptr=42, force_microsecond_precision=True, number_to_decimal=ANY)
@@ -1416,10 +1342,9 @@ class TestFetchModeValidation:
             list(cursor.fetch_arrow_batches())
 
     def test_arrow_then_row_raises(self, cursor):
-        with (
-            patch("snowflake.connector.cursor._base.get_stream_ptr", return_value=42),
-            patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])),
-        ):
+        cursor._query_result._stream_ptr = 42
+
+        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             cursor.fetch_arrow_all()
 
         with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
@@ -1489,95 +1414,98 @@ class TestReset:
 
     def test_reset_clears_all_state_together(self, cursor):
         """reset() frees heavy result data but preserves lightweight metadata."""
-        cursor._execute_result = MagicMock()
+        mock_desc = [MagicMock()]
+        cursor._query_result = _QueryResult(
+            description=mock_desc,
+            sqlstate="42601",
+            sfqid="abc-123",
+            query="SELECT 1",
+            _stream_ptr=0xABCD,
+            rowcount=100,
+        )
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
-        mock_desc = [MagicMock()]
-        cursor._description = mock_desc
-        cursor._sqlstate = "42601"
-        cursor._sfqid = "abc-123"
-        cursor._query = "SELECT 1"
         cursor._fetch_mode = FetchMode.ROW
-        cursor._rowcount = 100
 
         cursor.reset()
 
         # Cleared by reset
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
-        assert cursor._rowcount is None
+        assert cursor._query_result.rowcount is None
         # Preserved by reset (matches old driver)
         assert cursor._rownumber == 10
-        assert cursor._description is mock_desc
-        assert cursor._sqlstate == "42601"
-        assert cursor._sfqid == "abc-123"
-        assert cursor._query == "SELECT 1"
+        assert cursor._query_result.description is mock_desc
+        assert cursor._query_result.sqlstate == "42601"
+        assert cursor._query_result.sfqid == "abc-123"
+        assert cursor._query_result.query == "SELECT 1"
 
     def test_reset_is_idempotent(self, cursor):
         """Calling reset() twice produces the same state as calling it once."""
-        cursor._execute_result = MagicMock()
+        cursor._query_result = _QueryResult(_stream_ptr=0xABCD, rowcount=42)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
-        cursor._rowcount = 42
 
         cursor.reset()
         cursor.reset()
 
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._fetch_mode is None
-        assert cursor._rowcount is None
+        assert cursor._query_result.rowcount is None
         assert cursor._rownumber == -1
 
     def test_reset_on_fresh_cursor_is_noop(self, cursor):
         """reset() on a freshly created cursor doesn't break anything."""
         cursor.reset()
 
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
-        assert cursor._sqlstate is None
+        assert cursor.sqlstate is None
         assert cursor._fetch_mode is None
         assert cursor._binding_data is None
         assert cursor._rownumber == -1
-        assert cursor._rowcount is None
+        assert cursor.rowcount is None
 
     def test_reset_closing_true_clears_everything_except_rowcount(self, cursor):
-        """reset(closing=True) preserves _rowcount in addition to the usual preserved fields."""
-        cursor._execute_result = MagicMock()
+        """reset(closing=True) preserves rowcount in addition to the usual preserved fields."""
+        mock_desc = [MagicMock()]
+        cursor._query_result = _QueryResult(
+            description=mock_desc,
+            sqlstate="42601",
+            sfqid="abc-123",
+            query="SELECT 1",
+            _stream_ptr=0xABCD,
+            rowcount=100,
+        )
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
-        mock_desc = [MagicMock()]
-        cursor._description = mock_desc
-        cursor._sqlstate = "42601"
-        cursor._sfqid = "abc-123"
-        cursor._query = "SELECT 1"
         cursor._fetch_mode = FetchMode.ARROW
-        cursor._rowcount = 100
 
         cursor.reset(closing=True)
 
         # Cleared by reset
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
         # Preserved by reset (always)
         assert cursor._rownumber == 10
-        assert cursor._description is mock_desc
-        assert cursor._sqlstate == "42601"
-        assert cursor._sfqid == "abc-123"
-        assert cursor._query == "SELECT 1"
+        assert cursor._query_result.description is mock_desc
+        assert cursor._query_result.sqlstate == "42601"
+        assert cursor._query_result.sfqid == "abc-123"
+        assert cursor._query_result.query == "SELECT 1"
         # Preserved by reset(closing=True) specifically
-        assert cursor._rowcount == 100
+        assert cursor._query_result.rowcount == 100
 
     def test_reset_preserves_query_and_sfqid(self, cursor):
         """After reset(), query and sfqid are preserved (matches old driver)."""
-        cursor._sfqid = "abc-123"
-        cursor._query = "SELECT 1"
+        cursor._query_result.sfqid = "abc-123"
+        cursor._query_result.query = "SELECT 1"
 
         assert cursor.query == "SELECT 1"
         assert cursor.sfqid == "abc-123"
@@ -1621,23 +1549,22 @@ class TestClose:
 
     def test_close_preserves_rowcount(self, cursor):
         """close() preserves _rowcount via reset(closing=True)."""
-        cursor._rowcount = 42
+        cursor._query_result.rowcount = 42
         cursor.close()
-        assert cursor._rowcount == 42
+        assert cursor._query_result.rowcount == 42
 
     def test_close_clears_result_state(self, cursor):
         """close() clears result-related state via reset (except description)."""
-        cursor._execute_result = MagicMock()
-        cursor._iterator = iter([(1,)])
         mock_desc = [MagicMock()]
-        cursor._description = mock_desc
+        cursor._query_result = _QueryResult(description=mock_desc, _stream_ptr=0xABCD)
+        cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 
         cursor.close()
 
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
-        assert cursor._description is mock_desc
+        assert cursor._query_result.description is mock_desc
         assert cursor._fetch_mode is None
 
     def test_close_returns_none_on_exception(self, cursor):
@@ -1683,42 +1610,42 @@ class TestResetIntegration:
 
     def test_close_calls_reset_with_closing_true(self, cursor):
         """close() calls reset(closing=True) to preserve rowcount."""
-        cursor._rowcount = 42
-        cursor._execute_result = MagicMock()
+        cursor._query_result = _QueryResult(rowcount=42, _stream_ptr=0xABCD)
         cursor._iterator = iter([(1,)])
 
         cursor.close()
 
         # Rowcount should be preserved
-        assert cursor._rowcount == 42
+        assert cursor._query_result.rowcount == 42
         # Other state should be cleared
-        assert cursor._execute_result is None
+        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._closed is True
 
     def test_execute_calls_reset_before_executing(self, cursor, mock_connection):
         """execute() calls reset() before executing to clear old state."""
-        cursor._execute_result = MagicMock()
+        cursor._query_result = _QueryResult(
+            description=[MagicMock()],
+            _stream_ptr=0xABCD,
+            rowcount=100,
+        )
         cursor._iterator = iter([(1,)])
-        cursor._description = [MagicMock()]
-        cursor._rowcount = 100
 
         cursor.execute("SELECT 1")
 
         # Old state should have been cleared by reset()
-        # New execute_result will be set by the execution
         assert cursor._iterator is None
         assert cursor._binding_data is None
 
     def test_executemany_calls_reset_once_before_loop(self, cursor, mock_connection):
         """executemany() calls reset() once before the loop, not for each execute."""
         mock_connection.paramstyle = ParamStyle.PYFORMAT
-        cursor._rowcount = 100
+        cursor._query_result.rowcount = 100
 
         with patch.object(cursor, "reset") as mock_reset:
             with patch.object(cursor, "_execute") as mock_execute:
                 mock_execute.return_value = cursor
-                cursor._rowcount = 1  # simulate execute setting rowcount
+                cursor._query_result.rowcount = 1
                 cursor.executemany("INSERT INTO t VALUES (%s)", [(1,), (2,), (3,)])
 
         # reset should be called once, not 3 times
@@ -1736,43 +1663,41 @@ class TestResetIntegration:
 
     def test_execute_overwrites_sqlstate_with_new_result(self, cursor, mock_connection):
         """execute() overwrites sqlstate from the new query result."""
-        cursor._sqlstate = "42601"
+        cursor._query_result.sqlstate = "42601"
 
         cursor.execute("SELECT 1")
 
-        assert cursor._sqlstate is None
+        assert cursor.sqlstate is None
 
     def test_execute_resets_description_before_new_query(self, cursor, mock_connection):
         """execute() clears old description; new one is populated from the result."""
-        cursor._description = [MagicMock()]
+        cursor._query_result.description = [MagicMock()]
 
         cursor.execute("SELECT 1")
 
         # Mock has no columns, so description becomes None
-        assert cursor._description is None
+        assert cursor.description is None
 
     def test_executemany_server_side_binding_delegates_reset_to_execute(self, cursor, mock_connection):
         """executemany() with server-side (qmark) binding delegates to execute(), which performs its own reset."""
         mock_connection.paramstyle = ParamStyle.QMARK
         cursor._fetch_mode = FetchMode.ARROW
-        cursor._sqlstate = "42601"
+        cursor._query_result.sqlstate = "42601"
 
         cursor.executemany("INSERT INTO t VALUES (?)", [(1,), (2,), (3,)])
 
         assert cursor._fetch_mode is None
-        assert cursor._sqlstate is None
+        assert cursor.sqlstate is None
 
     def test_executemany_empty_params_does_not_reset(self, cursor, mock_connection):
         """executemany() with empty seq_of_parameters returns early without calling reset."""
         cursor._fetch_mode = FetchMode.ARROW
-        cursor._rowcount = 42
-        cursor._execute_result = MagicMock()
+        cursor._query_result = _QueryResult(rowcount=42)
 
         cursor.executemany("INSERT INTO t VALUES (?)", [])
 
         assert cursor._fetch_mode == FetchMode.ARROW
-        assert cursor._rowcount == 42
-        assert cursor._execute_result is not None
+        assert cursor._query_result.rowcount == 42
 
 
 class TestDescribe:
@@ -1807,8 +1732,7 @@ class TestDescribe:
         col.HasField = lambda f: f in ("precision", "scale")
         self._setup_prepare(mock_connection, columns=[col])
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream"):
-            result = cursor.describe("SELECT 1 AS COL1")
+        result = cursor.describe("SELECT 1 AS COL1")
 
         assert result is not None
         assert len(result) == 1
@@ -1819,13 +1743,12 @@ class TestDescribe:
         """describe() returns None when the statement produces no result set."""
         self._setup_prepare(mock_connection, columns=[])
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream"):
-            assert cursor.describe("INSERT INTO t VALUES (1)") is None
+        assert cursor.describe("INSERT INTO t VALUES (1)") is None
 
     def test_describe_side_effects_with_columns(self, cursor, mock_connection):
         """describe() sets sfqid, query, sqlstate, rowcount when result has columns."""
         col = MagicMock(type="FIXED", nullable=True, precision=10, scale=0)
-        col.name = "COL1"  # `name` is reserved by MagicMock; must be set after init
+        col.name = "COL1"
         col.HasField = lambda f: f in ("precision", "scale")
         self._setup_prepare(
             mock_connection,
@@ -1835,13 +1758,11 @@ class TestDescribe:
             sql_state="00000",
         )
 
-        cursor._rowcount = 42
+        cursor._query_result.rowcount = 42
         cursor._fetch_mode = FetchMode.ARROW
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream"):
-            cursor.describe("SELECT 1")
+        cursor.describe("SELECT 1")
 
-        assert cursor._execute_result is None
         assert cursor.sfqid == "01abc-def"
         assert cursor.query == "SELECT 1"
         assert cursor.sqlstate is None  # "00000" is normalized to None
@@ -1851,7 +1772,7 @@ class TestDescribe:
     def test_describe_forwards_non_success_sqlstate(self, cursor, mock_connection):
         """describe() forwards sqlstate when it differs from '00000'."""
         col = MagicMock(type="FIXED", nullable=True, precision=10, scale=0)
-        col.name = "COL1"  # `name` is reserved by MagicMock; must be set after init
+        col.name = "COL1"
         col.HasField = lambda f: f in ("precision", "scale")
         self._setup_prepare(
             mock_connection,
@@ -1859,21 +1780,18 @@ class TestDescribe:
             sql_state="02000",
         )
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream"):
-            cursor.describe("SELECT 1")
+        cursor.describe("SELECT 1")
 
         assert cursor.sqlstate == "02000"
 
     def test_describe_side_effects_without_columns(self, cursor, mock_connection):
         """describe() resets state; sfqid/query/sqlstate are set from result even without columns."""
-        cursor._rowcount = 42
+        cursor._query_result.rowcount = 42
         cursor._fetch_mode = FetchMode.ARROW
         self._setup_prepare(mock_connection)
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream"):
-            cursor.describe("SELECT 1")
+        cursor.describe("SELECT 1")
 
-        assert cursor._execute_result is None
         assert cursor.sfqid is None
         assert cursor.rowcount is None
         assert cursor._fetch_mode is None
@@ -1882,12 +1800,12 @@ class TestDescribe:
         """describe() allocates/releases statement handle and releases the arrow stream."""
         self._setup_prepare(mock_connection)
 
-        with patch("snowflake.connector.cursor._base.release_arrow_stream") as mock_iter:
+        with patch("snowflake.connector.cursor._query_result.release_arrow_stream") as mock_release:
             cursor.describe("SELECT 1")
 
         mock_connection.db_api.statement_new.assert_called_once()
         mock_connection.db_api.statement_release.assert_called_once()
-        mock_iter.assert_called_once()
+        mock_release.assert_called()
 
     def test_describe_raises_when_closed(self, cursor, mock_connection):
         """describe() raises InterfaceError on closed cursor or connection."""
@@ -1941,7 +1859,7 @@ class TestQueryResult:
         col.HasField = MagicMock(return_value=False)
         col.nullable = True
 
-        result = self._stub_result(
+        self._stub_result(
             mock_connection,
             columns=[col],
             rows_affected=42,
@@ -1952,7 +1870,6 @@ class TestQueryResult:
         ret = cursor.query_result("01234567-abcd-ef01-0000-000000000001")
 
         assert ret is cursor
-        assert cursor._execute_result is result
         assert cursor.description is not None
         assert len(cursor.description) == 1
         assert cursor.description[0].name == "ID"
@@ -1965,7 +1882,7 @@ class TestQueryResult:
 
     def test_query_result_resets_prior_state(self, cursor, mock_connection):
         """query_result clears iterator and fetch mode from a previous execute."""
-        cursor._execute_result = MagicMock()
+        cursor._query_result = _QueryResult(_stream_ptr=0xABCD)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 


### PR DESCRIPTION
### TL;DR

Refactored cursor query result management by introducing a `_QueryResult` class to encapsulate query metadata and Arrow stream lifecycle management, fixing memory leaks and code organization.  
  
Memory leaks were caused by not releasing arrows stream, when they were not consumed (e.g. in `executemany()`).

### What changed?

- Created a new `_QueryResult` class that encapsulates query metadata (description, sqlstate, sfqid, query, stats, rowcount) and manages the Arrow stream pointer lifecycle
- Replaced individual cursor fields (`_description`, `_sqlstate`, `_sfqid`, etc.) with a single `_query_result` field
- Added automatic memory management through `_QueryResult.__del__()` to prevent Arrow stream memory leaks
- Enhanced `release_arrow_stream()` with better error handling and documentation
- Updated cursor methods to use the new `_QueryResult` interface, including `consume_stream()` for one-time stream access
- Modified cursor reset logic to work with the consolidated query result state