### PR TITLE
SNOW-2872349: convert E2E logout tests to sync, remove catch_unwind panic swallow

### DIFF
--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -488,32 +488,23 @@ impl SnowflakeTestClient {
 
 impl Drop for SnowflakeTestClient {
     fn drop(&mut self) {
-        // catch_unwind prevents double-panic abort when Drop runs during stack
-        // unwinding (e.g. test panic) or inside a tokio async context where
-        // block_on panics with "Cannot start a runtime from within a runtime".
-        if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Release the connection when the client is dropped
-            if let Err(e) = self
-                .client
-                .connection_release_blocking(ConnectionReleaseRequest {
-                    conn_handle: Some(self.conn_handle),
-                })
-            {
-                tracing::warn!("Failed to release connection in Drop: {e:?}");
-            }
-            // Release the database handle
-            if let Err(e) = self
-                .client
-                .database_release_blocking(DatabaseReleaseRequest {
-                    db_handle: Some(self.db_handle),
-                })
-            {
-                tracing::warn!("Failed to release database handle in Drop: {e:?}");
-            }
-        })) {
-            // Use eprintln! not tracing::warn! — the tracing subscriber may
-            // itself be torn down during the panic that triggered this Drop.
-            eprintln!("SnowflakeTestClient::drop panicked: {payload:?}");
+        // Release the connection when the client is dropped
+        if let Err(e) = self
+            .client
+            .connection_release_blocking(ConnectionReleaseRequest {
+                conn_handle: Some(self.conn_handle),
+            })
+        {
+            tracing::warn!("Failed to release connection in Drop: {e:?}");
+        }
+        // Release the database handle
+        if let Err(e) = self
+            .client
+            .database_release_blocking(DatabaseReleaseRequest {
+                db_handle: Some(self.db_handle),
+            })
+        {
+            tracing::warn!("Failed to release database handle in Drop: {e:?}");
         }
     }
 }

--- a/sf_core/tests/e2e/session/logout.rs
+++ b/sf_core/tests/e2e/session/logout.rs
@@ -5,8 +5,6 @@
 //! use WireMock so "Only one logout request is sent" can be honestly verified
 //! via HTTP request counting.
 
-use std::sync::Arc;
-
 use crate::common::mocks::auth::mount_jwt_login_success;
 use crate::common::mocks::session::is_logout_request;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
@@ -72,49 +70,37 @@ fn should_cleanup_all_tokens_on_close_regardless_of_whether_logout_was_sent() {
     }
 }
 
-#[tokio::test]
-async fn should_be_idempotent_when_close_called_multiple_times() {
-    //Given Snowflake client is logged in
-    let server = MockServer::start().await;
-    mount_jwt_login_success(&server).await;
-    mount_logout_success(&server).await;
+#[test]
+fn should_be_idempotent_when_close_called_multiple_times() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
 
-    let server_uri = server.uri();
-    let client = Arc::new(
-        tokio::task::spawn_blocking(move || {
-            SnowflakeTestClient::connect_integration_test(Some(&server_uri))
-        })
-        .await
-        .unwrap(),
-    );
+    //Given Snowflake client is logged in
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        mount_jwt_login_success(&server).await;
+        mount_logout_success(&server).await;
+        server
+    });
+
+    let client = SnowflakeTestClient::connect_integration_test(Some(&server.uri()));
 
     //When Connection is closed
-    let result1 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result1 = client.connection_close_blocking();
 
     //And Connection is closed again
-    let result2 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result2 = client.connection_close_blocking();
 
     //And Connection is closed a third time
-    let result3 = tokio::task::spawn_blocking({
-        let c = Arc::clone(&client);
-        move || c.connection_close_blocking()
-    })
-    .await
-    .unwrap();
+    let result3 = client.connection_close_blocking();
 
     //Then Only one logout request is sent
-    let requests = server.received_requests().await.unwrap();
-    let logout_count = requests.iter().filter(|r| is_logout_request(r)).count();
+    let logout_count = rt.block_on(async {
+        let requests = server.received_requests().await.unwrap();
+        requests.iter().filter(|r| is_logout_request(r)).count()
+    });
     assert_eq!(
         logout_count, 1,
         "Exactly one logout HTTP request should be sent"
@@ -130,37 +116,41 @@ async fn should_be_idempotent_when_close_called_multiple_times() {
 //                        Concurrency
 // ===========================================================================
 
-#[tokio::test]
-async fn should_handle_concurrent_close_calls_safely() {
+#[test]
+fn should_handle_concurrent_close_calls_safely() {
     use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
 
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
     //Given Snowflake client is logged in
-    let server = MockServer::start().await;
-    mount_jwt_login_success(&server).await;
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        mount_jwt_login_success(&server).await;
 
-    // Logout response with delay: thread 1 blocks on I/O while threads 2-5 race
-    Mock::given(method("POST"))
-        .and(path("/session"))
-        .and(query_param("delete", "true"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "success": true }))
-                .insert_header("Content-Type", "application/json")
-                .set_delay(Duration::from_millis(500)),
-        )
-        .mount(&server)
-        .await;
+        // Logout response with delay: thread 1 blocks on I/O while threads 2-5 race
+        Mock::given(method("POST"))
+            .and(path("/session"))
+            .and(query_param("delete", "true"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "success": true }))
+                    .insert_header("Content-Type", "application/json")
+                    .set_delay(Duration::from_millis(500)),
+            )
+            .mount(&server)
+            .await;
 
-    let server_uri = server.uri();
-    let client = Arc::new(
-        tokio::task::spawn_blocking(move || {
-            SnowflakeTestClient::connect_integration_test(Some(&server_uri))
-        })
-        .await
-        .unwrap(),
-    );
+        server
+    });
+
+    let client = Arc::new(SnowflakeTestClient::connect_integration_test(Some(
+        &server.uri(),
+    )));
     let barrier = Arc::new(Barrier::new(5));
 
     //When Connection is closed from multiple threads concurrently
@@ -181,8 +171,10 @@ async fn should_handle_concurrent_close_calls_safely() {
         .collect();
 
     //Then Only one logout request is sent
-    let requests = server.received_requests().await.unwrap();
-    let logout_count = requests.iter().filter(|r| is_logout_request(r)).count();
+    let logout_count = rt.block_on(async {
+        let requests = server.received_requests().await.unwrap();
+        requests.iter().filter(|r| is_logout_request(r)).count()
+    });
     assert_eq!(
         logout_count, 1,
         "Exactly one logout HTTP request despite 5 concurrent close() calls"


### PR DESCRIPTION
…rom Drop

The two WireMock-based E2E logout tests used #[tokio::test] which created a nested-runtime panic when SnowflakeTestClient methods called BLOCKING_CLIENT_RUNTIME.block_on() from inside the test's async context.

The previous fix (PR #921) worked around this with Arc + spawn_blocking wrappers and catch_unwind in Drop. The catch_unwind silently leaked connection and database handles — the release RPCs never executed.

Root cause fix: convert both tests from #[tokio::test] to #[test] with a manual current_thread runtime. Between rt.block_on() calls the tokio thread-local CONTEXT is cleared, so blocking RPC calls work. Drop runs on the main thread outside any runtime context, so handles are properly released. WireMock's MockServer runs on its own dedicated OS thread (wiremock::BareMockServer spawns std::thread with private runtime), independent of the test runtime.

Changes:
- should_be_idempotent: #[test] + manual runtime, no Arc, no spawn_blocking
- should_handle_concurrent: #[test] + manual runtime, Arc kept for 5 threads
- Drop: removed catch_unwind, restored direct release calls
- Removed unused top-level Arc import