### PR TITLE
SNOW-2881694 Add multistatement support to python

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -576,6 +576,8 @@ enum ChunkFormat {
 message RemoteChunk {
   string url = 1;
   map<string, string> headers = 2;
+  int64 compressed_size = 3;
+  int64 uncompressed_size = 4;
 }
 
 message ResultChunk {
@@ -589,8 +591,6 @@ message ResultChunk {
     RemoteChunk remote = 3;
   }
   int32 row_count = 4;
-  optional int64 compressed_size = 5;
-  optional int64 uncompressed_size = 6;
 }
 
 message ResultChunksResult {

--- a/python/src/snowflake/connector/_internal/statement_utils.py
+++ b/python/src/snowflake/connector/_internal/statement_utils.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING
 
 from .protobuf_gen.database_driver_v1_pb2 import (
     DatabaseFetchChunkResponse,
-    ExecuteResult,
     PrepareResult,
+    ResultSetDescriptor,
+    ResultSetResponse,
     StatementHandle,
     StatementNewRequest,
     StatementReleaseRequest,
@@ -48,25 +49,7 @@ def create_statement(connection: Connection, query: str) -> Generator[StatementH
         connection.db_api.statement_release(release_request)
 
 
-def extract_rowcount(result: ExecuteResult | None) -> int:
-    """Return the number of rows affected by the executed statement.
-
-    If the result is falsy or the ``rows_affected`` field is not present
-    (e.g. for SELECT queries), returns ``-1`` following the DB-API 2.0
-    convention for an indeterminate row count.
-
-    Args:
-        result: The protobuf response returned by ``statement_execute``.
-
-    Returns:
-        Non-negative row count, or ``-1`` when the count is unavailable.
-    """
-    if result and result.HasField("rows_affected"):
-        return result.rows_affected
-    return -1
-
-
-def extract_sqlstate(result: ExecuteResult | PrepareResult | None) -> str | None:
+def extract_sqlstate(result: PrepareResult | None) -> str | None:
     """Return the SQLSTATE code from an execute result, if meaningful.
 
     SQLSTATE ``"00000"`` (successful completion) is normalised to ``None``
@@ -87,7 +70,7 @@ def extract_sqlstate(result: ExecuteResult | PrepareResult | None) -> str | None
     return None
 
 
-def get_stream_ptr(result: DatabaseFetchChunkResponse | ExecuteResult | PrepareResult | None) -> int:
+def get_stream_ptr(result: DatabaseFetchChunkResponse | PrepareResult | ResultSetResponse | None) -> int:
     """Extract a C ArrowArrayStream pointer from an execute result.
 
     The pointer is stored as an 8-byte little-endian value inside
@@ -130,3 +113,42 @@ def get_stream_ptr(result: DatabaseFetchChunkResponse | ExecuteResult | PrepareR
         raise RuntimeError("Stream pointer is null")
 
     return stream_ptr
+
+
+def extract_rowcount_from_descriptor(descriptor: ResultSetDescriptor | None) -> int:
+    """Return the number of rows affected from a ResultSetDescriptor.
+
+    Returns the rows_affected value from the server if present, otherwise -1.
+
+    Args:
+        descriptor: The ResultSetDescriptor from a proto response.
+
+    Returns:
+        Row count from server, or ``-1`` when unavailable.
+    """
+    if not descriptor:
+        return -1
+
+    # Return rows_affected if present (for SELECT, DML, and DDL)
+    if descriptor.HasField("rows_affected"):
+        return descriptor.rows_affected
+
+    return -1
+
+
+def extract_sqlstate_from_descriptor(descriptor: ResultSetDescriptor | None) -> str | None:
+    """Return the SQLSTATE code from a descriptor, if meaningful.
+
+    SQLSTATE ``"00000"`` (successful completion) is normalised to ``None``
+    for backwards compatibility.
+
+    Args:
+        descriptor: The ResultSetDescriptor from a proto response.
+
+    Returns:
+        A five-character SQLSTATE string for warnings/errors, or ``None`` on success.
+    """
+    sql_state = descriptor.sql_state if descriptor else None
+    if sql_state and sql_state != "00000":
+        return sql_state
+    return None

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -32,17 +32,22 @@ from .._internal.errorcode import ER_CURSOR_IS_CLOSED, ER_INVALID_VALUE
 from .._internal.extras import check_dependency, pandas, pyarrow, requires_dependency
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     BinaryDataPtr,
+    ConfigSetting,
     ConnectionAbortQueryRequest,
     ConnectionGetQueryResultRequest,
-    ExecuteResult,
+    ConnectionGetResultSetRequest,
+    ExecuteQueryResponse,
     PrepareResult,
     QueryBindings,
     ResultChunk,
+    ResultSetResponse,
     StatementExecuteAsyncRequest,
     StatementExecuteQueryRequest,
+    StatementGetResultSetRequest,
     StatementHandle,
     StatementPrepareRequest,
     StatementResultChunksRequest,
+    StatementSetOptionsRequest,
 )
 from .._internal.statement_utils import create_statement
 from ..errors import InterfaceError, NotSupportedError, ProgrammingError
@@ -161,6 +166,14 @@ class SnowflakeCursorBase(abc.ABC):
         self._iterator: ArrowStreamIterator | None = None
         self._fetch_mode: FetchMode | None = None
 
+        # -- Multi-statement state (cleared on execute/reset) --
+        self._multi_statement_query_ids: list[str] = []
+        self._multi_statement_current_index: int = 0
+        self._multi_statement_parent_qid: str | None = None
+
+        # -- Statement parameters (persists until explicitly changed) --
+        self._statement_parameters: dict[str, Any] = {}
+
         # Keep binding data reference to prevent garbage collection while Rust uses it
         self._binding_data: None | bytes = None
         # Deferred result loading (set by get_results_from_sfqid, invoked on first fetch)
@@ -276,6 +289,26 @@ class SnowflakeCursorBase(abc.ABC):
         """The SQLSTATE code of the last executed operation."""
         return self._query_result.sqlstate
 
+    @property
+    def multi_statement_parent_sfqid(self) -> str | None:
+        """
+        Read-only attribute containing the parent Snowflake Query ID for multi-statement queries.
+
+        Returns:
+            str | None: Parent query ID for multi-statement, or None for single statements.
+        """
+        return self._multi_statement_parent_qid
+
+    @property
+    def multi_statement_savedIds(self) -> list[str]:
+        """
+        Read-only attribute containing child query IDs for multi-statement queries.
+
+        Returns:
+            list[str]: List of child query IDs (empty list for single statements).
+        """
+        return self._multi_statement_query_ids
+
     @overload
     def callproc(self, procname: str) -> tuple: ...
 
@@ -304,6 +337,28 @@ class SnowflakeCursorBase(abc.ABC):
         command = f"CALL {procname}({self._connection.paramstyle.placeholders(len(args))})"
         self.execute(command, args)
         return args
+
+    def set_statement_parameter(self, key: str, value: Any) -> None:
+        """Set a statement-level parameter (e.g., MULTI_STATEMENT_COUNT).
+
+        This must be called before execute() to take effect.
+
+        Args:
+            key: Parameter name (e.g., "MULTI_STATEMENT_COUNT").
+            value: Parameter value.
+
+        Raises:
+            InterfaceError: If cursor is closed.
+
+        Example:
+            cursor.set_statement_parameter("MULTI_STATEMENT_COUNT", 3)
+            cursor.execute("SELECT 1; SELECT 2; SELECT 3")
+        """
+        if self.is_closed():
+            raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+
+        # Store in cursor for application in _execute
+        self._statement_parameters[key] = value
 
     @property
     def is_file_transfer(self) -> bool:
@@ -394,6 +449,7 @@ class SnowflakeCursorBase(abc.ABC):
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
+        num_statements: int | None = None,
         **kwargs: Any,
     ) -> SnowflakeCursorBase:
         """
@@ -406,7 +462,11 @@ class SnowflakeCursorBase(abc.ABC):
                 For qmark/numeric paramstyle: sequence of values
                 For pyformat paramstyle: sequence (%s) or dict (%(name)s)
                 For format paramstyle: sequence (%s)
+            num_statements (int, optional): Number of statements in a multistatement query.
         """
+        if num_statements is not None:
+            self.set_statement_parameter("MULTI_STATEMENT_COUNT", num_statements)
+
         self.reset()
         return self._execute(operation, parameters, _is_put_get, **kwargs)
 
@@ -426,35 +486,156 @@ class SnowflakeCursorBase(abc.ABC):
 
         query, bindings = self._prepare_query(operation, parameters)
 
-        result: ExecuteResult | None = None
         with create_statement(self.connection, query) as stmt_handle:
-            result = self._execute_query(stmt_handle, bindings)
-            self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle)
+            # Apply statement parameters if set
+            if self._statement_parameters:
+                self._apply_statement_parameters(stmt_handle)
 
-        self._query_result = _QueryResult.from_execute_result(result)
+            response = self._execute_query(stmt_handle, bindings)
+
+            # Dispatch based on response type
+            if response.HasField("multi"):
+                self._handle_multi_statement_response(response, stmt_handle, query)
+            else:
+                self._handle_single_statement_response(response, stmt_handle, query)
+
         self._rownumber = -1  # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
-
         return self
 
-    def _fetch_result_chunk_metadata(self, stmt_handle: StatementHandle) -> list[ResultChunk] | None:
-        """Retrieve chunk metadata while the statement handle is still alive."""
+    def _fetch_result_chunk_metadata(
+        self, stmt_handle: StatementHandle, query_id: str | None = None
+    ) -> list[ResultChunk] | None:
+        """Retrieve chunk metadata for a specific query ID while the statement handle is alive.
+
+        For single-statement queries, query_id should be None (server infers from statement handle).
+        For multi-statement queries, query_id must specify which child query's chunks to return.
+        """
         try:
-            request = StatementResultChunksRequest(stmt_handle=stmt_handle)
+            # Only include query_id in request if explicitly provided (for multistatement)
+            if query_id is not None:
+                logger.debug(f"Fetching chunk metadata WITH query_id={query_id}")
+                request = StatementResultChunksRequest(stmt_handle=stmt_handle, query_id=query_id)
+            else:
+                logger.debug("Fetching chunk metadata WITHOUT query_id")
+                request = StatementResultChunksRequest(stmt_handle=stmt_handle)
             response = self._connection.db_api.statement_result_chunks(request)
             if response.HasField("result"):
                 return list(response.result.chunks)
+            logger.warning("No result field in response")
             return None
         except Exception:
-            logger.warning("Failed to fetch result chunk metadata", exc_info=True)
+            logger.warning(f"Failed to fetch result chunk metadata for query_id={query_id}", exc_info=True)
             return None
 
-    def _execute_query(self, stmt_handle: StatementHandle, bindings: QueryBindings | None) -> ExecuteResult:
+    def _execute_query(self, stmt_handle: StatementHandle, bindings: QueryBindings | None) -> ExecuteQueryResponse:
+        """Execute query and return ExecuteQueryResponse (single or multi)."""
         try:
             request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
-            return self._connection.db_api.statement_execute_query(request).result
+            return self._connection.db_api.statement_execute_query(request)
         except ProgrammingError as exc:
             self._query_result = _QueryResult.from_programming_error(exc)
             raise
+
+    def _fetch_result_set(self, stmt_handle: StatementHandle, query_id: str) -> ResultSetResponse:
+        """Fetch a result set by query ID via StatementGetResultSet RPC.
+
+        Args:
+            stmt_handle: Active statement handle.
+            query_id: Query ID to fetch.
+
+        Returns:
+            ResultSetResponse containing descriptor and arrow stream.
+
+        Raises:
+            ProgrammingError: If the fetch fails.
+        """
+        try:
+            request = StatementGetResultSetRequest(
+                stmt_handle=stmt_handle,
+                query_id=query_id,
+            )
+            return self._connection.db_api.statement_get_result_set(request)
+        except Exception as exc:
+            # Wrap non-ProgrammingError exceptions for consistency
+            if isinstance(exc, ProgrammingError):
+                raise
+            raise ProgrammingError(f"Failed to fetch result set for query_id={query_id}: {exc}") from exc
+
+    def _handle_single_statement_response(
+        self, response: ExecuteQueryResponse, stmt_handle: StatementHandle, query: str
+    ) -> None:
+        """Handle single-statement execution response."""
+        # Clear any previous multistatement state
+        self._multi_statement_query_ids = []
+        self._multi_statement_current_index = 0
+        self._multi_statement_parent_qid = None
+
+        descriptor = response.single
+
+        # Fetch the result set (metadata + arrow stream)
+        result_set_response = self._fetch_result_set(stmt_handle, descriptor.query_id)
+        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor, query)
+        # For single-statement, pass the query_id to chunks request
+        self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle, query_id=descriptor.query_id)
+
+    def _handle_multi_statement_response(
+        self, response: ExecuteQueryResponse, stmt_handle: StatementHandle, query: str
+    ) -> None:
+        """Handle multi-statement execution response."""
+        multi_result = response.multi
+
+        # Store parent query ID and child IDs
+        parent = multi_result.parent
+        self._multi_statement_parent_qid = parent.query_id if parent.query_id else None
+        self._multi_statement_query_ids = list(multi_result.query_ids)
+        self._multi_statement_current_index = 0
+
+        # Edge case: empty multi-statement result
+        if not self._multi_statement_query_ids:
+            self._query_result = _QueryResult(query=query)
+            self._result_chunks = None
+            self._multi_statement_parent_qid = None  # Clear parent QID for consistency
+            return
+
+        # Immediately fetch and apply the first child result
+        first_qid = self._multi_statement_query_ids[0]
+        result_set_response = self._fetch_result_set(stmt_handle, first_qid)
+        descriptor = result_set_response.result_descriptor
+
+        # For first result in multistatement, pass the full query
+        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor, query)
+        self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle, first_qid)
+        self._multi_statement_current_index = 1
+
+    def _apply_statement_parameters(self, stmt_handle: StatementHandle) -> None:
+        """Apply stored statement parameters to the statement handle via SetOptions RPC."""
+        if not self._statement_parameters:
+            return
+
+        # Build options map with ConfigSetting values
+        options = {}
+        for key, value in self._statement_parameters.items():
+            config_setting = ConfigSetting()
+            if isinstance(value, int):
+                config_setting.int_value = value
+            elif isinstance(value, str):
+                config_setting.string_value = value
+            elif isinstance(value, bool):
+                config_setting.bool_value = value
+            elif isinstance(value, float):
+                config_setting.double_value = value
+            elif isinstance(value, bytes):
+                config_setting.bytes_value = value
+            else:
+                raise TypeError(
+                    f"Unsupported parameter type for key '{key}': {type(value).__name__}. "
+                    f"Supported types: int, str, bool, float, bytes"
+                )
+            options[key] = config_setting
+
+        # Send single RPC with all options
+        request = StatementSetOptionsRequest(stmt_handle=stmt_handle, options=options)
+        self._connection.db_api.statement_set_options(request)
 
     def _prepare(self, stmt_handle: StatementHandle) -> PrepareResult:
         try:
@@ -687,17 +868,67 @@ class SnowflakeCursorBase(abc.ABC):
     # ------------------------------------------------------------------
 
     @pep249
-    def nextset(self) -> None:
+    def nextset(self) -> SnowflakeCursorBase | None:
         """
-        Skip to the next available set, discarding any remaining rows from current set.
+        Skip to the next available result set, discarding remaining rows from current set.
+
+        This method is used for multi-statement queries where a single execute() produces
+        multiple result sets. Call nextset() to advance to the next query's results.
 
         Returns:
-            bool: True if next set is available, False/None otherwise
+            SnowflakeCursorBase: Self if next set is available.
+            None: If no more result sets are available.
 
         Raises:
-            NotImplementedError: If not implemented
+            InterfaceError: If cursor is closed.
+
+        Example:
+            cursor.set_statement_parameter("MULTI_STATEMENT_COUNT", 3)
+            cursor.execute("SELECT 1; SELECT 2; SELECT 3")
+            print(cursor.fetchone())  # (1,)
+            cursor.nextset()
+            print(cursor.fetchone())  # (2,)
+            cursor.nextset()
+            print(cursor.fetchone())  # (3,)
+            result = cursor.nextset()  # None - no more results
         """
-        raise NotImplementedError("nextset is not implemented")
+        if self.is_closed():
+            raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+
+        # Check if there are more child results to fetch
+        if self._multi_statement_current_index >= len(self._multi_statement_query_ids):
+            return None
+
+        # Save multistatement state before reset (reset clears it)
+        query_ids = self._multi_statement_query_ids
+        current_idx = self._multi_statement_current_index
+        parent_qid = self._multi_statement_parent_qid
+
+        # Reset cursor state for new result set
+        self.reset()
+
+        # Restore multistatement state
+        self._multi_statement_query_ids = query_ids
+        self._multi_statement_current_index = current_idx + 1
+        self._multi_statement_parent_qid = parent_qid
+
+        # Fetch the next child result
+        query_id = query_ids[current_idx]
+
+        # Use connection-level GetResultSet since statement handle is no longer available
+        request = ConnectionGetResultSetRequest(
+            conn_handle=self._connection.conn_handle,
+            query_id=query_id,
+        )
+        result_set_response = self._connection.db_api.connection_get_result_set(request)
+        descriptor = result_set_response.result_descriptor
+
+        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor)
+        self._rownumber = -1
+        # Note: chunk metadata not available for child results without statement handle
+        self._result_chunks = None
+
+        return self
 
     @pep249
     def setinputsizes(self, sizes: Sequence[Any]) -> None:
@@ -753,6 +984,8 @@ class SnowflakeCursorBase(abc.ABC):
         preserving metadata that the old driver also keeps across resets:
         ``description``, ``rownumber``, ``sfqid``, ``query``, and ``sqlstate``.
 
+        Multi-statement state is also cleared: query IDs, current index, and parent query ID.
+
         Args:
             closing: If True, do not reset rowcount,
                      see: SNOW-647539: Do not erase the rowcount information when closing the cursor.
@@ -764,6 +997,10 @@ class SnowflakeCursorBase(abc.ABC):
         self._fetch_mode = None
         self._binding_data = None
         self._prefetch_hook = None
+        # Clear multistatement state
+        self._multi_statement_query_ids = []
+        self._multi_statement_current_index = 0
+        self._multi_statement_parent_qid = None
 
     @pep249
     def close(self) -> bool | None:
@@ -951,7 +1188,30 @@ class SnowflakeCursorBase(abc.ABC):
         )
         response = self._connection.db_api.connection_get_query_result(request)
 
-        self._query_result = _QueryResult.from_execute_result(response.result)
+        # Handle single or multi-statement response
+        if response.HasField("multi"):
+            # For async, we only support fetching the first result of multi-statement
+            multi_result = response.multi
+            if multi_result.query_ids:
+                first_qid = multi_result.query_ids[0]
+                result_request = ConnectionGetResultSetRequest(
+                    conn_handle=self._connection.conn_handle,
+                    query_id=first_qid,
+                )
+                result_set = self._connection.db_api.connection_get_result_set(result_request)
+                self._query_result = _QueryResult.from_result_set_response(result_set)
+            else:
+                self._query_result = _QueryResult()
+        else:
+            # Single statement
+            descriptor = response.single
+            result_request = ConnectionGetResultSetRequest(
+                conn_handle=self._connection.conn_handle,
+                query_id=descriptor.query_id,
+            )
+            result_set = self._connection.db_api.connection_get_result_set(result_request)
+            self._query_result = _QueryResult.from_result_set_response(result_set, descriptor)
+
         self._rownumber = -1
 
         return self

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -130,6 +130,36 @@ def _requires_fetch_mode(mode: FetchMode) -> Callable[[F], F]:
     return decorator
 
 
+def _create_config_setting(value: Any) -> ConfigSetting:
+    """Create a ConfigSetting protobuf from a Python value.
+
+    Args:
+        value: Python value (int, str, bool, float, or bytes).
+
+    Returns:
+        ConfigSetting protobuf message.
+
+    Raises:
+        TypeError: If value type is not supported.
+    """
+    config_setting = ConfigSetting()
+    if isinstance(value, bool):  # Check bool before int (bool is subclass of int)
+        config_setting.bool_value = value
+    elif isinstance(value, int):
+        config_setting.int_value = value
+    elif isinstance(value, str):
+        config_setting.string_value = value
+    elif isinstance(value, float):
+        config_setting.double_value = value
+    elif isinstance(value, bytes):
+        config_setting.bytes_value = value
+    else:
+        raise TypeError(
+            f"Unsupported parameter type: {type(value).__name__}. Supported types: int, str, bool, float, bytes"
+        )
+    return config_setting
+
+
 class SnowflakeCursorBase(abc.ABC):
     """
     Base cursor class for database operations (PEP 249).
@@ -338,6 +368,7 @@ class SnowflakeCursorBase(abc.ABC):
         self.execute(command, args)
         return args
 
+    @_requires_open
     def set_statement_parameter(self, key: str, value: Any) -> None:
         """Set a statement-level parameter (e.g., MULTI_STATEMENT_COUNT).
 
@@ -354,9 +385,6 @@ class SnowflakeCursorBase(abc.ABC):
             cursor.set_statement_parameter("MULTI_STATEMENT_COUNT", 3)
             cursor.execute("SELECT 1; SELECT 2; SELECT 3")
         """
-        if self.is_closed():
-            raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
-
         # Store in cursor for application in _execute
         self._statement_parameters[key] = value
 
@@ -465,6 +493,7 @@ class SnowflakeCursorBase(abc.ABC):
             num_statements (int, optional): Number of statements in a multistatement query.
         """
         if num_statements is not None:
+            # TODO Create a global known parameters registry
             self.set_statement_parameter("MULTI_STATEMENT_COUNT", num_statements)
 
         self.reset()
@@ -574,7 +603,7 @@ class SnowflakeCursorBase(abc.ABC):
 
         # Fetch the result set (metadata + arrow stream)
         result_set_response = self._fetch_result_set(stmt_handle, descriptor.query_id)
-        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor, query)
+        self._query_result = _QueryResult._from_result_set_response(result_set_response, descriptor, query)
         # For single-statement, pass the query_id to chunks request
         self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle, query_id=descriptor.query_id)
 
@@ -587,6 +616,8 @@ class SnowflakeCursorBase(abc.ABC):
         # Store parent query ID and child IDs
         parent = multi_result.parent
         self._multi_statement_parent_qid = parent.query_id if parent.query_id else None
+
+        # Extract query IDs from multi-statement result
         self._multi_statement_query_ids = list(multi_result.query_ids)
         self._multi_statement_current_index = 0
 
@@ -603,7 +634,7 @@ class SnowflakeCursorBase(abc.ABC):
         descriptor = result_set_response.result_descriptor
 
         # For first result in multistatement, pass the full query
-        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor, query)
+        self._query_result = _QueryResult._from_result_set_response(result_set_response, descriptor, query)
         self._result_chunks = self._fetch_result_chunk_metadata(stmt_handle, first_qid)
         self._multi_statement_current_index = 1
 
@@ -615,23 +646,10 @@ class SnowflakeCursorBase(abc.ABC):
         # Build options map with ConfigSetting values
         options = {}
         for key, value in self._statement_parameters.items():
-            config_setting = ConfigSetting()
-            if isinstance(value, int):
-                config_setting.int_value = value
-            elif isinstance(value, str):
-                config_setting.string_value = value
-            elif isinstance(value, bool):
-                config_setting.bool_value = value
-            elif isinstance(value, float):
-                config_setting.double_value = value
-            elif isinstance(value, bytes):
-                config_setting.bytes_value = value
-            else:
-                raise TypeError(
-                    f"Unsupported parameter type for key '{key}': {type(value).__name__}. "
-                    f"Supported types: int, str, bool, float, bytes"
-                )
-            options[key] = config_setting
+            try:
+                options[key] = _create_config_setting(value)
+            except TypeError as err:
+                raise TypeError(f"Cannot set parameter '{key}': {err}") from err
 
         # Send single RPC with all options
         request = StatementSetOptionsRequest(stmt_handle=stmt_handle, options=options)
@@ -868,6 +886,7 @@ class SnowflakeCursorBase(abc.ABC):
     # ------------------------------------------------------------------
 
     @pep249
+    @_requires_open
     def nextset(self) -> SnowflakeCursorBase | None:
         """
         Skip to the next available result set, discarding remaining rows from current set.
@@ -892,9 +911,6 @@ class SnowflakeCursorBase(abc.ABC):
             print(cursor.fetchone())  # (3,)
             result = cursor.nextset()  # None - no more results
         """
-        if self.is_closed():
-            raise InterfaceError("Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
-
         # Check if there are more child results to fetch
         if self._multi_statement_current_index >= len(self._multi_statement_query_ids):
             return None
@@ -923,7 +939,7 @@ class SnowflakeCursorBase(abc.ABC):
         result_set_response = self._connection.db_api.connection_get_result_set(request)
         descriptor = result_set_response.result_descriptor
 
-        self._query_result = _QueryResult.from_result_set_response(result_set_response, descriptor)
+        self._query_result = _QueryResult._from_result_set_response(result_set_response, descriptor)
         self._rownumber = -1
         # Note: chunk metadata not available for child results without statement handle
         self._result_chunks = None
@@ -1199,7 +1215,7 @@ class SnowflakeCursorBase(abc.ABC):
                     query_id=first_qid,
                 )
                 result_set = self._connection.db_api.connection_get_result_set(result_request)
-                self._query_result = _QueryResult.from_result_set_response(result_set)
+                self._query_result = _QueryResult._from_result_set_response(result_set)
             else:
                 self._query_result = _QueryResult()
         else:
@@ -1210,7 +1226,7 @@ class SnowflakeCursorBase(abc.ABC):
                 query_id=descriptor.query_id,
             )
             result_set = self._connection.db_api.connection_get_result_set(result_request)
-            self._query_result = _QueryResult.from_result_set_response(result_set, descriptor)
+            self._query_result = _QueryResult._from_result_set_response(result_set, descriptor)
 
         self._rownumber = -1
 

--- a/python/src/snowflake/connector/cursor/_query_result.py
+++ b/python/src/snowflake/connector/cursor/_query_result.py
@@ -106,7 +106,7 @@ class _QueryResult:
         )
 
     @staticmethod
-    def from_result_set_response(
+    def _from_result_set_response(
         response: ResultSetResponse,
         descriptor: ResultSetDescriptor | None = None,
         query: str | None = None,
@@ -125,7 +125,7 @@ class _QueryResult:
             descriptor = response.result_descriptor
 
         return _QueryResult(
-            description=ResultMetadata.create_description_from_descriptor(descriptor),
+            description=ResultMetadata._create_description_from_descriptor(descriptor),
             sqlstate=extract_sqlstate_from_descriptor(descriptor),
             sfqid=descriptor.query_id if descriptor.query_id else None,
             query=query,  # Query text passed from caller

--- a/python/src/snowflake/connector/cursor/_query_result.py
+++ b/python/src/snowflake/connector/cursor/_query_result.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 from .._internal.arrow_stream_utils import release_arrow_stream
-from .._internal.protobuf_gen.database_driver_v1_pb2 import ExecuteResult, PrepareResult
-from .._internal.statement_utils import extract_rowcount, extract_sqlstate, get_stream_ptr
+from .._internal.protobuf_gen.database_driver_v1_pb2 import (
+    PrepareResult,
+    ResultSetDescriptor,
+    ResultSetResponse,
+)
+from .._internal.statement_utils import (
+    extract_rowcount_from_descriptor,
+    extract_sqlstate,
+    extract_sqlstate_from_descriptor,
+    get_stream_ptr,
+)
 from ..errors import ProgrammingError
 from ._result_metadata import QueryResultStats, ResultMetadata
 
@@ -75,22 +84,6 @@ class _QueryResult:
             self.rowcount = None
 
     @staticmethod
-    def from_execute_result(result: ExecuteResult | None) -> _QueryResult:
-        return _QueryResult(
-            description=ResultMetadata.create_description(result),
-            sqlstate=extract_sqlstate(result),
-            sfqid=(result.query_id if result.query_id else None) if result else None,
-            query=(result.query if result.query else None) if result else None,
-            rowcount=extract_rowcount(result),
-            _stream_ptr=get_stream_ptr(result),
-            stats=(
-                QueryResultStats.from_query_stats(result.stats)
-                if (result and result.HasField("stats"))
-                else QueryResultStats()
-            ),
-        )
-
-    @staticmethod
     def from_prepare_result(result: PrepareResult | None) -> _QueryResult:
         stream_ptr = get_stream_ptr(result)
         release_arrow_stream(stream_ptr)
@@ -110,4 +103,37 @@ class _QueryResult:
             sqlstate=exc.sqlstate or None,
             sfqid=exc.sfqid or None,
             query=exc.query or None,
+        )
+
+    @staticmethod
+    def from_result_set_response(
+        response: ResultSetResponse,
+        descriptor: ResultSetDescriptor | None = None,
+        query: str | None = None,
+    ) -> _QueryResult:
+        """Create _QueryResult from ResultSetResponse (used for multistatement children).
+
+        Args:
+            response: ResultSetResponse from StatementGetResultSet or ConnectionGetResultSet.
+            descriptor: Optional descriptor (if already extracted from response).
+            query: Optional query text (not available in proto, must be passed separately).
+
+        Returns:
+            _QueryResult instance.
+        """
+        if descriptor is None:
+            descriptor = response.result_descriptor
+
+        return _QueryResult(
+            description=ResultMetadata.create_description_from_descriptor(descriptor),
+            sqlstate=extract_sqlstate_from_descriptor(descriptor),
+            sfqid=descriptor.query_id if descriptor.query_id else None,
+            query=query,  # Query text passed from caller
+            rowcount=extract_rowcount_from_descriptor(descriptor),
+            _stream_ptr=get_stream_ptr(response),
+            stats=(
+                QueryResultStats.from_query_stats(descriptor.stats)
+                if descriptor.HasField("stats")
+                else QueryResultStats()
+            ),
         )

--- a/python/src/snowflake/connector/cursor/_result_metadata.py
+++ b/python/src/snowflake/connector/cursor/_result_metadata.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any, NamedTuple
 
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
-    ExecuteResult,
     PrepareResult,
     QueryStats,
+    ResultSetDescriptor,
 )
 from .._internal.type_codes import get_type_code
 
@@ -51,10 +51,24 @@ class ResultMetadata(NamedTuple):
         )
 
     @classmethod
-    def create_description(cls, result: ExecuteResult | PrepareResult | None) -> list[ResultMetadata] | None:
+    def create_description(cls, result: PrepareResult | None) -> list[ResultMetadata] | None:
         """Extract description from execute result column metadata."""
         if result and result.columns:
             return [cls.from_column(col) for col in result.columns]
+        return None
+
+    @classmethod
+    def create_description_from_descriptor(cls, descriptor: ResultSetDescriptor | None) -> list[ResultMetadata] | None:
+        """Extract description from ResultSetDescriptor column metadata.
+
+        Args:
+            descriptor: ResultSetDescriptor from a proto response.
+
+        Returns:
+            List of ResultMetadata or ``None`` if no columns.
+        """
+        if descriptor and descriptor.columns:
+            return [cls.from_column(col) for col in descriptor.columns]
         return None
 
 

--- a/python/src/snowflake/connector/cursor/_result_metadata.py
+++ b/python/src/snowflake/connector/cursor/_result_metadata.py
@@ -58,7 +58,7 @@ class ResultMetadata(NamedTuple):
         return None
 
     @classmethod
-    def create_description_from_descriptor(cls, descriptor: ResultSetDescriptor | None) -> list[ResultMetadata] | None:
+    def _create_description_from_descriptor(cls, descriptor: ResultSetDescriptor | None) -> list[ResultMetadata] | None:
         """Extract description from ResultSetDescriptor column metadata.
 
         Args:

--- a/python/src/snowflake/connector/result_batch.py
+++ b/python/src/snowflake/connector/result_batch.py
@@ -117,14 +117,14 @@ class ResultBatch:
 
     @property
     def compressed_size(self) -> int | None:
-        if self._chunk.HasField("compressed_size"):
-            return self._chunk.compressed_size
+        if self._chunk.HasField("remote"):
+            return self._chunk.remote.compressed_size
         return None
 
     @property
     def uncompressed_size(self) -> int | None:
-        if self._chunk.HasField("uncompressed_size"):
-            return self._chunk.uncompressed_size
+        if self._chunk.HasField("remote"):
+            return self._chunk.remote.uncompressed_size
         return None
 
     @property

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -1,0 +1,178 @@
+"""Multistatement query execution tests for Universal Driver (Python).
+
+This module implements the test scenarios from:
+  tests/definitions/shared/query/multistatement.feature
+
+These are cross-driver tests that validate shared multistatement behavior.
+Python-specific tests are in tests/integ/query/test_multistatement.py
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from snowflake.connector.errors import ProgrammingError
+
+
+def random_table_name(prefix: str = "ms_test") -> str:
+    """Generate a random table name to avoid conflicts."""
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+class TestMultipleSelectStatements:
+    """Tests for multiple SELECT statement execution."""
+
+    def test_should_execute_multiple_select_statements(self, cursor):
+        # Given Snowflake client is logged in
+        pass
+        # When multistatement query with 3 SELECTs is executed
+        cursor.execute("SELECT 1 AS a; SELECT 2 AS b; SELECT 3 AS c", num_statements=3)
+
+        # Then 3 result sets are returned
+        pass
+        # And each result set contains correct data
+
+        # First result
+        assert cursor.description is not None
+        assert cursor.description[0].name == "A"
+        row1 = cursor.fetchone()
+        assert row1 is not None
+        assert row1[0] == 1
+
+        # Second result
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.description is not None
+        assert cursor.description[0].name == "B"
+        row2 = cursor.fetchone()
+        assert row2 is not None
+        assert row2[0] == 2
+
+        # Third result
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.description is not None
+        assert cursor.description[0].name == "C"
+        row3 = cursor.fetchone()
+        assert row3 is not None
+        assert row3[0] == 3
+
+        # No more results
+        result = cursor.nextset()
+        assert result is None
+
+
+class TestMultipleDMLStatements:
+    """Tests for multiple DML statement execution."""
+
+    def test_should_execute_multiple_dml_statements(self, cursor):
+        # Given Snowflake client is logged in
+        pass
+        # When multistatement query with CREATE TABLE, INSERT, and DROP is executed
+        table_name = random_table_name("ms_dml")
+        sql = (
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id INT); "
+            f"INSERT INTO {table_name} VALUES (1),(2),(3); "
+            f"DROP TABLE {table_name}"
+        )
+        cursor.execute(sql, num_statements=3)
+
+        # Then 3 result sets are returned
+
+        # First result: CREATE TABLE
+        assert cursor.rowcount == 1
+
+        # Second result: INSERT
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 3
+
+        # Third result: DROP TABLE
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 1
+
+        # No more results
+        result = cursor.nextset()
+        assert result is None
+
+
+class TestMixedStatementTypes:
+    """Tests for mixed statement type execution."""
+
+    def test_should_execute_mixed_statement_types(self, cursor):
+        # Given Snowflake client is logged in
+        pass
+        # When multistatement query with various types is executed
+        table_name = random_table_name("ms_mix")
+        sql = (
+            "ALTER SESSION SET TIMEZONE='UTC'; "
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(val TEXT); "
+            f"INSERT INTO {table_name} VALUES ('hello'); "
+            f"SELECT val FROM {table_name}; "
+            f"DROP TABLE {table_name}"
+        )
+        cursor.execute(sql, num_statements=5)
+
+        # Then 5 result sets are returned
+        pass
+        # 1. ALTER SESSION
+        assert cursor.rowcount == 1
+
+        # 2. CREATE TABLE
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 1
+
+        # 3. INSERT
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 1
+
+        # 4. SELECT - and the SELECT result contains expected data
+        result = cursor.nextset()
+        assert result is cursor
+        # And the SELECT result contains expected data
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == "hello"
+
+        # 5. DROP TABLE
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 1
+
+        # No more results
+        result = cursor.nextset()
+        assert result is None
+
+
+class TestErrorHandling:
+    """Tests for multistatement error handling."""
+
+    def test_should_fail_when_multistatement_sql_is_sent_without_multi_statement_count(self, cursor):
+        # Given Snowflake client is logged in
+        pass
+        # When multistatement SQL is executed without configuring multi_statement_count
+        pass
+        # Then an error is returned indicating multi-statement is not enabled
+        with pytest.raises(ProgrammingError) as exc_info:
+            cursor.execute("SELECT 1; SELECT 2")
+
+        # Verify error indicates multi-statement is not enabled
+        assert exc_info.value is not None
+
+    def test_should_fail_when_multi_statement_count_does_not_match_actual_statement_count(self, cursor):
+        # Given Snowflake client is logged in
+        pass
+        # When single SELECT is executed with multi_statement_count set to 3
+        pass
+
+        # Then an error is returned indicating statement count mismatch
+        with pytest.raises(ProgrammingError) as exc_info:
+            cursor.execute("SELECT 1", num_statements=3)
+
+        # Verify error is raised
+        assert exc_info.value is not None

--- a/python/tests/integ/query/test_multistatement.py
+++ b/python/tests/integ/query/test_multistatement.py
@@ -1,0 +1,91 @@
+"""Python-specific multistatement query tests (integration).
+
+These tests cover Python-specific behavior not in the shared feature file:
+- nextset() return values and behavior
+- Cursor state management across nextset() calls
+- Query ID tracking (multi_statement_savedIds and multi_statement_parent_sfqid)
+- Mixed fetch modes (fetchall + nextset)
+"""
+
+from __future__ import annotations
+
+
+class TestNextsetBehavior:
+    """Tests for Python-specific nextset() behavior."""
+
+    def test_nextset_returns_none_without_multistatement(self, cursor):
+        """Test that nextset returns None for single-statement queries."""
+        # Execute single statement
+        cursor.execute("SELECT 1")
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+        # nextset should return None
+        result = cursor.nextset()
+        assert result is None
+
+    def test_nextset_resets_cursor_state(self, cursor):
+        """Test that nextset properly resets cursor state."""
+        cursor.execute("SELECT 1, 2; SELECT 3, 4, 5", num_statements=2)
+
+        # First result: 2 columns
+        assert cursor.description is not None
+        assert len(cursor.description) == 2
+        cursor.fetchone()
+
+        # After nextset, description should reflect new columns
+        cursor.nextset()
+        assert cursor.description is not None
+        assert len(cursor.description) == 3
+
+        # rownumber should be reset
+        assert cursor.rownumber is None or cursor.rownumber == -1
+
+    def test_parent_query_id_tracking(self, cursor):
+        """Test that query IDs are tracked for multi-statement."""
+        cursor.execute("SELECT 1; SELECT 2", num_statements=2)
+
+        # Verify multi_statement_savedIds contains child query IDs
+        assert hasattr(cursor, "multi_statement_savedIds")
+        assert len(cursor.multi_statement_savedIds) == 2
+
+        # Verify multi_statement_parent_sfqid if available
+        if hasattr(cursor, "multi_statement_parent_sfqid"):
+            parent_qid = cursor.multi_statement_parent_sfqid
+            # Parent QID should persist across nextset
+            cursor.nextset()
+            assert cursor.multi_statement_parent_sfqid == parent_qid
+
+    def test_fetchall_then_nextset(self, cursor):
+        """Test that fetchall works before nextset."""
+        cursor.execute("SELECT 1 UNION ALL SELECT 2; SELECT 3", num_statements=2)
+
+        # Fetch all from first result
+        rows = cursor.fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == 1
+        assert rows[1][0] == 2
+
+        # Move to second result
+        cursor.nextset()
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == 3
+
+    def test_parameter_persistence(self, cursor):
+        """Test that num_statements parameter works across multiple executions."""
+        # First execution
+        cursor.execute("SELECT 1; SELECT 2", num_statements=2)
+        cursor.fetchone()
+        cursor.nextset()
+        cursor.fetchone()
+        assert cursor.nextset() is None
+
+        # Second execution
+        cursor.execute("SELECT 3; SELECT 4", num_statements=2)
+        cursor.fetchone()
+        result = cursor.nextset()
+        assert result is cursor
+        cursor.fetchone()
+        assert cursor.nextset() is None

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -1222,15 +1222,6 @@ class TestCursorMethods:
         # Just verify it's callable and accepts empty sequence without error
         cursor.executemany("INSERT INTO test VALUES (?)", [])
 
-    @pytest.mark.skip_reference(
-        reason="Reference driver returns None from nextset instead of raising NotImplementedError"
-    )
-    def test_nextset_not_implemented(self, cursor):
-        """Test that nextset raises NotImplementedError."""
-        with pytest.raises(NotImplementedError) as excinfo:
-            cursor.nextset()
-        assert "nextset is not implemented" in str(excinfo.value)
-
     def test_setinputsizes_no_op(self, cursor):
         """Test that setinputsizes is a no-op."""
         # Should not raise any exception

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -564,16 +564,51 @@ class TestSqlstate:
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
+    def _stub_execute_result(self, mock_connection, **overrides):
+        """Set up the mock to return an execute result with the given overrides."""
+        # Mock ResultSetDescriptor
+        descriptor = MagicMock()
+        descriptor.query_id = overrides.get("query_id", "test-query-id")
+        descriptor.columns = overrides.get("columns", [])
+        descriptor.rows_affected = overrides.get("rows_affected", 0)
+        descriptor.sql_state = overrides.get("sql_state", "")
+        descriptor.statement_type_id = overrides.get("statement_type_id", 0x0000)
+
+        def has_field_impl(field_name):
+            if field_name == "rows_affected":
+                return overrides.get("has_rows_affected", False)
+            elif field_name == "sql_state":
+                return bool(overrides.get("sql_state", ""))
+            elif field_name == "stats":
+                return overrides.get("has_stats", False)
+            elif field_name == "statement_type_id":
+                return "statement_type_id" in overrides
+            return False
+
+        descriptor.HasField = MagicMock(side_effect=has_field_impl)
+
+        # Mock ExecuteQueryResponse with single statement
+        execute_response = MagicMock()
+        execute_response.single = descriptor
+        execute_response.HasField = MagicMock(side_effect=lambda f: f == "single")
+        mock_connection.db_api.statement_execute_query.return_value = execute_response
+
+        # Mock StatementGetResultSetResponse
+        result_set_response = MagicMock()
+        result_set_response.result_descriptor = descriptor
+        result_set_response.stream = MagicMock()
+        result_set_response.stream.value = (0).to_bytes(8, byteorder="little")
+        mock_connection.db_api.statement_get_result_set.return_value = result_set_response
+
+        return descriptor
+
     def test_sqlstate_none_before_execute(self, cursor):
         """sqlstate is None on a fresh cursor."""
         assert cursor.sqlstate is None
 
     def test_sqlstate_none_after_successful_execute(self, cursor, mock_connection):
         """sqlstate is None when server returns '00000' (successful completion)."""
-        result = MagicMock()
-        result.columns = []
-        result.sql_state = "00000"
-        mock_connection.db_api.statement_execute_query.return_value.result = result
+        self._stub_execute_result(mock_connection, sql_state="00000")
 
         cursor.execute("SELECT 1")
 
@@ -581,10 +616,7 @@ class TestSqlstate:
 
     def test_sqlstate_populated_with_error_code(self, cursor, mock_connection):
         """sqlstate reflects non-success sql_state from execute result."""
-        result = MagicMock()
-        result.columns = []
-        result.sql_state = "42601"
-        mock_connection.db_api.statement_execute_query.return_value.result = result
+        self._stub_execute_result(mock_connection, sql_state="42601")
 
         cursor.execute("SELECT 1")
 
@@ -592,10 +624,7 @@ class TestSqlstate:
 
     def test_sqlstate_none_when_field_absent(self, cursor, mock_connection):
         """sqlstate is None when the server does not return sql_state."""
-        result = MagicMock()
-        result.columns = []
-        result.sql_state = ""
-        mock_connection.db_api.statement_execute_query.return_value.result = result
+        self._stub_execute_result(mock_connection, sql_state="")
 
         cursor.execute("SELECT 1")
 
@@ -603,19 +632,14 @@ class TestSqlstate:
 
     def test_sqlstate_updates_on_subsequent_execute(self, cursor, mock_connection):
         """sqlstate is refreshed on every execute call."""
-        first_result = MagicMock()
-        first_result.columns = []
-        first_result.sql_state = "42601"
+        # First execute with error
+        self._stub_execute_result(mock_connection, sql_state="42601")
 
-        second_result = MagicMock()
-        second_result.columns = []
-        second_result.sql_state = "00000"
-
-        mock_connection.db_api.statement_execute_query.return_value.result = first_result
         cursor.execute("SELECT 1")
         assert cursor.sqlstate == "42601"
 
-        mock_connection.db_api.statement_execute_query.return_value.result = second_result
+        # Second execute with success
+        self._stub_execute_result(mock_connection, sql_state="00000")
         cursor.execute("SELECT 2")
         assert cursor.sqlstate is None
 
@@ -1891,13 +1915,43 @@ class TestQueryResult:
 
     def _stub_result(self, mock_connection, **overrides):
         """Set up the mock RPC to return a result with the given overrides."""
-        result = MagicMock()
-        result.columns = overrides.get("columns", [])
-        result.rows_affected = overrides.get("rows_affected", 0)
-        result.HasField = MagicMock(return_value=overrides.get("has_rows_affected", False))
-        result.sql_state = overrides.get("sql_state", "")
-        mock_connection.db_api.connection_get_query_result.return_value.result = result
-        return result
+        # Mock ResultSetDescriptor
+        descriptor = MagicMock()
+        descriptor.query_id = overrides.get("query_id", "test-query-id")
+        descriptor.columns = overrides.get("columns", [])
+        descriptor.rows_affected = overrides.get("rows_affected", 0)
+        descriptor.statement_type_id = overrides.get("statement_type_id", 0x0000)  # Default to UNKNOWN
+
+        # Mock HasField to handle different field types
+        def has_field_impl(field_name):
+            if field_name == "rows_affected":
+                return overrides.get("has_rows_affected", False)
+            elif field_name == "sql_state":
+                return bool(overrides.get("sql_state", ""))
+            elif field_name == "stats":
+                return overrides.get("has_stats", False)
+            elif field_name == "statement_type_id":
+                return "statement_type_id" in overrides
+            return False
+
+        descriptor.HasField = MagicMock(side_effect=has_field_impl)
+        descriptor.sql_state = overrides.get("sql_state", "")
+        descriptor.stats = overrides.get("stats", None)
+
+        # Mock ConnectionGetQueryResultResponse with single statement
+        query_result_response = MagicMock()
+        query_result_response.single = descriptor
+        query_result_response.HasField = MagicMock(side_effect=lambda f: f == "single")
+        mock_connection.db_api.connection_get_query_result.return_value = query_result_response
+
+        # Mock ConnectionGetResultSetResponse
+        result_set_response = MagicMock()
+        result_set_response.result_descriptor = descriptor
+        result_set_response.stream = MagicMock()
+        result_set_response.stream.value = (0).to_bytes(8, byteorder="little")  # Null pointer
+        mock_connection.db_api.connection_get_result_set.return_value = result_set_response
+
+        return descriptor
 
     def test_query_result_populates_cursor_state(self, cursor, mock_connection):
         """query_result returns self, sends correct RPC args, and populates all cursor fields."""

--- a/python/tests/unit/test_result_batch.py
+++ b/python/tests/unit/test_result_batch.py
@@ -146,7 +146,9 @@ class TestProperties:
         assert _make_batch().compressed_size is None
 
     def test_compressed_size_from_chunk(self):
-        chunk = ResultChunk(compressed_size=1024)
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import RemoteChunk
+
+        chunk = ResultChunk(remote=RemoteChunk(url="http://example.com", compressed_size=1024))
         batch = ResultBatch(chunk=chunk, description=_make_description("ID"), connection=None)
         assert batch.compressed_size == 1024
 
@@ -154,7 +156,9 @@ class TestProperties:
         assert _make_batch().uncompressed_size is None
 
     def test_uncompressed_size_from_chunk(self):
-        chunk = ResultChunk(uncompressed_size=4096)
+        from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import RemoteChunk
+
+        chunk = ResultChunk(remote=RemoteChunk(url="http://example.com", uncompressed_size=4096))
         batch = ResultBatch(chunk=chunk, description=_make_description("ID"), connection=None)
         assert batch.uncompressed_size == 4096
 

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -663,7 +663,30 @@ fn to_driver_exception(error: ApiError) -> DriverException {
         ApiError::ConnectionLocking { .. } => StatusCode::InternalError,
         ApiError::StatementLocking { .. } => StatusCode::InternalError,
         ApiError::DatabaseLocking { .. } => StatusCode::InternalError,
-        ApiError::QueryResponseProcessing { .. } => StatusCode::InternalError,
+        ApiError::QueryResponseProcessing {
+            source: boxed_error,
+            ..
+        } => {
+            use crate::apis::database_driver_v1::error::QueryResponseProcessingError;
+            use crate::compression_types::CompressionTypeError;
+            use crate::file_manager::FileManagerError;
+
+            match boxed_error.as_ref() {
+                QueryResponseProcessingError::FileUpload { source, .. }
+                | QueryResponseProcessingError::FileDownload { source, .. } => match source {
+                    FileManagerError::NoFilesMatched { .. } => StatusCode::LocalFileNotFound,
+                    FileManagerError::CompressionType {
+                        source: CompressionTypeError::UnsupportedCompressionType { .. },
+                        ..
+                    } => StatusCode::UnsupportedCompression,
+                    _ => StatusCode::InternalError,
+                },
+                QueryResponseProcessingError::RemoteFileNotFound { .. } => {
+                    StatusCode::RemoteFileNotFound
+                }
+                _ => StatusCode::InternalError,
+            }
+        }
         ApiError::ConnectionNotInitialized { .. } => StatusCode::InternalError,
         ApiError::TlsClientCreation { .. } => StatusCode::AuthenticationError,
         ApiError::SessionRefresh { .. } => StatusCode::AuthenticationError,

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -748,12 +748,18 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let mut chunks = Vec::new();
 
         if let Some(base64_data) = chunk_info.initial_chunk_base64 {
+            // Calculate inline chunk row count: total from descriptor minus remote chunks
+            let remote_rows: i32 = chunk_info.chunks.iter().map(|c| c.row_count).sum();
+            let inline_row_count = chunk_info
+                .descriptor
+                .rows_affected
+                .map(|total| (total as i32).saturating_sub(remote_rows))
+                .unwrap_or(0);
+
             chunks.push(ResultChunk {
                 format: ChunkFormat::ArrowIpc as i32,
                 data: Some(result_chunk::Data::Inline(base64_data)),
-                row_count: 0,
-                compressed_size: None,
-                uncompressed_size: None,
+                row_count: inline_row_count,
             });
         }
 
@@ -763,10 +769,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
                 data: Some(result_chunk::Data::Remote(RemoteChunk {
                     url: c.url.clone(),
                     headers: c.headers.clone(),
+                    compressed_size: c.compressed_size,
+                    uncompressed_size: c.uncompressed_size,
                 })),
                 row_count: c.row_count,
-                compressed_size: Some(c.compressed_size),
-                uncompressed_size: Some(c.uncompressed_size),
             });
         }
 

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -1,11 +1,11 @@
-@core @jdbc @odbc
+@core @jdbc @odbc @python
 Feature: Multistatement query execution
 
   # ============================================================================
   # MULTIPLE SELECTS
   # ============================================================================
 
-  @core_e2e @jdbc_e2e @odbc_e2e
+  @core_e2e @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should execute multiple SELECT statements
     Given Snowflake client is logged in
     When Multistatement query with 3 SELECTs is executed
@@ -16,7 +16,7 @@ Feature: Multistatement query execution
   # MULTIPLE DML STATEMENTS
   # ============================================================================
 
-  @core_e2e @jdbc_e2e @odbc_e2e
+  @core_e2e @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should execute multiple DML statements
     Given Snowflake client is logged in
     When Multistatement query with CREATE TABLE, INSERT, and DROP is executed
@@ -26,7 +26,7 @@ Feature: Multistatement query execution
   # MIXED STATEMENT TYPES
   # ============================================================================
 
-  @core_e2e @jdbc_e2e @odbc_e2e
+  @core_e2e @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should execute mixed statement types
     Given Snowflake client is logged in
     When Multistatement query with various types is executed
@@ -37,13 +37,13 @@ Feature: Multistatement query execution
   # ERROR HANDLING
   # ============================================================================
 
-  @core_e2e @jdbc_e2e @odbc_e2e
+  @core_e2e @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should fail when multistatement SQL is sent without multi_statement_count
     Given Snowflake client is logged in
     When Multistatement SQL is executed without configuring multi_statement_count
     Then an error is returned indicating multi-statement is not enabled
 
-  @core_e2e @jdbc_e2e @odbc_e2e
+  @core_e2e @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should fail when multi_statement_count does not match actual statement count
     Given Snowflake client is logged in
     When Single SELECT is executed with multi_statement_count set to 3


### PR DESCRIPTION
### TL;DR

Implements multi-statement query support for the Python Snowflake connector, allowing execution of multiple SQL statements in a single call with proper result set navigation.

### What changed?

- Added `set_statement_parameter()` method to configure multi-statement execution with parameters like `MULTI_STATEMENT_COUNT`
- Implemented `nextset()` method to navigate between result sets from multi-statement queries, returning the cursor for next results or `None` when exhausted
- Added `multi_statement_parent_sfqid` property to track the parent query ID for multi-statement executions
- Refactored query execution to handle both single and multi-statement responses through new protobuf message types (`ExecuteQueryResponse`, `ResultSetResponse`, `ResultSetDescriptor`)
- Updated statement utilities to extract metadata from `ResultSetDescriptor` instead of `ExecuteResult`
- Added connection-level result set fetching for accessing child query results after statement handles are released
- Enhanced cursor state management to preserve multi-statement context across `nextset()` calls while properly resetting fetch state