### PR TITLE
Add api_telemetry decorator for tracking public API usage

### DIFF
--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -13,7 +13,7 @@ import types
 
 from collections.abc import Callable, Generator
 from contextvars import ContextVar
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from .backward_compatibility import apply_backward_compatibility
 

--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -9,6 +9,7 @@ to just the decorator façade.
 from __future__ import annotations
 
 import functools
+import inspect
 
 from contextvars import ContextVar
 from typing import Any, Callable, TypeVar, cast
@@ -88,9 +89,14 @@ def api_telemetry(func: F) -> F:
     therefore suppressed automatically, ensuring only the outermost
     user-initiated call is recorded.
 
+    For generator functions, tracking stays suppressed for the entire lifetime
+    of the generator (including iteration), so that nested decorated calls
+    during ``yield`` are also suppressed.
+
     The ``api_method`` string is derived at runtime as
     ``"{ClassName}.{method_name}"``.
     """
+    _is_generator = inspect.isgeneratorfunction(func)
 
     @functools.wraps(func)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
@@ -104,6 +110,9 @@ def api_telemetry(func: F) -> F:
             elif isinstance(self, SnowflakeCursorBase):
                 self._connection._telemetry_client.send_api_usage(api_name)
 
+            if _is_generator:
+                return _suppress_tracking_generator(func(self, *args, **kwargs))
+
             token = _TRACKING.set(False)
             try:
                 return func(self, *args, **kwargs)
@@ -112,3 +121,12 @@ def api_telemetry(func: F) -> F:
         return func(self, *args, **kwargs)
 
     return cast(F, wrapper)
+
+
+def _suppress_tracking_generator(gen: Any) -> Any:
+    """Wrap a generator so _TRACKING is False during each iteration step."""
+    token = _TRACKING.set(False)
+    try:
+        yield from gen
+    finally:
+        _TRACKING.reset(token)

--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -9,8 +9,9 @@ to just the decorator façade.
 from __future__ import annotations
 
 import functools
-import inspect
+import types
 
+from collections.abc import Generator
 from contextvars import ContextVar
 from typing import Any, Callable, TypeVar, cast
 
@@ -76,7 +77,7 @@ def backward_compatibility(obj: T) -> T:
     return apply_backward_compatibility(obj)
 
 
-_TRACKING = ContextVar("_api_tracking", default=True)
+_TRACKING: ContextVar[bool] = ContextVar("_api_tracking", default=True)
 
 
 def api_telemetry(func: F) -> F:
@@ -89,14 +90,16 @@ def api_telemetry(func: F) -> F:
     therefore suppressed automatically, ensuring only the outermost
     user-initiated call is recorded.
 
-    For generator functions, tracking stays suppressed for the entire lifetime
-    of the generator (including iteration), so that nested decorated calls
-    during ``yield`` are also suppressed.
+    For generator functions (including generators wrapped by other decorators),
+    tracking stays suppressed for the entire lifetime of the generator
+    (including iteration), so that nested decorated calls during ``yield``
+    are also suppressed.  Detection is done at runtime via ``isinstance``
+    on the return value rather than ``inspect.isgeneratorfunction``, which
+    would fail when intermediate decorators hide the generator nature.
 
     The ``api_method`` string is derived at runtime as
     ``"{ClassName}.{method_name}"``.
     """
-    _is_generator = inspect.isgeneratorfunction(func)
 
     @functools.wraps(func)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
@@ -110,22 +113,29 @@ def api_telemetry(func: F) -> F:
             elif isinstance(self, SnowflakeCursorBase):
                 self._connection._telemetry_client.send_api_usage(api_name)
 
-            if _is_generator:
-                return _suppress_tracking_generator(func(self, *args, **kwargs))
-
             token = _TRACKING.set(False)
             try:
-                return func(self, *args, **kwargs)
-            finally:
+                result = func(self, *args, **kwargs)
+            except BaseException:
                 _TRACKING.reset(token)
+                raise
+
+            if isinstance(result, types.GeneratorType):
+                # Keep tracking suppressed for the generator's entire lifetime.
+                return _suppress_tracking_generator(result, token)
+
+            _TRACKING.reset(token)
+            return result
         return func(self, *args, **kwargs)
 
     return cast(F, wrapper)
 
 
-def _suppress_tracking_generator(gen: Any) -> Any:
-    """Wrap a generator so _TRACKING is False during each iteration step."""
-    token = _TRACKING.set(False)
+def _suppress_tracking_generator(
+    gen: Generator[Any, Any, Any],
+    token: Any,
+) -> Generator[Any, Any, Any]:
+    """Wrap a generator so ``_TRACKING`` stays ``False`` for its entire lifetime."""
     try:
         yield from gen
     finally:

--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -8,12 +8,15 @@ to just the decorator façade.
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+import functools
+
+from contextvars import ContextVar
+from typing import Any, Callable, TypeVar, cast
 
 from .backward_compatibility import apply_backward_compatibility
 
 
-F = TypeVar("F", bound=Callable)
+F = TypeVar("F", bound=Callable[..., Any])
 
 # Generic pass-through: functions, classes, and descriptors all round-trip
 # through ``@backward_compatibility`` as the same logical type (a class stays
@@ -70,3 +73,42 @@ def backward_compatibility(obj: T) -> T:
       call-time wrapper is installed before the descriptor is built on top.
     """
     return apply_backward_compatibility(obj)
+
+
+_TRACKING = ContextVar("_api_tracking", default=True)
+
+
+def api_telemetry(func: F) -> F:
+    """Send api_usage telemetry on the first public-method entry.
+
+    When the decorated method is called and tracking is enabled (the default),
+    record the call via :pymeth:`TelemetryClient.send_api_usage` and then
+    *disable* tracking for the duration of the method body.  Any nested
+    decorated calls (e.g. ``commit`` -> ``cursor`` -> ``execute``) are
+    therefore suppressed automatically, ensuring only the outermost
+    user-initiated call is recorded.
+
+    The ``api_method`` string is derived at runtime as
+    ``"{ClassName}.{method_name}"``.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if _TRACKING.get():
+            from snowflake.connector.connection import Connection
+            from snowflake.connector.cursor._base import SnowflakeCursorBase
+
+            api_name = f"{type(self).__name__}.{func.__name__}"
+            if isinstance(self, Connection):
+                self._telemetry_client.send_api_usage(api_name)
+            elif isinstance(self, SnowflakeCursorBase):
+                self._connection._telemetry_client.send_api_usage(api_name)
+
+            token = _TRACKING.set(False)
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                _TRACKING.reset(token)
+        return func(self, *args, **kwargs)
+
+    return cast(F, wrapper)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -49,7 +49,7 @@ from snowflake.connector._internal.sqlstate import SQLSTATE_CONNECTION_NOT_EXIST
 from ._internal._private_key_helper import normalize_private_key
 from ._internal.api_client.client_api import database_driver_client
 from ._internal.binding_converters import ParamStyle
-from ._internal.decorators import backward_compatibility, internal_api, pep249
+from ._internal.decorators import api_telemetry, backward_compatibility, internal_api, pep249
 from ._internal.errorhandler import ErrorHandlerMixin
 from ._internal.extras import check_dependency
 from ._internal.extras import numpy as np
@@ -62,7 +62,7 @@ from ._internal.text_utils import split_statements
 from .constants import QueryStatus
 from .cursor import CursorInstance, CursorType, DictCursor, SnowflakeCursor
 from .errors import DatabaseError, Error, ErrorValue, InterfaceError, ProgrammingError
-from .telemetry import TelemetryClient
+from .telemetry import TelemetryClient as _BackwardCompatTelemetryClient
 from .version import __version__
 
 
@@ -243,9 +243,17 @@ class Connection(ErrorHandlerMixin):
                 ),
             )
         )
+        from ._internal.telemetry import TelemetryClient
+
+        self._telemetry_client = TelemetryClient(db_api=self.db_api, conn_handle=self.conn_handle)
 
         if self._should_auto_cleanup():
             atexit.register(self._close_at_process_exit)
+
+    @pep249
+    @api_telemetry
+    def close(self) -> None:
+        """Close the connection now.
 
     def _parse_kwargs(self, kwargs: dict[str, Any], autocommit: bool | None) -> None:
         """Parse and extract all special params from kwargs in-place.
@@ -436,6 +444,7 @@ class Connection(ErrorHandlerMixin):
         self._messages = value
 
     @pep249
+    @api_telemetry
     @_requires_open
     def commit(self) -> None:
         """Commit any pending transaction to the database."""
@@ -446,6 +455,7 @@ class Connection(ErrorHandlerMixin):
             cur.close()
 
     @pep249
+    @api_telemetry
     @_requires_open
     def rollback(self) -> None:
         """Roll back to the start of any pending transaction."""
@@ -456,6 +466,7 @@ class Connection(ErrorHandlerMixin):
             cur.close()
 
     @pep249
+    @api_telemetry
     @_requires_open
     def cursor(self, cursor_class: CursorType = SnowflakeCursor) -> CursorInstance:
         """
@@ -500,6 +511,7 @@ class Connection(ErrorHandlerMixin):
         return value is not None and value.lower() == "true"
 
     @_requires_open
+    @api_telemetry
     def set_autocommit(self, autocommit: bool) -> None:
         """Set the autocommit mode. Executes ALTER SESSION SET autocommit on the server."""
         # FIXME: set autocommit via core
@@ -513,6 +525,7 @@ class Connection(ErrorHandlerMixin):
         finally:
             cur.close()
 
+    @api_telemetry
     def get_autocommit(self) -> bool:
         """
         Get the current autocommit mode.
@@ -601,6 +614,7 @@ class Connection(ErrorHandlerMixin):
         """Normalize assignments to ``_paramstyle`` (e.g. SnowPy ``temporary_paramstyle``)."""
         self.paramstyle = value
 
+    @api_telemetry
     def execute_string(
         self,
         sql_text: str,
@@ -618,6 +632,7 @@ class Connection(ErrorHandlerMixin):
             pass
         return []
 
+    @api_telemetry
     def execute_stream(
         self,
         stream: StringIO,
@@ -652,8 +667,8 @@ class Connection(ErrorHandlerMixin):
 
     @internal_api
     @backward_compatibility
-    def _telemetry(self) -> TelemetryClient:
-        return TelemetryClient()
+    def _telemetry(self) -> _BackwardCompatTelemetryClient:
+        return _BackwardCompatTelemetryClient()
 
     @backward_compatibility
     def _rewrite_private_key_password(self, kwargs: ConnectionParameters) -> ConnectionParameters:
@@ -905,11 +920,13 @@ class Connection(ErrorHandlerMixin):
             row: dict[str, Any] = cur.fetchone()  # type: ignore[assignment]
         return str(row["VERSION"]).split(" ")[0]
 
+    @api_telemetry
     def get_query_status(self, sf_qid: str) -> QueryStatus:
         """Retrieve the status of query with sf_qid."""
         status, _ = self._get_query_status_with_response(sf_qid)
         return status
 
+    @api_telemetry
     def get_query_status_throw_if_error(self, sf_qid: str) -> QueryStatus:
         """Retrieve the status of query with sf_qid and raises an exception if the query terminated with an error."""
         status, response = self._get_query_status_with_response(sf_qid)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -245,7 +245,10 @@ class Connection(ErrorHandlerMixin):
         )
         from ._internal.telemetry import TelemetryClient
 
-        self._telemetry_client = TelemetryClient(db_api=self.db_api, conn_handle=self.conn_handle)
+        self._telemetry_client = TelemetryClient(
+            db_api=self.db_api,
+            conn_handle=cast(ConnectionHandle, self.conn_handle),
+        )
 
         if self._should_auto_cleanup():
             atexit.register(self._close_at_process_exit)

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -253,11 +253,6 @@ class Connection(ErrorHandlerMixin):
         if self._should_auto_cleanup():
             atexit.register(self._close_at_process_exit)
 
-    @pep249
-    @api_telemetry
-    def close(self) -> None:
-        """Close the connection now.
-
     def _parse_kwargs(self, kwargs: dict[str, Any], autocommit: bool | None) -> None:
         """Parse and extract all special params from kwargs in-place.
 
@@ -309,6 +304,7 @@ class Connection(ErrorHandlerMixin):
                 warnings.warn(warning.message, stacklevel=2)
 
     @pep249
+    @api_telemetry
     def close(self, retry: bool = True) -> None:
         """
         Close the connection, send logout, and release handles.

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -28,7 +28,7 @@ from .._internal.binding_converters import (
     ParamStyle,
 )
 from .._internal.config_utils import create_config_setting
-from .._internal.decorators import pep249
+from .._internal.decorators import api_telemetry, pep249
 from .._internal.errorcode import ER_CURSOR_IS_CLOSED, ER_INVALID_VALUE
 from .._internal.errorhandler import ErrorHandlerMixin
 from .._internal.extras import check_dependency, pandas, pyarrow, requires_dependency
@@ -338,6 +338,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     def callproc(self, procname: str, args: T) -> T: ...
 
     @pep249
+    @api_telemetry
     @_requires_open
     def callproc(self, procname: str, args: Any = None) -> Any:
         """Call a stored procedure.
@@ -465,6 +466,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             return operation, bindings
 
     @pep249
+    @api_telemetry
     @_requires_open
     def execute(
         self,
@@ -610,6 +612,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             raise
 
     @pep249
+    @api_telemetry
     @_requires_open
     def executemany(self, operation: str, seq_of_parameters: Sequence[Sequence[Any] | dict[str, Any]]) -> None:
         """
@@ -673,6 +676,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         # Execute using array binding (existing path handles list values)
         self.execute(operation, transposed)
 
+    @api_telemetry
     @_requires_open
     def describe(
         self,
@@ -739,6 +743,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         """Fetch the next row of a query result set."""
 
     @pep249
+    @api_telemetry
     @_requires_open_cursor_not_connection
     @_requires_fetch_mode(FetchMode.ROW)
     def fetchmany(self, size: int | None = None) -> list[Any]:
@@ -772,6 +777,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         return rows
 
     @pep249
+    @api_telemetry
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
     @_requires_fetch_mode(FetchMode.ROW)
@@ -834,6 +840,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     # ------------------------------------------------------------------
 
     @pep249
+    @api_telemetry
     @_requires_open
     def nextset(self) -> SnowflakeCursorBase | None:
         """
@@ -900,6 +907,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         return None
 
     @pep249
+    @api_telemetry
     def scroll(self, value: int, mode: str = "relative") -> None:
         """Scroll the cursor in the result set."""
         raise NotSupportedError("scroll is not supported")
@@ -964,6 +972,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         self._multi_statement = None
 
     @pep249
+    @api_telemetry
     def close(self) -> bool | None:
         """Close the cursor now.
 
@@ -1061,6 +1070,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     # ------------------------------------------------------------------
 
     @requires_dependency(pyarrow)
+    @api_telemetry
     @_requires_open
     @_with_prefetch_hook
     @_requires_fetch_mode(FetchMode.ARROW)
@@ -1078,6 +1088,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             yield pyarrow.Table.from_batches([batch])
 
     @requires_dependency(pyarrow)
+    @api_telemetry
     @_requires_open
     @_with_prefetch_hook
     @_requires_fetch_mode(FetchMode.ARROW)
@@ -1099,6 +1110,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         )
 
     @requires_dependency(pandas)
+    @api_telemetry
     @_requires_open
     def fetch_pandas_batches(self, **kwargs: Any) -> Iterator[DataFrame]:
         """Fetch Pandas DataFrames in batches."""
@@ -1106,6 +1118,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             yield table.to_pandas()
 
     @requires_dependency(pandas)
+    @api_telemetry
     @_requires_open
     def fetch_pandas_all(self, **kwargs: Any) -> DataFrame:
         """Fetch all results as a single Pandas DataFrame."""
@@ -1122,6 +1135,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     # Distributed fetch
     # ------------------------------------------------------------------
 
+    @api_telemetry
     @_requires_open
     @_with_prefetch_hook
     def get_result_batches(self) -> list[ResultBatch] | None:
@@ -1161,6 +1175,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     # Async query support
     # ------------------------------------------------------------------
 
+    @api_telemetry
     @_requires_open
     def query_result(self, qid: str) -> SnowflakeCursorBase:
         """Fetch the result of a previously executed query by its Snowflake Query ID.
@@ -1214,6 +1229,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         return self
 
+    @api_telemetry
     @_requires_open
     def get_results_from_sfqid(self, sfqid: str) -> None:
         """Get results from a previously executed query.
@@ -1247,6 +1263,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         self._prefetch_hook = prefetch_hook
 
+    @api_telemetry
     @_requires_open
     def execute_async(
         self,
@@ -1293,6 +1310,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         return {"queryId": query_id}
 
+    @api_telemetry
     @_requires_open
     def abort_query(self, qid: str) -> bool:
         """Abort a running query."""

--- a/python/src/snowflake/connector/cursor/_dict_cursor.py
+++ b/python/src/snowflake/connector/cursor/_dict_cursor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .._internal.decorators import api_telemetry
 from ._base import DictRow, SnowflakeCursorBase
 
 
@@ -20,6 +21,7 @@ class DictCursor(SnowflakeCursorBase):
     def _use_dict_result(self) -> bool:
         return True
 
+    @api_telemetry
     def fetchone(self) -> DictRow | None:
         """
         Fetch the next row of a query result set as a dictionary.

--- a/python/src/snowflake/connector/cursor/_snowflake_cursor.py
+++ b/python/src/snowflake/connector/cursor/_snowflake_cursor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .._internal.decorators import api_telemetry
 from ._base import Row, SnowflakeCursorBase
 
 
@@ -15,6 +16,7 @@ class SnowflakeCursor(SnowflakeCursorBase):
     def _use_dict_result(self) -> bool:
         return False
 
+    @api_telemetry
     def fetchone(self) -> Row | None:
         """
         Fetch the next row of a query result set.

--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -135,7 +135,11 @@ def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory
             "code.namespace": "sf_core::apis::database_driver_v1::connection",
         }
         for key, expected in expected_exact.items():
-            assert message.get(key) == expected, (
+            actual = message.get(key)
+            # Normalize path separators for cross-platform compatibility (Windows uses backslashes)
+            if key == "code.filepath" and isinstance(actual, str):
+                actual = actual.replace("\\", "/")
+            assert actual == expected, (
                 f"api_call message[{key!r}] expected {expected!r}, got {message.get(key)!r}. Full message: {message}"
             )
 

--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -3,6 +3,8 @@ import json
 
 from pathlib import Path
 
+import pytest
+
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, load_pem_private_key
 
 from tests.compatibility import is_new_driver
@@ -21,15 +23,7 @@ def test_session_init_telemetry_sent_on_connection_open(int_test_connection_fact
         wiremock.add_mapping("auth/login_success_jwt.json")
         wiremock.add_mapping("telemetry/telemetry_send_success.json")
 
-        # The old driver needs private_key as DER bytes; the universal driver uses private_key_file
-        extra_params = {}
-        if not is_new_driver():
-            pem_data = Path(get_test_private_key_path()).read_bytes()
-            pk = load_pem_private_key(pem_data, password=None)
-            extra_params["private_key"] = pk.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
-            extra_params["private_key_file"] = None
-
-        connection = int_test_connection_factory(server_url=wiremock.http_url(), **extra_params)
+        connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
         connection.close()
 
         # Telemetry is exported synchronously on connection release via
@@ -64,15 +58,7 @@ def test_session_init_telemetry_sent_on_connection_open(int_test_connection_fact
         assert normalized_headers["accept"] == "application/json"
         assert normalized_headers["user-agent"] is not None
 
-        # Validate top-level payload structure.
-        # Wiremock may transparently decompress gzip, so try both.
-        raw_body = request["body"]
-        if isinstance(raw_body, str):
-            raw_body = raw_body.encode("latin-1")
-        try:
-            body = json.loads(gzip.decompress(raw_body))
-        except gzip.BadGzipFile:
-            body = json.loads(raw_body)
+        body = _decode_telemetry_body(request)
         assert "logs" in body, "Telemetry payload must contain 'logs' array"
         assert isinstance(body["logs"], list)
         assert len(body["logs"]) >= 1, "Expected at least one log entry"
@@ -83,3 +69,126 @@ def test_session_init_telemetry_sent_on_connection_open(int_test_connection_fact
             assert "timestamp" in entry, "Log entry must contain 'timestamp'"
             assert isinstance(entry["message"], dict)
             assert isinstance(entry["timestamp"], str)
+
+
+@pytest.mark.skip_reference(reason="api_usage telemetry is universal-driver only")
+def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory):
+    """Verify that an api_usage telemetry event is recorded when a cursor is created.
+
+    ``Connection.cursor`` is decorated with ``@api_telemetry``, which calls
+    ``TelemetryClient.send_api_usage('Connection.cursor')``. sf_core records
+    this as an ``api_call`` span event with an ``api_method`` attribute, which
+    the Snowflake exporter then serializes into a log entry on
+    ``/telemetry/send`` with ``message.type == 'api_call'`` and
+    ``message.api_method == 'Connection.cursor'``.
+    """
+    with WiremockClient().start() as wiremock:
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("telemetry/telemetry_send_success.json")
+
+        connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
+        try:
+            cursor = connection.cursor()
+            cursor.close()
+        finally:
+            # Closing the connection flushes pending telemetry spans via
+            # SimpleSpanProcessor, so it must happen before we poll wiremock.
+            connection.close()
+
+        telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
+        assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after cursor creation"
+
+        log_entries = _collect_log_entries(telemetry_requests)
+
+        cursor_entries = [
+            entry
+            for entry in log_entries
+            if entry["message"].get("type") == "api_call" and entry["message"].get("api_method") == "Connection.cursor"
+        ]
+        assert len(cursor_entries) == 1, (
+            "Expected exactly one api_call telemetry log entry with "
+            f"api_method='Connection.cursor'. Got entries: {log_entries}"
+        )
+
+        entry = cursor_entries[0]
+
+        # Log envelope: {"message": {...}, "timestamp": "<epoch_millis>"}
+        assert set(entry.keys()) == {"message", "timestamp"}, f"Unexpected log entry envelope keys: {set(entry.keys())}"
+        assert isinstance(entry["timestamp"], str) and entry["timestamp"].isdigit(), (
+            f"timestamp must be a decimal epoch-millis string, got: {entry['timestamp']!r}"
+        )
+
+        message = entry["message"]
+
+        # Event attributes (from record_api_call) + inherited connection-span
+        # attributes. `snowflake.session.id` comes from the login mapping
+        # (tests/wiremock/mappings/auth/login_success_jwt.json -> sessionId).
+        # The `code.*`, `busy_ns`, `idle_ns`, `thread.id` attributes are
+        # auto-populated by `tracing::info_span!` at
+        # sf_core/src/apis/database_driver_v1/connection.rs where the
+        # "connection" span is created.
+        expected_exact = {
+            "type": "api_call",
+            "api_method": "Connection.cursor",
+            "snowflake.session.id": 12345,
+            "code.filepath": "sf_core/src/apis/database_driver_v1/connection.rs",
+            "code.namespace": "sf_core::apis::database_driver_v1::connection",
+        }
+        for key, expected in expected_exact.items():
+            assert message.get(key) == expected, (
+                f"api_call message[{key!r}] expected {expected!r}, got {message.get(key)!r}. Full message: {message}"
+            )
+
+        numeric_attrs = {"code.lineno", "busy_ns", "idle_ns", "thread.id"}
+        for key in numeric_attrs:
+            assert isinstance(message.get(key), int), (
+                f"api_call message[{key!r}] expected int, got {type(message.get(key)).__name__}: {message.get(key)!r}"
+            )
+
+        # Guard against the event silently gaining or losing attributes: the
+        # api_call message is the union of the exact and numeric attribute
+        # sets above — nothing more, nothing less.
+        assert set(message.keys()) == set(expected_exact.keys()) | numeric_attrs, (
+            f"Unexpected api_call message keys: {sorted(message.keys())}"
+        )
+
+
+def _jwt_private_key_params() -> dict:
+    """Return connection overrides needed for JWT auth against Wiremock.
+
+    The old driver needs ``private_key`` as DER bytes; the universal driver
+    accepts ``private_key_file`` directly.
+    """
+    if is_new_driver():
+        return {}
+    pem_data = Path(get_test_private_key_path()).read_bytes()
+    pk = load_pem_private_key(pem_data, password=None)
+    return {
+        "private_key": pk.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption()),
+        "private_key_file": None,
+    }
+
+
+def _decode_telemetry_body(request: dict) -> dict:
+    """Decode the JSON body of a Wiremock-captured ``/telemetry/send`` request.
+
+    Wiremock may transparently decompress gzip, so try both.
+    """
+    raw_body = request["body"]
+    if isinstance(raw_body, str):
+        raw_body = raw_body.encode("latin-1")
+    try:
+        return json.loads(gzip.decompress(raw_body))
+    except gzip.BadGzipFile:
+        return json.loads(raw_body)
+
+
+def _collect_log_entries(telemetry_requests: list[dict]) -> list[dict]:
+    """Flatten the ``logs`` arrays across every captured telemetry request."""
+    entries: list[dict] = []
+    for request in telemetry_requests:
+        body = _decode_telemetry_body(request)
+        for entry in body.get("logs", []):
+            if isinstance(entry, dict) and isinstance(entry.get("message"), dict):
+                entries.append(entry)
+    return entries

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -8,7 +8,7 @@ from snowflake.connector._internal.decorators import _TRACKING
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     DatabaseHandle,
-    ExecuteResult,
+    ExecuteQueryResponse,
     StatementHandle,
 )
 
@@ -22,7 +22,7 @@ def mock_db_api():
     db_api.connection_get_parameter.return_value = MagicMock(value="")
     # Provide a real StatementHandle so protobuf field validation passes
     db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
-    db_api.statement_execute_query.return_value = MagicMock(result=ExecuteResult())
+    db_api.statement_execute_query.return_value = ExecuteQueryResponse()
     db_api.statement_result_chunks.return_value = MagicMock(HasField=MagicMock(return_value=False))
     return db_api
 
@@ -197,7 +197,7 @@ class TestApiTelemetryResetBehavior:
 
         # Tracking should be re-enabled
         mock_db_api.statement_execute_query.side_effect = None
-        mock_db_api.statement_execute_query.return_value = MagicMock(result=ExecuteResult())
+        mock_db_api.statement_execute_query.return_value = ExecuteQueryResponse()
         mock_db_api.telemetry_send_api_usage.reset_mock()
         cursor.execute("SELECT 2")
 

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -1,0 +1,218 @@
+"""Unit tests for api_telemetry decorator and api_usage tracking."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake.connector._internal.decorators import _TRACKING
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ConnectionHandle,
+    DatabaseHandle,
+    ExecuteResult,
+    StatementHandle,
+)
+
+
+@pytest.fixture
+def mock_db_api():
+    """Create a mock DatabaseDriverClient with minimal stubs for Connection.__init__."""
+    db_api = MagicMock()
+    db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
+    db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
+    db_api.connection_get_parameter.return_value = MagicMock(value="")
+    # Provide a real StatementHandle so protobuf field validation passes
+    db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+    db_api.statement_execute_query.return_value = MagicMock(result=ExecuteResult())
+    db_api.statement_result_chunks.return_value = MagicMock(HasField=MagicMock(return_value=False))
+    return db_api
+
+
+@pytest.fixture
+def connection(mock_db_api):
+    """Create a Connection with a mocked db_api."""
+    from snowflake.connector.connection import Connection
+
+    with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+        conn = Connection(user="test_user", account="test_account")
+    return conn
+
+
+@pytest.fixture
+def cursor(connection, mock_db_api):
+    """Create a cursor from the mocked connection."""
+    # Reset telemetry calls from connection setup
+    mock_db_api.telemetry_send_api_usage.reset_mock()
+    return connection.cursor()
+
+
+@pytest.fixture(autouse=True)
+def reset_tracking():
+    """Ensure _TRACKING ContextVar is reset before each test."""
+    token = _TRACKING.set(True)
+    yield
+    _TRACKING.reset(token)
+
+
+def _get_api_methods(mock_db_api):
+    """Extract api_method strings from all telemetry_send_api_usage calls."""
+    return [call[0][0].api_method for call in mock_db_api.telemetry_send_api_usage.call_args_list]
+
+
+class TestConnectionApiTelemetry:
+    """Tests that Connection public methods send api_usage telemetry."""
+
+    def test_cursor_sends_telemetry(self, connection, mock_db_api):
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.cursor()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.cursor" in methods
+
+    def test_close_sends_telemetry(self, connection, mock_db_api):
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.close()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.close" in methods
+
+    def test_get_autocommit_sends_telemetry(self, connection, mock_db_api):
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.get_autocommit()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.get_autocommit" in methods
+
+    def test_commit_suppresses_inner_calls(self, connection, mock_db_api):
+        """commit() calls cursor(), execute(), close() internally — only commit should be tracked."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.commit()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.commit" in methods
+        assert "Connection.cursor" not in methods
+        assert "SnowflakeCursor.execute" not in methods
+        assert "SnowflakeCursor.close" not in methods
+
+    def test_rollback_suppresses_inner_calls(self, connection, mock_db_api):
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.rollback()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.rollback" in methods
+        assert "Connection.cursor" not in methods
+        assert "SnowflakeCursor.execute" not in methods
+
+    def test_execute_string_suppresses_inner_calls(self, connection, mock_db_api):
+        """execute_string calls execute_stream which calls cursor() + execute() — only outermost tracked."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.execute_string("SELECT 1; SELECT 2")
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.execute_string" in methods
+        assert "Connection.execute_stream" not in methods
+        assert "Connection.cursor" not in methods
+        assert "SnowflakeCursor.execute" not in methods
+
+    def test_api_method_uses_runtime_class_name(self, connection, mock_db_api):
+        """api_method should be derived from type(self).__name__, not hardcoded."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.close()
+
+        req = mock_db_api.telemetry_send_api_usage.call_args[0][0]
+        assert req.api_method == "Connection.close"
+
+
+class TestCursorApiTelemetry:
+    """Tests that Cursor public methods send api_usage telemetry."""
+
+    def test_execute_sends_telemetry(self, cursor, mock_db_api):
+        cursor.execute("SELECT 1")
+
+        methods = _get_api_methods(mock_db_api)
+        assert "SnowflakeCursor.execute" in methods
+
+    def test_close_sends_telemetry(self, cursor, mock_db_api):
+        cursor.close()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "SnowflakeCursor.close" in methods
+
+    def test_fetchone_sends_telemetry(self, cursor, mock_db_api):
+        # fetchone requires a prior execute — mock the iterator
+        cursor._execute_result = MagicMock()
+        cursor._iterator = iter([])
+        cursor._fetch_mode = None
+        cursor.fetchone()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "SnowflakeCursor.fetchone" in methods
+
+    def test_fetchmany_suppresses_fetchone(self, cursor, mock_db_api):
+        """fetchmany() calls fetchone() internally — only fetchmany should be tracked."""
+        cursor._execute_result = MagicMock()
+        cursor._iterator = iter([(1,), (2,)])
+        cursor._fetch_mode = None
+        cursor.fetchmany(2)
+
+        methods = _get_api_methods(mock_db_api)
+        assert "SnowflakeCursor.fetchmany" in methods
+        assert "SnowflakeCursor.fetchone" not in methods
+
+    def test_dict_cursor_fetchone_uses_correct_class_name(self, connection, mock_db_api):
+        from snowflake.connector.cursor import DictCursor
+
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        cur = connection.cursor(DictCursor)
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+
+        cur._execute_result = MagicMock()
+        cur._iterator = iter([])
+        cur._fetch_mode = None
+        cur.fetchone()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "DictCursor.fetchone" in methods
+
+
+class TestApiTelemetryResetBehavior:
+    """Tests that tracking is properly reset after each call."""
+
+    def test_tracking_resets_after_method_returns(self, connection, mock_db_api):
+        """After a tracked method returns, subsequent calls should also be tracked."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        connection.close()
+        connection.get_autocommit()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.close" in methods
+        assert "Connection.get_autocommit" in methods
+        assert mock_db_api.telemetry_send_api_usage.call_count == 2
+
+    def test_tracking_resets_after_exception(self, cursor, mock_db_api):
+        """If a method raises, tracking should still reset for the next call."""
+        mock_db_api.statement_execute_query.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            cursor.execute("SELECT 1")
+
+        # Tracking should be re-enabled
+        mock_db_api.statement_execute_query.side_effect = None
+        mock_db_api.statement_execute_query.return_value = MagicMock(result=ExecuteResult())
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        cursor.execute("SELECT 2")
+
+        methods = _get_api_methods(mock_db_api)
+        assert "SnowflakeCursor.execute" in methods
+
+
+class TestApiTelemetryFailureIsolation:
+    """Tests that telemetry failures don't break the actual method."""
+
+    def test_telemetry_rpc_failure_does_not_break_method(self, connection, mock_db_api):
+        """If send_api_usage raises, the decorated method should still execute."""
+        mock_db_api.telemetry_send_api_usage.side_effect = RuntimeError("telemetry down")
+
+        # close() should still work despite telemetry failure
+        # (send_api_usage swallows exceptions internally)
+        connection.close()
+        assert connection.is_closed()

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -9,8 +9,14 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     DatabaseHandle,
     ExecuteQueryResponse,
+    ResultSetDescriptor,
     StatementHandle,
 )
+
+
+def _make_execute_response(query_id: str = "fake-qid") -> ExecuteQueryResponse:
+    """Return an ExecuteQueryResponse with a single-statement descriptor."""
+    return ExecuteQueryResponse(single=ResultSetDescriptor(query_id=query_id))
 
 
 @pytest.fixture
@@ -22,7 +28,12 @@ def mock_db_api():
     db_api.connection_get_parameter.return_value = MagicMock(value="")
     # Provide a real StatementHandle so protobuf field validation passes
     db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
-    db_api.statement_execute_query.return_value = ExecuteQueryResponse()
+    # Mock the two-step execute flow: execute_query returns a descriptor,
+    # then get_result_set returns the result set (get_stream_ptr is patched).
+    db_api.statement_execute_query.return_value = _make_execute_response()
+    db_api.statement_get_result_set.return_value = MagicMock(
+        result_descriptor=ResultSetDescriptor(query_id="fake-qid"),
+    )
     db_api.statement_result_chunks.return_value = MagicMock(HasField=MagicMock(return_value=False))
     return db_api
 
@@ -32,9 +43,13 @@ def connection(mock_db_api):
     """Create a Connection with a mocked db_api."""
     from snowflake.connector.connection import Connection
 
-    with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+    # Return stream_ptr=0 so release_arrow_stream (called in __del__) is a no-op.
+    with (
+        patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api),
+        patch("snowflake.connector.cursor._query_result.get_stream_ptr", return_value=0),
+    ):
         conn = Connection(user="test_user", account="test_account")
-    return conn
+        yield conn
 
 
 @pytest.fixture
@@ -113,6 +128,20 @@ class TestConnectionApiTelemetry:
         assert "Connection.cursor" not in methods
         assert "SnowflakeCursor.execute" not in methods
 
+    def test_execute_stream_suppresses_during_iteration(self, connection, mock_db_api):
+        """execute_stream is a generator — nested calls during iteration must be suppressed."""
+        from io import StringIO
+
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+        # Iterate the generator so the body actually runs
+        cursors = list(connection.execute_stream(StringIO("SELECT 1; SELECT 2")))
+        assert len(cursors) == 2
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.execute_stream" in methods
+        assert "Connection.cursor" not in methods
+        assert "SnowflakeCursor.execute" not in methods
+
     def test_api_method_uses_runtime_class_name(self, connection, mock_db_api):
         """api_method should be derived from type(self).__name__, not hardcoded."""
         mock_db_api.telemetry_send_api_usage.reset_mock()
@@ -147,16 +176,17 @@ class TestCursorApiTelemetry:
         methods = _get_api_methods(mock_db_api)
         assert "SnowflakeCursor.fetchone" in methods
 
-    def test_fetchmany_suppresses_fetchone(self, cursor, mock_db_api):
-        """fetchmany() calls fetchone() internally — only fetchmany should be tracked."""
+    def test_fetchmany_sends_telemetry(self, cursor, mock_db_api):
+        """fetchmany() should send its own telemetry event."""
+        mock_iterator = MagicMock()
+        mock_iterator.fetch_many.return_value = [(1,), (2,)]
         cursor._execute_result = MagicMock()
-        cursor._iterator = iter([(1,), (2,)])
+        cursor._iterator = mock_iterator
         cursor._fetch_mode = None
         cursor.fetchmany(2)
 
         methods = _get_api_methods(mock_db_api)
         assert "SnowflakeCursor.fetchmany" in methods
-        assert "SnowflakeCursor.fetchone" not in methods
 
     def test_dict_cursor_fetchone_uses_correct_class_name(self, connection, mock_db_api):
         from snowflake.connector.cursor import DictCursor
@@ -197,7 +227,7 @@ class TestApiTelemetryResetBehavior:
 
         # Tracking should be re-enabled
         mock_db_api.statement_execute_query.side_effect = None
-        mock_db_api.statement_execute_query.return_value = ExecuteQueryResponse()
+        mock_db_api.statement_execute_query.return_value = _make_execute_response()
         mock_db_api.telemetry_send_api_usage.reset_mock()
         cursor.execute("SELECT 2")
 

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -7,6 +7,7 @@ import pytest
 from snowflake.connector._internal.decorators import _TRACKING
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
+    ConnectionIsClosedResponse,
     DatabaseHandle,
     ExecuteQueryResponse,
     ResultSetDescriptor,
@@ -26,6 +27,15 @@ def mock_db_api():
     db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
     db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
     db_api.connection_get_parameter.return_value = MagicMock(value="")
+
+    # connection_is_closed reports "closed" once the conn_handle has been
+    # released (Connection.close() swaps the handle to None, which ends up as
+    # id=0 after protobuf default initialization). Mirrors real Core behavior
+    # and lets tests call close() then assert is_closed() == True.
+    def _connection_is_closed(request):
+        return ConnectionIsClosedResponse(is_closed=request.conn_handle.id == 0)
+
+    db_api.connection_is_closed.side_effect = _connection_is_closed
     # Provide a real StatementHandle so protobuf field validation passes
     db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
     # Mock the two-step execute flow: execute_query returns a descriptor,

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -10,18 +10,18 @@ pub mod snowflake_exporter;
 pub mod os_details;
 pub mod platform_detection;
 
-use opentelemetry::trace::TraceContextExt;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Record a session_init event on the **current** tracing span.
 ///
 /// The caller must have entered the connection span before calling this.
-/// Uses the OTel API directly because `tracing::event!` does not support
-/// dotted field names (e.g. `service.name`).
+/// Uses `OpenTelemetrySpanExt::add_event` (rather than `tracing::event!`)
+/// because events with dotted field names (e.g. `service.name`) are not
+/// supported by the `event!` macro, and because
+/// `Span::current().context().span().add_event(...)` operates on a detached
+/// `SpanRef` and does not mutate the underlying tracing span.
 pub fn record_session_init(env: &environment::EnvironmentInfo) {
     let span = tracing::Span::current();
-    let otel_ctx = span.context();
-    let otel_span = otel_ctx.span();
     let mut attrs = vec![
         opentelemetry::KeyValue::new("service.name", env.driver_name.clone()),
         opentelemetry::KeyValue::new("service.version", env.driver_version.clone()),
@@ -37,15 +37,12 @@ pub fn record_session_init(env: &environment::EnvironmentInfo) {
             compiler.clone(),
         ));
     }
-    otel_span.add_event("session_init", attrs);
+    span.add_event("session_init", attrs);
 }
 
 /// Record an api_call event on the **current** tracing span.
 pub fn record_api_call(api_method: &str) {
-    let span = tracing::Span::current();
-    let otel_ctx = span.context();
-    let otel_span = otel_ctx.span();
-    otel_span.add_event(
+    tracing::Span::current().add_event(
         "api_call",
         vec![opentelemetry::KeyValue::new(
             "api_method",
@@ -56,10 +53,7 @@ pub fn record_api_call(api_method: &str) {
 
 /// Record an exception event on the **current** tracing span.
 pub fn record_exception(exception_type: &str, error_source: &str) {
-    let span = tracing::Span::current();
-    let otel_ctx = span.context();
-    let otel_span = otel_ctx.span();
-    otel_span.add_event(
+    tracing::Span::current().add_event(
         "exception",
         vec![
             opentelemetry::KeyValue::new("exception.type", exception_type.to_string()),


### PR DESCRIPTION
## Summary
- Add `@api_telemetry` decorator that records API usage telemetry only for outermost user-initiated calls
- Uses a `ContextVar[bool]` that self-suppresses: the first decorated method in a call stack sends telemetry and disables tracking for all nested calls, then resets on return
- Wire `TelemetryClient` in `Connection.__init__` and decorate all public methods on Connection (10), SnowflakeCursorBase (18), SnowflakeCursor (1), and DictCursor (1)
- `api_method` is derived at runtime from `type(self).__name__` + `func.__name__` (e.g., `Connection.commit`, `SnowflakeCursor.execute`)

## How it works
```
User calls conn.commit()        → tracking=True  → sends "Connection.commit", sets False
  self.cursor()                 → tracking=False → skipped
  cur.execute("COMMIT")         → tracking=False → skipped
  cur.close()                   → tracking=False → skipped
commit() returns                → reset to True
User calls cursor.execute()     → tracking=True  → sends "SnowflakeCursor.execute"
```

## Test plan
- [x] 16 new unit tests covering direct calls, nested suppression, exception recovery, DictCursor class name, and telemetry failure isolation
- [x] All existing unit tests pass (388 passed, 1 skipped)
- [x] Pre-commit hooks pass (ruff format, ruff check, mypy)
- [ ] Integration telemetry test (`test_session_init_telemetry_sent_on_connection_open`) — pre-existing failure unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)