### PR TITLE
Injectable DiskReader interface

### DIFF
--- a/sf_core/src/apis/database_driver_v1/disk_reader.rs
+++ b/sf_core/src/apis/database_driver_v1/disk_reader.rs
@@ -1,0 +1,116 @@
+//! Abstraction layer for disk reads within `DatabaseDriverV1`.
+//!
+//! This module defines the interface for all filesystem reads performed by the
+//! driver. Its primary purpose is to allow integration tests to inject a
+//! [`MockDiskReader`] and avoid actual filesystem access—for example, to supply
+//! canned data for paths such as `/etc/hosts` or simulated private key files.
+//!
+//! The [`DiskReader`] trait is deliberately minimal for now but is expected
+//! to evolve with additional safety and auditing features that should apply
+//! uniformly to all disk reads, such as:
+//!
+//! - Verifying file ownership and permissions before reading;
+//! - Enforcing a file size limit;
+//! - Centralized logging and error handling.
+//!
+//! Important: To ensure all future safeguards are applied consistently, production code
+//! should never use [`std::fs`] directly. All file reads must go through a [`DiskReader`].
+//!
+//! In normal operation, a [`DiskReader`] instance is managed by
+//! [`crate::apis::database_driver_v1::DatabaseDriverV1`].
+//! For proper testability, all subcomponents of `DatabaseDriverV1` which
+//! need to read from disk should receive a reference to the `DiskReader` via
+//! dependency injection, ensuring they always use the correct mechanism.
+
+use std::io;
+use std::path::Path;
+
+pub trait DiskReader: Send + Sync {
+    fn read_to_string(&self, path: &Path) -> io::Result<String>;
+}
+
+#[derive(Default)]
+pub struct RealDiskReader;
+
+impl DiskReader for RealDiskReader {
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+}
+
+#[cfg(test)]
+pub use mock::MockDiskReader;
+
+#[cfg(test)]
+mod mock {
+    use super::DiskReader;
+    use std::collections::HashMap;
+    use std::io;
+    use std::path::{Path, PathBuf};
+
+    /// In-memory [`DiskReader`] used by tests.
+    ///
+    /// Construct with [`MockDiskReader::new`] and register canned responses
+    /// via [`MockDiskReader::with_file`]. Reads for unregistered paths
+    /// return [`io::ErrorKind::NotFound`], matching the behavior production
+    /// code already expects from [`std::fs::read_to_string`].
+    #[derive(Default)]
+    pub struct MockDiskReader {
+        files: HashMap<PathBuf, String>,
+    }
+
+    impl MockDiskReader {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        #[must_use]
+        pub fn with_file(mut self, path: impl Into<PathBuf>, contents: impl Into<String>) -> Self {
+            self.files.insert(path.into(), contents.into());
+            self
+        }
+    }
+
+    impl DiskReader for MockDiskReader {
+        fn read_to_string(&self, path: &Path) -> io::Result<String> {
+            self.files.get(path).cloned().ok_or_else(|| {
+                let display = path.display();
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("MockDiskReader: no file registered for {display}"),
+                )
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_returns_registered_contents() {
+        let reader = MockDiskReader::new()
+            .with_file("/etc/hosts", "127.0.0.1 localhost\n")
+            .with_file("/etc/resolv.conf", "nameserver 1.1.1.1\n");
+
+        let hosts = reader
+            .read_to_string(Path::new("/etc/hosts"))
+            .expect("hosts entry should exist");
+        assert_eq!(hosts, "127.0.0.1 localhost\n");
+
+        let resolv = reader
+            .read_to_string(Path::new("/etc/resolv.conf"))
+            .expect("resolv entry should exist");
+        assert_eq!(resolv, "nameserver 1.1.1.1\n");
+    }
+
+    #[test]
+    fn mock_returns_not_found_for_unknown_paths() {
+        let reader = MockDiskReader::new();
+        let err = reader
+            .read_to_string(Path::new("/does/not/exist"))
+            .expect_err("unknown path should error");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -2,6 +2,7 @@ use tokio::sync::Mutex;
 
 use super::connection::Connection;
 use super::database::Database;
+use super::disk_reader::{DiskReader, RealDiskReader};
 use super::statement::Statement;
 use crate::handle_manager::HandleManager;
 use crate::token_cache::{KeyringTokenCache, TokenCacheError};
@@ -12,6 +13,7 @@ pub struct DatabaseDriverV1 {
     pub(super) connections: HandleManager<Mutex<Connection>>,
     pub(super) statements: HandleManager<Mutex<Statement>>,
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
+    disk_reader: once_cell::sync::OnceCell<Box<dyn DiskReader>>,
 }
 
 impl DatabaseDriverV1 {
@@ -21,17 +23,33 @@ impl DatabaseDriverV1 {
             connections: HandleManager::new(),
             statements: HandleManager::new(),
             token_cache: once_cell::sync::OnceCell::new(),
+            disk_reader: once_cell::sync::OnceCell::new(),
         }
     }
 
     pub fn token_cache(&self) -> Result<&KeyringTokenCache, TokenCacheError> {
         self.token_cache.get_or_try_init(KeyringTokenCache::new)
     }
+
+    pub fn disk_reader(&self) -> &dyn DiskReader {
+        self.disk_reader
+            .get_or_init(|| Box::new(RealDiskReader))
+            .as_ref()
+    }
+
+    #[cfg(test)]
+    pub fn set_disk_reader(&self, reader: Box<dyn DiskReader>) {
+        if self.disk_reader.set(reader).is_err() {
+            panic!("set_disk_reader called after disk_reader() was already initialized");
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::disk_reader::MockDiskReader;
     use super::*;
+    use std::path::Path;
 
     static DRIVER_STATE: DatabaseDriverV1 = DatabaseDriverV1::new();
 
@@ -59,5 +77,31 @@ mod tests {
     fn driver_state_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<DatabaseDriverV1>();
+    }
+
+    #[test]
+    fn disk_reader_defaults_to_real_reader() {
+        let driver = DatabaseDriverV1::new();
+        let err = driver
+            .disk_reader()
+            .read_to_string(Path::new(
+                "/this/path/should/not/exist/for/universal_driver/tests",
+            ))
+            .expect_err("real reader should fail on a nonexistent path");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn set_disk_reader_injects_mock() {
+        let driver = DatabaseDriverV1::new();
+        driver.set_disk_reader(Box::new(
+            MockDiskReader::new().with_file("/etc/hosts", "127.0.0.1 localhost\n"),
+        ));
+
+        let contents = driver
+            .disk_reader()
+            .read_to_string(Path::new("/etc/hosts"))
+            .expect("mock should return canned /etc/hosts");
+        assert_eq!(contents, "127.0.0.1 localhost\n");
     }
 }

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -2,6 +2,7 @@
 mod alter_session_parser;
 pub mod connection;
 mod database;
+mod disk_reader;
 pub(crate) mod error;
 mod global_state;
 mod query;
@@ -12,6 +13,7 @@ pub use crate::config::settings::Setting;
 pub use crate::handle_manager::Handle;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use database::FetchChunkInput;
+pub use disk_reader::{DiskReader, RealDiskReader};
 pub use error::ApiError;
 pub use global_state::DatabaseDriverV1;
 pub use statement::{BindingType, ColumnMetadata, DataPtr, ExecuteResult, StoredChunkInfo};


### PR DESCRIPTION
## Summary

Introduce a `DiskReader` abstraction for all filesystem reads performed by `DatabaseDriverV1`, and wire it through the driver's global state so tests can inject canned file contents instead of touching the real filesystem.

## Motivation

Driver code today reaches for `std::fs::read_to_string` directly when it needs to read files such as `/etc/hosts` or private key files. This makes integration tests hard to write deterministically and leaves no central place to add cross-cutting safeguards (ownership/permission checks, size limits, audit logging) that we will want for any disk read the driver performs.

## Changes

- Add `sf_core/src/apis/database_driver_v1/disk_reader.rs` defining:
  - `DiskReader` trait (`Send + Sync`) with a single `read_to_string(&Path) -> io::Result<String>` method.
  - `RealDiskReader`, the production implementation backed by `std::fs::read_to_string`.
  - `MockDiskReader` (test-only), an in-memory implementation built via a `with_file(path, contents)` builder; unregistered paths return `io::ErrorKind::NotFound` to match the behavior production code already expects.
- Extend `DatabaseDriverV1` (`global_state.rs`) with a lazily-initialized `OnceCell<Box<dyn DiskReader>>`:
  - `disk_reader()` returns `&dyn DiskReader`, defaulting to `RealDiskReader` on first use.
  - `set_disk_reader()` (test-only) injects a custom reader; panics if called after the cell is already initialized.
- Re-export `DiskReader` and `RealDiskReader` from `apis::database_driver_v1` (`mod.rs`).
- Unit tests cover: mock returning registered contents, mock returning `NotFound` for unknown paths, default reader behavior on the real driver, and mock injection via `set_disk_reader`.

## Notes for reviewers / follow-ups

- This PR only introduces the abstraction; no existing call sites are migrated yet. Subcomponents that read from disk should subsequently take a `&dyn DiskReader` via dependency injection rather than calling `std::fs` directly.
- The trait is intentionally minimal. Planned extensions (documented in the module docs): file ownership/permission verification, size limits, and centralized logging/error handling — all of which become possible precisely because reads now flow through a single chokepoint.
