### PR TITLE
NO-SNOW: Migrate connection handles to integer ID registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,11 +2856,10 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3314,6 +3313,7 @@ dependencies = [
  "error_trace",
  "libc",
  "odbc-sys",
+ "parking_lot",
  "proto_utils",
  "serde_json",
  "sf_core",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4.43"
 base64 = "0.22.1"
 serde_json = "1.0"
 libc = "0.2"
+parking_lot = { version = "0.12.5", features = ["arc_lock"] }
 
 proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -12,7 +12,7 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::{
-    ConnectionState, GetDataExtensions, OdbcResult, conn_from_handle,
+    ConnectionState, Dbc, GetDataExtensions, OdbcResult, conn_from_handle,
     types::{AccessMode, AutocommitValue, ConnectionAttribute, StatementState},
 };
 use crate::conversion::warning::{Warning, Warnings};
@@ -20,6 +20,7 @@ use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use snafu::ResultExt;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing;
 
 const SQL_TXN_READ_COMMITTED: sql::UInteger = 2;
@@ -234,7 +235,8 @@ fn connect_with_params(
         options.insert("port".to_owned(), port_int.into());
     }
 
-    let dbc = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle)?;
+    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let connection = &mut dbc.connection;
     apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
 
@@ -562,7 +564,8 @@ fn read_dsn_config(dsn: &str) -> OdbcResult<HashMap<String, String>> {
 pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("disconnect: disconnecting from database");
 
-    let dbc = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle)?;
+    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let connection = &mut dbc.connection;
     if let ConnectionState::Connected {
         db_handle,
@@ -623,7 +626,8 @@ pub fn native_sql<E: OdbcEncoding>(
         .fail();
     }
 
-    let dbc = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle)?;
+    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let conn = &mut dbc.connection;
     if matches!(conn.state, ConnectionState::Disconnected) {
         return crate::api::error::DisconnectedSnafu.fail();
@@ -668,7 +672,8 @@ pub fn set_connect_attr<E: OdbcEncoding>(
     string_length: sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let dbc = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle)?;
+    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let connection = &mut dbc.connection;
     tracing::debug!("set_connect_attr: attribute={attribute}");
 
@@ -876,7 +881,8 @@ pub fn get_connect_attr<E: OdbcEncoding>(
     string_length_ptr: *mut sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let dbc = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle)?;
+    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let connection = &mut dbc.connection;
     tracing::debug!("get_connect_attr: attribute={attribute}");
 
@@ -1147,7 +1153,7 @@ pub fn get_info<E: OdbcEncoding>(
 ) -> OdbcResult<()> {
     tracing::debug!("get_info: connection_handle={connection_handle:?}, info_type={info_type}");
 
-    let _conn = conn_from_handle(connection_handle);
+    let _conn = conn_from_handle(connection_handle)?;
 
     let info_type = InfoType::try_from(info_type)?;
     tracing::debug!("get_info: info_type={info_type:?}");

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -234,7 +234,8 @@ fn connect_with_params(
         options.insert("port".to_owned(), port_int.into());
     }
 
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
 
     // Check before moving `options` into the RPC call below.
@@ -561,7 +562,8 @@ fn read_dsn_config(dsn: &str) -> OdbcResult<HashMap<String, String>> {
 pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("disconnect: disconnecting from database");
 
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     if let ConnectionState::Connected {
         db_handle,
         conn_handle,
@@ -621,7 +623,8 @@ pub fn native_sql<E: OdbcEncoding>(
         .fail();
     }
 
-    let conn = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let conn = &mut dbc.connection;
     if matches!(conn.state, ConnectionState::Disconnected) {
         return crate::api::error::DisconnectedSnafu.fail();
     }
@@ -665,7 +668,8 @@ pub fn set_connect_attr<E: OdbcEncoding>(
     string_length: sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     tracing::debug!("set_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -872,7 +876,8 @@ pub fn get_connect_attr<E: OdbcEncoding>(
     string_length_ptr: *mut sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let connection = conn_from_handle(connection_handle);
+    let dbc = conn_from_handle(connection_handle);
+    let connection = &mut dbc.connection;
     tracing::debug!("get_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -12,7 +12,7 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::{
-    ConnectionState, Dbc, GetDataExtensions, OdbcResult, conn_from_handle,
+    ConnectionState, GetDataExtensions, OdbcResult, conn_from_handle,
     types::{AccessMode, AutocommitValue, ConnectionAttribute, StatementState},
 };
 use crate::conversion::warning::{Warning, Warnings};
@@ -20,7 +20,6 @@ use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::*;
 use snafu::ResultExt;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing;
 
 const SQL_TXN_READ_COMMITTED: sql::UInteger = 2;
@@ -236,16 +235,21 @@ fn connect_with_params(
     }
 
     let dbc = conn_from_handle(connection_handle)?;
-    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let connection = &mut dbc.connection;
-    apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
-
-    // Check before moving `options` into the RPC call below.
-    let login_timeout_in_options = options.contains_key("authentication_timeout");
-    let login_timeout_in_attrs = connection
-        .pre_connection_attrs
-        .contains_key(&ConnectionAttribute::LoginTimeout);
-    let pre_connection_attrs = connection.pre_connection_attrs.clone();
+    // Read pre-connection data under lock, then release before the async call.
+    let (pre_connection_attrs, login_timeout_in_options, login_timeout_in_attrs) = {
+        let connection = dbc.connection.lock();
+        apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
+        let login_timeout_in_options = options.contains_key("authentication_timeout");
+        let login_timeout_in_attrs = connection
+            .pre_connection_attrs
+            .contains_key(&ConnectionAttribute::LoginTimeout);
+        let pre_connection_attrs = connection.pre_connection_attrs.clone();
+        (
+            pre_connection_attrs,
+            login_timeout_in_options,
+            login_timeout_in_attrs,
+        )
+    };
 
     let (db_handle, conn_handle) = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
         let db_handle = c
@@ -303,7 +307,7 @@ fn connect_with_params(
 
     tracing::info!("connect_with_params: connection_init completed");
 
-    connection.state = ConnectionState::Connected {
+    dbc.connection.lock().state = ConnectionState::Connected {
         db_handle,
         conn_handle,
     };
@@ -312,7 +316,7 @@ fn connect_with_params(
     // already established (state = Connected). Use warn-and-continue rather than `?`
     // to avoid returning an error after the state was set to Connected.
     // ConnectionHandle is Copy, so conn_handle is still accessible after the move above.
-    connection.current_catalog = match global().context(OdbcRuntimeSnafu) {
+    let current_catalog = match global().context(OdbcRuntimeSnafu) {
         Ok(rt) => rt
             .block_on(async |c| {
                 let info = c
@@ -335,6 +339,7 @@ fn connect_with_params(
             None
         }
     };
+    dbc.connection.lock().current_catalog = current_catalog;
 
     Ok(())
 }
@@ -565,12 +570,14 @@ pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("disconnect: disconnecting from database");
 
     let dbc = conn_from_handle(connection_handle)?;
-    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let connection = &mut dbc.connection;
+    let old_state = {
+        let mut connection = dbc.connection.lock();
+        std::mem::replace(&mut connection.state, ConnectionState::Disconnected)
+    };
     if let ConnectionState::Connected {
         db_handle,
         conn_handle,
-    } = std::mem::replace(&mut connection.state, ConnectionState::Disconnected)
+    } = old_state
     {
         global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
             if let Err(e) = c
@@ -627,9 +634,7 @@ pub fn native_sql<E: OdbcEncoding>(
     }
 
     let dbc = conn_from_handle(connection_handle)?;
-    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let conn = &mut dbc.connection;
-    if matches!(conn.state, ConnectionState::Disconnected) {
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
         return crate::api::error::DisconnectedSnafu.fail();
     }
 
@@ -673,8 +678,6 @@ pub fn set_connect_attr<E: OdbcEncoding>(
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
     let dbc = conn_from_handle(connection_handle)?;
-    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let connection = &mut dbc.connection;
     tracing::debug!("set_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -697,7 +700,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                 }
                 .build()
             })?;
-            connection.access_mode = mode;
+            dbc.connection.lock().access_mode = mode;
             Ok(())
         }
         ConnectionAttribute::Autocommit => {
@@ -710,16 +713,24 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             })?;
             // NOTE: Per ODBC spec, HY011 must be returned if a transaction is currently open.
             // Transaction state tracking requires server-side awareness — deferred to SNOW-3240589.
-            match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
+            let maybe_conn_handle = {
+                let connection = dbc.connection.lock();
+                match &connection.state {
+                    ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                    ConnectionState::Disconnected => None,
+                }
+            };
+            match maybe_conn_handle {
+                Some(conn_handle) => {
                     let autocommit_on = matches!(val, AutocommitValue::On);
                     global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                         c.connection_set_autocommit(ConnectionSetAutocommitRequest {
-                            conn_handle: Some(*conn_handle),
+                            conn_handle: Some(conn_handle),
                             autocommit: autocommit_on,
                         })
                         .await
                     })?;
+                    let mut connection = dbc.connection.lock();
                     connection.cached_autocommit = val;
                     // Keep pre_connection_attrs in sync so a reconnect on the same handle
                     // re-applies the value set while connected rather than the stale pre-connect value.
@@ -728,7 +739,8 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                         .insert(attr, val.as_raw().to_string());
                     Ok(())
                 }
-                ConnectionState::Disconnected => {
+                None => {
+                    let mut connection = dbc.connection.lock();
                     connection.cached_autocommit = val;
                     connection
                         .pre_connection_attrs
@@ -738,6 +750,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             }
         }
         ConnectionAttribute::LoginTimeout => {
+            let mut connection = dbc.connection.lock();
             if matches!(connection.state, ConnectionState::Connected { .. }) {
                 return AttributeCannotBeSetNowSnafu {
                     attribute: attr.as_raw(),
@@ -761,34 +774,38 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::CurrentCatalog => {
-            let conn_handle = match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => *conn_handle,
-                ConnectionState::Disconnected => return DisconnectedSnafu.fail(),
-            };
-            // Return 24000 if any statement has an open cursor.
-            for (weak, raw_ptr) in &connection.child_statements {
-                // Use strong_count to check liveness without constructing Arc<Statement>
-                // (i.e., &Statement), which would coexist with the outer &mut Connection
-                // and create an aliasing hazard via Statement::conn: *mut Connection.
-                if weak.strong_count() == 0 {
-                    continue;
-                }
-                // SAFETY: strong_count > 0 guarantees the Arc allocation (and the Statement
-                // it points to) is still alive. We project to `state` via addr_of! rather than
-                // forming &Statement to avoid aliasing conn: *mut Connection with &mut Connection.
-                let is_cursor_open = unsafe {
-                    let state_ptr = std::ptr::addr_of!((*(*raw_ptr)).state);
-                    matches!(
-                        (*state_ptr).as_ref(),
-                        StatementState::QueryExecuted { .. } | StatementState::Fetching { .. }
-                    )
+            let (conn_handle, catalog) = {
+                let connection = dbc.connection.lock();
+                let conn_handle = match &connection.state {
+                    ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+                    ConnectionState::Disconnected => return DisconnectedSnafu.fail(),
                 };
-                if is_cursor_open {
-                    return InvalidCursorStateSnafu.fail();
+                // Return 24000 if any statement has an open cursor.
+                for (weak, raw_ptr) in &connection.child_statements {
+                    // Use strong_count to check liveness without constructing Arc<Statement>
+                    // (i.e., &Statement), which would coexist with the outer &mut Connection
+                    // and create an aliasing hazard via Statement::conn: *mut Connection.
+                    if weak.strong_count() == 0 {
+                        continue;
+                    }
+                    // SAFETY: strong_count > 0 guarantees the Arc allocation (and the Statement
+                    // it points to) is still alive. We project to `state` via addr_of! rather than
+                    // forming &Statement to avoid aliasing conn: *mut Connection with &mut Connection.
+                    let is_cursor_open = unsafe {
+                        let state_ptr = std::ptr::addr_of!((*(*raw_ptr)).state);
+                        matches!(
+                            (*state_ptr).as_ref(),
+                            StatementState::QueryExecuted { .. } | StatementState::Fetching { .. }
+                        )
+                    };
+                    if is_cursor_open {
+                        return InvalidCursorStateSnafu.fail();
+                    }
                 }
-            }
-            let catalog = read_string_from_pointer::<E>(value_ptr, string_length)?;
-            let catalog = catalog.trim().to_string();
+                let catalog = read_string_from_pointer::<E>(value_ptr, string_length)?;
+                let catalog = catalog.trim().to_string();
+                (conn_handle, catalog)
+            };
             global()
                 .context(OdbcRuntimeSnafu)?
                 .block_on(async |c| {
@@ -811,14 +828,15 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                         _ => e.into(),
                     }
                 })?;
-            connection.current_catalog = Some(catalog);
+            dbc.connection.lock().current_catalog = Some(catalog);
             Ok(())
         }
         ConnectionAttribute::QuietMode => {
-            connection.quiet_mode = value_ptr;
+            dbc.connection.lock().quiet_mode = value_ptr;
             Ok(())
         }
         ConnectionAttribute::PacketSize => {
+            let mut connection = dbc.connection.lock();
             if matches!(connection.state, ConnectionState::Connected { .. }) {
                 return AttributeCannotBeSetNowSnafu {
                     attribute: attr.as_raw(),
@@ -834,7 +852,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
         }
         ConnectionAttribute::MetadataId => {
             let val = value_ptr as sql::ULen;
-            connection.metadata_id = val != 0;
+            dbc.connection.lock().metadata_id = val != 0;
             Ok(())
         }
         ConnectionAttribute::ConnectionDead | ConnectionAttribute::AutoIpd => {
@@ -858,6 +876,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
         | ConnectionAttribute::PrivKeyPassword
         | ConnectionAttribute::PrivKeyBase64
         | ConnectionAttribute::Application => {
+            let mut connection = dbc.connection.lock();
             if matches!(connection.state, ConnectionState::Connected { .. }) {
                 return AttributeCannotBeSetNowSnafu {
                     attribute: attr.as_raw(),
@@ -882,8 +901,6 @@ pub fn get_connect_attr<E: OdbcEncoding>(
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
     let dbc = conn_from_handle(connection_handle)?;
-    let dbc = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let connection = &mut dbc.connection;
     tracing::debug!("get_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -896,9 +913,10 @@ pub fn get_connect_attr<E: OdbcEncoding>(
 
     match attr {
         ConnectionAttribute::AccessMode => {
+            let access_mode = dbc.connection.lock().access_mode;
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::UInteger) = connection.access_mode.as_raw();
+                    *(value_ptr as *mut sql::UInteger) = access_mode.as_raw();
                 }
             }
             if !string_length_ptr.is_null() {
@@ -912,34 +930,40 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             // Per spec: query the server for the actual autocommit state when connected;
             // fall back to the cached value if the RPC fails or the parameter is absent.
             // The cache is the authoritative source when disconnected.
-            let val: sql::UInteger = match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
-                    match get_session_parameter(conn_handle, "AUTOCOMMIT") {
-                        Ok(Some(v)) if v.eq_ignore_ascii_case("true") => {
-                            connection.cached_autocommit = AutocommitValue::On;
-                            AutocommitValue::On.as_raw()
-                        }
-                        Ok(Some(_)) => {
-                            connection.cached_autocommit = AutocommitValue::Off;
-                            AutocommitValue::Off.as_raw()
-                        }
-                        Ok(None) => {
-                            tracing::warn!(
-                                "get_connect_attr: AUTOCOMMIT session parameter missing, \
-                                 falling back to cached value"
-                            );
-                            connection.cached_autocommit.as_raw()
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "get_connect_attr: failed to read AUTOCOMMIT session parameter \
-                                 ({e}), falling back to cached value"
-                            );
-                            connection.cached_autocommit.as_raw()
-                        }
+            let (maybe_conn_handle, cached) = {
+                let connection = dbc.connection.lock();
+                let maybe_conn_handle = match &connection.state {
+                    ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                    ConnectionState::Disconnected => None,
+                };
+                (maybe_conn_handle, connection.cached_autocommit)
+            };
+            let val: sql::UInteger = match maybe_conn_handle {
+                Some(conn_handle) => match get_session_parameter(&conn_handle, "AUTOCOMMIT") {
+                    Ok(Some(v)) if v.eq_ignore_ascii_case("true") => {
+                        dbc.connection.lock().cached_autocommit = AutocommitValue::On;
+                        AutocommitValue::On.as_raw()
                     }
-                }
-                ConnectionState::Disconnected => connection.cached_autocommit.as_raw(),
+                    Ok(Some(_)) => {
+                        dbc.connection.lock().cached_autocommit = AutocommitValue::Off;
+                        AutocommitValue::Off.as_raw()
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            "get_connect_attr: AUTOCOMMIT session parameter missing, \
+                                 falling back to cached value"
+                        );
+                        cached.as_raw()
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "get_connect_attr: failed to read AUTOCOMMIT session parameter \
+                                 ({e}), falling back to cached value"
+                        );
+                        cached.as_raw()
+                    }
+                },
+                None => cached.as_raw(),
             };
             if !value_ptr.is_null() {
                 unsafe {
@@ -954,6 +978,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::LoginTimeout => {
+            let connection = dbc.connection.lock();
             let timeout: sql::UInteger = match connection.pre_connection_attrs.get(&attr) {
                 Some(s) => s.parse().unwrap_or_else(|_| {
                     tracing::warn!(
@@ -964,6 +989,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 }),
                 None => DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap(),
             };
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = timeout;
@@ -996,9 +1022,16 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 }
                 .fail();
             }
-            let database = match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
-                    let conn_handle = *conn_handle;
+            let (maybe_conn_handle, cached_catalog) = {
+                let connection = dbc.connection.lock();
+                let maybe_conn_handle = match &connection.state {
+                    ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                    ConnectionState::Disconnected => None,
+                };
+                (maybe_conn_handle, connection.current_catalog.clone())
+            };
+            let database = match maybe_conn_handle {
+                Some(conn_handle) => {
                     match global().context(OdbcRuntimeSnafu).and_then(|rt| {
                         rt.block_on(async |c| {
                             let info = c
@@ -1012,7 +1045,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                         })
                     }) {
                         Ok(db) => {
-                            connection.current_catalog = db.clone();
+                            dbc.connection.lock().current_catalog = db.clone();
                             db
                         }
                         Err(e) => {
@@ -1020,7 +1053,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                                 "get_connect_attr: failed to fetch current catalog from server: \
                                  {e:?}; falling back to cached value"
                             );
-                            connection.current_catalog.clone()
+                            cached_catalog
                         }
                     }
                 }
@@ -1028,7 +1061,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 // Per ODBC spec the catalog is indeterminate before connecting;
                 // returning an error would break applications that probe this attribute
                 // before calling SQLConnect.
-                ConnectionState::Disconnected => connection.current_catalog.clone(),
+                None => cached_catalog,
             };
             let database_str = database.as_deref().unwrap_or("");
             write_string_bytes_i32::<E>(
@@ -1041,17 +1074,19 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::QuietMode => {
+            let quiet_mode = dbc.connection.lock().quiet_mode;
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::Pointer) = connection.quiet_mode;
+                    *(value_ptr as *mut sql::Pointer) = quiet_mode;
                 }
             }
             Ok(())
         }
         ConnectionAttribute::PacketSize => {
+            let packet_size = dbc.connection.lock().packet_size;
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::UInteger) = connection.packet_size;
+                    *(value_ptr as *mut sql::UInteger) = packet_size;
                 }
             }
             if !string_length_ptr.is_null() {
@@ -1075,7 +1110,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::ConnectionDead => {
-            let dead = match &connection.state {
+            let dead = match dbc.connection.lock().state {
                 ConnectionState::Connected { .. } => SQL_CD_FALSE,
                 ConnectionState::Disconnected => SQL_CD_TRUE,
             };
@@ -1105,9 +1140,10 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::MetadataId => {
+            let metadata_id = dbc.connection.lock().metadata_id;
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::ULen) = connection.metadata_id as sql::ULen;
+                    *(value_ptr as *mut sql::ULen) = metadata_id as sql::ULen;
                 }
             }
             if !string_length_ptr.is_null() {
@@ -1121,13 +1157,16 @@ pub fn get_connect_attr<E: OdbcEncoding>(
         | ConnectionAttribute::PrivKeyPassword
         | ConnectionAttribute::PrivKeyBase64
         | ConnectionAttribute::Application => {
+            let connection = dbc.connection.lock();
             let value = connection
                 .pre_connection_attrs
                 .get(&attr)
                 .map(|s| s.as_str())
-                .unwrap_or("");
+                .unwrap_or("")
+                .to_owned();
+            drop(connection);
             write_string_bytes_i32::<E>(
-                value,
+                &value,
                 value_ptr as *mut E::Char,
                 buffer_length,
                 string_length_ptr,

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -459,9 +459,7 @@ fn execute_bindings_for_row(
                 array_ref,
                 field,
                 batch_idx,
-                // SAFETY: conn pointer is valid for the statement's lifetime;
-                // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.connection.numeric_settings,
+                &stmt.conn()?.connection.numeric_settings,
                 &mut None,
             )
             .context(ConversionSnafu)?;
@@ -583,9 +581,7 @@ pub fn get_data(
                 array_ref,
                 field,
                 *batch_idx,
-                // SAFETY: conn pointer is valid for the statement's lifetime;
-                // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.connection.numeric_settings,
+                &stmt.conn()?.connection.numeric_settings,
                 &mut offset,
             )
             .context(ConversionSnafu)?;

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -454,15 +454,9 @@ fn execute_bindings_for_row(
             }
             let array_ref = record_batch.column(arrow_col);
             let field = schema.field(arrow_col);
-            let w = read_arrow_value(
-                adjusted,
-                array_ref,
-                field,
-                batch_idx,
-                &stmt.conn()?.connection.numeric_settings,
-                &mut None,
-            )
-            .context(ConversionSnafu)?;
+            let settings = stmt.conn()?.connection.lock().numeric_settings;
+            let w = read_arrow_value(adjusted, array_ref, field, batch_idx, &settings, &mut None)
+                .context(ConversionSnafu)?;
             warnings.extend(w);
         }
     }
@@ -576,12 +570,13 @@ pub fn get_data(
                 datetime_interval_precision: ard_binding
                     .and_then(|b| b.datetime_interval_precision),
             };
+            let settings = stmt.conn()?.connection.lock().numeric_settings;
             let conversion_warnings = read_arrow_value(
                 &binding,
                 array_ref,
                 field,
                 *batch_idx,
-                &stmt.conn()?.connection.numeric_settings,
+                &settings,
                 &mut offset,
             )
             .context(ConversionSnafu)?;

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -461,7 +461,7 @@ fn execute_bindings_for_row(
                 batch_idx,
                 // SAFETY: conn pointer is valid for the statement's lifetime;
                 // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.numeric_settings,
+                &unsafe { stmt.conn() }.connection.numeric_settings,
                 &mut None,
             )
             .context(ConversionSnafu)?;
@@ -585,7 +585,7 @@ pub fn get_data(
                 *batch_idx,
                 // SAFETY: conn pointer is valid for the statement's lifetime;
                 // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.numeric_settings,
+                &unsafe { stmt.conn() }.connection.numeric_settings,
                 &mut offset,
             )
             .context(ConversionSnafu)?;

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -17,6 +17,7 @@ use crate::{
     conversion::warning::{Warning, Warnings},
 };
 use odbc_sys as sql;
+use std::sync::Arc;
 
 /// ODBC Diagnostic Identifiers according to the ODBC standard
 ///
@@ -259,8 +260,15 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
         guard.get_diag_info_mut().clear();
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
+        dbc_ref.get_diag_info_mut().clear();
+        return;
+    }
     let t: &mut dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
         _ => return,
@@ -273,7 +281,6 @@ fn from_handle_type_non_env<'a>(
     handle: sql::Handle,
 ) -> Option<&'a mut dyn WithDiagnosticInfo> {
     match handle_type {
-        sql::HandleType::Dbc => Some(conn_from_handle(handle)),
         sql::HandleType::Stmt => Some(stmt_from_handle(handle)),
         sql::HandleType::Desc => Some(desc_diag_from_handle(handle)),
         _ => {
@@ -326,6 +333,17 @@ pub fn set_diag_info_from_warnings(
         }
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
+        let diagnostic_info = dbc_ref.get_diag_info_mut();
+        for warning in warnings {
+            diagnostic_info.add_record(from_warning(warning));
+        }
+        return;
+    }
     if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         let diagnostic_info = t.get_diag_info_mut();
         for warning in warnings {
@@ -357,6 +375,14 @@ pub fn set_diag_info_from_result(
         add_from_result(guard.get_diag_info_mut());
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
+        add_from_result(dbc_ref.get_diag_info_mut());
+        return;
+    }
     if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         add_from_result(t.get_diag_info_mut());
     }
@@ -371,8 +397,11 @@ pub fn get_diag_info(
         let guard = env.environment.lock();
         return Ok(guard.get_diag_info().clone());
     }
+    if handle_type == sql::HandleType::Dbc {
+        let dbc = conn_from_handle(handle)?;
+        return Ok(dbc.get_diag_info().clone());
+    }
     let t: &dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
         _ => return InvalidHandleSnafu.fail(),

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     api::{
-        Connection, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
+        Dbc, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
         encoding::{OdbcEncoding, write_string_bytes, write_string_chars},
         env_from_handle,
         error::{
@@ -169,6 +169,8 @@ pub trait WithDiagnosticInfo {
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo;
 }
 
+// TODO: With changes to the environment locking mechanism we need to
+// rework this solution so that we do not acquire the environment 3 times during one call
 impl WithDiagnosticInfo for Environment {
     fn get_diag_info(&self) -> &DiagnosticInfo {
         &self.diagnostic_info
@@ -178,12 +180,12 @@ impl WithDiagnosticInfo for Environment {
     }
 }
 
-impl WithDiagnosticInfo for Connection {
+impl WithDiagnosticInfo for Dbc {
     fn get_diag_info(&self) -> &DiagnosticInfo {
-        &self.diagnostic_info
+        &self.connection.diagnostic_info
     }
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo {
-        &mut self.diagnostic_info
+        &mut self.connection.diagnostic_info
     }
 }
 
@@ -249,8 +251,15 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
     if handle.is_null() {
         return;
     }
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        guard.get_diag_info_mut().clear();
+        return;
+    }
     let t: &mut dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Env => env_from_handle(handle),
         sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
@@ -259,12 +268,11 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
     t.get_diag_info_mut().clear();
 }
 
-pub fn from_handle_type<'a>(
+fn from_handle_type_non_env<'a>(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> Option<&'a mut dyn WithDiagnosticInfo> {
     match handle_type {
-        sql::HandleType::Env => Some(env_from_handle(handle)),
         sql::HandleType::Dbc => Some(conn_from_handle(handle)),
         sql::HandleType::Stmt => Some(stmt_from_handle(handle)),
         sql::HandleType::Desc => Some(desc_diag_from_handle(handle)),
@@ -307,7 +315,18 @@ pub fn set_diag_info_from_warnings(
     if handle.is_null() {
         return;
     }
-    if let Some(t) = from_handle_type(handle_type, handle) {
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        let diagnostic_info = guard.get_diag_info_mut();
+        for warning in warnings {
+            diagnostic_info.add_record(from_warning(warning));
+        }
+        return;
+    }
+    if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         let diagnostic_info = t.get_diag_info_mut();
         for warning in warnings {
             diagnostic_info.add_record(from_warning(warning));
@@ -323,18 +342,23 @@ pub fn set_diag_info_from_result(
     if handle.is_null() {
         return;
     }
-    if let Some(t) = from_handle_type(handle_type, handle) {
-        let diagnostic_info = t.get_diag_info_mut();
-        match result {
-            Ok(_) => {}
-            // SQL_NEED_DATA is a success-class return code, not an error.
-            // Don't post a diagnostic record — the Driver Manager uses the
-            // return code alone to drive the DAE protocol.
-            Err(OdbcError::DaeRequired { .. }) => {}
-            Err(error) => {
-                diagnostic_info.add_record(error.to_diagnostic_record());
-            }
+    let add_from_result = |diagnostic_info: &mut DiagnosticInfo| match result {
+        Ok(_) => {}
+        Err(OdbcError::DaeRequired { .. }) => {}
+        Err(error) => {
+            diagnostic_info.add_record(error.to_diagnostic_record());
         }
+    };
+    if handle_type == sql::HandleType::Env {
+        let Ok(env) = env_from_handle(handle) else {
+            return;
+        };
+        let mut guard = env.environment.lock();
+        add_from_result(guard.get_diag_info_mut());
+        return;
+    }
+    if let Some(t) = from_handle_type_non_env(handle_type, handle) {
+        add_from_result(t.get_diag_info_mut());
     }
 }
 
@@ -342,8 +366,12 @@ pub fn get_diag_info(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> OdbcResult<DiagnosticInfo> {
+    if handle_type == sql::HandleType::Env {
+        let env = env_from_handle(handle)?;
+        let guard = env.environment.lock();
+        return Ok(guard.get_diag_info().clone());
+    }
     let t: &dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Env => env_from_handle(handle),
         sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
@@ -647,10 +675,10 @@ mod tests {
     }
 
     #[test]
-    fn from_handle_type_returns_some_for_desc() {
+    fn from_handle_type_non_env_returns_some_for_desc() {
         let mut apd = ApdDescriptor::new();
         let handle = &mut apd as *mut ApdDescriptor as sql::Handle;
-        assert!(from_handle_type(sql::HandleType::Desc, handle).is_some());
+        assert!(from_handle_type_non_env(sql::HandleType::Desc, handle).is_some());
     }
 
     #[test]

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     api::{
-        Dbc, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
+        Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
         encoding::{OdbcEncoding, write_string_bytes, write_string_chars},
         env_from_handle,
         error::{
@@ -17,7 +17,6 @@ use crate::{
     conversion::warning::{Warning, Warnings},
 };
 use odbc_sys as sql;
-use std::sync::Arc;
 
 /// ODBC Diagnostic Identifiers according to the ODBC standard
 ///
@@ -181,12 +180,12 @@ impl WithDiagnosticInfo for Environment {
     }
 }
 
-impl WithDiagnosticInfo for Dbc {
+impl WithDiagnosticInfo for crate::api::Connection {
     fn get_diag_info(&self) -> &DiagnosticInfo {
-        &self.connection.diagnostic_info
+        &self.diagnostic_info
     }
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo {
-        &mut self.connection.diagnostic_info
+        &mut self.diagnostic_info
     }
 }
 
@@ -264,8 +263,7 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
         let Ok(dbc) = conn_from_handle(handle) else {
             return;
         };
-        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-        dbc_ref.get_diag_info_mut().clear();
+        dbc.connection.lock().get_diag_info_mut().clear();
         return;
     }
     let t: &mut dyn WithDiagnosticInfo = match handle_type {
@@ -337,8 +335,8 @@ pub fn set_diag_info_from_warnings(
         let Ok(dbc) = conn_from_handle(handle) else {
             return;
         };
-        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-        let diagnostic_info = dbc_ref.get_diag_info_mut();
+        let mut conn = dbc.connection.lock();
+        let diagnostic_info = conn.get_diag_info_mut();
         for warning in warnings {
             diagnostic_info.add_record(from_warning(warning));
         }
@@ -379,8 +377,7 @@ pub fn set_diag_info_from_result(
         let Ok(dbc) = conn_from_handle(handle) else {
             return;
         };
-        let dbc_ref = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-        add_from_result(dbc_ref.get_diag_info_mut());
+        add_from_result(dbc.connection.lock().get_diag_info_mut());
         return;
     }
     if let Some(t) = from_handle_type_non_env(handle_type, handle) {
@@ -399,7 +396,7 @@ pub fn get_diag_info(
     }
     if handle_type == sql::HandleType::Dbc {
         let dbc = conn_from_handle(handle)?;
-        return Ok(dbc.get_diag_info().clone());
+        return Ok(dbc.connection.lock().get_diag_info().clone());
     }
     let t: &dyn WithDiagnosticInfo = match handle_type {
         sql::HandleType::Stmt => stmt_from_handle(handle),

--- a/odbc/src/api/environment.rs
+++ b/odbc/src/api/environment.rs
@@ -60,7 +60,8 @@ pub fn set_env_attribute(
 ) -> OdbcResult<()> {
     tracing::debug!("Setting environment attribute: {attribute}");
 
-    let env = env_from_handle(environment_handle);
+    let env = env_from_handle(environment_handle)?;
+    let mut environment = env.environment.lock();
     let attr = to_env_attr(attribute).ok_or(UnsupportedAttributeSnafu { attribute }.build())?;
 
     match attr {
@@ -69,7 +70,7 @@ pub fn set_env_attribute(
             match version {
                 SQL_OV_ODBC2 | SQL_OV_ODBC3 | SQL_OV_ODBC3_80 => {
                     tracing::debug!("Setting ODBC version: {version}");
-                    env.odbc_version = version;
+                    environment.odbc_version = version;
                     Ok(())
                 }
                 _ => {
@@ -85,14 +86,14 @@ pub fn set_env_attribute(
         sql::EnvironmentAttribute::ConnectionPooling => {
             let pooling = parse_connection_pooling(value as sql::UInteger, attribute)?;
             tracing::debug!("Setting connection pooling: {pooling:?}");
-            env.connection_pooling = pooling;
+            environment.connection_pooling = pooling;
             Ok(())
         }
         sql::EnvironmentAttribute::CpMatch => {
             let connection_pool_match =
                 parse_connection_pool_match(value as sql::UInteger, attribute)?;
             tracing::debug!("Setting connection pool match: {connection_pool_match:?}");
-            env.connection_pool_match = connection_pool_match;
+            environment.connection_pool_match = connection_pool_match;
             Ok(())
         }
         sql::EnvironmentAttribute::OutputNts => {
@@ -111,7 +112,8 @@ pub fn get_env_attribute(
 ) -> OdbcResult<()> {
     tracing::debug!("Getting environment attribute: {attribute}");
 
-    let env = env_from_handle(environment_handle);
+    let env = env_from_handle(environment_handle)?;
+    let environment = env.environment.lock();
     let attr = to_env_attr(attribute).ok_or(UnsupportedAttributeSnafu { attribute }.build())?;
 
     let write_string_length = || {
@@ -127,20 +129,23 @@ pub fn get_env_attribute(
 
     match attr {
         sql::EnvironmentAttribute::OdbcVersion => {
-            tracing::debug!("Getting ODBC version: {}", env.odbc_version);
+            tracing::debug!("Getting ODBC version: {}", environment.odbc_version);
             if !value.is_null() {
-                unsafe { std::ptr::write(value as *mut sql::Integer, env.odbc_version) };
+                unsafe { std::ptr::write(value as *mut sql::Integer, environment.odbc_version) };
             }
             write_string_length();
             Ok(())
         }
         sql::EnvironmentAttribute::ConnectionPooling => {
-            tracing::debug!("Getting connection pooling: {:?}", env.connection_pooling);
+            tracing::debug!(
+                "Getting connection pooling: {:?}",
+                environment.connection_pooling
+            );
             if !value.is_null() {
                 unsafe {
                     std::ptr::write(
                         value as *mut sql::UInteger,
-                        env.connection_pooling as sql::UInteger,
+                        environment.connection_pooling as sql::UInteger,
                     )
                 };
             }
@@ -150,13 +155,13 @@ pub fn get_env_attribute(
         sql::EnvironmentAttribute::CpMatch => {
             tracing::debug!(
                 "Getting connection pool match: {:?}",
-                env.connection_pool_match
+                environment.connection_pool_match
             );
             if !value.is_null() {
                 unsafe {
                     std::ptr::write(
                         value as *mut sql::UInteger,
-                        env.connection_pool_match as sql::UInteger,
+                        environment.connection_pool_match as sql::UInteger,
                     )
                 };
             }

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -25,6 +25,30 @@ use snafu::{Location, Snafu, location};
 #[derive(Snafu, Debug, ErrorTrace)]
 #[snafu(visibility(pub))]
 pub enum OdbcError {
+    #[snafu(display("Freeing environment failed: environment has connections"))]
+    EnvironmentHasConnections {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Freeing connection failed: connection is still connected"))]
+    ConnectionStillConnected {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Connection has no environment"))]
+    ConnectionHasNoEnvironment {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to lock environment"))]
+    EnvironmentLockPoisoned {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Connection is disconnected"))]
     Disconnected {
         #[snafu(implicit)]
@@ -499,6 +523,10 @@ impl OdbcError {
 
     pub fn to_sql_state(&self) -> SqlState {
         match self {
+            OdbcError::EnvironmentHasConnections { .. } => SqlState::FunctionSequenceError,
+            OdbcError::ConnectionStillConnected { .. } => SqlState::FunctionSequenceError,
+            OdbcError::ConnectionHasNoEnvironment { .. } => SqlState::GeneralError,
+            OdbcError::EnvironmentLockPoisoned { .. } => SqlState::GeneralError,
             OdbcError::Disconnected { .. } => SqlState::ConnectionDoesNotExist,
             OdbcError::InvalidHandle { .. } => SqlState::InvalidConnectionName,
             OdbcError::InvalidHandleType { .. } => SqlState::InvalidAttributeOptionIdentifier,

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -36,9 +36,9 @@ pub fn alloc_environment() -> OdbcResult<sql::Handle> {
 }
 
 /// Allocate a new connection handle
-pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
+pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new connection handle");
-    let dbc = Box::new(Dbc {
+    let dbc = Arc::new(Dbc {
         env: Arc::downgrade(&env),
         connection: Connection {
             state: ConnectionState::Disconnected,
@@ -54,15 +54,17 @@ pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
             metadata_id: false,
         },
     });
-    let ptr = Box::into_raw(dbc);
-    env.environment.lock().connections.push(ptr);
-    Ok(ptr)
+    let weak = Arc::downgrade(&dbc);
+    let handle = global().context(OdbcRuntimeSnafu)?.dbc_registry.add(weak)?;
+    env.environment.lock().connections.push(dbc);
+    Ok(handle.into())
 }
 
 /// Allocate a new statement handle
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
-    let conn = conn_from_handle(input_handle);
+    let dbc = conn_from_handle(input_handle)?;
+    let conn = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
     let connection = &mut conn.connection;
     match &mut connection.state {
         ConnectionState::Connected {
@@ -80,12 +82,12 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
                 .stmt_handle
                 .required("Statement handle is required")?;
 
-            // Statement is Send but not Sync (conn is *mut Connection with no synchronisation).
-            // Arc is used for reference-counted ownership and Weak tracking on Connection;
-            // the Arc is converted to a raw pointer immediately — it is never cloned and
-            // never shared across threads. Rc cannot be used because Connection: Send.
             #[allow(clippy::arc_with_non_send_sync)]
-            let stmt = Arc::new(Statement::new(conn as *mut Dbc, stmt_handle, metadata_id));
+            let stmt = Arc::new(Statement::new(
+                Arc::downgrade(&dbc),
+                stmt_handle,
+                metadata_id,
+            ));
             // Defensive prune: in correct code free_statement removes each entry before
             // dropping the Arc, so Weaks here are always upgradeable. This retain is a
             // safety net against a future bug in the removal logic, not a routine cleanup.
@@ -139,18 +141,15 @@ pub fn free_environment(handle: sql::Handle) -> OdbcResult<()> {
     Ok(())
 }
 
-fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
+fn cleanup_connection(dbc: Arc<Dbc>) -> OdbcResult<()> {
     // Release any outstanding statements whose ODBC handles were never freed.
     // Each Weak still in child_statements corresponds to an Arc::into_raw that was
     // never reclaimed by free_statement (strong count = 1, held by the raw ODBC handle).
     // Reconstruct the Arc to take back that ownership, then release the server resource.
-    let conn = unsafe { &mut *conn };
-    let connection = &mut conn.connection;
-    let stmts: Vec<_> = connection.child_statements.drain(..).collect();
+    let conn = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
+    let stmts: Vec<_> = conn.connection.child_statements.drain(..).collect();
     for (w, raw_ptr) in stmts {
         // Safety: raw_ptr was obtained via Arc::into_raw in alloc_statement.
-        // (Note: Arc::as_ptr and Arc::into_raw are NOT equivalent — as_ptr does not transfer
-        // strong-count ownership; into_raw does. Only into_raw satisfies Arc::from_raw's contract.)
         // free_statement removes its child_statements entry before dropping the Arc, so any
         // entry still present here means the ODBC handle was never freed — strong count == 1.
         // Guard: verify the Weak is still live before dereferencing raw_ptr. A dead Weak means
@@ -182,18 +181,6 @@ fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
             Err(e) => tracing::warn!("free_connection: runtime unavailable: {e:?}"),
         }
     }
-
-    unsafe {
-        drop(Box::from_raw(conn as *mut Dbc));
-    }
-    Ok(())
-}
-
-fn remove_connection_from_env(conn: *mut Dbc) -> OdbcResult<()> {
-    let dbc = unsafe { &mut *conn };
-    let env = dbc.env()?;
-    let mut environment = env.environment.lock();
-    environment.connections.retain(|c| *c != conn);
     Ok(())
 }
 
@@ -204,12 +191,29 @@ pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
     }
 
     tracing::info!("Freeing connection handle");
-    let dbc = handle as *mut Dbc;
-    let conn = unsafe { &*dbc };
-    if matches!(conn.connection.state, ConnectionState::Connected { .. }) {
+    let handle_id = HandleId::from(handle);
+    let dbc_removal = global()
+        .context(OdbcRuntimeSnafu)?
+        .dbc_registry
+        .remove(handle_id)?;
+    let dbc = dbc_removal
+        .upgrade()
+        .ok_or_else(|| InvalidHandleSnafu.build())?;
+
+    if matches!(dbc.connection.state, ConnectionState::Connected { .. }) {
         return ConnectionStillConnectedSnafu.fail();
     }
-    remove_connection_from_env(dbc)?;
+
+    // Resolve the parent env before committing any state changes.
+    let env = dbc.env()?;
+
+    // Commit: remove from registry and from the parent env's connections list.
+    dbc_removal.complete();
+    env.environment
+        .lock()
+        .connections
+        .retain(|c| !Arc::ptr_eq(c, &dbc));
+
     cleanup_connection(dbc)
 }
 
@@ -236,8 +240,8 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
     });
     if release_result.is_ok() {
         // Release succeeded — remove the bookkeeping entry and drop the Arc.
-        // Arc<Statement> doesn't implement DerefMut, so use conn_ptr() (takes &self via Arc::Deref)
-        // to get an independent &mut Connection.
+        // conn_ptr() returns a raw pointer derived from the Weak, valid because the
+        // parent Dbc is still alive (conn.child_statements still holds a Weak to it).
         unsafe { &mut *stmt.conn_ptr() }
             .connection
             .child_statements
@@ -296,7 +300,7 @@ pub fn sql_alloc_handle(
             );
             let env = env_from_handle(input_handle)?;
             let handle = alloc_connection(env)?;
-            unsafe { *output_handle = handle as sql::Handle };
+            unsafe { *output_handle = handle };
             Ok(())
         }
         sql::HandleType::Stmt => {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -40,7 +40,7 @@ pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new connection handle");
     let dbc = Arc::new(Dbc {
         env: Arc::downgrade(&env),
-        connection: Connection {
+        connection: Mutex::new(Connection {
             state: ConnectionState::Disconnected,
             diagnostic_info: DiagnosticInfo::default(),
             pre_connection_attrs: Default::default(),
@@ -52,7 +52,7 @@ pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<sql::Handle> {
             cached_autocommit: crate::api::types::AutocommitValue::On,
             current_catalog: None,
             metadata_id: false,
-        },
+        }),
     });
     let weak = Arc::downgrade(&dbc);
     let handle = global().context(OdbcRuntimeSnafu)?.dbc_registry.add(weak)?;
@@ -64,64 +64,68 @@ pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<sql::Handle> {
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
     let dbc = conn_from_handle(input_handle)?;
-    let conn = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let connection = &mut conn.connection;
-    match &mut connection.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let metadata_id = connection.metadata_id;
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_new(StatementNewRequest {
-                    conn_handle: Some(*conn_handle),
-                })
-                .await
-            })?;
-            let stmt_handle = response
-                .stmt_handle
-                .required("Statement handle is required")?;
+    // Extract needed data under a short-lived lock; release before the async call.
+    let (conn_handle, metadata_id) = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected {
+                db_handle: _,
+                conn_handle,
+            } => (*conn_handle, connection.metadata_id),
+            ConnectionState::Disconnected => {
+                tracing::error!("Cannot allocate statement: connection is disconnected");
+                return DisconnectedSnafu.fail();
+            }
+        }
+    };
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_new(StatementNewRequest {
+            conn_handle: Some(conn_handle),
+        })
+        .await
+    })?;
+    let stmt_handle = response
+        .stmt_handle
+        .required("Statement handle is required")?;
 
-            #[allow(clippy::arc_with_non_send_sync)]
-            let stmt = Arc::new(Statement::new(
-                Arc::downgrade(&dbc),
-                stmt_handle,
-                metadata_id,
-            ));
-            // Defensive prune: in correct code free_statement removes each entry before
-            // dropping the Arc, so Weaks here are always upgradeable. This retain is a
-            // safety net against a future bug in the removal logic, not a routine cleanup.
-            conn.connection.child_statements.retain(|(w, raw_ptr)| {
-                if w.upgrade().is_some() {
-                    return true;
-                }
-                // A dead Weak means free_statement dropped the Arc without removing the
-                // child_statements entry — this is a bug. Log it so leaks are visible.
-                tracing::error!(
-                    "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
-                     server-side statement handle may have leaked"
-                );
-                false
-            });
-            let weak = Arc::downgrade(&stmt);
-            // Transfer ownership to a raw pointer used as the opaque ODBC handle.
-            // Store the same pointer in child_statements so free_connection can call
-            // Arc::from_raw with a pointer that satisfies its documented contract.
-            let raw_ptr = Arc::into_raw(stmt);
-            // Set descriptor back-pointers now that the Statement has a stable heap address.
-            let stmt_mut = unsafe { &mut *(raw_ptr as *mut Statement) };
-            stmt_mut.ard.stmt = raw_ptr;
-            stmt_mut.ird.stmt = raw_ptr;
-            stmt_mut.apd.stmt = raw_ptr;
-            stmt_mut.ipd.stmt = raw_ptr;
-            conn.connection.child_statements.push((weak, raw_ptr));
-            Ok(raw_ptr as *mut Statement)
-        }
-        ConnectionState::Disconnected => {
-            tracing::error!("Cannot allocate statement: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
+    #[allow(clippy::arc_with_non_send_sync)]
+    let stmt = Arc::new(Statement::new(
+        Arc::downgrade(&dbc),
+        stmt_handle,
+        metadata_id,
+    ));
+    let weak = Arc::downgrade(&stmt);
+    // Transfer ownership to a raw pointer used as the opaque ODBC handle.
+    // Store the same pointer in child_statements so free_connection can call
+    // Arc::from_raw with a pointer that satisfies its documented contract.
+    let raw_ptr = Arc::into_raw(stmt);
+    // Set descriptor back-pointers now that the Statement has a stable heap address.
+    let stmt_mut = unsafe { &mut *(raw_ptr as *mut Statement) };
+    stmt_mut.ard.stmt = raw_ptr;
+    stmt_mut.ird.stmt = raw_ptr;
+    stmt_mut.apd.stmt = raw_ptr;
+    stmt_mut.ipd.stmt = raw_ptr;
+
+    {
+        let mut connection = dbc.connection.lock();
+        // Defensive prune: in correct code free_statement removes each entry before
+        // dropping the Arc, so Weaks here are always upgradeable. This retain is a
+        // safety net against a future bug in the removal logic, not a routine cleanup.
+        connection.child_statements.retain(|(w, raw_ptr)| {
+            if w.upgrade().is_some() {
+                return true;
+            }
+            // A dead Weak means free_statement dropped the Arc without removing the
+            // child_statements entry — this is a bug. Log it so leaks are visible.
+            tracing::error!(
+                "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
+                 server-side statement handle may have leaked"
+            );
+            false
+        });
+        connection.child_statements.push((weak, raw_ptr));
     }
+    Ok(raw_ptr as *mut Statement)
 }
 
 /// Free an environment handle
@@ -146,8 +150,7 @@ fn cleanup_connection(dbc: Arc<Dbc>) -> OdbcResult<()> {
     // Each Weak still in child_statements corresponds to an Arc::into_raw that was
     // never reclaimed by free_statement (strong count = 1, held by the raw ODBC handle).
     // Reconstruct the Arc to take back that ownership, then release the server resource.
-    let conn = unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) };
-    let stmts: Vec<_> = conn.connection.child_statements.drain(..).collect();
+    let stmts: Vec<_> = dbc.connection.lock().child_statements.drain(..).collect();
     for (w, raw_ptr) in stmts {
         // Safety: raw_ptr was obtained via Arc::into_raw in alloc_statement.
         // free_statement removes its child_statements entry before dropping the Arc, so any
@@ -200,7 +203,10 @@ pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
         .upgrade()
         .ok_or_else(|| InvalidHandleSnafu.build())?;
 
-    if matches!(dbc.connection.state, ConnectionState::Connected { .. }) {
+    if matches!(
+        dbc.connection.lock().state,
+        ConnectionState::Connected { .. }
+    ) {
         return ConnectionStillConnectedSnafu.fail();
     }
 
@@ -240,12 +246,12 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
     });
     if release_result.is_ok() {
         // Release succeeded — remove the bookkeeping entry and drop the Arc.
-        // conn_ptr() returns a raw pointer derived from the Weak, valid because the
-        // parent Dbc is still alive (conn.child_statements still holds a Weak to it).
-        unsafe { &mut *stmt.conn_ptr() }
-            .connection
-            .child_statements
-            .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
+        if let Ok(dbc) = stmt.conn() {
+            dbc.connection
+                .lock()
+                .child_statements
+                .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
+        }
         drop(stmt);
     } else {
         // Release failed — forget the Arc so the raw pointer in child_statements stays valid

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -1,10 +1,16 @@
-use crate::api::error::{DisconnectedSnafu, InvalidHandleSnafu, OdbcRuntimeSnafu, Required};
+use crate::api::env_from_handle;
+use crate::api::error::{
+    ConnectionStillConnectedSnafu, DisconnectedSnafu, EnvironmentHasConnectionsSnafu,
+    InvalidHandleSnafu, OdbcRuntimeSnafu, Required,
+};
+use crate::api::handle_registry::HandleId;
 use crate::api::{
-    Connection, ConnectionState, Environment, OdbcResult, Statement, conn_from_handle,
+    Connection, ConnectionState, Dbc, Env, Environment, OdbcResult, Statement, conn_from_handle,
     diagnostic::DiagnosticInfo,
     runtime::{env_allocated, env_freed, global},
 };
 use odbc_sys as sql;
+use parking_lot::Mutex;
 use sf_core::protobuf::generated::database_driver_v1::{
     StatementNewRequest, StatementReleaseRequest,
 };
@@ -13,47 +19,57 @@ use std::sync::Arc;
 use tracing;
 
 /// Allocate a new environment handle
-pub fn alloc_environment() -> OdbcResult<*mut Environment> {
+pub fn alloc_environment() -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new environment handle");
     env_allocated().context(OdbcRuntimeSnafu)?;
-    let env = Box::new(Environment {
-        odbc_version: 3,
-        connection_pooling: sql::AttrConnectionPooling::Off,
-        connection_pool_match: sql::AttrCpMatch::Strict,
-        diagnostic_info: DiagnosticInfo::default(),
+    let env = Arc::new(Env {
+        environment: Mutex::new(Environment {
+            odbc_version: 3,
+            connection_pooling: sql::AttrConnectionPooling::Off,
+            connection_pool_match: sql::AttrCpMatch::Strict,
+            diagnostic_info: DiagnosticInfo::default(),
+            connections: vec![],
+        }),
     });
-    Ok(Box::into_raw(env))
+    let handle = global().context(OdbcRuntimeSnafu)?.env_registry.add(env)?;
+    Ok(handle.into())
 }
 
 /// Allocate a new connection handle
-pub fn alloc_connection() -> OdbcResult<*mut Connection> {
+pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
     tracing::info!("Allocating new connection handle");
-    let dbc = Box::new(Connection {
-        state: ConnectionState::Disconnected,
-        diagnostic_info: DiagnosticInfo::default(),
-        pre_connection_attrs: Default::default(),
-        numeric_settings: Default::default(),
-        access_mode: crate::api::types::AccessMode::ReadWrite,
-        quiet_mode: std::ptr::null_mut(), // no window handle
-        packet_size: 0,                   // driver-defined
-        child_statements: vec![],
-        cached_autocommit: crate::api::types::AutocommitValue::On,
-        current_catalog: None,
-        metadata_id: false,
+    let dbc = Box::new(Dbc {
+        env: Arc::downgrade(&env),
+        connection: Connection {
+            state: ConnectionState::Disconnected,
+            diagnostic_info: DiagnosticInfo::default(),
+            pre_connection_attrs: Default::default(),
+            numeric_settings: Default::default(),
+            access_mode: crate::api::types::AccessMode::ReadWrite,
+            quiet_mode: std::ptr::null_mut(),
+            packet_size: 0,
+            child_statements: vec![],
+            cached_autocommit: crate::api::types::AutocommitValue::On,
+            current_catalog: None,
+            metadata_id: false,
+        },
     });
-    Ok(Box::into_raw(dbc))
+    let ptr = Box::into_raw(dbc);
+    env.environment.lock().connections.push(ptr);
+    Ok(ptr)
 }
 
 /// Allocate a new statement handle
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
     let conn = conn_from_handle(input_handle);
-    match &mut conn.state {
+    let connection = &mut conn.connection;
+    match &mut connection.state {
         ConnectionState::Connected {
             db_handle: _,
             conn_handle,
         } => {
-            let metadata_id = conn.metadata_id;
+            let metadata_id = connection.metadata_id;
             let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                 c.statement_new(StatementNewRequest {
                     conn_handle: Some(*conn_handle),
@@ -69,15 +85,11 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
             // the Arc is converted to a raw pointer immediately — it is never cloned and
             // never shared across threads. Rc cannot be used because Connection: Send.
             #[allow(clippy::arc_with_non_send_sync)]
-            let stmt = Arc::new(Statement::new(
-                conn as *mut Connection,
-                stmt_handle,
-                metadata_id,
-            ));
+            let stmt = Arc::new(Statement::new(conn as *mut Dbc, stmt_handle, metadata_id));
             // Defensive prune: in correct code free_statement removes each entry before
             // dropping the Arc, so Weaks here are always upgradeable. This retain is a
             // safety net against a future bug in the removal logic, not a routine cleanup.
-            conn.child_statements.retain(|(w, raw_ptr)| {
+            conn.connection.child_statements.retain(|(w, raw_ptr)| {
                 if w.upgrade().is_some() {
                     return true;
                 }
@@ -100,7 +112,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
             stmt_mut.ird.stmt = raw_ptr;
             stmt_mut.apd.stmt = raw_ptr;
             stmt_mut.ipd.stmt = raw_ptr;
-            conn.child_statements.push((weak, raw_ptr));
+            conn.connection.child_statements.push((weak, raw_ptr));
             Ok(raw_ptr as *mut Statement)
         }
         ConnectionState::Disconnected => {
@@ -112,34 +124,29 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
 
 /// Free an environment handle
 pub fn free_environment(handle: sql::Handle) -> OdbcResult<()> {
-    if handle.is_null() {
-        return InvalidHandleSnafu.fail();
+    let handle_id = HandleId::from(handle);
+    let env_removal_guard = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .remove(handle_id)?;
+    let environment = env_removal_guard.environment.lock();
+    if !environment.connections.is_empty() {
+        return EnvironmentHasConnectionsSnafu.fail();
     }
-
-    tracing::info!("Freeing environment handle");
-    unsafe {
-        drop(Box::from_raw(handle as *mut Environment));
-    }
+    drop(environment);
+    env_removal_guard.complete();
     env_freed().context(OdbcRuntimeSnafu)?;
     Ok(())
 }
 
-/// Free a connection handle
-pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
-    if handle.is_null() {
-        return InvalidHandleSnafu.fail();
-    }
-
-    tracing::info!("Freeing connection handle");
-
+fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
     // Release any outstanding statements whose ODBC handles were never freed.
     // Each Weak still in child_statements corresponds to an Arc::into_raw that was
     // never reclaimed by free_statement (strong count = 1, held by the raw ODBC handle).
     // Reconstruct the Arc to take back that ownership, then release the server resource.
-    let stmts: Vec<_> = {
-        let conn = unsafe { &mut *(handle as *mut Connection) };
-        conn.child_statements.drain(..).collect()
-    };
+    let conn = unsafe { &mut *conn };
+    let connection = &mut conn.connection;
+    let stmts: Vec<_> = connection.child_statements.drain(..).collect();
     for (w, raw_ptr) in stmts {
         // Safety: raw_ptr was obtained via Arc::into_raw in alloc_statement.
         // (Note: Arc::as_ptr and Arc::into_raw are NOT equivalent — as_ptr does not transfer
@@ -177,9 +184,33 @@ pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
     }
 
     unsafe {
-        drop(Box::from_raw(handle as *mut Connection));
+        drop(Box::from_raw(conn as *mut Dbc));
     }
     Ok(())
+}
+
+fn remove_connection_from_env(conn: *mut Dbc) -> OdbcResult<()> {
+    let dbc = unsafe { &mut *conn };
+    let env = dbc.env()?;
+    let mut environment = env.environment.lock();
+    environment.connections.retain(|c| *c != conn);
+    Ok(())
+}
+
+/// Free a connection handle
+pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
+    if handle.is_null() {
+        return InvalidHandleSnafu.fail();
+    }
+
+    tracing::info!("Freeing connection handle");
+    let dbc = handle as *mut Dbc;
+    let conn = unsafe { &*dbc };
+    if matches!(conn.connection.state, ConnectionState::Connected { .. }) {
+        return ConnectionStillConnectedSnafu.fail();
+    }
+    remove_connection_from_env(dbc)?;
+    cleanup_connection(dbc)
 }
 
 /// Free a statement handle
@@ -208,6 +239,7 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
         // Arc<Statement> doesn't implement DerefMut, so use conn_ptr() (takes &self via Arc::Deref)
         // to get an independent &mut Connection.
         unsafe { &mut *stmt.conn_ptr() }
+            .connection
             .child_statements
             .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
         drop(stmt);
@@ -262,7 +294,8 @@ pub fn sql_alloc_handle(
                 "Allocating new dbc: SQLAllocHandle: handle_type={:?}",
                 handle_type
             );
-            let handle = alloc_connection()?;
+            let env = env_from_handle(input_handle)?;
+            let handle = alloc_connection(env)?;
             unsafe { *output_handle = handle as sql::Handle };
             Ok(())
         }

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -29,26 +29,32 @@ impl From<sql::Handle> for HandleId {
 }
 
 pub struct RemovalGuard<T: Send + Sync + Clone> {
-    value: T,
+    value: Option<T>,
     guard: ArcMutexGuard<RawMutex, Option<T>>,
 }
 
 impl<T: Send + Sync + Clone> RemovalGuard<T> {
-    pub fn complete(self) -> T {
-        self.value.clone()
+    pub fn complete(mut self) -> T {
+        self.value
+            .take()
+            .expect("complete called on already-completed RemovalGuard")
     }
 }
 
 impl<T: Send + Sync + Clone> Drop for RemovalGuard<T> {
     fn drop(&mut self) {
-        *self.guard = Some(self.value.clone());
+        if let Some(value) = self.value.take() {
+            *self.guard = Some(value);
+        }
     }
 }
 
 impl<T: Send + Sync + Clone> Deref for RemovalGuard<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.value
+        self.value
+            .as_ref()
+            .expect("deref on completed RemovalGuard")
     }
 }
 
@@ -102,8 +108,11 @@ impl<T: Send + Sync + Clone> HandleRegistry<T> {
             .ok_or_else(|| InvalidHandleSnafu.build())?;
         let mut guard = handle.lock_arc();
         let value_opt = guard.take();
-        if let Some(value) = value_opt {
-            return Ok(RemovalGuard { value, guard });
+        if value_opt.is_some() {
+            return Ok(RemovalGuard {
+                value: value_opt,
+                guard,
+            });
         }
         InvalidHandleSnafu.fail()
     }

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
 
 use parking_lot::{ArcMutexGuard, Mutex, RawMutex, RwLock};
 
 use crate::api::error::InvalidHandleSnafu;
-use crate::api::{Env, OdbcResult};
+use crate::api::{Dbc, Env, OdbcResult};
 use odbc_sys as sql;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -128,6 +128,7 @@ impl<T: Send + Sync + Clone> HandleRegistry<T> {
 }
 
 pub type EnvironmentHandleRegistry = HandleRegistry<Arc<Env>>;
+pub type ConnectionHandleRegistry = HandleRegistry<Weak<Dbc>>;
 
 #[cfg(test)]
 mod tests {

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::{ArcMutexGuard, Mutex, RawMutex, RwLock};
+
+use crate::api::error::InvalidHandleSnafu;
+use crate::api::{Env, OdbcResult};
+use odbc_sys as sql;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HandleId {
+    id: usize,
+}
+
+impl From<HandleId> for sql::Handle {
+    fn from(handle_id: HandleId) -> Self {
+        handle_id.id as sql::Handle
+    }
+}
+
+impl From<sql::Handle> for HandleId {
+    fn from(handle: sql::Handle) -> Self {
+        Self {
+            id: handle as usize,
+        }
+    }
+}
+
+pub struct RemovalGuard<T: Send + Sync + Clone> {
+    value: T,
+    guard: ArcMutexGuard<RawMutex, Option<T>>,
+}
+
+impl<T: Send + Sync + Clone> RemovalGuard<T> {
+    pub fn complete(self) -> T {
+        self.value.clone()
+    }
+}
+
+impl<T: Send + Sync + Clone> Drop for RemovalGuard<T> {
+    fn drop(&mut self) {
+        *self.guard = Some(self.value.clone());
+    }
+}
+
+impl<T: Send + Sync + Clone> Deref for RemovalGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+// TODO Reclaim ids when handles are removed
+pub struct HandleRegistry<T: Send + Sync + Clone> {
+    handles: RwLock<HashMap<HandleId, Arc<Mutex<Option<T>>>>>,
+    next_id: AtomicUsize,
+}
+
+impl<T: Send + Sync + Clone> HandleRegistry<T> {
+    fn next_id(&self) -> HandleId {
+        HandleId {
+            id: self.next_id.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            handles: RwLock::new(HashMap::new()),
+            next_id: AtomicUsize::new(1),
+        }
+    }
+
+    pub fn add(&self, handle: T) -> OdbcResult<HandleId> {
+        let mut handles = self.handles.write();
+        let id = self.next_id();
+        handles.insert(id, Arc::new(Mutex::new(Some(handle))));
+        Ok(id)
+    }
+
+    pub fn get(&self, id: HandleId) -> OdbcResult<T> {
+        let mutex = self
+            .handles
+            .read()
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())?;
+        let value = mutex.lock();
+        value
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())
+    }
+
+    pub fn remove(&self, id: HandleId) -> OdbcResult<RemovalGuard<T>> {
+        let handle = self
+            .handles
+            .read()
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| InvalidHandleSnafu.build())?;
+        let mut guard = handle.lock_arc();
+        let value_opt = guard.take();
+        if let Some(value) = value_opt {
+            return Ok(RemovalGuard { value, guard });
+        }
+        InvalidHandleSnafu.fail()
+    }
+
+    #[allow(dead_code)]
+    pub fn cleanup(&self, ids: &[HandleId]) -> OdbcResult<()> {
+        let mut handles = self.handles.write();
+        for id in ids {
+            handles.remove(id);
+        }
+        Ok(())
+    }
+}
+
+pub type EnvironmentHandleRegistry = HandleRegistry<Arc<Env>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_id_has_pointer_size() {
+        assert_eq!(
+            std::mem::size_of::<HandleId>(),
+            std::mem::size_of::<sql::Handle>()
+        );
+    }
+
+    #[test]
+    fn registry_add_get_remove() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id = registry.add(42).unwrap();
+        assert_eq!(registry.get(id).unwrap(), 42);
+        assert_eq!(registry.remove(id).unwrap().complete(), 42);
+        assert!(registry.get(id).is_err());
+    }
+
+    #[test]
+    fn registry_cleanup() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id1 = registry.add(1).unwrap();
+        let id2 = registry.add(2).unwrap();
+        let id3 = registry.add(3).unwrap();
+        registry.cleanup(&[id1, id3]).unwrap();
+        assert!(registry.get(id1).is_err());
+        assert_eq!(registry.get(id2).unwrap(), 2);
+        assert!(registry.get(id3).is_err());
+    }
+
+    #[test]
+    fn registry_ids_start_at_one() {
+        let registry: HandleRegistry<i32> = HandleRegistry::new();
+        let id = registry.add(1).unwrap();
+        assert_eq!(id, HandleId { id: 1 });
+    }
+}

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod encoding;
 pub mod environment;
 pub mod error;
 pub mod handle_allocation;
+pub mod handle_registry;
 pub mod runtime;
 pub mod sql_state;
 pub mod statement;

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -4,7 +4,7 @@ use std::sync::RwLock;
 use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
 use snafu::{Location, ResultExt, Snafu};
 
-use crate::api::handle_registry::EnvironmentHandleRegistry;
+use crate::api::handle_registry::{ConnectionHandleRegistry, EnvironmentHandleRegistry};
 
 /// Holds the shared tokio runtime and driver client used by all ODBC
 /// environments in this process.
@@ -21,6 +21,7 @@ pub struct OdbcGlobals {
     runtime: tokio::runtime::Runtime,
     client: DatabaseDriverClient,
     pub env_registry: EnvironmentHandleRegistry,
+    pub dbc_registry: ConnectionHandleRegistry,
 }
 
 impl OdbcGlobals {
@@ -93,6 +94,7 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
             runtime,
             client,
             env_registry: EnvironmentHandleRegistry::new(),
+            dbc_registry: ConnectionHandleRegistry::new(),
         });
     }
     guard.env_count += 1;

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -4,6 +4,8 @@ use std::sync::RwLock;
 use sf_core::protobuf::apis::database_driver_v1::{DatabaseDriverClient, database_driver_client};
 use snafu::{Location, ResultExt, Snafu};
 
+use crate::api::handle_registry::EnvironmentHandleRegistry;
+
 /// Holds the shared tokio runtime and driver client used by all ODBC
 /// environments in this process.
 ///
@@ -18,6 +20,7 @@ use snafu::{Location, ResultExt, Snafu};
 pub struct OdbcGlobals {
     runtime: tokio::runtime::Runtime,
     client: DatabaseDriverClient,
+    pub env_registry: EnvironmentHandleRegistry,
 }
 
 impl OdbcGlobals {
@@ -86,7 +89,11 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
             .build()
             .context(RuntimeCreationSnafu)?;
         let client = database_driver_client();
-        guard.globals = Some(OdbcGlobals { runtime, client });
+        guard.globals = Some(OdbcGlobals {
+            runtime,
+            client,
+            env_registry: EnvironmentHandleRegistry::new(),
+        });
     }
     guard.env_count += 1;
     Ok(())

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -72,8 +72,8 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Validate connection before committing to NeedData state.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
-    match &mut conn.state {
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    match &mut dbc.connection.state {
         ConnectionState::Disconnected => {
             tracing::error!("exec_direct: connection is disconnected");
             return DisconnectedSnafu.fail();
@@ -111,7 +111,8 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Re-borrow connection for execution.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Connected {
             db_handle: _,
@@ -253,8 +254,9 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
         return CursorAlreadyOpenSnafu.fail();
     }
 
-    let conn = unsafe { &mut *stmt.conn_ptr() };
-    match &mut conn.state {
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let connection = &mut dbc.connection;
+    match &mut connection.state {
         ConnectionState::Connected {
             db_handle: _,
             conn_handle: _,
@@ -302,7 +304,7 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
                 .build()
             })?;
             stmt.prepared_param_count = Some(param_count);
-            let max_varchar = conn.numeric_settings.max_varchar_size;
+            let max_varchar = connection.numeric_settings.max_varchar_size;
             stmt.ipd.records.retain(|&k, _| k <= param_count);
             for i in 1..=param_count {
                 stmt.ipd
@@ -351,7 +353,8 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let is_prepared = origin.is_prepared();
 
     // Validate connection before committing to NeedData state.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Disconnected => {
             tracing::error!("execute: connection is disconnected");
@@ -380,7 +383,8 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     }
 
     // Re-borrow connection for execution.
-    let conn = unsafe { &mut *stmt.conn_ptr() };
+    let dbc = unsafe { &mut *stmt.conn_ptr() };
+    let conn = &mut dbc.connection;
     match &mut conn.state {
         ConnectionState::Connected {
             db_handle: _,

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -72,13 +72,10 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Validate connection before committing to NeedData state.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    match &mut dbc.connection.state {
-        ConnectionState::Disconnected => {
-            tracing::error!("exec_direct: connection is disconnected");
-            return DisconnectedSnafu.fail();
-        }
-        ConnectionState::Connected { .. } => {}
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("exec_direct: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
 
     // exec-direct supersedes any prior SQLPrepare on this handle; clear the
@@ -110,61 +107,59 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         return DaeRequiredSnafu.fail();
     }
 
-    // Re-borrow connection for execution.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let (bindings, _json_owner) =
-                apply_parameter_bindings(&stmt.apd, &stmt.ipd, false, None)?;
-            let stmt_handle = stmt.stmt_handle;
-
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
-            // _cancel_token.cancelled() to support cross-thread SQLCancel.
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: statement_text.to_string(),
-                })
-                .await?;
-
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                })
-                .await
-            });
-
-            tracing::info!("exec_direct: response={:?}", response);
-            let response = response?;
-
-            let query_id = response.result.as_ref().map(|r| r.query_id.clone());
-            update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
-            let execute_state = create_execute_state(response, ExecutionOrigin::Direct)?;
-            let is_zero_dml = matches!(
-                &execute_state,
-                StatementState::DmlExecuted {
-                    rows_affected: 0,
-                    ..
-                }
-            );
-            set_state(stmt, execute_state);
-            stmt.last_query_id = query_id.filter(|s| !s.is_empty());
-            if is_zero_dml {
-                return NoMoreDataSnafu.fail();
+    // Get conn_handle for execution under lock, then release before async call.
+    let conn_handle = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+            ConnectionState::Disconnected => {
+                tracing::error!("exec_direct: connection is disconnected");
+                return DisconnectedSnafu.fail();
             }
-            Ok(())
         }
-        ConnectionState::Disconnected => {
-            tracing::error!("exec_direct: connection is disconnected");
-            DisconnectedSnafu.fail()
+    };
+    let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, false, None)?;
+    let stmt_handle = stmt.stmt_handle;
+
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
+    // _cancel_token.cancelled() to support cross-thread SQLCancel.
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: statement_text.to_string(),
+        })
+        .await?;
+
+        c.statement_execute_query(StatementExecuteQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            bindings,
+        })
+        .await
+    });
+
+    tracing::info!("exec_direct: response={:?}", response);
+    let response = response?;
+
+    let query_id = response.result.as_ref().map(|r| r.query_id.clone());
+    let mut settings = dbc.connection.lock().numeric_settings;
+    update_numeric_settings(&conn_handle, &mut settings)?;
+    dbc.connection.lock().numeric_settings = settings;
+    let execute_state = create_execute_state(response, ExecutionOrigin::Direct)?;
+    let is_zero_dml = matches!(
+        &execute_state,
+        StatementState::DmlExecuted {
+            rows_affected: 0,
+            ..
         }
+    );
+    set_state(stmt, execute_state);
+    stmt.last_query_id = query_id.filter(|s| !s.is_empty());
+    if is_zero_dml {
+        return NoMoreDataSnafu.fail();
     }
+    Ok(())
 }
 
 use crate::conversion::NumericSettings;
@@ -254,77 +249,68 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
         return CursorAlreadyOpenSnafu.fail();
     }
 
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let connection = &mut dbc.connection;
-    match &mut connection.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle: _,
-        } => {
-            tracing::debug!("prepare: query = {query}");
-
-            let stmt_handle = stmt.stmt_handle;
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wire _cancel_token into tokio::select!
-            // alongside the RPC future to support cancellation.
-            let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: query.to_string(),
-                })
-                .await?;
-
-                c.statement_prepare(StatementPrepareRequest {
-                    stmt_handle: Some(stmt_handle),
-                })
-                .await
-            })?;
-
-            let result = prepare_result.result.required("Result is required")?;
-            let stream_ptr = result.stream.required("Stream is required")?;
-            let reader = reader_from_protobuf_stream(stream_ptr)?;
-            let schema = reader.schema();
-            stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
-
-            if result.number_of_binds < 0 {
-                tracing::warn!(
-                    "prepare: server reported negative bind count ({}), treating as 0",
-                    result.number_of_binds
-                );
-            }
-            let raw_bind_count = result.number_of_binds.max(0);
-            let param_count = u16::try_from(raw_bind_count).map_err(|_| {
-                crate::api::error::CountFieldIncorrectSnafu {
-                    reason: format!(
-                        "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
-                        u16::MAX
-                    ),
-                }
-                .build()
-            })?;
-            stmt.prepared_param_count = Some(param_count);
-            let max_varchar = connection.numeric_settings.max_varchar_size;
-            stmt.ipd.records.retain(|&k, _| k <= param_count);
-            for i in 1..=param_count {
-                stmt.ipd
-                    .records
-                    .entry(i)
-                    .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
-            }
-            tracing::info!(
-                "prepare: auto-IPD populated {param_count} parameter markers (from server)"
-            );
-
-            stmt.state.set(StatementState::Prepared { schema });
-            tracing::info!("prepare: Successfully prepared statement");
-            Ok(())
-        }
-        ConnectionState::Disconnected => {
-            tracing::error!("prepare: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("prepare: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
+
+    tracing::debug!("prepare: query = {query}");
+
+    let stmt_handle = stmt.stmt_handle;
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wire _cancel_token into tokio::select!
+    // alongside the RPC future to support cancellation.
+    let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: query.to_string(),
+        })
+        .await?;
+
+        c.statement_prepare(StatementPrepareRequest {
+            stmt_handle: Some(stmt_handle),
+        })
+        .await
+    })?;
+
+    let result = prepare_result.result.required("Result is required")?;
+    let stream_ptr = result.stream.required("Stream is required")?;
+    let reader = reader_from_protobuf_stream(stream_ptr)?;
+    let schema = reader.schema();
+    stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
+
+    if result.number_of_binds < 0 {
+        tracing::warn!(
+            "prepare: server reported negative bind count ({}), treating as 0",
+            result.number_of_binds
+        );
+    }
+    let raw_bind_count = result.number_of_binds.max(0);
+    let param_count = u16::try_from(raw_bind_count).map_err(|_| {
+        crate::api::error::CountFieldIncorrectSnafu {
+            reason: format!(
+                "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
+                u16::MAX
+            ),
+        }
+        .build()
+    })?;
+    stmt.prepared_param_count = Some(param_count);
+    let max_varchar = dbc.connection.lock().numeric_settings.max_varchar_size;
+    stmt.ipd.records.retain(|&k, _| k <= param_count);
+    for i in 1..=param_count {
+        stmt.ipd
+            .records
+            .entry(i)
+            .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
+    }
+    tracing::info!("prepare: auto-IPD populated {param_count} parameter markers (from server)");
+
+    stmt.state.set(StatementState::Prepared { schema });
+    tracing::info!("prepare: Successfully prepared statement");
+    Ok(())
 }
 
 /// Execute a prepared statement
@@ -353,14 +339,10 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let is_prepared = origin.is_prepared();
 
     // Validate connection before committing to NeedData state.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Disconnected => {
-            tracing::error!("execute: connection is disconnected");
-            return DisconnectedSnafu.fail();
-        }
-        ConnectionState::Connected { .. } => {}
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("execute: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
 
     let dae_params = find_dae_params(&stmt.apd, stmt.prepared_param_count);
@@ -382,58 +364,53 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         return DaeRequiredSnafu.fail();
     }
 
-    // Re-borrow connection for execution.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(
-                &stmt.apd,
-                &stmt.ipd,
-                is_prepared,
-                stmt.prepared_param_count,
-            )?;
-
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
-            // _cancel_token.cancelled() to support cross-thread SQLCancel.
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt.stmt_handle),
-                    bindings,
-                })
-                .await
-            })?;
-
-            tracing::info!("execute: Successfully executed statement");
-            update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
-
-            let query_id = response.result.as_ref().map(|r| r.query_id.clone());
-
-            let execute_state = create_execute_state(response, origin)?;
-            let is_zero_dml = matches!(
-                &execute_state,
-                StatementState::DmlExecuted {
-                    rows_affected: 0,
-                    ..
-                }
-            );
-            set_state(stmt, execute_state);
-            stmt.last_query_id = query_id.filter(|s| !s.is_empty());
-            if is_zero_dml {
-                return NoMoreDataSnafu.fail();
+    // Get conn_handle for execution under lock, then release before async call.
+    let conn_handle = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+            ConnectionState::Disconnected => {
+                tracing::error!("execute: connection is disconnected");
+                return DisconnectedSnafu.fail();
             }
-            Ok(())
         }
-        ConnectionState::Disconnected => {
-            tracing::error!("execute: connection is disconnected");
-            DisconnectedSnafu.fail()
+    };
+    let (bindings, _json_owner) =
+        apply_parameter_bindings(&stmt.apd, &stmt.ipd, is_prepared, stmt.prepared_param_count)?;
+
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
+    // _cancel_token.cancelled() to support cross-thread SQLCancel.
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_execute_query(StatementExecuteQueryRequest {
+            stmt_handle: Some(stmt.stmt_handle),
+            bindings,
+        })
+        .await
+    })?;
+
+    tracing::info!("execute: Successfully executed statement");
+    let mut settings = dbc.connection.lock().numeric_settings;
+    update_numeric_settings(&conn_handle, &mut settings)?;
+    dbc.connection.lock().numeric_settings = settings;
+
+    let query_id = response.result.as_ref().map(|r| r.query_id.clone());
+
+    let execute_state = create_execute_state(response, origin)?;
+    let is_zero_dml = matches!(
+        &execute_state,
+        StatementState::DmlExecuted {
+            rows_affected: 0,
+            ..
         }
+    );
+    set_state(stmt, execute_state);
+    stmt.last_query_id = query_id.filter(|s| !s.is_empty());
+    if is_zero_dml {
+        return NoMoreDataSnafu.fail();
     }
+    Ok(())
 }
 
 const STATEMENT_TYPE_ID_MANAGE_PATS: i64 = 0x6244;

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1,5 +1,9 @@
 use crate::api::bitmask::Bitmask;
-use crate::api::error::InvalidDescriptorKindSnafu;
+use crate::api::error::{
+    ConnectionHasNoEnvironmentSnafu, InvalidDescriptorKindSnafu, OdbcRuntimeSnafu,
+};
+use crate::api::handle_registry::HandleId;
+use crate::api::runtime::global;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::conversion::Binding;
 use crate::conversion::warning::Warnings;
@@ -9,8 +13,11 @@ use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::{
     ConnectionHandle as TConnectionHandle, DatabaseHandle as TDatabaseHandle, StatementHandle,
 };
+use snafu::ResultExt;
 use std::collections::HashMap;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
+
+use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use super::CDataType;
@@ -862,12 +869,21 @@ impl ToSqlReturn for OdbcResult<()> {
         self.to_sql_return(warnings).0
     }
 }
+pub struct Env {
+    pub environment: Mutex<Environment>,
+}
+
+// TODO: this is a hack to allow the Env to be used in a multi-threaded environment
+// Will be removed after this PR stack is completed
+unsafe impl Send for Env {}
+unsafe impl Sync for Env {}
 
 pub struct Environment {
     pub odbc_version: sql::Integer,
     pub connection_pooling: sql::AttrConnectionPooling,
     pub connection_pool_match: sql::AttrCpMatch,
     pub diagnostic_info: DiagnosticInfo,
+    pub connections: Vec<*mut Dbc>,
 }
 
 pub enum ConnectionState {
@@ -882,6 +898,19 @@ pub enum ConnectionState {
 /// Pre-connection attributes set via SQLSetConnectAttr before connecting.
 /// These are applied to the sf_core connection during driver_connect/connect.
 pub type PreConnectionAttributes = HashMap<ConnectionAttribute, String>;
+
+pub struct Dbc {
+    pub connection: Connection,
+    pub env: Weak<Env>,
+}
+
+impl Dbc {
+    pub fn env(&self) -> Result<Arc<Env>, OdbcError> {
+        self.env
+            .upgrade()
+            .ok_or(ConnectionHasNoEnvironmentSnafu.build())
+    }
+}
 
 pub struct Connection {
     pub state: ConnectionState,
@@ -1206,7 +1235,7 @@ impl GetDataState {
 pub struct Statement {
     /// Raw pointer to the owning connection. Valid for the entire lifetime of this Statement
     /// (the connection always outlives its statements). Access via `conn()` / `conn_ptr()`.
-    conn: *mut Connection,
+    conn: *mut Dbc,
     pub stmt_handle: StatementHandle,
     pub state: State<StatementState>,
     pub ard: ArdDescriptor,
@@ -1251,7 +1280,7 @@ unsafe impl Send for Statement {}
 
 impl Statement {
     /// Construct a new Statement for the given connection.
-    pub fn new(conn: *mut Connection, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
+    pub fn new(conn: *mut Dbc, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
         Self {
             conn,
             stmt_handle,
@@ -1277,7 +1306,7 @@ impl Statement {
     /// # Safety
     /// The caller must ensure the Connection outlives this borrow and no other
     /// mutable reference to the Connection exists simultaneously.
-    pub unsafe fn conn(&self) -> &Connection {
+    pub unsafe fn conn(&self) -> &Dbc {
         debug_assert!(
             !self.conn.is_null(),
             "Statement::conn: connection pointer is null"
@@ -1297,19 +1326,23 @@ impl Statement {
     /// derived from this statement) exists while the returned pointer is dereferenced
     /// mutably. Having both an active `&Connection` and a `&mut Connection` pointing
     /// to the same allocation is undefined behaviour.
-    pub(crate) unsafe fn conn_ptr(&self) -> *mut Connection {
+    pub(crate) unsafe fn conn_ptr(&self) -> *mut Dbc {
         self.conn
     }
 }
 
 // Helper functions for handle conversion
-pub fn env_from_handle<'a>(handle: sql::Handle) -> &'a mut Environment {
-    let env_ptr = handle as *mut Environment;
-    unsafe { env_ptr.as_mut().unwrap() }
+pub fn env_from_handle(handle: sql::Handle) -> OdbcResult<Arc<Env>> {
+    let handle_id = HandleId::from(handle);
+    let env = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .get(handle_id)?;
+    Ok(env)
 }
 
-pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Connection {
-    let conn_ptr = handle as *mut Connection;
+pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Dbc {
+    let conn_ptr = handle as *mut Dbc;
     unsafe { conn_ptr.as_mut().unwrap() }
 }
 

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -883,7 +883,7 @@ pub struct Environment {
     pub connection_pooling: sql::AttrConnectionPooling,
     pub connection_pool_match: sql::AttrCpMatch,
     pub diagnostic_info: DiagnosticInfo,
-    pub connections: Vec<*mut Dbc>,
+    pub connections: Vec<Arc<Dbc>>,
 }
 
 pub enum ConnectionState {
@@ -911,6 +911,10 @@ impl Dbc {
             .ok_or(ConnectionHasNoEnvironmentSnafu.build())
     }
 }
+
+// Temporary — same pattern as Env; will be cleaned up later in the stack.
+unsafe impl Send for Dbc {}
+unsafe impl Sync for Dbc {}
 
 pub struct Connection {
     pub state: ConnectionState,
@@ -1233,9 +1237,10 @@ impl GetDataState {
 }
 
 pub struct Statement {
-    /// Raw pointer to the owning connection. Valid for the entire lifetime of this Statement
-    /// (the connection always outlives its statements). Access via `conn()` / `conn_ptr()`.
-    conn: *mut Dbc,
+    /// Weak reference to the owning connection. Upgraded to `Arc<Dbc>` on access.
+    /// A failed upgrade means the connection was freed before the statement —
+    /// an invariant violation surfaced as an error rather than UB.
+    conn: Weak<Dbc>,
     pub stmt_handle: StatementHandle,
     pub state: State<StatementState>,
     pub ard: ArdDescriptor,
@@ -1269,18 +1274,16 @@ pub struct Statement {
 }
 
 /// Safety: Statement is always accessed on the single ODBC thread that holds the handle.
-// The conn raw pointer is valid for the Statement's lifetime (Connection outlives Statement).
 // `Send` allows moving the allocation across threads (e.g. when the runtime hands the raw
 // Arc pointer back on an arbitrary thread). `Sync` is NOT implemented: sharing `&Statement`
-// across threads is unsound because `conn` is a `*mut Connection` with no synchronisation.
-// Connection itself uses `unsafe impl Send` to suppress auto-trait checks on the
-// `Vec<(Weak<Statement>, *const Statement)>` field, so `Statement: Sync` is not required
-// for `Connection: Send`.
+// across threads is unsound because `conn` is a `Weak<Dbc>` with no synchronisation on
+// the Connection fields. Connection itself uses `unsafe impl Send` to suppress auto-trait
+// checks on `Vec<(Weak<Statement>, *const Statement)>`, so `Statement: Sync` is not required.
 unsafe impl Send for Statement {}
 
 impl Statement {
     /// Construct a new Statement for the given connection.
-    pub fn new(conn: *mut Dbc, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
+    pub fn new(conn: Weak<Dbc>, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
         Self {
             conn,
             stmt_handle,
@@ -1301,33 +1304,27 @@ impl Statement {
         }
     }
 
-    /// Borrow the owning connection.
+    /// Upgrade the weak connection reference to an `Arc<Dbc>`.
     ///
-    /// # Safety
-    /// The caller must ensure the Connection outlives this borrow and no other
-    /// mutable reference to the Connection exists simultaneously.
-    pub unsafe fn conn(&self) -> &Dbc {
-        debug_assert!(
-            !self.conn.is_null(),
-            "Statement::conn: connection pointer is null"
-        );
-        unsafe { &*self.conn }
+    /// Returns an error if the parent connection has already been freed.
+    pub fn conn(&self) -> Result<Arc<Dbc>, OdbcError> {
+        use crate::api::error::InvalidHandleSnafu;
+        self.conn
+            .upgrade()
+            .ok_or_else(|| InvalidHandleSnafu.build())
     }
 
-    /// Return the raw connection pointer without creating a Rust borrow on `self`.
+    /// Return the raw connection pointer without upgrading the `Weak`.
     ///
-    /// Use this when you need both a `&mut Connection` and access to other
-    /// `Statement` fields in the same scope — the raw pointer carries no borrow
-    /// on `self`, so the borrow checker treats the resulting `&mut Connection`
-    /// as independent.
+    /// Use this when you need a `*mut Dbc` independently of the `Weak` lifetime,
+    /// for example to remove a child_statements entry via `retain` while also
+    /// holding the `Arc<Statement>`.
     ///
     /// # Safety
-    /// The caller must ensure that no live `conn()` borrow (or any other `&Connection`
-    /// derived from this statement) exists while the returned pointer is dereferenced
-    /// mutably. Having both an active `&Connection` and a `&mut Connection` pointing
-    /// to the same allocation is undefined behaviour.
+    /// The caller must ensure the connection is still alive (i.e., `conn()` would
+    /// succeed) and that no other mutable borrow of the `Dbc` exists concurrently.
     pub(crate) unsafe fn conn_ptr(&self) -> *mut Dbc {
-        self.conn
+        self.conn.as_ptr() as *mut Dbc
     }
 }
 
@@ -1341,9 +1338,16 @@ pub fn env_from_handle(handle: sql::Handle) -> OdbcResult<Arc<Env>> {
     Ok(env)
 }
 
-pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Dbc {
-    let conn_ptr = handle as *mut Dbc;
-    unsafe { conn_ptr.as_mut().unwrap() }
+pub fn conn_from_handle(handle: sql::Handle) -> OdbcResult<Arc<Dbc>> {
+    use crate::api::error::InvalidHandleSnafu;
+    use crate::api::runtime::global;
+    use snafu::ResultExt;
+    let handle_id = HandleId::from(handle);
+    let weak = global()
+        .context(OdbcRuntimeSnafu)?
+        .dbc_registry
+        .get(handle_id)?;
+    weak.upgrade().ok_or_else(|| InvalidHandleSnafu.build())
 }
 
 pub fn stmt_from_handle<'a>(handle: sql::Handle) -> &'a mut Statement {

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -900,7 +900,7 @@ pub enum ConnectionState {
 pub type PreConnectionAttributes = HashMap<ConnectionAttribute, String>;
 
 pub struct Dbc {
-    pub connection: Connection,
+    pub connection: Mutex<Connection>,
     pub env: Weak<Env>,
 }
 
@@ -911,10 +911,6 @@ impl Dbc {
             .ok_or(ConnectionHasNoEnvironmentSnafu.build())
     }
 }
-
-// Temporary — same pattern as Env; will be cleaned up later in the stack.
-unsafe impl Send for Dbc {}
-unsafe impl Sync for Dbc {}
 
 pub struct Connection {
     pub state: ConnectionState,
@@ -947,12 +943,9 @@ pub struct Connection {
     pub metadata_id: bool,
 }
 
-// Safety: Send is required so that the async runtime can transfer ownership of the
-// Connection allocation between threads (e.g. when a Tokio task completes on a
-// different thread than it started). All ODBC API access remains serialised on the
-// single caller thread — the raw-pointer DBC handle is never shared across threads.
-// `*const Statement` inside `child_statements` is `!Send`, but Connection is never
-// accessed concurrently, so this is safe.
+// Safety: `*const Statement` inside `child_statements` is `!Send`, but access to
+// Connection is always serialised through the Mutex<Connection> in Dbc, and ODBC
+// guarantees that a single connection handle is only used from one thread at a time.
 unsafe impl Send for Connection {}
 
 /// Application Parameter Descriptor (APD) record.
@@ -1273,12 +1266,10 @@ pub struct Statement {
     pub cancel_token: CancellationToken,
 }
 
-/// Safety: Statement is always accessed on the single ODBC thread that holds the handle.
-// `Send` allows moving the allocation across threads (e.g. when the runtime hands the raw
-// Arc pointer back on an arbitrary thread). `Sync` is NOT implemented: sharing `&Statement`
-// across threads is unsound because `conn` is a `Weak<Dbc>` with no synchronisation on
-// the Connection fields. Connection itself uses `unsafe impl Send` to suppress auto-trait
-// checks on `Vec<(Weak<Statement>, *const Statement)>`, so `Statement: Sync` is not required.
+// Safety: `Send` allows moving the Statement allocation across threads when the Arc is
+// handed back on an arbitrary thread. `Sync` is NOT derived: sharing `&Statement`
+// across threads is unsound because `child_statements` contains `*const Statement`
+// pointers that carry no synchronisation.
 unsafe impl Send for Statement {}
 
 impl Statement {
@@ -1312,19 +1303,6 @@ impl Statement {
         self.conn
             .upgrade()
             .ok_or_else(|| InvalidHandleSnafu.build())
-    }
-
-    /// Return the raw connection pointer without upgrading the `Weak`.
-    ///
-    /// Use this when you need a `*mut Dbc` independently of the `Weak` lifetime,
-    /// for example to remove a child_statements entry via `retain` while also
-    /// holding the `Arc<Statement>`.
-    ///
-    /// # Safety
-    /// The caller must ensure the connection is still alive (i.e., `conn()` would
-    /// succeed) and that no other mutable borrow of the `Dbc` exists concurrently.
-    pub(crate) unsafe fn conn_ptr(&self) -> *mut Dbc {
-        self.conn.as_ptr() as *mut Dbc
     }
 }
 

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -148,8 +148,9 @@ pub fn col_attribute<E: OdbcEncoding>(
         DescField::Type | DescField::ConciseType => {
             // SAFETY: conn pointer is valid for the statement's lifetime;
             // no mutable reference to the Connection exists in this scope.
-            let sql_type = sql_type_from_field(field, &unsafe { stmt.conn() }.numeric_settings)
-                .context(ConversionSnafu)?;
+            let sql_type =
+                sql_type_from_field(field, &unsafe { stmt.conn() }.connection.numeric_settings)
+                    .context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);
@@ -251,7 +252,8 @@ pub fn describe_col<E: OdbcEncoding>(
     let field = schema.field(col_idx);
     // SAFETY: conn pointer is valid for the statement's lifetime;
     // no mutable reference to the Connection exists in this scope.
-    let conn = unsafe { stmt.conn() };
+    let dbc = unsafe { stmt.conn() };
+    let numeric_settings = &dbc.connection.numeric_settings;
 
     let name = field.name();
     write_string_chars::<E>(
@@ -263,20 +265,17 @@ pub fn describe_col<E: OdbcEncoding>(
     );
 
     if !data_type_ptr.is_null() {
-        let sql_type =
-            sql_type_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let sql_type = sql_type_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(data_type_ptr, sql_type.0 as sql::SmallInt) };
     }
 
     if !column_size_ptr.is_null() {
-        let col_size =
-            column_size_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let col_size = column_size_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(column_size_ptr, col_size) };
     }
 
     if !decimal_digits_ptr.is_null() {
-        let digits =
-            decimal_digits_from_field(field, &conn.numeric_settings).context(ConversionSnafu)?;
+        let digits = decimal_digits_from_field(field, numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(decimal_digits_ptr, digits) };
     }
 

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -146,8 +146,9 @@ pub fn col_attribute<E: OdbcEncoding>(
 
     match desc_field {
         DescField::Type | DescField::ConciseType => {
-            let sql_type = sql_type_from_field(field, &stmt.conn()?.connection.numeric_settings)
-                .context(ConversionSnafu)?;
+            let dbc = stmt.conn()?;
+            let settings = dbc.connection.lock().numeric_settings;
+            let sql_type = sql_type_from_field(field, &settings).context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);
@@ -248,7 +249,7 @@ pub fn describe_col<E: OdbcEncoding>(
 
     let field = schema.field(col_idx);
     let dbc = stmt.conn()?;
-    let numeric_settings = &dbc.connection.numeric_settings;
+    let numeric_settings = dbc.connection.lock().numeric_settings;
 
     let name = field.name();
     write_string_chars::<E>(
@@ -260,17 +261,18 @@ pub fn describe_col<E: OdbcEncoding>(
     );
 
     if !data_type_ptr.is_null() {
-        let sql_type = sql_type_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let sql_type = sql_type_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(data_type_ptr, sql_type.0 as sql::SmallInt) };
     }
 
     if !column_size_ptr.is_null() {
-        let col_size = column_size_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let col_size = column_size_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(column_size_ptr, col_size) };
     }
 
     if !decimal_digits_ptr.is_null() {
-        let digits = decimal_digits_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let digits =
+            decimal_digits_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(decimal_digits_ptr, digits) };
     }
 

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -146,11 +146,8 @@ pub fn col_attribute<E: OdbcEncoding>(
 
     match desc_field {
         DescField::Type | DescField::ConciseType => {
-            // SAFETY: conn pointer is valid for the statement's lifetime;
-            // no mutable reference to the Connection exists in this scope.
-            let sql_type =
-                sql_type_from_field(field, &unsafe { stmt.conn() }.connection.numeric_settings)
-                    .context(ConversionSnafu)?;
+            let sql_type = sql_type_from_field(field, &stmt.conn()?.connection.numeric_settings)
+                .context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);
@@ -250,9 +247,7 @@ pub fn describe_col<E: OdbcEncoding>(
     }
 
     let field = schema.field(col_idx);
-    // SAFETY: conn pointer is valid for the statement's lifetime;
-    // no mutable reference to the Connection exists in this scope.
-    let dbc = unsafe { stmt.conn() };
+    let dbc = stmt.conn()?;
     let numeric_settings = &dbc.connection.numeric_settings;
 
     let name = field.name();


### PR DESCRIPTION
Replace raw `*mut Dbc` ODBC handles with opaque integer `HandleId`s managed through a new `ConnectionHandleRegistry`.

- Add `ConnectionHandleRegistry = HandleRegistry<Weak<Dbc>>` type alias
- Add `dbc_registry` field to `OdbcGlobals`, initialised in `env_allocated()`
- `Environment.connections` now holds `Vec<Arc<Dbc>>` (was `Vec<*mut Dbc>`)
- `Statement.conn` changed from `*mut Dbc` to `Weak<Dbc>`; `conn()` now returns `OdbcResult<Arc<Dbc>>` — a failed upgrade surfaces a freed-parent invariant violation as an error instead of UB
- `conn_from_handle` looks up the `Weak<Dbc>` in the registry and upgrades it to `Arc<Dbc>` (mirrors `env_from_handle` for environment handles)
- `alloc_connection` creates `Arc<Dbc>`, registers the `Weak` in the registry and pushes the `Arc` into `env.connections`
- `free_connection` removes the `Weak` from the registry, removes the `Arc` from `env.connections`, then runs statement cleanup
- Call sites in `connection.rs`, `diagnostic.rs`, `data.rs`, and `utils.rs` updated to handle the new `OdbcResult<Arc<Dbc>>` return type
- `unsafe impl Send/Sync for Dbc` added (same temporary-hack pattern as `Env`)