### PR TITLE
Fix per-row String allocation regression in Date/Time → CHAR (follow-up to #844)

### DIFF
--- a/odbc/src/api/encoding.rs
+++ b/odbc/src/api/encoding.rs
@@ -27,10 +27,21 @@ pub fn is_ascii_locale() -> bool {
     false
 }
 
-pub fn mask_non_ascii_characters(src: &str) -> String {
-    src.chars()
-        .map(|c| if !c.is_ascii() { '\x1a' } else { c })
-        .collect()
+/// Replace each non-ASCII character with `\x1a` (SUB control character).
+///
+/// Returns a borrow for pure-ASCII input to avoid a per-call heap allocation
+/// on the `write_char_string` hot path. ODBC ANSI output is ASCII-only in
+/// C/POSIX locales, and in practice the vast majority of values that flow
+/// through here (numbers, dates, times, English text) are already ASCII.
+pub fn mask_non_ascii_characters(src: &str) -> std::borrow::Cow<'_, str> {
+    if src.is_ascii() {
+        return std::borrow::Cow::Borrowed(src);
+    }
+    std::borrow::Cow::Owned(
+        src.chars()
+            .map(|c| if !c.is_ascii() { '\x1a' } else { c })
+            .collect(),
+    )
 }
 
 /// Abstracts over ANSI (narrow) and Unicode (wide) ODBC string operations,

--- a/odbc/src/conversion/date.rs
+++ b/odbc/src/conversion/date.rs
@@ -1,3 +1,5 @@
+use std::io::{Cursor, Write as _};
+
 use arrow::array::{Array, PrimitiveArray};
 use arrow::datatypes::Date32Type;
 use chrono::{Datelike, NaiveDate};
@@ -11,6 +13,23 @@ use crate::conversion::error::{
     NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
 use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
+
+/// Format a `NaiveDate` as `YYYY-MM-DD` into a stack buffer without heap
+/// allocation. 32 bytes is sufficient for any year chrono can represent.
+fn format_date_ascii<'a>(date: &NaiveDate, buf: &'a mut [u8; 32]) -> &'a str {
+    let mut cursor = Cursor::new(&mut buf[..]);
+    // Infallible: the buffer is large enough for any year chrono produces.
+    let _ = write!(
+        cursor,
+        "{:04}-{:02}-{:02}",
+        date.year(),
+        date.month(),
+        date.day()
+    );
+    let len = cursor.position() as usize;
+    // SAFETY: we only wrote ASCII digits and '-' above.
+    unsafe { std::str::from_utf8_unchecked(&buf[..len]) }
+}
 use crate::conversion::traits::Binding;
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::Warnings;
@@ -81,13 +100,9 @@ impl WriteODBCType for SnowflakeDate {
                     }
                     .fail();
                 }
-                let formatted = format!(
-                    "{:04}-{:02}-{:02}",
-                    snowflake_value.year(),
-                    snowflake_value.month(),
-                    snowflake_value.day()
-                );
-                Ok(binding.write_char_string(&formatted, get_data_offset))
+                let mut buf = [0u8; 32];
+                let s = format_date_ascii(&snowflake_value, &mut buf);
+                Ok(binding.write_char_string(s, get_data_offset))
             }
             CDataType::WChar => {
                 if binding.buffer_length > 0 && binding.buffer_length < 22 {
@@ -97,28 +112,11 @@ impl WriteODBCType for SnowflakeDate {
                     }
                     .fail();
                 }
-                let formatted = format!(
-                    "{:04}-{:02}-{:02}",
-                    snowflake_value.year(),
-                    snowflake_value.month(),
-                    snowflake_value.day()
-                );
-                Ok(binding.write_wchar_string(&formatted, get_data_offset))
+                let mut buf = [0u8; 32];
+                let s = format_date_ascii(&snowflake_value, &mut buf);
+                Ok(binding.write_wchar_string(s, get_data_offset))
             }
             CDataType::Binary => {
-                let date = sql::Date {
-                    year: snowflake_value.year() as i16,
-                    month: snowflake_value.month() as u16,
-                    day: snowflake_value.day() as u16,
-                };
-                let mut bytes = [0u8; std::mem::size_of::<sql::Date>()];
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        &date as *const sql::Date as *const u8,
-                        bytes.as_mut_ptr(),
-                        bytes.len(),
-                    );
-                }
                 if binding.buffer_length > 0
                     && (binding.buffer_length as usize) < std::mem::size_of::<sql::Date>()
                 {
@@ -127,7 +125,22 @@ impl WriteODBCType for SnowflakeDate {
                     }
                     .fail();
                 }
-                Ok(binding.write_binary(&bytes, get_data_offset))
+                let date = sql::Date {
+                    year: snowflake_value.year() as i16,
+                    month: snowflake_value.month() as u16,
+                    day: snowflake_value.day() as u16,
+                };
+                // SAFETY: `sql::Date` is a POD struct (repr(C), no padding
+                // beyond the u16/i16 layout) defined by odbc_sys. Borrowing
+                // its bytes for the duration of this call is sound and lets
+                // us avoid an intermediate stack copy per row.
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(
+                        &date as *const sql::Date as *const u8,
+                        std::mem::size_of::<sql::Date>(),
+                    )
+                };
+                Ok(binding.write_binary(bytes, get_data_offset))
             }
             CDataType::TimeStamp | CDataType::TypeTimestamp => {
                 let ts = sql::Timestamp {
@@ -200,5 +213,38 @@ impl WriteJson for SnowflakeDate {
 
     fn sf_type(&self) -> SnowflakeLogicalType {
         SnowflakeLogicalType::Date
+    }
+}
+
+#[cfg(test)]
+mod format_date_ascii_tests {
+    use super::*;
+
+    #[test]
+    fn formats_typical_date() {
+        let mut buf = [0u8; 32];
+        let d = NaiveDate::from_ymd_opt(2026, 4, 12).unwrap();
+        assert_eq!(format_date_ascii(&d, &mut buf), "2026-04-12");
+    }
+
+    #[test]
+    fn pads_single_digit_components() {
+        let mut buf = [0u8; 32];
+        let d = NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
+        assert_eq!(format_date_ascii(&d, &mut buf), "0001-01-01");
+    }
+
+    #[test]
+    fn formats_large_year() {
+        let mut buf = [0u8; 32];
+        let d = NaiveDate::from_ymd_opt(9999, 12, 31).unwrap();
+        assert_eq!(format_date_ascii(&d, &mut buf), "9999-12-31");
+    }
+
+    #[test]
+    fn formats_negative_year() {
+        let mut buf = [0u8; 32];
+        let d = NaiveDate::from_ymd_opt(-44, 3, 15).unwrap();
+        assert_eq!(format_date_ascii(&d, &mut buf), "-044-03-15");
     }
 }

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -1,3 +1,5 @@
+use std::io::{Cursor, Write as _};
+
 use arrow::array::{Array, PrimitiveArray};
 use arrow::datatypes::Int64Type;
 use chrono::{Datelike, NaiveTime, Timelike};
@@ -11,6 +13,36 @@ use crate::conversion::error::{
     UnsupportedCDataTypeSnafu, UnsupportedOdbcTypeSnafu, WriteOdbcError,
 };
 use crate::conversion::param_binding::{read_char_str, read_unaligned, read_wchar_str};
+
+/// Format a `NaiveTime` as `HH:MM:SS[.fffffffff]` into a stack buffer without
+/// heap allocation. 32 bytes is ample for the widest output (`HH:MM:SS.` + 9
+/// fractional digits = 18 bytes).
+fn format_time_ascii<'a>(time: &NaiveTime, buf: &'a mut [u8; 32]) -> &'a str {
+    let len = {
+        let mut cursor = Cursor::new(&mut buf[..]);
+        let _ = write!(
+            cursor,
+            "{:02}:{:02}:{:02}",
+            time.hour(),
+            time.minute(),
+            time.second()
+        );
+        let nanos = time.nanosecond();
+        if nanos != 0 {
+            let _ = write!(cursor, ".{nanos:09}");
+        }
+        cursor.position() as usize
+    };
+    // Trim trailing zeros from the optional fractional part.
+    let mut end = len;
+    if buf[..end].contains(&b'.') {
+        while end > 0 && buf[end - 1] == b'0' {
+            end -= 1;
+        }
+    }
+    // SAFETY: only ASCII digits, `:`, and `.` written above.
+    unsafe { std::str::from_utf8_unchecked(&buf[..end]) }
+}
 use crate::conversion::traits::{Binding, ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
@@ -112,8 +144,9 @@ impl WriteODBCType for SnowflakeTime {
                     }
                     .fail();
                 }
-                let formatted = format_time_string(&snowflake_value);
-                Ok(binding.write_char_string(&formatted, get_data_offset))
+                let mut buf = [0u8; 32];
+                let s = format_time_ascii(&snowflake_value, &mut buf);
+                Ok(binding.write_char_string(s, get_data_offset))
             }
             CDataType::WChar => {
                 if binding.buffer_length > 0 && binding.buffer_length < 18 {
@@ -123,23 +156,11 @@ impl WriteODBCType for SnowflakeTime {
                     }
                     .fail();
                 }
-                let formatted = format_time_string(&snowflake_value);
-                Ok(binding.write_wchar_string(&formatted, get_data_offset))
+                let mut buf = [0u8; 32];
+                let s = format_time_ascii(&snowflake_value, &mut buf);
+                Ok(binding.write_wchar_string(s, get_data_offset))
             }
             CDataType::Binary => {
-                let time = sql::Time {
-                    hour: snowflake_value.hour() as u16,
-                    minute: snowflake_value.minute() as u16,
-                    second: snowflake_value.second() as u16,
-                };
-                let mut bytes = [0u8; std::mem::size_of::<sql::Time>()];
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        &time as *const sql::Time as *const u8,
-                        bytes.as_mut_ptr(),
-                        bytes.len(),
-                    );
-                }
                 if binding.buffer_length > 0
                     && (binding.buffer_length as usize) < std::mem::size_of::<sql::Time>()
                 {
@@ -148,7 +169,21 @@ impl WriteODBCType for SnowflakeTime {
                     }
                     .fail();
                 }
-                Ok(binding.write_binary(&bytes, get_data_offset))
+                let time = sql::Time {
+                    hour: snowflake_value.hour() as u16,
+                    minute: snowflake_value.minute() as u16,
+                    second: snowflake_value.second() as u16,
+                };
+                // SAFETY: `sql::Time` is a POD struct; borrowing its bytes
+                // for the duration of this call avoids an intermediate stack
+                // copy per row.
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(
+                        &time as *const sql::Time as *const u8,
+                        std::mem::size_of::<sql::Time>(),
+                    )
+                };
+                Ok(binding.write_binary(bytes, get_data_offset))
             }
             CDataType::TimeStamp | CDataType::TypeTimestamp => {
                 let today = chrono::Local::now().date_naive();
@@ -173,27 +208,6 @@ impl WriteODBCType for SnowflakeTime {
             }
             .fail(),
         }
-    }
-}
-
-fn format_time_string(time: &NaiveTime) -> String {
-    let nanos = time.nanosecond();
-    if nanos == 0 {
-        format!(
-            "{:02}:{:02}:{:02}",
-            time.hour(),
-            time.minute(),
-            time.second()
-        )
-    } else {
-        let frac = format!("{nanos:09}");
-        let trimmed = frac.trim_end_matches('0');
-        format!(
-            "{:02}:{:02}:{:02}.{trimmed}",
-            time.hour(),
-            time.minute(),
-            time.second()
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #844 (eaeeef8 *Add DATE and TIME to C_CHAR, C_BINARY, C_TIMESTAMP conversions and tests*). That PR introduced the new arms but implemented the `SQL_C_CHAR` / `SQL_C_WCHAR` paths with `format!(...)`, which heap-allocates a `String` on every row, and the `SQL_C_BINARY` paths with an intermediate `[u8; N]` stack buffer copy per row.

This PR keeps the behavior identical but removes the per-row allocations.

## The regression

The ODBC perf dashboard on `main` shows a clean regression between **build 450 (2026-04-15 05:21 UTC)** and **build 456 (2026-04-16 05:56 UTC)** that matches the shape of #844's change:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| SELECT 1M 15-columns, arrow fetch e2e (TPC-H `LINEITEM`, 3× `DATE`) | ~1.4 s | ~8.3 s | **+5×** |
| SELECT 1M 15-columns, recorded HTTP | ~2.0 s | ~9.1 s | **+4.5×** |
| SELECT 1M DATE, arrow fetch e2e | ~0.34 s | ~0.60 s | **+75 %** |
| SELECT 1M DATE, recorded HTTP | ~0.35 s | ~0.60 s | **+74 %** |
| NUMBER / STRING / BINARY / TIMESTAMP | unchanged | unchanged | — |

Why it fits:

- The ODBC perf client binds **every** column as `SQL_C_CHAR`:

    ```cpp
    SQLBindCol(stmt, i+1, SQL_C_CHAR, char_bufs[i].data(), CHAR_COL_BUF_LEN, indicators[i].data());
    ```

  (`tests/performance/drivers/odbc/app/query_execution.cpp`)

- The 15-columns benchmark selects `LINEITEM` columns that include three DATE columns (`L_SHIPDATE`, `L_COMMITDATE`, `L_RECEIPTDATE`). So each 1M-row iteration goes through the new Date→CHAR path ~3M times.
- Before #844 the non-temporal paths were unchanged, which is consistent with only DATE-touching benchmarks regressing.
- #851 (file locking) is the only other non-test, non-Python change in the window but lives on the credential-cache path, which the JWT-authenticated perf client does not exercise.

All other commits in the window are Python-only or tests-only, so #844 is the only candidate that can move the ODBC driver's fetch-hot-path for these types.

## The fix

`odbc/src/conversion/date.rs` and `odbc/src/conversion/time.rs`:

- Replace `format!(\"{:04}-{:02}-{:02}\", …)` / `format_time_string(..)` with stack-buffer-based helpers `format_date_ascii` / `format_time_ascii` that write into a 32-byte `[u8; 32]` via `std::io::Cursor` + `write!`. No heap allocation; output bytes are byte-for-byte identical, including the trailing-zero trimming for fractional seconds.
- In the `CDataType::Binary` arms, drop the intermediate `[u8; N]` + `copy_nonoverlapping` and pass a `&[u8]` view of the `sql::Date` / `sql::Time` POD struct directly to `write_binary`. Also move the `buffer_length` check above the struct construction so we don't do work we're about to discard.
- Add unit tests for `format_date_ascii` (no `date_tests.rs` exists today). The time path is already covered by `write_char`, `write_wchar`, `write_char_scale_3_includes_fractional`, and `write_wchar_scale_9_includes_fractional` in `time_tests.rs`.

No public API, no SQLSTATE, and no e2e semantics change. The e2e suites added in #844 should continue to pass unmodified.

## Test plan

- [x] `cargo build -p odbc --lib` — clean
- [x] `cargo test -p odbc --lib` — 922 passed
- [x] `cargo clippy -p odbc --all-targets -- -D warnings` — clean
- [x] `pre-commit run` on modified files — clean
- [ ] CI: full ODBC build + unit + e2e
- [ ] Watch next perf run on `main` after merge — expect the 15-columns and DATE benchmarks to return to the build-450 baseline (~1.4 s / ~0.34 s).

## Notes for reviewer

cc @sfc-gh-pbulawa — friendly follow-up on #844, the semantics you added are preserved and guarded by existing tests + the new ones in `format_date_ascii_tests`. Happy to discuss if you'd prefer a different helper location (e.g. promoting it into `param_binding.rs` for reuse by `timestamp.rs` — I kept it module-local to minimize the diff here).

Made with [Cursor](https://cursor.com)