### PR TITLE
Performance smoke tests on branch

### DIFF
--- a/.github/workflows/accept-performance-changes.yml
+++ b/.github/workflows/accept-performance-changes.yml
@@ -1,0 +1,55 @@
+name: Accept Performance Changes
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  accept-performance-changes:
+    if: github.event.label.name == 'ACCEPT_PERFORMANCE_CHANGES'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Accept performance regression
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+
+            // Override the performance/regression status so the merge gate unblocks immediately.
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'success',
+              context: 'performance/regression',
+              description: 'Regression accepted via ACCEPT_PERFORMANCE_CHANGES label.',
+            });
+
+  remove-label-on-push:
+    if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove ACCEPT_PERFORMANCE_CHANGES label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ACCEPT_PERFORMANCE_CHANGES'
+              });
+              core.info('Removed ACCEPT_PERFORMANCE_CHANGES label — re-add it to accept the regression on the new commit.');
+            } catch (e) {
+              if (e.status === 404) {
+                core.info('ACCEPT_PERFORMANCE_CHANGES label not present, nothing to remove.');
+              } else {
+                throw e;
+              }
+            }

--- a/tests/performance/Jenkinsfile.pr-check
+++ b/tests/performance/Jenkinsfile.pr-check
@@ -1,5 +1,24 @@
 #!/usr/bin/env groovy
 
+import groovy.transform.Field
+
+// Regression check configuration
+@Field def REGRESSION_THRESHOLD = 10.0
+@Field def REGRESSION_SCREEN_ITERATIONS = 10
+@Field def REGRESSION_SCREEN_ITERATIONS_SLOW = 3
+@Field def REGRESSION_RERUN_ITERATIONS = 10
+@Field def REGRESSION_BASELINE_ITERATIONS = 10
+@Field def REGRESSION_WARMUP_ITERATIONS = 2
+@Field def REGRESSION_FAST_TEST_FILTER = "test_select_string_1M_arrow_recorded_http or test_select_float_1M_arrow_recorded_http or test_select_timestamp_tz_1M_arrow_recorded_http"
+@Field def REGRESSION_SLOW_TEST_FILTER = "test_select_15columns_1M_arrow_recorded_http"
+@Field def REGRESSION_TEST_FILTER = "${REGRESSION_FAST_TEST_FILTER} or ${REGRESSION_SLOW_TEST_FILTER}"
+@Field def ACCEPT_PERF_LABEL = 'ACCEPT_PERFORMANCE_CHANGES'
+@Field def REGRESSION_STATUS_CONTEXT = 'performance/regression'
+@Field def REGRESSION_EXIT_CODE = 77
+
+// Track whether the Python+ODBC lane detected a confirmed regression
+@Field def regressionDetected = false
+
 def setupVenv() {
     dir('tests/performance') {
         sh '''
@@ -12,6 +31,185 @@ def setupVenv() {
     }
 }
 
+def hasPrLabel(String labelName) {
+    if (!env.CHANGE_ID) {
+        return false
+    }
+    try {
+        def labels = ''
+        withCredentials([usernamePassword(
+            credentialsId: 'jenkins-snowflake-github-app-3-snowflakedb',
+            usernameVariable: 'GITHUB_APP',
+            passwordVariable: 'GITHUB_TOKEN'
+        )]) {
+            labels = sh(
+                returnStdout: true,
+                script: """
+                    curl -sf \
+                        -H "Authorization: token \${GITHUB_TOKEN}" \
+                        -H "Accept: application/vnd.github.v3+json" \
+                        "https://api.github.com/repos/snowflakedb/universal-driver/issues/${env.CHANGE_ID}/labels" \
+                    | python3 -c "import sys,json; print('\\n'.join(l['name'] for l in json.load(sys.stdin)))"
+                """
+            ).trim()
+        }
+        return labels.split('\n').any { it.trim() == labelName }
+    } catch (Exception e) {
+        echo "Warning: Could not check PR labels via GitHub API: ${e.message}"
+        return false
+    }
+}
+
+def postRegressionStatus(String conclusion, String description) {
+    // Use the commit Status API (not the Checks API) so that the
+    // accept-performance-changes GitHub Actions workflow can override the
+    // status with a simple createCommitStatus call.  The Checks API scopes
+    // check runs to the creating app, making cross-app overrides impossible.
+    if (!env.CHANGE_ID) {
+        return
+    }
+    try {
+        def state = (conclusion == 'SUCCESS') ? 'success' : 'failure'
+        // Jenkins merges the PR into main before building, so GIT_COMMIT is a
+        // local merge SHA unknown to GitHub. The PR head is fetched by the
+        // Jenkins refspec to refs/remotes/origin/PR-<number>, so resolve it
+        // directly from git — no API call, no shell fallback, no newline risk.
+        def prHeadSha = sh(
+            returnStdout: true,
+            script: "git rev-parse refs/remotes/origin/PR-${env.CHANGE_ID}"
+        ).trim()
+        withCredentials([usernamePassword(
+            credentialsId: 'jenkins-snowflake-github-app-3-snowflakedb',
+            usernameVariable: 'GITHUB_APP',
+            passwordVariable: 'GITHUB_TOKEN'
+        )]) {
+            sh """
+                curl -sf --retry 3 --retry-delay 5 \
+                    -X POST \
+                    -H "Authorization: token \${GITHUB_TOKEN}" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    "https://api.github.com/repos/snowflakedb/universal-driver/statuses/${prHeadSha}" \
+                    -d '{"state":"${state}","context":"${REGRESSION_STATUS_CONTEXT}","description":"${description}"}'
+            """
+        }
+    } catch (Exception e) {
+        echo "Warning: failed to post regression status: ${e.message}"
+    }
+}
+
+def combineExitCodes(int exitFast, int exitSlow) {
+    if (exitFast != 0 && exitFast != REGRESSION_EXIT_CODE) {
+        return exitFast
+    } else if (exitSlow != 0 && exitSlow != REGRESSION_EXIT_CODE) {
+        return exitSlow
+    } else if (exitFast == REGRESSION_EXIT_CODE || exitSlow == REGRESSION_EXIT_CODE) {
+        return REGRESSION_EXIT_CODE
+    }
+    return 0
+}
+
+def runRegressionTests(String driver) {
+    def exitFast = sh(
+        returnStatus: true,
+        script: """
+            source .venv/bin/activate
+            export CLOUD=aws
+            python -m hatch run -- python -m pytest \
+                tests/test_select_1M_recorded_http.py \
+                -k "${REGRESSION_FAST_TEST_FILTER}" \
+                --driver=${driver} --driver-type=universal \
+                --iterations=${REGRESSION_SCREEN_ITERATIONS} --warmup-iterations=${REGRESSION_WARMUP_ITERATIONS} \
+                --preserve-mappings \
+                --regression-check --regression-threshold=${REGRESSION_THRESHOLD} \
+                --regression-rerun-iterations=${REGRESSION_RERUN_ITERATIONS} \
+                -s -v
+        """
+    )
+    def exitSlow = sh(
+        returnStatus: true,
+        script: """
+            source .venv/bin/activate
+            export CLOUD=aws
+            python -m hatch run -- python -m pytest \
+                tests/test_select_1M_recorded_http.py \
+                -k "${REGRESSION_SLOW_TEST_FILTER}" \
+                --driver=${driver} --driver-type=universal \
+                --iterations=${REGRESSION_SCREEN_ITERATIONS_SLOW} --warmup-iterations=${REGRESSION_WARMUP_ITERATIONS} \
+                --preserve-mappings \
+                --regression-check --regression-threshold=${REGRESSION_THRESHOLD} \
+                --regression-rerun-iterations=${REGRESSION_RERUN_ITERATIONS} \
+                -s -v
+        """
+    )
+    return [exitFast: exitFast, exitSlow: exitSlow, combined: combineExitCodes(exitFast, exitSlow)]
+}
+
+def exitCodeLabel(int code) {
+    if (code == 0)                  return '✅ PASSED'
+    if (code == REGRESSION_EXIT_CODE) return '⚠️  REGRESSION'
+    return '❌ FAILED'
+}
+
+def printRegressionSummary(Map python, Map odbc) {
+    def sep = '=' * 72
+    echo """
+${sep}
+PERFORMANCE REGRESSION CHECK SUMMARY
+${sep}
+  Driver   Test group   Result
+  ------   ----------   ------
+  Python   Fast         ${exitCodeLabel(python.exitFast)}
+  Python   Slow         ${exitCodeLabel(python.exitSlow)}
+  ODBC     Fast         ${exitCodeLabel(odbc.exitFast)}
+  ODBC     Slow         ${exitCodeLabel(odbc.exitSlow)}
+${sep}
+  Fast tests : ${REGRESSION_FAST_TEST_FILTER}
+  Slow tests : ${REGRESSION_SLOW_TEST_FILTER}
+  Threshold  : ${REGRESSION_THRESHOLD}%  |  Rerun iters: ${REGRESSION_RERUN_ITERATIONS}
+${sep}"""
+
+    for (driver in ['python', 'odbc']) {
+        def summaryFile = "results/regression_summary_${driver}.json"
+        if (!fileExists(summaryFile)) {
+            echo "  [${driver.toUpperCase()}] No regression summary file found (${summaryFile})"
+            continue
+        }
+        def data = readJSON file: summaryFile
+        def header = String.format("  %-52s  %8s  %8s  %7s  %s",
+            "Test", "main(s)", "PR(s)", "diff%", "Status")
+        def line = '  ' + '-' * 70
+        def lines = [
+            "",
+            "  ${driver.toUpperCase()} driver — baseline run_key: ${data.baseline_run_key ?: 'N/A'}",
+            header,
+            line,
+        ]
+        for (t in data.tests) {
+            def icon = t.status == 'REGRESSED' ? '❌' : (t.status == 'noise' ? '⚠️ ' : '✅')
+            def reruns = t.confirmation_runs ? " reruns:[${t.confirmation_runs.join(', ')}s]" : ''
+            lines << String.format("  %-52s  %8.3f  %8.3f  %+6.1f%%  %s %s%s",
+                t.name, t.main_s, t.pr_s, t.diff_pct, icon, t.status, reruns)
+        }
+        lines << line
+        echo lines.join('\n')
+    }
+    echo sep
+}
+
+def runBaselineTests(String driver) {
+    sh """
+        source .venv/bin/activate
+        export CLOUD=aws
+        python -m hatch run -- python -m pytest \
+            tests/test_select_1M_recorded_http.py \
+            -k "${REGRESSION_TEST_FILTER}" \
+            --driver=${driver} --driver-type=universal \
+            --iterations=${REGRESSION_BASELINE_ITERATIONS} --warmup-iterations=${REGRESSION_WARMUP_ITERATIONS} \
+            --upload-to-benchstore \
+            -s -v
+    """
+}
+
 pipeline {
     agent none
 
@@ -19,7 +217,7 @@ pipeline {
         timestamps()
         disableResume()
         buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '50'))
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
     }
 
     environment {
@@ -34,7 +232,7 @@ pipeline {
             failFast true
             parallel {
                 stage('Core') {
-                    agent { label 'regular-memory-node-snowos' }
+                    agent { label 'drivers-perf-regular-memory-node-snowos' }
                     stages {
                         stage('Setup - Core') {
                             steps {
@@ -79,14 +277,17 @@ pipeline {
                 }
 
                 stage('Python + ODBC') {
-                    agent { label 'regular-memory-node-snowos' }
+                    agent { label 'drivers-perf-regular-memory-node-snowos' }
+                    environment {
+                        JENKINS_NODE_LABEL = 'drivers-perf-regular-memory-node-snowos'
+                    }
                     stages {
                         stage('Setup - Python/ODBC') {
                             steps {
                                 setupVenv()
                             }
                         }
-                        stage('Build - Python + ODBC') {
+                        stage('Build - Python + ODBC + WireMock') {
                             steps {
                                 withCredentials([
                                     usernamePassword(
@@ -101,7 +302,7 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Smoke Test - Python + ODBC') {
+                        stage('Test - Python + ODBC') {
                             steps {
                                 withCredentials([
                                     string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')
@@ -112,12 +313,54 @@ pipeline {
                                     withCredentials([
                                         file(credentialsId: '22401612-0c52-4682-8d00-fb9ee98927ac', variable: 'SF_PERF_CONFIG')
                                     ]) {
-                                        sh '''
-                                            source .venv/bin/activate
-                                            export CLOUD=aws
-                                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=python --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
-                                            python -m hatch run -- python -m pytest tests/test_select_1M.py::test_select_string_1M_arrow --driver=odbc --driver-type=both --iterations=1 --warmup-iterations=0 -s -v
-                                        '''
+                                        script {
+                                            def isMainBranch = (env.CHANGE_ID == null)
+
+                                            if (isMainBranch) {
+                                                runBaselineTests('python')
+                                                runBaselineTests('odbc')
+                                            } else {
+                                                def python = runRegressionTests('python')
+                                                def odbc   = runRegressionTests('odbc')
+
+                                                printRegressionSummary(python, odbc)
+
+                                                def exitCode = combineExitCodes(python.combined, odbc.combined)
+
+                                                if (exitCode == REGRESSION_EXIT_CODE) {
+                                                    regressionDetected = true
+                                                    postRegressionStatus('FAILURE', 'Performance regression detected')
+                                                    echo "Performance regression detected (exit code ${REGRESSION_EXIT_CODE})"
+                                                } else if (exitCode != 0) {
+                                                    postRegressionStatus('FAILURE', 'Tests failed before regression check could complete')
+                                                    error("Tests failed with exit code ${exitCode}")
+                                                } else {
+                                                    postRegressionStatus('SUCCESS', 'No performance regression detected')
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        stage('Regression Gate') {
+                            when {
+                                expression { env.CHANGE_ID != null }
+                            }
+                            steps {
+                                script {
+                                    if (!regressionDetected) {
+                                        echo "No regression detected — gate passed"
+                                        return
+                                    }
+
+                                    def accepted = hasPrLabel(ACCEPT_PERF_LABEL)
+                                    if (accepted) {
+                                        echo "Regression detected but '${ACCEPT_PERF_LABEL}' label is present — accepting performance changes"
+                                        postRegressionStatus('SUCCESS', "Regression accepted via ${ACCEPT_PERF_LABEL} label".toString())
+                                    } else {
+                                        echo "Regression detected and '${ACCEPT_PERF_LABEL}' label is NOT present — add the label and re-run to accept"
+                                        postRegressionStatus('FAILURE', "Regression confirmed — add ${ACCEPT_PERF_LABEL} label to accept".toString())
                                     }
                                 }
                             }
@@ -130,7 +373,7 @@ pipeline {
 
     post {
         success {
-            echo 'PR check passed: all driver images built and 1M tests passed'
+            echo 'PR check passed: all driver images built and tests passed'
         }
         failure {
             echo 'PR check failed'

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -11,6 +11,7 @@
 - [Metrics Reference](#metrics-reference)
     - [Core Instrumentation Metrics](#core-instrumentation-metrics)
 - [Docker Builds Approach](#docker-builds-approach)
+- [PR Regression Detection Smoke Tests](#pr-regression-detection-smoke-tests)
 
 ---
 
@@ -701,4 +702,66 @@ This creates an intermediate image containing Core libraries:
 These libraries are copied into the final driver images:
 - **Python**: Copies `libsf_core.so` → Used by `snowflake-connector-python` package
 - **ODBC**: Copies both `libsf_core.so` and `libsfodbc.so` → Loaded by unixODBC driver manager
+
+---
+
+## PR Regression Detection Smoke Tests
+
+The CI pipeline (`Jenkinsfile.pr-check`) automatically detects performance regressions on every PR.
+
+### Pipeline Structure
+
+Two parallel lanes run on dedicated performance nodes (`drivers-perf-regular-memory-node-snowos`).
+
+| Lane | Build | Test | Regression check |
+|------|-------|------|-----------------|
+| **Core** | Core + WireMock | Smoke test (1 iteration) | No |
+| **Python + ODBC** | Python + ODBC + WireMock | Recorded HTTP tests | Yes (PR only) |
+
+### Main vs PR Behavior
+
+| Branch | What happens | Benchstore target |
+|--------|-------------|-------------------|
+| **main** | Runs baseline tests with `--upload-to-benchstore` to populate baselines | `Universal_Driver` |
+| **PR** | Runs tests with `--regression-check` and compares against main baselines | `Universal_Driver_PR_Regression` |
+
+### Regression Detection Flow (PRs)
+
+1. **Screen** — run selected tests (10 iterations for fast tests, 3 for slow tests like `select_15columns_1M`)
+2. **Compare** — fetch the latest main branch baselines from Benchstore (median of last 3 runs) and compare PR medians against them
+3. **Confirm** — if any test exceeds the threshold (default: 5%), re-run only the regressed tests with more iterations (default: 10) up to 2 times. Regression is confirmed if it appears in at least 2 of 3 total runs (majority vote)
+4. **Report** — log a results table and upload all data to Benchstore with `REGRESSION_DETECTED` tag
+5. **Gate** — post a `performance/regression` GitHub commit status (`SUCCESS` or `FAILURE`)
+
+### Exit Code Handling
+
+The test stage distinguishes between functional test failures and performance regressions using exit codes:
+
+| Exit code | Meaning | Pipeline behavior |
+|-----------|---------|-------------------|
+| 0 | Tests passed, no regression | Post `SUCCESS` status |
+| 77 | Tests passed, regression confirmed | Post `FAILURE` status, proceed to Regression Gate |
+| Any other | Test error (crash, assertion, infra) | Fail the build immediately |
+
+### Relevant CLI Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--regression-check` | Enable regression detection | `false` |
+| `--regression-threshold` | Regression threshold percentage | `5.0` |
+| `--regression-rerun-iterations` | Iterations for confirmation re-runs | `10` |
+
+### ACCEPT_PERFORMANCE_CHANGES Label
+
+When a PR intentionally adds overhead (e.g., new functionality), the `performance/regression` status will block merging. To accept the regression:
+
+1. Add the `ACCEPT_PERFORMANCE_CHANGES` label to the PR
+2. Re-run the `Python + ODBC` lane in Jenkins
+3. The `Regression Gate` sub-stage sees the label and re-posts the GitHub status as `success`
+
+The regression is still detected, reported in logs, and uploaded to Benchstore for observability — only the merge gate is overridden.
+
+### Branch Protection Setup
+
+A repo admin must add `performance/regression` as a required status check in GitHub branch protection settings for this gate to block merges. Without this, the posted status is informational only.
 

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -19,6 +19,9 @@ _current_run_dir = None
 # Track performance history comparisons for the session summary
 _perf_comparisons = []
 
+# Registry of test parameters for regression re-runs (test_name -> params dict)
+_regression_test_params = {}
+
 
 def pytest_configure():
     """Configure pytest and suppress verbose library logs"""
@@ -95,6 +98,26 @@ def pytest_addoption(parser):
         action="store",
         default=None,
         help="Reuse existing WireMock mappings directory (e.g., 'run_20251230_155413'). Skips recording phase.",
+    )
+    parser.addoption(
+        "--regression-check",
+        action="store_true",
+        default=False,
+        help="Enable regression detection: compare PR results against Benchstore main baseline after tests complete",
+    )
+    parser.addoption(
+        "--regression-threshold",
+        action="store",
+        default=5.0,
+        type=float,
+        help="Regression threshold percentage (default: 5.0). Only used with --regression-check",
+    )
+    parser.addoption(
+        "--regression-rerun-iterations",
+        action="store",
+        default=10,
+        type=int,
+        help="Number of iterations for regression confirmation re-runs (default: 10). Only used with --regression-check",
     )
 
 
@@ -380,6 +403,13 @@ def perf_test(parameters_json, results_dir, run_id, iterations, warmup_iteration
         s3_files_dir = _download_s3_files_if_needed(s3_download_url, s3_download_dir)
         is_comparison = _should_run_comparison(driver, driver_type)
 
+        if test_type == PerfTestType.SELECT_RECORDED_HTTP:
+            _regression_test_params[test_name] = {
+                "sql_command": sql_command,
+                "parameters_json": parameters_json,
+                "setup_queries": final_setup_queries,
+            }
+
         # Route to appropriate runner based on test type
         if test_type == PerfTestType.SELECT_RECORDED_HTTP:
             result = _run_wiremock_test(
@@ -635,6 +665,75 @@ def pytest_sessionfinish(session, exitstatus):
                 handler.setLevel(level)
     else:
         logger.info("\nSkipping Benchstore upload (use --upload-to-benchstore to enable)")
+
+    # Regression check (PR vs main baseline from Benchstore)
+    regression_check_enabled = session.config.getoption("--regression-check")
+    if regression_check_enabled:
+        if exitstatus != 0:
+            logger.warning("Skipping regression check — test session already failed (exit code %d)", exitstatus)
+            return
+
+        driver_type_val = session.config.getoption("--driver-type") or os.getenv("DRIVER_TYPE", "universal")
+        if driver_type_val == "both":
+            logger.error("--regression-check is not supported with --driver-type=both (results are split into universal/ and old/ subdirs)")
+            session.exitstatus = 1
+            return
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info(">>> REGRESSION CHECK")
+        logger.info("=" * 80)
+        logger.info("")
+
+        if not _current_run_dir:
+            logger.error("No run directory found - cannot perform regression check")
+            session.exitstatus = pytest.ExitCode.USAGE_ERROR
+            return
+
+        # Suppress noisy library logs but keep our runner.* logs visible
+        _noisy_loggers = ["snowflake", "benchstore", "urllib3", "botocore"]
+        _saved_lib_levels = {}
+        for name in _noisy_loggers:
+            lib_logger = logging.getLogger(name)
+            _saved_lib_levels[name] = lib_logger.level
+            lib_logger.setLevel(logging.WARNING)
+
+        try:
+            from runner.pr_smoke_reg_detection.regression_check import run_regression_check
+
+            driver_val = session.config.getoption("--driver") or os.getenv("PERF_DRIVER", "core")
+            threshold = session.config.getoption("--regression-threshold")
+
+            run_id_val = _current_run_dir.name if _current_run_dir else None
+
+            rerun_iterations = session.config.getoption("--regression-rerun-iterations")
+
+            passed = run_regression_check(
+                results_dir=_current_run_dir,
+                driver=driver_val,
+                driver_type=driver_type_val,
+                threshold_pct=threshold,
+                use_local_auth=local_benchstore_upload,
+                test_params_registry=_regression_test_params,
+                run_id=run_id_val,
+                iterations=rerun_iterations,
+                warmup_iterations=session.config.getoption("--warmup-iterations") if session.config.getoption("--warmup-iterations") is not None else 2,
+            )
+
+            REGRESSION_EXIT_CODE = 77
+
+            if not passed:
+                session.exitstatus = REGRESSION_EXIT_CODE
+                logger.error("Regression check FAILED - performance regression confirmed (exit code 77)")
+
+        except Exception as e:
+            logger.error(f"\nRegression check failed with error: {e}")
+            session.exitstatus = pytest.ExitCode.TESTS_FAILED
+            raise
+        finally:
+            for name, level in _saved_lib_levels.items():
+                logging.getLogger(name).setLevel(level)
+    else:
+        logger.info("\nSkipping regression check (use --regression-check to enable)")
 
 
 def _download_s3_files_if_needed(s3_download_url: str = None, s3_download_dir: str = None):

--- a/tests/performance/drivers/Dockerfile.sf_core_builder
+++ b/tests/performance/drivers/Dockerfile.sf_core_builder
@@ -64,8 +64,11 @@ RUN cargo chef cook --release --recipe-path recipe.json --package sf_core --pack
 
 # Re-copy Cargo.toml files that cargo-chef may have overwritten from the recipe,
 # which can strip the [lib] section (e.g. proc-macro = true).
+# Also restores the package version, which cargo-chef stubs as 0.0.1 — without
+# this, env!("CARGO_PKG_VERSION") compiles to "0.0.1" instead of the real version.
 COPY error_trace/Cargo.toml ./error_trace/Cargo.toml
 COPY error_trace_derive/Cargo.toml ./error_trace_derive/Cargo.toml
+COPY odbc/Cargo.toml ./odbc/Cargo.toml
 
 # Copy source files
 COPY sf_core/src/ ./sf_core/src/

--- a/tests/performance/runner/local_compare.py
+++ b/tests/performance/runner/local_compare.py
@@ -45,7 +45,7 @@ def _read_median(csv_path: Path, metric_col: str) -> Optional[float]:
         return None
 
 
-def _is_main_result_file(path: Path) -> bool:
+def is_main_result_file(path: Path) -> bool:
     """Return True if file is a main result CSV (not a record/memory/wiremock file)."""
     name = path.name
     if name.startswith("memory_timeline_"):
@@ -62,7 +62,7 @@ def _is_main_result_file(path: Path) -> bool:
 
 def _pick_main_file(files: list[Path]) -> Optional[Path]:
     return max(
-        (f for f in files if _is_main_result_file(f)),
+        (f for f in files if is_main_result_file(f)),
         key=lambda p: p.stat().st_mtime,
         default=None,
     )
@@ -81,7 +81,7 @@ def _find_result_file(
         pattern = f"{test_name}_{driver}_{driver_type}_*.csv"
     else:
         pattern = f"{test_name}_{driver}_*.csv"
-    candidates = [f for f in test_dir.glob(pattern) if _is_main_result_file(f)]
+    candidates = [f for f in test_dir.glob(pattern) if is_main_result_file(f)]
     if not candidates:
         return None
     return max(candidates, key=lambda p: p.stat().st_mtime)

--- a/tests/performance/runner/pr_smoke_reg_detection/benchstore_baseline.py
+++ b/tests/performance/runner/pr_smoke_reg_detection/benchstore_baseline.py
@@ -1,0 +1,118 @@
+"""Query Benchstore for the latest main branch performance baselines."""
+
+import logging
+import statistics
+from typing import Optional
+
+from benchstore.proto import benchstore_pb2
+from benchstore.client import benchmark_manager
+
+from runner.benchstore_upload import (
+    PROJECT_NAME,
+    BENCHMARK_NAME,
+    login_to_benchstore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_metric_key_to_label(sf_storage, benchmark_info) -> dict[int, str]:
+    """Resolve metric_key (int) -> label (str) from BenchmarkInfo."""
+    query = benchstore_pb2.BenchmarkInfoQuery(benchmark_key=benchmark_info.benchmark_key)
+    response = sf_storage.query_benchmark_info(query)
+
+    key_to_label = {}
+    for info in response.benchmark_info_list:
+        for vi in info.metric_info_list:
+            key_to_label[vi.value_key] = vi.label
+    return key_to_label
+
+
+def get_main_baseline(
+    test_names: list[str],
+    driver: str = "python",
+    driver_type: str = "universal",
+    use_local_auth: bool = False,
+    num_runs: int = 3,
+) -> tuple[dict[str, float], Optional[int]]:
+    """
+    Query Benchstore for the latest main branch median fetch_s values.
+
+    Fetches the last `num_runs` runs and computes the median of their medians
+    to reduce sensitivity to single-run outliers.
+
+    Args:
+        test_names: Test names to look up (without 'test_' prefix).
+        driver: Driver name (python, odbc, core).
+        driver_type: universal or old.
+        use_local_auth: Use browser auth instead of config file.
+        num_runs: Number of recent main runs to average over (default 3).
+
+    Returns:
+        (baselines, latest_run_key) where baselines maps test_name -> median fetch_s,
+        and latest_run_key is the Benchstore run key of the most recent baseline.
+    """
+    sf_storage = login_to_benchstore(use_local_auth=use_local_auth)
+
+    benchmark_info = benchmark_manager.find_or_create_benchmark(
+        PROJECT_NAME, BENCHMARK_NAME, sf_storage
+    )
+    benchmark_key = benchmark_info.benchmark_key
+
+    key_to_label = _build_metric_key_to_label(sf_storage, benchmark_info)
+
+    driver_tag = f"{driver}_old" if driver_type == "old" else driver
+
+    query = benchstore_pb2.RunInfoQuery(
+        benchmark_key=benchmark_key,
+        tags=[
+            "BRANCH_NAME=main",
+            f"DRIVER={driver_tag}",
+        ],
+        limit=num_runs,
+    )
+    response = sf_storage.query_run_info(query)
+
+    if not response.run_info_list:
+        logger.warning("No main branch runs found in Benchstore")
+        return {}, None
+
+    latest_run_key = response.run_info_list[0].run_key
+
+    logger.info(f"Fetched {len(response.run_info_list)} baseline run(s):")
+    for run_info in response.run_info_list:
+        logger.info(f"  run_key={run_info.run_key}")
+        for tag in run_info.tags:
+            if tag.startswith("BUILD_NUMBER=") or tag.startswith("BRANCH_NAME="):
+                logger.info(f"    {tag}")
+
+    # Collect per-test medians from each run
+    per_test_values: dict[str, list[float]] = {name: [] for name in test_names}
+
+    for run_info in response.run_info_list:
+        label_to_agg = {}
+        for agg in run_info.aggregate.metric_aggregate_list:
+            label = key_to_label.get(agg.metric_key)
+            if label:
+                label_to_agg[label] = agg
+
+        for test_name in test_names:
+            fetch_label = f"{test_name}_fetch_s"
+            agg = label_to_agg.get(fetch_label)
+            if agg and agg.median > 0:
+                per_test_values[test_name].append(agg.median)
+
+    baselines: dict[str, float] = {}
+    for test_name in test_names:
+        values = per_test_values[test_name]
+        if values:
+            baseline = statistics.median(values)
+            baselines[test_name] = baseline
+            logger.info(
+                f"  {test_name}: baseline={baseline:.4f}s "
+                f"(from {len(values)} run(s): {', '.join(f'{v:.4f}' for v in values)})"
+            )
+        else:
+            logger.warning(f"  {test_name}: no baseline found in Benchstore")
+
+    return baselines, latest_run_key

--- a/tests/performance/runner/pr_smoke_reg_detection/regression_check.py
+++ b/tests/performance/runner/pr_smoke_reg_detection/regression_check.py
@@ -1,0 +1,601 @@
+"""
+PR performance regression detection.
+
+Compares PR test results against Benchstore main branch baselines.
+When regression exceeds threshold, re-runs only regressed tests to confirm.
+Every run is uploaded to a separate Benchstore benchmark with diff_pct aggregates
+and a REGRESSION_DETECTED tag for full observability.
+"""
+
+import csv
+import json
+import logging
+import os
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from runner.pr_smoke_reg_detection.benchstore_baseline import get_main_baseline
+from runner.local_compare import is_main_result_file
+
+logger = logging.getLogger(__name__)
+
+PR_REGRESSION_BENCHMARK = "Universal_Driver_PR_Regression"
+
+
+@dataclass
+class RegressionResult:
+    test_name: str
+    main_median: float
+    pr_median: float
+    diff_pct: float
+    is_regressed: bool
+    confirmation_runs: list[float] = field(default_factory=list)
+    confirmed: bool = False
+
+
+def read_pr_medians(results_dir: Path, driver: str, driver_type: str) -> dict[str, float]:
+    """
+    Read median fetch_s (or query_s for PUT/GET) from PR result CSVs.
+
+    Returns:
+        dict mapping test_name -> median value
+    """
+    driver_type_subdir = driver_type if driver != "core" else "universal"
+    search_dir = results_dir / driver_type_subdir
+
+    if not search_dir.exists():
+        logger.warning(f"Results directory not found: {search_dir}")
+        return {}
+
+    medians = {}
+
+    for test_dir in sorted(search_dir.iterdir()):
+        if not test_dir.is_dir():
+            continue
+
+        test_name = test_dir.name
+        csv_files = [
+            f for f in test_dir.glob("*.csv") if is_main_result_file(f)
+        ]
+        if not csv_files:
+            continue
+
+        result_csv = max(csv_files, key=lambda p: p.stat().st_mtime)
+
+        try:
+            with open(result_csv, "r") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+
+            if not rows:
+                continue
+
+            metric_col = "fetch_s" if "fetch_s" in rows[0] else "query_s"
+            values = [float(r[metric_col]) for r in rows if r.get(metric_col)]
+            if values:
+                medians[test_name] = statistics.median(values)
+        except Exception as e:
+            logger.warning(f"Failed to read results for {test_name}: {e}")
+
+    return medians
+
+
+def check_regression(
+    pr_results: dict[str, float],
+    baselines: dict[str, float],
+    threshold_pct: float = 5.0,
+) -> list[RegressionResult]:
+    """Compare PR medians vs baselines. Return list of RegressionResult."""
+    results = []
+    for test_name, pr_median in pr_results.items():
+        main_median = baselines.get(test_name)
+        if main_median is None or main_median == 0:
+            logger.warning(f"No baseline for {test_name}, skipping regression check")
+            continue
+
+        diff_pct = (pr_median - main_median) / main_median * 100
+        is_regressed = diff_pct > threshold_pct
+
+        results.append(
+            RegressionResult(
+                test_name=test_name,
+                main_median=main_median,
+                pr_median=pr_median,
+                diff_pct=diff_pct,
+                is_regressed=is_regressed,
+            )
+        )
+    return results
+
+
+def _rerun_test(
+    test_name: str,
+    test_params: dict,
+    results_dir: Path,
+    run_id: str,
+    driver: str,
+    driver_type: str,
+    iterations: int,
+    warmup_iterations: int,
+) -> Optional[float]:
+    """
+    Re-run a single test using WireMock replay with existing mappings.
+
+    Returns the median fetch_s from the re-run, or None on failure.
+    """
+    from runner.modes.wiremock_runner import run_wiremock_performance_test
+
+    sql_command = test_params["sql_command"]
+    parameters_json = test_params["parameters_json"]
+    setup_queries = test_params.get("setup_queries", [])
+
+    rerun_dir = results_dir / f"_rerun_{test_name}_{int(time.time())}"
+    rerun_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result_files = run_wiremock_performance_test(
+            test_name=test_name,
+            sql_command=sql_command,
+            parameters_json=parameters_json,
+            results_dir=rerun_dir,
+            iterations=iterations,
+            warmup_iterations=warmup_iterations,
+            driver=driver,
+            driver_type=driver_type if driver != "core" else None,
+            setup_queries=setup_queries,
+            run_id=run_id,
+            preserve_mappings=True,
+            reuse_mappings_dir=run_id,
+        )
+    except Exception as e:
+        logger.error(f"Re-run failed for {test_name}: {e}")
+        return None
+
+    main_files = [f for f in result_files if is_main_result_file(f)]
+    if not main_files:
+        logger.error(f"No result files from re-run of {test_name}")
+        return None
+
+    result_csv = max(main_files, key=lambda p: p.stat().st_mtime)
+    try:
+        with open(result_csv, "r") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        if not rows:
+            return None
+        metric_col = "fetch_s" if "fetch_s" in rows[0] else "query_s"
+        values = [float(r[metric_col]) for r in rows if r.get(metric_col)]
+        return statistics.median(values) if values else None
+    except Exception as e:
+        logger.error(f"Failed to read re-run results for {test_name}: {e}")
+        return None
+
+
+def _log_report(
+    results: list[RegressionResult],
+    threshold_pct: float,
+    baseline_run_key: Optional[int],
+    passed: bool,
+):
+    """Log a formatted regression report table."""
+    logger.info("")
+    logger.info("=" * 100)
+    if passed:
+        logger.info("REGRESSION CHECK PASSED")
+    else:
+        logger.error("REGRESSION CHECK FAILED")
+    logger.info("=" * 100)
+    logger.info("")
+
+    header = f"{'Test':<50} | {'Main':>10} | {'PR':>10} | {'Diff':>8} | {'Status'}"
+    logger.info(header)
+    logger.info("-" * len(header))
+
+    for r in results:
+        status = "OK"
+        if r.is_regressed:
+            if r.confirmed:
+                runs_str = ", ".join(f"{v:.3f}s" for v in r.confirmation_runs)
+                status = f"REGRESSED (confirmed, reruns: [{runs_str}])"
+            else:
+                status = "noise (not confirmed on re-run)"
+
+        logger.info(
+            f"{r.test_name:<50} | {r.main_median:>9.3f}s | {r.pr_median:>9.3f}s | "
+            f"{r.diff_pct:>+7.1f}% | {status}"
+        )
+
+    logger.info("")
+    logger.info(f"Threshold: {threshold_pct}%")
+    if baseline_run_key is not None:
+        logger.info(f"Baseline: Benchstore run_key={baseline_run_key}")
+    logger.info("=" * 100)
+    logger.info("")
+
+
+def _upload_to_benchstore(
+    results: list[RegressionResult],
+    results_dir: Path,
+    driver: str,
+    driver_type: str,
+    baseline_run_key: Optional[int],
+    threshold_pct: float,
+    use_local_auth: bool,
+    regression_detected: bool,
+):
+    """Upload PR regression check data to the separate PR regression benchmark.
+
+    Every run is uploaded for full observability. A REGRESSION_DETECTED tag
+    marks whether a confirmed regression was found, and per-test diff_pct
+    aggregates are always included so trends are visible even for passing runs.
+    """
+    from benchstore.proto import benchstore_pb2
+    from benchstore.client.quickstore import Quickstore
+    from google.protobuf.timestamp_pb2 import Timestamp
+
+    from benchstore.client import benchmark_manager
+
+    from runner.benchstore_upload import (
+        PROJECT_NAME,
+        login_to_benchstore,
+        get_snowhouse_config,
+        get_snowflake_connection_params,
+        get_local_connection_params,
+        read_csv_results,
+        _sanitize_tag,
+    )
+    from runner.container import get_resource_limits
+    from runner.utils import collect_node_info
+
+    sf_storage = login_to_benchstore(use_local_auth=use_local_auth)
+    benchmark_manager.find_or_create_benchmark(
+        PROJECT_NAME, PR_REGRESSION_BENCHMARK, sf_storage
+    )
+    if use_local_auth:
+        connection_params = get_local_connection_params()
+    else:
+        snowhouse_config = get_snowhouse_config()
+        connection_params = get_snowflake_connection_params(snowhouse_config)
+
+    is_local = os.getenv("BUILD_NUMBER") is None
+    build_number = "LOCAL" if is_local else os.getenv("BUILD_NUMBER")
+    branch_name = "LOCAL" if is_local else os.getenv("BRANCH_NAME", "unknown")
+    jenkins_node = os.getenv("JENKINS_NODE_LABEL", "UNKNOWN")
+    pr_number = os.getenv("CHANGE_ID", "LOCAL")
+
+    resource_limits = get_resource_limits()
+    node_info = collect_node_info()
+
+    driver_tag_value = f"{driver}_old" if driver_type == "old" else driver
+
+    tags = [
+        f"BUILD_NUMBER={build_number}",
+        f"BRANCH_NAME={branch_name}",
+        f"DRIVER={driver_tag_value}",
+        f"JENKINS_NODE={jenkins_node}",
+        f"DOCKER_MEMORY={resource_limits['memory']}",
+        f"DOCKER_CPU={resource_limits['cpu']}",
+        f"PR_NUMBER={pr_number}",
+        f"REGRESSION_THRESHOLD={threshold_pct}",
+        f"BASELINE_RUN_KEY={baseline_run_key or 'UNKNOWN'}",
+        f"REGRESSION_DETECTED={'true' if regression_detected else 'false'}",
+        f"NODE_CPU_MODEL={node_info.get('node_cpu_model', 'UNKNOWN')}",
+        f"NODE_CPU_CORES={node_info.get('node_cpu_cores', 'UNKNOWN')}",
+        f"NODE_MEMORY_GB={node_info.get('node_memory_gb', 'UNKNOWN')}",
+    ]
+    if "node_instance_type" in node_info:
+        tags.append(f"NODE_INSTANCE_TYPE={node_info['node_instance_type']}")
+
+    tags = [_sanitize_tag(t) for t in tags]
+
+    tested_names = {r.test_name for r in results}
+
+    comparable_tags = [t for t in tags if t.startswith("DRIVER=") or t.startswith("JENKINS_NODE=")]
+
+    quickstore_input = benchstore_pb2.QuickstoreInput(
+        benchmark_name_lookup=benchstore_pb2.BenchmarkNameLookup(
+            project_name=PROJECT_NAME,
+            benchmark_name=PR_REGRESSION_BENCHMARK,
+        ),
+        tags=tags,
+        default_comparable_tags=comparable_tags,
+    )
+
+    driver_type_subdir = driver_type if driver != "core" else "universal"
+    search_dir = results_dir / driver_type_subdir
+
+    try:
+        with Quickstore(quickstore_input, snowflake_connection_params=connection_params) as quickstore:
+            uploaded = 0
+            for test_dir in sorted(search_dir.iterdir()):
+                if not test_dir.is_dir():
+                    continue
+                if test_dir.name not in tested_names:
+                    continue
+
+                csv_files = [
+                    f for f in test_dir.glob("*.csv") if is_main_result_file(f)
+                ]
+                if not csv_files:
+                    continue
+                result_csv = max(csv_files, key=lambda p: p.stat().st_mtime)
+
+                try:
+                    rows = read_csv_results(result_csv)
+                except Exception:
+                    continue
+
+                for row in rows:
+                    metrics = {f"{test_dir.name}_query_s": row["query_s"]}
+                    if "fetch_s" in row:
+                        metrics[f"{test_dir.name}_fetch_s"] = row["fetch_s"]
+                    if "cpu_time_s" in row:
+                        metrics[f"{test_dir.name}_cpu_time_s"] = row["cpu_time_s"]
+                    if "peak_rss_mb" in row:
+                        metrics[f"{test_dir.name}_peak_rss_mb"] = row["peak_rss_mb"]
+
+                    ts = Timestamp()
+                    ts.FromMilliseconds(row["timestamp"])
+                    quickstore.add_sample_point_from_input(
+                        benchstore_pb2.AddSamplePointInput(timestamp=ts, metrics=metrics)
+                    )
+                    uploaded += 1
+
+            for r in results:
+                quickstore.add_run_aggregate(
+                    benchstore_pb2.AddRunAggregateInput(
+                        custom_aggregate_label=f"{r.test_name}_diff_pct",
+                        custom_aggregate_value=r.diff_pct,
+                    )
+                )
+
+            logger.info(
+                f"Uploaded {uploaded} sample points + diff_pct aggregates "
+                f"for {len(results)} tests to {PR_REGRESSION_BENCHMARK} "
+                f"(regression_detected={regression_detected})"
+            )
+
+    except Exception as e:
+        logger.error(f"Failed to upload regression data to Benchstore: {e}")
+
+
+def _write_summary_file(
+    results: list[RegressionResult],
+    results_dir: Path,
+    driver: str,
+    passed: bool,
+    threshold_pct: float,
+    baseline_run_key: Optional[int],
+):
+    """Write a compact JSON summary to results/../regression_summary_{driver}.json.
+
+    The Jenkinsfile reads this file to include per-test details in the
+    pipeline-level summary that is easy to find without scrolling through logs.
+    """
+    summary = {
+        "driver": driver,
+        "passed": passed,
+        "threshold_pct": threshold_pct,
+        "baseline_run_key": baseline_run_key,
+        "tests": [
+            {
+                "name": r.test_name,
+                "main_s": round(r.main_median, 4),
+                "pr_s": round(r.pr_median, 4),
+                "diff_pct": round(r.diff_pct, 1),
+                "status": (
+                    "REGRESSED" if r.confirmed
+                    else "noise" if r.is_regressed
+                    else "OK"
+                ),
+                "confirmation_runs": [round(v, 4) for v in r.confirmation_runs],
+            }
+            for r in results
+        ],
+    }
+    out_path = results_dir.parent / f"regression_summary_{driver}.json"
+    try:
+        # Merge with existing file so fast + slow runs both appear in one summary.
+        if out_path.exists():
+            existing = json.loads(out_path.read_text())
+            summary["tests"] = existing.get("tests", []) + summary["tests"]
+            summary["passed"] = existing.get("passed", True) and summary["passed"]
+        out_path.write_text(json.dumps(summary, indent=2))
+        logger.info(f"Wrote regression summary: {out_path}")
+    except Exception as e:
+        logger.warning(f"Could not write regression summary file: {e}")
+
+
+def run_regression_check(
+    results_dir: Path,
+    driver: str,
+    driver_type: str,
+    threshold_pct: float,
+    use_local_auth: bool = False,
+    test_params_registry: Optional[dict] = None,
+    run_id: Optional[str] = None,
+    iterations: int = 10,
+    warmup_iterations: int = 2,
+    max_retries: int = 2,
+) -> bool:
+    """
+    Main entry point: compare PR results against Benchstore baseline.
+
+    Flow:
+        1. Read PR results from results_dir CSVs
+        2. Query Benchstore for latest main baselines
+        3. Compare PR medians vs main medians
+        4. If no regression > threshold: PASS
+        5. If regression detected: re-run regressed tests (up to max_retries)
+        6. Confirm regression if it appears in >= 2 of (1 + max_retries) total runs
+        7. Upload all results to PR_Regression benchmark (with REGRESSION_DETECTED tag
+           and per-test diff_pct aggregates)
+        8. Return True if passed, False if regression confirmed
+
+    Args:
+        results_dir: Path to run results directory
+        driver: Driver name
+        driver_type: Driver type (universal/old)
+        threshold_pct: Regression threshold percentage
+        use_local_auth: Use browser auth for Benchstore
+        test_params_registry: Dict mapping test_name -> {sql_command, parameters_json, ...}
+        run_id: Run ID for reusing WireMock mappings
+        iterations: Iterations for re-runs
+        warmup_iterations: Warmup iterations for re-runs
+        max_retries: Max re-runs for regressed tests (default 2, total runs = 1 + max_retries)
+
+    Returns:
+        True if check passed, False if confirmed regression found
+    """
+    logger.info("")
+    logger.info("=" * 100)
+    logger.info(">>> REGRESSION CHECK: Comparing PR results against Benchstore main baseline")
+    logger.info("=" * 100)
+    logger.info("")
+
+    # 1. Read PR results
+    pr_medians = read_pr_medians(results_dir, driver, driver_type)
+    if not pr_medians:
+        logger.warning("No PR results found - skipping regression check")
+        return True
+
+    logger.info(f"PR results for {len(pr_medians)} tests:")
+    for name, val in sorted(pr_medians.items()):
+        logger.info(f"  {name}: {val:.4f}s")
+
+    # 2. Query Benchstore for baselines
+    logger.info("")
+    logger.info("Querying Benchstore for main branch baselines...")
+    baselines, baseline_run_key = get_main_baseline(
+        test_names=list(pr_medians.keys()),
+        driver=driver,
+        driver_type=driver_type,
+        use_local_auth=use_local_auth,
+    )
+
+    if not baselines:
+        logger.warning("No baselines found in Benchstore - skipping regression check")
+        return True
+
+    # 3. Compare
+    logger.info("")
+    logger.info("Comparing PR results against baselines...")
+    results = check_regression(pr_medians, baselines, threshold_pct)
+
+    regressed = [r for r in results if r.is_regressed]
+
+    if not regressed:
+        _log_report(results, threshold_pct, baseline_run_key, passed=True)
+        _write_summary_file(results, results_dir, driver, passed=True, threshold_pct=threshold_pct, baseline_run_key=baseline_run_key)
+        logger.info("Uploading regression check data to Benchstore...")
+        try:
+            _upload_to_benchstore(
+                results=results,
+                results_dir=results_dir,
+                driver=driver,
+                driver_type=driver_type,
+                baseline_run_key=baseline_run_key,
+                threshold_pct=threshold_pct,
+                use_local_auth=use_local_auth,
+                regression_detected=False,
+            )
+        except Exception as e:
+            logger.error(f"Benchstore upload failed (non-fatal): {e}")
+        return True
+
+    logger.info("")
+    logger.info(
+        f"Potential regression detected in {len(regressed)} test(s): "
+        + ", ".join(r.test_name for r in regressed)
+    )
+
+    # 4. Re-run regressed tests to confirm
+    if test_params_registry is None or run_id is None:
+        logger.warning(
+            "Cannot re-run tests (missing test_params_registry or run_id). "
+            "Treating initial regression as confirmed."
+        )
+        for r in regressed:
+            r.confirmed = True
+    else:
+        for r in regressed:
+            r.confirmation_runs.append(r.pr_median)
+
+            for retry_num in range(1, max_retries + 1):
+                logger.info("")
+                logger.info(
+                    f"Re-run {retry_num}/{max_retries} for {r.test_name}..."
+                )
+
+                params = test_params_registry.get(r.test_name)
+                if params is None:
+                    logger.error(
+                        f"No test params found for {r.test_name} - cannot re-run"
+                    )
+                    break
+
+                rerun_median = _rerun_test(
+                    test_name=r.test_name,
+                    test_params=params,
+                    results_dir=results_dir,
+                    run_id=run_id,
+                    driver=driver,
+                    driver_type=driver_type,
+                    iterations=iterations,
+                    warmup_iterations=warmup_iterations,
+                )
+
+                if rerun_median is not None:
+                    r.confirmation_runs.append(rerun_median)
+                    logger.info(f"  Re-run median: {rerun_median:.4f}s")
+                else:
+                    logger.warning(f"  Re-run {retry_num} produced no result")
+
+            # Confirm if regression appears in >= 2 of total runs.
+            # If reruns failed to produce results (len < expected), treat
+            # conservatively as confirmed since we can't disprove the regression.
+            expected_runs = 1 + max_retries
+            if len(r.confirmation_runs) < expected_runs:
+                r.confirmed = True
+                logger.warning(
+                    f"  {r.test_name}: only {len(r.confirmation_runs)}/{expected_runs} "
+                    f"runs produced results — treating as CONFIRMED (cannot disprove)"
+                )
+            else:
+                regressed_count = sum(
+                    1
+                    for m in r.confirmation_runs
+                    if r.main_median > 0
+                    and (m - r.main_median) / r.main_median * 100 > threshold_pct
+                )
+                r.confirmed = regressed_count >= 2
+                logger.info(
+                    f"  {r.test_name}: regressed in {regressed_count}/{len(r.confirmation_runs)} runs "
+                    f"-> {'CONFIRMED' if r.confirmed else 'NOT CONFIRMED (noise)'}"
+                )
+
+    # 5. Report
+    any_confirmed = any(r.confirmed for r in results)
+    _log_report(results, threshold_pct, baseline_run_key, passed=not any_confirmed)
+    _write_summary_file(results, results_dir, driver, passed=not any_confirmed, threshold_pct=threshold_pct, baseline_run_key=baseline_run_key)
+
+    # 6. Upload every run for observability (tagged with regression status)
+    logger.info("Uploading regression check data to Benchstore...")
+    try:
+        _upload_to_benchstore(
+            results=results,
+            results_dir=results_dir,
+            driver=driver,
+            driver_type=driver_type,
+            baseline_run_key=baseline_run_key,
+            threshold_pct=threshold_pct,
+            use_local_auth=use_local_auth,
+            regression_detected=any_confirmed,
+        )
+    except Exception as e:
+        logger.error(f"Benchstore upload failed (non-fatal): {e}")
+
+    return not any_confirmed

--- a/tests/performance/wiremock/Dockerfile
+++ b/tests/performance/wiremock/Dockerfile
@@ -1,34 +1,26 @@
 # WireMock standalone container for performance testing
-# 
-# Build: cd tests/performance/wiremock && docker build -t wiremock-perf:latest .
+#
+# Build: cd <repo-root> && tests/performance/wiremock/build.sh
 # Run: docker run -p 8080:8080 -v /tmp/wiremock_mappings:/wiremock wiremock-perf:latest
 
 FROM eclipse-temurin:17-jdk
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create directory for WireMock
 RUN mkdir -p /opt/wiremock
 
 WORKDIR /wiremock
 
-# Download WireMock standalone
-ARG WIREMOCK_VERSION=3.13.2
-RUN curl -L "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" \
-    -o /opt/wiremock/wiremock-standalone.jar
+COPY tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar \
+    /opt/wiremock/wiremock-standalone.jar
 
 # Copy and compile custom launcher and extension
-COPY WireMockLauncher.java /opt/wiremock/
-COPY extensions/ResponseTimeExtension.java /opt/wiremock/extensions/
+COPY tests/performance/wiremock/WireMockLauncher.java /opt/wiremock/
+COPY tests/performance/wiremock/extensions/ResponseTimeExtension.java /opt/wiremock/extensions/
 RUN javac -cp /opt/wiremock/wiremock-standalone.jar \
     /opt/wiremock/WireMockLauncher.java \
     /opt/wiremock/extensions/ResponseTimeExtension.java
 
 # Generate static CA certificate for HTTPS MITM proxy
-COPY generate_certs.sh /opt/wiremock/
+COPY tests/performance/wiremock/generate_certs.sh /opt/wiremock/
 RUN /opt/wiremock/generate_certs.sh
 
 # Expose WireMock port

--- a/tests/performance/wiremock/build.sh
+++ b/tests/performance/wiremock/build.sh
@@ -3,11 +3,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 echo "Building WireMock container for performance testing..."
 
-# Build Docker image
-docker build -t wiremock-perf:latest .
+# Build Docker image with repo root as context so the local WireMock JAR is accessible
+docker build -f "$SCRIPT_DIR/Dockerfile" -t wiremock-perf:latest "$REPO_ROOT"
 
 echo "✓ WireMock container built successfully: wiremock-perf:latest"

--- a/tests/performance/wiremock/mapping_transformer.py
+++ b/tests/performance/wiremock/mapping_transformer.py
@@ -118,9 +118,14 @@ class MappingTransformer:
                 # OPTIMIZATION 2: Assign priority (data chunks are MOST common - check first)
                 mapping['priority'] = 1
             else:
-                # Other URLs: add wildcard for query parameters
+                # Other URLs: match exact path with optional query string only.
+                # Using `base_path.*` would match sub-paths too (e.g. `/session.*` would
+                # match `/session/v1/login-request`), so we restrict to query-string
+                # variations only with `(\\?.*)?`.  This prevents the logout mapping
+                # (`/session?delete=true` → `/session(\\?.*)?`) from overshadowing the
+                # login mapping (`/session/v1/login-request`) during replay.
                 base_path = current_url.split('?')[0] if '?' in current_url else current_url
-                mapping['request']['urlPattern'] = f"{base_path}.*"
+                mapping['request']['urlPattern'] = f"{base_path}(\\?.*)?$"
                 if url_field != 'urlPattern' and url_field in mapping['request']:
                     del mapping['request'][url_field]
                 # Remove ALL query parameters for faster matching


### PR DESCRIPTION
Performance regression detection for PRs

  Adds automated performance smoke tests that run on every PR. The CI runs performance benchmarks with recorded HTTP traffic for selected SELECT tests and compares results against recent main branch baselines from Benchstore. If a regression >5% is detected, it's re-run to confirm it's not noise.

  When a confirmed regression is found, the performance/regression status blocks the PR. To accept a performance change, add the ACCEPT_PERFORMANCE_CHANGES label — a GitHub Actions workflow immediately overrides the status to success,
  unblocking the merge gate. The label is automatically removed on the next push, so each new commit must be explicitly accepted.