### PR TITLE
Drop Python 3.9 from CI test matrix

### DIFF
--- a/.buildkite/pipelines/ci-tests/pipeline.yml
+++ b/.buildkite/pipelines/ci-tests/pipeline.yml
@@ -154,15 +154,15 @@ steps:
 
               echo "--- :hammer: Building Python Wheel"
               RUSTFLAGS="" hatch build -t wheel
-              hatch run test-pandas.py3.9:install-wheel
+              hatch run test-pandas.py3.10:install-wheel
 
               echo "--- :test_tube: Running Integ + E2E Tests"
               mkdir -p /workdir/junit-results
               set +e
               if [ "$$TEST_FILTER" = "ALL" ]; then
-                hatch run test-pandas.py3.9:all -- tests/integ/ tests/e2e/ -v --timeout=900 --junitxml=/workdir/junit-results/python-junit.xml
+                hatch run test-pandas.py3.10:all -- tests/integ/ tests/e2e/ -v --timeout=900 --junitxml=/workdir/junit-results/python-junit.xml
               else
-                hatch run test-pandas.py3.9:all -- $$TEST_FILTER -v --timeout=900 --junitxml=/workdir/junit-results/python-junit.xml
+                hatch run test-pandas.py3.10:all -- $$TEST_FILTER -v --timeout=900 --junitxml=/workdir/junit-results/python-junit.xml
               fi
               exit $$?
             ' || DOCKER_EXIT=$$?

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -126,14 +126,14 @@ jobs:
       # or python_tests_reference. If you add a new test cell, add a matching build entry.
       #
       # Excluded combinations and why:
-      #   - ubuntu × 3.10, 3.11, 3.12 : not exercised by python_tests
-      #   - windows-11-arm × 3.9, 3.10, 3.14 : no native ARM64 Windows builds in uv
+      #   - ubuntu × 3.11, 3.12 : not exercised by python_tests
+      #   - windows-11-arm × 3.10, 3.14 : no native ARM64 Windows builds in uv
       #     (revisit 3.14 once https://github.com/astral-sh/uv/releases ships ARM64 builds)
       #   - windows-11-arm × 3.13 : not exercised by python_tests
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.9"
+            py: "3.10"
           - os: ubuntu-latest
             py: "3.13"  # Reference combination consumed by python_tests_reference
           - os: ubuntu-latest
@@ -348,7 +348,7 @@ jobs:
             hatch_env: "test"
             cloud_provider: gcp
           - os: ubuntu-latest
-            py: "3.9"
+            py: "3.10"
             hatch_env: "test"
             cloud_provider: azure
           - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
@@ -369,7 +369,7 @@ jobs:
             cloud_provider: azure
           # test integration with Pandas
           - os: ubuntu-latest
-            py: "3.9"
+            py: "3.10"
             hatch_env: "test-pandas"
             cloud_provider: gcp
           - os: ubuntu-latest # Reference combination for Pandas integration — keep in sync with REFERENCE_* env vars above


### PR DESCRIPTION
## Summary
- Python 3.9 reached end-of-life in October 2025
- Replace 3.9 test entries with 3.10 in build_wheel, python_tests, and test-pandas matrices
- Update excluded-combinations comment to remove 3.9 reference

**Stack: 1/3** — next: `pczajka/reusable-wheel-build`

* this PR
* #917 
* #918 

## Test plan
- [ ] CI passes with 3.10 in place of 3.9
- [ ] No remaining references to Python 3.9 in test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)