### PR TITLE
Migrate env handles to a safe solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,11 +2856,10 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3314,6 +3313,7 @@ dependencies = [
  "error_trace",
  "libc",
  "odbc-sys",
+ "parking_lot",
  "proto_utils",
  "serde_json",
  "sf_core",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4.43"
 base64 = "0.22.1"
 serde_json = "1.0"
 libc = "0.2"
+parking_lot = { version = "0.12.5", features = ["arc_lock"] }
 
 proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -234,7 +234,8 @@ fn connect_with_params(
         options.insert("port".to_owned(), port_int.into());
     }
 
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
 
     // Check before moving `options` into the RPC call below.
@@ -561,7 +562,8 @@ fn read_dsn_config(dsn: &str) -> OdbcResult<HashMap<String, String>> {
 pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("disconnect: disconnecting from database");
 
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     if let ConnectionState::Connected {
         db_handle,
         conn_handle,
@@ -621,7 +623,8 @@ pub fn native_sql<E: OdbcEncoding>(
         .fail();
     }
 
-    let conn = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let conn = &mut dbc.connection;
     if matches!(conn.state, ConnectionState::Disconnected) {
         return crate::api::error::DisconnectedSnafu.fail();
     }
@@ -665,7 +668,8 @@ pub fn set_connect_attr<E: OdbcEncoding>(
     string_length: sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     tracing::debug!("set_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -872,7 +876,8 @@ pub fn get_connect_attr<E: OdbcEncoding>(
     string_length_ptr: *mut sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     tracing::debug!("get_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -461,7 +461,7 @@ fn execute_bindings_for_row(
                 batch_idx,
                 // SAFETY: conn pointer is valid for the statement's lifetime;
                 // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.numeric_settings,
+                &unsafe { stmt.conn() }.connection.numeric_settings,
                 &mut None,
             )
             .context(ConversionSnafu)?;
@@ -585,7 +585,7 @@ pub fn get_data(
                 *batch_idx,
                 // SAFETY: conn pointer is valid for the statement's lifetime;
                 // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.numeric_settings,
+                &unsafe { stmt.conn() }.connection.numeric_settings,
                 &mut offset,
             )
             .context(ConversionSnafu)?;

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     api::{
-        Connection, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
+        Dbc, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
         encoding::{OdbcEncoding, write_string_bytes, write_string_chars},
         env_from_handle,
         error::{
@@ -169,6 +169,8 @@ pub trait WithDiagnosticInfo {
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo;
 }
 
+// TODO: With changes to the environment locking mechanism we need to
+// rework this solution so that we do not acquire the environment 3 times during one call
 impl WithDiagnosticInfo for Environment {
     fn get_diag_info(&self) -> &DiagnosticInfo {
         &self.diagnostic_info
@@ -178,12 +180,12 @@ impl WithDiagnosticInfo for Environment {
     }
 }
 
-impl WithDiagnosticInfo for Connection {
+impl WithDiagnosticInfo for Dbc {
     fn get_diag_info(&self) -> &DiagnosticInfo {
-        &self.diagnostic_info
+        &self.connection.diagnostic_info
     }
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo {
-        &mut self.diagnostic_info
+        &mut self.connection.diagnostic_info
     }
 }
 
@@ -249,8 +251,15 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
     if handle.is_null() {
         return;
     }
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        guard.get_diag_info_mut().clear();
+        return;
+    }
     let t: &mut dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Env => env_from_handle(handle),
         sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
@@ -259,12 +268,11 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
     t.get_diag_info_mut().clear();
 }
 
-pub fn from_handle_type<'a>(
+fn from_handle_type_non_env<'a>(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> Option<&'a mut dyn WithDiagnosticInfo> {
     match handle_type {
-        sql::HandleType::Env => Some(env_from_handle(handle)),
         sql::HandleType::Dbc => Some(conn_from_handle(handle)),
         sql::HandleType::Stmt => Some(stmt_from_handle(handle)),
         sql::HandleType::Desc => Some(desc_diag_from_handle(handle)),
@@ -307,7 +315,18 @@ pub fn set_diag_info_from_warnings(
     if handle.is_null() {
         return;
     }
-    if let Some(t) = from_handle_type(handle_type, handle) {
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        let diagnostic_info = guard.get_diag_info_mut();
+        for warning in warnings {
+            diagnostic_info.add_record(from_warning(warning));
+        }
+        return;
+    }
+    if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         let diagnostic_info = t.get_diag_info_mut();
         for warning in warnings {
             diagnostic_info.add_record(from_warning(warning));
@@ -323,18 +342,23 @@ pub fn set_diag_info_from_result(
     if handle.is_null() {
         return;
     }
-    if let Some(t) = from_handle_type(handle_type, handle) {
-        let diagnostic_info = t.get_diag_info_mut();
-        match result {
-            Ok(_) => {}
-            // SQL_NEED_DATA is a success-class return code, not an error.
-            // Don't post a diagnostic record — the Driver Manager uses the
-            // return code alone to drive the DAE protocol.
-            Err(OdbcError::DaeRequired { .. }) => {}
-            Err(error) => {
-                diagnostic_info.add_record(error.to_diagnostic_record());
-            }
+    let add_from_result = |diagnostic_info: &mut DiagnosticInfo| match result {
+        Ok(_) => {}
+        Err(OdbcError::DaeRequired { .. }) => {}
+        Err(error) => {
+            diagnostic_info.add_record(error.to_diagnostic_record());
         }
+    };
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        add_from_result(guard.get_diag_info_mut());
+        return;
+    }
+    if let Some(t) = from_handle_type_non_env(handle_type, handle) {
+        add_from_result(t.get_diag_info_mut());
     }
 }
 
@@ -342,8 +366,12 @@ pub fn get_diag_info(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> OdbcResult<DiagnosticInfo> {
+    if handle_type == sql::HandleType::Env {
+        let env = env_from_handle(handle)?;
+        let guard = env.environment.lock();
+        return Ok(guard.get_diag_info().clone());
+    }
     let t: &dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Env => env_from_handle(handle),
         sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
@@ -647,10 +675,10 @@ mod tests {
     }
 
     #[test]
-    fn from_handle_type_returns_some_for_desc() {
+    fn from_handle_type_non_env_returns_some_for_desc() {
         let mut apd = ApdDescriptor::new();
         let handle = &mut apd as *mut ApdDescriptor as sql::Handle;
-        assert!(from_handle_type(sql::HandleType::Desc, handle).is_some());
+        assert!(from_handle_type_non_env(sql::HandleType::Desc, handle).is_some());
     }
 
     #[test]

--- a/odbc/src/api/environment.rs
+++ b/odbc/src/api/environment.rs
@@ -60,7 +60,8 @@ pub fn set_env_attribute(
 ) -> OdbcResult<()> {
     tracing::debug!("Setting environment attribute: {attribute}");
 
-    let env = env_from_handle(environment_handle);
+    let env = env_from_handle(environment_handle)?;
+    let mut environment = env.environment.lock();
     let attr = to_env_attr(attribute).ok_or(UnsupportedAttributeSnafu { attribute }.build())?;
 
     match attr {
@@ -69,7 +70,7 @@ pub fn set_env_attribute(
             match version {
                 SQL_OV_ODBC2 | SQL_OV_ODBC3 | SQL_OV_ODBC3_80 => {
                     tracing::debug!("Setting ODBC version: {version}");
-                    env.odbc_version = version;
+                    environment.odbc_version = version;
                     Ok(())
                 }
                 _ => {
@@ -85,14 +86,14 @@ pub fn set_env_attribute(
         sql::EnvironmentAttribute::ConnectionPooling => {
             let pooling = parse_connection_pooling(value as sql::UInteger, attribute)?;
             tracing::debug!("Setting connection pooling: {pooling:?}");
-            env.connection_pooling = pooling;
+            environment.connection_pooling = pooling;
             Ok(())
         }
         sql::EnvironmentAttribute::CpMatch => {
             let connection_pool_match =
                 parse_connection_pool_match(value as sql::UInteger, attribute)?;
             tracing::debug!("Setting connection pool match: {connection_pool_match:?}");
-            env.connection_pool_match = connection_pool_match;
+            environment.connection_pool_match = connection_pool_match;
             Ok(())
         }
         sql::EnvironmentAttribute::OutputNts => {
@@ -111,7 +112,8 @@ pub fn get_env_attribute(
 ) -> OdbcResult<()> {
     tracing::debug!("Getting environment attribute: {attribute}");
 
-    let env = env_from_handle(environment_handle);
+    let env = env_from_handle(environment_handle)?;
+    let environment = env.environment.lock();
     let attr = to_env_attr(attribute).ok_or(UnsupportedAttributeSnafu { attribute }.build())?;
 
     let write_string_length = || {
@@ -127,20 +129,23 @@ pub fn get_env_attribute(
 
     match attr {
         sql::EnvironmentAttribute::OdbcVersion => {
-            tracing::debug!("Getting ODBC version: {}", env.odbc_version);
+            tracing::debug!("Getting ODBC version: {}", environment.odbc_version);
             if !value.is_null() {
-                unsafe { std::ptr::write(value as *mut sql::Integer, env.odbc_version) };
+                unsafe { std::ptr::write(value as *mut sql::Integer, environment.odbc_version) };
             }
             write_string_length();
             Ok(())
         }
         sql::EnvironmentAttribute::ConnectionPooling => {
-            tracing::debug!("Getting connection pooling: {:?}", env.connection_pooling);
+            tracing::debug!(
+                "Getting connection pooling: {:?}",
+                environment.connection_pooling
+            );
             if !value.is_null() {
                 unsafe {
                     std::ptr::write(
                         value as *mut sql::UInteger,
-                        env.connection_pooling as sql::UInteger,
+                        environment.connection_pooling as sql::UInteger,
                     )
                 };
             }
@@ -150,13 +155,13 @@ pub fn get_env_attribute(
         sql::EnvironmentAttribute::CpMatch => {
             tracing::debug!(
                 "Getting connection pool match: {:?}",
-                env.connection_pool_match
+                environment.connection_pool_match
             );
             if !value.is_null() {
                 unsafe {
                     std::ptr::write(
                         value as *mut sql::UInteger,
-                        env.connection_pool_match as sql::UInteger,
+                        environment.connection_pool_match as sql::UInteger,
                     )
                 };
             }

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -25,6 +25,30 @@ use snafu::{Location, Snafu, location};
 #[derive(Snafu, Debug, ErrorTrace)]
 #[snafu(visibility(pub))]
 pub enum OdbcError {
+    #[snafu(display("Freeing environment failed: environment has connections"))]
+    EnvironmentHasConnections {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Freeing connection failed: connection is still connected"))]
+    ConnectionStillConnected {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Connection has no environment"))]
+    ConnectionHasNoEnvironment {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to lock environment"))]
+    EnvironmentLockPoisoned {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Connection is disconnected"))]
     Disconnected {
         #[snafu(implicit)]
@@ -499,6 +523,10 @@ impl OdbcError {
 
     pub fn to_sql_state(&self) -> SqlState {
         match self {
+            OdbcError::EnvironmentHasConnections { .. } => SqlState::FunctionSequenceError,
+            OdbcError::ConnectionStillConnected { .. } => SqlState::FunctionSequenceError,
+            OdbcError::ConnectionHasNoEnvironment { .. } => SqlState::GeneralError,
+            OdbcError::EnvironmentLockPoisoned { .. } => SqlState::GeneralError,
             OdbcError::Disconnected { .. } => SqlState::ConnectionDoesNotExist,
             OdbcError::InvalidHandle { .. } => SqlState::InvalidConnectionName,
             OdbcError::InvalidHandleType { .. } => SqlState::InvalidAttributeOptionIdentifier,

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -1,10 +1,16 @@
-use crate::api::error::{DisconnectedSnafu, InvalidHandleSnafu, OdbcRuntimeSnafu, Required};
+use crate::api::env_from_handle;
+use crate::api::error::{
+    ConnectionStillConnectedSnafu, DisconnectedSnafu, EnvironmentHasConnectionsSnafu,
+    InvalidHandleSnafu, OdbcRuntimeSnafu, Required,
+};
+use crate::api::handle_registry::HandleId;
 use crate::api::{
-    Connection, ConnectionState, Environment, OdbcResult, Statement, conn_from_handle,
+    Connection, ConnectionState, Dbc, Env, Environment, OdbcResult, Statement, conn_from_handle,
     diagnostic::DiagnosticInfo,
     runtime::{env_allocated, env_freed, global},
 };
 use odbc_sys as sql;
+use parking_lot::Mutex;
 use sf_core::protobuf::generated::database_driver_v1::{
     StatementNewRequest, StatementReleaseRequest,
 };
@@ -13,47 +19,57 @@ use std::sync::Arc;
 use tracing;
 
 /// Allocate a new environment handle
-pub fn alloc_environment() -> OdbcResult<*mut Environment> {
+pub fn alloc_environment() -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new environment handle");
     env_allocated().context(OdbcRuntimeSnafu)?;
-    let env = Box::new(Environment {
-        odbc_version: 3,
-        connection_pooling: sql::AttrConnectionPooling::Off,
-        connection_pool_match: sql::AttrCpMatch::Strict,
-        diagnostic_info: DiagnosticInfo::default(),
+    let env = Arc::new(Env {
+        environment: Mutex::new(Environment {
+            odbc_version: 3,
+            connection_pooling: sql::AttrConnectionPooling::Off,
+            connection_pool_match: sql::AttrCpMatch::Strict,
+            diagnostic_info: DiagnosticInfo::default(),
+            connections: vec![],
+        }),
     });
-    Ok(Box::into_raw(env))
+    let handle = global().context(OdbcRuntimeSnafu)?.env_registry.add(env)?;
+    Ok(handle.into())
 }
 
 /// Allocate a new connection handle
-pub fn alloc_connection() -> OdbcResult<*mut Connection> {
+pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
     tracing::info!("Allocating new connection handle");
-    let dbc = Box::new(Connection {
-        state: ConnectionState::Disconnected,
-        diagnostic_info: DiagnosticInfo::default(),
-        pre_connection_attrs: Default::default(),
-        numeric_settings: Default::default(),
-        access_mode: crate::api::types::AccessMode::ReadWrite,
-        quiet_mode: std::ptr::null_mut(), // no window handle
-        packet_size: 0,                   // driver-defined
-        child_statements: vec![],
-        cached_autocommit: crate::api::types::AutocommitValue::On,
-        current_catalog: None,
-        metadata_id: false,
+    let dbc = Box::new(Dbc {
+        env: Arc::downgrade(&env),
+        connection: Connection {
+            state: ConnectionState::Disconnected,
+            diagnostic_info: DiagnosticInfo::default(),
+            pre_connection_attrs: Default::default(),
+            numeric_settings: Default::default(),
+            access_mode: crate::api::types::AccessMode::ReadWrite,
+            quiet_mode: std::ptr::null_mut(),
+            packet_size: 0,
+            child_statements: vec![],
+            cached_autocommit: crate::api::types::AutocommitValue::On,
+            current_catalog: None,
+            metadata_id: false,
+        },
     });
-    Ok(Box::into_raw(dbc))
+    let ptr = Box::into_raw(dbc);
+    env.environment.lock().connections.push(ptr);
+    Ok(ptr)
 }
 
 /// Allocate a new statement handle
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
     let conn = conn_from_handle(input_handle);
-    match &mut conn.state {
+    let connection = &mut conn.connection;
+    match &mut connection.state {
         ConnectionState::Connected {
             db_handle: _,
             conn_handle,
         } => {
-            let metadata_id = conn.metadata_id;
+            let metadata_id = connection.metadata_id;
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                 c.statement_new(StatementNewRequest {
                     conn_handle: Some(*conn_handle),
@@ -69,15 +85,11 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
             // the Arc is converted to a raw pointer immediately — it is never cloned and
             // never shared across threads. Rc cannot be used because Connection: Send.
             #[allow(clippy::arc_with_non_send_sync)]
-            let stmt = Arc::new(Statement::new(
-                conn as *mut Connection,
-                stmt_handle,
-                metadata_id,
-            ));
+            let stmt = Arc::new(Statement::new(conn as *mut Dbc, stmt_handle, metadata_id));
             // Defensive prune: in correct code free_statement removes each entry before
             // dropping the Arc, so Weaks here are always upgradeable. This retain is a
             // safety net against a future bug in the removal logic, not a routine cleanup.
-            conn.child_statements.retain(|(w, raw_ptr)| {
+            conn.connection.child_statements.retain(|(w, raw_ptr)| {
                 if w.upgrade().is_some() {
                     return true;
                 }
@@ -100,7 +112,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
             stmt_mut.ird.stmt = raw_ptr;
             stmt_mut.apd.stmt = raw_ptr;
             stmt_mut.ipd.stmt = raw_ptr;
-            conn.child_statements.push((weak, raw_ptr));
+            conn.connection.child_statements.push((weak, raw_ptr));
             Ok(raw_ptr as *mut Statement)
         }
         ConnectionState::Disconnected => {
@@ -112,34 +124,29 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
 
 /// Free an environment handle
 pub fn free_environment(handle: sql::Handle) -> OdbcResult<()> {
-    if handle.is_null() {
-        return InvalidHandleSnafu.fail();
+    let handle_id = HandleId::from(handle);
+    let env_removal_guard = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .remove(handle_id)?;
+    let environment = env_removal_guard.environment.lock();
+    if !environment.connections.is_empty() {
+        return EnvironmentHasConnectionsSnafu.fail();
     }
-
-    tracing::info!("Freeing environment handle");
-    unsafe {
-        drop(Box::from_raw(handle as *mut Environment));
-    }
+    drop(environment);
+    env_removal_guard.complete();
     env_freed().context(OdbcRuntimeSnafu)?;
     Ok(())
 }
 
-/// Free a connection handle
-pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
-    if handle.is_null() {
-        return InvalidHandleSnafu.fail();
-    }
-
-    tracing::info!("Freeing connection handle");
-
+fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
     // Release any outstanding statements whose ODBC handles were never freed.
     // Each Weak still in child_statements corresponds to an Arc::into_raw that was
     // never reclaimed by free_statement (strong count = 1, held by the raw ODBC handle).
     // Reconstruct the Arc to take back that ownership, then release the server resource.
-    let stmts: Vec<_> = {
-        let conn = unsafe { &mut *(handle as *mut Connection) };
-        conn.child_statements.drain(..).collect()
-    };
+    let conn = unsafe { &mut *conn };
+    let connection = &mut conn.connection;
+    let stmts: Vec<_> = connection.child_statements.drain(..).collect();
     for (w, raw_ptr) in stmts {
         // Safety: raw_ptr was obtained via Arc::into_raw in alloc_statement.
         // (Note: Arc::as_ptr and Arc::into_raw are NOT equivalent — as_ptr does not transfer
@@ -177,9 +184,33 @@ pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
     }
 
     unsafe {
-        drop(Box::from_raw(handle as *mut Connection));
+        drop(Box::from_raw(conn as *mut Dbc));
     }
     Ok(())
+}
+
+fn remove_connection_from_env(conn: *mut Dbc) -> OdbcResult<()> {
+    let dbc = unsafe { &mut *conn };
+    let env = dbc.env()?;
+    let mut environment = env.environment.lock();
+    environment.connections.retain(|c| *c != conn);
+    Ok(())
+}
+
+/// Free a connection handle
+pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
+    if handle.is_null() {
+        return InvalidHandleSnafu.fail();
+    }
+
+    tracing::info!("Freeing connection handle");
+    let dbc = handle as *mut Dbc;
+    let conn = unsafe { &*dbc };
+    if matches!(conn.connection.state, ConnectionState::Connected { .. }) {
+        return ConnectionStillConnectedSnafu.fail();
+    }
+    remove_connection_from_env(dbc)?;
+    cleanup_connection(dbc)
 }
 
 /// Free a statement handle
@@ -208,6 +239,7 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
         // Arc<Statement> doesn't implement DerefMut, so use conn_ptr() (takes &self via Arc::Deref)
         // to get an independent &mut Connection.
         unsafe { &mut *stmt.conn_ptr() }
+            .connection
             .child_statements
             .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
         drop(stmt);
@@ -262,7 +294,8 @@ pub fn sql_alloc_handle(
                 "Allocating new dbc: SQLAllocHandle: handle_type={:?}",
                 handle_type
             );
-            let handle = alloc_connection()?;
+            let env = env_from_handle(input_handle)?;
+            let handle = alloc_connection(env)?;
             unsafe { *output_handle = handle as sql::Handle };
             Ok(())
         }

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -29,26 +29,32 @@ impl From<sql::Handle> for HandleId {
 }
 
 pub struct RemovalGuard<T: Send + Sync + Clone> {
-    value: T,
+    value: Option<T>,
     guard: ArcMutexGuard<RawMutex, Option<T>>,
 }
 
 impl<T: Send + Sync + Clone> RemovalGuard<T> {
-    pub fn complete(self) -> T {
-        self.value.clone()
+    pub fn complete(mut self) -> T {
+        self.value
+            .take()
+            .expect("complete called on already-completed RemovalGuard")
     }
 }
 
 impl<T: Send + Sync + Clone> Drop for RemovalGuard<T> {
     fn drop(&mut self) {
-        *self.guard = Some(self.value.clone());
+        if let Some(value) = self.value.take() {
+            *self.guard = Some(value);
+        }
     }
 }
 
 impl<T: Send + Sync + Clone> Deref for RemovalGuard<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.value
+        self.value
+            .as_ref()
+            .expect("deref on completed RemovalGuard")
     }
 }
 
@@ -102,8 +108,11 @@ impl<T: Send + Sync + Clone> HandleRegistry<T> {
             .ok_or_else(|| InvalidHandleSnafu.build())?;
         let mut guard = handle.lock_arc();
         let value_opt = guard.take();
-        if let Some(value) = value_opt {
-            return Ok(RemovalGuard { value, guard });
+        if value_opt.is_some() {
+            return Ok(RemovalGuard {
+                value: value_opt,
+                guard,
+            });
         }
         InvalidHandleSnafu.fail()
     }

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::{ArcMutexGuard, Mutex, RawMutex, RwLock};
+
+use crate::api::error::InvalidHandleSnafu;
+use crate::api::{Env, OdbcResult};
+use odbc_sys as sql;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HandleId {
+    id: usize,
+}
+
+impl From<HandleId> for sql::Handle {
+    fn from(handle_id: HandleId) -> Self {
+        handle_id.id as sql::Handle
+    }
+}
+
+impl From<sql::Handle> for HandleId {
+    fn from(handle: sql::Handle) -> Self {
+        Self {
+            id: handle as usize,
+        }
+    }
+}
+
+pub struct RemovalGuard<T: Send + Sync + Clone> {
+    value: T,
+    guard: ArcMutexGuard<RawMutex, Option<T>>,
+}
+
+impl<T: Send + Sync + Clone> RemovalGuard<T> {
+    pub fn complete(self) -> T {
+        self.value.clone()
+    }
+}
+
+impl<T: Send + Sync + Clone> Drop for RemovalGuard<T> {
+    fn drop(&mut self) {
+        *self.guard = Some(self.value.clone());
+    }
+}
+
+impl<T: Send + Sync + Clone> Deref for RemovalGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+// TODO Reclaim ids when handles are removed
+pub struct HandleRegistry<T: Send + Sync + Clone> {
+    handles: RwLock<HashMap<HandleId, Arc<Mutex<Option<T>>>>>,
+    next_id: AtomicUsize,
+}
+
+impl<T: Send + Sync + Clone> HandleRegistry<T> {
+    fn next_id(&self) -> HandleId {
+        HandleId {
+            id: self.next_id.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            handles: RwLock::new(HashMap::new()),
+            next_id: AtomicUsize::new(1),
+        }
+    }
+
+    pub fn add(&self, handle: T) -> OdbcResult<HandleId> {
+        let mut handles = self.handles.write();
+        let id = self.next_id();
+        handles.insert(id, Arc::new(Mutex::new(Some(handle))));
+        Ok(id)
+    }
+
+    pub fn get(&self, id: HandleId) -> OdbcResult<T> {
+        let mutex = self
+            .handles
+            .read()
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())?;
+        let value = mutex.lock();
+        value
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())
+    }
+
+    pub fn remove(&self, id: HandleId) -> OdbcResult<RemovalGuard<T>> {
+        let handle = self
+            .handles
+            .read()
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())?;
+        let mut guard = handle.lock_arc();
+        let value_opt = guard.take();
+        if let Some(value) = value_opt {
+            return Ok(RemovalGuard { value, guard });
+        }
+        InvalidHandleSnafu.fail()
+    }
+
+    #[allow(dead_code)]
+    pub fn cleanup(&self, ids: &[HandleId]) -> OdbcResult<()> {
+        let mut handles = self.handles.write();
+        for id in ids {
+            handles.remove(id);
+        }
+        Ok(())
+    }
+}
+
+pub type EnvironmentHandleRegistry = HandleRegistry<Arc<Env>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_id_has_pointer_size() {
+        assert_eq!(
+            std::mem::size_of::<HandleId>(),
+            std::mem::size_of::<sql::Handle>()
+        );
+    }
+
+    #[test]
+    fn registry_add_get_remove() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id = registry.add(42).unwrap();
+        assert_eq!(registry.get(id).unwrap(), 42);
+        assert_eq!(registry.remove(id).unwrap().complete(), 42);
+        assert!(registry.get(id).is_err());
+    }
+
+    #[test]
+    fn registry_cleanup() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id1 = registry.add(1).unwrap();
+        let id2 = registry.add(2).unwrap();
+        let id3 = registry.add(3).unwrap();
+        registry.cleanup(&[id1, id3]).unwrap();
+        assert!(registry.get(id1).is_err());
+        assert_eq!(registry.get(id2).unwrap(), 2);
+        assert!(registry.get(id3).is_err());
+    }
+
+    #[test]
+    fn registry_ids_start_at_one() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id = registry.add(1).unwrap();
+        assert_eq!(id, HandleId { id: 1 });
+    }
+}

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod encoding;
 pub mod environment;
 pub mod error;
 pub mod handle_allocation;
+pub mod handle_registry;
 pub mod runtime;
 pub mod sql_state;
 pub mod statement;

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -4,6 +4,8 @@ use std::sync::RwLock;
 use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
 use snafu::{Location, ResultExt, Snafu};
 
+use crate::api::handle_registry::EnvironmentHandleRegistry;
+
 /// Holds the shared tokio runtime and driver client used by all ODBC
 /// environments in this process.
 ///
@@ -18,6 +20,7 @@ use snafu::{Location, ResultExt, Snafu};
 pub struct OdbcGlobals {
     runtime: tokio::runtime::Runtime,
     client: DatabaseDriverClient,
+    pub env_registry: EnvironmentHandleRegistry,
 }
 
 impl OdbcGlobals {
@@ -86,7 +89,11 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
             .build()
             .context(RuntimeCreationSnafu)?;
         let client = database_driver_client();
-        guard.globals = Some(OdbcGlobals { runtime, client });
+        guard.globals = Some(OdbcGlobals {
+            runtime,
+            client,
+            env_registry: EnvironmentHandleRegistry::new(),
+        });
     }
     guard.env_count += 1;
     Ok(())

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -72,8 +72,8 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Validate connection before committing to NeedData state.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
-    match &mut conn.state {
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    match &mut dbc.connection.state {
         ConnectionState::Disconnected => {
             tracing::error!("exec_direct: connection is disconnected");
             return DisconnectedSnafu.fail();
@@ -111,7 +111,8 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Re-borrow connection for execution.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Connected {
             db_handle: _,
@@ -253,8 +254,9 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
         return CursorAlreadyOpenSnafu.fail();
     }
 
-    let conn = unsafe { &mut *stmt.conn_ptr() };
-    match &mut conn.state {
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let connection = &mut dbc.connection;
+    match &mut connection.state {
         ConnectionState::Connected {
             db_handle: _,
             conn_handle: _,
@@ -302,7 +304,7 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
                 .build()
             })?;
             stmt.prepared_param_count = Some(param_count);
-            let max_varchar = conn.numeric_settings.max_varchar_size;
+            let max_varchar = connection.numeric_settings.max_varchar_size;
             stmt.ipd.records.retain(|&k, _| k <= param_count);
             for i in 1..=param_count {
                 stmt.ipd
@@ -351,7 +353,8 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let is_prepared = origin.is_prepared();
 
     // Validate connection before committing to NeedData state.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Disconnected => {
             tracing::error!("execute: connection is disconnected");
@@ -380,7 +383,8 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     }
 
     // Re-borrow connection for execution.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Connected {
             db_handle: _,

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1,5 +1,9 @@
 use crate::api::bitmask::Bitmask;
-use crate::api::error::InvalidDescriptorKindSnafu;
+use crate::api::error::{
+    ConnectionHasNoEnvironmentSnafu, InvalidDescriptorKindSnafu, OdbcRuntimeSnafu,
+};
+use crate::api::handle_registry::HandleId;
+use crate::api::runtime::global;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::conversion::Binding;
 use crate::conversion::warning::Warnings;
@@ -9,8 +13,11 @@ use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::{
     ConnectionHandle as TConnectionHandle, DatabaseHandle as TDatabaseHandle, StatementHandle,
 };
+use snafu::ResultExt;
 use std::collections::HashMap;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
+
+use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use super::CDataType;
@@ -862,12 +869,21 @@ impl ToSqlReturn for OdbcResult<()> {
         self.to_sql_return(warnings).0
     }
 }
+pub struct Env {
+    pub environment: Mutex<Environment>,
+}
+
+// TODO: this is a hack to allow the Env to be used in a multi-threaded environment
+// Will be removed after this PR stack is completed
+unsafe impl Send for Env {}
+unsafe impl Sync for Env {}
 
 pub struct Environment {
     pub odbc_version: sql::Integer,
     pub connection_pooling: sql::AttrConnectionPooling,
     pub connection_pool_match: sql::AttrCpMatch,
     pub diagnostic_info: DiagnosticInfo,
+    pub connections: Vec<*mut Dbc>,
 }
 
 pub enum ConnectionState {
@@ -882,6 +898,19 @@ pub enum ConnectionState {
 /// Pre-connection attributes set via SQLSetConnectAttr before connecting.
 /// These are applied to the sf_core connection during driver_connect/connect.
 pub type PreConnectionAttributes = HashMap<ConnectionAttribute, String>;
+
+pub struct Dbc {
+    pub connection: Connection,
+    pub env: Weak<Env>,
+}
+
+impl Dbc {
+    pub fn env(&self) -> Result<Arc<Env>, OdbcError> {
+        self.env
+            .upgrade()
+            .ok_or(ConnectionHasNoEnvironmentSnafu.build())
+    }
+}
 
 pub struct Connection {
     pub state: ConnectionState,
@@ -1206,7 +1235,7 @@ impl GetDataState {
 pub struct Statement {
     /// Raw pointer to the owning connection. Valid for the entire lifetime of this Statement
     /// (the connection always outlives its statements). Access via `conn()` / `conn_ptr()`.
-    conn: *mut Connection,
+    conn: *mut Dbc,
     pub stmt_handle: StatementHandle,
     pub state: State<StatementState>,
     pub ard: ArdDescriptor,
@@ -1251,7 +1280,7 @@ unsafe impl Send for Statement {}
 
 impl Statement {
     /// Construct a new Statement for the given connection.
-    pub fn new(conn: *mut Connection, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
+    pub fn new(conn: *mut Dbc, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
         Self {
             conn,
             stmt_handle,
@@ -1277,7 +1306,7 @@ impl Statement {
     /// # Safety
     /// The caller must ensure the Connection outlives this borrow and no other
     /// mutable reference to the Connection exists simultaneously.
-    pub unsafe fn conn(&self) -> &Connection {
+    pub unsafe fn conn(&self) -> &Dbc {
         debug_assert!(
             !self.conn.is_null(),
             "Statement::conn: connection pointer is null"
@@ -1297,19 +1326,23 @@ impl Statement {
     /// derived from this statement) exists while the returned pointer is dereferenced
     /// mutably. Having both an active `&Connection` and a `&mut Connection` pointing
     /// to the same allocation is undefined behaviour.
-    pub(crate) unsafe fn conn_ptr(&self) -> *mut Connection {
+    pub(crate) unsafe fn conn_ptr(&self) -> *mut Dbc {
         self.conn
     }
 }
 
 // Helper functions for handle conversion
-pub fn env_from_handle<'a>(handle: sql::Handle) -> &'a mut Environment {
-    let env_ptr = handle as *mut Environment;
-    unsafe { env_ptr.as_mut().unwrap() }
+pub fn env_from_handle(handle: sql::Handle) -> OdbcResult<Arc<Env>> {
+    let handle_id = HandleId::from(handle);
+    let env = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .get(handle_id)?;
+    Ok(env)
 }
 
-pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Connection {
-    let conn_ptr = handle as *mut Connection;
+pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Dbc {
+    let conn_ptr = handle as *mut Dbc;
     unsafe { conn_ptr.as_mut().unwrap() }
 }
 

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -148,8 +148,9 @@ pub fn col_attribute<E: OdbcEncoding>(
         DescField::Type | DescField::ConciseType => {
             // SAFETY: conn pointer is valid for the statement's lifetime;
             // no mutable reference to the Connection exists in this scope.
-            let sql_type = sql_type_from_field(field, &unsafe { stmt.conn() }.numeric_settings)
-                .context(ConversionSnafu)?;
+            let sql_type =
+                sql_type_from_field(field, &unsafe { stmt.conn() }.connection.numeric_settings)
+                    .context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);
@@ -251,7 +252,8 @@ pub fn describe_col<E: OdbcEncoding>(
     let field = schema.field(col_idx);
     // SAFETY: conn pointer is valid for the statement's lifetime;
     // no mutable reference to the Connection exists in this scope.
-    let conn = unsafe { stmt.conn() };
+    let dbc = unsafe { stmt.conn() };
+    let numeric_settings = &dbc.connection.numeric_settings;
 
     let name = field.name();
     write_string_chars::<E>(
@@ -263,20 +265,17 @@ pub fn describe_col<E: OdbcEncoding>(
     );
 
     if !data_type_ptr.is_null() {
-        let sql_type =
-            sql_type_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let sql_type = sql_type_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(data_type_ptr, sql_type.0 as sql::SmallInt) };
     }
 
     if !column_size_ptr.is_null() {
-        let col_size =
-            column_size_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let col_size = column_size_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(column_size_ptr, col_size) };
     }
 
     if !decimal_digits_ptr.is_null() {
-        let digits =
-            decimal_digits_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let digits = decimal_digits_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(decimal_digits_ptr, digits) };
     }
 


### PR DESCRIPTION
Migrate environment handles to a registry-based solution

- Introduce Env wrapper with Mutex<Environment> for thread-safe access to environment state
- Add HandleRegistry to manage environment handles by ID instead of raw pointers
- Wrap connection handles in a new Dbc struct with a Weak<Env> back-reference to the parent environment
- Track parent-child relationships between environments and connections
- Cascade cleanup of child connections when freeing an environment handle