### PR TITLE
SNOW-3240517: SQLPutData Implementation and additional tests

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -481,6 +481,18 @@ pub enum OdbcError {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Non-character and non-binary data sent in pieces"))]
+    NonCharBinarySentInPieces {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Attempt to concatenate a null value"))]
+    ConcatNullValue {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub trait Required<T>: Sized {
@@ -601,6 +613,8 @@ impl OdbcError {
             OdbcError::InvalidConnectionString { .. } => ErrorSource::ConfigParsing,
             OdbcError::DaeRequired { .. } => ErrorSource::ApiMisuse,
             OdbcError::InvalidDuringDae { .. } => ErrorSource::ApiMisuse,
+            OdbcError::NonCharBinarySentInPieces { .. } => ErrorSource::ApiMisuse,
+            OdbcError::ConcatNullValue { .. } => ErrorSource::ApiMisuse,
         }
     }
 
@@ -865,6 +879,10 @@ impl OdbcError {
             OdbcError::InvalidConnectionString { .. } => SqlState::InvalidConnectionStringAttribute,
             OdbcError::DaeRequired { .. } => SqlState::GeneralError,
             OdbcError::InvalidDuringDae { .. } => SqlState::FunctionSequenceError,
+            OdbcError::NonCharBinarySentInPieces { .. } => {
+                SqlState::NonCharacterAndNonBinaryDataSentInPieces
+            }
+            OdbcError::ConcatNullValue { .. } => SqlState::AttemptToConcatenateNullValue,
         }
     }
 

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -2,12 +2,13 @@ use crate::api::CDataType;
 use crate::api::TimestampSubtype;
 use crate::api::encoding::OdbcEncoding;
 use crate::api::error::{
-    ArrowArrayStreamReaderCreationSnafu, CursorAlreadyOpenSnafu, DaeRequiredSnafu,
-    DisconnectedSnafu, InvalidAttributeValueSnafu, InvalidBufferLengthSnafu,
+    ArrowArrayStreamReaderCreationSnafu, ConcatNullValueSnafu, CursorAlreadyOpenSnafu,
+    DaeRequiredSnafu, DisconnectedSnafu, InvalidAttributeValueSnafu, InvalidBufferLengthSnafu,
     InvalidCursorStateSnafu, InvalidDuringDaeSnafu, InvalidHandleSnafu,
     InvalidParameterNumberSnafu, InvalidPrecisionOrScaleSnafu, JsonBindingSnafu, NoMoreDataSnafu,
-    NullPointerSnafu, OdbcRuntimeSnafu, OperationCanceledSnafu, ReadOnlyAttributeSnafu, Required,
-    StatementNotExecutedSnafu, UnsupportedAttributeSnafu, UnsupportedFeatureSnafu,
+    NonCharBinarySentInPiecesSnafu, NullPointerSnafu, OdbcRuntimeSnafu, OperationCanceledSnafu,
+    ReadOnlyAttributeSnafu, Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
+    UnsupportedFeatureSnafu,
 };
 use crate::api::query_type::{QueryType, ResultKind};
 use crate::api::runtime::global;
@@ -2142,12 +2143,12 @@ pub fn put_data(
     let mut inner = guard.inner.lock();
 
     match inner.state.take() {
+        // S9 → S10 on success, S9 → S9 on error
         StatementState::AwaitingPutData {
             mut dae_context,
             origin,
         } => {
-            let param_num = dae_context.dae_params[dae_context.current_index];
-            let result = accumulate_put_data(&mut dae_context, param_num, data_ptr, str_len_or_ind);
+            let result = put_data_inner(&inner.apd, &mut dae_context, data_ptr, str_len_or_ind);
             inner.state.set(if result.is_ok() {
                 StatementState::PutDataCalled {
                     dae_context,
@@ -2161,13 +2162,12 @@ pub fn put_data(
             });
             result
         }
-
+        // S10 → S10 regardless of success or error
         StatementState::PutDataCalled {
             mut dae_context,
             origin,
         } => {
-            let param_num = dae_context.dae_params[dae_context.current_index];
-            let result = accumulate_put_data(&mut dae_context, param_num, data_ptr, str_len_or_ind);
+            let result = put_data_inner(&inner.apd, &mut dae_context, data_ptr, str_len_or_ind);
             inner.state.set(StatementState::PutDataCalled {
                 dae_context,
                 origin,
@@ -2182,12 +2182,49 @@ pub fn put_data(
     }
 }
 
+/// Validate inputs and accumulate one `SQLPutData` chunk.
+///
+/// Separated from `put_data()` so that each match arm can restore its own
+/// state variant on error. This makes it structurally impossible to restore
+/// the wrong ODBC state (S9 vs S10) after a validation failure -- the
+/// compiler enforces correctness rather than relying on a manual boolean flag.
+fn put_data_inner(
+    apd: &crate::api::ApdDescriptor,
+    dae_context: &mut DaeContext,
+    data_ptr: sql::Pointer,
+    str_len_or_ind: sql::Len,
+) -> OdbcResult<()> {
+    let param_num = dae_context.dae_params[dae_context.current_index];
+
+    // HY009: null DataPtr with non-null-data, non-zero indicator.
+    // Per spec, (null, 0) and (null, SQL_NULL_DATA) are both valid.
+    if data_ptr.is_null() && str_len_or_ind != sql::NULL_DATA && str_len_or_ind != 0 {
+        return NullPointerSnafu.fail();
+    }
+
+    // HY090: negative StrLen_or_Ind that isn't SQL_NTS or SQL_NULL_DATA
+    if str_len_or_ind < 0 && str_len_or_ind != sql::NTS && str_len_or_ind != sql::NULL_DATA {
+        return InvalidBufferLengthSnafu {
+            length: str_len_or_ind as i64,
+        }
+        .fail();
+    }
+
+    let c_type = apd
+        .records
+        .get(&param_num)
+        .map(|r| r.value_type)
+        .unwrap_or(CDataType::Default);
+    accumulate_put_data(dae_context, param_num, data_ptr, str_len_or_ind, c_type)
+}
+
 /// Accumulate a single `SQLPutData` chunk into the DAE context.
 fn accumulate_put_data(
     ctx: &mut DaeContext,
     param_num: u16,
     data_ptr: sql::Pointer,
     str_len_or_ind: sql::Len,
+    c_type: CDataType,
 ) -> OdbcResult<()> {
     let entry = ctx.pushed_data.get_mut(&param_num).ok_or_else(|| {
         crate::api::error::CountFieldIncorrectSnafu {
@@ -2196,13 +2233,34 @@ fn accumulate_put_data(
         .build()
     })?;
 
+    // HY020: cannot mix SQL_NULL_DATA with previously sent data chunks
+    if matches!(entry, ParamValue::Data(chunks) if !chunks.is_empty())
+        && str_len_or_ind == sql::NULL_DATA
+    {
+        return ConcatNullValueSnafu.fail();
+    }
+
     if str_len_or_ind == sql::NULL_DATA {
         *entry = ParamValue::Null;
         return Ok(());
     }
 
-    if data_ptr.is_null() {
-        return NullPointerSnafu.fail();
+    // HY020: cannot send data after SQL_NULL_DATA was already set
+    if matches!(entry, ParamValue::Null) {
+        return ConcatNullValueSnafu.fail();
+    }
+
+    // HY019: only character (SQL_C_CHAR, SQL_C_WCHAR) and binary (SQL_C_BINARY)
+    // types may be sent in multiple pieces. A second chunk for any other type
+    // is a spec violation.
+    if matches!(entry, ParamValue::Data(chunks) if !chunks.is_empty()) {
+        let splittable = matches!(
+            c_type,
+            CDataType::Char | CDataType::WChar | CDataType::Binary
+        );
+        if !splittable {
+            return NonCharBinarySentInPiecesSnafu.fail();
+        }
     }
 
     let len = if str_len_or_ind == sql::NTS {
@@ -2219,12 +2277,16 @@ fn accumulate_put_data(
         str_len_or_ind as usize
     };
 
+    if len == 0 {
+        return Ok(());
+    }
+
     let chunk = unsafe { std::slice::from_raw_parts(data_ptr as *const u8, len) }.to_vec();
 
     match entry {
         ParamValue::Pending => *entry = ParamValue::Data(vec![chunk]),
         ParamValue::Data(chunks) => chunks.push(chunk),
-        ParamValue::Null => *entry = ParamValue::Data(vec![chunk]),
+        ParamValue::Null => unreachable!("NULL case handled above"),
     }
     Ok(())
 }

--- a/odbc_tests/tests/odbc-api/submitting_request/param_data_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/param_data_tests.cpp
@@ -20,15 +20,13 @@
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution flow for single parameter",
                  "[odbc-api][paramdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -39,35 +37,33 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution 
   REQUIRE(valuePtr == reinterpret_cast<SQLPOINTER>(1));
 
   ret = SQLPutData(stmt_handle(), const_cast<char*>("hello"), 5);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLCHAR buf[64] = {};
   SQLLEN ind = 0;
   ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "hello");
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution flow for multiple parameters",
                  "[odbc-api][paramdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS v1, ? AS v2"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae1 = SQL_DATA_AT_EXEC, dae2 = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(100), 0, &dae1);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   ret = SQLBindParameter(stmt_handle(), 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(200), 0, &dae2);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -78,38 +74,36 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution 
   REQUIRE(ret == SQL_NEED_DATA);
   REQUIRE(valuePtr == reinterpret_cast<SQLPOINTER>(100));
   ret = SQLPutData(stmt_handle(), const_cast<char*>("first"), 5);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
   REQUIRE(ret == SQL_NEED_DATA);
   REQUIRE(valuePtr == reinterpret_cast<SQLPOINTER>(200));
   ret = SQLPutData(stmt_handle(), const_cast<char*>("second"), 6);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLCHAR b1[64] = {}, b2[64] = {};
   SQLLEN i1 = 0, i2 = 0;
   ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, b1, sizeof(b1), &i1);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   ret = SQLBindCol(stmt_handle(), 2, SQL_C_CHAR, b2, sizeof(b2), &i2);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(std::string(reinterpret_cast<char*>(b1)) == "first");
   REQUIRE(std::string(reinterpret_cast<char*>(b2)) == "second");
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution flow initiated by SQLExecDirect",
                  "[odbc-api][paramdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   SQLRETURN ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                                    reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecDirect(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
   REQUIRE(ret == SQL_NEED_DATA);
@@ -120,32 +114,30 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Drives data-at-execution 
   REQUIRE(valuePtr == reinterpret_cast<SQLPOINTER>(1));
 
   ret = SQLPutData(stmt_handle(), const_cast<char*>("direct"), 6);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLCHAR buf[64] = {};
   SQLLEN ind = 0;
   ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "direct");
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: Succeeds with NULL ValuePtrPtr",
                  "[odbc-api][paramdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -194,15 +186,13 @@ TEST_CASE_METHOD(StmtSessionSchemaFixture,
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: SQLCancel aborts data-at-execution and restores prepared state",
                  "[odbc-api][paramdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -212,15 +202,15 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: SQLCancel aborts data-at-
   REQUIRE(ret == SQL_NEED_DATA);
 
   ret = SQLCancel(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLINTEGER val = 42;
   SQLLEN ind = 0;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &val, 0, &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 }
 
 // ============================================================================
@@ -236,24 +226,20 @@ TEST_CASE("SQLParamData: SQL_INVALID_HANDLE for null statement handle",
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: HY010 without prior SQL_NEED_DATA",
                  "[odbc-api][paramdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLPOINTER vp = nullptr;
-  SQLRETURN ret = SQLParamData(stmt_handle(), &vp);
+  const SQLRETURN ret = SQLParamData(stmt_handle(), &vp);
   REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLParamData: HY010 when called consecutively without SQLPutData",
                  "[odbc-api][paramdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);

--- a/odbc_tests/tests/odbc-api/submitting_request/put_data_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/put_data_tests.cpp
@@ -18,15 +18,13 @@
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: Sends data in a single call",
                  "[odbc-api][putdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -36,32 +34,30 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: Sends data in a single call
   REQUIRE(ret == SQL_NEED_DATA);
 
   ret = SQLPutData(stmt_handle(), const_cast<char*>("hello"), 5);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLCHAR buf[64] = {};
   SQLLEN ind = 0;
   ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "hello");
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: Sends data in multiple chunks which are concatenated",
                  "[odbc-api][putdata][submitting_request]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 200, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -71,21 +67,129 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: Sends data in multiple chun
   REQUIRE(ret == SQL_NEED_DATA);
 
   ret = SQLPutData(stmt_handle(), const_cast<char*>("AAA"), 3);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   ret = SQLPutData(stmt_handle(), const_cast<char*>("BBB"), 3);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLParamData(stmt_handle(), &valuePtr);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLCHAR buf[64] = {};
   SQLLEN ind = 0;
   ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLFetch(stmt_handle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "AAABBB");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: SQL_NULL_DATA sets parameter to NULL",
+                 "[odbc-api][putdata][submitting_request]") {
+  SKIP_OLD_DRIVER("SNOW-3240517", "Reference driver does not propagate SQL_NULL_DATA indicator for DAE params");
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER valuePtr = nullptr;
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLPutData(stmt_handle(), nullptr, SQL_NULL_DATA);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLCHAR buf[64] = {};
+  SQLLEN ind = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(ind == SQL_NULL_DATA);
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: SQL_NTS sends null-terminated string",
+                 "[odbc-api][putdata][submitting_request]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER valuePtr = nullptr;
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLPutData(stmt_handle(), const_cast<char*>("nts_test"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLCHAR buf[64] = {};
+  SQLLEN ind = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "nts_test");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: SQL_C_BINARY data sent in multiple chunks",
+                 "[odbc-api][putdata][submitting_request]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 200, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER valuePtr = nullptr;
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  unsigned char chunk1[] = {0xDE, 0xAD};
+  unsigned char chunk2[] = {0xBE, 0xEF};
+  ret = SQLPutData(stmt_handle(), chunk1, sizeof(chunk1));
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  ret = SQLPutData(stmt_handle(), chunk2, sizeof(chunk2));
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLParamData(stmt_handle(), &valuePtr);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  unsigned char buf[64] = {};
+  SQLLEN ind = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_BINARY, buf, sizeof(buf), &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(ind == 4);
+  REQUIRE(buf[0] == 0xDE);
+  REQUIRE(buf[1] == 0xAD);
+  REQUIRE(buf[2] == 0xBE);
+  REQUIRE(buf[3] == 0xEF);
 }
 
 // ============================================================================
@@ -100,23 +204,19 @@ TEST_CASE("SQLPutData: SQL_INVALID_HANDLE for null statement handle",
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY010 without prior SQL_NEED_DATA",
                  "[odbc-api][putdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
-  const SQLRETURN ret = SQLPutData(stmt_handle(), const_cast<char*>("x"), 1);
+  SQLRETURN ret = SQLPutData(stmt_handle(), const_cast<char*>("x"), 1);
   REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 }
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY009 for null DataPtr with SQL_NTS",
                  "[odbc-api][putdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -133,15 +233,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY009 for null DataPtr with
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY090 for negative StrLen_or_Ind",
                  "[odbc-api][putdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -158,15 +256,13 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY090 for negative StrLen_o
 
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY019 for non-character data sent in pieces",
                  "[odbc-api][putdata][submitting_request][error]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   SQLLEN dae_ind = SQL_DATA_AT_EXEC;
   ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
                          reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   ret = SQLExecute(stmt_handle());
   REQUIRE(ret == SQL_NEED_DATA);
@@ -177,11 +273,155 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY019 for non-character dat
 
   SQLINTEGER val = 42;
   ret = SQLPutData(stmt_handle(), &val, sizeof(val));
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
 
   // Second PutData for non-char/binary type triggers HY019
   ret = SQLPutData(stmt_handle(), &val, sizeof(val));
   REQUIRE_EXPECTED_ERROR(ret, "HY019", stmt_handle(), SQL_HANDLE_STMT);
+
+  SQLCancel(stmt_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY020 for SQL_NULL_DATA after data chunk",
+                 "[odbc-api][putdata][submitting_request][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER vp = nullptr;
+  ret = SQLParamData(stmt_handle(), &vp);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLPutData(stmt_handle(), const_cast<char*>("abc"), 3);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  // Sending SQL_NULL_DATA after a data chunk triggers HY020.
+  // The unixODBC Driver Manager may intercept this call in state S10 and
+  // return HY011 before the driver sees it, so accept either SQLSTATE.
+  char dummy = '\0';
+  ret = SQLPutData(stmt_handle(), &dummy, SQL_NULL_DATA);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()),
+               OdbcMatchers::HasSqlState("HY020") || OdbcMatchers::HasSqlState("HY011"));
+
+  SQLCancel(stmt_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY020 for data after SQL_NULL_DATA",
+                 "[odbc-api][putdata][submitting_request][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER vp = nullptr;
+  ret = SQLParamData(stmt_handle(), &vp);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  ret = SQLPutData(stmt_handle(), nullptr, SQL_NULL_DATA);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  // Sending data after SQL_NULL_DATA triggers HY020
+  ret = SQLPutData(stmt_handle(), const_cast<char*>("abc"), 3);
+  REQUIRE_EXPECTED_ERROR(ret, "HY020", stmt_handle(), SQL_HANDLE_STMT);
+
+  SQLCancel(stmt_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: Error recovery preserves S9 state (retry after HY009)",
+                 "[odbc-api][putdata][submitting_request][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ? AS val"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER vp = nullptr;
+  ret = SQLParamData(stmt_handle(), &vp);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  // Trigger HY009 with null DataPtr and non-zero, non-NULL_DATA indicator
+  ret = SQLPutData(stmt_handle(), nullptr, SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+
+  // State S9 should be preserved — a valid PutData call should still work
+  ret = SQLPutData(stmt_handle(), const_cast<char*>("recovered"), 9);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLParamData(stmt_handle(), &vp);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLCHAR buf[64] = {};
+  SQLLEN ind = 0;
+  ret = SQLBindCol(stmt_handle(), 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLFetch(stmt_handle());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+  REQUIRE(std::string(reinterpret_cast<char*>(buf)) == "recovered");
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY010 in state S8 (before SQLParamData)",
+                 "[odbc-api][putdata][submitting_request][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  // S8: Execute returned NEED_DATA but SQLParamData has not been called yet.
+  // The unixODBC DM may intercept this as HY010 itself, so accept either.
+  ret = SQLPutData(stmt_handle(), const_cast<char*>("x"), 1);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::IsError());
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()),
+               OdbcMatchers::HasSqlState("HY010") || OdbcMatchers::HasSqlState("HY011"));
+
+  SQLCancel(stmt_handle());
+}
+
+TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY009 with null DataPtr and negative indicator",
+                 "[odbc-api][putdata][submitting_request][error]") {
+  SQLRETURN ret = SQLPrepare(stmt_handle(), sqlchar("SELECT ?"), SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  SQLLEN dae_ind = SQL_DATA_AT_EXEC;
+  ret = SQLBindParameter(stmt_handle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 100, 0,
+                         reinterpret_cast<SQLPOINTER>(1), 0, &dae_ind);
+  REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
+
+  ret = SQLExecute(stmt_handle());
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  SQLPOINTER vp = nullptr;
+  ret = SQLParamData(stmt_handle(), &vp);
+  REQUIRE(ret == SQL_NEED_DATA);
+
+  // null DataPtr with an arbitrary negative indicator (not SQL_NULL_DATA or SQL_NTS)
+  ret = SQLPutData(stmt_handle(), nullptr, -99);
+  REQUIRE_EXPECTED_ERROR(ret, "HY009", stmt_handle(), SQL_HANDLE_STMT);
 
   SQLCancel(stmt_handle());
 }


### PR DESCRIPTION
### TL;DR

Hardened `SQLPutData` input validation and ODBC state machine correctness, adding proper error handling for HY019, HY020, HY009, and HY090 conditions.

### What changed?

- Extracted a `put_data_inner` helper that centralizes all `SQLPutData` validation logic, making it structurally impossible to restore the wrong ODBC state (S9 vs S10) after a validation failure — the compiler enforces correctness rather than relying on manual flags.
- State S9 (`AwaitingPutData`) now returns to S9 on error, while S10 (`PutDataCalled`) stays in S10 regardless of success or error, matching the ODBC spec.
- Added HY019 enforcement: only `SQL_C_CHAR`, `SQL_C_WCHAR`, and `SQL_C_BINARY` types may be sent in multiple pieces; a second chunk for any other type now returns an error.
- Added HY020 enforcement: mixing `SQL_NULL_DATA` with previously sent data chunks (or sending data after `SQL_NULL_DATA`) now returns an error.
- Added HY009 enforcement: a null `DataPtr` with a non-zero, non-`SQL_NULL_DATA` indicator is now rejected.
- Added HY090 enforcement: a negative `StrLen_or_Ind` that is neither `SQL_NTS` nor `SQL_NULL_DATA` is now rejected.
- Added two new `OdbcError` variants (`NonCharBinarySentInPieces` and `ConcatNullValue`) mapped to their respective SQL states.
- `accumulate_put_data` now returns `OdbcResult<()>` and propagates errors instead of silently proceeding.
- Removed `SKIP_NEW_DRIVER_NOT_IMPLEMENTED()` guards from all `SQLParamData` and `SQLPutData` tests, marking these flows as fully implemented.

### How to test?

Run the existing and newly added C++ integration tests in `param_data_tests.cpp` and `put_data_tests.cpp`. New test cases cover:
- `SQL_NULL_DATA` setting a parameter to NULL
- `SQL_NTS` sending a null-terminated string
- `SQL_C_BINARY` data sent in multiple chunks
- HY020 for `SQL_NULL_DATA` after a data chunk and vice versa
- S9 state preservation after a validation error (retry after HY009)
- HY010 in state S8 before `SQLParamData` is called
- HY009 with a null `DataPtr` and a negative indicator

### Why make this change?

The previous implementation did not validate `SQLPutData` inputs or enforce ODBC state transitions correctly. Errors during `put_data` left the statement in an inconsistent state, and spec-required error conditions (HY019, HY020, HY009, HY090) were silently ignored. This change brings the driver into full compliance with the ODBC specification for data-at-execution parameter handling.