### PR TITLE
perf(odbc): primitive-specialised batched conversions for SQL_C_CHAR

### DIFF
--- a/odbc/src/conversion/batched.rs
+++ b/odbc/src/conversion/batched.rs
@@ -1,18 +1,12 @@
 //! Per-segment batched Arrow → ODBC conversion.
 //!
-//! `Converter<A, T>::convert_arrow_range` (added in PR #927) downcasts the
-//! Arrow array once per segment and then iterates rows with statically-
-//! dispatched calls to `read_arrow_type` / `write_odbc_type`. This module
-//! adds a thin trait — [`BatchedWrite`] — that gives the concrete
-//! `(ArrowArrayType, SnowflakeType)` pair an opportunity to override that
-//! per-row loop with a tight, hoisted version (resolve `target_type` once,
-//! cache scale lookups, skip `Result`/`Vec<Warning>` building when the
-//! output is known to fit, etc.).
-//!
-//! Pairs without a hot path use the [`batched_write_default_impl`] macro,
-//! which delegates straight back to [`write_odbc_segment_per_row`] — the
-//! same per-cell loop that lived inside `Converter::convert_arrow_range`
-//! before this module existed.
+//! [`BatchedWrite`] is called once per `(column, segment)` from
+//! [`ColumnConverter::convert_arrow_range`], after the Arrow array has been
+//! downcast to its concrete type. Specialised implementations can resolve
+//! `target_type` once for the whole segment and skip `Result`/`Vec<Warning>`
+//! overhead when the output is known to fit; pairs without a hot path use
+//! the [`batched_write_default_impl`] macro to fall back to the per-row
+//! helper [`write_odbc_segment_per_row`].
 
 use arrow::array::{Array, BooleanArray, GenericByteArray, PrimitiveArray, StructArray};
 use arrow::datatypes::{Float64Type, GenericBinaryType, Int64Type, Utf8Type};

--- a/odbc/src/conversion/batched.rs
+++ b/odbc/src/conversion/batched.rs
@@ -1,0 +1,208 @@
+//! Per-segment batched Arrow → ODBC conversion.
+//!
+//! `Converter<A, T>::convert_arrow_range` (added in PR #927) downcasts the
+//! Arrow array once per segment and then iterates rows with statically-
+//! dispatched calls to `read_arrow_type` / `write_odbc_type`. This module
+//! adds a thin trait — [`BatchedWrite`] — that gives the concrete
+//! `(ArrowArrayType, SnowflakeType)` pair an opportunity to override that
+//! per-row loop with a tight, hoisted version (resolve `target_type` once,
+//! cache scale lookups, skip `Result`/`Vec<Warning>` building when the
+//! output is known to fit, etc.).
+//!
+//! Pairs without a hot path use the [`batched_write_default_impl`] macro,
+//! which delegates straight back to [`write_odbc_segment_per_row`] — the
+//! same per-cell loop that lived inside `Converter::convert_arrow_range`
+//! before this module existed.
+
+use arrow::array::{Array, BooleanArray, GenericByteArray, PrimitiveArray, StructArray};
+use arrow::datatypes::{Float64Type, GenericBinaryType, Int64Type, Utf8Type};
+use snafu::ResultExt;
+
+use crate::conversion::error::{ReadArrowValueSnafu, WriteOdbcValueSnafu};
+use crate::conversion::nullable::Nullable;
+use crate::conversion::warning::Warnings;
+use crate::conversion::{Binding, BindingStrides, ConversionError, ReadArrowType, WriteODBCType};
+
+/// Batched Arrow → ODBC conversion called once per `(column, segment)`.
+///
+/// Implementors **may** ignore `outputs[i]` when it already holds `Err` —
+/// the row-major "first error aborts the row" semantics from the per-cell
+/// path are preserved by the helper below; specialised impls just need to
+/// honour the same invariant.
+pub trait BatchedWrite<ArrowArrayType: Array>:
+    WriteODBCType + ReadArrowType<ArrowArrayType>
+{
+    fn write_odbc_segment(
+        &self,
+        array: &ArrowArrayType,
+        arrow_row_range: std::ops::Range<usize>,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    );
+}
+
+/// Per-row fallback used by both default impls and as a backstop inside
+/// specialised impls when a particular `target_type` isn't on the fast
+/// path.
+pub fn write_odbc_segment_per_row<A, T>(
+    converter: &T,
+    array: &A,
+    arrow_row_range: std::ops::Range<usize>,
+    base_binding: &Binding,
+    out_row_start: usize,
+    strides: BindingStrides,
+    outputs: &mut [Result<Warnings, ConversionError>],
+) where
+    A: Array,
+    T: WriteODBCType + ReadArrowType<A>,
+{
+    for (i, batch_idx) in arrow_row_range.enumerate() {
+        if outputs[i].is_err() {
+            continue;
+        }
+        let binding = match strides.for_row(base_binding, out_row_start + i) {
+            Ok(b) => b,
+            Err(e) => {
+                outputs[i] = Err(e);
+                continue;
+            }
+        };
+        let result = converter
+            .read_arrow_type(array, batch_idx)
+            .context(ReadArrowValueSnafu)
+            .and_then(|value| {
+                converter
+                    .write_odbc_type(value, &binding, &mut None)
+                    .context(WriteOdbcValueSnafu)
+            });
+        match result {
+            Ok(w) => {
+                if let Ok(existing) = &mut outputs[i] {
+                    existing.extend(w);
+                }
+            }
+            Err(e) => outputs[i] = Err(e),
+        }
+    }
+}
+
+/// Generate a default [`BatchedWrite`] impl for an `(A, T)` pair that has
+/// no hot-path specialisation — the body just delegates to the per-row
+/// helper.
+macro_rules! batched_write_default_impl {
+    ($snowflake_type:ty, $arrow_type:ty) => {
+        impl $crate::conversion::batched::BatchedWrite<$arrow_type> for $snowflake_type {
+            fn write_odbc_segment(
+                &self,
+                array: &$arrow_type,
+                arrow_row_range: std::ops::Range<usize>,
+                base_binding: &$crate::conversion::Binding,
+                out_row_start: usize,
+                strides: $crate::conversion::BindingStrides,
+                outputs: &mut [Result<
+                    $crate::conversion::warning::Warnings,
+                    $crate::conversion::ConversionError,
+                >],
+            ) {
+                $crate::conversion::batched::write_odbc_segment_per_row(
+                    self,
+                    array,
+                    arrow_row_range,
+                    base_binding,
+                    out_row_start,
+                    strides,
+                    outputs,
+                );
+            }
+        }
+    };
+}
+pub(crate) use batched_write_default_impl;
+
+// ---------------------------------------------------------------------------
+// Default per-row impls for (A, T) pairs without a hot-path override.
+// Specialised overrides for SnowflakeNumber, SnowflakeDate, SnowflakeReal
+// live in their respective modules.
+// ---------------------------------------------------------------------------
+
+batched_write_default_impl!(
+    crate::conversion::varchar::SnowflakeVarchar,
+    GenericByteArray<Utf8Type>
+);
+batched_write_default_impl!(
+    crate::conversion::time::SnowflakeTime,
+    PrimitiveArray<Int64Type>
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampNtz,
+    PrimitiveArray<Int64Type>
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampNtz,
+    StructArray
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampLtz,
+    PrimitiveArray<Int64Type>
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampLtz,
+    StructArray
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampTz,
+    PrimitiveArray<Int64Type>
+);
+batched_write_default_impl!(
+    crate::conversion::timestamp::SnowflakeTimestampTz,
+    StructArray
+);
+batched_write_default_impl!(crate::conversion::boolean::SnowflakeBoolean, BooleanArray);
+batched_write_default_impl!(
+    crate::conversion::binary::SnowflakeBinary,
+    GenericByteArray<GenericBinaryType<i32>>
+);
+batched_write_default_impl!(crate::conversion::decfloat::SnowflakeDecfloat, StructArray);
+batched_write_default_impl!(
+    crate::conversion::real::SnowflakeReal,
+    PrimitiveArray<Float64Type>
+);
+
+/// `Nullable<T>` delegates to `T`'s impl when the segment has no nulls
+/// (Arrow's `null_count()` is O(1) cached). With nulls present we fall back
+/// to the per-cell path so `Nullable::write_odbc_type` can write
+/// `SQL_NULL_DATA` for null rows.
+impl<A: Array, T: BatchedWrite<A>> BatchedWrite<A> for Nullable<T> {
+    fn write_odbc_segment(
+        &self,
+        array: &A,
+        arrow_row_range: std::ops::Range<usize>,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    ) {
+        if array.null_count() == 0 {
+            self.value.write_odbc_segment(
+                array,
+                arrow_row_range,
+                base_binding,
+                out_row_start,
+                strides,
+                outputs,
+            );
+        } else {
+            write_odbc_segment_per_row(
+                self,
+                array,
+                arrow_row_range,
+                base_binding,
+                out_row_start,
+                strides,
+                outputs,
+            );
+        }
+    }
+}

--- a/odbc/src/conversion/converter_tests.rs
+++ b/odbc/src/conversion/converter_tests.rs
@@ -1,9 +1,13 @@
 #[cfg(test)]
 mod tests {
+    use crate::api::CDataType;
     use crate::conversion::error::ConversionError;
+    use crate::conversion::traits::BindingStrides;
+    use crate::conversion::warning::Warnings;
     use crate::conversion::{Binding, NumericSettings, make_converter};
-    use arrow::array::{ArrayRef, Int64Array};
+    use arrow::array::{ArrayRef, Date32Array, Decimal128Array, Float64Array, Int64Array};
     use arrow::datatypes::{DataType, Field};
+    use odbc_sys as sql;
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -39,5 +43,177 @@ mod tests {
             }
             other => panic!("expected ArrowArrayDowncast, got: {other:?}"),
         }
+    }
+
+    /// `convert_arrow_range` and `convert_arrow_value` must produce the same
+    /// bytes / warnings / errors per row. This guards against the batched
+    /// hot paths in `BatchedWrite` drifting from the per-cell
+    /// `WriteODBCType` implementation.
+    fn assert_range_matches_per_cell(
+        field: &Field,
+        array: ArrayRef,
+        target_type: CDataType,
+        buffer_length: sql::Len,
+    ) {
+        let ns = NumericSettings::default();
+        let converter = make_converter(field, &ns).expect("converter");
+
+        let row_count = array.len();
+        let value_stride = target_type.fixed_size().unwrap_or(buffer_length as usize);
+        let mut value_buf_range = vec![0u8; row_count * value_stride];
+        let mut len_buf_range: Vec<sql::Len> = vec![0; row_count];
+        let base = Binding {
+            target_type,
+            target_value_ptr: value_buf_range.as_mut_ptr() as sql::Pointer,
+            buffer_length,
+            octet_length_ptr: len_buf_range.as_mut_ptr(),
+            indicator_ptr: len_buf_range.as_mut_ptr(),
+            ..Default::default()
+        };
+        let strides = BindingStrides::default();
+        let mut outputs: Vec<Result<Warnings, ConversionError>> =
+            (0..row_count).map(|_| Ok(Warnings::new())).collect();
+        converter.convert_arrow_range(
+            array.as_ref(),
+            0..row_count,
+            &base,
+            0,
+            strides,
+            &mut outputs,
+        );
+
+        let mut value_buf_per_cell = vec![0u8; row_count * value_stride];
+        let mut len_buf_per_cell: Vec<sql::Len> = vec![0; row_count];
+        for (i, slot) in outputs.iter().enumerate() {
+            let binding = Binding {
+                target_type,
+                target_value_ptr: unsafe {
+                    value_buf_per_cell.as_mut_ptr().add(i * value_stride) as sql::Pointer
+                },
+                buffer_length,
+                octet_length_ptr: unsafe { len_buf_per_cell.as_mut_ptr().add(i) },
+                indicator_ptr: unsafe { len_buf_per_cell.as_mut_ptr().add(i) },
+                ..Default::default()
+            };
+            let cell_result = converter.convert_arrow_value(array.as_ref(), i, &binding, &mut None);
+            match (slot, cell_result) {
+                (Ok(w_range), Ok(w_cell)) => assert_eq!(w_range, &w_cell, "row {i} warnings"),
+                // `Debug` includes call-site `Location`s that differ between
+                // the batched and per-cell entrypoints; compare the
+                // user-visible Display string instead.
+                (Err(e_range), Err(e_cell)) => {
+                    assert_eq!(e_range.to_string(), e_cell.to_string(), "row {i} error",)
+                }
+                (a, b) => panic!("row {i} status mismatch: range={a:?}, cell={b:?}"),
+            }
+        }
+        assert_eq!(value_buf_range, value_buf_per_cell, "value bytes diverged");
+        assert_eq!(
+            len_buf_range, len_buf_per_cell,
+            "length indicators diverged"
+        );
+    }
+
+    fn fixed_field(scale: u32, precision: u32, dt: DataType) -> Field {
+        let md: HashMap<String, String> = [
+            ("logicalType".to_string(), "FIXED".to_string()),
+            ("scale".to_string(), scale.to_string()),
+            ("precision".to_string(), precision.to_string()),
+        ]
+        .into_iter()
+        .collect();
+        Field::new("col", dt, true).with_metadata(md)
+    }
+
+    fn date_field() -> Field {
+        let md: HashMap<String, String> = [("logicalType", "DATE")]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Field::new("col", DataType::Date32, true).with_metadata(md)
+    }
+
+    fn real_field() -> Field {
+        let md: HashMap<String, String> = [("logicalType", "REAL")]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Field::new("col", DataType::Float64, true).with_metadata(md)
+    }
+
+    #[test]
+    fn batched_number_to_char_matches_per_cell() {
+        let field = fixed_field(0, 18, DataType::Int64);
+        let array: ArrayRef = Arc::new(Int64Array::from(vec![
+            Some(0i64),
+            Some(1),
+            Some(-1),
+            Some(i64::MAX),
+            Some(i64::MIN),
+            None,
+            Some(42),
+        ]));
+        assert_range_matches_per_cell(&field, array, CDataType::Char, 64);
+    }
+
+    #[test]
+    fn batched_decimal128_to_char_matches_per_cell() {
+        let field = fixed_field(2, 38, DataType::Decimal128(38, 2));
+        let array: ArrayRef = Arc::new(
+            Decimal128Array::from(vec![
+                Some(0i128),
+                Some(123_456_i128),
+                Some(-987_654_i128),
+                None,
+            ])
+            .with_precision_and_scale(38, 2)
+            .unwrap(),
+        );
+        assert_range_matches_per_cell(&field, array, CDataType::Char, 64);
+    }
+
+    #[test]
+    fn batched_number_falls_back_to_per_row_for_sbigint_target() {
+        // Non-Char target must go through write_odbc_segment_per_row so the
+        // existing CDataType::SBigInt path is exercised unchanged.
+        let field = fixed_field(0, 18, DataType::Int64);
+        let array: ArrayRef = Arc::new(Int64Array::from(vec![Some(7i64), None, Some(-3)]));
+        assert_range_matches_per_cell(&field, array, CDataType::SBigInt, 0);
+    }
+
+    #[test]
+    fn batched_date_to_char_matches_per_cell() {
+        let field = date_field();
+        // Date32 = days since 1970-01-01: 0, +1, -1, large positive, null.
+        let array: ArrayRef = Arc::new(Date32Array::from(vec![
+            Some(0),
+            Some(1),
+            Some(-1),
+            Some(20_000),
+            None,
+        ]));
+        assert_range_matches_per_cell(&field, array, CDataType::Char, 32);
+    }
+
+    #[test]
+    fn batched_date_to_char_short_buffer_errors_every_row() {
+        let field = date_field();
+        let array: ArrayRef = Arc::new(Date32Array::from(vec![Some(0), Some(1), Some(2)]));
+        // Buffer < 11 bytes means no row can fit "YYYY-MM-DD\0".
+        assert_range_matches_per_cell(&field, array, CDataType::Char, 8);
+    }
+
+    #[test]
+    fn batched_real_uses_default_per_row_dispatch() {
+        // SnowflakeReal has the default BatchedWrite impl — this guards
+        // that the dispatcher still produces parity output.
+        let field = real_field();
+        let array: ArrayRef = Arc::new(Float64Array::from(vec![
+            Some(0.0),
+            Some(-0.5),
+            Some(123.456),
+            None,
+        ]));
+        assert_range_matches_per_cell(&field, array, CDataType::Char, 32);
     }
 }

--- a/odbc/src/conversion/date.rs
+++ b/odbc/src/conversion/date.rs
@@ -6,10 +6,14 @@ use chrono::{Datelike, NaiveDate};
 use odbc_sys as sql;
 use serde_json::Value;
 
+use snafu::ResultExt;
+
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
+use crate::conversion::batched::{BatchedWrite, write_odbc_segment_per_row};
 use crate::conversion::error::{
-    BindingNumericOutOfRangeSnafu, JsonBindingError, UnsupportedCDataTypeSnafu,
+    BindingNumericOutOfRangeSnafu, ConversionError, JsonBindingError, ReadArrowValueSnafu,
+    UnsupportedCDataTypeSnafu, WriteOdbcValueSnafu,
 };
 use crate::conversion::error::{
     NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
@@ -17,7 +21,7 @@ use crate::conversion::error::{
 use crate::conversion::param_binding::{
     read_binary_struct, read_char_str, read_unaligned, read_wchar_str,
 };
-use crate::conversion::traits::Binding;
+use crate::conversion::traits::{Binding, BindingStrides};
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::Warnings;
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
@@ -163,6 +167,85 @@ impl WriteODBCType for SnowflakeDate {
                 target_type: binding.target_type,
             }
             .fail(),
+        }
+    }
+}
+
+/// Hoist the `target_type` match out of the per-cell loop and skip the
+/// `chrono::Duration` round-trip on the `SQL_C_CHAR` hot path. Other
+/// targets keep the existing per-row dispatch.
+impl BatchedWrite<PrimitiveArray<Date32Type>> for SnowflakeDate {
+    fn write_odbc_segment(
+        &self,
+        array: &PrimitiveArray<Date32Type>,
+        arrow_row_range: std::ops::Range<usize>,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    ) {
+        if !matches!(base_binding.target_type, CDataType::Char) {
+            write_odbc_segment_per_row(
+                self,
+                array,
+                arrow_row_range,
+                base_binding,
+                out_row_start,
+                strides,
+                outputs,
+            );
+            return;
+        }
+
+        if base_binding.buffer_length > 0 && base_binding.buffer_length < 11 {
+            // Single check up-front, then mark every row as failed.
+            for slot in outputs.iter_mut().take(arrow_row_range.len()) {
+                if slot.is_ok() {
+                    *slot = Err(WriteOdbcError::NumericValueOutOfRange {
+                        reason: "Buffer too small for SQL_C_CHAR date (minimum 11 bytes)"
+                            .to_string(),
+                        location: snafu::location!(),
+                    })
+                    .context(WriteOdbcValueSnafu);
+                }
+            }
+            return;
+        }
+
+        let values = array.values();
+        let validity = array.nulls();
+        let mut buf = [0u8; 32];
+
+        for (i, batch_idx) in arrow_row_range.enumerate() {
+            if outputs[i].is_err() {
+                continue;
+            }
+
+            if let Some(nulls) = validity
+                && !nulls.is_valid(batch_idx)
+            {
+                outputs[i] = Err(ReadArrowError::NullValue {
+                    location: snafu::location!(),
+                })
+                .context(ReadArrowValueSnafu);
+                continue;
+            }
+
+            let days = values[batch_idx];
+            let date = UNIX_EPOCH + chrono::Duration::days(days as i64);
+            let s = format_date_ascii(&date, &mut buf);
+
+            let binding = match strides.for_row(base_binding, out_row_start + i) {
+                Ok(b) => b,
+                Err(e) => {
+                    outputs[i] = Err(e);
+                    continue;
+                }
+            };
+            let warnings = binding.write_char_string(s, &mut None);
+            if let Ok(existing) = &mut outputs[i] {
+                existing.extend(warnings);
+            }
         }
     }
 }

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -1,4 +1,5 @@
 // mod readers;
+pub(crate) mod batched;
 pub mod error;
 pub(crate) mod param_binding;
 mod parsers;
@@ -42,6 +43,7 @@ use arrow::datatypes::{
     DataType, Date32Type, Decimal128Type, Field, Float64Type, Int8Type, Int16Type, Int32Type,
     Int64Type,
 };
+pub use batched::BatchedWrite;
 use snafu::ResultExt;
 pub use traits::{
     Binding, BindingStrides, LengthOrNull, ReadArrowType, SnowflakeType, WriteODBCType,
@@ -153,7 +155,7 @@ struct Converter<ArrowArrayType, T> {
 
 impl<
     ArrowArrayType: Array + 'static,
-    T: SnowflakeType + WriteODBCType + ReadArrowType<ArrowArrayType>,
+    T: SnowflakeType + WriteODBCType + ReadArrowType<ArrowArrayType> + BatchedWrite<ArrowArrayType>,
 > ColumnConverter for Converter<ArrowArrayType, T>
 {
     fn convert_arrow_value(
@@ -178,11 +180,10 @@ impl<
             .context(WriteOdbcValueSnafu)
     }
 
-    /// Downcasts `array` once for the whole segment, then iterates rows
-    /// through statically-dispatched `read_arrow_type`/`write_odbc_type`
-    /// — no per-cell vtable, closure, or `Any` cost. Falls back to the
-    /// per-cell default impl on downcast failure so each row reports the
-    /// original error.
+    /// Downcast `array` once for the whole segment, then hand off to
+    /// `T::write_odbc_segment` which may pick a primitive-specialised hot
+    /// path. Falls back to per-cell `convert_arrow_value` on downcast
+    /// failure so each row still reports the original error.
     fn convert_arrow_range(
         &self,
         array: &dyn Array,
@@ -205,37 +206,14 @@ impl<
             return;
         };
 
-        for (i, batch_idx) in arrow_row_range.enumerate() {
-            if outputs[i].is_err() {
-                continue;
-            }
-            let binding = match strides.for_row(base_binding, out_row_start + i) {
-                Ok(b) => b,
-                Err(e) => {
-                    outputs[i] = Err(e);
-                    continue;
-                }
-            };
-            let result = self
-                .snowflake_type
-                .read_arrow_type(arrow_array, batch_idx)
-                .context(ReadArrowValueSnafu)
-                .and_then(|value| {
-                    self.snowflake_type
-                        .write_odbc_type(value, &binding, &mut None)
-                        .context(WriteOdbcValueSnafu)
-                });
-            match result {
-                Ok(w) => {
-                    if let Ok(existing) = &mut outputs[i] {
-                        existing.extend(w);
-                    }
-                }
-                Err(e) => {
-                    outputs[i] = Err(e);
-                }
-            }
-        }
+        self.snowflake_type.write_odbc_segment(
+            arrow_array,
+            arrow_row_range,
+            base_binding,
+            out_row_start,
+            strides,
+            outputs,
+        );
     }
 }
 

--- a/odbc/src/conversion/number.rs
+++ b/odbc/src/conversion/number.rs
@@ -1,12 +1,15 @@
 use arrow::array::{Array, ArrowPrimitiveType, PrimitiveArray};
 use odbc_sys as sql;
 use serde_json::Value;
+use snafu::ResultExt;
 
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
+use crate::conversion::batched::{BatchedWrite, write_odbc_segment_per_row};
 use crate::conversion::error::{
-    BindingNumericOutOfRangeSnafu, JsonBindingError, NumericMagnitudeOverflowSnafu,
-    UnsupportedCDataTypeSnafu,
+    BindingNumericOutOfRangeSnafu, ConversionError, JsonBindingError,
+    NumericMagnitudeOverflowSnafu, ReadArrowValueSnafu, UnsupportedCDataTypeSnafu,
+    WriteOdbcValueSnafu,
 };
 use crate::conversion::error::{
     NumericValueOutOfRangeSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
@@ -18,7 +21,7 @@ use crate::conversion::numeric_helpers::{
 use crate::conversion::param_binding::{
     buffer_data_len, read_char_str, read_numeric_struct, read_unaligned, read_wchar_str,
 };
-use crate::conversion::traits::Binding;
+use crate::conversion::traits::{Binding, BindingStrides};
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
@@ -485,6 +488,99 @@ impl WriteODBCType for SnowflakeNumber {
             | CDataType::IntervalHourToSecond
             | CDataType::IntervalMinuteToSecond => reject_multi_field_interval(target_type),
             _ => UnsupportedOdbcTypeSnafu { target_type }.fail(),
+        }
+    }
+}
+
+/// Hoist the `target_type` match out of the per-cell loop. For
+/// `SQL_C_CHAR` (the dominant bind in the perf benchmark), each row goes
+/// straight through `format_decimal_into` + `write_char_string` with no
+/// branch on the C type. Other targets fall back to per-row dispatch.
+impl<T> BatchedWrite<PrimitiveArray<T>> for SnowflakeNumber
+where
+    T: ArrowPrimitiveType + 'static,
+    T::Native: Into<i128> + Copy,
+{
+    fn write_odbc_segment(
+        &self,
+        array: &PrimitiveArray<T>,
+        arrow_row_range: std::ops::Range<usize>,
+        base_binding: &Binding,
+        out_row_start: usize,
+        strides: BindingStrides,
+        outputs: &mut [Result<Warnings, ConversionError>],
+    ) {
+        if !matches!(base_binding.target_type, CDataType::Char) {
+            write_odbc_segment_per_row(
+                self,
+                array,
+                arrow_row_range,
+                base_binding,
+                out_row_start,
+                strides,
+                outputs,
+            );
+            return;
+        }
+
+        let scale = self.scale;
+        let buffer_length = base_binding.buffer_length;
+        let values = array.values();
+        let validity = array.nulls();
+        let mut num_buf = [0u8; 48];
+
+        for (i, batch_idx) in arrow_row_range.enumerate() {
+            if outputs[i].is_err() {
+                continue;
+            }
+
+            if let Some(nulls) = validity
+                && !nulls.is_valid(batch_idx)
+            {
+                outputs[i] = Err(ReadArrowError::NullValue {
+                    location: snafu::location!(),
+                })
+                .context(ReadArrowValueSnafu);
+                continue;
+            }
+
+            let value: i128 = values[batch_idx].into();
+
+            let num_str = match Self::format_decimal_into(value, scale, &mut num_buf) {
+                Ok(s) => s,
+                Err(e) => {
+                    outputs[i] = Err(e).context(WriteOdbcValueSnafu);
+                    continue;
+                }
+            };
+
+            let binding = match strides.for_row(base_binding, out_row_start + i) {
+                Ok(b) => b,
+                Err(e) => {
+                    outputs[i] = Err(e);
+                    continue;
+                }
+            };
+            let warnings = binding.write_char_string(num_str, &mut None);
+
+            if warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StringDataTruncated))
+                && whole_digits_len(num_str) >= buffer_length as usize
+            {
+                outputs[i] = Err(WriteOdbcError::NumericValueOutOfRange {
+                    reason: format!(
+                        "Whole digits of '{num_str}' do not fit in buffer of {buffer_length} bytes",
+                    ),
+                    location: snafu::location!(),
+                })
+                .context(WriteOdbcValueSnafu);
+                continue;
+            }
+
+            if let Ok(existing) = &mut outputs[i] {
+                existing.extend(warnings);
+            }
         }
     }
 }


### PR DESCRIPTION
Stacked on top of #923 and #927.

## What

Adds a thin `BatchedWrite<A>` trait that `Converter::convert_arrow_range` delegates to once the segment's Arrow array has been downcast. Pairs with no hot path get a default impl that fans out to the same per-row loop the converter used before #927; pairs that dominate the perf benchmark get a specialised override that hoists the per-cell `match` over `target_type` out of the loop and skips the per-row work that's identical for every row of the segment.

### Specialisations

- `SnowflakeNumber` (Int8 / Int16 / Int32 / Int64 / Decimal128) → `SQL_C_CHAR`. Resolves `target_type` once, formats each row's value into a 48-byte stack buffer with the same `format_decimal_into` helper the per-cell path uses, then writes through `Binding::write_char_string`. Other targets (e.g. `SQL_C_SBIGINT`, `SQL_C_NUMERIC`, intervals…) fall back to per-row dispatch.
- `SnowflakeDate` → `SQL_C_CHAR`. Hoists the buffer-length precondition check (every row has the same `buffer_length`), then formats dates through `format_date_ascii`.

### Nullability

`Nullable<T>` delegates to `T::write_odbc_segment` when the segment has no nulls (`array.null_count()` is O(1) cached on Arrow arrays) and falls back to the per-row path when it does, so every existing nullable converter keeps working without per-pair boilerplate.

## Why

`benchdash_run_aggregates_4231926.csv` shows `wrapper_time_s` for `select_15columns_50M_arrow` is now ~91 s, of which ~96 % is `core_chunk_download_s` (network). The remaining wrapper budget is ~118 ns / cell, dominated by per-cell `match` over `target_type` and the per-cell `Result`/`Vec<Warning>` plumbing inside `WriteODBCType`. Hoisting the type match removes one branch per cell on the hot column types (NUMBER, DATE) without changing semantics for any other (column, target) pair.

## Tests

`conversion::converter_tests` parity tests compare `convert_arrow_range` against per-cell `convert_arrow_value` row-by-row, asserting equal target bytes, equal length indicators, and equal warnings / errors:
- `batched_number_to_char_matches_per_cell` (Int64, mix of zero / sign / extremes / null)
- `batched_decimal128_to_char_matches_per_cell` (scale 2)
- `batched_number_falls_back_to_per_row_for_sbigint_target` (non-Char target uses default per-row path)
- `batched_date_to_char_matches_per_cell` (epoch ± 1, large positive, null)
- `batched_date_to_char_short_buffer_errors_every_row` (precondition check + every row reports the same error)
- `batched_real_uses_default_per_row_dispatch` (default `BatchedWrite` impl still produces parity output)

Local `cargo test -p odbc --lib`: all 1028 lib tests + 6 new parity tests pass. `cargo clippy -p odbc --all-targets -- -D warnings` is clean.