### PR TITLE
NO-SNOW: Reduce sf_core binary size by ~17%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,29 +3329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,16 +3394,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
 
 [[package]]
 name = "pkcs8"
@@ -3848,15 +3815,6 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -4418,7 +4376,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "pkcs1",
  "pprof",
  "prost 0.14.1",
  "proto_generator",
@@ -4994,7 +4951,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ resolver = "2"
 [profile.release]
 strip = true
 opt-level = "z"
-lto = false
+lto = "thin"
+codegen-units = 1
 
 [profile.bench]
 debug = 1

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -12,6 +12,7 @@ fips = ["rustls/fips"]
 protobuf = ["prost", "proto_utils"]
 auth_mfa_e2e = []
 perf_timing = []
+cli = ["clap"]
 
 [dependencies]
 tracing-opentelemetry = "0.31.0"
@@ -26,7 +27,7 @@ reqwest = { version = "0.12.23", features = ["json", "rustls-tls", "gzip"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.143", features = ["raw_value"] }
 futures = "0.3"
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 tokio-util = { version = "0.7", features = ["time"] }
 tokio-stream = "0.1"
 toml = "0.8"
@@ -78,10 +79,9 @@ hex = "0.4"
 memchr = "2"
 sonic-rs = "0.5"
 sha2 = "0.10"
-clap = { version = "4.5", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env"], optional = true }
 signature = "2"
 der = "0.7"
-pkcs1 = "0.7"
 num-traits = "0.2.19"
 
 [build-dependencies]
@@ -117,10 +117,12 @@ path = "tests/e2e/mod.rs"
 [[bin]]
 name = "tls_client"
 path = "src/bin/tls_client.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "collect_chunk_data"
 path = "src/bin/collect_chunk_data.rs"
+required-features = ["cli"]
 
 [[bench]]
 name = "prefetch_bench"

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -91,6 +91,7 @@ proto_generator = { path = "../proto_generator" }
 libc = "0.2"
 
 [dev-dependencies]
+tokio = { version = "1.47.1", features = ["fs"] }
 tempfile = "3.21.0"
 arrow_deserialize_macro = { path = "tests/common/arrow_deserialize_macro" }
 bzip2 = "0.6.0"


### PR DESCRIPTION
- Enable LTO (thin) and codegen-units=1 in release profile
- Reduce tokio features from "full" to minimal set (rt-multi-thread, sync, time, macros)
- Make clap optional behind "cli" feature (only used by bin targets)
- Remove unused pkcs1 dependency

# sf_core Binary Size Analysis

**Date:** 2026-04-10
**Binary:** `libsf_core.so` (cdylib)
**Platform:** Linux aarch64

## Current State

| Metric | Value |
|---|---|
| Binary size (before optimization) | 18.1 MB |
| Binary size (after optimization) | 15.0 MB |
| Reduction | 3.1 MB (16.9%) |

## Applied Optimizations

The following changes were applied to reduce binary size:

### 1. Release profile tuning (`Cargo.toml`)

```toml
[profile.release]
strip = true          # already set
opt-level = "z"       # already set
lto = "thin"          # was: false — enables cross-crate dead code elimination
codegen-units = 1     # was: default (16) — fewer units = better optimization
```

Build time tradeoff: ~1m24s -> ~2m01s.

### 2. Tokio feature reduction (`sf_core/Cargo.toml`)

```toml
# Before
tokio = { version = "1.47.1", features = ["full"] }

# After
tokio = { version = "1.47.1", features = ["rt-multi-thread", "sync", "time", "macros"] }
```

Dropped unused features: `fs`, `signal`, `process`, `io-util`, `net`, `io-std`, `parking_lot`.

### 3. Optional clap dependency (`sf_core/Cargo.toml`)

Clap is only used by `[[bin]]` targets (tls_client, collect_chunk_data), not the library. Made optional behind a `cli` feature with `required-features = ["cli"]` on both binaries.

### 4. Removed unused `pkcs1` dependency

No `use pkcs1` found anywhere in sf_core/src.

## Binary Composition

### By section

| Section | Size | % of binary | Purpose |
|---|---|---|---|
| `.text` | 7.1 MB | 47% | Executable code |
| `.eh_frame` + `.eh_frame_hdr` + `.gcc_except_table` | 3.5 MB | 23% | Panic unwinding tables |
| `.rodata` | 2.1 MB | 14% | Read-only data (crypto tables, string literals) |
| `.rela.dyn` | 1.3 MB | 9% | Dynamic relocation entries |
| `.data.rel.ro` | 0.9 MB | 6% | Relocatable read-only data (vtables, trait objects) |
| Other | ~0.1 MB | 1% | `.data`, `.bss`, `.got`, etc. |

### By crate (code size from symbol analysis)

| Crate | Code Size | What it does |
|---|---|---|
| AWS SDK (s3, config, sts, sso) | 1,199 KB | S3 file transfer, credential resolution |
| aws-lc / ring (crypto) | 606 KB | TLS cryptography + precomputed curve tables |
| sf_core (driver code) | 317 KB | The actual driver logic |
| tokio | 207 KB | Async runtime |
| arrow | 201 KB | Columnar data format + FFI |
| hyper | 196 KB | HTTP/1.1 + HTTP/2 |
| encoding_rs | 152 KB | Character encoding tables (transitive via reqwest) |
| http | 129 KB | HTTP header parsing tables |
| rustls | 129 KB | TLS protocol |
| html_escape | 68 KB | HTML entity decode tables |

Note: symbol analysis accounts for ~8.7 MB of the 15 MB binary. The remainder is in data sections, alignment padding, and unwinding tables.

### Key observations

1. **The driver's own code is only 317 KB (2%)** — the binary is dominated by dependencies.
2. **Unwinding tables cost 3.5 MB (23%)** — required because `catch_unwind` is used at the FFI boundary (`protobuf/c_api.rs:65`) to prevent panics from crashing host processes (Python, Java). Cannot use `panic = "abort"`.
3. **AWS SDK is the largest code contributor at 1.2 MB** — the S3 endpoint resolver alone is 57 KB.
4. **Crypto precomputed tables (aws-lc/ring) add 606 KB** — mostly elliptic curve lookup tables in `.rodata`. Unavoidable for TLS.
5. **encoding_rs (152 KB)** is pulled transitively by reqwest for charset handling — likely rarely exercised for a Snowflake driver.

## Runtime Dependencies

The binary is **not self-contained**. It dynamically links against:

```
$ ldd target/release/libsf_core.so
libssl.so.3      => OpenSSL TLS
libcrypto.so.3   => OpenSSL crypto
libgcc_s.so.1    => Unwinding support (for catch_unwind)
libc.so.6        => Standard C library
libm.so.6        => Math library
libdl.so.2       => Dynamic loader
libpthread.so.0  => POSIX threads
```

| Dependency | Required | Notes |
|---|---|---|
| **OpenSSL 3.x** | Yes | Used for JWT signing, private key parsing, X.509 operations |
| **libgcc_s** | Yes | Required for panic unwinding at FFI boundary |
| **libc, libm, libdl, libpthread** | Yes | Standard system libraries, always present |

OpenSSL is the only non-trivial runtime dependency.

### Why both OpenSSL and rustls?

The driver uses **two TLS stacks** for different purposes:

| Library | Used for |
|---|---|
| **rustls** (+ aws-lc-rs) | TLS connections to Snowflake and AWS |
| **openssl** | JWT signing, private key parsing, certificate operations (via `jwt` and `x509-parser` crates) |

Eliminating OpenSSL would require replacing the `jwt` crate and X.509 utilities with pure-Rust alternatives.