### PR TITLE
Python - fixup optional dependency version detection

### DIFF
--- a/python/src/snowflake/connector/_internal/extras.py
+++ b/python/src/snowflake/connector/_internal/extras.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import importlib
 
+from importlib import metadata
 from logging import getLogger
 from types import ModuleType
 from typing import Any, Callable, TypeVar, cast
@@ -53,7 +54,11 @@ def _import_or_missing(module_name: str) -> ModuleType | MissingOptionalDependen
     """
     try:
         mod = importlib.import_module(module_name)
-        logger.info("%s is installed (version: %s)", module_name, mod.__version__)
+        try:
+            version = metadata.version(module_name)
+        except metadata.PackageNotFoundError:
+            version = "unknown"
+        logger.info("%s is installed (version: %s)", module_name, version)
         return mod
     except ImportError:
         logger.info("%s is not installed; %s-based features will be unavailable", module_name, module_name)


### PR DESCRIPTION
Fixup optional dependecy version detection to use `importlib.metadata.version` instead of directly accessing `__version__` attribute, which is not supported by all packages.

[Detected by CLI tests](https://github.com/snowflakedb/snowflake-cli/actions/runs/24239155036/job/70769194217)