### PR TITLE
Add Python release build workflow

### DIFF
--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -7,7 +7,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   PYTHON_REFERENCE_DRIVER_VERSION: "4.3.0"
-  SDIST_PYTHON_VERSION: "3.13"
 
 jobs:
   # ── Build wheels (shared reusable workflow) ────────────────────────
@@ -16,20 +15,27 @@ jobs:
     with:
       targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"]}'
 
-  # ── Test wheels against cloud providers ────────────────────────────
-  test_wheels:
+  # ── Test wheels and sdist against cloud providers ───────────────────
+  # Each Python version tested once per env, cloud providers distributed evenly.
+  # Python 3.10 tests from sdist (builds sf_core from source), others from wheels.
+  test:
     needs: build_wheels
     strategy:
       fail-fast: false
       matrix:
-        py: ["3.11", "3.12", "3.13", "3.14"]
-        hatch_env: ["test", "test-pandas"]
-        cloud_provider: ["aws", "gcp", "azure"]
-        exclude:
-          - hatch_env: "test-pandas"
-            cloud_provider: "gcp"
-          - hatch_env: "test-pandas"
-            cloud_provider: "azure"
+        include:
+          # test env — cloud providers rotated across versions
+          - { py: "3.10", hatch_env: "test",        cloud_provider: "aws"   }
+          - { py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
+          - { py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
+          - { py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
+          # test-pandas env
+          - { py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
     runs-on: ubuntu-latest
     name: test (${{ matrix.hatch_env }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:
@@ -56,10 +62,27 @@ jobs:
         run: uv python install ${{ matrix.py }}
 
       - name: Download wheel
+        if: matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
           name: manylinux_x86_64_py${{ matrix.py }}
           path: python/dist
+
+      - name: Download sdist
+        if: matrix.py == '3.10'
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdist
+          path: python/dist
+
+      # sdist installs build sf_core from source, so Rust is needed
+      - name: Restore Rust cache (sdist)
+        if: matrix.py == '3.10'
+        id: rust-cache
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: sdist-test
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
@@ -70,12 +93,30 @@ jobs:
         run: uv tool install hatch --with "virtualenv<21.0.0"
 
       - name: Install snowflake ud driver from wheel
+        if: matrix.py != '3.10'
         working-directory: python
         run: |
-          PY_TAG="cp$(echo '${{ matrix.py }}' | tr -d '.')"
-          export WHEEL_PATH="$(ls dist/*-${PY_TAG}-*.whl | head -1)"
+          WHEELS=(dist/*.whl)
+          if [[ ${#WHEELS[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly 1 wheel, found ${#WHEELS[@]}"; ls -la dist/; exit 1
+          fi
+          export WHEEL_PATH="${WHEELS[0]}"
           echo "Installing wheel: $WHEEL_PATH"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+
+      - name: Install snowflake ud driver from sdist
+        if: matrix.py == '3.10'
+        working-directory: python
+        run: |
+          SDISTS=(dist/*.tar.gz)
+          if [[ ${#SDISTS[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly 1 sdist, found ${#SDISTS[@]}"; ls -la dist/; exit 1
+          fi
+          export WHEEL_PATH="${SDISTS[0]}"
+          echo "Installing sdist: $WHEEL_PATH"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+        env:
+          SKIP_CORE_BUILD: "false"
 
       - name: Run tests
         working-directory: python
@@ -86,70 +127,18 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
-  # ── Test sdist (aws, with and without pandas) ──────────────────────
-  # sdist is built by the reusable _build-python-wheels.yml workflow
-  test_sdist:
-    needs: build_wheels
-    strategy:
-      fail-fast: false
-      matrix:
-        hatch_env: ["test", "test-pandas"]
-    runs-on: ubuntu-latest
-    name: test_sdist (${{ matrix.hatch_env }})
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
+      - name: Save Rust cache (sdist)
+        if: always() && matrix.py == '3.10'
+        uses: ./.github/actions/cargo-cache
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.1
-        with:
-          version: "0.9.28"
-
-      - name: Set up Python ${{ env.SDIST_PYTHON_VERSION }}
-        run: uv python install ${{ env.SDIST_PYTHON_VERSION }}
-
-      - name: Download sdist
-        uses: actions/download-artifact@v4
-        with:
-          name: python-sdist
-          path: python/dist
-
-      - name: Decode secrets
-        run: ./scripts/decode_secrets.sh aws
-        env:
-          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
-
-      - name: Install Hatch
-        run: uv tool install hatch --with "virtualenv<21.0.0"
-
-      - name: Install snowflake ud driver from sdist
-        working-directory: python
-        run: hatch run ${{ matrix.hatch_env }}.py${{ env.SDIST_PYTHON_VERSION }}:install-wheel
-        env:
-          WHEEL_PATH: dist/*.tar.gz
-          SKIP_CORE_BUILD: "false"
-
-      - name: Run tests
-        working-directory: python
-        run: |
-          hatch run ${{ matrix.hatch_env }}.py${{ env.SDIST_PYTHON_VERSION }}:cov \
-            --junitxml=reports/sdist-${{ matrix.hatch_env }}.xml
-        env:
-          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
-          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
+          mode: save
+          shared-key: sdist-test
+          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
   # ── Clean up intermediate artifacts ────────────────────────────────
   cleanup:
-    needs: [build_wheels, test_wheels]
+    needs: [build_wheels, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -166,7 +155,7 @@ jobs:
 
   # ── Status gate ────────────────────────────────────────────────────
   release_status:
-    needs: [build_wheels, test_wheels, test_sdist]
+    needs: [build_wheels, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -175,16 +164,13 @@ jobs:
           echo "=== Python Release Build Status ==="
 
           if [[ "${{ needs.build_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.test_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.test_sdist.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "FAILED"
             echo "  build_wheels: ${{ needs.build_wheels.result }}"
-            echo "  test_wheels:  ${{ needs.test_wheels.result }}"
-            echo "  test_sdist:   ${{ needs.test_sdist.result }}"
+            echo "  test:         ${{ needs.test.result }}"
             exit 1
           fi
 
           echo "PASSED"
           echo "  build_wheels: ${{ needs.build_wheels.result }}"
-          echo "  test_wheels:  ${{ needs.test_wheels.result }}"
-          echo "  test_sdist:   ${{ needs.test_sdist.result }}"
+          echo "  test:         ${{ needs.test.result }}"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -54,10 +54,10 @@ jobs:
       - name: Set up Python ${{ matrix.py }}
         run: uv python install ${{ matrix.py }}
 
-      - name: Download wheels
+      - name: Download wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheels-linux-x86_64
+          name: manylinux_x86_64_py${{ matrix.py }}
           path: python/dist
 
       - name: Decode secrets

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -39,6 +39,8 @@ jobs:
           # Windows ARM64
           - { os: windows-11-arm,  py: "3.11", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-11-arm,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: windows-11-arm,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: windows-11-arm,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.hatch_env }}, ${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -13,7 +13,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.10","3.11","3.12","3.13","3.14"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"]}'
 
   # ── Test wheels against cloud providers ────────────────────────────
   test_wheels:
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        py: ["3.11", "3.12", "3.13", "3.14"]
         hatch_env: ["test", "test-pandas"]
         cloud_provider: ["aws", "gcp", "azure"]
         exclude:
@@ -85,61 +85,10 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
-  # ── Build sdist ────────────────────────────────────────────────────
-  build_sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache proto generator target
-        uses: actions/cache@v5
-        with:
-          path: proto-target
-          key: ${{ runner.os }}-proto-target-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-proto-target-
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.1
-        with:
-          version: "0.9.28"
-
-      - name: Set up Python
-        run: uv python install ${{ env.SDIST_PYTHON_VERSION }}
-
-      - name: Build sdist
-        working-directory: ./python
-        run: >
-          uv run --python ${{ env.SDIST_PYTHON_VERSION }}
-          --with hatch --with cython --with setuptools --with "virtualenv<21.0.0"
-          hatch build --target sdist
-        env:
-          PROTO_CARGO_TARGET_DIR: ${{ github.workspace }}/proto-target
-
-      - name: Inspect sdist
-        working-directory: ./python
-        run: tar tzf dist/*.tar.gz | head -40
-
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-sdist
-          path: python/dist/*.tar.gz
-
   # ── Test sdist (aws, with and without pandas) ──────────────────────
+  # sdist is built by the reusable _build-python-wheels.yml workflow
   test_sdist:
-    needs: build_sdist
+    needs: build_wheels
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +165,7 @@ jobs:
 
   # ── Status gate ────────────────────────────────────────────────────
   release_status:
-    needs: [build_wheels, test_wheels, build_sdist, test_sdist]
+    needs: [build_wheels, test_wheels, test_sdist]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -226,12 +175,10 @@ jobs:
 
           if [[ "${{ needs.build_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.build_sdist.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test_sdist.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "FAILED"
             echo "  build_wheels: ${{ needs.build_wheels.result }}"
             echo "  test_wheels:  ${{ needs.test_wheels.result }}"
-            echo "  build_sdist:  ${{ needs.build_sdist.result }}"
             echo "  test_sdist:   ${{ needs.test_sdist.result }}"
             exit 1
           fi
@@ -239,5 +186,4 @@ jobs:
           echo "PASSED"
           echo "  build_wheels: ${{ needs.build_wheels.result }}"
           echo "  test_wheels:  ${{ needs.test_wheels.result }}"
-          echo "  build_sdist:  ${{ needs.build_sdist.result }}"
           echo "  test_sdist:   ${{ needs.test_sdist.result }}"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -1,6 +1,7 @@
 name: Python Release Build
 
 on:
+  push:  # DEBUG: remove before merge
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -13,7 +13,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # ── Test wheels and sdist against cloud providers ───────────────────
   # Each Python version tested once per env, cloud providers distributed evenly.
@@ -24,24 +24,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # test env — cloud providers rotated across versions
-          - { py: "3.10", hatch_env: "test",        cloud_provider: "aws"   }
-          - { py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
-          - { py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
-          - { py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
-          - { py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
-          # test-pandas env
-          - { py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
-          - { py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws"   }
-          - { py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
-          - { py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
-          - { py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
-    runs-on: ubuntu-latest
-    name: test (${{ matrix.hatch_env }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
+          # Linux — test env, cloud providers rotated across versions
+          - { os: ubuntu-latest,   py: "3.10", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: ubuntu-latest,   py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: ubuntu-latest,   py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: ubuntu-latest,   py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: ubuntu-latest,   py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
+          # Linux — test-pandas env
+          - { os: ubuntu-latest,   py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: ubuntu-latest,   py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: ubuntu-latest,   py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: ubuntu-latest,   py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: ubuntu-latest,   py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          # Windows ARM64
+          - { os: windows-11-arm,  py: "3.11", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: windows-11-arm,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
+    runs-on: ${{ matrix.os }}
+    name: test (${{ matrix.hatch_env }}, ${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:
-      MATRIX_KEY: ${{ matrix.py }}-${{ matrix.hatch_env }}-${{ matrix.cloud_provider }}
-      UV_CACHE_DIR: /tmp/.uv-cache
+      MATRIX_KEY: ${{ matrix.os }}-${{ matrix.py }}-${{ matrix.hatch_env }}-${{ matrix.cloud_provider }}
     steps:
+      - name: Set UV cache dir
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "UV_CACHE_DIR=$RUNNER_TEMP/.uv-cache" >> $GITHUB_ENV
+          else
+            echo "UV_CACHE_DIR=/tmp/.uv-cache" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Install uv
@@ -52,20 +63,27 @@ jobs:
       - name: Restore uv cache
         uses: actions/cache@v5
         with:
-          path: /tmp/.uv-cache
+          path: ${{ env.UV_CACHE_DIR }}
           key: uv-${{ env.MATRIX_KEY }}-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
           restore-keys: |
             uv-${{ env.MATRIX_KEY }}-
-            uv-${{ matrix.py }}-
+            uv-${{ matrix.os }}-${{ matrix.py }}-
 
       - name: Set up Python ${{ matrix.py }}
-        run: uv python install ${{ matrix.py }}
+        run: uv python install ${{ matrix.os == 'windows-11-arm' && format('cpython-{0}-windows-aarch64-none', matrix.py) || matrix.py }}
 
-      - name: Download wheel
-        if: matrix.py != '3.10'
+      - name: Download wheel (Linux)
+        if: runner.os == 'Linux' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
           name: manylinux_x86_64_py${{ matrix.py }}
+          path: python/dist
+
+      - name: Download wheel (Windows ARM64)
+        if: runner.os == 'Windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: win_arm64_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist
@@ -88,12 +106,50 @@ jobs:
         run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      # ── Windows ARM64 OpenSSL (needed by cryptography dependency) ──
+      - name: Capture vcpkg version for cache key (Windows ARM64)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/vcpkg-version
+
+      - name: Restore vcpkg ARM64 static OpenSSL cache (Windows ARM64)
+        if: runner.os == 'Windows'
+        id: vcpkg-cache-test
+        uses: actions/cache/restore@v5
+        with:
+          path: C:\vcpkg\installed\arm64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Install ARM64 OpenSSL (static) via vcpkg
+        if: runner.os == 'Windows' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          vcpkg install openssl:arm64-windows-static-md
+
+      - name: Save vcpkg ARM64 static OpenSSL cache (Windows ARM64)
+        if: runner.os == 'Windows' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: C:\vcpkg\installed\arm64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Configure ARM64 build environment
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows-static-md\lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          echo "RUSTFLAGS=-C linker=rust-lld" >> $env:GITHUB_ENV
+          echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
       - name: Install Hatch
         run: uv tool install hatch --with "virtualenv<21.0.0"
 
-      - name: Install snowflake ud driver from wheel
-        if: matrix.py != '3.10'
+      - name: Install snowflake ud driver from wheel (Linux)
+        if: runner.os == 'Linux' && matrix.py != '3.10'
         working-directory: python
         run: |
           WHEELS=(dist/*.whl)
@@ -102,6 +158,18 @@ jobs:
           fi
           export WHEEL_PATH="${WHEELS[0]}"
           echo "Installing wheel: $WHEEL_PATH"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+
+      - name: Install snowflake ud driver from wheel (Windows)
+        if: runner.os == 'Windows'
+        working-directory: python
+        shell: pwsh
+        run: |
+          $wheels = @(Get-ChildItem dist/*.whl)
+          if ($wheels.Count -ne 1) {
+            Write-Error "Expected exactly 1 wheel, found $($wheels.Count)"; Get-ChildItem dist/; exit 1
+          }
+          $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
       - name: Install snowflake ud driver from sdist
@@ -118,13 +186,25 @@ jobs:
         env:
           SKIP_CORE_BUILD: "false"
 
-      - name: Run tests
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
         working-directory: python
         run: |
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov \
             --junitxml=reports/release-${{ env.MATRIX_KEY }}.xml
         env:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        working-directory: python
+        shell: pwsh
+        run: |
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov `
+            --junitxml=reports/release-${{ env.MATRIX_KEY }}.xml
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
       - name: Save Rust cache (sdist)
@@ -136,9 +216,54 @@ jobs:
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
+  # ── Reference driver compatibility check ──────────────────────────
+  test_reference:
+    needs: build_wheels
+    strategy:
+      fail-fast: false
+      matrix:
+        hatch_env: ["reference", "reference-pandas"]
+    runs-on: ubuntu-latest
+    name: test_reference (${{ matrix.hatch_env }})
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.2.1
+        with:
+          version: "0.9.28"
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: manylinux_x86_64_py3.13
+          path: python/dist
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh aws
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+
+      - name: Install Hatch
+        run: uv tool install hatch --with "virtualenv<21.0.0"
+
+      - name: Run reference integration tests
+        working-directory: python
+        run: |
+          mkdir -p reports
+          hatch run ${{ matrix.hatch_env }}:test \
+            --junitxml=reports/reference-${{ matrix.hatch_env }}.xml
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+
   # ── Clean up intermediate artifacts ────────────────────────────────
   cleanup:
-    needs: [build_wheels, test]
+    needs: [build_wheels, test, test_reference]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -155,7 +280,7 @@ jobs:
 
   # ── Status gate ────────────────────────────────────────────────────
   release_status:
-    needs: [build_wheels, test]
+    needs: [build_wheels, test, test_reference]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -164,13 +289,16 @@ jobs:
           echo "=== Python Release Build Status ==="
 
           if [[ "${{ needs.build_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test_reference.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "FAILED"
-            echo "  build_wheels: ${{ needs.build_wheels.result }}"
-            echo "  test:         ${{ needs.test.result }}"
+            echo "  build_wheels:    ${{ needs.build_wheels.result }}"
+            echo "  test:            ${{ needs.test.result }}"
+            echo "  test_reference:  ${{ needs.test_reference.result }}"
             exit 1
           fi
 
           echo "PASSED"
-          echo "  build_wheels: ${{ needs.build_wheels.result }}"
-          echo "  test:         ${{ needs.test.result }}"
+          echo "  build_wheels:    ${{ needs.build_wheels.result }}"
+          echo "  test:            ${{ needs.test.result }}"
+          echo "  test_reference:  ${{ needs.test_reference.result }}"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -36,11 +36,9 @@ jobs:
           - { os: ubuntu-latest,   py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: ubuntu-latest,   py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-latest,   py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
-          # Windows ARM64
+          # Windows ARM64 (no test-pandas — pyarrow has no win_arm64 wheel)
           - { os: windows-11-arm,  py: "3.11", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-11-arm,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
-          - { os: windows-11-arm,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
-          - { os: windows-11-arm,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.hatch_env }}, ${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
     env:

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -1,0 +1,251 @@
+name: Python Release Build
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  PYTHON_REFERENCE_DRIVER_VERSION: "4.3.0"
+  SDIST_PYTHON_VERSION: "3.13"
+
+jobs:
+  # ── Build wheels (shared reusable workflow) ────────────────────────
+  build_wheels:
+    uses: ./.github/workflows/_build-python-wheels.yml
+    with:
+      sf-core-matrix: >-
+        [{"target":"linux-x86_64","os":"ubuntu-latest",
+          "container":"quay.io/pypa/manylinux_2_28_x86_64",
+          "lib_name":"libsf_core.so",
+          "cargo_extra_args":"--features vendored-openssl"}]
+      cibw-matrix: >-
+        [{"target":"linux-x86_64","os":"ubuntu-latest",
+          "cibw_build":"cp3{10,11,12,13,14}-manylinux_x86_64",
+          "sf_core_artifact":"sf-core-linux-x86_64"}]
+
+  # ── Test wheels against cloud providers ────────────────────────────
+  test_wheels:
+    needs: build_wheels
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        hatch_env: ["test", "test-pandas"]
+        cloud_provider: ["aws", "gcp", "azure"]
+        exclude:
+          - hatch_env: "test-pandas"
+            cloud_provider: "gcp"
+          - hatch_env: "test-pandas"
+            cloud_provider: "azure"
+    runs-on: ubuntu-latest
+    name: test (${{ matrix.hatch_env }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }})
+    env:
+      MATRIX_KEY: ${{ matrix.py }}-${{ matrix.hatch_env }}-${{ matrix.cloud_provider }}
+      UV_CACHE_DIR: /tmp/.uv-cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.2.1
+        with:
+          version: "0.9.28"
+
+      - name: Restore uv cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.uv-cache
+          key: uv-${{ env.MATRIX_KEY }}-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
+          restore-keys: |
+            uv-${{ env.MATRIX_KEY }}-
+            uv-${{ matrix.py }}-
+
+      - name: Set up Python ${{ matrix.py }}
+        run: uv python install ${{ matrix.py }}
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheels-linux-x86_64
+          path: python/dist
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+
+      - name: Install Hatch
+        run: uv tool install hatch --with "virtualenv<21.0.0"
+
+      - name: Install snowflake ud driver from wheel
+        working-directory: python
+        run: |
+          PY_TAG="cp$(echo '${{ matrix.py }}' | tr -d '.')"
+          export WHEEL_PATH="$(ls dist/*-${PY_TAG}-*.whl | head -1)"
+          echo "Installing wheel: $WHEEL_PATH"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+
+      - name: Run tests
+        working-directory: python
+        run: |
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov \
+            --junitxml=reports/release-${{ env.MATRIX_KEY }}.xml
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
+
+  # ── Build sdist ────────────────────────────────────────────────────
+  build_sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache proto generator target
+        uses: actions/cache@v5
+        with:
+          path: proto-target
+          key: ${{ runner.os }}-proto-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-proto-target-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.2.1
+        with:
+          version: "0.9.28"
+
+      - name: Set up Python
+        run: uv python install ${{ env.SDIST_PYTHON_VERSION }}
+
+      - name: Build sdist
+        working-directory: ./python
+        run: >
+          uv run --python ${{ env.SDIST_PYTHON_VERSION }}
+          --with hatch --with cython --with setuptools --with "virtualenv<21.0.0"
+          hatch build --target sdist
+        env:
+          PROTO_CARGO_TARGET_DIR: ${{ github.workspace }}/proto-target
+
+      - name: Inspect sdist
+        working-directory: ./python
+        run: tar tzf dist/*.tar.gz | head -40
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sdist
+          path: python/dist/*.tar.gz
+
+  # ── Test sdist (aws, with and without pandas) ──────────────────────
+  test_sdist:
+    needs: build_sdist
+    strategy:
+      fail-fast: false
+      matrix:
+        hatch_env: ["test", "test-pandas"]
+    runs-on: ubuntu-latest
+    name: test_sdist (${{ matrix.hatch_env }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.2.1
+        with:
+          version: "0.9.28"
+
+      - name: Set up Python ${{ env.SDIST_PYTHON_VERSION }}
+        run: uv python install ${{ env.SDIST_PYTHON_VERSION }}
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdist
+          path: python/dist
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh aws
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+
+      - name: Install Hatch
+        run: uv tool install hatch --with "virtualenv<21.0.0"
+
+      - name: Install snowflake ud driver from sdist
+        working-directory: python
+        run: hatch run ${{ matrix.hatch_env }}.py${{ env.SDIST_PYTHON_VERSION }}:install-wheel
+        env:
+          WHEEL_PATH: dist/*.tar.gz
+          SKIP_CORE_BUILD: "false"
+
+      - name: Run tests
+        working-directory: python
+        run: |
+          hatch run ${{ matrix.hatch_env }}.py${{ env.SDIST_PYTHON_VERSION }}:cov \
+            --junitxml=reports/sdist-${{ matrix.hatch_env }}.xml
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
+
+  # ── Clean up intermediate artifacts ────────────────────────────────
+  cleanup:
+    needs: [build_wheels, test_wheels]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete sf-core artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --paginate -q '.artifacts[] | select(.name | startswith("sf-core-")) | .id' \
+          | while read id; do
+              echo "Deleting artifact $id"
+              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
+            done
+
+  # ── Status gate ────────────────────────────────────────────────────
+  release_status:
+    needs: [build_wheels, test_wheels, build_sdist, test_sdist]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status
+        run: |
+          echo "=== Python Release Build Status ==="
+
+          if [[ "${{ needs.build_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test_wheels.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.build_sdist.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test_sdist.result }}" =~ ^(failure|cancelled)$ ]]; then
+            echo "FAILED"
+            echo "  build_wheels: ${{ needs.build_wheels.result }}"
+            echo "  test_wheels:  ${{ needs.test_wheels.result }}"
+            echo "  build_sdist:  ${{ needs.build_sdist.result }}"
+            echo "  test_sdist:   ${{ needs.test_sdist.result }}"
+            exit 1
+          fi
+
+          echo "PASSED"
+          echo "  build_wheels: ${{ needs.build_wheels.result }}"
+          echo "  test_wheels:  ${{ needs.test_wheels.result }}"
+          echo "  build_sdist:  ${{ needs.build_sdist.result }}"
+          echo "  test_sdist:   ${{ needs.test_sdist.result }}"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -13,15 +13,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      sf-core-matrix: >-
-        [{"target":"linux-x86_64","os":"ubuntu-latest",
-          "container":"quay.io/pypa/manylinux_2_28_x86_64",
-          "lib_name":"libsf_core.so",
-          "cargo_extra_args":"--features vendored-openssl"}]
-      cibw-matrix: >-
-        [{"target":"linux-x86_64","os":"ubuntu-latest",
-          "cibw_build":"cp3{10,11,12,13,14}-manylinux_x86_64",
-          "sf_core_artifact":"sf-core-linux-x86_64"}]
+      targets: '{"linux_x86": ["3.10","3.11","3.12","3.13","3.14"]}'
 
   # ── Test wheels against cloud providers ────────────────────────────
   test_wheels:

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -1,7 +1,8 @@
 name: Python Release Build
 
 on:
-  push:  # DEBUG: remove before merge
+  push:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Add build_python_release workflow, which would run tests on full matrix and create release artifacts after each merge to main. The build use exact same script used in reduced matrix on PRs

**Limited support for Windows ARM - no pyarrow release for this archotecture, "pandas" extension not available**

Full test matrix:
```
  ┌─────┬────────────────┬─────────────┬────────┬──────────────────┬───────┬────────┐        
  │  #  │      Job       │     OS      │ Python │       Env        │ Cloud │ Source │
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 1   │ test           │ ubuntu      │ 3.10   │ test             │ aws   │ sdist  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 2   │ test           │ ubuntu      │ 3.11   │ test             │ gcp   │ wheel  │        
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 3   │ test           │ ubuntu      │ 3.12   │ test             │ azure │ wheel  │        
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 4   │ test           │ ubuntu      │ 3.13   │ test             │ aws   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 5   │ test           │ ubuntu      │ 3.14   │ test             │ gcp   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 6   │ test           │ ubuntu      │ 3.10   │ test-pandas      │ azure │ sdist  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 7   │ test           │ ubuntu      │ 3.11   │ test-pandas      │ aws   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 8   │ test           │ ubuntu      │ 3.12   │ test-pandas      │ gcp   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 9   │ test           │ ubuntu      │ 3.13   │ test-pandas      │ azure │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 10  │ test           │ ubuntu      │ 3.14   │ test-pandas      │ aws   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 11  │ test           │ windows-arm │ 3.11   │ test             │ azure │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 12  │ test           │ windows-arm │ 3.12   │ test             │ gcp   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 13  │ test_reference │ ubuntu      │ 3.13   │ reference        │ aws   │ wheel  │      
  ├─────┼────────────────┼─────────────┼────────┼──────────────────┼───────┼────────┤        
  │ 14  │ test_reference │ ubuntu      │ 3.13   │ reference-pandas │ aws   │ wheel  │      
  └─────┴────────────────┴─────────────┴────────┴──────────────────┴───────┴────────┘ 
  ```