### PR TITLE
Add azure to CI/CD in Python and ODBC

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -238,6 +238,18 @@ jobs:
             name: Windows x64
             driver_lib: sfodbc.dll
             cloud_provider: gcp
+          - os: ubuntu-latest
+            name: Linux x64
+            driver_lib: libsfodbc.so
+            cloud_provider: azure
+          - os: macos-latest
+            name: macOS ARM64
+            driver_lib: libsfodbc.dylib
+            cloud_provider: azure
+          - os: windows-latest
+            name: Windows x64
+            driver_lib: sfodbc.dll
+            cloud_provider: azure
     runs-on: ${{ matrix.os }}
     name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }})
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -328,7 +328,7 @@ jobs:
             hatch_env: "test"
             cloud_provider: aws
           - os: windows-11-arm
-            py: "3.10"
+            py: "3.11"
             hatch_env: "test"
             cloud_provider: gcp
           - os: windows-11-arm

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -345,9 +345,13 @@ jobs:
             hatch_env: "test-pandas"
             cloud_provider: aws
           - os: windows-11-arm
-            py: "3.14"
+            py: "3.12"
             hatch_env: "test-pandas"
             cloud_provider: azure
+          - os: ubuntu-latest
+            py: "3.14"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -344,14 +344,10 @@ jobs:
             py: "3.13"
             hatch_env: "test-pandas"
             cloud_provider: aws
-          - os: windows-11-arm
-            py: "3.12"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
           - os: ubuntu-latest
             py: "3.14"
             hatch_env: "test-pandas"
-            cloud_provider: aws
+            cloud_provider: azure
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -316,25 +316,13 @@ jobs:
             hatch_env: "test"
             cloud_provider: gcp
           - os: ubuntu-latest
-            py: "3.12"
+            py: "3.10"
             hatch_env: "test"
             cloud_provider: azure
           - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
             py: "3.13"
             hatch_env: "test"
             cloud_provider: aws
-          - os: macos-latest
-            py: "3.9"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: macos-latest
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: macos-latest
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: azure
           - os: windows-11-arm
             py: "3.12"
             hatch_env: "test"
@@ -348,7 +336,7 @@ jobs:
             hatch_env: "test"
             cloud_provider: azure
           # test integration with Pandas
-          - os: macos-latest
+          - os: ubuntu-latest
             py: "3.9"
             hatch_env: "test-pandas"
             cloud_provider: gcp

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -312,35 +312,43 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.9"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-latest
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: ubuntu-latest
             py: "3.14"
             hatch_env: "test"
-            cloud_provider: aws
-          - os: windows-11-arm
-            py: "3.11"
-            hatch_env: "test"
             cloud_provider: gcp
-          - os: windows-11-arm
+          - os: ubuntu-latest
             py: "3.12"
             hatch_env: "test"
-            cloud_provider: aws
-          - os: windows-11-arm
-            py: "3.13"
-            hatch_env: "test"
-            cloud_provider: gcp
+            cloud_provider: azure
           - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
             py: "3.13"
             hatch_env: "test"
             cloud_provider: aws
+          - os: macos-latest
+            py: "3.9"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: macos-latest
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: macos-latest
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: azure
+          - os: windows-11-arm
+            py: "3.12"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: windows-11-arm
+            py: "3.9"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: windows-11-arm
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: azure
           # test integration with Pandas
-          - os: ubuntu-latest
+          - os: macos-latest
             py: "3.9"
             hatch_env: "test-pandas"
             cloud_provider: gcp
@@ -348,10 +356,10 @@ jobs:
             py: "3.13"
             hatch_env: "test-pandas"
             cloud_provider: aws
-          - os: ubuntu-latest
+          - os: windows-11-arm
             py: "3.14"
             hatch_env: "test-pandas"
-            cloud_provider: gcp
+            cloud_provider: azure
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -128,10 +128,6 @@ jobs:
             py: "3.9"
           - os: windows-11-arm
             py: "3.10"
-          # TODO: Remove when Python 3.14 ARM64 Windows builds are available in uv
-          # (check https://github.com/astral-sh/uv/releases after 3.14 final release)
-          - os: windows-11-arm
-            py: "3.14"
     runs-on: ${{ matrix.os }}
     name: build_wheel (${{ matrix.os }}, py${{ matrix.py }})
     env:
@@ -312,7 +308,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.14"
+            py: "3.9"
             hatch_env: "test"
             cloud_provider: gcp
           - os: ubuntu-latest
@@ -328,7 +324,7 @@ jobs:
             hatch_env: "test"
             cloud_provider: aws
           - os: windows-11-arm
-            py: "3.9"
+            py: "3.14"
             hatch_env: "test"
             cloud_provider: gcp
           - os: windows-11-arm

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -128,6 +128,10 @@ jobs:
             py: "3.9"
           - os: windows-11-arm
             py: "3.10"
+          # TODO: Remove when Python 3.14 ARM64 Windows builds are available in uv
+          # (check https://github.com/astral-sh/uv/releases after 3.14 final release)
+          - os: windows-11-arm
+            py: "3.14"
     runs-on: ${{ matrix.os }}
     name: build_wheel (${{ matrix.os }}, py${{ matrix.py }})
     env:
@@ -308,11 +312,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.9"
+            py: "3.14"
             hatch_env: "test"
             cloud_provider: gcp
           - os: ubuntu-latest
-            py: "3.10"
+            py: "3.9"
             hatch_env: "test"
             cloud_provider: azure
           - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
@@ -324,7 +328,7 @@ jobs:
             hatch_env: "test"
             cloud_provider: aws
           - os: windows-11-arm
-            py: "3.14"
+            py: "3.10"
             hatch_env: "test"
             cloud_provider: gcp
           - os: windows-11-arm


### PR DESCRIPTION
Add:
* azure to ODBC and Python pipelines
* rewrite Python test matrix to cover each version + OS (windows/ubuntu) x cloud:
```
  ┌────────────────┬──────────────┬────────┬────────┐                            
  │       OS       │     aws      │  gcp   │ azure  │
  ├────────────────┼──────────────┼────────┼────────┤                            
  │ ubuntu-latest  │ py3.13 (ref) │ py3.14 │ py3.9  │                          
  ├────────────────┼──────────────┼────────┼────────┤                            
  │ windows-11-arm │ py3.12       │ py3.11 │ py3.11 │                            
  └────────────────┴──────────────┴────────┴────────┘ 
  ```