### PR TITLE
Replace mkdir-based file locking with OS-level flock/LockFileEx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,6 +4384,7 @@ dependencies = [
  "dirs",
  "error_trace",
  "flate2",
+ "fs2",
  "futures",
  "glob",
  "hex",

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -49,6 +49,7 @@ aws-config = "1.8.5"
 aws-credential-types = "1.2.5"
 snafu = "0.8.7"
 error_trace = { path = "../error_trace" }
+fs2 = "0.4"
 glob = "0.3.3"
 
 # CRL and TLS dependencies

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -939,14 +939,29 @@ mod tests {
             }
         }
 
-        /// Stress test: runs the concurrent-writes scenario many times to expose
-        /// lock-acquisition flakiness.  Run with:
+        /// Stress test that deliberately uses a tight retry budget to expose
+        /// lock-acquisition reliability under heavy contention.
+        ///
+        /// With the old `create_dir`/`remove_dir` approach, all threads sleep
+        /// for the same fixed delay and wake up simultaneously (convoy effect),
+        /// wasting retry attempts.  With OS-level locking + jittered backoff,
+        /// threads spread out their retries and acquire the lock more
+        /// efficiently within the same budget.
+        ///
+        /// Run with:
         ///   cargo test -p sf_core -- stress_concurrent_lock --ignored --nocapture
         #[test]
         #[ignore] // slow — run manually to validate locking reliability
         fn stress_concurrent_lock() {
-            const ITERATIONS: usize = 50;
-            const STRESS_THREADS: usize = 20;
+            const ITERATIONS: usize = 20;
+            const STRESS_THREADS: usize = 100;
+            // Tight budget: enough for OS-level locking with jitter,
+            // but causes convoy-driven exhaustion with fixed-delay retries.
+            // With 100 threads and 30 retries at fixed 2ms delay, the convoy
+            // effect caps success at ~31 threads per round. With jittered
+            // backoff, threads spread their wakeups and all 100 can succeed.
+            const STRESS_RETRY_COUNT: u32 = 30;
+            const STRESS_RETRY_DELAY: Duration = Duration::from_millis(2);
 
             let mut failures = 0;
 
@@ -954,8 +969,8 @@ mod tests {
                 let dir = tempfile::tempdir().expect("Failed to create temp dir");
                 let cache = Arc::new(
                     FileTokenCache::with_directory(dir.path().to_path_buf())
-                        .retry_count(LOCK_RETRY_COUNT)
-                        .retry_delay(Duration::from_millis(50)),
+                        .retry_count(STRESS_RETRY_COUNT)
+                        .retry_delay(STRESS_RETRY_DELAY),
                 );
                 let barrier = Arc::new(Barrier::new(STRESS_THREADS));
 
@@ -988,7 +1003,6 @@ mod tests {
                 }
 
                 if round_ok {
-                    // verify all keys readable
                     for i in 0..STRESS_THREADS {
                         let key = format!("key_{i}");
                         let expected = format!("value_{i}");
@@ -1008,8 +1022,11 @@ mod tests {
             }
 
             eprintln!(
-                "\nStress test result: {}/{ITERATIONS} rounds passed, {failures} failed",
-                ITERATIONS - failures
+                "\nStress test: {}/{ITERATIONS} rounds passed, {failures} failed  \
+                 (threads={STRESS_THREADS}, retries={STRESS_RETRY_COUNT}, \
+                 delay={}ms)",
+                ITERATIONS - failures,
+                STRESS_RETRY_DELAY.as_millis(),
             );
             assert_eq!(
                 failures, 0,

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -4,13 +4,16 @@ use std::fs;
 #[cfg(unix)]
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+
+use fs2::FileExt;
+use rand::Rng;
 
 use keyring::credential::{CredentialApi, CredentialBuilderApi, CredentialPersistence};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, ensure};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use super::{
     CacheDirectoryResolutionSnafu, LockAcquisitionSnafu, LockExhaustedSnafu, TokenCacheError,
@@ -22,7 +25,6 @@ use super::{FileNotOwnedByCurrentUserSnafu, InsufficientPermissionsSnafu, Irregu
 const DEFAULT_CACHE_FILE_NAME: &str = "credential_cache_v2.json";
 const DEFAULT_RETRY_COUNT: u32 = 5;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_millis(100);
-const DEFAULT_STALE_LOCK_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CacheFileContent {
@@ -101,11 +103,16 @@ fn hash_cache_key(key: &str) -> String {
     hex::encode(hash)
 }
 
-/// RAII file lock guard that uses a `.lck` file alongside the cache file.
+/// RAII file lock guard using OS-level file locking (`flock` on Unix,
+/// `LockFileEx` on Windows) via the `fs2` crate.
 ///
-/// The lock is released (file removed) when the guard is dropped.
+/// The lock is released when the guard is dropped (closing the file
+/// descriptor). The `.lck` file persists on disk but holds no lock once
+/// the handle is closed — this is harmless and avoids the
+/// `RemoveDirectory` pending-delete race that plagued the old
+/// `create_dir`/`remove_dir` approach on Windows.
 struct FileLock {
-    lock_path: PathBuf,
+    _file: fs::File,
 }
 
 impl FileLock {
@@ -113,114 +120,44 @@ impl FileLock {
         cache_path: &Path,
         retry_count: u32,
         retry_delay: Duration,
-        stale_timeout: Duration,
     ) -> Result<Self, TokenCacheError> {
         let lock_path = cache_path.with_extension(format!("{DEFAULT_CACHE_FILE_NAME}.lck"));
 
+        let file = Self::open_lock_file(&lock_path)?;
+
+        let base_ms = retry_delay.as_millis() as f64;
+        let mut sleep_ms = base_ms;
+
         for attempt in 0..retry_count {
-            match fs::create_dir(&lock_path) {
-                Ok(()) => {
-                    return Ok(FileLock { lock_path });
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    // TOCTOU: another thread could acquire the lock between
-                    // is_stale returning true and remove_dir. This only matters
-                    // when the lock is genuinely stale (>60s, i.e. holder
-                    // crashed), which is rare. The proper fix is replacing
-                    // mkdir-based locking with flock(2) / LockFileEx, which
-                    // lets the OS release locks on process crash and removes
-                    // the need for stale detection entirely.
-                    if Self::is_stale(&lock_path, stale_timeout) {
-                        let _ = fs::remove_dir(&lock_path);
-                        continue;
-                    }
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(FileLock { _file: file }),
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     if attempt < retry_count - 1 {
-                        std::thread::sleep(retry_delay);
+                        // Decorrelated jitter: sleep ∈ [base, min(3×prev, 16×base)]
+                        let upper = (sleep_ms * 3.0).min(base_ms * 16.0);
+                        sleep_ms = rand::rng().random_range(base_ms..=upper);
+                        std::thread::sleep(Duration::from_millis(sleep_ms as u64));
                     }
                 }
-                // On Windows, concurrent create_dir + remove_dir can transiently
-                // fail when the directory is in a pending-delete state.  Treat
-                // these as retryable lock contention rather than fatal errors.
-                // On the final attempt, fall through to the Err(e) arm so the
-                // original OS error is preserved (avoids masking genuine
-                // permission failures behind a generic LockExhausted).
-                #[cfg(windows)]
-                Err(ref e)
-                    if Self::is_transient_windows_error(e, &lock_path)
-                        && attempt < retry_count - 1 =>
-                {
-                    std::thread::sleep(retry_delay);
-                }
-                Err(e) => {
-                    return Err(e).context(LockAcquisitionSnafu);
-                }
+                Err(e) => return Err(e).context(LockAcquisitionSnafu),
             }
         }
 
         LockExhaustedSnafu.fail()
     }
 
-    /// On Windows, `RemoveDirectory` marks a directory for deletion-on-close
-    /// rather than removing it synchronously.  Between that mark and the actual
-    /// removal, `CreateDirectory` on the same path can fail with one of several
-    /// transient error codes instead of `ERROR_ALREADY_EXISTS`.
-    ///
-    /// `ERROR_SHARING_VIOLATION` and `ERROR_DELETE_PENDING` are unambiguously
-    /// transient.  `ERROR_ACCESS_DENIED` is broader (can also mean genuine ACL
-    /// denial), so we only treat it as transient when the lock directory still
-    /// exists — that indicates contention rather than a permission problem on
-    /// the parent directory.
-    ///
-    /// See <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectoryw>
-    #[cfg(windows)]
-    fn is_transient_windows_error(e: &std::io::Error, lock_path: &Path) -> bool {
-        // Win32 system error codes.
-        // https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
-        const ERROR_ACCESS_DENIED: i32 = 5;
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-        const ERROR_DELETE_PENDING: i32 = 303;
+    fn open_lock_file(lock_path: &Path) -> Result<fs::File, TokenCacheError> {
+        let mut opts = fs::OpenOptions::new();
+        opts.create(true).truncate(false).write(true);
 
-        match e.raw_os_error() {
-            Some(ERROR_SHARING_VIOLATION | ERROR_DELETE_PENDING) => true,
-            Some(ERROR_ACCESS_DENIED) => lock_path.exists(),
-            _ => false,
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.custom_flags(libc::O_NOFOLLOW);
+            opts.mode(0o600);
         }
-    }
 
-    fn is_stale(lock_path: &Path, stale_timeout: Duration) -> bool {
-        let metadata = match fs::metadata(lock_path) {
-            Ok(m) => m,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return false,
-            Err(e) => {
-                warn!(
-                    path = ?lock_path,
-                    error = %e,
-                    "failed to read lock metadata while checking staleness"
-                );
-                return false;
-            }
-        };
-        let modified = match metadata.modified() {
-            Ok(t) => t,
-            Err(e) => {
-                debug!(
-                    path = ?lock_path,
-                    error = %e,
-                    "filesystem does not support modification times, cannot determine lock staleness"
-                );
-                return false;
-            }
-        };
-        match SystemTime::now().duration_since(modified) {
-            Ok(age) => age > stale_timeout,
-            Err(_) => false,
-        }
-    }
-}
-
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.lock_path);
+        opts.open(lock_path).context(LockAcquisitionSnafu)
     }
 }
 
@@ -398,7 +335,6 @@ pub(super) struct FileTokenCache {
     cache_file_path: PathBuf,
     retry_count: u32,
     retry_delay: Duration,
-    stale_lock_timeout: Duration,
 }
 
 impl FileTokenCache {
@@ -411,7 +347,6 @@ impl FileTokenCache {
             cache_file_path: cache_dir.join(file_name),
             retry_count: DEFAULT_RETRY_COUNT,
             retry_delay: DEFAULT_RETRY_DELAY,
-            stale_lock_timeout: DEFAULT_STALE_LOCK_TIMEOUT,
         })
     }
 
@@ -423,7 +358,6 @@ impl FileTokenCache {
             cache_file_path: cache_dir.join(file_name),
             retry_count: DEFAULT_RETRY_COUNT,
             retry_delay: DEFAULT_RETRY_DELAY,
-            stale_lock_timeout: DEFAULT_STALE_LOCK_TIMEOUT,
         }
     }
 
@@ -436,12 +370,6 @@ impl FileTokenCache {
     #[allow(dead_code)]
     pub fn retry_delay(mut self, delay: Duration) -> Self {
         self.retry_delay = delay;
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn stale_lock_timeout(mut self, timeout: Duration) -> Self {
-        self.stale_lock_timeout = timeout;
         self
     }
 
@@ -577,12 +505,7 @@ impl FileTokenCache {
     }
 
     fn acquire_lock(&self) -> Result<FileLock, TokenCacheError> {
-        FileLock::acquire(
-            &self.cache_file_path,
-            self.retry_count,
-            self.retry_delay,
-            self.stale_lock_timeout,
-        )
+        FileLock::acquire(&self.cache_file_path, self.retry_count, self.retry_delay)
     }
 }
 
@@ -661,57 +584,6 @@ impl CredentialApi for FileTokenCacheEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cfg(windows)]
-    mod file_lock_tests {
-        use super::*;
-        use std::path::Path;
-
-        #[test]
-        fn transient_error_sharing_violation_and_delete_pending() {
-            let path = Path::new("unused");
-            // ERROR_SHARING_VIOLATION (32) and ERROR_DELETE_PENDING (303)
-            // are unconditionally transient regardless of path existence.
-            for code in [32, 303] {
-                let err = std::io::Error::from_raw_os_error(code);
-                assert!(
-                    FileLock::is_transient_windows_error(&err, path),
-                    "expected code {code} to be transient"
-                );
-            }
-        }
-
-        #[test]
-        fn transient_error_access_denied_only_when_lock_dir_exists() {
-            let temp_dir = tempfile::tempdir().expect("failed to create temp dir for test");
-            let existing = temp_dir.path().to_path_buf(); // guaranteed to exist for the duration of the test
-            let missing = existing.join("nonexistent_child");
-            assert!(!missing.exists(), "test precondition: path must not exist");
-
-            let err = std::io::Error::from_raw_os_error(5); // ERROR_ACCESS_DENIED
-            assert!(
-                FileLock::is_transient_windows_error(&err, &existing),
-                "ACCESS_DENIED should be transient when lock dir exists"
-            );
-            assert!(
-                !FileLock::is_transient_windows_error(&err, &missing),
-                "ACCESS_DENIED should NOT be transient when lock dir is absent"
-            );
-        }
-
-        #[test]
-        fn unrelated_error_codes_are_not_transient() {
-            let path = Path::new("unused");
-            // ERROR_FILE_NOT_FOUND (2), ERROR_PATH_NOT_FOUND (3), ERROR_INVALID_HANDLE (6)
-            for code in [2, 3, 6, 123, 9999] {
-                let err = std::io::Error::from_raw_os_error(code);
-                assert!(
-                    !FileLock::is_transient_windows_error(&err, path),
-                    "expected code {code} to NOT be transient"
-                );
-            }
-        }
-    }
 
     mod file_token_cache_tests {
         use super::*;
@@ -875,35 +747,24 @@ mod tests {
         }
 
         #[test]
-        fn lock_file_removed_after_operation() {
+        fn lock_released_after_operation() {
             let (_dir, cache) = create_temp_cache();
 
             cache
                 .set_secret("key", b"val")
                 .expect("Failed to set secret");
 
+            // The .lck file persists on disk but the OS-level lock must be
+            // released once the FileLock guard is dropped.
             let lock_path = cache.cache_file_path.with_extension("json.lck");
-            assert!(
-                !lock_path.exists(),
-                "Lock directory should be removed after operation"
-            );
-        }
-
-        #[test]
-        fn stale_lock_is_broken() {
-            let dir = tempfile::tempdir().expect("Failed to create temp dir");
-            let cache = FileTokenCache::with_directory(dir.path().to_path_buf())
-                .stale_lock_timeout(Duration::from_millis(50));
-            let lock_path = cache.cache_file_path.with_extension("json.lck");
-            fs::create_dir(&lock_path).expect("Failed to create stale lock dir");
-            std::thread::sleep(Duration::from_millis(100));
-
-            cache
-                .set_secret("key", b"val")
-                .expect("Should succeed after breaking stale lock");
-
-            let result = cache.get_secret("key").expect("Failed to get secret");
-            assert_eq!(result, Some(b"val".to_vec()));
+            let file = fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .write(true)
+                .open(&lock_path)
+                .expect("Failed to open lock file");
+            file.try_lock_exclusive()
+                .expect("Lock should be released after operation");
         }
 
         #[test]
@@ -911,12 +772,10 @@ mod tests {
             let dir = tempfile::tempdir().expect("Failed to create temp dir");
             let cache = FileTokenCache::with_directory(dir.path().to_path_buf())
                 .retry_count(10)
-                .retry_delay(Duration::from_millis(50))
-                .stale_lock_timeout(Duration::from_secs(30));
+                .retry_delay(Duration::from_millis(50));
 
             assert_eq!(cache.retry_count, 10);
             assert_eq!(cache.retry_delay, Duration::from_millis(50));
-            assert_eq!(cache.stale_lock_timeout, Duration::from_secs(30));
         }
     }
 
@@ -960,14 +819,7 @@ mod tests {
         use std::sync::{Arc, Barrier};
 
         const THREAD_COUNT: usize = 10;
-
-        // On Windows, `RemoveDirectory` is asynchronous and the
-        // "pending delete" state can cause `CreateDirectory` to return
-        // transient errors (`ERROR_DELETE_PENDING`,
-        // `ERROR_ACCESS_DENIED`, etc.), so threads need a larger retry
-        // budget to avoid spurious lock-exhaustion failures under high
-        // contention.
-        const LOCK_RETRY_COUNT: u32 = if cfg!(windows) { 1000 } else { 100 };
+        const LOCK_RETRY_COUNT: u32 = 100;
 
         fn create_shared_cache() -> (tempfile::TempDir, Arc<FileTokenCache>) {
             let dir = tempfile::tempdir().expect("Failed to create temp dir");
@@ -1085,6 +937,84 @@ mod tests {
                     String::from_utf8_lossy(&actual),
                 );
             }
+        }
+
+        /// Stress test: runs the concurrent-writes scenario many times to expose
+        /// lock-acquisition flakiness.  Run with:
+        ///   cargo test -p sf_core -- stress_concurrent_lock --ignored --nocapture
+        #[test]
+        #[ignore] // slow — run manually to validate locking reliability
+        fn stress_concurrent_lock() {
+            const ITERATIONS: usize = 50;
+            const STRESS_THREADS: usize = 20;
+
+            let mut failures = 0;
+
+            for round in 0..ITERATIONS {
+                let dir = tempfile::tempdir().expect("Failed to create temp dir");
+                let cache = Arc::new(
+                    FileTokenCache::with_directory(dir.path().to_path_buf())
+                        .retry_count(LOCK_RETRY_COUNT)
+                        .retry_delay(Duration::from_millis(50)),
+                );
+                let barrier = Arc::new(Barrier::new(STRESS_THREADS));
+
+                let handles: Vec<_> = (0..STRESS_THREADS)
+                    .map(|i| {
+                        let cache = Arc::clone(&cache);
+                        let barrier = Arc::clone(&barrier);
+                        std::thread::spawn(move || {
+                            barrier.wait();
+                            let key = format!("key_{i}");
+                            let value = format!("value_{i}");
+                            cache.set_secret(&key, value.as_bytes())
+                        })
+                    })
+                    .collect();
+
+                let mut round_ok = true;
+                for handle in handles {
+                    match handle.join() {
+                        Ok(Err(e)) => {
+                            eprintln!("  round {round}: set_secret error: {e}");
+                            round_ok = false;
+                        }
+                        Err(_) => {
+                            eprintln!("  round {round}: thread panicked");
+                            round_ok = false;
+                        }
+                        Ok(Ok(())) => {}
+                    }
+                }
+
+                if round_ok {
+                    // verify all keys readable
+                    for i in 0..STRESS_THREADS {
+                        let key = format!("key_{i}");
+                        let expected = format!("value_{i}");
+                        match cache.get_secret(&key) {
+                            Ok(Some(v)) if v == expected.as_bytes() => {}
+                            other => {
+                                eprintln!("  round {round}: read mismatch for {key}: {other:?}");
+                                round_ok = false;
+                            }
+                        }
+                    }
+                }
+
+                if !round_ok {
+                    failures += 1;
+                }
+            }
+
+            eprintln!(
+                "\nStress test result: {}/{ITERATIONS} rounds passed, {failures} failed",
+                ITERATIONS - failures
+            );
+            assert_eq!(
+                failures, 0,
+                "{failures}/{ITERATIONS} rounds failed — lock acquisition is unreliable"
+            );
         }
 
         #[test]

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -23,7 +23,7 @@ use super::{
 use super::{FileNotOwnedByCurrentUserSnafu, InsufficientPermissionsSnafu, IrregularFileTypeSnafu};
 
 const DEFAULT_CACHE_FILE_NAME: &str = "credential_cache_v2.json";
-const DEFAULT_RETRY_COUNT: u32 = 5;
+const DEFAULT_RETRY_COUNT: u32 = 20;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -138,7 +138,7 @@ impl FileLock {
         for attempt in 0..retry_count {
             match file.try_lock_exclusive() {
                 Ok(()) => return Ok(FileLock { _file: file }),
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(ref e) if Self::is_lock_contention(e) => {
                     if attempt < retry_count - 1 {
                         // Decorrelated jitter: sleep ∈ [base, min(3×prev, 16×base)]
                         let upper = (sleep_ms * 3.0).min(base_ms * 16.0);
@@ -151,6 +151,27 @@ impl FileLock {
         }
 
         LockExhaustedSnafu.fail()
+    }
+
+    /// Returns `true` when the error indicates the lock is held by another
+    /// handle/process and the caller should retry.
+    ///
+    /// On Unix, `flock` returns `EWOULDBLOCK` (`ErrorKind::WouldBlock`).
+    /// On Windows, `LockFileEx` with `LOCKFILE_FAIL_IMMEDIATELY` returns
+    /// `ERROR_LOCK_VIOLATION` (code 33) which Rust maps to
+    /// `ErrorKind::Uncategorized` rather than `WouldBlock`.
+    fn is_lock_contention(e: &std::io::Error) -> bool {
+        if e.kind() == std::io::ErrorKind::WouldBlock {
+            return true;
+        }
+        #[cfg(windows)]
+        {
+            const ERROR_LOCK_VIOLATION: i32 = 33;
+            if e.raw_os_error() == Some(ERROR_LOCK_VIOLATION) {
+                return true;
+            }
+        }
+        false
     }
 
     fn open_lock_file(lock_path: &Path) -> Result<fs::File, TokenCacheError> {

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -116,12 +116,19 @@ struct FileLock {
 }
 
 impl FileLock {
+    /// Derives the lock file path by appending `.lck` to the cache path.
+    fn lock_path(cache_path: &Path) -> PathBuf {
+        let mut p = cache_path.as_os_str().to_os_string();
+        p.push(".lck");
+        PathBuf::from(p)
+    }
+
     fn acquire(
         cache_path: &Path,
         retry_count: u32,
         retry_delay: Duration,
     ) -> Result<Self, TokenCacheError> {
-        let lock_path = cache_path.with_extension(format!("{DEFAULT_CACHE_FILE_NAME}.lck"));
+        let lock_path = Self::lock_path(cache_path);
 
         let file = Self::open_lock_file(&lock_path)?;
 
@@ -756,7 +763,7 @@ mod tests {
 
             // The .lck file persists on disk but the OS-level lock must be
             // released once the FileLock guard is dropped.
-            let lock_path = cache.cache_file_path.with_extension("json.lck");
+            let lock_path = FileLock::lock_path(&cache.cache_file_path);
             let file = fs::OpenOptions::new()
                 .create(true)
                 .truncate(false)


### PR DESCRIPTION
## Summary

- Replace `create_dir`/`remove_dir` mutex with OS-level file locking via the `fs2` crate (`flock` on Unix, `LockFileEx` on Windows)
- Eliminates the Windows `RemoveDirectory` pending-delete race that caused `concurrent_writes_do_not_corrupt` to be flaky on Windows ARM64 CI
- Removes stale lock detection (`is_stale`) and its documented TOCTOU bug — OS releases locks on process crash
- Adds exponential backoff with decorrelated jitter to the retry loop, eliminating the convoy effect
- Handles Windows `ERROR_LOCK_VIOLATION` (code 33) which Rust maps to `Uncategorized` instead of `WouldBlock`
- Increases `DEFAULT_RETRY_COUNT` from 5 to 20 for robustness under slow I/O environments (Docker overlay fs + coverage instrumentation)

## Context

The credential cache file lock used directory creation/removal as a mutex. On Windows, `RemoveDirectory` is asynchronous — the directory enters a "pending delete" state during which `CreateDirectory` fails with `ERROR_ACCESS_DENIED` (code 5). Even with 1000 retries at fixed 50ms delay, this race was not reliably overcome on Windows ARM64 CI runners.

The code itself had a comment (previously at line 126-132) recommending this exact fix:
> The proper fix is replacing mkdir-based locking with flock(2) / LockFileEx, which lets the OS release locks on process crash and removes the need for stale detection entirely.

### Changes
- **`sf_core/Cargo.toml`**: Add `fs2 = "0.4"` dependency
- **`sf_core/src/token_cache/file_cache.rs`**:
  - `FileLock` now holds an open `fs::File` with an exclusive OS lock
  - Lock released when guard is dropped (fd close), no directory removal needed
  - Removed `is_transient_windows_error()`, `is_stale()`, `Drop` impl
  - Removed `stale_lock_timeout` field and builder method
  - Unified `LOCK_RETRY_COUNT` (no longer needs Windows-specific inflation)
  - Added `is_lock_contention()` helper for cross-platform lock error detection (Unix `WouldBlock` + Windows `ERROR_LOCK_VIOLATION`)
  - Fixed lock path derivation — now appends `.lck` instead of `with_extension()` which produced double-name paths
  - Increased `DEFAULT_RETRY_COUNT` from 5 → 20 (~8s budget with jitter vs old ~500ms)
  - Added `stress_concurrent_lock` ignored test for manual validation
  - Updated `lock_released_after_operation` test to verify OS lock release
  - Removed obsolete `stale_lock_is_broken` and Windows error code tests

### Why increase DEFAULT_RETRY_COUNT?

The Jenkins coverage pipeline runs `cargo tarpaulin` inside a Docker container (`Jenkinsfile.coverage`, line 172). Docker's overlay filesystem makes each lock-hold cycle (open → read → parse JSON → update → write → close) significantly slower than native fs due to copy-on-write. Combined with ptrace overhead from tarpaulin, the 5 MFA integration tests that share the system credential cache (`KeyringTokenCache::new()` → `FileTokenCache`) exhaust the old 5-retry budget. The same tests pass in GH Actions tarpaulin on native fs.

Increasing to 20 retries with jitter gives ~8 seconds of effective budget — comfortable even under overlay fs + ptrace instrumentation.

### Stress test results (100 threads, 30 retries, 2ms base delay, 20 rounds)

The stress test uses a deliberately tight retry budget to expose the convoy effect in fixed-delay retries. With 100 threads and only 30 retries, the old code's fixed-delay pattern allows at most ~31 threads to succeed per round (one per retry cycle, since all losers wake simultaneously). The new code's jittered backoff spreads wakeups so all 100 threads acquire the lock.

| | OLD code (mkdir, fixed delay) | NEW code (fs2, jittered backoff) |
|---|---|---|
| **Rounds passed** | **0/20** | **20/20** |
| **Failure mode** | ~69 threads exhaust retries per round (convoy effect) | All threads succeed |

Run locally: `cargo test -p sf_core -- stress_concurrent_lock --ignored --nocapture`

## Test plan

- [x] All 15 `file_cache` unit tests pass
- [x] Pre-commit hooks pass (fmt, clippy, cargo check, format validator)
- [x] Stress test passes 20/20 on new code, fails 20/20 on old code
- [x] Windows ARM64 CI passes (validated `ERROR_LOCK_VIOLATION` handling)
- [ ] Jenkins coverage pipeline passes (MFA integration tests under Docker overlay + tarpaulin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)