### PR TITLE
Fixup SnowPy tests

### DIFF
--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -324,17 +324,29 @@ class Connection:
         Returns:
             ParamStyle: The paramstyle enum value
         """
-        return self._paramstyle
+        return self.__paramstyle
 
     @paramstyle.setter
     def paramstyle(self, value: str | ParamStyle) -> None:
         """Set binding style from a :class:`ParamStyle` or PEP 249 string (e.g. ``"pyformat"``)."""
         if isinstance(value, ParamStyle):
-            self._paramstyle = value
+            self.__paramstyle = value
         elif isinstance(value, str):
-            self._paramstyle = ParamStyle.from_string(value)
+            self.__paramstyle = ParamStyle.from_string(value)
         else:
             raise ProgrammingError(f"paramstyle must be str or ParamStyle, got {type(value).__name__}")
+
+    @property
+    @backward_compatibility
+    def _paramstyle(self) -> ParamStyle:
+        """Internal binding-style storage (legacy callers assign to ``_paramstyle``)."""
+        return self.__paramstyle
+
+    @_paramstyle.setter
+    @backward_compatibility
+    def _paramstyle(self, value: str | ParamStyle) -> None:
+        """Normalize assignments to ``_paramstyle`` (e.g. SnowPy ``temporary_paramstyle``)."""
+        self.paramstyle = value
 
     def execute_string(
         self,

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -120,6 +120,12 @@ class TestParamstyleSetter:
         connection.paramstyle = "  QMARK  "
         assert connection.paramstyle == ParamStyle.QMARK
 
+    def test_assign_via_private_paramstyle_normalizes(self, connection):
+        """Legacy / SnowPy code sets ``conn._paramstyle`` directly; must coerce like ``paramstyle``."""
+        connection._paramstyle = "numeric"
+        assert connection.paramstyle == ParamStyle.NUMERIC
+        assert connection._paramstyle == ParamStyle.NUMERIC
+
     def test_assign_enum_unchanged(self, connection):
         connection.paramstyle = ParamStyle.NUMERIC
         assert connection.paramstyle == ParamStyle.NUMERIC

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -1747,6 +1747,36 @@ class TestResetIntegration:
         assert cursor._query_result.rowcount == 42
 
 
+class TestStringParamstyleOnWrappedConnection:
+    """snowflake.core passes a connection whose paramstyle is a PEP 249 str, not ParamStyle."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = MagicMock()
+        conn.conn_handle = ConnectionHandle(id=1)
+        conn.is_closed.return_value = False
+        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        execute_result = MagicMock()
+        execute_result.columns = []
+        execute_result.HasField = MagicMock(return_value=False)
+        execute_result.sql_state = "00000"
+        conn.db_api.statement_execute_query.return_value.result = execute_result
+        conn.paramstyle = "pyformat"
+        return conn
+
+    @pytest.fixture
+    def cursor(self, mock_connection):
+        return SnowflakeCursor(mock_connection)
+
+    def test_execute_with_string_paramstyle(self, cursor, mock_connection):
+        cursor.execute("SELECT %(v)s", {"v": 1})
+        mock_connection.db_api.statement_execute_query.assert_called()
+
+    def test_callproc_with_string_paramstyle(self, cursor, mock_connection):
+        cursor.callproc("myproc", (1, 2))
+        mock_connection.db_api.statement_execute_query.assert_called()
+
+
 class TestDescribe:
     """Unit tests for Cursor.describe method."""
 

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -1747,36 +1747,6 @@ class TestResetIntegration:
         assert cursor._query_result.rowcount == 42
 
 
-class TestStringParamstyleOnWrappedConnection:
-    """snowflake.core passes a connection whose paramstyle is a PEP 249 str, not ParamStyle."""
-
-    @pytest.fixture
-    def mock_connection(self):
-        conn = MagicMock()
-        conn.conn_handle = ConnectionHandle(id=1)
-        conn.is_closed.return_value = False
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
-        execute_result = MagicMock()
-        execute_result.columns = []
-        execute_result.HasField = MagicMock(return_value=False)
-        execute_result.sql_state = "00000"
-        conn.db_api.statement_execute_query.return_value.result = execute_result
-        conn.paramstyle = "pyformat"
-        return conn
-
-    @pytest.fixture
-    def cursor(self, mock_connection):
-        return SnowflakeCursor(mock_connection)
-
-    def test_execute_with_string_paramstyle(self, cursor, mock_connection):
-        cursor.execute("SELECT %(v)s", {"v": 1})
-        mock_connection.db_api.statement_execute_query.assert_called()
-
-    def test_callproc_with_string_paramstyle(self, cursor, mock_connection):
-        cursor.callproc("myproc", (1, 2))
-        mock_connection.db_api.statement_execute_query.assert_called()
-
-
 class TestDescribe:
     """Unit tests for Cursor.describe method."""
 


### PR DESCRIPTION
SnowPy uses private member "_paramstyle", which was breaking the value parsing. This PR fixes it up