### PR TITLE
Add CI-level PAT cleanup for aborted/failed builds

### DIFF
--- a/.buildkite/pipelines/ci-tests/pipeline.yml
+++ b/.buildkite/pipelines/ci-tests/pipeline.yml
@@ -333,8 +333,9 @@ steps:
         -e BUILDKITE_BUILD_NUMBER \
         "$$DOCKER_IMAGE" \
         bash -c '
+          set -euo pipefail
           ./scripts/decode_secrets.sh
-          pip3 install snowflake-connector-python -q
+          python3 -m pip install snowflake-connector-python -q
           python3 scripts/cleanup_test_pats.py \
             --parameter-path /workdir/parameters.json
         '

--- a/.buildkite/pipelines/ci-tests/pipeline.yml
+++ b/.buildkite/pipelines/ci-tests/pipeline.yml
@@ -300,3 +300,41 @@ steps:
             ' || DOCKER_EXIT=$$?
 
           ci/upload_test_results.sh jdbc "JDBC" "$$DOCKER_EXIT" "junit-results/jdbc-junit.xml"
+
+  # ==========================================================================
+  # PAT Cleanup (safety net for aborted/timed-out builds)
+  # ==========================================================================
+  - label: ":broom: Cleanup test PATs"
+    key: "pat-cleanup"
+    depends_on:
+      - step: "rust-core"
+        allow_failure: true
+      - step: "python"
+        allow_failure: true
+      - step: "odbc"
+        allow_failure: true
+      - step: "jdbc"
+        allow_failure: true
+    soft_fail: true
+    agents:
+      queue: "discovery"
+      repo: "snowflakedb/universal-driver"
+    plugins:
+      - ${GLOBAL_PLUGIN}/vault_secrets:
+          secrets:
+            - path: "secret/jenkins/rt-tests/driver_validation_parameters_secret"
+              env_name: "PARAMETERS_SECRET"
+    command: |
+      set -euo pipefail
+      docker run --rm \
+        -v "$$PWD:/workdir" \
+        -w /workdir \
+        -e PARAMETERS_SECRET \
+        -e BUILDKITE_BUILD_NUMBER \
+        "$$DOCKER_IMAGE" \
+        bash -c '
+          ./scripts/decode_secrets.sh
+          pip3 install snowflake-connector-python -q
+          python3 scripts/cleanup_test_pats.py \
+            --parameter-path /workdir/parameters.json
+        '

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -466,6 +466,15 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           DRIVER_TYPE: NEW
 
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          pip3 install snowflake-connector-python -q
+          python3 scripts/cleanup_test_pats.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
       - name: Cleanup orphaned test schemas
         if: always() && runner.os == 'Linux'
         run: |

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -471,8 +471,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          pip3 install snowflake-connector-python -q
-          python3 scripts/cleanup_test_pats.py \
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
             --parameter-path "${{ github.workspace }}/parameters.json"
 
       - name: Cleanup orphaned test schemas

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -566,8 +566,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          pip3 install snowflake-connector-python -q
-          python3 scripts/cleanup_test_pats.py \
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
             --parameter-path "${{ github.workspace }}/parameters.json"
 
       - name: Upload test results as GitHub artifact

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -561,6 +561,15 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          pip3 install snowflake-connector-python -q
+          python3 scripts/cleanup_test_pats.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
       - name: Upload test results as GitHub artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -154,6 +154,14 @@ jobs:
           cargo tarpaulin --packages sf_core --all-features --skip-clean --no-fail-fast --out lcov --output-dir .
           mv lcov.info lcov-${{ matrix.os }}-${{ matrix.rust-version }}.info
 
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        run: |
+          pip3 install snowflake-connector-python -q
+          python3 scripts/cleanup_test_pats.py \
+            --parameter-path $(pwd)/parameters.json
+
       - name: Save Rust cache
         if: always()
         uses: ./.github/actions/cargo-cache
@@ -276,6 +284,15 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo test --package sf_core --target aarch64-pc-windows-msvc -- --nocapture
+
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          pip3 install snowflake-connector-python -q
+          python3 scripts/cleanup_test_pats.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
 
       - name: Save Rust cache
         if: always()

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -158,8 +158,8 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          pip3 install snowflake-connector-python -q
-          python3 scripts/cleanup_test_pats.py \
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
             --parameter-path $(pwd)/parameters.json
 
       - name: Save Rust cache
@@ -290,8 +290,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          pip3 install snowflake-connector-python -q
-          python3 scripts/cleanup_test_pats.py \
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
             --parameter-path "${{ github.workspace }}/parameters.json"
 
       - name: Save Rust cache

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -385,30 +385,40 @@ pipeline {
                 }
                 sh label: 'Install system dependencies', script: 'yum install -y unzip'
 
-                sh label: 'Rust Core VPN E2E tests', script: '''
-                  set +x
-                  export PARAMETER_PATH=$(pwd)/parameters.json
-                  cargo test --package sf_core -- --ignored
-                '''
+                try {
+                  sh label: 'Rust Core VPN E2E tests', script: '''
+                    set +x
+                    export PARAMETER_PATH=$(pwd)/parameters.json
+                    cargo test --package sf_core -- --ignored
+                  '''
 
-                sh label: 'ODBC VPN E2E tests', script: '''
-                  set +x
-                  cargo build
-                  source /opt/rh/gcc-toolset-11/enable
-                  cd odbc_tests
-                  mkdir -p cmake-build
-                  cmake -B cmake-build \
-                      -D ODBC_LIBRARY="/usr/lib64/libodbc.so" \
-                      -D ODBC_INCLUDE_DIR="/usr/include" \
-                      -D DRIVER_TYPE=NEW \
-                      .
-                  cmake --build cmake-build -- -j $(nproc)
+                  sh label: 'ODBC VPN E2E tests', script: '''
+                    set +x
+                    cargo build
+                    source /opt/rh/gcc-toolset-11/enable
+                    cd odbc_tests
+                    mkdir -p cmake-build
+                    cmake -B cmake-build \
+                        -D ODBC_LIBRARY="/usr/lib64/libodbc.so" \
+                        -D ODBC_INCLUDE_DIR="/usr/include" \
+                        -D DRIVER_TYPE=NEW \
+                        .
+                    cmake --build cmake-build -- -j $(nproc)
 
-                  WORKSPACE_ROOT=$(pwd)/..
-                  export DRIVER_PATH=${WORKSPACE_ROOT}/target/debug/libsfodbc.so
-                  export PARAMETER_PATH=${WORKSPACE_ROOT}/parameters.json
-                  ctest -j 1 -C Debug --test-dir cmake-build --output-on-failure -R "native_okta" --no-tests=error
-                '''
+                    WORKSPACE_ROOT=$(pwd)/..
+                    export DRIVER_PATH=${WORKSPACE_ROOT}/target/debug/libsfodbc.so
+                    export PARAMETER_PATH=${WORKSPACE_ROOT}/parameters.json
+                    ctest -j 1 -C Debug --test-dir cmake-build --output-on-failure -R "native_okta" --no-tests=error
+                  '''
+                } finally {
+                  sh label: 'Cleanup test PATs', script: '''
+                    set +x
+                    pip3 install snowflake-connector-python -q 2>/dev/null || true
+                    python3 scripts/cleanup_test_pats.py \
+                      --parameter-path $(pwd)/parameters.json \
+                      --build-tag "JNK_${BUILD_NUMBER}" || true
+                  '''
+                }
               }
             }
           }

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -178,6 +178,15 @@ pipeline {
                                         export PARAMETER_PATH=$(pwd)/parameters.json
                                         cargo tarpaulin --packages sf_core --all-features --skip-clean --no-fail-fast --out lcov --output-dir .
                                     ''')
+
+                                    sh(label: 'Cleanup test PATs', returnStatus: true, script: '''
+                                        set +x
+                                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                                        python3 scripts/cleanup_test_pats.py \
+                                            --parameter-path $(pwd)/parameters.json \
+                                            --build-tag "JNK_${BUILD_NUMBER}" || true
+                                    ''')
+
                                     if (testExitCode != 0) {
                                         echo "Rust Core tests failed with exit code ${testExitCode}, continuing to generate coverage"
                                         unstable(message: "Rust Core tests failed")
@@ -236,6 +245,14 @@ pipeline {
                                             unstable(message: "Python tests failed")
                                         }
                                     }
+
+                                    sh(label: 'Cleanup test PATs', returnStatus: true, script: '''
+                                        set +x
+                                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                                        python3 scripts/cleanup_test_pats.py \
+                                            --parameter-path $(pwd)/parameters.json \
+                                            --build-tag "JNK_${BUILD_NUMBER}" || true
+                                    ''')
                                     
                                     def coverage = parseCoberturaCoverage('python/reports/coverage-python.xml')
                                     uploadToCodecov('python', 'python/reports/coverage-python.xml')
@@ -285,6 +302,15 @@ pipeline {
                                         # Exclude CRL tests - they require Wiremock server which is not started in coverage job
                                         ctest -j 1 -C Debug --test-dir cmake-build --output-on-failure -E "crl"
                                     ''')
+
+                                    sh(label: 'Cleanup test PATs', returnStatus: true, script: '''
+                                        set +x
+                                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                                        python3 scripts/cleanup_test_pats.py \
+                                            --parameter-path $(pwd)/parameters.json \
+                                            --build-tag "JNK_${BUILD_NUMBER}" || true
+                                    ''')
+
                                     if (testExitCode != 0) {
                                         echo "ODBC tests failed with exit code ${testExitCode}, continuing to generate coverage"
                                         unstable(message: "ODBC tests failed")

--- a/scripts/cleanup_test_pats.py
+++ b/scripts/cleanup_test_pats.py
@@ -86,12 +86,11 @@ def build_connection_kwargs(params):
 
 
 def _load_pem_private_key(pem_text, password=None):
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
 
     pwd_bytes = password.encode() if password else None
     private_key = serialization.load_pem_private_key(
-        pem_text.encode(), password=pwd_bytes, backend=default_backend()
+        pem_text.encode(), password=pwd_bytes
     )
     return private_key.private_bytes(
         encoding=serialization.Encoding.DER,

--- a/scripts/cleanup_test_pats.py
+++ b/scripts/cleanup_test_pats.py
@@ -178,14 +178,17 @@ def main():
     if not build_tag:
         bk = os.environ.get("BUILDKITE_BUILD_NUMBER")
         jnk = os.environ.get("BUILD_NUMBER")
+        gha = os.environ.get("GITHUB_RUN_NUMBER")
         if bk:
             build_tag = f"BK_{_sanitize(bk)}"
         elif jnk:
             build_tag = f"JNK_{_sanitize(jnk)}"
+        elif gha:
+            build_tag = f"GHA_{_sanitize(gha)}"
         else:
             log.error(
                 "Cannot determine build tag. Provide --build-tag or set "
-                "BUILD_NUMBER / BUILDKITE_BUILD_NUMBER."
+                "BUILD_NUMBER / BUILDKITE_BUILD_NUMBER / GITHUB_RUN_NUMBER."
             )
             sys.exit(1)
 

--- a/scripts/cleanup_test_pats.py
+++ b/scripts/cleanup_test_pats.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Remove orphaned PATs created by this CI build.
+
+Safety net for when in-process teardown (Rust Drop, Python finally,
+C++ destructors) doesn't execute — e.g. when a build is aborted or
+killed by a timeout.
+
+Connects to Snowflake using parameters.json and removes any
+PROGRAMMATIC ACCESS TOKENs whose name matches the UD_* prefix
+for the given build tag (e.g. UD_RUST_JNK_988_a3f2b1c0).
+
+Usage:
+    python3 scripts/cleanup_test_pats.py \
+        --parameter-path ./parameters.json \
+        --build-tag JNK_988
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger("pat-cleanup")
+
+
+def ensure_snowflake_connector():
+    try:
+        import snowflake.connector  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+    import subprocess
+
+    log.info("snowflake-connector-python not found, installing from PyPI...")
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "snowflake-connector-python", "-q"],
+    )
+
+
+def load_parameters(path):
+    with open(path) as f:
+        data = json.load(f)
+    return data.get("testconnection", data)
+
+
+def build_connection_kwargs(params):
+    kwargs = {
+        "account": params.get("SNOWFLAKE_TEST_ACCOUNT"),
+        "user": params.get("SNOWFLAKE_TEST_USER"),
+        "role": params.get("SNOWFLAKE_TEST_ROLE"),
+        "database": params.get("SNOWFLAKE_TEST_DATABASE"),
+        "schema": params.get("SNOWFLAKE_TEST_SCHEMA"),
+        "warehouse": params.get("SNOWFLAKE_TEST_WAREHOUSE"),
+    }
+    if params.get("SNOWFLAKE_TEST_HOST"):
+        kwargs["host"] = params["SNOWFLAKE_TEST_HOST"]
+    if params.get("SNOWFLAKE_TEST_PORT"):
+        kwargs["port"] = params["SNOWFLAKE_TEST_PORT"]
+    if params.get("SNOWFLAKE_TEST_PROTOCOL"):
+        kwargs["protocol"] = params["SNOWFLAKE_TEST_PROTOCOL"]
+
+    pk_contents = params.get("SNOWFLAKE_TEST_PRIVATE_KEY_CONTENTS")
+    pk_file = params.get("SNOWFLAKE_TEST_PRIVATE_KEY_FILE")
+    pk_password = params.get("SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD")
+
+    if pk_contents:
+        if isinstance(pk_contents, list):
+            pem_text = "\n".join(pk_contents)
+        else:
+            pem_text = pk_contents
+        kwargs["private_key"] = _load_pem_private_key(pem_text, pk_password)
+        kwargs["authenticator"] = "SNOWFLAKE_JWT"
+    elif pk_file:
+        with open(pk_file) as f:
+            pem_text = f.read()
+        kwargs["private_key"] = _load_pem_private_key(pem_text, pk_password)
+        kwargs["authenticator"] = "SNOWFLAKE_JWT"
+    elif params.get("SNOWFLAKE_TEST_PASSWORD"):
+        kwargs["password"] = params["SNOWFLAKE_TEST_PASSWORD"]
+
+    return kwargs
+
+
+def _load_pem_private_key(pem_text, password=None):
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
+    pwd_bytes = password.encode() if password else None
+    private_key = serialization.load_pem_private_key(
+        pem_text.encode(), password=pwd_bytes, backend=default_backend()
+    )
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _sanitize(s):
+    return re.sub(r"[^a-zA-Z0-9]", "", s)
+
+
+def cleanup_pats(conn_kwargs, build_tag):
+    import snowflake.connector
+
+    user = conn_kwargs["user"]
+
+    log.info("Connecting to Snowflake as %s...", user)
+    with snowflake.connector.connect(**conn_kwargs) as conn:
+        cur = conn.cursor()
+
+        log.info("Listing PATs for user %s matching build tag '%s'...", user, build_tag)
+        cur.execute(f"SHOW USER PROGRAMMATIC ACCESS TOKENS FOR USER {user}")
+        rows = cur.fetchall()
+        col_names = [desc[0].lower() for desc in cur.description]
+        name_idx = col_names.index("name")
+
+        removed = 0
+        for row in rows:
+            pat_name = row[name_idx]
+            if not _matches_build_tag(pat_name, build_tag):
+                continue
+            log.info("  Removing PAT: %s", pat_name)
+            try:
+                cur.execute(
+                    f"ALTER USER IF EXISTS {user} "
+                    f"REMOVE PROGRAMMATIC ACCESS TOKEN {pat_name}"
+                )
+                removed += 1
+            except Exception as e:
+                log.warning("  Failed to remove %s: %s", pat_name, e)
+
+        log.info("Cleanup complete: removed %d PAT(s)", removed)
+        return removed
+
+
+def _matches_build_tag(pat_name, build_tag):
+    """Check if a PAT name matches UD_{DRIVER}_{build_tag}_{random}.
+
+    PAT names are uppercased by Snowflake. The build_tag is already
+    sanitized (alphanumeric only) by the test code that created it.
+    """
+    upper = pat_name.upper()
+    tag_upper = build_tag.upper()
+    if not upper.startswith("UD_"):
+        return False
+    parts = upper.split("_", 3)
+    if len(parts) < 4:
+        return False
+    # parts = [UD, DRIVER, ...rest]. The rest starts with the CI tag.
+    remainder = upper[len("UD_" + parts[1] + "_") :]
+    return remainder.startswith(tag_upper + "_")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove orphaned PATs created by a CI build"
+    )
+    parser.add_argument(
+        "--parameter-path",
+        default=os.environ.get("PARAMETER_PATH", "parameters.json"),
+        help="Path to decoded parameters.json (default: $PARAMETER_PATH or parameters.json)",
+    )
+    parser.add_argument(
+        "--build-tag",
+        help=(
+            "CI build tag to match, e.g. JNK_988 or BK_1234. "
+            "Auto-detected from environment if not provided."
+        ),
+    )
+    args = parser.parse_args()
+
+    build_tag = args.build_tag
+    if not build_tag:
+        bk = os.environ.get("BUILDKITE_BUILD_NUMBER")
+        jnk = os.environ.get("BUILD_NUMBER")
+        if bk:
+            build_tag = f"BK_{_sanitize(bk)}"
+        elif jnk:
+            build_tag = f"JNK_{_sanitize(jnk)}"
+        else:
+            log.error(
+                "Cannot determine build tag. Provide --build-tag or set "
+                "BUILD_NUMBER / BUILDKITE_BUILD_NUMBER."
+            )
+            sys.exit(1)
+
+    log.info("Build tag: %s", build_tag)
+
+    if not os.path.exists(args.parameter_path):
+        log.error("Parameters file not found: %s", args.parameter_path)
+        sys.exit(1)
+
+    ensure_snowflake_connector()
+
+    params = load_parameters(args.parameter_path)
+    conn_kwargs = build_connection_kwargs(params)
+    cleanup_pats(conn_kwargs, build_tag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When a CI build is aborted or killed by a timeout, in-process teardown (Rust `Drop`, Python `finally`, C++ destructors) never executes, leaving orphaned PATs on the `sfctest0` account. This PR adds a safety-net cleanup step that removes any PATs matching the current build's tag after tests complete (or fail). Builds on the identifiable PAT naming from #873.

### Changes

- **`scripts/cleanup_test_pats.py`** — new script that connects to Snowflake, lists PATs for the test user, and removes any matching the `UD_{DRIVER}_{BUILD_TAG}_{RANDOM}` pattern for the current build. Supports both password and key-pair auth. Auto-detects the build tag from `BUILDKITE_BUILD_NUMBER` / `BUILD_NUMBER` / `GITHUB_RUN_NUMBER` env vars.

- **`ci/Jenkinsfile`** — wraps VPN E2E test steps in `try/finally` so cleanup runs even when tests fail or the stage is aborted.

- **`ci/Jenkinsfile.coverage`** — adds cleanup after the test execution step in each coverage stage (Rust Core, Python, ODBC). Uses `returnStatus: true` so cleanup failure doesn't mask test results.

- **`.buildkite/pipelines/ci-tests/pipeline.yml`** — adds a dedicated `:broom: Cleanup test PATs` step that depends on all test groups with `allow_failure: true` and uses `soft_fail: true`, ensuring it always runs regardless of test outcomes.

- **`.github/workflows/test-rust-core.yml`**, **`test-python.yml`**, **`test-odbc.yml`** — adds a `Cleanup test PATs` step to each workflow that creates PATs, using `if: always()` + `continue-on-error: true` so the step runs after both pass and fail paths without ever blocking the overall build.

### How it works

The test code from #873 creates PATs with identifiable names like `UD_RUST_BK_1234_a3f2b1c0` (for Buildkite), `UD_PYTHON_GHA_555_deadbeef` (for GitHub Actions), `UD_ODBC_JNK_988_cafef00d` (for Jenkins), etc. The cleanup script matches this pattern — it finds all PATs whose name starts with `UD_` and contains the current build's tag, then removes them. This is purely a safety net; the normal test teardown still handles cleanup in the happy path.

## Test plan

- [ ] Verify Jenkins VPN E2E stage runs cleanup in `finally` block (visible in console logs)
- [ ] Verify Buildkite cleanup step runs after all test groups complete
- [ ] Verify each GHA workflow runs the cleanup step on both success and failure paths
- [ ] Verify cleanup script correctly identifies and removes matching PATs
- [ ] Verify cleanup failure does not fail the overall build