### PR TITLE
Python: implement Connection.paramstyle setter

### DIFF
--- a/python/src/snowflake/connector/_internal/binding_converters.py
+++ b/python/src/snowflake/connector/_internal/binding_converters.py
@@ -65,15 +65,6 @@ class ParamStyle(Enum):
         available = [s.value for s in cls]
         raise ProgrammingError(f"Invalid paramstyle: {value!r}. Supported: {', '.join(sorted(available))}")
 
-    @classmethod
-    def from_str_or_class(cls, value: str | ParamStyle) -> ParamStyle:
-        """Return a member from a :class:`ParamStyle` or a PEP 249 paramstyle string."""
-        if isinstance(value, cls):
-            return value
-        if isinstance(value, str):
-            return cls.from_string(value)
-        raise ProgrammingError(f"paramstyle must be str or ParamStyle, got {type(value).__name__}")
-
     def is_client_side(self) -> bool:
         """Check if this style uses client-side SQL interpolation."""
         return self in (ParamStyle.FORMAT, ParamStyle.PYFORMAT)

--- a/python/src/snowflake/connector/_internal/binding_converters.py
+++ b/python/src/snowflake/connector/_internal/binding_converters.py
@@ -65,6 +65,15 @@ class ParamStyle(Enum):
         available = [s.value for s in cls]
         raise ProgrammingError(f"Invalid paramstyle: {value!r}. Supported: {', '.join(sorted(available))}")
 
+    @classmethod
+    def from_str_or_class(cls, value: str | ParamStyle) -> ParamStyle:
+        """Return a member from a :class:`ParamStyle` or a PEP 249 paramstyle string."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            return cls.from_string(value)
+        raise ProgrammingError(f"paramstyle must be str or ParamStyle, got {type(value).__name__}")
+
     def is_client_side(self) -> bool:
         """Check if this style uses client-side SQL interpolation."""
         return self in (ParamStyle.FORMAT, ParamStyle.PYFORMAT)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -109,7 +109,7 @@ class Connection:
         # paramstyle
         from snowflake.connector import paramstyle as default_paramstyle
 
-        self._paramstyle = ParamStyle.from_string(paramstyle or default_paramstyle)
+        self._paramstyle = ParamStyle.from_str_or_class(paramstyle or default_paramstyle)
 
         kwargs = self._rewrite_private_key_password(kwargs)
         kwargs = self._rewrite_mfa_params(kwargs)
@@ -347,6 +347,11 @@ class Connection:
             ParamStyle: The paramstyle enum value
         """
         return self._paramstyle
+
+    @paramstyle.setter
+    def paramstyle(self, value: str | ParamStyle) -> None:
+        """Set binding style from a :class:`ParamStyle` or PEP 249 string (e.g. ``"pyformat"``)."""
+        self._paramstyle = ParamStyle.from_str_or_class(value)
 
     def execute_string(
         self,

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -106,10 +106,10 @@ class Connection:
                 is ignored because the passcode flow is selected automatically.
             **kwargs: Additional connection parameters
         """
-        # paramstyle
+        # paramstyle (via setter so str | ParamStyle normalization is single-sourced)
         from snowflake.connector import paramstyle as default_paramstyle
 
-        self._paramstyle = ParamStyle.from_str_or_class(paramstyle or default_paramstyle)
+        self.paramstyle = paramstyle or default_paramstyle
 
         kwargs = self._rewrite_private_key_password(kwargs)
         kwargs = self._rewrite_mfa_params(kwargs)
@@ -351,7 +351,12 @@ class Connection:
     @paramstyle.setter
     def paramstyle(self, value: str | ParamStyle) -> None:
         """Set binding style from a :class:`ParamStyle` or PEP 249 string (e.g. ``"pyformat"``)."""
-        self._paramstyle = ParamStyle.from_str_or_class(value)
+        if isinstance(value, ParamStyle):
+            self._paramstyle = value
+        elif isinstance(value, str):
+            self._paramstyle = ParamStyle.from_string(value)
+        else:
+            raise ProgrammingError(f"paramstyle must be str or ParamStyle, got {type(value).__name__}")
 
     def execute_string(
         self,

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -348,7 +348,7 @@ class SnowflakeCursorBase(abc.ABC):
         if parameters is None:
             return operation, None
 
-        paramstyle = self._connection.paramstyle  # Always returns ParamStyle enum
+        paramstyle = self._connection.paramstyle
 
         if paramstyle.is_client_side():
             # format paramstyle only supports positional params (%s), not named params

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from snowflake.connector._internal.binding_converters import ParamStyle
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConfigSetting,
     ConnectionGetInfoResponse,
@@ -13,9 +14,11 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     ConnectionSetOptionsResponse,
     DatabaseHandle,
+    StatementHandle,
     ValidationIssue,
 )
 from snowflake.connector.constants import QueryStatus
+from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.errors import InterfaceError, ProgrammingError
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
@@ -96,6 +99,74 @@ class TestSetAutocommitValidation:
         with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
             with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
                 Connection(user="test_user", account="test_account", autocommit=1)
+
+
+class TestParamstyleSetter:
+    """PEP 249 uses string paramstyle; assignment normalizes once on the connection."""
+
+    @pytest.fixture(autouse=True)
+    def _no_native_stream_ops(self):
+        """Avoid touching real Arrow stream memory when cursor tests run execute()."""
+        with (
+            patch("snowflake.connector.cursor._query_result.get_stream_ptr", return_value=0),
+            patch("snowflake.connector.cursor._query_result.release_arrow_stream"),
+        ):
+            yield
+
+    def test_assign_string_normalizes(self, connection):
+        connection.paramstyle = "qmark"
+        assert connection.paramstyle == ParamStyle.QMARK
+        assert connection._paramstyle is ParamStyle.QMARK
+
+    def test_assign_enum_unchanged(self, connection):
+        connection.paramstyle = ParamStyle.NUMERIC
+        assert connection.paramstyle == ParamStyle.NUMERIC
+
+    def test_assign_invalid_string_raises(self, connection):
+        with pytest.raises(ProgrammingError, match="Invalid paramstyle"):
+            connection.paramstyle = "bogus"
+
+    def test_assign_invalid_type_raises(self, connection):
+        with pytest.raises(ProgrammingError, match="paramstyle must be str or ParamStyle"):
+            connection.paramstyle = 123  # type: ignore[assignment]
+
+    def test_paramstyle_from_str_or_class_enum_identity(self):
+        assert ParamStyle.from_str_or_class(ParamStyle.QMARK) is ParamStyle.QMARK
+
+    def test_paramstyle_from_str_or_class_string(self):
+        assert ParamStyle.from_str_or_class("  qmark ") == ParamStyle.QMARK
+
+    def test_paramstyle_from_str_or_class_rejects_bad_type(self):
+        with pytest.raises(ProgrammingError, match="paramstyle must be str or ParamStyle"):
+            ParamStyle.from_str_or_class(1)  # type: ignore[arg-type]
+
+    def test_cursor_execute_after_string_assign(self, connection, mock_db_api):
+        """Layered clients set ``connection.paramstyle = \"pyformat\"``; cursor must not see a bare str."""
+        mock_db_api.statement_new.return_value = MagicMock(stmt_handle=StatementHandle(id=1))
+        execute_result = MagicMock()
+        execute_result.columns = []
+        execute_result.HasField = MagicMock(return_value=False)
+        execute_result.sql_state = "00000"
+        mock_db_api.statement_execute_query.return_value.result = execute_result
+
+        connection.paramstyle = "pyformat"
+        cur = SnowflakeCursor(connection)
+        cur.execute("SELECT %(v)s", {"v": 1})
+        mock_db_api.statement_execute_query.assert_called()
+
+    def test_cursor_execute_qmark_after_string_assign(self, connection, mock_db_api):
+        mock_db_api.statement_new.return_value = MagicMock(stmt_handle=StatementHandle(id=1))
+        execute_result = MagicMock()
+        execute_result.columns = []
+        execute_result.HasField = MagicMock(return_value=False)
+        execute_result.sql_state = "00000"
+        mock_db_api.statement_execute_query.return_value.result = execute_result
+
+        connection.paramstyle = "qmark"
+        cur = SnowflakeCursor(connection)
+        cur.execute("SELECT ?", (1,))
+        req = mock_db_api.statement_execute_query.call_args[0][0]
+        assert req.HasField("bindings")
 
 
 class TestSetAutocommit:

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -117,6 +117,8 @@ class TestParamstyleSetter:
         connection.paramstyle = "qmark"
         assert connection.paramstyle == ParamStyle.QMARK
         assert connection._paramstyle is ParamStyle.QMARK
+        connection.paramstyle = "  QMARK  "
+        assert connection.paramstyle == ParamStyle.QMARK
 
     def test_assign_enum_unchanged(self, connection):
         connection.paramstyle = ParamStyle.NUMERIC
@@ -129,16 +131,6 @@ class TestParamstyleSetter:
     def test_assign_invalid_type_raises(self, connection):
         with pytest.raises(ProgrammingError, match="paramstyle must be str or ParamStyle"):
             connection.paramstyle = 123  # type: ignore[assignment]
-
-    def test_paramstyle_from_str_or_class_enum_identity(self):
-        assert ParamStyle.from_str_or_class(ParamStyle.QMARK) is ParamStyle.QMARK
-
-    def test_paramstyle_from_str_or_class_string(self):
-        assert ParamStyle.from_str_or_class("  qmark ") == ParamStyle.QMARK
-
-    def test_paramstyle_from_str_or_class_rejects_bad_type(self):
-        with pytest.raises(ProgrammingError, match="paramstyle must be str or ParamStyle"):
-            ParamStyle.from_str_or_class(1)  # type: ignore[arg-type]
 
     def test_cursor_execute_after_string_assign(self, connection, mock_db_api):
         """Layered clients set ``connection.paramstyle = \"pyformat\"``; cursor must not see a bare str."""

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -132,20 +132,6 @@ class TestParamstyleSetter:
         with pytest.raises(ProgrammingError, match="paramstyle must be str or ParamStyle"):
             connection.paramstyle = 123  # type: ignore[assignment]
 
-    def test_cursor_execute_after_string_assign(self, connection, mock_db_api):
-        """Layered clients set ``connection.paramstyle = \"pyformat\"``; cursor must not see a bare str."""
-        mock_db_api.statement_new.return_value = MagicMock(stmt_handle=StatementHandle(id=1))
-        execute_result = MagicMock()
-        execute_result.columns = []
-        execute_result.HasField = MagicMock(return_value=False)
-        execute_result.sql_state = "00000"
-        mock_db_api.statement_execute_query.return_value.result = execute_result
-
-        connection.paramstyle = "pyformat"
-        cur = SnowflakeCursor(connection)
-        cur.execute("SELECT %(v)s", {"v": 1})
-        mock_db_api.statement_execute_query.assert_called()
-
     def test_cursor_execute_qmark_after_string_assign(self, connection, mock_db_api):
         mock_db_api.statement_new.return_value = MagicMock(stmt_handle=StatementHandle(id=1))
         execute_result = MagicMock()


### PR DESCRIPTION
Implement paramstyle setter to avoid [error detected in SnowPy tests](https://github.com/snowflake-eng/snowpy/actions/runs/24240715059/job/70774327960):
`AttributeError: 'str' object has no attribute 'is_client_side'`