### PR TITLE
NO-SNOW: fix segfault on conversion errors in arrow stream iterator

### DIFF
--- a/python/src/snowflake/connector/_internal/nanoarrow_cpp/ArrowIterator/CArrowStreamIterator.cpp
+++ b/python/src/snowflake/connector/_internal/nanoarrow_cpp/ArrowIterator/CArrowStreamIterator.cpp
@@ -287,8 +287,6 @@ PyObject* CArrowStreamIterator::buildRowObject() {
       PyObject* val = m_columnConverters[colIdx]->toPyObject(m_currentRowIndex);
 
       if (py::checkPyError()) {
-        logger->debug(__FILE__, __func__, __LINE__,
-                      "Python error occurred during conversion of column %s", colName);
         Py_DECREF(pydict);
         return nullptr;
       }
@@ -312,8 +310,6 @@ PyObject* CArrowStreamIterator::buildRowObject() {
     PyObject* val = m_columnConverters[colIdx]->toPyObject(m_currentRowIndex);
 
     if (py::checkPyError()) {
-      logger->debug(__FILE__, __func__, __LINE__,
-                    "Python error occurred during conversion of column %lld", colIdx);
       Py_DECREF(pytuple);
       return nullptr;
     }


### PR DESCRIPTION
- Removed two `logger->debug(...)` calls inside `CArrowStreamIterator::buildRowObject()` that ran while a Python exception was already set, which caused pytest workers to segfault on Python 3.9 for the newly-enabled interval-overflow tests.
- `Logger::log` calls back into Python (`PyDict_New`, `PyObject_GetAttrString`, `Py_BuildValue`, `PyObject_Call` on the `SnowLogger.log` method). Invoking CPython APIs while `PyErr_Occurred()` is true is undefined behavior; 3.10+ happened to tolerate it, 3.9 did not.
- The debug lines don't add useful information: the underlying Python exception is already captured via `PyErr_Fetch` in `CArrowStreamIterator::next()` and propagated to Cython, which re-raises it as `InterfaceError(252005, ...).`

Note: the same anti-pattern exists in `Helpers.cpp::importPythonModule(..., Logger&)` and any other `if (py::checkPyError()) { logger->...; ... }` site, but they are not exercised on hot paths. A future change can wrap `Logger::log` in a `PyErr_Fetch` / `PyErr_Restore` guard to make all call sites defensive; this PR keeps the scope tight to unblock CI.  
  
Reference: https://docs.python.org/3/c-api/exceptions.html#exception-handling  
\>  If the error is not handled or carefully propagated, additional calls into the Python/C API may not behave as intended and may fail in mysterious ways.