### PR TITLE
SNOW-1924837: stabilise CI - resolve 503s by closing sessions

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -191,19 +191,5 @@ def pytest_runtest_setup(item):
         pytest.skip(reason)
 
 
-@pytest.fixture
-def core_proxy(monkeypatch):
-    """Wrap real Core client with MagicMock recording. Universal driver only.
-
-    Lazy imports avoid module-level _internal dependency — safe for reference
-    connector collection. Tests using this fixture must be marked @skip_reference.
-    """
-    from unittest.mock import MagicMock
-
-    from snowflake.connector._internal.api_client.client_api import database_driver_client
-    from tests.helpers.core_introspection import CoreIntrospector
-
-    real_client = database_driver_client()
-    spy = MagicMock(wraps=real_client)
-    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: spy)
-    return CoreIntrospector(spy)
+from tests.helpers.fixtures import core_proxy as core_proxy  # noqa: E402
+from tests.helpers.fixtures import mock_db_api as mock_db_api  # noqa: E402

--- a/python/tests/helpers/fixtures.py
+++ b/python/tests/helpers/fixtures.py
@@ -1,0 +1,42 @@
+"""Shared pytest fixtures for Core mock and introspection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_db_api():
+    """MagicMock db_api with stubs for all RPCs Connection.__init__ calls."""
+    from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+        ConnectionHandle,
+        ConnectionIsClosedResponse,
+        ConnectionSetOptionsResponse,
+        DatabaseHandle,
+    )
+
+    db_api = MagicMock()
+    db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
+    db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
+    db_api.connection_get_parameter.return_value = MagicMock(value="")
+    db_api.connection_is_closed.return_value = ConnectionIsClosedResponse(is_closed=False)
+    db_api.connection_set_options.return_value = ConnectionSetOptionsResponse(warnings=[])
+    return db_api
+
+
+@pytest.fixture
+def core_proxy(monkeypatch):
+    """Wrap real Core client with MagicMock recording. Universal driver only.
+
+    Lazy imports avoid module-level _internal dependency — safe for reference
+    connector collection. Tests using this fixture must be marked @skip_reference.
+    """
+    from snowflake.connector._internal.api_client.client_api import database_driver_client
+    from tests.helpers.core_introspection import CoreIntrospector
+
+    real_client = database_driver_client()
+    spy = MagicMock(wraps=real_client)
+    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: spy)
+    return CoreIntrospector(spy)

--- a/python/tests/integ/session/conftest.py
+++ b/python/tests/integ/session/conftest.py
@@ -2,10 +2,6 @@
 
 Provides ``core_mock`` for tests that verify what Python passes to Core
 without requiring a real Core backend or WireMock.
-
-All ``_internal`` imports are lazy (inside fixture bodies) so that this
-conftest loads without error on the reference connector, which has no
-``snowflake.connector._internal`` package.
 """
 
 from __future__ import annotations
@@ -18,29 +14,10 @@ from tests.helpers.core_introspection import CoreIntrospector
 
 
 @pytest.fixture
-def db_api_mock() -> MagicMock:
-    """A MagicMock db_api with minimal stubs for Connection.__init__ to work."""
-    from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
-        ConnectionHandle,
-        ConnectionIsClosedResponse,
-        ConnectionSetOptionsResponse,
-        DatabaseHandle,
-    )
-
-    db_api = MagicMock()
-    db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
-    db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
-    db_api.connection_get_parameter.return_value = MagicMock(value="")
-    db_api.connection_is_closed.return_value = ConnectionIsClosedResponse(is_closed=False)
-    db_api.connection_set_options.return_value = ConnectionSetOptionsResponse(warnings=[])
-    return db_api
-
-
-@pytest.fixture
-def core_mock(monkeypatch: pytest.MonkeyPatch, db_api_mock: MagicMock) -> CoreIntrospector:
+def core_mock(monkeypatch: pytest.MonkeyPatch, mock_db_api: MagicMock) -> CoreIntrospector:
     """Pure mock — no real Core. Auto-patches database_driver_client.
 
     Use for tests that only need to verify what Python passes to Core.
     """
-    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: db_api_mock)
-    return CoreIntrospector(db_api_mock)
+    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: mock_db_api)
+    return CoreIntrospector(mock_db_api)

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -11,10 +11,8 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConfigSetting,
     ConnectionGetInfoResponse,
     ConnectionGetQueryStatusResponse,
-    ConnectionHandle,
     ConnectionIsClosedResponse,
     ConnectionSetOptionsResponse,
-    DatabaseHandle,
     StatementHandle,
     ValidationIssue,
 )
@@ -25,17 +23,6 @@ from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
 pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
-
-
-@pytest.fixture
-def mock_db_api():
-    """Create a mock DatabaseDriverClient with minimal stubs for Connection.__init__."""
-    db_api = MagicMock()
-    db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
-    db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
-    db_api.connection_get_parameter.return_value = MagicMock(value="")
-    db_api.connection_is_closed.return_value = ConnectionIsClosedResponse(is_closed=False)
-    return db_api
 
 
 @pytest.fixture

--- a/python/tests/unit/test_connection_numpy.py
+++ b/python/tests/unit/test_connection_numpy.py
@@ -2,30 +2,17 @@
 Unit tests for Connection numpy parameter.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from snowflake.connector._internal.errorcode import ER_NO_NUMPY
 from snowflake.connector._internal.extras import MissingOptionalDependency
-from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
-    ConnectionHandle,
-    DatabaseHandle,
-)
 from snowflake.connector.errors import ProgrammingError
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
 pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
-
-
-@pytest.fixture
-def mock_db_api():
-    db_api = MagicMock()
-    db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
-    db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
-    db_api.connection_get_parameter.return_value = MagicMock(value="")
-    return db_api
 
 
 def make_connection(mock_db_api, **kwargs):

--- a/sf_core/tests/common/mocks/mod.rs
+++ b/sf_core/tests/common/mocks/mod.rs
@@ -8,3 +8,4 @@ pub mod mfa;
 pub mod okta;
 pub mod password;
 pub mod put_get;
+pub mod session;

--- a/sf_core/tests/common/mocks/session.rs
+++ b/sf_core/tests/common/mocks/session.rs
@@ -1,0 +1,8 @@
+/// Check whether a wiremock request is a logout (DELETE session) request.
+pub fn is_logout_request(r: &wiremock::Request) -> bool {
+    r.url.path() == "/session"
+        && r.url
+            .query()
+            .map(|q| q.contains("delete=true"))
+            .unwrap_or(false)
+}

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -488,32 +488,23 @@ impl SnowflakeTestClient {
 
 impl Drop for SnowflakeTestClient {
     fn drop(&mut self) {
-        // catch_unwind prevents double-panic abort when Drop runs during stack
-        // unwinding (e.g. test panic) or inside a tokio async context where
-        // block_on panics with "Cannot start a runtime from within a runtime".
-        if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Release the connection when the client is dropped
-            if let Err(e) = self
-                .client
-                .connection_release_blocking(ConnectionReleaseRequest {
-                    conn_handle: Some(self.conn_handle),
-                })
-            {
-                tracing::warn!("Failed to release connection in Drop: {e:?}");
-            }
-            // Release the database handle
-            if let Err(e) = self
-                .client
-                .database_release_blocking(DatabaseReleaseRequest {
-                    db_handle: Some(self.db_handle),
-                })
-            {
-                tracing::warn!("Failed to release database handle in Drop: {e:?}");
-            }
-        })) {
-            // Use eprintln! not tracing::warn! — the tracing subscriber may
-            // itself be torn down during the panic that triggered this Drop.
-            eprintln!("SnowflakeTestClient::drop panicked: {payload:?}");
+        // Release the connection when the client is dropped
+        if let Err(e) = self
+            .client
+            .connection_release_blocking(ConnectionReleaseRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+        {
+            tracing::warn!("Failed to release connection in Drop: {e:?}");
+        }
+        // Release the database handle
+        if let Err(e) = self
+            .client
+            .database_release_blocking(DatabaseReleaseRequest {
+                db_handle: Some(self.db_handle),
+            })
+        {
+            tracing::warn!("Failed to release database handle in Drop: {e:?}");
         }
     }
 }

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -491,7 +491,7 @@ impl Drop for SnowflakeTestClient {
         // catch_unwind prevents double-panic abort when Drop runs during stack
         // unwinding (e.g. test panic) or inside a tokio async context where
         // block_on panics with "Cannot start a runtime from within a runtime".
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             // Release the connection when the client is dropped
             if let Err(e) = self
                 .client
@@ -510,6 +510,10 @@ impl Drop for SnowflakeTestClient {
             {
                 tracing::warn!("Failed to release database handle in Drop: {e:?}");
             }
-        }));
+        })) {
+            // Use eprintln! not tracing::warn! — the tracing subscriber may
+            // itself be torn down during the panic that triggered this Drop.
+            eprintln!("SnowflakeTestClient::drop panicked: {payload:?}");
+        }
     }
 }

--- a/sf_core/tests/e2e/session/logout.rs
+++ b/sf_core/tests/e2e/session/logout.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 
 use crate::common::mocks::auth::mount_jwt_login_success;
+use crate::common::mocks::session::is_logout_request;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
 use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
@@ -244,12 +245,4 @@ async fn mount_logout_success(server: &MockServer) {
         )
         .mount(server)
         .await;
-}
-
-fn is_logout_request(r: &wiremock::Request) -> bool {
-    r.url.path() == "/session"
-        && r.url
-            .query()
-            .map(|q| q.contains("delete=true"))
-            .unwrap_or(false)
 }

--- a/sf_core/tests/e2e/session/logout.rs
+++ b/sf_core/tests/e2e/session/logout.rs
@@ -5,8 +5,6 @@
 //! use WireMock so "Only one logout request is sent" can be honestly verified
 //! via HTTP request counting.
 
-use std::sync::Arc;
-
 use crate::common::mocks::auth::mount_jwt_login_success;
 use crate::common::mocks::session::is_logout_request;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
@@ -72,49 +70,37 @@ fn should_cleanup_all_tokens_on_close_regardless_of_whether_logout_was_sent() {
     }
 }
 
-#[tokio::test]
-async fn should_be_idempotent_when_close_called_multiple_times() {
-    //Given Snowflake client is logged in
-    let server = MockServer::start().await;
-    mount_jwt_login_success(&server).await;
-    mount_logout_success(&server).await;
+#[test]
+fn should_be_idempotent_when_close_called_multiple_times() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
 
-    let server_uri = server.uri();
-    let client = Arc::new(
-        tokio::task::spawn_blocking(move || {
-            SnowflakeTestClient::connect_integration_test(Some(&server_uri))
-        })
-        .await
-        .unwrap(),
-    );
+    //Given Snowflake client is logged in
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        mount_jwt_login_success(&server).await;
+        mount_logout_success(&server).await;
+        server
+    });
+
+    let client = SnowflakeTestClient::connect_integration_test(Some(&server.uri()));
 
     //When Connection is closed
-    let result1 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result1 = client.connection_close_blocking();
 
     //And Connection is closed again
-    let result2 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result2 = client.connection_close_blocking();
 
     //And Connection is closed a third time
-    let result3 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result3 = client.connection_close_blocking();
 
     //Then Only one logout request is sent
-    let requests = server.received_requests().await.unwrap();
-    let logout_count = requests.iter().filter(|r| is_logout_request(r)).count();
+    let logout_count = rt.block_on(async {
+        let requests = server.received_requests().await.unwrap();
+        requests.iter().filter(|r| is_logout_request(r)).count()
+    });
     assert_eq!(
         logout_count, 1,
         "Exactly one logout HTTP request should be sent"
@@ -130,37 +116,41 @@ async fn should_be_idempotent_when_close_called_multiple_times() {
 //                        Concurrency
 // ===========================================================================
 
-#[tokio::test]
-async fn should_handle_concurrent_close_calls_safely() {
+#[test]
+fn should_handle_concurrent_close_calls_safely() {
     use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
 
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
     //Given Snowflake client is logged in
-    let server = MockServer::start().await;
-    mount_jwt_login_success(&server).await;
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        mount_jwt_login_success(&server).await;
 
-    // Logout response with delay: thread 1 blocks on I/O while threads 2-5 race
-    Mock::given(method("POST"))
-        .and(path("/session"))
-        .and(query_param("delete", "true"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "success": true }))
-                .insert_header("Content-Type", "application/json")
-                .set_delay(Duration::from_millis(500)),
-        )
-        .mount(&server)
-        .await;
+        // Logout response with delay: thread 1 blocks on I/O while threads 2-5 race
+        Mock::given(method("POST"))
+            .and(path("/session"))
+            .and(query_param("delete", "true"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "success": true }))
+                    .insert_header("Content-Type", "application/json")
+                    .set_delay(Duration::from_millis(500)),
+            )
+            .mount(&server)
+            .await;
 
-    let server_uri = server.uri();
-    let client = Arc::new(
-        tokio::task::spawn_blocking(move || {
-            SnowflakeTestClient::connect_integration_test(Some(&server_uri))
-        })
-        .await
-        .unwrap(),
-    );
+        server
+    });
+
+    let client = Arc::new(SnowflakeTestClient::connect_integration_test(Some(
+        &server.uri(),
+    )));
     let barrier = Arc::new(Barrier::new(5));
 
     //When Connection is closed from multiple threads concurrently
@@ -181,8 +171,10 @@ async fn should_handle_concurrent_close_calls_safely() {
         .collect();
 
     //Then Only one logout request is sent
-    let requests = server.received_requests().await.unwrap();
-    let logout_count = requests.iter().filter(|r| is_logout_request(r)).count();
+    let logout_count = rt.block_on(async {
+        let requests = server.received_requests().await.unwrap();
+        requests.iter().filter(|r| is_logout_request(r)).count()
+    });
     assert_eq!(
         logout_count, 1,
         "Exactly one logout HTTP request despite 5 concurrent close() calls"

--- a/sf_core/tests/integration/session/logout.rs
+++ b/sf_core/tests/integration/session/logout.rs
@@ -4,6 +4,7 @@
 //! logout behavior without connecting to real Snowflake.
 
 use crate::common::mocks::auth::mount_jwt_login_success;
+use crate::common::mocks::session::is_logout_request;
 use crate::common::private_key_helper;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
 use crate::common::test_server::{
@@ -1831,14 +1832,6 @@ async fn should_reject_queries_client_side_after_connection_is_closed() {
 }
 
 // Helper functions
-
-fn is_logout_request(r: &wiremock::Request) -> bool {
-    r.url.path() == "/session"
-        && r.url
-            .query()
-            .map(|q| q.contains("delete=true"))
-            .unwrap_or(false)
-}
 
 fn test_client_info() -> ClientInfo {
     ClientInfo {


### PR DESCRIPTION
E1: Single mock_db_api fixture in tests/helpers/fixtures.py, imported via root conftest. Replaces 3 drifting copies (3/4/5 stubs) with one canonical definition (5 stubs). core_proxy also moved to helpers.

E2: Extract is_logout_request to sf_core/tests/common/mocks/session.rs. Removes identical 5-line function from e2e and integration logout tests.

E3: Log catch_unwind panic payload in SnowflakeTestClient::drop instead of silently discarding it with let _ =. Uses eprintln! (not tracing) since the subscriber may be torn down during the panic.