### PR TITLE
SNOW-3055676 Implement SMK_ID_AS_STRING capability

### DIFF
--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -16,6 +16,12 @@ where
 
 // TODO: Delete all unused fields when we are sure they are not needed
 
+#[derive(Debug, Serialize, Default)]
+pub struct AuthRequestClientCapabilities {
+    #[serde(rename = "SMK_ID_AS_STRING")]
+    pub smk_id_as_string: bool,
+}
+
 // TODO: Currently this is only compatible with Python, should be generalized later
 #[derive(Debug, Serialize, Default)]
 pub struct AuthRequestClientEnvironment {
@@ -67,6 +73,8 @@ pub struct AuthRequestData {
     pub authenticator: Option<String>,
     #[serde(rename = "SESSION_PARAMETERS", skip_serializing_if = "Option::is_none")]
     pub session_parameters: Option<HashMap<String, serde_json::Value>>,
+    #[serde(rename = "CLIENT_CAPABILITIES")]
+    pub client_capabilities: AuthRequestClientCapabilities,
     #[serde(rename = "CLIENT_ENVIRONMENT")]
     pub client_environment: AuthRequestClientEnvironment,
     #[serde(

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -14,7 +14,8 @@ use crate::config::rest_parameters::ClientInfo;
 use crate::config::rest_parameters::{LoginMethod, LoginParameters, QueryParameters};
 use crate::config::retry::RetryPolicy;
 use crate::rest::snowflake::auth::{
-    AuthRequest, AuthRequestClientEnvironment, AuthRequestData, AuthResponse,
+    AuthRequest, AuthRequestClientCapabilities, AuthRequestClientEnvironment, AuthRequestData,
+    AuthResponse,
 };
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::native_okta::fetch_native_okta_saml;
@@ -169,6 +170,9 @@ fn base_auth_request_data(login_parameters: &LoginParameters) -> AuthRequestData
         account_name: login_parameters.account_name.clone(),
         client_app_id: login_parameters.client_info.application.clone(),
         client_app_version: login_parameters.client_info.version.clone(),
+        client_capabilities: AuthRequestClientCapabilities {
+            smk_id_as_string: true,
+        },
         client_environment: AuthRequestClientEnvironment {
             application: login_parameters.client_info.application.clone(),
             os: login_parameters.client_info.os.clone(),

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -284,7 +284,7 @@ pub struct EncryptionMaterial {
     #[serde(rename = "queryId")]
     query_id: String,
     #[serde(rename = "smkId")]
-    smk_id: i64,
+    smk_id: String,
 }
 
 impl Data {
@@ -789,8 +789,7 @@ impl From<&EncryptionMaterial> for file_manager::EncryptionMaterial {
         Self {
             query_stage_master_key: value.query_stage_master_key.clone().into(),
             query_id: value.query_id.clone(),
-            // Snowflake sends smk_id as i64, but later expects it as a string
-            smk_id: value.smk_id.to_string(),
+            smk_id: value.smk_id.clone(),
         }
     }
 }
@@ -1099,7 +1098,7 @@ mod tests {
     #[test]
     fn upload_encryption_material_single_returns_some() {
         let json = make_upload_json(
-            r#""encryptionMaterial": {"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": 42},"#,
+            r#""encryptionMaterial": {"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": "42"},"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data.to_file_upload_data().unwrap();
@@ -1109,7 +1108,7 @@ mod tests {
     #[test]
     fn upload_encryption_material_array_of_one_returns_some() {
         let json = make_upload_json(
-            r#""encryptionMaterial": [{"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": 42}],"#,
+            r#""encryptionMaterial": [{"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": "42"}],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data.to_file_upload_data().unwrap();
@@ -1120,8 +1119,8 @@ mod tests {
     fn upload_encryption_material_array_of_many_returns_error() {
         let json = make_upload_json(
             r#""encryptionMaterial": [
-                {"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": 1},
-                {"queryStageMasterKey": "b3l6","queryId": "qid-2","smkId": 2}
+                {"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": "1"},
+                {"queryStageMasterKey": "b3l6","queryId": "qid-2","smkId": "2"}
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();

--- a/sf_core/tests/common/mocks/put_get.rs
+++ b/sf_core/tests/common/mocks/put_get.rs
@@ -37,7 +37,7 @@ pub async fn mount_unsupported_compression(server: &MockServer, repo_root: &str)
                         "encryptionMaterial": {
                             "queryStageMasterKey": "mock_key==",
                             "queryId": "mock-query-id",
-                            "smkId": 1
+                            "smkId": "1"
                         },
                         "src_locations": [src_locations_pattern],
                         "autoCompress": true,

--- a/tests/wiremock/mappings/put_get/put_unsupported_compression_type.json
+++ b/tests/wiremock/mappings/put_get/put_unsupported_compression_type.json
@@ -30,7 +30,7 @@
         "encryptionMaterial": {
           "queryStageMasterKey": "mock_key==",
           "queryId": "mock-query-id",
-          "smkId": 1
+          "smkId": "1"
         },
         "src_locations": [
           "{{REPO_ROOT}}/tests/test_data/generated_test_data/compression/*.xz"


### PR DESCRIPTION
## Summary
- Send `CLIENT_CAPABILITIES.SMK_ID_AS_STRING = true` in the auth request so that Snowflake returns `smkId` as a string instead of an integer
- Change `EncryptionMaterial.smk_id` from `i64` to `String`, removing the unnecessary `to_string()` conversion in the `From` impl
- Update all test fixtures and wiremock mappings to use string-typed `smkId` values

## Context
Snowflake can return `smkId` in the encryption material as either a number or a string depending on the `SMK_ID_AS_STRING` client capability. By opting into the string representation at login time, we avoid type mismatches and simplify the conversion code — `smk_id` is ultimately used as a string anyway, so receiving it as one eliminates the `i64 → String` roundtrip.

## Test plan
- Existing unit tests in `query_response.rs` (`upload_encryption_material_*`) updated to use string `smkId` values and should now pass
- Wiremock fixture `put_unsupported_compression_type.json` and mock helper `put_get.rs` updated to match the new string format
- Run `cargo test -p sf_core` to verify all deserialization and upload-data conversion tests pass