### PR TITLE
SNOW-32405: Prevent spurious binding dereference in JSON Binding

### DIFF
--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -27,11 +27,11 @@ use tokio_util::sync::CancellationToken;
 use tracing;
 
 /// Scan the APD for parameters marked as data-at-execution.
-fn find_dae_params(apd: &crate::api::ApdDescriptor, param_limit: Option<usize>) -> Vec<u16> {
+fn find_dae_params(apd: &crate::api::ApdDescriptor, param_limit: Option<u16>) -> Vec<u16> {
     let mut dae_params = Vec::new();
     for (&param_num, record) in &apd.records {
         if let Some(limit) = param_limit
-            && param_num as usize > limit
+            && param_num > limit
         {
             continue;
         }
@@ -81,6 +81,11 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         ConnectionState::Connected { .. } => {}
     }
 
+    // exec-direct supersedes any prior SQLPrepare on this handle; clear the
+    // stale marker count before the DAE scan so it cannot leak into a later
+    // free_stmt(ResetParams) or SQLCancel → SQLExecute flow.
+    stmt.prepared_param_count = None;
+
     // No param_limit for exec-direct: enter DAE if any APD record has a DAE
     // indicator, regardless of the SQL text.  We deliberately avoid client-side
     // `?` parsing because (a) it can disagree with the server's parser on edge
@@ -112,7 +117,8 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, false)?;
+            let (bindings, _json_owner) =
+                apply_parameter_bindings(&stmt.apd, &stmt.ipd, false, None)?;
             let stmt_handle = stmt.stmt_handle;
 
             stmt.cancel_token = CancellationToken::new();
@@ -279,14 +285,29 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
             let schema = reader.schema();
             stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
 
-            let param_count = result.number_of_binds.max(0) as usize;
+            if result.number_of_binds < 0 {
+                tracing::warn!(
+                    "prepare: server reported negative bind count ({}), treating as 0",
+                    result.number_of_binds
+                );
+            }
+            let raw_bind_count = result.number_of_binds.max(0);
+            let param_count = u16::try_from(raw_bind_count).map_err(|_| {
+                crate::api::error::CountFieldIncorrectSnafu {
+                    reason: format!(
+                        "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
+                        u16::MAX
+                    ),
+                }
+                .build()
+            })?;
             stmt.prepared_param_count = Some(param_count);
             let max_varchar = conn.numeric_settings.max_varchar_size;
-            stmt.ipd.records.retain(|&k, _| (k as usize) <= param_count);
+            stmt.ipd.records.retain(|&k, _| k <= param_count);
             for i in 1..=param_count {
                 stmt.ipd
                     .records
-                    .entry(i as u16)
+                    .entry(i)
                     .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
             }
             tracing::info!(
@@ -365,8 +386,12 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             db_handle: _,
             conn_handle,
         } => {
-            let (bindings, _json_owner) =
-                apply_parameter_bindings(&stmt.apd, &stmt.ipd, is_prepared)?;
+            let (bindings, _json_owner) = apply_parameter_bindings(
+                &stmt.apd,
+                &stmt.ipd,
+                is_prepared,
+                stmt.prepared_param_count,
+            )?;
 
             stmt.cancel_token = CancellationToken::new();
             let _cancel_token = stmt.cancel_token.clone();
@@ -473,37 +498,49 @@ fn create_execute_state(
 /// provided parameter count and we validate that the APD covers every marker.
 /// When `prepared` is false (SQLExecDirect), the IPD only has records from
 /// SQLBindParameter — we send whatever the APD has and let the server validate.
+///
+/// `prepared_param_count` caps how many parameters are serialized for prepared
+/// statements, preventing phantom bindings beyond the server-reported marker
+/// count from being dereferenced.
 fn apply_parameter_bindings(
     apd: &crate::api::ApdDescriptor,
     ipd: &crate::api::IpdDescriptor,
     prepared: bool,
+    prepared_param_count: Option<u16>,
 ) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
+    let effective_count: u16 = if prepared {
+        prepared_param_count.ok_or_else(|| {
+            crate::api::error::CountFieldIncorrectSnafu {
+                reason: "prepared statement is missing prepared_param_count".to_string(),
+            }
+            .build()
+        })?
+    } else {
+        apd.desc_count().max(ipd.desc_count())
+    };
+
+    if effective_count == 0 {
+        return Ok((None, None));
+    }
+
     if apd.records.is_empty() {
         if prepared {
-            let ipd_count = ipd.desc_count() as usize;
-            if ipd_count > 0 {
-                return crate::api::error::CountFieldIncorrectSnafu {
-                    reason: format!(
-                        "parameter 1 is not bound (statement has {ipd_count} parameter markers)"
-                    ),
-                }
-                .fail();
+            return crate::api::error::CountFieldIncorrectSnafu {
+                reason: format!(
+                    "parameter 1 is not bound (statement has {effective_count} parameter markers)"
+                ),
             }
+            .fail();
         }
         return Ok((None, None));
     }
 
-    let ipd_count = ipd.desc_count() as usize;
-    if ipd_count == 0 && !prepared {
-        return Ok((None, None));
-    }
-
     if prepared {
-        for i in 1..=ipd_count {
-            if !apd.records.contains_key(&(i as u16)) {
+        for i in 1..=effective_count {
+            if !apd.records.contains_key(&i) {
                 return crate::api::error::CountFieldIncorrectSnafu {
                     reason: format!(
-                        "parameter {i} is not bound (statement has {ipd_count} parameter markers)"
+                        "parameter {i} is not bound (statement has {effective_count} parameter markers)"
                     ),
                 }
                 .fail();
@@ -511,11 +548,13 @@ fn apply_parameter_bindings(
         }
     }
     tracing::info!(
-        "apply_parameter_bindings: Found {} bound parameters",
-        apd.records.len()
+        "apply_parameter_bindings: Found {} bound parameters (effective_count={})",
+        apd.records.len(),
+        effective_count,
     );
 
-    let json_string = odbc_bindings_to_json(apd, ipd).context(JsonBindingSnafu {})?;
+    let json_string =
+        odbc_bindings_to_json(apd, ipd, effective_count).context(JsonBindingSnafu {})?;
 
     let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
     let json_data_len = json_string.len();
@@ -687,7 +726,7 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
             // the actual marker count are removed, while server-populated
             // records from SQLPrepare are preserved.
             if let Some(count) = stmt.prepared_param_count {
-                stmt.ipd.records.retain(|&k, _| (k as usize) <= count);
+                stmt.ipd.records.retain(|&k, _| k <= count);
             }
         }
     }
@@ -1152,4 +1191,20 @@ pub fn cancel(statement_handle: sql::Handle) -> OdbcResult<()> {
 
     stmt.cancel_token.cancel();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{ApdDescriptor, IpdDescriptor, SqlState};
+
+    #[test]
+    fn apply_bindings_prepared_without_param_count_errors() {
+        let apd = ApdDescriptor::new();
+        let ipd = IpdDescriptor::new();
+        let result = apply_parameter_bindings(&apd, &ipd, true, None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.to_sql_state(), SqlState::CountFieldIncorrect);
+    }
 }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1229,7 +1229,7 @@ pub struct Statement {
     /// `SQLPrepare`. Used to ignore spurious APD bindings on non-existent
     /// parameters (e.g. DAE detection for "SELECT 1" with a bound param).
     /// `None` before the first prepare or after exec-direct.
-    pub prepared_param_count: Option<usize>,
+    pub prepared_param_count: Option<u16>,
     /// Query ID of the last executed query (`SQL_SF_STMT_ATTR_LAST_QUERY_ID`).
     pub last_query_id: Option<String>,
     /// Cancelled by `SQLCancel` (possibly from another thread) and observed

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -209,12 +209,11 @@ fn make_converter(
 pub fn odbc_bindings_to_json(
     apd: &ApdDescriptor,
     ipd: &IpdDescriptor,
+    max_params: u16,
 ) -> Result<String, JsonBindingError> {
     let mut json_bindings = Map::new();
 
-    let max_key = apd.desc_count().max(ipd.desc_count());
-
-    for param_num in 1..=max_key {
+    for param_num in 1..=max_params {
         let apd_rec = apd.records.get(&param_num).ok_or_else(|| {
             tracing::error!(
                 "odbc_bindings_to_json: APD record #{param_num} not found. \
@@ -1678,7 +1677,7 @@ mod tests {
             0,
             &mut ind,
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd)?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -1695,7 +1694,7 @@ mod tests {
             0,
             std::ptr::null_mut(),
         )]);
-        assert!(odbc_bindings_to_json(&apd, &ipd).is_err());
+        assert!(odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count())).is_err());
     }
 
     #[test]
@@ -1740,7 +1739,7 @@ mod tests {
             0,
             std::ptr::null_mut(),
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd)?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "FIXED");
         assert_eq!(parsed["1"]["value"], "7");
@@ -1758,7 +1757,7 @@ mod tests {
             0,
             &mut ind,
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd)?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -1792,7 +1791,64 @@ mod tests {
                 ..IpdRecord::default()
             },
         );
-        assert!(odbc_bindings_to_json(&apd, &ipd).is_err());
+        assert!(odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count())).is_err());
+    }
+
+    #[test]
+    fn max_params_zero_skips_phantom_dae_binding() -> TestResult {
+        // Simulates: SQLPrepare("SELECT 1") → 0 markers, then
+        // SQLBindParameter(1, ..., (SQLPOINTER)1, ..., SQL_DATA_AT_EXEC).
+        // The DM may or may not strip phantom bindings, so we test the
+        // serializer directly. With max_params=0 the dummy pointer at
+        // address 0x1 must never be dereferenced.
+        let mut dae_ind: sql::Len = sql::DATA_AT_EXEC;
+        let (apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Char,
+            sql::SqlDataType::VARCHAR,
+            1usize as sql::Pointer, // dummy DAE token, not a real address
+            0,
+            &mut dae_ind,
+        )]);
+        let json = odbc_bindings_to_json(&apd, &ipd, 0)?;
+        let parsed: serde_json::Value = serde_json::from_str(&json)?;
+        assert_eq!(parsed, serde_json::json!({}));
+        Ok(())
+    }
+
+    #[test]
+    fn max_params_caps_serialization_to_valid_range() -> TestResult {
+        // Simulates: SQLPrepare("SELECT ?") → 1 marker, then two bindings:
+        //   param 1 = valid integer
+        //   param 2 = phantom DAE bind with dummy pointer
+        // With max_params=1, only param 1 is serialized; the dummy pointer
+        // for param 2 is never touched.
+        let val: i32 = 42;
+        let mut dae_ind: sql::Len = sql::DATA_AT_EXEC;
+        let (apd, ipd) = make_descriptors(vec![
+            (
+                1,
+                CDataType::Long,
+                sql::SqlDataType::INTEGER,
+                &val as *const i32 as sql::Pointer,
+                0,
+                std::ptr::null_mut(),
+            ),
+            (
+                2,
+                CDataType::Char,
+                sql::SqlDataType::VARCHAR,
+                1usize as sql::Pointer, // dummy DAE token
+                0,
+                &mut dae_ind,
+            ),
+        ]);
+        let json = odbc_bindings_to_json(&apd, &ipd, 1)?;
+        let parsed: serde_json::Value = serde_json::from_str(&json)?;
+        assert_eq!(parsed["1"]["type"], "FIXED");
+        assert_eq!(parsed["1"]["value"], "42");
+        assert!(parsed.get("2").is_none());
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Fix potential unsafe memory access by capping parameter serialization to the server-reported marker count and tightening the `prepared_param_count` type from `usize` to `u16`.

### What changed?

- `prepared_param_count` on `Statement` is now `Option<u16>` instead of `Option<usize>`, matching the ODBC maximum parameter count.
- `apply_parameter_bindings` now accepts a `prepared_param_count: Option<u16>` argument. For prepared statements, this value is required and used as the authoritative parameter count (`effective_count`). For `SQLExecDirect`, the effective count is derived from the APD/IPD descriptor counts as before.
- `odbc_bindings_to_json` now accepts an explicit `max_params: u16` ceiling, replacing the internally computed `max_key`. This prevents the serializer from ever dereferencing APD records beyond the server-reported marker count.
- `prepare_impl` now validates that the server-reported bind count fits in a `u16`, returning a `CountFieldIncorrect` error if it does not, and logs a warning when the server reports a negative count.
- `exec_direct_impl` resets `prepared_param_count` to `None` and passes `None` as the cap to `apply_parameter_bindings`.
- DAE parameter detection in `find_dae_params` uses `u16` comparisons throughout.
- All `ipd.records.retain` calls compare against `u16` directly.

### How to test?

- New unit tests in `statement.rs` verify that calling `apply_parameter_bindings` with `prepared=true` and `prepared_param_count=None` returns a `CountFieldIncorrect` error.
- New unit tests in `param_binding.rs` verify:
  - `max_params=0` produces an empty JSON object even when a phantom DAE binding with a dummy pointer exists, confirming the pointer is never dereferenced.
  - `max_params=1` serializes only the first parameter when two bindings are present, leaving the phantom second binding (with a dummy pointer) untouched.

### Why make this change?

When a prepared statement has fewer parameter markers than the number of APD bindings (e.g., `SELECT 1` with a bound DAE parameter), the serializer could attempt to dereference APD records that point to invalid or dummy memory addresses, causing undefined behavior or crashes. By threading the server-reported marker count through as an explicit cap, phantom bindings beyond the actual marker count are never accessed.