### PR TITLE
NO-SNOW: fetch columns in segments to amortise Arrow array downcast

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -442,16 +442,9 @@ fn current_batch_idx(stmt: &Statement) -> usize {
     }
 }
 
-/// Advance `batch_idx` by `delta` rows within the current `RecordBatch`
-/// (caller must ensure the batch has at least `delta` more rows left).
-///
-/// Returns `OdbcError::InternalError` when an invariant is violated:
-///   * advancing would cross the batch boundary, or
-///   * the statement is not in the `Fetching` state.
-///
-/// Both indicate a driver bug; raising a real error (instead of a
-/// `debug_assert!` no-op in release builds) prevents silent cursor
-/// corruption and surfaces the problem to the application.
+/// Advance `batch_idx` by `delta` rows within the current `RecordBatch`.
+/// Returns `OdbcError::InternalError` if advancing would cross the batch
+/// boundary or the statement is not in the `Fetching` state.
 fn bump_batch_idx(
     state: &mut crate::api::State<StatementState>,
     delta: usize,

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1,10 +1,10 @@
 use crate::api::CDataType;
 use crate::api::error::{
     ConversionSnafu, DataNotFetchedSnafu, FetchDataSnafu, FetchTypeOutOfRangeSnafu,
-    InvalidBufferLengthSnafu, InvalidCursorPositionSnafu, InvalidCursorStateSnafu,
-    InvalidDescriptorIndexSnafu, InvalidDuringDaeSnafu, MixedCursorFunctionsSnafu, NoMoreDataSnafu,
-    NullPointerSnafu, OdbcError, StatementErrorStateSnafu, StatementNotExecutedSnafu,
-    UnsupportedFeatureSnafu,
+    InternalSnafu, InvalidBufferLengthSnafu, InvalidCursorPositionSnafu,
+    InvalidCursorStateSnafu, InvalidDescriptorIndexSnafu, InvalidDuringDaeSnafu,
+    MixedCursorFunctionsSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcError,
+    StatementErrorStateSnafu, StatementNotExecutedSnafu, UnsupportedFeatureSnafu,
 };
 use crate::api::{
     GetDataState, OdbcResult, Statement, StatementState, WithState, stmt_from_handle,
@@ -416,7 +416,7 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
         // `advance_cursor` already landed on the first row of the segment;
         // skip the rest so the next call lands on the row after it.
         if segment_len > 1 {
-            bump_batch_idx(&mut stmt.state, segment_len - 1);
+            bump_batch_idx(&mut stmt.state, segment_len - 1)?;
         }
     }
 
@@ -444,11 +444,22 @@ fn current_batch_idx(stmt: &Statement) -> usize {
 
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`
 /// (caller must ensure the batch has at least `delta` more rows left).
-fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) {
+///
+/// Returns `OdbcError::InternalError` when an invariant is violated:
+///   * advancing would cross the batch boundary, or
+///   * the statement is not in the `Fetching` state.
+///
+/// Both indicate a driver bug; raising a real error (instead of a
+/// `debug_assert!` no-op in release builds) prevents silent cursor
+/// corruption and surfaces the problem to the application.
+fn bump_batch_idx(
+    state: &mut crate::api::State<StatementState>,
+    delta: usize,
+) -> OdbcResult<()> {
     if delta == 0 {
-        return;
+        return Ok(());
     }
-    let _: Result<(), ()> = state.transition_or_err(|s| match s {
+    state.transition_or_err(|s| match s {
         StatementState::Fetching {
             reader,
             record_batch,
@@ -456,13 +467,24 @@ fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) {
             rows_affected,
             origin,
         } => {
-            debug_assert!(
-                batch_idx + delta < record_batch.num_rows(),
-                "bump_batch_idx crossed batch boundary (delta={}, batch_idx={}, num_rows={})",
-                delta,
-                batch_idx,
-                record_batch.num_rows(),
-            );
+            let num_rows = record_batch.num_rows();
+            if batch_idx + delta >= num_rows {
+                let err = InternalSnafu {
+                    message: format!(
+                        "bump_batch_idx crossed batch boundary (delta={delta}, \
+                         batch_idx={batch_idx}, num_rows={num_rows})"
+                    ),
+                }
+                .build();
+                let restored = StatementState::Fetching {
+                    reader,
+                    record_batch,
+                    batch_idx,
+                    rows_affected,
+                    origin,
+                };
+                return Err((restored, err));
+            }
             Ok((
                 StatementState::Fetching {
                     reader,
@@ -475,10 +497,13 @@ fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) {
             ))
         }
         other => {
-            debug_assert!(false, "bump_batch_idx called outside Fetching state",);
-            Err((other, ()))
+            let err = InternalSnafu {
+                message: "bump_batch_idx called outside Fetching state".to_string(),
+            }
+            .build();
+            Err((other, err))
         }
-    });
+    })
 }
 
 /// `SQLFetchScroll` — currently only `SQL_FETCH_NEXT` is supported.

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -36,9 +36,9 @@ fn read_arrow_value(
 }
 
 /// Per-batch cache of converters and `Binding` snapshots for the bound
-/// columns. Lets the `SQLFetch` inner loop avoid rebuilding a converter and
-/// re-reading the ARD `HashMap` for every cell. Lives for one fetch call and
-/// is rebuilt whenever the cursor crosses into a new `RecordBatch`.
+/// columns. Built once per `RecordBatch` and reused across the column-major
+/// segments processed by `Converter::convert_arrow_range`, keeping both the
+/// ARD `HashMap` and the per-cell Arrow downcast out of the inner loop.
 struct FetchConverterCache {
     /// `Arc::as_ptr(record_batch.column(0))` when the batch has columns,
     /// otherwise the schema `Arc` pointer. Null means "no cache yet".
@@ -287,17 +287,28 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     let bind_offset_ptr = stmt.ard.bind_offset_ptr;
     let row_status_ptr = stmt.ird.array_status_ptr;
     let rows_fetched_ptr = stmt.ird.rows_processed_ptr;
+    let bind_offset = if !bind_offset_ptr.is_null() {
+        unsafe { *bind_offset_ptr }
+    } else {
+        0
+    };
 
     let mut cache = FetchConverterCache::new();
+    let numeric_settings = unsafe { stmt.conn() }.connection.numeric_settings;
 
+    // Single-row fast path: old behaviour propagated the first conversion
+    // error to the caller (rather than marking the row as Error and
+    // returning Ok). We preserve that by funnelling the single row through
+    // the same segment helper but inspecting its outcome here.
     if array_size == 1 && bind_offset_ptr.is_null() {
         advance_cursor(&mut stmt.state)?;
-        let numeric_settings = unsafe { stmt.conn() }.connection.numeric_settings;
         cache.refresh_if_needed(stmt, &numeric_settings)?;
         if !rows_fetched_ptr.is_null() {
             unsafe { *rows_fetched_ptr = 1 };
         }
-        match execute_bindings_for_row(stmt, &cache, 0, 0, 0) {
+        let arrow_start = current_batch_idx(stmt);
+        let outputs = execute_bindings_for_segment(stmt, &cache, arrow_start, 1, 0, 0, 0);
+        match outputs.into_iter().next().unwrap_or_else(|| Ok(Vec::new())) {
             Ok(row_warnings) => {
                 let status = if row_warnings.is_empty() {
                     RowStatus::Success
@@ -309,59 +320,27 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
             }
             Err(e) => {
                 write_row_status(row_status_ptr, 0, RowStatus::Error);
-                return Err(e);
+                return Err(e).context(ConversionSnafu);
             }
         }
         return Ok(());
     }
 
-    let bind_offset = if !bind_offset_ptr.is_null() {
-        unsafe { *bind_offset_ptr }
-    } else {
-        0
-    };
-
     let mut rows_fetched: usize = 0;
     let mut has_error = false;
-    let numeric_settings = unsafe { stmt.conn() }.connection.numeric_settings;
 
-    for row_idx in 0..array_size {
+    // Column-major block-cursor loop. Each iteration advances into the next
+    // available row, then processes as many rows as fit in the current
+    // record batch in a single column-major segment. `advance_cursor`
+    // handles both "move one row inside the current batch" and "load the
+    // next batch" exactly as before; `bump_batch_idx` then skips over the
+    // rest of the segment we just consumed so the next `advance_cursor`
+    // call lands on the following row (or on the next batch).
+    while rows_fetched < array_size {
         match advance_cursor(&mut stmt.state) {
-            Ok(()) => {
-                if let Err(e) = cache.refresh_if_needed(stmt, &numeric_settings) {
-                    if rows_fetched == 0 {
-                        return Err(e);
-                    }
-                    write_row_status(row_status_ptr, row_idx, RowStatus::Error);
-                    has_error = true;
-                    // Errored rows count toward `SQL_ATTR_ROWS_FETCHED_PTR`
-                    // per the ODBC spec, so the row-status array and the
-                    // reported count stay consistent.
-                    rows_fetched += 1;
-                    for remaining in (row_idx + 1)..array_size {
-                        write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
-                    }
-                    break;
-                }
-                rows_fetched += 1;
-                match execute_bindings_for_row(stmt, &cache, row_idx, bind_type, bind_offset) {
-                    Ok(w) => {
-                        let status = if w.is_empty() {
-                            RowStatus::Success
-                        } else {
-                            RowStatus::SuccessWithInfo
-                        };
-                        write_row_status(row_status_ptr, row_idx, status);
-                        warnings.extend(w);
-                    }
-                    Err(_) => {
-                        write_row_status(row_status_ptr, row_idx, RowStatus::Error);
-                        has_error = true;
-                    }
-                }
-            }
+            Ok(()) => {}
             Err(crate::api::OdbcError::NoMoreData { .. }) => {
-                for remaining in row_idx..array_size {
+                for remaining in rows_fetched..array_size {
                     write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
                 }
                 break;
@@ -370,14 +349,82 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
                 if rows_fetched == 0 {
                     return Err(e);
                 }
-                write_row_status(row_status_ptr, row_idx, RowStatus::Error);
+                write_row_status(row_status_ptr, rows_fetched, RowStatus::Error);
                 has_error = true;
+                // Errored rows count toward `SQL_ATTR_ROWS_FETCHED_PTR`
+                // per the ODBC spec, so the row-status array and the
+                // reported count stay consistent.
                 rows_fetched += 1;
-                for remaining in (row_idx + 1)..array_size {
+                for remaining in rows_fetched..array_size {
                     write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
                 }
                 break;
             }
+        }
+
+        if let Err(e) = cache.refresh_if_needed(stmt, &numeric_settings) {
+            if rows_fetched == 0 {
+                return Err(e);
+            }
+            write_row_status(row_status_ptr, rows_fetched, RowStatus::Error);
+            has_error = true;
+            rows_fetched += 1;
+            for remaining in rows_fetched..array_size {
+                write_row_status(row_status_ptr, remaining, RowStatus::NoRow);
+            }
+            break;
+        }
+
+        let (arrow_start, segment_len) = {
+            let StatementState::Fetching {
+                record_batch,
+                batch_idx,
+                ..
+            } = stmt.state.as_ref()
+            else {
+                unreachable!("advance_cursor must leave state in Fetching");
+            };
+            let in_batch_remaining = record_batch.num_rows().saturating_sub(*batch_idx);
+            let wanted = array_size - rows_fetched;
+            (*batch_idx, in_batch_remaining.min(wanted).max(1))
+        };
+
+        let outputs = execute_bindings_for_segment(
+            stmt,
+            &cache,
+            arrow_start,
+            segment_len,
+            rows_fetched,
+            bind_type,
+            bind_offset,
+        );
+
+        for (i, outcome) in outputs.into_iter().enumerate() {
+            let out_row = rows_fetched + i;
+            match outcome {
+                Ok(w) => {
+                    let status = if w.is_empty() {
+                        RowStatus::Success
+                    } else {
+                        RowStatus::SuccessWithInfo
+                    };
+                    write_row_status(row_status_ptr, out_row, status);
+                    warnings.extend(w);
+                }
+                Err(_) => {
+                    write_row_status(row_status_ptr, out_row, RowStatus::Error);
+                    has_error = true;
+                }
+            }
+        }
+        rows_fetched += segment_len;
+
+        // advance_cursor already put us on the first row of this segment; if
+        // we processed more than one row we need to bump batch_idx so the
+        // next advance_cursor call lands on the row after the segment (or
+        // on the next batch when the segment ends exactly at a boundary).
+        if segment_len > 1 {
+            bump_batch_idx(&mut stmt.state, segment_len - 1);
         }
     }
 
@@ -394,6 +441,58 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     }
 
     Ok(())
+}
+
+fn current_batch_idx(stmt: &Statement) -> usize {
+    match stmt.state.as_ref() {
+        StatementState::Fetching { batch_idx, .. } => *batch_idx,
+        _ => 0,
+    }
+}
+
+/// Advance `batch_idx` by `delta` rows within the current `RecordBatch`
+/// without crossing a batch boundary.
+///
+/// The caller is responsible for calling this only when the state is
+/// `Fetching` and the current batch has at least `delta` additional rows
+/// remaining. This is the post-condition we guarantee by deriving
+/// `segment_len` from `record_batch.num_rows() - batch_idx` in
+/// [`fetch_impl`].
+fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) {
+    if delta == 0 {
+        return;
+    }
+    let _: Result<(), ()> = state.transition_or_err(|s| match s {
+        StatementState::Fetching {
+            reader,
+            record_batch,
+            batch_idx,
+            rows_affected,
+            origin,
+        } => {
+            debug_assert!(
+                batch_idx + delta < record_batch.num_rows(),
+                "bump_batch_idx crossed batch boundary (delta={}, batch_idx={}, num_rows={})",
+                delta,
+                batch_idx,
+                record_batch.num_rows(),
+            );
+            Ok((
+                StatementState::Fetching {
+                    reader,
+                    record_batch,
+                    batch_idx: batch_idx + delta,
+                    rows_affected,
+                    origin,
+                },
+                (),
+            ))
+        }
+        other => {
+            debug_assert!(false, "bump_batch_idx called outside Fetching state",);
+            Err((other, ()))
+        }
+    });
 }
 
 /// `SQLFetchScroll` — currently only `SQL_FETCH_NEXT` is supported.
@@ -532,38 +631,51 @@ fn adjust_binding_for_row(
     }
 }
 
-/// Execute column bindings for a single row within a block-cursor fetch
-/// using the pre-built `FetchConverterCache`.
-fn execute_bindings_for_row(
+/// Column-major hot path for `SQLFetch`/`SQLExtendedFetch`. Iterates over
+/// the cached columns and dispatches each one to
+/// [`Converter::convert_arrow_range`] once for the whole segment, so the
+/// Arrow downcast and vtable call are paid per `(column, segment)` rather
+/// than per cell. Returns one `Result` per row, preserving the row-major
+/// "first error aborts the row" semantics.
+fn execute_bindings_for_segment(
     stmt: &Statement,
     cache: &FetchConverterCache,
-    row_idx: usize,
+    arrow_start: usize,
+    segment_len: usize,
+    out_row_start: usize,
     bind_type: usize,
     bind_offset: isize,
-) -> OdbcResult<Warnings> {
-    let mut warnings = vec![];
-    if let StatementState::Fetching {
-        record_batch,
-        batch_idx,
-        ..
-    } = stmt.state.as_ref()
-    {
-        let batch_idx = *batch_idx;
+) -> Vec<Result<Warnings, ConversionError>> {
+    let mut outputs: Vec<Result<Warnings, ConversionError>> =
+        (0..segment_len).map(|_| Ok(Vec::new())).collect();
 
-        for cached in &cache.entries {
-            // Out-of-range columns were reported once in `refresh_if_needed`.
-            let Some(converter) = cached.converter.as_deref() else {
-                continue;
-            };
-            let adjusted = adjust_binding_for_row(&cached.binding, row_idx, bind_type, bind_offset);
-            let array_ref = record_batch.column(cached.arrow_col);
-            let w = converter
-                .convert_arrow_value(array_ref.as_ref(), batch_idx, &adjusted, &mut None)
-                .context(ConversionSnafu)?;
-            warnings.extend(w);
-        }
+    let StatementState::Fetching { record_batch, .. } = stmt.state.as_ref() else {
+        return outputs;
+    };
+
+    let arrow_row_range = arrow_start..(arrow_start + segment_len);
+
+    for cached in &cache.entries {
+        // Out-of-range columns were reported once in `refresh_if_needed`.
+        let Some(converter) = cached.converter.as_deref() else {
+            continue;
+        };
+        let array_ref = record_batch.column(cached.arrow_col);
+        // `cached.binding` is a plain `Copy`; the closure can capture it by
+        // value and compute each output row's adjusted binding on the fly.
+        let base_binding = cached.binding;
+        let mut binding_fn = |i: usize| {
+            adjust_binding_for_row(&base_binding, out_row_start + i, bind_type, bind_offset)
+        };
+        converter.convert_arrow_range(
+            array_ref.as_ref(),
+            arrow_row_range.clone(),
+            &mut binding_fn,
+            &mut outputs,
+        );
     }
-    Ok(warnings)
+
+    outputs
 }
 
 /// Get data from a specific column

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -304,7 +304,22 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
         if !rows_fetched_ptr.is_null() {
             unsafe { *rows_fetched_ptr = 1 };
         }
-        let arrow_start = current_batch_idx(stmt);
+        // Same invariant as the multi-row path: after a successful
+        // `advance_cursor` the state must be `Fetching`. A bare
+        // `current_batch_idx` would silently fall back to `0` if the
+        // invariant ever broke and `execute_bindings_for_segment` would
+        // happily report success while skipping conversion. Match
+        // explicitly and fail with `InternalError` instead.
+        let arrow_start = match stmt.state.as_ref() {
+            StatementState::Fetching { batch_idx, .. } => *batch_idx,
+            _ => {
+                return InternalSnafu {
+                    message: "advance_cursor returned Ok but state is not Fetching in fast path"
+                        .to_string(),
+                }
+                .fail();
+            }
+        };
         let outputs = execute_bindings_for_segment(stmt, &cache, arrow_start, 1, 0, 0, 0);
         match outputs.into_iter().next().unwrap_or_else(|| Ok(Vec::new())) {
             Ok(row_warnings) => {
@@ -454,13 +469,6 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     }
 
     Ok(())
-}
-
-fn current_batch_idx(stmt: &Statement) -> usize {
-    match stmt.state.as_ref() {
-        StatementState::Fetching { batch_idx, .. } => *batch_idx,
-        _ => 0,
-    }
 }
 
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`.

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -376,11 +376,32 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
                 ..
             } = stmt.state.as_ref()
             else {
-                unreachable!("advance_cursor must leave state in Fetching");
+                return InternalSnafu {
+                    message: "advance_cursor returned Ok but state is not Fetching".to_string(),
+                }
+                .fail();
             };
-            let in_batch_remaining = record_batch.num_rows().saturating_sub(*batch_idx);
+            let num_rows = record_batch.num_rows();
+            let in_batch_remaining = num_rows.saturating_sub(*batch_idx);
+            if in_batch_remaining == 0 {
+                // Invariant: after a successful `advance_cursor`,
+                // `batch_idx` must point at a valid row.
+                // `next_non_empty_batch` guarantees `num_rows >= 1` and
+                // `batch_idx == 0` for fresh batches; the in-batch branch
+                // only stays in `Fetching` when `new_idx < num_rows`. If we
+                // ever observe `batch_idx >= num_rows` here it's a driver
+                // bug — fail loudly with `InternalError` rather than
+                // silently producing an out-of-bounds Arrow index.
+                return InternalSnafu {
+                    message: format!(
+                        "advance_cursor left batch_idx ({}) >= num_rows ({}) in fetch_impl",
+                        *batch_idx, num_rows,
+                    ),
+                }
+                .fail();
+            }
             let wanted = array_size - rows_fetched;
-            (*batch_idx, in_batch_remaining.min(wanted).max(1))
+            (*batch_idx, in_batch_remaining.min(wanted))
         };
 
         let outputs = execute_bindings_for_segment(

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -11,7 +11,7 @@ use crate::api::{
 };
 use crate::conversion::warning::Warnings;
 use crate::conversion::{
-    Binding, ColumnConverter, ConversionError, NumericSettings, make_converter,
+    Binding, BindingStrides, ColumnConverter, ConversionError, NumericSettings, make_converter,
 };
 use arrow::array::{Array, RecordBatchReader};
 use arrow::datatypes::Field;
@@ -37,7 +37,7 @@ fn read_arrow_value(
 
 /// Per-batch cache of converters and `Binding` snapshots for the bound
 /// columns. Built once per `RecordBatch` and reused across the column-major
-/// segments processed by `Converter::convert_arrow_range`, keeping both the
+/// segments processed by `ColumnConverter::convert_arrow_range`, keeping both the
 /// ARD `HashMap` and the per-cell Arrow downcast out of the inner loop.
 struct FetchConverterCache {
     /// `Arc::as_ptr(record_batch.column(0))` when the batch has columns,
@@ -296,10 +296,8 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     let mut cache = FetchConverterCache::new();
     let numeric_settings = unsafe { stmt.conn() }.connection.numeric_settings;
 
-    // Single-row fast path: old behaviour propagated the first conversion
-    // error to the caller (rather than marking the row as Error and
-    // returning Ok). We preserve that by funnelling the single row through
-    // the same segment helper but inspecting its outcome here.
+    // Fast path: a single-row fetch propagates the conversion error to
+    // the caller instead of just marking the row as Error.
     if array_size == 1 && bind_offset_ptr.is_null() {
         advance_cursor(&mut stmt.state)?;
         cache.refresh_if_needed(stmt, &numeric_settings)?;
@@ -329,13 +327,9 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     let mut rows_fetched: usize = 0;
     let mut has_error = false;
 
-    // Column-major block-cursor loop. Each iteration advances into the next
-    // available row, then processes as many rows as fit in the current
-    // record batch in a single column-major segment. `advance_cursor`
-    // handles both "move one row inside the current batch" and "load the
-    // next batch" exactly as before; `bump_batch_idx` then skips over the
-    // rest of the segment we just consumed so the next `advance_cursor`
-    // call lands on the following row (or on the next batch).
+    // Column-major block-cursor loop. Each iteration advances into the
+    // next row and then processes as many rows as fit in the current
+    // record batch in a single column-major segment.
     while rows_fetched < array_size {
         match advance_cursor(&mut stmt.state) {
             Ok(()) => {}
@@ -419,10 +413,8 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
         }
         rows_fetched += segment_len;
 
-        // advance_cursor already put us on the first row of this segment; if
-        // we processed more than one row we need to bump batch_idx so the
-        // next advance_cursor call lands on the row after the segment (or
-        // on the next batch when the segment ends exactly at a boundary).
+        // `advance_cursor` already landed on the first row of the segment;
+        // skip the rest so the next call lands on the row after it.
         if segment_len > 1 {
             bump_batch_idx(&mut stmt.state, segment_len - 1);
         }
@@ -451,13 +443,7 @@ fn current_batch_idx(stmt: &Statement) -> usize {
 }
 
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`
-/// without crossing a batch boundary.
-///
-/// The caller is responsible for calling this only when the state is
-/// `Fetching` and the current batch has at least `delta` additional rows
-/// remaining. This is the post-condition we guarantee by deriving
-/// `segment_len` from `record_batch.num_rows() - batch_idx` in
-/// [`fetch_impl`].
+/// (caller must ensure the batch has at least `delta` more rows left).
 fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) {
     if delta == 0 {
         return;
@@ -560,80 +546,9 @@ fn write_row_status(row_status_ptr: *mut u16, row_idx: usize, status: RowStatus)
     }
 }
 
-fn value_stride(binding: &Binding, bind_type: usize) -> usize {
-    if bind_type == 0 {
-        binding
-            .target_type
-            .fixed_size()
-            .unwrap_or(binding.buffer_length as usize)
-    } else {
-        bind_type
-    }
-}
-
-fn indicator_or_length_stride(bind_type: usize) -> usize {
-    if bind_type == 0 {
-        size_of::<sql::Len>()
-    } else {
-        bind_type
-    }
-}
-
-fn advance_by_element_stride<T>(
-    ptr: *mut T,
-    row_idx: usize,
-    element_stride: usize,
-    bind_offset: isize,
-) -> *mut T {
-    if ptr.is_null() {
-        return std::ptr::null_mut();
-    }
-    let stride = row_idx
-        .checked_mul(element_stride)
-        .expect("row index and element stride multiplication overflowed");
-    let byte_ptr = ptr as *mut u8;
-    unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T }
-}
-
-/// Create an adjusted `Binding` whose pointers target `row_idx` within the
-/// bound arrays, taking into account column-wise vs row-wise binding and an
-/// optional bind offset.
-fn adjust_binding_for_row(
-    binding: &Binding,
-    row_idx: usize,
-    bind_type: usize,
-    bind_offset: isize,
-) -> Binding {
-    Binding {
-        target_type: binding.target_type,
-        target_value_ptr: advance_by_element_stride(
-            binding.target_value_ptr,
-            row_idx,
-            value_stride(binding, bind_type),
-            bind_offset,
-        ),
-        buffer_length: binding.buffer_length,
-        octet_length_ptr: advance_by_element_stride(
-            binding.octet_length_ptr,
-            row_idx,
-            indicator_or_length_stride(bind_type),
-            bind_offset,
-        ),
-        indicator_ptr: advance_by_element_stride(
-            binding.indicator_ptr,
-            row_idx,
-            indicator_or_length_stride(bind_type),
-            bind_offset,
-        ),
-        precision: binding.precision,
-        scale: binding.scale,
-        datetime_interval_precision: binding.datetime_interval_precision,
-    }
-}
-
 /// Column-major hot path for `SQLFetch`/`SQLExtendedFetch`. Iterates over
 /// the cached columns and dispatches each one to
-/// [`Converter::convert_arrow_range`] once for the whole segment, so the
+/// [`ColumnConverter::convert_arrow_range`] once for the whole segment, so the
 /// Arrow downcast and vtable call are paid per `(column, segment)` rather
 /// than per cell. Returns one `Result` per row, preserving the row-major
 /// "first error aborts the row" semantics.
@@ -654,6 +569,10 @@ fn execute_bindings_for_segment(
     };
 
     let arrow_row_range = arrow_start..(arrow_start + segment_len);
+    let strides = BindingStrides {
+        bind_type,
+        bind_offset,
+    };
 
     for cached in &cache.entries {
         // Out-of-range columns were reported once in `refresh_if_needed`.
@@ -661,16 +580,12 @@ fn execute_bindings_for_segment(
             continue;
         };
         let array_ref = record_batch.column(cached.arrow_col);
-        // `cached.binding` is a plain `Copy`; the closure can capture it by
-        // value and compute each output row's adjusted binding on the fly.
-        let base_binding = cached.binding;
-        let mut binding_fn = |i: usize| {
-            adjust_binding_for_row(&base_binding, out_row_start + i, bind_type, bind_offset)
-        };
         converter.convert_arrow_range(
             array_ref.as_ref(),
             arrow_row_range.clone(),
-            &mut binding_fn,
+            &cached.binding,
+            out_row_start,
+            strides,
             &mut outputs,
         );
     }

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1,10 +1,10 @@
 use crate::api::CDataType;
 use crate::api::error::{
-    ConversionSnafu, DataNotFetchedSnafu, FetchDataSnafu, FetchTypeOutOfRangeSnafu,
-    InternalSnafu, InvalidBufferLengthSnafu, InvalidCursorPositionSnafu,
-    InvalidCursorStateSnafu, InvalidDescriptorIndexSnafu, InvalidDuringDaeSnafu,
-    MixedCursorFunctionsSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcError,
-    StatementErrorStateSnafu, StatementNotExecutedSnafu, UnsupportedFeatureSnafu,
+    ConversionSnafu, DataNotFetchedSnafu, FetchDataSnafu, FetchTypeOutOfRangeSnafu, InternalSnafu,
+    InvalidBufferLengthSnafu, InvalidCursorPositionSnafu, InvalidCursorStateSnafu,
+    InvalidDescriptorIndexSnafu, InvalidDuringDaeSnafu, MixedCursorFunctionsSnafu, NoMoreDataSnafu,
+    NullPointerSnafu, OdbcError, StatementErrorStateSnafu, StatementNotExecutedSnafu,
+    UnsupportedFeatureSnafu,
 };
 use crate::api::{
     GetDataState, OdbcResult, Statement, StatementState, WithState, stmt_from_handle,
@@ -445,10 +445,7 @@ fn current_batch_idx(stmt: &Statement) -> usize {
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`.
 /// Returns `OdbcError::InternalError` if advancing would cross the batch
 /// boundary or the statement is not in the `Fetching` state.
-fn bump_batch_idx(
-    state: &mut crate::api::State<StatementState>,
-    delta: usize,
-) -> OdbcResult<()> {
+fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) -> OdbcResult<()> {
     if delta == 0 {
         return Ok(());
     }

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -256,6 +256,13 @@ pub enum OdbcError {
         location: Location,
     },
 
+    #[snafu(display("Internal driver error: {message}"))]
+    InternalError {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Optional feature not implemented"))]
     UnsupportedFeature {
         #[snafu(implicit)]
@@ -561,6 +568,7 @@ impl OdbcError {
             OdbcError::NoMoreData { .. } => SqlState::NoDataFound,
             OdbcError::InvalidCursorPosition { .. } => SqlState::InvalidCursorPosition,
             OdbcError::MixedCursorFunctions { .. } => SqlState::FunctionSequenceError,
+            OdbcError::InternalError { .. } => SqlState::GeneralError,
             OdbcError::UnsupportedFeature { .. } => SqlState::OptionalFeatureNotImplemented,
             OdbcError::FetchTypeOutOfRange { .. } => SqlState::FetchTypeOutOfRange,
             OdbcError::ExtendedFetchUsed { .. } => SqlState::FunctionSequenceError,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -959,6 +959,16 @@ pub fn bind_col(
         tracing::debug!("bind_col: unbinding column {}", column_number);
         stmt.ard.bindings.remove(&column_number);
     } else {
+        // ODBC: BufferLength < 0 is invalid (HY090). Reject at bind time so
+        // downstream stride/copy code paths can safely treat `buffer_length`
+        // as a non-negative byte count and use unchecked `as usize` casts on
+        // the hot SQLFetch path.
+        if buffer_length < 0 {
+            return InvalidBufferLengthSnafu {
+                length: buffer_length as i64,
+            }
+            .fail();
+        }
         stmt.ard.bindings.insert(
             column_number,
             Binding {

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -155,6 +155,24 @@ pub enum ConversionError {
         #[snafu(implicit)]
         location: Location,
     },
+
+    /// Address arithmetic for a per-row binding overflowed `usize`. This
+    /// can only happen with a pathological `SQL_ATTR_ROW_BIND_TYPE` /
+    /// large rowset combination, but we surface it as a row-level error
+    /// instead of panicking across the FFI boundary.
+    #[snafu(display(
+        "Binding stride overflow at row_idx={row_idx} \
+         (value_stride={value_stride}, indicator_stride={indicator_stride}, \
+         bind_offset={bind_offset})"
+    ))]
+    BindingStrideOverflow {
+        row_idx: usize,
+        value_stride: usize,
+        indicator_stride: usize,
+        bind_offset: isize,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 #[derive(Debug, Snafu, ErrorTrace)]

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -43,7 +43,9 @@ use arrow::datatypes::{
     Int64Type,
 };
 use snafu::ResultExt;
-pub use traits::{Binding, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType};
+pub use traits::{
+    Binding, BindingStrides, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType,
+};
 
 pub use error::{
     ArrowArrayDowncastSnafu, ConversionError, FieldMetadataParsingSnafu, MissingFieldMetadataSnafu,
@@ -78,20 +80,23 @@ pub trait ColumnConverter {
 
     /// Convert each row in `arrow_row_range` into `outputs[i]`, skipping
     /// rows that already hold `Err` (preserving row-major "first error
-    /// aborts the row" semantics). Default impl is per-cell;
+    /// aborts the row" semantics). The per-row `Binding` is materialised
+    /// inline via `BindingStrides::for_row`. Default impl is per-cell;
     /// `Converter<A, T>` overrides it to downcast once per segment.
     fn convert_arrow_range(
         &self,
         array: &dyn Array,
         arrow_row_range: std::ops::Range<usize>,
-        binding_fn: &mut dyn FnMut(usize) -> Binding,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
         outputs: &mut [Result<Warnings, ConversionError>],
     ) {
         for (i, batch_idx) in arrow_row_range.enumerate() {
             if outputs[i].is_err() {
                 continue;
             }
-            let binding = binding_fn(i);
+            let binding = strides.for_row(base_binding, out_row_start + i);
             match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
                 Ok(w) => {
                     if let Ok(existing) = &mut outputs[i] {
@@ -143,25 +148,18 @@ impl<
             .context(WriteOdbcValueSnafu)
     }
 
-    /// Column-major hot path.
-    ///
-    /// Performs the `Any` downcast exactly once for the whole segment and
-    /// then iterates over rows with statically-dispatched
-    /// [`ReadArrowType`]/[`WriteODBCType`] calls — the compiler inlines
-    /// both through `self.snowflake_type: T`. The only dynamic dispatch
-    /// remaining per fetch is one vtable call per `(column, segment)`
-    /// pair, versus one per cell under the per-row scheme.
-    ///
-    /// If the downcast fails (a schema/converter mismatch that the driver
-    /// would consider a bug) we fall back to the trait's default
-    /// implementation so that each row reports the real downcast error
-    /// through its own `outputs` slot, matching the old per-cell
-    /// behaviour.
+    /// Downcasts `array` once for the whole segment, then iterates rows
+    /// through statically-dispatched `read_arrow_type`/`write_odbc_type`
+    /// — no per-cell vtable, closure, or `Any` cost. Falls back to the
+    /// per-cell default impl on downcast failure so each row reports the
+    /// original error.
     fn convert_arrow_range(
         &self,
         array: &dyn Array,
         arrow_row_range: std::ops::Range<usize>,
-        binding_fn: &mut dyn FnMut(usize) -> Binding,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
         outputs: &mut [Result<Warnings, ConversionError>],
     ) {
         let Some(arrow_array) = array.as_any().downcast_ref::<ArrowArrayType>() else {
@@ -169,7 +167,7 @@ impl<
                 if outputs[i].is_err() {
                     continue;
                 }
-                let binding = binding_fn(i);
+                let binding = strides.for_row(base_binding, out_row_start + i);
                 match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
                     Ok(w) => {
                         if let Ok(existing) = &mut outputs[i] {
@@ -188,7 +186,7 @@ impl<
             if outputs[i].is_err() {
                 continue;
             }
-            let binding = binding_fn(i);
+            let binding = strides.for_row(base_binding, out_row_start + i);
             let result = self
                 .snowflake_type
                 .read_arrow_type(arrow_array, batch_idx)

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -58,9 +58,10 @@ use crate::conversion::warning::Warnings;
 
 /// Per-column converter from Arrow values to ODBC buffers.
 ///
-/// `'static` so it can be cached and reused across every cell of a column
-/// within a `RecordBatch`. The array is passed in per call rather than held
-/// by the converter.
+/// `'static` so it can be cached per column per `RecordBatch`. Two entry
+/// points: `convert_arrow_value` for single-cell `SQLGetData`, and
+/// `convert_arrow_range` for `SQLFetch` segments (overridden to amortise the
+/// Arrow downcast across the whole segment).
 ///
 /// This is the type-erased handle stored in the per-batch cache as
 /// `Box<dyn ColumnConverter>`. The single concrete implementation is
@@ -74,6 +75,35 @@ pub trait ColumnConverter {
         binding: &Binding,
         get_data_offset: &mut Option<usize>,
     ) -> Result<Warnings, ConversionError>;
+
+    /// Convert each row in `arrow_row_range` into `outputs[i]`, skipping
+    /// rows that already hold `Err` (preserving row-major "first error
+    /// aborts the row" semantics). Default impl is per-cell;
+    /// `Converter<A, T>` overrides it to downcast once per segment.
+    fn convert_arrow_range(
+        &self,
+        array: &dyn Array,
+        arrow_row_range: std::ops::Range<usize>,
+        binding_fn: &mut dyn FnMut(usize) -> Binding,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    ) {
+        for (i, batch_idx) in arrow_row_range.enumerate() {
+            if outputs[i].is_err() {
+                continue;
+            }
+            let binding = binding_fn(i);
+            match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
+                Ok(w) => {
+                    if let Ok(existing) = &mut outputs[i] {
+                        existing.extend(w);
+                    }
+                }
+                Err(e) => {
+                    outputs[i] = Err(e);
+                }
+            }
+        }
+    }
 }
 
 /// Concrete column converter, parameterised over a single Arrow array type
@@ -111,6 +141,74 @@ impl<
         self.snowflake_type
             .write_odbc_type(value, binding, get_data_offset)
             .context(WriteOdbcValueSnafu)
+    }
+
+    /// Column-major hot path.
+    ///
+    /// Performs the `Any` downcast exactly once for the whole segment and
+    /// then iterates over rows with statically-dispatched
+    /// [`ReadArrowType`]/[`WriteODBCType`] calls — the compiler inlines
+    /// both through `self.snowflake_type: T`. The only dynamic dispatch
+    /// remaining per fetch is one vtable call per `(column, segment)`
+    /// pair, versus one per cell under the per-row scheme.
+    ///
+    /// If the downcast fails (a schema/converter mismatch that the driver
+    /// would consider a bug) we fall back to the trait's default
+    /// implementation so that each row reports the real downcast error
+    /// through its own `outputs` slot, matching the old per-cell
+    /// behaviour.
+    fn convert_arrow_range(
+        &self,
+        array: &dyn Array,
+        arrow_row_range: std::ops::Range<usize>,
+        binding_fn: &mut dyn FnMut(usize) -> Binding,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    ) {
+        let Some(arrow_array) = array.as_any().downcast_ref::<ArrowArrayType>() else {
+            for (i, batch_idx) in arrow_row_range.enumerate() {
+                if outputs[i].is_err() {
+                    continue;
+                }
+                let binding = binding_fn(i);
+                match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
+                    Ok(w) => {
+                        if let Ok(existing) = &mut outputs[i] {
+                            existing.extend(w);
+                        }
+                    }
+                    Err(e) => {
+                        outputs[i] = Err(e);
+                    }
+                }
+            }
+            return;
+        };
+
+        for (i, batch_idx) in arrow_row_range.enumerate() {
+            if outputs[i].is_err() {
+                continue;
+            }
+            let binding = binding_fn(i);
+            let result = self
+                .snowflake_type
+                .read_arrow_type(arrow_array, batch_idx)
+                .context(ReadArrowValueSnafu)
+                .and_then(|value| {
+                    self.snowflake_type
+                        .write_odbc_type(value, &binding, &mut None)
+                        .context(WriteOdbcValueSnafu)
+                });
+            match result {
+                Ok(w) => {
+                    if let Ok(existing) = &mut outputs[i] {
+                        existing.extend(w);
+                    }
+                }
+                Err(e) => {
+                    outputs[i] = Err(e);
+                }
+            }
+        }
     }
 }
 

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -121,7 +121,13 @@ fn per_cell_convert_range(
         if outputs[i].is_err() {
             continue;
         }
-        let binding = strides.for_row(base_binding, out_row_start + i);
+        let binding = match strides.for_row(base_binding, out_row_start + i) {
+            Ok(b) => b,
+            Err(e) => {
+                outputs[i] = Err(e);
+                continue;
+            }
+        };
         match converter.convert_arrow_value(array, batch_idx, &binding, &mut None) {
             Ok(w) => {
                 if let Ok(existing) = &mut outputs[i] {
@@ -203,7 +209,13 @@ impl<
             if outputs[i].is_err() {
                 continue;
             }
-            let binding = strides.for_row(base_binding, out_row_start + i);
+            let binding = match strides.for_row(base_binding, out_row_start + i) {
+                Ok(b) => b,
+                Err(e) => {
+                    outputs[i] = Err(e);
+                    continue;
+                }
+            };
             let result = self
                 .snowflake_type
                 .read_arrow_type(arrow_array, batch_idx)

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -81,8 +81,9 @@ pub trait ColumnConverter {
     /// Convert each row in `arrow_row_range` into `outputs[i]`, skipping
     /// rows that already hold `Err` (preserving row-major "first error
     /// aborts the row" semantics). The per-row `Binding` is materialised
-    /// inline via `BindingStrides::for_row`. Default impl is per-cell;
-    /// `Converter<A, T>` overrides it to downcast once per segment.
+    /// inline via `BindingStrides::for_row`. Default impl is per-cell via
+    /// [`per_cell_convert_range`]; `Converter<A, T>` overrides it to
+    /// downcast once per segment.
     fn convert_arrow_range(
         &self,
         array: &dyn Array,
@@ -92,20 +93,43 @@ pub trait ColumnConverter {
         strides: BindingStrides,
         outputs: &mut [Result<Warnings, ConversionError>],
     ) {
-        for (i, batch_idx) in arrow_row_range.enumerate() {
-            if outputs[i].is_err() {
-                continue;
+        per_cell_convert_range(
+            self,
+            array,
+            arrow_row_range,
+            base_binding,
+            out_row_start,
+            strides,
+            outputs,
+        );
+    }
+}
+
+/// Shared per-row loop used by both the default `convert_arrow_range`
+/// impl and the downcast-failure fallback in `Converter`. Extracted so
+/// the row-skip / first-error semantics live in exactly one place.
+fn per_cell_convert_range(
+    converter: &(impl ColumnConverter + ?Sized),
+    array: &dyn Array,
+    arrow_row_range: std::ops::Range<usize>,
+    base_binding: &Binding,
+    out_row_start: usize,
+    strides: BindingStrides,
+    outputs: &mut [Result<Warnings, ConversionError>],
+) {
+    for (i, batch_idx) in arrow_row_range.enumerate() {
+        if outputs[i].is_err() {
+            continue;
+        }
+        let binding = strides.for_row(base_binding, out_row_start + i);
+        match converter.convert_arrow_value(array, batch_idx, &binding, &mut None) {
+            Ok(w) => {
+                if let Ok(existing) = &mut outputs[i] {
+                    existing.extend(w);
+                }
             }
-            let binding = strides.for_row(base_binding, out_row_start + i);
-            match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
-                Ok(w) => {
-                    if let Ok(existing) = &mut outputs[i] {
-                        existing.extend(w);
-                    }
-                }
-                Err(e) => {
-                    outputs[i] = Err(e);
-                }
+            Err(e) => {
+                outputs[i] = Err(e);
             }
         }
     }
@@ -163,22 +187,15 @@ impl<
         outputs: &mut [Result<Warnings, ConversionError>],
     ) {
         let Some(arrow_array) = array.as_any().downcast_ref::<ArrowArrayType>() else {
-            for (i, batch_idx) in arrow_row_range.enumerate() {
-                if outputs[i].is_err() {
-                    continue;
-                }
-                let binding = strides.for_row(base_binding, out_row_start + i);
-                match self.convert_arrow_value(array, batch_idx, &binding, &mut None) {
-                    Ok(w) => {
-                        if let Ok(existing) = &mut outputs[i] {
-                            existing.extend(w);
-                        }
-                    }
-                    Err(e) => {
-                        outputs[i] = Err(e);
-                    }
-                }
-            }
+            per_cell_convert_range(
+                self,
+                array,
+                arrow_row_range,
+                base_binding,
+                out_row_start,
+                strides,
+                outputs,
+            );
             return;
         };
 

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -551,22 +551,65 @@ pub(crate) trait WriteJson: SnowflakeType {
 mod binding_strides_tests {
     use super::*;
 
-    /// Pointer fields are non-null sentinels but never dereferenced — only
-    /// the address arithmetic produced by `for_row` is checked.
-    fn base_binding(target_type: CDataType, buffer_length: sql::Len) -> Binding {
-        Binding {
-            target_type,
-            target_value_ptr: 1024usize as sql::Pointer,
-            buffer_length,
-            octet_length_ptr: 2048usize as *mut sql::Len,
-            indicator_ptr: 4096usize as *mut sql::Len,
-            ..Default::default()
+    /// Backing buffers for the synthetic `Binding` pointers. Pointer
+    /// arithmetic in `advance_ptr` (`offset` / `add`) requires the result
+    /// to stay in-bounds of the same allocated object the pointer was
+    /// derived from, so the tests must operate on real allocations
+    /// (rather than integer-cast sentinel addresses) to be well-defined.
+    ///
+    /// Each "logical" base is positioned `PREFIX` bytes into the
+    /// allocation so tests with a negative `bind_offset` still produce
+    /// in-bounds pointers. Buffers are large enough for all stride/row
+    /// combinations exercised by the tests below.
+    struct Fixture {
+        value_buf: Vec<u8>,
+        octet_buf: Vec<u8>,
+        indicator_buf: Vec<u8>,
+    }
+
+    impl Fixture {
+        const PREFIX: usize = 64;
+        const SIZE: usize = 4096;
+
+        fn new() -> Self {
+            Self {
+                value_buf: vec![0u8; Self::SIZE],
+                octet_buf: vec![0u8; Self::SIZE],
+                indicator_buf: vec![0u8; Self::SIZE],
+            }
+        }
+
+        fn value_base(&mut self) -> *mut u8 {
+            unsafe { self.value_buf.as_mut_ptr().add(Self::PREFIX) }
+        }
+
+        fn octet_base(&mut self) -> *mut sql::Len {
+            unsafe { self.octet_buf.as_mut_ptr().add(Self::PREFIX) as *mut sql::Len }
+        }
+
+        fn indicator_base(&mut self) -> *mut sql::Len {
+            unsafe { self.indicator_buf.as_mut_ptr().add(Self::PREFIX) as *mut sql::Len }
+        }
+
+        fn binding(&mut self, target_type: CDataType, buffer_length: sql::Len) -> Binding {
+            Binding {
+                target_type,
+                target_value_ptr: self.value_base() as sql::Pointer,
+                buffer_length,
+                octet_length_ptr: self.octet_base(),
+                indicator_ptr: self.indicator_base(),
+                ..Default::default()
+            }
         }
     }
 
     #[test]
     fn column_wise_uses_fixed_size_for_value_stride() {
-        let base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as usize;
+        let octet_base = fx.octet_base() as usize;
+        let indicator_base = fx.indicator_base() as usize;
+        let base = fx.binding(CDataType::SBigInt, 0);
         let strides = BindingStrides {
             bind_type: 0,
             bind_offset: 0,
@@ -574,15 +617,17 @@ mod binding_strides_tests {
         let row3 = strides
             .for_row(&base, 3)
             .expect("for_row must not overflow in tests");
-        assert_eq!(row3.target_value_ptr as usize, 1024 + 3 * 8);
+        assert_eq!(row3.target_value_ptr as usize - value_base, 3 * 8);
         let len_size = size_of::<sql::Len>();
-        assert_eq!(row3.octet_length_ptr as usize, 2048 + 3 * len_size);
-        assert_eq!(row3.indicator_ptr as usize, 4096 + 3 * len_size);
+        assert_eq!(row3.octet_length_ptr as usize - octet_base, 3 * len_size);
+        assert_eq!(row3.indicator_ptr as usize - indicator_base, 3 * len_size);
     }
 
     #[test]
     fn column_wise_falls_back_to_buffer_length_for_variable_size_type() {
-        let base = base_binding(CDataType::Char, 64);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as usize;
+        let base = fx.binding(CDataType::Char, 64);
         let strides = BindingStrides {
             bind_type: 0,
             bind_offset: 0,
@@ -590,12 +635,16 @@ mod binding_strides_tests {
         let row5 = strides
             .for_row(&base, 5)
             .expect("for_row must not overflow in tests");
-        assert_eq!(row5.target_value_ptr as usize, 1024 + 5 * 64);
+        assert_eq!(row5.target_value_ptr as usize - value_base, 5 * 64);
     }
 
     #[test]
     fn row_wise_uses_bind_type_for_every_pointer_stride() {
-        let base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as usize;
+        let octet_base = fx.octet_base() as usize;
+        let indicator_base = fx.indicator_base() as usize;
+        let base = fx.binding(CDataType::SBigInt, 0);
         let strides = BindingStrides {
             bind_type: 64,
             bind_offset: 0,
@@ -603,14 +652,18 @@ mod binding_strides_tests {
         let row2 = strides
             .for_row(&base, 2)
             .expect("for_row must not overflow in tests");
-        assert_eq!(row2.target_value_ptr as usize, 1024 + 2 * 64);
-        assert_eq!(row2.octet_length_ptr as usize, 2048 + 2 * 64);
-        assert_eq!(row2.indicator_ptr as usize, 4096 + 2 * 64);
+        assert_eq!(row2.target_value_ptr as usize - value_base, 2 * 64);
+        assert_eq!(row2.octet_length_ptr as usize - octet_base, 2 * 64);
+        assert_eq!(row2.indicator_ptr as usize - indicator_base, 2 * 64);
     }
 
     #[test]
     fn bind_offset_is_applied_before_striding() {
-        let base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as usize;
+        let octet_base = fx.octet_base() as usize;
+        let indicator_base = fx.indicator_base() as usize;
+        let base = fx.binding(CDataType::SBigInt, 0);
         let strides = BindingStrides {
             bind_type: 0,
             bind_offset: 32,
@@ -618,15 +671,17 @@ mod binding_strides_tests {
         let row1 = strides
             .for_row(&base, 1)
             .expect("for_row must not overflow in tests");
-        assert_eq!(row1.target_value_ptr as usize, 1024 + 32 + 8);
+        assert_eq!(row1.target_value_ptr as usize - value_base, 32 + 8);
         let len_size = size_of::<sql::Len>();
-        assert_eq!(row1.octet_length_ptr as usize, 2048 + 32 + len_size);
-        assert_eq!(row1.indicator_ptr as usize, 4096 + 32 + len_size);
+        assert_eq!(row1.octet_length_ptr as usize - octet_base, 32 + len_size);
+        assert_eq!(row1.indicator_ptr as usize - indicator_base, 32 + len_size);
     }
 
     #[test]
     fn negative_bind_offset_walks_pointer_back() {
-        let base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as isize;
+        let base = fx.binding(CDataType::SBigInt, 0);
         let strides = BindingStrides {
             bind_type: 0,
             bind_offset: -16,
@@ -634,12 +689,14 @@ mod binding_strides_tests {
         let row0 = strides
             .for_row(&base, 0)
             .expect("for_row must not overflow in tests");
-        assert_eq!(row0.target_value_ptr as usize, 1024 - 16);
+        assert_eq!(row0.target_value_ptr as isize - value_base, -16);
     }
 
     #[test]
     fn null_pointers_remain_null_after_adjustment() {
-        let mut base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let value_base = fx.value_base() as usize;
+        let mut base = fx.binding(CDataType::SBigInt, 0);
         base.octet_length_ptr = std::ptr::null_mut();
         base.indicator_ptr = std::ptr::null_mut();
         let strides = BindingStrides {
@@ -651,12 +708,13 @@ mod binding_strides_tests {
             .expect("for_row must not overflow in tests");
         assert!(row7.octet_length_ptr.is_null());
         assert!(row7.indicator_ptr.is_null());
-        assert_eq!(row7.target_value_ptr as usize, 1024 + 64 + 7 * 8);
+        assert_eq!(row7.target_value_ptr as usize - value_base, 64 + 7 * 8);
     }
 
     #[test]
     fn for_row_returns_err_on_stride_overflow() {
-        let base = base_binding(CDataType::SBigInt, 0);
+        let mut fx = Fixture::new();
+        let base = fx.binding(CDataType::SBigInt, 0);
         let strides = BindingStrides {
             bind_type: usize::MAX / 2,
             bind_offset: 0,
@@ -672,7 +730,8 @@ mod binding_strides_tests {
 
     #[test]
     fn metadata_fields_are_propagated_unchanged() {
-        let mut base = base_binding(CDataType::Numeric, size_of::<sql::Numeric>() as sql::Len);
+        let mut fx = Fixture::new();
+        let mut base = fx.binding(CDataType::Numeric, size_of::<sql::Numeric>() as sql::Len);
         base.precision = Some(10);
         base.scale = Some(2);
         base.datetime_interval_precision = Some(6);

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -4,7 +4,8 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::{
-    IndicatorRequiredSnafu, JsonBindingError, ReadArrowError, WriteOdbcError,
+    BindingStrideOverflowSnafu, ConversionError, IndicatorRequiredSnafu, JsonBindingError,
+    ReadArrowError, WriteOdbcError,
 };
 use crate::conversion::warning::{Warning, Warnings};
 
@@ -93,8 +94,14 @@ impl BindingStrides {
     /// application's bound buffers, given the column's `base` binding.
     /// `#[inline]` so callers in `convert_arrow_range` monomorphise and
     /// LLVM can hoist the stride math.
+    ///
+    /// Returns `ConversionError::BindingStrideOverflow` if the address
+    /// arithmetic for any of the three per-row pointers would overflow
+    /// `usize`. This can only happen with a pathological combination of
+    /// caller-supplied `bind_type` and `array_size` values, but a row
+    /// error is still preferable to a panic across the FFI boundary.
     #[inline]
-    pub fn for_row(self, base: &Binding, row_idx: usize) -> Binding {
+    pub fn for_row(self, base: &Binding, row_idx: usize) -> Result<Binding, ConversionError> {
         let value_stride = if self.bind_type == 0 {
             base.target_type
                 .fixed_size()
@@ -107,49 +114,62 @@ impl BindingStrides {
         } else {
             self.bind_type
         };
-        Binding {
-            target_type: base.target_type,
-            target_value_ptr: advance_ptr(
-                base.target_value_ptr,
+        let overflow_err = || {
+            BindingStrideOverflowSnafu {
                 row_idx,
                 value_stride,
-                self.bind_offset,
-            ),
+                indicator_stride,
+                bind_offset: self.bind_offset,
+            }
+            .build()
+        };
+        let target_value_ptr =
+            advance_ptr(base.target_value_ptr, row_idx, value_stride, self.bind_offset)
+                .ok_or_else(overflow_err)?;
+        let octet_length_ptr = advance_ptr(
+            base.octet_length_ptr,
+            row_idx,
+            indicator_stride,
+            self.bind_offset,
+        )
+        .ok_or_else(overflow_err)?;
+        let indicator_ptr = advance_ptr(
+            base.indicator_ptr,
+            row_idx,
+            indicator_stride,
+            self.bind_offset,
+        )
+        .ok_or_else(overflow_err)?;
+        Ok(Binding {
+            target_type: base.target_type,
+            target_value_ptr,
             buffer_length: base.buffer_length,
-            octet_length_ptr: advance_ptr(
-                base.octet_length_ptr,
-                row_idx,
-                indicator_stride,
-                self.bind_offset,
-            ),
-            indicator_ptr: advance_ptr(
-                base.indicator_ptr,
-                row_idx,
-                indicator_stride,
-                self.bind_offset,
-            ),
+            octet_length_ptr,
+            indicator_ptr,
             precision: base.precision,
             scale: base.scale,
             datetime_interval_precision: base.datetime_interval_precision,
-        }
+        })
     }
 }
 
+/// Returns `None` if `row_idx * element_stride` overflows `usize`. The
+/// raw pointer arithmetic is unchanged; the caller is responsible for
+/// ensuring the resulting address stays inside the bound allocation
+/// (the same guarantee the application makes via `SQLBindCol`).
 #[inline]
 fn advance_ptr<T>(
     ptr: *mut T,
     row_idx: usize,
     element_stride: usize,
     bind_offset: isize,
-) -> *mut T {
+) -> Option<*mut T> {
     if ptr.is_null() {
-        return std::ptr::null_mut();
+        return Some(std::ptr::null_mut());
     }
-    let stride = row_idx
-        .checked_mul(element_stride)
-        .expect("row index and element stride multiplication overflowed");
+    let stride = row_idx.checked_mul(element_stride)?;
     let byte_ptr = ptr as *mut u8;
-    unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T }
+    Some(unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T })
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -547,7 +567,7 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row3 = strides.for_row(&base, 3);
+        let row3 = strides.for_row(&base, 3).expect("for_row must not overflow in tests");
         assert_eq!(row3.target_value_ptr as usize, 1024 + 3 * 8);
         let len_size = size_of::<sql::Len>();
         assert_eq!(row3.octet_length_ptr as usize, 2048 + 3 * len_size);
@@ -561,7 +581,7 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row5 = strides.for_row(&base, 5);
+        let row5 = strides.for_row(&base, 5).expect("for_row must not overflow in tests");
         assert_eq!(row5.target_value_ptr as usize, 1024 + 5 * 64);
     }
 
@@ -572,7 +592,7 @@ mod binding_strides_tests {
             bind_type: 64,
             bind_offset: 0,
         };
-        let row2 = strides.for_row(&base, 2);
+        let row2 = strides.for_row(&base, 2).expect("for_row must not overflow in tests");
         assert_eq!(row2.target_value_ptr as usize, 1024 + 2 * 64);
         assert_eq!(row2.octet_length_ptr as usize, 2048 + 2 * 64);
         assert_eq!(row2.indicator_ptr as usize, 4096 + 2 * 64);
@@ -585,7 +605,7 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 32,
         };
-        let row1 = strides.for_row(&base, 1);
+        let row1 = strides.for_row(&base, 1).expect("for_row must not overflow in tests");
         assert_eq!(row1.target_value_ptr as usize, 1024 + 32 + 8);
         let len_size = size_of::<sql::Len>();
         assert_eq!(row1.octet_length_ptr as usize, 2048 + 32 + len_size);
@@ -599,7 +619,7 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: -16,
         };
-        let row0 = strides.for_row(&base, 0);
+        let row0 = strides.for_row(&base, 0).expect("for_row must not overflow in tests");
         assert_eq!(row0.target_value_ptr as usize, 1024 - 16);
     }
 
@@ -612,10 +632,26 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 64,
         };
-        let row7 = strides.for_row(&base, 7);
+        let row7 = strides.for_row(&base, 7).expect("for_row must not overflow in tests");
         assert!(row7.octet_length_ptr.is_null());
         assert!(row7.indicator_ptr.is_null());
         assert_eq!(row7.target_value_ptr as usize, 1024 + 64 + 7 * 8);
+    }
+
+    #[test]
+    fn for_row_returns_err_on_stride_overflow() {
+        let base = base_binding(CDataType::SBigInt, 0);
+        let strides = BindingStrides {
+            bind_type: usize::MAX / 2,
+            bind_offset: 0,
+        };
+        let err = strides
+            .for_row(&base, 4)
+            .expect_err("expected BindingStrideOverflow on pathological stride");
+        assert!(
+            matches!(err, ConversionError::BindingStrideOverflow { .. }),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -628,7 +664,7 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row4 = strides.for_row(&base, 4);
+        let row4 = strides.for_row(&base, 4).expect("for_row must not overflow in tests");
         assert_eq!(row4.precision, Some(10));
         assert_eq!(row4.scale, Some(2));
         assert_eq!(row4.datetime_interval_precision, Some(6));

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -76,6 +76,82 @@ pub enum LengthOrNull {
     Length(sql::Len),
 }
 
+/// ARD stride parameters that decide how a base [`Binding`] is laid out
+/// across the rows of a block-cursor fetch. `bind_type` is
+/// `SQL_ATTR_ROW_BIND_TYPE` (0 ⇒ column-wise; non-zero ⇒ row-wise byte
+/// stride); `bind_offset` is the value of `*SQL_ATTR_ROW_BIND_OFFSET_PTR`
+/// at fetch entry. `Copy` so it can be passed by value into the per-row
+/// hot path with no indirection.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BindingStrides {
+    pub bind_type: usize,
+    pub bind_offset: isize,
+}
+
+impl BindingStrides {
+    /// Materialise the [`Binding`] that targets row `row_idx` within the
+    /// application's bound buffers, given the column's `base` binding.
+    /// `#[inline]` so callers in `convert_arrow_range` monomorphise and
+    /// LLVM can hoist the stride math.
+    #[inline]
+    pub fn for_row(self, base: &Binding, row_idx: usize) -> Binding {
+        let value_stride = if self.bind_type == 0 {
+            base.target_type
+                .fixed_size()
+                .unwrap_or(base.buffer_length as usize)
+        } else {
+            self.bind_type
+        };
+        let indicator_stride = if self.bind_type == 0 {
+            size_of::<sql::Len>()
+        } else {
+            self.bind_type
+        };
+        Binding {
+            target_type: base.target_type,
+            target_value_ptr: advance_ptr(
+                base.target_value_ptr,
+                row_idx,
+                value_stride,
+                self.bind_offset,
+            ),
+            buffer_length: base.buffer_length,
+            octet_length_ptr: advance_ptr(
+                base.octet_length_ptr,
+                row_idx,
+                indicator_stride,
+                self.bind_offset,
+            ),
+            indicator_ptr: advance_ptr(
+                base.indicator_ptr,
+                row_idx,
+                indicator_stride,
+                self.bind_offset,
+            ),
+            precision: base.precision,
+            scale: base.scale,
+            datetime_interval_precision: base.datetime_interval_precision,
+        }
+    }
+}
+
+#[inline]
+fn advance_ptr<T>(
+    ptr: *mut T,
+    row_idx: usize,
+    element_stride: usize,
+    bind_offset: isize,
+) -> *mut T {
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    let stride = row_idx
+        .checked_mul(element_stride)
+        .expect("row index and element stride multiplication overflowed");
+    let byte_ptr = ptr as *mut u8;
+    unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T }
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Binding {
     pub target_type: CDataType,
@@ -445,4 +521,118 @@ pub(crate) trait ReadODBC: SnowflakeType {
 pub(crate) trait WriteJson: SnowflakeType {
     fn write_json(&self, value: Self::Representation<'_>) -> Result<Value, JsonBindingError>;
     fn sf_type(&self) -> SnowflakeLogicalType;
+}
+
+#[cfg(test)]
+mod binding_strides_tests {
+    use super::*;
+
+    /// Pointer fields are non-null sentinels but never dereferenced — only
+    /// the address arithmetic produced by `for_row` is checked.
+    fn base_binding(target_type: CDataType, buffer_length: sql::Len) -> Binding {
+        Binding {
+            target_type,
+            target_value_ptr: 1024usize as sql::Pointer,
+            buffer_length,
+            octet_length_ptr: 2048usize as *mut sql::Len,
+            indicator_ptr: 4096usize as *mut sql::Len,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn column_wise_uses_fixed_size_for_value_stride() {
+        let base = base_binding(CDataType::SBigInt, 0);
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: 0,
+        };
+        let row3 = strides.for_row(&base, 3);
+        assert_eq!(row3.target_value_ptr as usize, 1024 + 3 * 8);
+        let len_size = size_of::<sql::Len>();
+        assert_eq!(row3.octet_length_ptr as usize, 2048 + 3 * len_size);
+        assert_eq!(row3.indicator_ptr as usize, 4096 + 3 * len_size);
+    }
+
+    #[test]
+    fn column_wise_falls_back_to_buffer_length_for_variable_size_type() {
+        let base = base_binding(CDataType::Char, 64);
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: 0,
+        };
+        let row5 = strides.for_row(&base, 5);
+        assert_eq!(row5.target_value_ptr as usize, 1024 + 5 * 64);
+    }
+
+    #[test]
+    fn row_wise_uses_bind_type_for_every_pointer_stride() {
+        let base = base_binding(CDataType::SBigInt, 0);
+        let strides = BindingStrides {
+            bind_type: 64,
+            bind_offset: 0,
+        };
+        let row2 = strides.for_row(&base, 2);
+        assert_eq!(row2.target_value_ptr as usize, 1024 + 2 * 64);
+        assert_eq!(row2.octet_length_ptr as usize, 2048 + 2 * 64);
+        assert_eq!(row2.indicator_ptr as usize, 4096 + 2 * 64);
+    }
+
+    #[test]
+    fn bind_offset_is_applied_before_striding() {
+        let base = base_binding(CDataType::SBigInt, 0);
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: 32,
+        };
+        let row1 = strides.for_row(&base, 1);
+        assert_eq!(row1.target_value_ptr as usize, 1024 + 32 + 8);
+        let len_size = size_of::<sql::Len>();
+        assert_eq!(row1.octet_length_ptr as usize, 2048 + 32 + len_size);
+        assert_eq!(row1.indicator_ptr as usize, 4096 + 32 + len_size);
+    }
+
+    #[test]
+    fn negative_bind_offset_walks_pointer_back() {
+        let base = base_binding(CDataType::SBigInt, 0);
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: -16,
+        };
+        let row0 = strides.for_row(&base, 0);
+        assert_eq!(row0.target_value_ptr as usize, 1024 - 16);
+    }
+
+    #[test]
+    fn null_pointers_remain_null_after_adjustment() {
+        let mut base = base_binding(CDataType::SBigInt, 0);
+        base.octet_length_ptr = std::ptr::null_mut();
+        base.indicator_ptr = std::ptr::null_mut();
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: 64,
+        };
+        let row7 = strides.for_row(&base, 7);
+        assert!(row7.octet_length_ptr.is_null());
+        assert!(row7.indicator_ptr.is_null());
+        assert_eq!(row7.target_value_ptr as usize, 1024 + 64 + 7 * 8);
+    }
+
+    #[test]
+    fn metadata_fields_are_propagated_unchanged() {
+        let mut base = base_binding(CDataType::Numeric, size_of::<sql::Numeric>() as sql::Len);
+        base.precision = Some(10);
+        base.scale = Some(2);
+        base.datetime_interval_precision = Some(6);
+        let strides = BindingStrides {
+            bind_type: 0,
+            bind_offset: 0,
+        };
+        let row4 = strides.for_row(&base, 4);
+        assert_eq!(row4.precision, Some(10));
+        assert_eq!(row4.scale, Some(2));
+        assert_eq!(row4.datetime_interval_precision, Some(6));
+        assert_eq!(row4.target_type, CDataType::Numeric);
+        assert_eq!(row4.buffer_length, base.buffer_length);
+    }
 }

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -123,9 +123,13 @@ impl BindingStrides {
             }
             .build()
         };
-        let target_value_ptr =
-            advance_ptr(base.target_value_ptr, row_idx, value_stride, self.bind_offset)
-                .ok_or_else(overflow_err)?;
+        let target_value_ptr = advance_ptr(
+            base.target_value_ptr,
+            row_idx,
+            value_stride,
+            self.bind_offset,
+        )
+        .ok_or_else(overflow_err)?;
         let octet_length_ptr = advance_ptr(
             base.octet_length_ptr,
             row_idx,
@@ -567,7 +571,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row3 = strides.for_row(&base, 3).expect("for_row must not overflow in tests");
+        let row3 = strides
+            .for_row(&base, 3)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row3.target_value_ptr as usize, 1024 + 3 * 8);
         let len_size = size_of::<sql::Len>();
         assert_eq!(row3.octet_length_ptr as usize, 2048 + 3 * len_size);
@@ -581,7 +587,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row5 = strides.for_row(&base, 5).expect("for_row must not overflow in tests");
+        let row5 = strides
+            .for_row(&base, 5)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row5.target_value_ptr as usize, 1024 + 5 * 64);
     }
 
@@ -592,7 +600,9 @@ mod binding_strides_tests {
             bind_type: 64,
             bind_offset: 0,
         };
-        let row2 = strides.for_row(&base, 2).expect("for_row must not overflow in tests");
+        let row2 = strides
+            .for_row(&base, 2)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row2.target_value_ptr as usize, 1024 + 2 * 64);
         assert_eq!(row2.octet_length_ptr as usize, 2048 + 2 * 64);
         assert_eq!(row2.indicator_ptr as usize, 4096 + 2 * 64);
@@ -605,7 +615,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 32,
         };
-        let row1 = strides.for_row(&base, 1).expect("for_row must not overflow in tests");
+        let row1 = strides
+            .for_row(&base, 1)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row1.target_value_ptr as usize, 1024 + 32 + 8);
         let len_size = size_of::<sql::Len>();
         assert_eq!(row1.octet_length_ptr as usize, 2048 + 32 + len_size);
@@ -619,7 +631,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: -16,
         };
-        let row0 = strides.for_row(&base, 0).expect("for_row must not overflow in tests");
+        let row0 = strides
+            .for_row(&base, 0)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row0.target_value_ptr as usize, 1024 - 16);
     }
 
@@ -632,7 +646,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 64,
         };
-        let row7 = strides.for_row(&base, 7).expect("for_row must not overflow in tests");
+        let row7 = strides
+            .for_row(&base, 7)
+            .expect("for_row must not overflow in tests");
         assert!(row7.octet_length_ptr.is_null());
         assert!(row7.indicator_ptr.is_null());
         assert_eq!(row7.target_value_ptr as usize, 1024 + 64 + 7 * 8);
@@ -664,7 +680,9 @@ mod binding_strides_tests {
             bind_type: 0,
             bind_offset: 0,
         };
-        let row4 = strides.for_row(&base, 4).expect("for_row must not overflow in tests");
+        let row4 = strides
+            .for_row(&base, 4)
+            .expect("for_row must not overflow in tests");
         assert_eq!(row4.precision, Some(10));
         assert_eq!(row4.scale, Some(2));
         assert_eq!(row4.datetime_interval_precision, Some(6));


### PR DESCRIPTION
Layered on top of the per-batch converter cache from the prior commit.
That cache already removed the HashMap lookup, converter construction
and tracing cost from the per-cell path, but the remaining work still
ran row-major: for every bound cell we called
`ColumnConverter::convert_arrow_value`, which in turn did an `Any`
downcast plus one vtable call. On a 1M-row x 15-col `SELECT` that is
15M downcasts even though the column type is fixed for the whole batch.

This change flips the inner loops:

* `ColumnConverter` grows a `convert_arrow_range(array, row_range,
  binding_fn, outputs)` method. The default implementation forwards to
  the existing per-cell `convert_arrow_value` so every implementor
  keeps working, but `Converter<A, T>` (the concrete struct) overrides
  it to do the `Any` downcast exactly once per segment and then iterate
  over rows with statically-dispatched `ReadArrowType` /
  `WriteODBCType` calls that `T: SnowflakeType` monomorphises away.
  Dynamic dispatch per fetch drops from `O(rows * cols)` to
  `O(segments * cols)`.

* `fetch_impl` no longer walks row-major over the block cursor. For
  each `SQLFetch`/`SQLExtendedFetch` call it advances into the next
  row, determines how many rows fit in the current `RecordBatch`, and
  hands that contiguous `[batch_idx, batch_idx + seg_len)` range to
  every cached column in one go via `execute_bindings_for_segment`. A
  small `bump_batch_idx` helper then skips over the segment we just
  consumed so the next `advance_cursor` call lands on the following
  row or crosses into the next batch.

* Per-row error semantics are preserved. Results come back as
  `Vec<Result<Warnings, ConversionError>>`; each converter skips rows
  whose outcome is already `Err`, so the "first column error on a row
  aborts that row for every subsequent column" behaviour from the old
  row loop is bit-for-bit equivalent. The single-row fast path still
  propagates the first conversion error up to the caller instead of
  swallowing it into `SQL_SUCCESS_WITH_INFO`.

Naming reminder (introduced in the parent PR): `ColumnConverter` is the
type-erased trait stored in the per-batch cache as
`Box<dyn ColumnConverter>`; `Converter<A, T>` is the single concrete
struct, monomorphised once per `(ArrowArrayType, SnowflakeType)` pair.

No new benchmarks are added here; the existing `prefetch_bench` plus
the perf-dash `SELECT 1M 15 Columns` scenario cover the hot path. The
expected win stacks on top of the cache PR by roughly the cost of the
removed per-cell downcast (~O(rows * cols) `Any` + vtable calls).

Made-with: Cursor