### PR TITLE
Add identifiable naming to test PATs for traceability

### DIFF
--- a/odbc_tests/tests/e2e/authentication/pat.cpp
+++ b/odbc_tests/tests/e2e/authentication/pat.cpp
@@ -3,7 +3,11 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <iomanip>
+#include <iterator>
 #include <optional>
 #include <random>
 #include <sstream>
@@ -41,6 +45,20 @@ class PatSetup {
 
   ~PatSetup() { cleanup(); }
 
+  static std::string sanitize(const std::string& s) {
+    std::string result;
+    std::copy_if(s.begin(), s.end(), std::back_inserter(result), ::isalnum);
+    return result;
+  }
+
+  static std::string ci_build_tag() {
+    const char* bk = std::getenv("BUILDKITE_BUILD_NUMBER");
+    if (bk && bk[0] != '\0') return "BK_" + sanitize(bk);
+    const char* jnk = std::getenv("BUILD_NUMBER");
+    if (jnk && jnk[0] != '\0') return "JNK_" + sanitize(jnk);
+    return "LOCAL_0";
+  }
+
   PatResult acquire() {
     PatResult result;
 
@@ -49,7 +67,7 @@ class PatSetup {
     std::uniform_int_distribution<uint32_t> dis;
     uint32_t random_number = dis(gen);
     std::stringstream ss;
-    ss << "pat_" << std::hex << std::setw(8) << std::setfill('0') << random_number;
+    ss << "UD_ODBC_" << ci_build_tag() << "_" << std::hex << std::setw(8) << std::setfill('0') << random_number;
     token_name = ss.str();
     result.token_name = token_name;
 

--- a/odbc_tests/tests/e2e/authentication/pat.cpp
+++ b/odbc_tests/tests/e2e/authentication/pat.cpp
@@ -52,12 +52,18 @@ class PatSetup {
   }
 
   static std::string ci_build_tag() {
-    const char* bk = std::getenv("BUILDKITE_BUILD_NUMBER");
-    if (bk && bk[0] != '\0') return "BK_" + sanitize(bk);
-    const char* jnk = std::getenv("BUILD_NUMBER");
-    if (jnk && jnk[0] != '\0') return "JNK_" + sanitize(jnk);
-    const char* gha = std::getenv("GITHUB_RUN_NUMBER");
-    if (gha && gha[0] != '\0') return "GHA_" + sanitize(gha);
+    struct CiVar {
+      const char* env;
+      const char* prefix;
+    };
+    for (auto [env, prefix] :
+         {CiVar{"BUILDKITE_BUILD_NUMBER", "BK"}, CiVar{"BUILD_NUMBER", "JNK"}, CiVar{"GITHUB_RUN_NUMBER", "GHA"}}) {
+      const char* raw = std::getenv(env);
+      if (raw) {
+        auto s = sanitize(raw);
+        if (!s.empty()) return std::string(prefix) + "_" + s;
+      }
+    }
     return "LOCAL_0";
   }
 

--- a/odbc_tests/tests/e2e/authentication/pat.cpp
+++ b/odbc_tests/tests/e2e/authentication/pat.cpp
@@ -56,6 +56,8 @@ class PatSetup {
     if (bk && bk[0] != '\0') return "BK_" + sanitize(bk);
     const char* jnk = std::getenv("BUILD_NUMBER");
     if (jnk && jnk[0] != '\0') return "JNK_" + sanitize(jnk);
+    const char* gha = std::getenv("GITHUB_RUN_NUMBER");
+    if (gha && gha[0] != '\0') return "GHA_" + sanitize(gha);
     return "LOCAL_0";
   }
 

--- a/python/tests/e2e/authentication/test_pat.py
+++ b/python/tests/e2e/authentication/test_pat.py
@@ -1,10 +1,25 @@
 import logging
+import os
 import random
 
 import pytest
 
 from ...config import get_test_parameters
 from .auth_helpers import verify_login_error, verify_simple_query_execution
+
+
+def _sanitize(s: str) -> str:
+    return "".join(c for c in s if c.isalnum())
+
+
+def _ci_build_tag() -> str:
+    bk = os.environ.get("BUILDKITE_BUILD_NUMBER")
+    if bk:
+        return f"BK_{_sanitize(bk)}"
+    jnk = os.environ.get("BUILD_NUMBER")
+    if jnk:
+        return f"JNK_{_sanitize(jnk)}"
+    return "LOCAL_0"
 
 
 @pytest.fixture(scope="class")
@@ -61,7 +76,7 @@ class PAT:
         self._token_secret = None
 
     def acquire_token(self) -> str:
-        token_name = f"pat_{random.randint(0, 2**32 - 1):x}"
+        token_name = f"UD_PYTHON_{_ci_build_tag()}_{random.randint(0, 2**32 - 1):08x}"
         test_params = get_test_parameters()
         user = test_params.get("SNOWFLAKE_TEST_USER")
         role = test_params.get("SNOWFLAKE_TEST_ROLE")

--- a/python/tests/e2e/authentication/test_pat.py
+++ b/python/tests/e2e/authentication/test_pat.py
@@ -9,19 +9,20 @@ from .auth_helpers import verify_login_error, verify_simple_query_execution
 
 
 def _sanitize(s: str) -> str:
-    return "".join(c for c in s if c.isalnum())
+    return "".join(c for c in s if c.isascii() and c.isalnum())
 
 
 def _ci_build_tag() -> str:
-    bk = os.environ.get("BUILDKITE_BUILD_NUMBER")
-    if bk:
-        return f"BK_{_sanitize(bk)}"
-    jnk = os.environ.get("BUILD_NUMBER")
-    if jnk:
-        return f"JNK_{_sanitize(jnk)}"
-    gha = os.environ.get("GITHUB_RUN_NUMBER")
-    if gha:
-        return f"GHA_{_sanitize(gha)}"
+    for var, prefix in [
+        ("BUILDKITE_BUILD_NUMBER", "BK"),
+        ("BUILD_NUMBER", "JNK"),
+        ("GITHUB_RUN_NUMBER", "GHA"),
+    ]:
+        raw = os.environ.get(var)
+        if raw:
+            s = _sanitize(raw)
+            if s:
+                return f"{prefix}_{s}"
     return "LOCAL_0"
 
 

--- a/python/tests/e2e/authentication/test_pat.py
+++ b/python/tests/e2e/authentication/test_pat.py
@@ -19,6 +19,9 @@ def _ci_build_tag() -> str:
     jnk = os.environ.get("BUILD_NUMBER")
     if jnk:
         return f"JNK_{_sanitize(jnk)}"
+    gha = os.environ.get("GITHUB_RUN_NUMBER")
+    if gha:
+        return f"GHA_{_sanitize(gha)}"
     return "LOCAL_0"
 
 

--- a/sf_core/tests/e2e/authentication/pat.rs
+++ b/sf_core/tests/e2e/authentication/pat.rs
@@ -66,7 +66,7 @@ struct Pat {
 
 impl Pat {
     fn acquire() -> Self {
-        let name = format!("pat_{:x}", rand::random::<u32>());
+        let name = format!("UD_RUST_{}_{:08x}", ci_build_tag(), rand::random::<u32>());
         let client = SnowflakeTestClient::connect_with_default_auth();
         let user = client.parameters.user.clone().unwrap();
         let role = client.parameters.role.clone().unwrap();
@@ -109,4 +109,22 @@ fn set_pat_token(client: &SnowflakeTestClient, token_secret: &str) {
 
 fn set_invalid_pat_token(client: &SnowflakeTestClient) {
     client.set_connection_option("token", "invalid_token_12345");
+}
+
+fn ci_build_tag() -> String {
+    if let Ok(build) = std::env::var("BUILDKITE_BUILD_NUMBER")
+        && !build.is_empty()
+    {
+        return format!("BK_{}", sanitize(&build));
+    }
+    if let Ok(build) = std::env::var("BUILD_NUMBER")
+        && !build.is_empty()
+    {
+        return format!("JNK_{}", sanitize(&build));
+    }
+    "LOCAL_0".to_string()
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars().filter(|c| c.is_ascii_alphanumeric()).collect()
 }

--- a/sf_core/tests/e2e/authentication/pat.rs
+++ b/sf_core/tests/e2e/authentication/pat.rs
@@ -112,20 +112,17 @@ fn set_invalid_pat_token(client: &SnowflakeTestClient) {
 }
 
 fn ci_build_tag() -> String {
-    if let Ok(build) = std::env::var("BUILDKITE_BUILD_NUMBER")
-        && !build.is_empty()
-    {
-        return format!("BK_{}", sanitize(&build));
-    }
-    if let Ok(build) = std::env::var("BUILD_NUMBER")
-        && !build.is_empty()
-    {
-        return format!("JNK_{}", sanitize(&build));
-    }
-    if let Ok(build) = std::env::var("GITHUB_RUN_NUMBER")
-        && !build.is_empty()
-    {
-        return format!("GHA_{}", sanitize(&build));
+    for (var, prefix) in [
+        ("BUILDKITE_BUILD_NUMBER", "BK"),
+        ("BUILD_NUMBER", "JNK"),
+        ("GITHUB_RUN_NUMBER", "GHA"),
+    ] {
+        if let Ok(raw) = std::env::var(var) {
+            let s = sanitize(&raw);
+            if !s.is_empty() {
+                return format!("{prefix}_{s}");
+            }
+        }
     }
     "LOCAL_0".to_string()
 }

--- a/sf_core/tests/e2e/authentication/pat.rs
+++ b/sf_core/tests/e2e/authentication/pat.rs
@@ -122,6 +122,11 @@ fn ci_build_tag() -> String {
     {
         return format!("JNK_{}", sanitize(&build));
     }
+    if let Ok(build) = std::env::var("GITHUB_RUN_NUMBER")
+        && !build.is_empty()
+    {
+        return format!("GHA_{}", sanitize(&build));
+    }
     "LOCAL_0".to_string()
 }
 


### PR DESCRIPTION
## Summary

- PATs created during E2E tests now use the naming pattern `UD_{DRIVER}_{CI}_{BUILD}_{RANDOM}` (e.g. `UD_RUST_JNK_988_a3f2b1c0`) instead of the previous opaque `pat_{random}` format
- The naming encodes: driver origin (RUST/PYTHON/ODBC), CI system (BK=Buildkite, JNK=Jenkins, GHA=GitHub Actions, LOCAL=dev), build number, and a random suffix for uniqueness
- This allows orphaned PATs on the sfctest0 account to be immediately traced back to the specific build that created them

## Context

PATs are accumulating on the sfctest0 account because cleanup relies on in-process destructors (`Drop` in Rust, `finally` in Python, destructors in C++) which don't execute when builds are aborted/killed (e.g. the 16 consecutive timeout-aborted builds #965-#980). With identifiable names, we can determine which CI system and build left orphaned PATs.

This is the first of two PRs — the follow-up (#876) will add a CI-level cleanup step to remove stale PATs belonging to the current build.

## Changes

| File | Change |
|------|--------|
| `sf_core/tests/e2e/authentication/pat.rs` | PAT name: `UD_RUST_{ci}_{build}_{hex}` + `ci_build_tag()` helper |
| `python/tests/e2e/authentication/test_pat.py` | PAT name: `UD_PYTHON_{ci}_{build}_{hex}` + `_ci_build_tag()` helper |
| `odbc_tests/tests/e2e/authentication/pat.cpp` | PAT name: `UD_ODBC_{ci}_{build}_{hex}` + `ci_build_tag()` static method |

CI systems detected via environment variables:
- `BUILDKITE_BUILD_NUMBER` → `BK_{build}`
- `BUILD_NUMBER` → `JNK_{build}`
- `GITHUB_RUN_NUMBER` → `GHA_{build}`
- None set → `LOCAL_0`

Build numbers are sanitized to ASCII alphanumeric only.

## Test plan

- [ ] Verify PAT E2E tests still pass (naming change is transparent to Snowflake)
- [ ] Confirm PAT names in CI logs contain the expected `UD_*` prefix
- [ ] Check that cleanup (Drop/finally/destructor) still works with the new naming