### PR TITLE
Introduce test-utils and reusable ClientInfo for tests

### DIFF
--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -98,6 +98,7 @@ tokio = { version = "1.47.1", features = ["fs"] }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["experimental_metrics_custom_reader"] }
 tempfile = "3.21.0"
 arrow_deserialize_macro = { path = "tests/common/arrow_deserialize_macro" }
+sf_core = { path = ".", features = ["test-utils"] }
 bzip2 = "0.6.0"
 brotli = "8.0.2"
 zstd = "0.13.3"

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -98,7 +98,6 @@ tokio = { version = "1.47.1", features = ["fs"] }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["experimental_metrics_custom_reader"] }
 tempfile = "3.21.0"
 arrow_deserialize_macro = { path = "tests/common/arrow_deserialize_macro" }
-sf_core = { path = ".", features = ["test-utils"] }
 bzip2 = "0.6.0"
 brotli = "8.0.2"
 zstd = "0.13.3"

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -102,6 +102,28 @@ impl ClientInfo {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_fixtures {
+    use super::ClientInfo;
+    use crate::crl::config::CrlConfig;
+    use crate::tls::config::TlsConfig;
+
+    /// Minimal [`ClientInfo`] for tests. Uses [`TlsConfig::insecure`] so it works
+    /// with plain-HTTP mock servers. Override specific fields with struct-update
+    /// syntax: `ClientInfo { application: "foo".into(), ..test_client_info() }`.
+    pub fn test_client_info() -> ClientInfo {
+        ClientInfo {
+            application: "sf_core_test".to_string(),
+            version: "1.0.0".to_string(),
+            os: std::env::consts::OS.to_string(),
+            os_version: "1.0".to_string(),
+            ocsp_mode: None,
+            crl_config: CrlConfig::default(),
+            tls_config: TlsConfig::insecure(),
+        }
+    }
+}
+
 pub struct LoginParameters {
     pub account_name: String,
     pub login_method: LoginMethod,

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod integration_tests {
     use crate::config::rest_parameters::ClientInfo;
+    use crate::config::rest_parameters::test_fixtures::test_client_info;
     use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
     use crate::rest::snowflake;
     use crate::tls::config::TlsConfig;
@@ -37,15 +38,12 @@ mod integration_tests {
         };
         let client_info = ClientInfo {
             application: "PythonConnector".to_string(),
-            version: "3.15.0".to_string(),
-            os: "Darwin".to_string(),
-            os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
-            ocsp_mode: Some("FAIL_OPEN".to_string()),
             crl_config: crl_config.clone(),
             tls_config: TlsConfig {
                 crl_config,
                 ..Default::default()
             },
+            ..test_client_info()
         };
 
         assert_eq!(
@@ -136,10 +134,7 @@ mod integration_tests {
             application: "PythonConnector".to_string(),
             version: "3.15.0".to_string(),
             os: "Darwin".to_string(),
-            os_version: "macOS-15.5-arm64-arm-64bit".to_string(),
-            ocsp_mode: Some("FAIL_OPEN".to_string()),
-            crl_config: CrlConfig::default(),
-            tls_config: TlsConfig::default(),
+            ..test_client_info()
         };
         let user_agent = snowflake::user_agent(&client_info);
 

--- a/sf_core/src/rest/snowflake/heartbeat.rs
+++ b/sf_core/src/rest/snowflake/heartbeat.rs
@@ -73,23 +73,10 @@ pub async fn send_heartbeat(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::rest_parameters::test_fixtures::test_client_info;
     use serde_json::json;
     use wiremock::matchers::{header, header_regex, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    fn test_client_info() -> ClientInfo {
-        use crate::crl::config::CrlConfig;
-        use crate::tls::config::TlsConfig;
-        ClientInfo {
-            application: "TestApp".to_string(),
-            version: "1.0.0".to_string(),
-            os: "Linux".to_string(),
-            os_version: "5.15".to_string(),
-            ocsp_mode: None,
-            crl_config: CrlConfig::default(),
-            tls_config: TlsConfig::default(),
-        }
-    }
 
     #[tokio::test]
     async fn heartbeat_request_url_and_headers() {

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1648,6 +1648,7 @@ pub enum SnowflakeResponseError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::rest_parameters::test_fixtures::test_client_info;
     use crate::token_cache::{TokenCache, TokenCacheError, TokenType};
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -2037,18 +2038,6 @@ mod tests {
         assert!(!response.success);
         assert!(response.data.is_none());
         assert_eq!(response.message.as_deref(), Some("Unauthorized"));
-    }
-
-    fn test_client_info() -> ClientInfo {
-        ClientInfo {
-            application: "TestApp".to_string(),
-            version: "1.0.0".to_string(),
-            os: "Linux".to_string(),
-            os_version: "5.15".to_string(),
-            ocsp_mode: None,
-            crl_config: Default::default(),
-            tls_config: Default::default(),
-        }
     }
 
     #[test]

--- a/sf_core/tests/e2e/session/session_refresh.rs
+++ b/sf_core/tests/e2e/session/session_refresh.rs
@@ -4,8 +4,8 @@ use crate::common::arrow_result_helper::ArrowResultHelper;
 use crate::common::config::{get_parameters, setup_logging};
 use crate::common::private_key_helper;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use sf_core::config::rest_parameters::{ClientInfo, LoginMethod, LoginParameters};
-use sf_core::crl::config::CrlConfig;
+use sf_core::config::rest_parameters::test_fixtures::test_client_info;
+use sf_core::config::rest_parameters::{LoginMethod, LoginParameters};
 use sf_core::rest::snowflake::{refresh_session, snowflake_login_with_client};
 use sf_core::sensitive::SensitiveString;
 use sf_core::tls::client::create_tls_client_with_config;
@@ -74,15 +74,7 @@ fn should_refresh_session_proactively() {
             .get_server_url()
             .expect("server_url or host required");
 
-        let client_info = ClientInfo {
-            application: "sf_core_test".to_string(),
-            version: "1.0.0".to_string(),
-            os: std::env::consts::OS.to_string(),
-            os_version: "1.0".to_string(),
-            ocsp_mode: None,
-            crl_config: CrlConfig::default(),
-            tls_config: TlsConfig::insecure(),
-        };
+        let client_info = test_client_info();
 
         let private_key = SensitiveString::from(
             fs::read_to_string(temp_key_file.path()).expect("Failed to read private key file"),

--- a/sf_core/tests/integration/http/session_refresh.rs
+++ b/sf_core/tests/integration/http/session_refresh.rs
@@ -1,27 +1,13 @@
 //! Integration tests for session token refresh functionality.
 
-use sf_core::config::rest_parameters::ClientInfo;
-use sf_core::crl::config::CrlConfig;
+use sf_core::config::rest_parameters::test_fixtures::test_client_info;
 use sf_core::rest::snowflake::{SessionTokens, refresh_session};
 use sf_core::sensitive::SensitiveString;
-use sf_core::tls::config::TlsConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-
-fn test_client_info() -> ClientInfo {
-    ClientInfo {
-        application: "test".to_string(),
-        version: "1.0".to_string(),
-        os: "test-os".to_string(),
-        os_version: "1.0".to_string(),
-        ocsp_mode: None,
-        crl_config: CrlConfig::default(),
-        tls_config: TlsConfig::insecure(),
-    }
-}
 
 fn test_tokens() -> SessionTokens {
     SessionTokens {

--- a/sf_core/tests/integration/http/sync_retry.rs
+++ b/sf_core/tests/integration/http/sync_retry.rs
@@ -6,11 +6,10 @@
 //! - Retry uses the same requestId for server-side idempotency
 //! - Sync mode is the default execution mode
 
-use sf_core::config::rest_parameters::{ClientInfo, DEFAULT_LOG_MAX_QUERY_LENGTH, QueryParameters};
+use sf_core::config::rest_parameters::test_fixtures::test_client_info;
+use sf_core::config::rest_parameters::{DEFAULT_LOG_MAX_QUERY_LENGTH, QueryParameters};
 use sf_core::config::retry::RetryPolicy;
-use sf_core::crl::config::CrlConfig;
 use sf_core::rest::snowflake::{QueryExecutionMode, QueryInput, snowflake_query_with_client};
-use sf_core::tls::config::TlsConfig;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -206,15 +205,7 @@ async fn should_use_sync_mode_by_default() {
 fn test_query_params(addr: &SocketAddr) -> QueryParameters {
     QueryParameters {
         server_url: format!("http://{}", addr),
-        client_info: ClientInfo {
-            application: "test".to_string(),
-            version: "1.0.0".to_string(),
-            os: "test-os".to_string(),
-            os_version: "1.0".to_string(),
-            ocsp_mode: None,
-            crl_config: CrlConfig::default(),
-            tls_config: TlsConfig::insecure(),
-        },
+        client_info: test_client_info(),
         log_max_query_length: DEFAULT_LOG_MAX_QUERY_LENGTH,
     }
 }

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -1,30 +1,16 @@
 //! Integration tests for session refresh with concurrent requests.
 
 use sf_core::apis::database_driver_v1::{Connection, with_valid_session};
-use sf_core::config::rest_parameters::ClientInfo;
+use sf_core::config::rest_parameters::test_fixtures::test_client_info;
 use sf_core::config::retry::RetryPolicy;
-use sf_core::crl::config::CrlConfig;
 use sf_core::rest::snowflake::SessionTokens;
 use sf_core::sensitive::SensitiveString;
-use sf_core::tls::config::TlsConfig;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock as AsyncRwLock;
-
-fn test_client_info() -> ClientInfo {
-    ClientInfo {
-        application: "test".to_string(),
-        version: "1.0".to_string(),
-        os: "test-os".to_string(),
-        os_version: "1.0".to_string(),
-        ocsp_mode: None,
-        crl_config: CrlConfig::default(),
-        tls_config: TlsConfig::insecure(),
-    }
-}
 
 #[tokio::test]
 async fn should_only_refresh_once_with_concurrent_401_errors() {


### PR DESCRIPTION
## Summary

Consolidates 7 duplicated `ClientInfo { ... }` test fixtures into a single shared `test_client_info()` helper colocated with the struct definition in `sf_core/src/config/rest_parameters.rs`.

## Changes

- Added `test_fixtures::test_client_info()` gated on `#[cfg(any(test, feature = "test-utils"))]`.
- Added `test-utils` cargo feature (off by default) + self-referential dev-dep so `tests/**` can access it.
- Replaced 7 call sites across `src/rest/snowflake/{mod,heartbeat}.rs`, `src/crl/integration_test.rs`, `tests/integration/{session,http}/session_refresh.rs`, `tests/integration/http/sync_retry.rs`, and `tests/e2e/session/session_refresh.rs`. Sites with value-specific assertions use struct-update syntax (`..test_client_info()`) to override only the fields they care about.
- Out of scope: `src/bin/collect_chunk_data.rs` (production code) and the `python/sf_core/**` parallel tree.

## Test plan

- [x] `cargo check -p sf_core` — fixture doesn't leak into non-test builds.
- [x] `cargo test -p sf_core --lib` — all 475 lib tests pass.
- [x] `cargo test -p sf_core --test integration_tests -- session::session_refresh http::session_refresh http::sync_retry` — all 7 affected integration tests pass.