### PR TITLE
SNOW-2881807 Add JSON to Arrow conversion for interval data types

### DIFF
--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -215,6 +215,40 @@ pub fn create_field_with_type(
                     .with_metadata(metadata),
             )
         }
+        RowType::IntervalYearMonth {
+            name,
+            nullable,
+            precision,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "INTERVAL_YEAR_MONTH".to_string());
+            metadata.insert("precision".to_string(), precision.to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            Ok(Field::new(
+                name,
+                data_type.unwrap_or(DataType::Int64), // Int64 is the default representation; large values may use Int32 or Decimal128
+                *nullable,
+            )
+            .with_metadata(metadata))
+        }
+        RowType::IntervalDaySecond {
+            name,
+            nullable,
+            precision,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "INTERVAL_DAY_TIME".to_string());
+            metadata.insert("precision".to_string(), precision.to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            Ok(Field::new(
+                name,
+                data_type.unwrap_or(DataType::Int64), // Int64 is the default; values >106,751 days require Decimal128
+                *nullable,
+            )
+            .with_metadata(metadata))
+        }
     }
 }
 

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -162,6 +162,19 @@ pub(super) enum FixedStorage {
     },
 }
 
+/// i64 fast-path storage for INTERVAL DAY TO SECOND columns. Falls back to Decimal128
+/// when a nanosecond value exceeds i64 range (>106,751 days).
+pub(super) enum IntervalDaySecondStorage {
+    /// All values so far fit in i64 nanoseconds.
+    I64 {
+        builder: arrow::array::PrimitiveBuilder<Int64Type>,
+    },
+    /// At least one value exceeded i64 range.
+    I128 {
+        builder: arrow::array::PrimitiveBuilder<Decimal128Type>,
+    },
+}
+
 pub(super) fn convert_i64_to_decimal128(
     builder: &mut arrow::array::PrimitiveBuilder<Int64Type>,
 ) -> arrow::array::PrimitiveBuilder<Decimal128Type> {
@@ -238,6 +251,12 @@ pub(super) enum ColumnBuilder {
         exp_builder: arrow::array::PrimitiveBuilder<arrow::datatypes::Int16Type>,
         mant_builder: arrow::array::BinaryBuilder,
         nulls: arrow::array::BooleanBufferBuilder,
+    },
+    IntervalYearMonth {
+        builder: arrow::array::PrimitiveBuilder<Int64Type>,
+    },
+    IntervalDaySecond {
+        storage: IntervalDaySecondStorage,
     },
 }
 
@@ -322,6 +341,14 @@ impl ColumnBuilder {
                 mant_builder: arrow::array::BinaryBuilder::with_capacity(capacity, capacity * 8),
                 nulls: arrow::array::BooleanBufferBuilder::new(capacity),
             },
+            RowType::IntervalYearMonth { .. } => ColumnBuilder::IntervalYearMonth {
+                builder: arrow::array::PrimitiveBuilder::with_capacity(capacity),
+            },
+            RowType::IntervalDaySecond { .. } => ColumnBuilder::IntervalDaySecond {
+                storage: IntervalDaySecondStorage::I64 {
+                    builder: arrow::array::PrimitiveBuilder::with_capacity(capacity),
+                },
+            },
         }
     }
 
@@ -380,6 +407,11 @@ impl ColumnBuilder {
                 mant_builder.append_value(&[] as &[u8]);
                 nulls.append(false);
             }
+            ColumnBuilder::IntervalYearMonth { builder } => builder.append_null(),
+            ColumnBuilder::IntervalDaySecond { storage } => match storage {
+                IntervalDaySecondStorage::I64 { builder } => builder.append_null(),
+                IntervalDaySecondStorage::I128 { builder } => builder.append_null(),
+            },
         }
     }
 
@@ -514,6 +546,35 @@ impl ColumnBuilder {
                 mant_builder.append_value(mantissa);
                 nulls.append(true);
             }
+            ColumnBuilder::IntervalYearMonth { builder } => {
+                let months = parse_int_bytes::<i64>(cell)?;
+                builder.append_value(months);
+            }
+            ColumnBuilder::IntervalDaySecond { storage } => match storage {
+                // Start with i64 for compactness. On the first value that overflows i64,
+                // promote the entire column to Decimal128 and stay there for all
+                // subsequent values in this chunk.
+                IntervalDaySecondStorage::I64 { builder } => {
+                    // Interval day-time values are stored as nanoseconds in JSON.
+                    // Max i64: 9,223,372,036,854,775,807 nanoseconds = ~106,751 days
+                    // Snowflake supports up to 999,999,999 days, so large values need i128.
+                    let nanoseconds_i128 = parse_int_bytes::<i128>(cell)?;
+                    if let Ok(nanoseconds_i64) = i64::try_from(nanoseconds_i128) {
+                        builder.append_value(nanoseconds_i64);
+                    } else {
+                        // Value exceeds i64, promote to Decimal128
+                        let mut decimal_builder = convert_i64_to_decimal128(builder);
+                        decimal_builder.append_value(nanoseconds_i128);
+                        *storage = IntervalDaySecondStorage::I128 {
+                            builder: decimal_builder,
+                        };
+                    }
+                }
+                IntervalDaySecondStorage::I128 { builder } => {
+                    let nanoseconds = parse_int_bytes::<i128>(cell)?;
+                    builder.append_value(nanoseconds);
+                }
+            },
         }
         Ok(())
     }
@@ -684,6 +745,31 @@ impl ColumnBuilder {
                 );
                 Ok((field, Arc::new(struct_arr)))
             }
+            ColumnBuilder::IntervalYearMonth { mut builder } => Ok((
+                create_field(row_type).map_err(err)?,
+                Arc::new(builder.finish()),
+            )),
+            ColumnBuilder::IntervalDaySecond { storage } => match storage {
+                IntervalDaySecondStorage::I64 { mut builder } => {
+                    let arr = builder.finish();
+                    Ok((
+                        create_field_with_type(row_type, Some(DataType::Int64)).map_err(err)?,
+                        Arc::new(arr),
+                    ))
+                }
+                IntervalDaySecondStorage::I128 { mut builder } => {
+                    // Use Decimal128(38, 0) for large interval nanosecond values
+                    let arr = builder
+                        .finish()
+                        .with_precision_and_scale(38, 0)
+                        .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+                    Ok((
+                        create_field_with_type(row_type, Some(DataType::Decimal128(38, 0)))
+                            .map_err(err)?,
+                        Arc::new(arr),
+                    ))
+                }
+            },
         }
     }
 }

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -66,6 +66,18 @@ pub enum RowType {
         name: String,
         nullable: bool,
     },
+    IntervalYearMonth {
+        name: String,
+        nullable: bool,
+        precision: u64,
+        scale: u64,
+    },
+    IntervalDaySecond {
+        name: String,
+        nullable: bool,
+        precision: u64,
+        scale: u64,
+    },
 }
 
 impl RowType {
@@ -183,6 +195,24 @@ impl RowType {
         RowType::Array {
             name: name.to_string(),
             nullable,
+        }
+    }
+
+    pub fn interval_year_month(name: &str, nullable: bool, precision: u64, scale: u64) -> Self {
+        RowType::IntervalYearMonth {
+            name: name.to_string(),
+            nullable,
+            precision,
+            scale,
+        }
+    }
+
+    pub fn interval_day_second(name: &str, nullable: bool, precision: u64, scale: u64) -> Self {
+        RowType::IntervalDaySecond {
+            name: name.to_string(),
+            nullable,
+            precision,
+            scale,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -633,6 +633,34 @@ impl TryFrom<&RowType> for query_types::RowType {
             "OBJECT" => Ok(query_types::RowType::object(&name, nullable)),
             "ARRAY" => Ok(query_types::RowType::array(&name, nullable)),
             "VARIANT" => Ok(query_types::RowType::variant(&name, nullable)),
+            "INTERVAL_YEAR_MONTH" => {
+                let precision = value.precision.context(MissingParameterSnafu {
+                    parameter: format!(
+                        "row type -> precision for INTERVAL_YEAR_MONTH column '{name}'"
+                    ),
+                })?;
+                let scale = value.scale.context(MissingParameterSnafu {
+                    parameter: format!("row type -> scale for INTERVAL_YEAR_MONTH column '{name}'"),
+                })?;
+                Ok(query_types::RowType::interval_year_month(
+                    &name, nullable, precision, scale,
+                ))
+            }
+            "INTERVAL_DAY_SECOND" | "INTERVAL_DAY_TIME" => {
+                let precision = value.precision.context(MissingParameterSnafu {
+                    parameter: format!(
+                        "row type -> precision for INTERVAL_DAY_TIME/DAY_SECOND column '{name}'"
+                    ),
+                })?;
+                let scale = value.scale.context(MissingParameterSnafu {
+                    parameter: format!(
+                        "row type -> scale for INTERVAL_DAY_TIME/DAY_SECOND column '{name}'"
+                    ),
+                })?;
+                Ok(query_types::RowType::interval_day_second(
+                    &name, nullable, precision, scale,
+                ))
+            }
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
             }

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -173,6 +173,8 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
             "scale",
             "physicalType",
         ],
+        "INTERVAL_YEAR_MONTH" => &["finalType", "byteLength", "charLength"],
+        "INTERVAL_DAY_TIME" => &["finalType", "byteLength", "charLength"],
         _ => &[],
     }
 }
@@ -222,7 +224,10 @@ fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
     // FIXED columns may use different integer widths (e.g. Arrow-native Int8
     // vs JSON-converted Int64). Accept any integer/decimal pair.
     let is_fixed = logical_type == "FIXED";
-    if !is_fixed {
+    // INTERVAL_YEAR_MONTH and INTERVAL_DAY_TIME columns may also use different integer widths.
+    let is_interval_ym = logical_type == "INTERVAL_YEAR_MONTH";
+    let is_interval_ds = logical_type == "INTERVAL_DAY_TIME";
+    if !is_fixed && !is_interval_ym && !is_interval_ds {
         assert_eq!(
             discriminant(left.data_type()),
             discriminant(right.data_type()),
@@ -272,10 +277,10 @@ fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
                 .zip(right_fields.iter())
                 .for_each(|(a, j)| assert_fields_match(a, j));
         }
-        (left_dt, right_dt) if is_fixed => {
+        (left_dt, right_dt) if is_fixed || is_interval_ym || is_interval_ds => {
             assert!(
                 is_integer_or_decimal(left_dt) && is_integer_or_decimal(right_dt),
-                "FIXED field '{}' has non-numeric types: left={:?}, right={:?}",
+                "FIXED/INTERVAL field '{}' has non-numeric types: left={:?}, right={:?}",
                 left.name(),
                 left_dt,
                 right_dt

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -160,6 +160,76 @@ fn should_return_array_as_arrow_even_if_json_result_set_is_returned() {
 }
 
 #[test]
+fn should_return_interval_year_to_month_family_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_interval_ytm (\
+            year_col INTERVAL YEAR, \
+            month_col INTERVAL MONTH, \
+            ytm_col INTERVAL YEAR TO MONTH)",
+        "INSERT INTO json_result_set_interval_ytm VALUES \
+            ('0', '0', '0-0'), \
+            ('1', '1', '1-2'), \
+            ('-5', '-14', '-1-3'), \
+            ('9999', '9999', '9999-11'), \
+            ('-9999', '-9999', '-9999-11'), \
+            (NULL, NULL, NULL)",
+        "SELECT * FROM json_result_set_interval_ytm",
+    )
+}
+
+#[test]
+fn should_return_interval_simple_day_to_second_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_interval_simple (\
+            day_col INTERVAL DAY, \
+            hour_col INTERVAL HOUR, \
+            minute_col INTERVAL MINUTE, \
+            second_col INTERVAL SECOND)",
+        "INSERT INTO json_result_set_interval_simple VALUES \
+            ('0', '0', '0', '0'), \
+            ('1', '1', '1', '1.5'), \
+            ('-1', '-1', '-1', '-1.5'), \
+            ('99999', '99999', '99999', '99999.999999'), \
+            ('-99999', '-99999', '-99999', '-99999.999999'), \
+            (NULL, NULL, NULL, NULL)",
+        "SELECT * FROM json_result_set_interval_simple",
+    )
+}
+
+#[test]
+fn should_return_interval_compound_day_to_second_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_interval_compound (\
+            d2h_col INTERVAL DAY TO HOUR, \
+            d2m_col INTERVAL DAY TO MINUTE, \
+            d2s_col INTERVAL DAY TO SECOND, \
+            h2m_col INTERVAL HOUR TO MINUTE, \
+            h2s_col INTERVAL HOUR TO SECOND, \
+            m2s_col INTERVAL MINUTE TO SECOND)",
+        "INSERT INTO json_result_set_interval_compound VALUES \
+            ('0 0', '0 0:0', '0 0:0:0.0', '0:0', '0:0:0.0', '0:0.0'), \
+            ('1 2', '1 2:30', '12 3:4:5.678', '1:30', '1:30:45.123', '30:45.123'), \
+            ('-1 2', '-1 2:30', '-1 2:3:4.567', '-1:30', '-1:30:45.123', '-30:45.123'), \
+            ('99999 23', '99999 23:59', '99999 23:59:59.999999', '99999:59', '99999:59:59.999999', '99999:59.999999'), \
+            (NULL, NULL, '-99999 23:59:59.999999', '-99999:59', '-99999:59:59.999999', '-99999:59.999999'), \
+            (NULL, NULL, NULL, NULL, NULL, NULL)",
+        "SELECT * FROM json_result_set_interval_compound",
+    )
+}
+
+#[test]
+fn should_return_large_interval_day_to_second_as_decimal128_for_arrow_and_json() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_large_interval (\
+            large_day INTERVAL DAY, \
+            large_hour INTERVAL HOUR)",
+        "INSERT INTO json_result_set_large_interval VALUES \
+            ('120000', '3000000')",
+        "SELECT * FROM json_result_set_large_interval",
+    )
+}
+
+#[test]
 fn should_handle_empty_result_set_for_arrow_and_json() {
     let client = SnowflakeTestClient::connect_with_default_auth();
     let stmt = client.new_statement();


### PR DESCRIPTION
### TL;DR

Adds support for Snowflake `INTERVAL_YEAR_MONTH` and `INTERVAL_DAY_SECOND` column types in both JSON and Arrow result set parsing.

### What changed?

- Added `IntervalYearMonth` and `IntervalDaySecond` variants to the `RowType` enum, each carrying `name`, `nullable`, `precision`, and `scale` fields, along with constructor methods.
- Added Arrow field creation for both interval types in `create_field_with_type`, using `Int64` as the physical data type to match Snowflake's Arrow IPC format, with `logicalType`, `precision`, and `scale` stored in field metadata.
- Added `IntervalYearMonth` and `IntervalDaySecond` `ColumnBuilder` variants in the JSON parser, which parse interval values as `i64` integers (months for year-month, nanoseconds for day-second).
- Added deserialization of `INTERVAL_YEAR_MONTH`, `INTERVAL_DAY_SECOND`, and `INTERVAL_DAY_TIME` type strings from Snowflake query responses into the corresponding `RowType` variants.
- Updated the Arrow result comparison helper to handle integer width differences for interval types, consistent with how `FIXED` columns are already handled.

### How to test?

Three new integration tests cover the interval types against a live Snowflake instance:

- `should_return_interval_year_to_month_family_as_arrow_even_if_json_result_set_is_returned` — tests `INTERVAL YEAR`, `INTERVAL MONTH`, and `INTERVAL YEAR TO MONTH` columns.
- `should_return_interval_simple_day_to_second_as_arrow_even_if_json_result_set_is_returned` — tests `INTERVAL DAY`, `HOUR`, `MINUTE`, and `SECOND` columns.
- `should_return_interval_compound_day_to_second_as_arrow_even_if_json_result_set_is_returned` — tests compound intervals such as `DAY TO HOUR`, `DAY TO SECOND`, `HOUR TO SECOND`, etc.

Each test creates a table, inserts representative values including nulls and boundary values, and asserts that the JSON and Arrow result sets match.

### Why make this change?

Snowflake supports interval types (`INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND`) but they were previously unrecognized, causing query failures for any result set containing these column types. This change enables correct parsing and representation of interval data in both JSON and Arrow code paths.