### PR TITLE
fix: emit "Infinity" / "-Infinity" for non-finite f64 in real bind serialization

### DIFF
--- a/odbc/src/conversion/real.rs
+++ b/odbc/src/conversion/real.rs
@@ -493,39 +493,3 @@ impl WriteJson for SnowflakeReal {
         SnowflakeLogicalType::Real
     }
 }
-
-#[cfg(test)]
-mod write_json_non_finite_tests {
-    use super::*;
-    use crate::conversion::traits::WriteJson;
-
-    fn write(value: f64) -> Value {
-        SnowflakeReal.write_json(value).unwrap()
-    }
-
-    #[test]
-    fn finite_values_use_default_display() {
-        assert_eq!(write(0.0), Value::String("0".to_string()));
-        assert_eq!(write(1.5), Value::String("1.5".to_string()));
-        assert_eq!(write(-12345.6789), Value::String("-12345.6789".to_string()));
-    }
-
-    #[test]
-    fn nan_serializes_as_capital_n_a_n() {
-        assert_eq!(write(f64::NAN), Value::String("NaN".to_string()));
-    }
-
-    #[test]
-    fn positive_infinity_serializes_as_full_word_infinity() {
-        // Server rejects Rust's default "inf" — must be the full word.
-        assert_eq!(write(f64::INFINITY), Value::String("Infinity".to_string()));
-    }
-
-    #[test]
-    fn negative_infinity_serializes_as_full_word_with_sign() {
-        assert_eq!(
-            write(f64::NEG_INFINITY),
-            Value::String("-Infinity".to_string())
-        );
-    }
-}

--- a/odbc/src/conversion/real.rs
+++ b/odbc/src/conversion/real.rs
@@ -467,10 +467,65 @@ impl ReadODBC for SnowflakeReal {
 
 impl WriteJson for SnowflakeReal {
     fn write_json(&self, value: Self::Representation<'_>) -> Result<Value, JsonBindingError> {
-        Ok(Value::String(value.to_string()))
+        // Snowflake's JSON parameter-binding parser is stricter than its
+        // SQL `TO_DOUBLE()` text parser. The SQL parser accepts any of
+        // `nan`, `inf`, `infinity` (case-insensitive), but the JSON bind
+        // parser requires the full word `"Infinity"` / `"-Infinity"` with
+        // the leading `I` capitalized. Rust's `<f64 as Display>::fmt`
+        // emits the short form `"inf"` / `"-inf"`, which the server
+        // rejects with `SQL compilation error: Invalid bind value (inf)`.
+        //
+        // `NaN` happens to match what Rust already produces, and finite
+        // values flow through unchanged.
+        let s = if value.is_nan() {
+            "NaN".to_string()
+        } else if value == f64::INFINITY {
+            "Infinity".to_string()
+        } else if value == f64::NEG_INFINITY {
+            "-Infinity".to_string()
+        } else {
+            value.to_string()
+        };
+        Ok(Value::String(s))
     }
 
     fn sf_type(&self) -> SnowflakeLogicalType {
         SnowflakeLogicalType::Real
+    }
+}
+
+#[cfg(test)]
+mod write_json_non_finite_tests {
+    use super::*;
+    use crate::conversion::traits::WriteJson;
+
+    fn write(value: f64) -> Value {
+        SnowflakeReal.write_json(value).unwrap()
+    }
+
+    #[test]
+    fn finite_values_use_default_display() {
+        assert_eq!(write(0.0), Value::String("0".to_string()));
+        assert_eq!(write(1.5), Value::String("1.5".to_string()));
+        assert_eq!(write(-12345.6789), Value::String("-12345.6789".to_string()));
+    }
+
+    #[test]
+    fn nan_serializes_as_capital_n_a_n() {
+        assert_eq!(write(f64::NAN), Value::String("NaN".to_string()));
+    }
+
+    #[test]
+    fn positive_infinity_serializes_as_full_word_infinity() {
+        // Server rejects Rust's default "inf" — must be the full word.
+        assert_eq!(write(f64::INFINITY), Value::String("Infinity".to_string()));
+    }
+
+    #[test]
+    fn negative_infinity_serializes_as_full_word_with_sign() {
+        assert_eq!(
+            write(f64::NEG_INFINITY),
+            Value::String("-Infinity".to_string())
+        );
     }
 }

--- a/odbc/src/conversion/real_tests.rs
+++ b/odbc/src/conversion/real_tests.rs
@@ -1724,4 +1724,52 @@ mod tests {
             "-0.0 should produce positive interval"
         );
     }
+
+    // ======================================================================
+    // write_json: non-finite f64 serialization for Snowflake JSON bind parser
+    //
+    // The server's JSON bind parser is stricter than its TO_DOUBLE() text
+    // parser. It accepts "NaN" (matching Rust's Display) but rejects Rust's
+    // short-form "inf" / "-inf" — it requires the full word "Infinity" /
+    // "-Infinity" with the leading 'I' capitalized.
+    // ======================================================================
+
+    use crate::conversion::traits::WriteJson;
+    use serde_json::Value;
+
+    fn write_json(value: f64) -> Value {
+        SnowflakeReal.write_json(value).unwrap()
+    }
+
+    #[test]
+    fn write_json_finite_values_use_default_display() {
+        assert_eq!(write_json(0.0), Value::String("0".to_string()));
+        assert_eq!(write_json(1.5), Value::String("1.5".to_string()));
+        assert_eq!(
+            write_json(-12345.6789),
+            Value::String("-12345.6789".to_string())
+        );
+    }
+
+    #[test]
+    fn write_json_nan_serializes_as_capital_n_a_n() {
+        assert_eq!(write_json(f64::NAN), Value::String("NaN".to_string()));
+    }
+
+    #[test]
+    fn write_json_positive_infinity_serializes_as_full_word_infinity() {
+        // Server rejects Rust's default "inf" — must be the full word.
+        assert_eq!(
+            write_json(f64::INFINITY),
+            Value::String("Infinity".to_string())
+        );
+    }
+
+    #[test]
+    fn write_json_negative_infinity_serializes_as_full_word_with_sign() {
+        assert_eq!(
+            write_json(f64::NEG_INFINITY),
+            Value::String("-Infinity".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`SnowflakeReal::write_json` used to serialize bound `f64` values with Rust's
`<f64 as Display>::fmt`, which emits the short form `"inf"` / `"-inf"` for
IEEE-754 ±Infinity. Snowflake's JSON parameter-binding parser rejects those
and requires the full word `"Infinity"` / `"-Infinity"`, so any bind path
that reached `write_json` with ±Infinity failed server-side:

```
SQLSTATE=42000: SQL compilation error: Invalid bind value (inf) for type (REAL).
```

(`NaN` round-tripped by accident: Rust's `Display` for `f64::NAN` is already
`"NaN"`, which the bind parser accepts.)

This PR maps the three special IEEE-754 values explicitly to the strings
the JSON bind parser accepts and leaves all finite values on the existing
`value.to_string()` path.

## Paths fixed

- `SQL_C_DOUBLE` / `SQL_C_FLOAT` → `SQL_REAL` / `SQL_DOUBLE` with ±Infinity
  now round-trip end-to-end.
- `SQL_C_BINARY` → `SQL_REAL` / `SQL_DOUBLE` with ±Infinity round-trips once
  #834 removes its client-side `is_finite()` gate (stacked on top of this PR).
- `SQL_C_CHAR` / `SQL_C_WCHAR` → `SQL_REAL` / `SQL_DOUBLE` with literal
  `"Infinity"` / `"NaN"` is *intentionally* rejected client-side with
  SQLSTATE 22018 per the ODBC spec — see #901.

## Test plan

- [x] Unit tests for `write_json` emitting `"Infinity"` / `"-Infinity"` / `"NaN"`
- [x] Pre-commit, `cargo test --lib`, clippy
- [ ] CI green on AWS / Azure / GCP