### PR TITLE
Send OS_DETAILS in CLIENT_ENVIRONMENT

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -175,6 +175,7 @@ impl DatabaseDriverV1 {
                     let mut client_info =
                         ClientInfo::from_settings(&resolved).context(ConfigurationSnafu)?;
                     client_info.platforms = self.platforms().await.clone();
+                    client_info.os_details = self.os_details().clone();
                     let init_params = conn.init_session_parameters.clone();
                     let resolved_snapshot = resolved.clone();
 

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -7,6 +8,7 @@ use super::database::Database;
 use super::statement::Statement;
 use crate::fs_adapter::{FsAdapter, RealFs};
 use crate::handle_manager::HandleManager;
+use crate::telemetry::os_details::detect_os_details;
 use crate::telemetry::platform_detection::detect_platforms;
 use crate::token_cache::{KeyringTokenCache, TokenCacheError};
 
@@ -28,6 +30,7 @@ pub struct DatabaseDriverV1 {
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
+    os_details: once_cell::sync::OnceCell<Option<HashMap<String, String>>>,
 }
 
 impl Default for DatabaseDriverV1 {
@@ -49,6 +52,7 @@ impl DatabaseDriverV1 {
             token_cache: once_cell::sync::OnceCell::new(),
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),
+            os_details: once_cell::sync::OnceCell::new(),
         }
     }
 
@@ -62,6 +66,11 @@ impl DatabaseDriverV1 {
 
     pub async fn platforms(&self) -> &Vec<String> {
         self.platforms.get_or_init(detect_platforms).await
+    }
+
+    pub fn os_details(&self) -> &Option<HashMap<String, String>> {
+        self.os_details
+            .get_or_init(|| detect_os_details(self.fs.as_ref()))
     }
 }
 

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -125,6 +125,7 @@ fn default_client_info() -> ClientInfo {
         crl_config: CrlConfig::default(),
         tls_config: TlsConfig::default(),
         platforms: Vec::new(),
+        os_details: None,
     }
 }
 

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -79,6 +79,7 @@ pub struct ClientInfo {
     pub crl_config: CrlConfig,
     pub tls_config: TlsConfig,
     pub platforms: Vec<String>,
+    pub os_details: Option<HashMap<String, String>>,
 }
 
 impl ClientInfo {
@@ -99,6 +100,7 @@ impl ClientInfo {
             crl_config,
             tls_config,
             platforms: Vec::new(),
+            os_details: None,
         };
         Ok(client_info)
     }
@@ -123,6 +125,7 @@ pub mod test_fixtures {
             crl_config: CrlConfig::default(),
             tls_config: TlsConfig::insecure(),
             platforms: Vec::new(),
+            os_details: None,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -35,6 +35,8 @@ pub struct AuthRequestClientEnvironment {
     pub python_runtime: Option<String>,
     #[serde(rename = "PYTHON_COMPILER", skip_serializing_if = "Option::is_none")]
     pub python_compiler: Option<String>,
+    #[serde(rename = "OS_DETAILS", skip_serializing_if = "Option::is_none")]
+    pub os_details: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Default)]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -179,6 +179,7 @@ fn base_auth_request_data(login_parameters: &LoginParameters) -> AuthRequestData
             python_version: Some("3.11.6".to_string()),
             python_runtime: Some("CPython".to_string()),
             python_compiler: Some("Clang 13.0.0 (clang-1300.0.29.30)".to_string()),
+            os_details: login_parameters.client_info.os_details.clone(),
         },
         ..Default::default()
     }

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -7,6 +7,7 @@ pub mod serialization;
 #[doc(hidden)]
 pub mod snowflake_exporter;
 
+pub mod os_details;
 pub mod platform_detection;
 
 use environment::EnvironmentInfo;

--- a/sf_core/src/telemetry/os_details.rs
+++ b/sf_core/src/telemetry/os_details.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::fs_adapter::FsAdapter;
+
+const OS_RELEASE_PATH: &str = "/etc/os-release";
+const ALLOWED_KEYS: &[&str] = &[
+    "NAME",
+    "PRETTY_NAME",
+    "ID",
+    "BUILD_ID",
+    "IMAGE_ID",
+    "IMAGE_VERSION",
+    "VERSION",
+    "VERSION_ID",
+];
+
+/// Detect OS details for telemetry.
+///
+/// Returns `Some(map)` on Linux when `/etc/os-release` can be read and
+/// contains at least one allow-listed key; otherwise returns `None`.
+pub fn detect_os_details(fs: &dyn FsAdapter) -> Option<HashMap<String, String>> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+
+    match fs.read_to_string(Path::new(OS_RELEASE_PATH)) {
+        Ok(contents) => {
+            let parsed = parse_os_release(&contents);
+            if parsed.is_empty() {
+                None
+            } else {
+                Some(parsed)
+            }
+        }
+        Err(e) => {
+            tracing::debug!(
+                path = OS_RELEASE_PATH,
+                error = %e,
+                "Failed to read OS release file for telemetry"
+            );
+            None
+        }
+    }
+}
+
+/// Parse an `os-release(5)` file body and return the allow-listed keys.
+///
+/// Each line is expected to be `KEY=value` or `KEY="value"`. Lines that do
+/// not match or whose key is not in [`ALLOWED_KEYS`] are ignored.
+fn parse_os_release(contents: &str) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        if !is_valid_key(key) || !ALLOWED_KEYS.contains(&key) {
+            continue;
+        }
+        let value = strip_surrounding_double_quotes(raw_value);
+        result.insert(key.to_string(), value.to_string());
+    }
+    result
+}
+
+fn is_valid_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+fn strip_surrounding_double_quotes(value: &str) -> &str {
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs_adapter::mock::MockFs;
+
+    const MOCK_OS_RELEASE: &str = r#"
+NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID=arch
+BUILD_ID=rolling
+VERSION_ID=20251019.0.436919
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinux.org/"
+DOCUMENTATION_URL="https://wiki.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
+PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
+LOGO=archlinux-logo
+"#;
+
+    #[test]
+    fn parses_allowed_keys_from_os_release() {
+        let parsed = parse_os_release(MOCK_OS_RELEASE);
+        assert_eq!(parsed.get("NAME").map(String::as_str), Some("Arch Linux"));
+        assert_eq!(
+            parsed.get("PRETTY_NAME").map(String::as_str),
+            Some("Arch Linux")
+        );
+        assert_eq!(parsed.get("ID").map(String::as_str), Some("arch"));
+        assert_eq!(parsed.get("BUILD_ID").map(String::as_str), Some("rolling"));
+        assert_eq!(
+            parsed.get("VERSION_ID").map(String::as_str),
+            Some("20251019.0.436919")
+        );
+        assert_eq!(parsed.len(), 5, "unexpected extra keys: {parsed:?}");
+    }
+
+    #[test]
+    fn ignores_disallowed_keys_and_unquotes() {
+        let parsed = parse_os_release(MOCK_OS_RELEASE);
+        assert!(!parsed.contains_key("ANSI_COLOR"));
+        assert!(!parsed.contains_key("HOME_URL"));
+        assert!(!parsed.contains_key("LOGO"));
+    }
+
+    #[test]
+    fn unquoted_values_are_preserved() {
+        let contents = "ID=arch\nBUILD_ID=rolling\n";
+        let parsed = parse_os_release(contents);
+        assert_eq!(parsed.get("ID").map(String::as_str), Some("arch"));
+        assert_eq!(parsed.get("BUILD_ID").map(String::as_str), Some("rolling"));
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped() {
+        let contents = "NOT_A_LINE_WITHOUT_EQUALS\n#NAME=comment\n=no-key\nNAME=\"Fine\"\n";
+        let parsed = parse_os_release(contents);
+        assert_eq!(parsed.get("NAME").map(String::as_str), Some("Fine"));
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn lowercase_keys_are_rejected() {
+        let contents = "name=\"lowercase\"\nNAME=\"Upper\"\n";
+        let parsed = parse_os_release(contents);
+        assert_eq!(parsed.get("NAME").map(String::as_str), Some("Upper"));
+        assert!(!parsed.contains_key("name"));
+    }
+
+    #[test]
+    fn detect_returns_none_on_non_linux() {
+        if cfg!(target_os = "linux") {
+            return;
+        }
+        let fs = MockFs::new().with_file(OS_RELEASE_PATH, MOCK_OS_RELEASE);
+        assert!(detect_os_details(&fs).is_none());
+    }
+
+    #[test]
+    fn detect_parses_allowed_keys_on_linux() {
+        if !cfg!(target_os = "linux") {
+            return;
+        }
+        let fs = MockFs::new().with_file(OS_RELEASE_PATH, MOCK_OS_RELEASE);
+        let details = detect_os_details(&fs).expect("expected Some on Linux with valid file");
+        assert_eq!(details.get("ID").map(String::as_str), Some("arch"));
+        assert_eq!(details.get("NAME").map(String::as_str), Some("Arch Linux"));
+        assert_eq!(details.len(), 5);
+    }
+
+    #[test]
+    fn detect_returns_none_when_file_missing_on_linux() {
+        if !cfg!(target_os = "linux") {
+            return;
+        }
+        let fs = MockFs::new();
+        assert!(detect_os_details(&fs).is_none());
+    }
+}

--- a/sf_core/src/telemetry/os_details.rs
+++ b/sf_core/src/telemetry/os_details.rs
@@ -46,8 +46,11 @@ pub fn detect_os_details(fs: &dyn FsAdapter) -> Option<HashMap<String, String>> 
 
 /// Parse an `os-release(5)` file body and return the allow-listed keys.
 ///
-/// Each line is expected to be `KEY=value` or `KEY="value"`. Lines that do
-/// not match or whose key is not in [`ALLOWED_KEYS`] are ignored.
+/// Each line is expected to be `KEY=value`, `KEY="value"`, or `KEY='value'`.
+/// Lines that do not match or whose key is not in [`ALLOWED_KEYS`] are
+/// ignored. Inside double quotes the shell-style escapes `\$`, `\"`, `\\`,
+/// and `` \` `` are honored (per `os-release(5)`); single-quoted values are
+/// taken literally. Malformed lines (e.g. unterminated quotes) are skipped.
 fn parse_os_release(contents: &str) -> HashMap<String, String> {
     let mut result = HashMap::new();
     for line in contents.lines() {
@@ -61,8 +64,10 @@ fn parse_os_release(contents: &str) -> HashMap<String, String> {
         if !is_valid_key(key) || !ALLOWED_KEYS.contains(&key) {
             continue;
         }
-        let value = strip_surrounding_double_quotes(raw_value);
-        result.insert(key.to_string(), value.to_string());
+        let Some(value) = unquote_value(raw_value) else {
+            continue;
+        };
+        result.insert(key.to_string(), value);
     }
     result
 }
@@ -74,11 +79,58 @@ fn is_valid_key(key: &str) -> bool {
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
-fn strip_surrounding_double_quotes(value: &str) -> &str {
-    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
-        &value[1..value.len() - 1]
+/// Unquote an `os-release(5)` value.
+///
+/// Returns `None` when the value is malformed (e.g. an unterminated quote or
+/// trailing garbage after a closing quote).
+fn unquote_value(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    match bytes.first() {
+        Some(&b'"') => unquote_double(&value[1..]),
+        Some(&b'\'') => unquote_single(&value[1..]),
+        _ => Some(value.to_string()),
+    }
+}
+
+/// Parse the remainder of a double-quoted value (opening `"` already stripped).
+///
+/// Honors `\\`, `\"`, `\$`, and `` \` `` escapes. Any other backslash is kept
+/// verbatim, matching the behavior of common `os-release` producers.
+fn unquote_double(inner: &str) -> Option<String> {
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => {
+                return if chars.next().is_none() {
+                    Some(out)
+                } else {
+                    None
+                };
+            }
+            '\\' => match chars.next() {
+                Some(next @ ('\\' | '"' | '$' | '`')) => out.push(next),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => return None,
+            },
+            other => out.push(other),
+        }
+    }
+    None
+}
+
+/// Parse the remainder of a single-quoted value (opening `'` already stripped).
+///
+/// Single-quoted values are literal: no escape sequences are interpreted.
+fn unquote_single(inner: &str) -> Option<String> {
+    let (content, rest) = inner.split_once('\'')?;
+    if rest.is_empty() {
+        Some(content.to_string())
     } else {
-        value
+        None
     }
 }
 
@@ -149,6 +201,29 @@ LOGO=archlinux-logo
         let parsed = parse_os_release(contents);
         assert_eq!(parsed.get("NAME").map(String::as_str), Some("Upper"));
         assert!(!parsed.contains_key("name"));
+    }
+
+    #[test]
+    fn single_quoted_values_are_literal() {
+        let contents = "NAME='Arch Linux'\nID='a\\$b'\n";
+        let parsed = parse_os_release(contents);
+        assert_eq!(parsed.get("NAME").map(String::as_str), Some("Arch Linux"));
+        assert_eq!(parsed.get("ID").map(String::as_str), Some("a\\$b"));
+    }
+
+    #[test]
+    fn double_quoted_escapes_and_malformed_quotes() {
+        let contents = concat!(
+            "NAME=\"a\\\"b\\\\c\\$d\\`e\"\n",
+            "PRETTY_NAME=\"unterminated\n",
+            "VERSION=\"ok\"junk\n",
+            "ID=arch\n",
+        );
+        let parsed = parse_os_release(contents);
+        assert_eq!(parsed.get("NAME").map(String::as_str), Some("a\"b\\c$d`e"));
+        assert!(!parsed.contains_key("PRETTY_NAME"));
+        assert!(!parsed.contains_key("VERSION"));
+        assert_eq!(parsed.get("ID").map(String::as_str), Some("arch"));
     }
 
     #[test]

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,4 +1,5 @@
 pub mod native_okta;
+pub mod os_details;
 pub mod private_key_auth;
 pub mod spcs_token;
 pub mod user_password;

--- a/sf_core/tests/integration/authentication/os_details.rs
+++ b/sf_core/tests/integration/authentication/os_details.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use crate::common::mocks::password;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+use sf_core::fs_adapter::mock::MockFs;
+use sf_core::protobuf::apis::database_driver_v1::DriverProviders;
+use wiremock::Mock;
+use wiremock::matchers::{body_partial_json, method, path_regex};
+
+const MOCK_OS_RELEASE: &str = r#"
+NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID=arch
+BUILD_ID=rolling
+VERSION_ID=20251019.0.436919
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinux.org/"
+"#;
+
+#[test]
+fn should_include_os_details_on_linux() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
+    let fs = Arc::new(MockFs::new().with_file("/etc/os-release", MOCK_OS_RELEASE));
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params_using(
+        Some(&mock.http_url()),
+        DriverProviders { fs: Some(fs) },
+    );
+    client.set_connection_option("password", "test_password"); // pragma: allowlist secret
+
+    mock.mount(
+        Mock::given(method("POST"))
+            .and(path_regex(r"/session/v1/login-request"))
+            .and(body_partial_json(serde_json::json!({
+                "data": {
+                    "CLIENT_ENVIRONMENT": {
+                        "OS_DETAILS": {
+                            "ID": "arch",
+                            "NAME": "Arch Linux",
+                            "PRETTY_NAME": "Arch Linux",
+                            "BUILD_ID": "rolling",
+                            "VERSION_ID": "20251019.0.436919"
+                        }
+                    }
+                }
+            })))
+            .respond_with(password::success_login_response()),
+    );
+
+    let result = client.connect();
+    assert!(
+        result.is_ok(),
+        "Expected login with OS_DETAILS to succeed, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `OS_DETAILS` field to the login request's `CLIENT_ENVIRONMENT`, mirroring the Node.js driver's telemetry feature (snowflake-connector-nodejs `lib/telemetry/os_details`).
- New `sf_core::telemetry::os_details::detect_os_details` module that parses `/etc/os-release` on Linux via the existing `FsAdapter` and extracts an allow-listed subset of keys (`NAME`, `PRETTY_NAME`, `ID`, `BUILD_ID`, `IMAGE_ID`, `IMAGE_VERSION`, `VERSION`, `VERSION_ID`). Returns `None` on non-Linux platforms or on read/parse failure.
- Result is cached on `DatabaseDriverV1` in a `OnceCell` (same pattern as `platforms`) and wired through `ClientInfo.os_details` into `AuthRequestClientEnvironment.OS_DETAILS` with `skip_serializing_if = Option::is_none`, so the field is omitted when unavailable.
- No new crate dependency: the `os-release` format is trivial enough to hand-parse, avoiding a `regex` dep.

## Context
Follow-up to the telemetry foundations that added `FsAdapter`, SPCS token plumbing, and the `PLATFORM` field in the login request. `OS_DETAILS` is the next CLIENT_ENVIRONMENT field being rolled out across all connectors for server-side telemetry.

Node.js reference:
- https://github.com/snowflakedb/snowflake-connector-nodejs/blob/master/lib/telemetry/os_details/index.ts
- https://github.com/snowflakedb/snowflake-connector-nodejs/blob/master/lib/telemetry/os_details/linux_os_release.ts

## Test plan
- Unit tests in `sf_core/src/telemetry/os_details.rs` (8 cases): parses the Node.js Arch Linux fixture, ignores disallowed keys, handles unquoted values and malformed/commented lines, rejects lowercase keys, and covers the Linux-only detect paths (`detect_returns_none_when_file_missing_on_linux`, `detect_parses_allow_listed_keys_via_mock_fs_on_linux`, `detect_returns_none_on_non_linux`).
- Integration test `sf_core/tests/integration/authentication/os_details.rs`: compiles on every platform; on non-Linux it early-returns (`if !cfg!(target_os = "linux") { return; }`). On Linux it injects a `MockFs` holding a fake `/etc/os-release`, mounts a wiremock matcher that asserts `data.CLIENT_ENVIRONMENT.OS_DETAILS` contains the expected allow-listed keys, and exercises `connection_init` end-to-end.
- Verified locally on macOS:
  - `cargo build -p sf_core --lib` — clean
  - `cargo build -p sf_core --bin collect_chunk_data --features cli` — clean
  - `cargo test -p sf_core --lib telemetry::os_details` — 8/8 pass
  - `cargo test -p sf_core --test integration_tests authentication` — 37/37 pass (existing auth suite still green; new test early-returns on macOS as designed)
  - `cargo test -p sf_core --lib rest::snowflake` — 79/79 pass
  - `cargo clippy -p sf_core --lib --tests --all-features -- -D warnings` — clean