### PR TITLE
NO-SNOW: Macro for verifying invalid handles safely

### DIFF
--- a/odbc_tests/common/include/odbc_matchers.hpp
+++ b/odbc_tests/common/include/odbc_matchers.hpp
@@ -4,9 +4,21 @@
 #include <sql.h>
 #include <sqlext.h>
 
+#include <cerrno>
+#include <csetjmp>
+#include <csignal>
+#include <cstring>
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_tostring.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 
@@ -43,6 +55,100 @@ struct StringMaker<OdbcResult> {
   }
 };
 }  // namespace Catch
+
+// ---------------------------------------------------------------------------
+// InvalidHandleProbe — result of a crash-isolated SQLFreeHandle call.
+// Used to verify that an ODBC handle has been invalidated without crashing
+// the test runner if the Driver Manager dereferences freed memory.
+// ---------------------------------------------------------------------------
+struct InvalidHandleProbe {
+  bool crashed = false;
+  SQLRETURN returnCode = SQL_SUCCESS;
+};
+
+namespace Catch {
+template <>
+struct StringMaker<InvalidHandleProbe> {
+  static std::string convert(const InvalidHandleProbe& probe) {
+    if (probe.crashed) return "handle access caused crash (SIGSEGV/access violation)";
+    return "SQLFreeHandle returned " + return_code_to_string(probe.returnCode);
+  }
+};
+}  // namespace Catch
+
+// ---------------------------------------------------------------------------
+// probe_invalid_handle — crash-isolated SQLFreeHandle probe.
+//
+// Per the ODBC spec, using a freed handle is undefined behavior: some Driver
+// Managers return SQL_INVALID_HANDLE while others let the driver dereference
+// freed memory.  Both outcomes prove the handle is no longer valid.
+//
+// Platform strategies:
+//   MSVC:          SEH __try/__except  (scoped, compiler-native)
+//   MinGW/non-MSVC Windows: signal(SIGSEGV) + setjmp/longjmp  (MSVCRT translates
+//                           EXCEPTION_ACCESS_VIOLATION → SIGSEGV)
+//   POSIX:         fork() child process  (full address-space isolation)
+// ---------------------------------------------------------------------------
+#if defined(_WIN32) && defined(_MSC_VER)
+
+inline InvalidHandleProbe probe_invalid_handle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+  InvalidHandleProbe probe;
+  __try {
+    probe.returnCode = SQLFreeHandle(handle_type, handle);
+  } __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER
+                                                               : EXCEPTION_CONTINUE_SEARCH) {
+    probe.crashed = true;
+  }
+  return probe;
+}
+
+#elif defined(_WIN32)
+
+inline InvalidHandleProbe probe_invalid_handle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+  static thread_local std::jmp_buf rih_jmp_buf;
+  auto prev_handler = std::signal(SIGSEGV, [](int) { std::longjmp(rih_jmp_buf, 1); });
+
+  InvalidHandleProbe probe;
+  if (setjmp(rih_jmp_buf) == 0) {
+    probe.returnCode = SQLFreeHandle(handle_type, handle);
+  } else {
+    probe.crashed = true;
+  }
+
+  std::signal(SIGSEGV, prev_handler);
+  return probe;
+}
+
+#else
+
+inline InvalidHandleProbe probe_invalid_handle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    FAIL("fork() failed: " << std::strerror(errno));
+  }
+  if (pid == 0) {
+    SQLRETURN r = SQLFreeHandle(handle_type, handle);
+    _exit(r == SQL_INVALID_HANDLE ? 0 : 1);
+  }
+
+  int status = 0;
+  while (waitpid(pid, &status, 0) == -1) {
+    if (errno != EINTR) {
+      FAIL("waitpid() failed: " << std::strerror(errno));
+    }
+  }
+
+  InvalidHandleProbe probe;
+  probe.crashed = WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS);
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+    probe.returnCode = SQL_INVALID_HANDLE;
+  } else if (!probe.crashed) {
+    probe.returnCode = SQL_SUCCESS;
+  }
+  return probe;
+}
+
+#endif
 
 namespace OdbcMatchers {
 
@@ -136,6 +242,16 @@ class HasDiagMessage : public Catch::Matchers::MatcherBase<OdbcResult> {
   std::string describe() const override { return "has diagnostic message containing \"" + substring_ + "\""; }
 };
 
+// Matches when a handle probe shows the handle is invalid (either the DM
+// returned SQL_INVALID_HANDLE or the call crashed with an access violation).
+class IsHandleInvalid : public Catch::Matchers::MatcherBase<InvalidHandleProbe> {
+ public:
+  bool match(const InvalidHandleProbe& probe) const override {
+    return probe.crashed || probe.returnCode == SQL_INVALID_HANDLE;
+  }
+  std::string describe() const override { return "handle is invalid (SQL_INVALID_HANDLE or access violation)"; }
+};
+
 }  // namespace OdbcMatchers
 
 // ---------------------------------------------------------------------------
@@ -170,5 +286,9 @@ class HasDiagMessage : public Catch::Matchers::MatcherBase<OdbcResult> {
 #define REQUIRE_EXPECTED_WARNING(ret, expectedState, handle, handleType) \
   REQUIRE_THAT(OdbcResult(ret, handleType, handle),                      \
                OdbcMatchers::IsSuccessWithInfo() && OdbcMatchers::HasSqlState(expectedState))
+
+// Asserts that an ODBC handle has been invalidated (crash or SQL_INVALID_HANDLE).
+#define REQUIRE_INVALID_HANDLE(handle_type, handle) \
+  REQUIRE_THAT(probe_invalid_handle(handle_type, handle), OdbcMatchers::IsHandleInvalid())
 
 #endif  // ODBC_MATCHERS_HPP

--- a/odbc_tests/tests/odbc-api/submitting_request/put_data_tests.cpp
+++ b/odbc_tests/tests/odbc-api/submitting_request/put_data_tests.cpp
@@ -8,7 +8,6 @@
 
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
@@ -103,7 +102,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLPutData: HY010 without prior SQL_NEE
                  "[odbc-api][putdata][submitting_request][error]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-  SQLRETURN ret = SQLPutData(stmt_handle(), const_cast<char*>("x"), 1);
+  const SQLRETURN ret = SQLPutData(stmt_handle(), const_cast<char*>("x"), 1);
   REQUIRE_EXPECTED_ERROR(ret, "HY010", stmt_handle(), SQL_HANDLE_STMT);
 }
 

--- a/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/disconnect_tests.cpp
@@ -8,9 +8,8 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "test_macros.hpp"
+#include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
 // ============================================================================
@@ -97,14 +96,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Closes open statements au
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  // Verify the statement is no longer usable by trying to allocate a new one.
-  // After disconnect, the DBC is in a disconnected state and cannot allocate
-  // new statements (08003: Connection not open).
-  // Note: We do NOT use the old `stmt` handle after disconnect as that is
-  // undefined and segfaults on some platforms.
-  SQLHSTMT new_stmt = SQL_NULL_HSTMT;
-  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &new_stmt);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt);
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Handles active transactions",
@@ -160,8 +152,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With active result sets",
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt);
 }
 
 // ============================================================================
@@ -232,14 +223,9 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: With multiple statement h
   ret = SQLDisconnect(dbc_handle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt1, sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
-
-  ret = SQLExecDirect(stmt2, sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
-
-  ret = SQLExecDirect(stmt3, sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt1);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt2);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt3);
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLDisconnect: Preserves connection handle for reuse",

--- a/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_connection/free_handle_tests.cpp
@@ -8,9 +8,8 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "compatibility.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
-#include "test_macros.hpp"
+#include "odbc_matchers.hpp"
 #include "test_setup.hpp"
 
 // ============================================================================
@@ -75,8 +74,7 @@ TEST_CASE("SQLFreeHandle: Double free environment handle", "[odbc-api][freehandl
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_ENV, env);
 }
 
 // ============================================================================
@@ -142,16 +140,45 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Can free disconnected con
   release_dbc();
 }
 
-// SQLFreeHandle: Frees dependent statement handles when connection handle is freed
-// Note: Reference driver should free the statement handle and it shouldn't be
-// reusable after. Attempeting to use this handle is undefined behavior and SEGFAULTs
-// on some platforms.
-// Skipping test case to prevent SEGFAULT
+TEST_CASE_METHOD(DbcDefaultDSNFixture,
+                 "SQLFreeHandle: Frees dependent statement handles when connection handle is freed",
+                 "[odbc-api][freehandle][terminating_connection]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
-// SQLFreeHandle: Double free connection handle
-// Note: Reference driver crashes on double-free of connection handle
-// This is undefined behavior that must be avoided.
-// Skipping test case to prevent crash
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+  ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc_handle(), &stmt);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+  release_dbc();
+
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt);
+}
+
+TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Double free connection handle",
+                 "[odbc-api][freehandle][terminating_connection][error]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLDisconnect(dbc_handle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLHDBC dbc = dbc_handle();
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+  REQUIRE(ret == SQL_SUCCESS);
+  release_dbc();
+
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_DBC, dbc);
+}
 
 // ============================================================================
 // SQLFreeHandle - Statement Handle
@@ -292,11 +319,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeHandle: Double free statement han
   ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
   REQUIRE(ret == SQL_SUCCESS);
 
-  // Note: Using a freed handle is undefined behavior per ODBC spec. The reference
-  // driver returns SQL_INVALID_HANDLE for statement handles but crashes for
-  // connection handles.
-  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt);
 
   SQLDisconnect(dbc_handle());
 }

--- a/odbc_tests/tests/odbc-api/terminating_statement/free_stmt_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/free_stmt_tests.cpp
@@ -7,7 +7,9 @@
 #include "ODBCConfig.hpp"
 #include "ODBCFixtures.hpp"
 #include "SessionParameterOverride.hpp"
+#include "compatibility.hpp"
 #include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
 #include "test_macros.hpp"
 #include "test_setup.hpp"
 
@@ -903,11 +905,7 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLFreeStmt: SQL_DROP frees statement ha
   ret = SQLFreeStmt(stmt, SQL_DROP);
   REQUIRE(ret == SQL_SUCCESS);
 
-  // Note: Using a freed handle is undefined behavior per ODBC spec. The reference
-  // driver returns SQL_INVALID_HANDLE for statement handles but crashes for
-  // connection handles.
-  ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-  REQUIRE(ret == SQL_INVALID_HANDLE);
+  REQUIRE_INVALID_HANDLE(SQL_HANDLE_STMT, stmt);
 
   SQLDisconnect(dbc_handle());
 }


### PR DESCRIPTION
### TL;DR

Introduces crash-isolated handle validation via a new `REQUIRE_INVALID_HANDLE` macro, replacing unsafe direct calls to freed ODBC handles in tests.

### What changed?

A new `probe_invalid_handle` function and `IsHandleInvalid` matcher were added to `odbc_matchers.hpp` to safely verify that an ODBC handle has been invalidated after being freed. Because the ODBC spec treats use of a freed handle as undefined behavior — some Driver Managers return `SQL_INVALID_HANDLE` while others dereference freed memory and crash — the probe uses platform-specific isolation strategies:

- **MSVC (Windows):** Structured Exception Handling (`__try`/`__except`) to catch `EXCEPTION_ACCESS_VIOLATION`
- **MinGW/non-MSVC Windows:** `signal(SIGSEGV)` + `setjmp`/`longjmp`
- **POSIX:** `fork()` to run the probe in a child process with full address-space isolation

A `REQUIRE_INVALID_HANDLE(handle_type, handle)` macro wraps the probe and matcher together for use in tests.

Previously skipped or commented-out test cases for double-freeing connection handles and freeing dependent statement handles are now re-enabled using this safe probing mechanism. Direct post-free calls to `SQLFreeHandle`, `SQLExecDirect`, and similar functions on freed handles have been replaced with `REQUIRE_INVALID_HANDLE` throughout the disconnect and free-handle test suites.

### How to test?

Run the existing ODBC test suite, particularly the tests in:
- `terminating_connection/disconnect_tests.cpp`
- `terminating_connection/free_handle_tests.cpp`
- `terminating_statement/free_stmt_tests.cpp`

The previously skipped double-free and dependent-handle tests should now execute and pass without crashing the test runner on any supported platform.

### Why make this change?

Directly calling ODBC functions on freed handles is undefined behavior and was causing segfaults on certain platforms, forcing some tests to be skipped or replaced with indirect workarounds. The new crash-isolated probe allows the test suite to assert correct handle invalidation behavior robustly across all supported platforms (Windows MSVC, Windows MinGW, and POSIX) without risking test runner crashes.