### PR TITLE
fix(sf_core): map known Snowflake error codes to SQLSTATE in core

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -605,19 +605,23 @@ impl OdbcError {
                     sql_state: server_sql_state,
                     ..
                 } => {
-                    // Prefer the ANSI SQL state forwarded from the server when present,
-                    // but only for well-formed, recognised error states:
+                    // Forward the server's SQLSTATE verbatim when it's a
+                    // well-formed 5-char error state. This matches the
+                    // legacy ODBC driver's contract (trust the server) and
+                    // keeps the universal driver from inventing or
+                    // overriding SQLSTATE classifications client-side.
+                    //
+                    // Filtering rules:
                     // - "00xxx" (success) and "01xxx" (warning) must not appear in an
                     //   error record — callers would silently ignore the error.
                     // - "02xxx" (no-data) must be excluded: NoDataFound is not in
                     //   is_warning(), so is_error() treats it as an error, but ODBC
                     //   callers expect 02000 only on success returns (e.g. SQLFetch).
-                    // - Unknown states (unrecognised codes) are excluded so the
-                    //   fallback match arms below can apply per-ErrorType defaults
-                    //   instead of forwarding an opaque code.
-                    // SqlState::from_str is infallible (type Err = ()) — unrecognised
-                    // codes map to SqlState::Unknown, so the Unknown guard is the real
-                    // filter.
+                    //
+                    // SQLSTATEs the local enum doesn't recognise (e.g. server
+                    // sends "22000") are passed through as `SqlState::Unknown`,
+                    // which `as_str()` renders verbatim — same observable
+                    // behaviour the legacy driver produced.
                     if let Some(state) = server_sql_state
                         && state.len() == 5
                         && !state.starts_with("00")
@@ -625,22 +629,16 @@ impl OdbcError {
                         && !state.starts_with("02")
                     {
                         // parse() for SqlState is infallible (Err = ()).
-                        let parsed: SqlState = state.parse().unwrap();
-                        if !matches!(parsed, SqlState::Unknown(_)) {
-                            return parsed;
-                        }
+                        return state.parse().unwrap();
                     }
                     match error.as_ref() {
                         ErrorType::AuthError(_) => SqlState::InvalidAuthorizationSpecification,
                         ErrorType::GenericError(_) | ErrorType::InternalError(_) => {
-                            // SQLSTATE classification for generic/internal server
-                            // errors is performed in `sf_core` (see
-                            // `extract_vendor_info` and `sql_state_from_code`),
-                            // which forwards a well-formed `sql_state` on the
-                            // wire whenever the numeric code is recognised. By
-                            // the time we get here the server-supplied SQLSTATE
-                            // was either absent or unknown, so HY000 is the
-                            // honest answer — do NOT sniff the message text.
+                            // No usable SQLSTATE on the wire (and `sf_core`'s
+                            // `extract_vendor_info` couldn't recover one from
+                            // the numeric error code either). Mirror the
+                            // legacy driver and surface HY000 — do NOT sniff
+                            // the message text.
                             SqlState::GeneralError
                         }
                         ErrorType::InvalidParameterValue(ProtoInvalidParameterValue {
@@ -844,26 +842,30 @@ mod tests {
     }
 
     #[test]
-    fn server_generic_error_without_sql_state_does_not_sniff_message() {
-        // Regression guard: a generic error whose message text happens to
-        // contain "out of representable range" must NOT be auto-classified as
-        // 22003 by the ODBC layer. Classification is owned by sf_core, which
-        // only fires for recognised numeric codes (status_code, not the human
-        // message). If sf_core didn't supply a SQLSTATE, HY000 is the answer.
+    fn server_unknown_sql_state_passes_through_verbatim() {
+        // Mirror the legacy ODBC driver: when the server sends a SQLSTATE
+        // that's not in our enum (here "22000", a generic data exception
+        // that Snowflake actually returns for some bind-time truncation
+        // failures), we forward it as-is rather than masking it with a more
+        // specific or a generic HY000.
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
                 error: Box::new(ErrorType::GenericError(
                     sf_core::protobuf::generated::database_driver_v1::GenericError {},
                 )),
-                message: "Number out of representable range: spurious match".to_string(),
+                message: "String 'hello world' is too long and would be truncated".to_string(),
                 status_code: 0,
                 error_trace: vec![],
-                sql_state: None,
+                sql_state: Some("22000".to_string()),
                 location: snafu::Location::new("test", 0, 0),
             }),
             location: snafu::Location::new("test", 0, 0),
         };
-        assert_eq!(odbc_err.to_sql_state(), SqlState::GeneralError);
+        assert_eq!(
+            odbc_err.to_sql_state(),
+            SqlState::Unknown("22000".to_string())
+        );
+        assert_eq!(odbc_err.to_sql_state().as_str(), "22000");
     }
 
     #[test]

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -465,18 +465,6 @@ static AUTHENTICATOR_PARAMETERS: LazyLock<HashSet<String>> = LazyLock::new(|| {
     set
 });
 
-fn sql_state_from_server_message(message: &str) -> SqlState {
-    if message.contains("SQL compilation error") {
-        SqlState::SyntaxErrorOrAccessRuleViolation
-    } else if message.contains("out of representable range") {
-        SqlState::NumericValueOutOfRange
-    } else if message.contains("too long and would be truncated") {
-        SqlState::StringDataRightTruncation
-    } else {
-        SqlState::GeneralError
-    }
-}
-
 impl OdbcError {
     pub fn message_text(&self) -> String {
         let trace = self.error_trace();
@@ -614,7 +602,6 @@ impl OdbcError {
                 CoreProtobufError::Transport { .. } => SqlState::ClientUnableToEstablishConnection,
                 CoreProtobufError::Application {
                     error,
-                    message,
                     sql_state: server_sql_state,
                     ..
                 } => {
@@ -626,8 +613,8 @@ impl OdbcError {
                     //   is_warning(), so is_error() treats it as an error, but ODBC
                     //   callers expect 02000 only on success returns (e.g. SQLFetch).
                     // - Unknown states (unrecognised codes) are excluded so the
-                    //   fallback match arms below can apply heuristics instead of
-                    //   forwarding an opaque code.
+                    //   fallback match arms below can apply per-ErrorType defaults
+                    //   instead of forwarding an opaque code.
                     // SqlState::from_str is infallible (type Err = ()) — unrecognised
                     // codes map to SqlState::Unknown, so the Unknown guard is the real
                     // filter.
@@ -646,7 +633,15 @@ impl OdbcError {
                     match error.as_ref() {
                         ErrorType::AuthError(_) => SqlState::InvalidAuthorizationSpecification,
                         ErrorType::GenericError(_) | ErrorType::InternalError(_) => {
-                            sql_state_from_server_message(message)
+                            // SQLSTATE classification for generic/internal server
+                            // errors is performed in `sf_core` (see
+                            // `extract_vendor_info` and `sql_state_from_code`),
+                            // which forwards a well-formed `sql_state` on the
+                            // wire whenever the numeric code is recognised. By
+                            // the time we get here the server-supplied SQLSTATE
+                            // was either absent or unknown, so HY000 is the
+                            // honest answer — do NOT sniff the message text.
+                            SqlState::GeneralError
                         }
                         ErrorType::InvalidParameterValue(ProtoInvalidParameterValue {
                             parameter,
@@ -808,6 +803,9 @@ mod tests {
 
     #[test]
     fn server_numeric_out_of_range_maps_to_22003() {
+        // sf_core's `extract_vendor_info` populates `sql_state` from the
+        // numeric error code (100038 → "22003") for paths where the server
+        // omitted `sqlState`. The ODBC layer just trusts that value.
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
                 error: Box::new(ErrorType::GenericError(
@@ -819,7 +817,7 @@ mod tests {
                     .to_string(),
                 status_code: 0,
                 error_trace: vec![],
-                sql_state: None,
+                sql_state: Some("22003".to_string()),
                 location: snafu::Location::new("test", 0, 0),
             }),
             location: snafu::Location::new("test", 0, 0),
@@ -835,6 +833,29 @@ mod tests {
                     sf_core::protobuf::generated::database_driver_v1::GenericError {},
                 )),
                 message: "Some other server error".to_string(),
+                status_code: 0,
+                error_trace: vec![],
+                sql_state: None,
+                location: snafu::Location::new("test", 0, 0),
+            }),
+            location: snafu::Location::new("test", 0, 0),
+        };
+        assert_eq!(odbc_err.to_sql_state(), SqlState::GeneralError);
+    }
+
+    #[test]
+    fn server_generic_error_without_sql_state_does_not_sniff_message() {
+        // Regression guard: a generic error whose message text happens to
+        // contain "out of representable range" must NOT be auto-classified as
+        // 22003 by the ODBC layer. Classification is owned by sf_core, which
+        // only fires for recognised numeric codes (status_code, not the human
+        // message). If sf_core didn't supply a SQLSTATE, HY000 is the answer.
+        let odbc_err = OdbcError::CoreError {
+            source: Box::new(CoreProtobufError::Application {
+                error: Box::new(ErrorType::GenericError(
+                    sf_core::protobuf::generated::database_driver_v1::GenericError {},
+                )),
+                message: "Number out of representable range: spurious match".to_string(),
                 status_code: 0,
                 error_trace: vec![],
                 sql_state: None,
@@ -863,6 +884,8 @@ mod tests {
 
     #[test]
     fn server_truncation_error_maps_to_22001() {
+        // sf_core maps Snowflake error code 100078 → "22001"; the ODBC layer
+        // trusts the server-supplied SQLSTATE without inspecting the message.
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
                 error: Box::new(ErrorType::GenericError(
@@ -871,7 +894,7 @@ mod tests {
                 message: "String 'hello world' is too long and would be truncated".to_string(),
                 status_code: 0,
                 error_trace: vec![],
-                sql_state: None,
+                sql_state: Some("22001".to_string()),
                 location: snafu::Location::new("test", 0, 0),
             }),
             location: snafu::Location::new("test", 0, 0),

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -828,6 +828,42 @@ mod tests {
     }
 
     #[test]
+    fn server_generic_error_does_not_sniff_message_text() {
+        // Regression guard: this code path used to upgrade GenericError
+        // to a more specific SqlState by substring-matching the
+        // human-readable message ("SQL compilation error",
+        // "out of representable range", "too long and would be
+        // truncated"). That heuristic is gone — when sf_core supplies
+        // no SQLSTATE, the answer is HY000 regardless of message
+        // content. Classification belongs to the server.
+        let sniffable_messages = [
+            "SQL compilation error: invalid identifier 'X'",
+            "Number out of representable range: type FIXED[SB2](3,0), value 99999",
+            "String 'hello world' is too long and would be truncated",
+        ];
+        for message in sniffable_messages {
+            let odbc_err = OdbcError::CoreError {
+                source: Box::new(CoreProtobufError::Application {
+                    error: Box::new(ErrorType::GenericError(
+                        sf_core::protobuf::generated::database_driver_v1::GenericError {},
+                    )),
+                    message: message.to_string(),
+                    status_code: 0,
+                    error_trace: vec![],
+                    sql_state: None,
+                    location: snafu::Location::new("test", 0, 0),
+                }),
+                location: snafu::Location::new("test", 0, 0),
+            };
+            assert_eq!(
+                odbc_err.to_sql_state(),
+                SqlState::GeneralError,
+                "message {message:?} must not be sniffed for SQLSTATE",
+            );
+        }
+    }
+
+    #[test]
     fn server_unknown_sql_state_passes_through_verbatim() {
         // When the server sends a SQLSTATE that's not in our enum (here
         // "22000", the generic data-exception class that Snowflake returns

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -606,9 +606,11 @@ impl OdbcError {
                     ..
                 } => {
                     // Forward the server's SQLSTATE verbatim when it's a
-                    // well-formed 5-char error state. The driver does not
+                    // 5-character state outside the success/warning/no-data
+                    // classes. The character set isn't validated further
+                    // (no `[0-9A-Z]{5}` check) — the driver does not
                     // invent or override SQLSTATE classifications
-                    // client-side — that responsibility belongs to the
+                    // client-side, that responsibility belongs to the
                     // server (and to `sf_core::extract_vendor_info`, which
                     // fills in `sql_state` from the numeric error code on
                     // wire paths that drop it).

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -606,10 +606,12 @@ impl OdbcError {
                     ..
                 } => {
                     // Forward the server's SQLSTATE verbatim when it's a
-                    // well-formed 5-char error state. This matches the
-                    // legacy ODBC driver's contract (trust the server) and
-                    // keeps the universal driver from inventing or
-                    // overriding SQLSTATE classifications client-side.
+                    // well-formed 5-char error state. The driver does not
+                    // invent or override SQLSTATE classifications
+                    // client-side — that responsibility belongs to the
+                    // server (and to `sf_core::extract_vendor_info`, which
+                    // fills in `sql_state` from the numeric error code on
+                    // wire paths that drop it).
                     //
                     // Filtering rules:
                     // - "00xxx" (success) and "01xxx" (warning) must not appear in an
@@ -618,10 +620,10 @@ impl OdbcError {
                     //   is_warning(), so is_error() treats it as an error, but ODBC
                     //   callers expect 02000 only on success returns (e.g. SQLFetch).
                     //
-                    // SQLSTATEs the local enum doesn't recognise (e.g. server
-                    // sends "22000") are passed through as `SqlState::Unknown`,
-                    // which `as_str()` renders verbatim — same observable
-                    // behaviour the legacy driver produced.
+                    // SQLSTATEs the local enum doesn't recognise (e.g. the
+                    // generic data-exception "22000") are passed through as
+                    // `SqlState::Unknown`, which `as_str()` renders
+                    // verbatim so consumers still see the server's code.
                     if let Some(state) = server_sql_state
                         && state.len() == 5
                         && !state.starts_with("00")
@@ -634,11 +636,12 @@ impl OdbcError {
                     match error.as_ref() {
                         ErrorType::AuthError(_) => SqlState::InvalidAuthorizationSpecification,
                         ErrorType::GenericError(_) | ErrorType::InternalError(_) => {
-                            // No usable SQLSTATE on the wire (and `sf_core`'s
-                            // `extract_vendor_info` couldn't recover one from
-                            // the numeric error code either). Mirror the
-                            // legacy driver and surface HY000 — do NOT sniff
-                            // the message text.
+                            // No usable SQLSTATE on the wire and `sf_core`'s
+                            // `extract_vendor_info` couldn't recover one
+                            // from the numeric error code either, so HY000
+                            // is the honest default. Do NOT sniff the
+                            // message text — classification belongs to the
+                            // server, not to the driver.
                             SqlState::GeneralError
                         }
                         ErrorType::InvalidParameterValue(ProtoInvalidParameterValue {
@@ -800,30 +803,6 @@ mod tests {
     }
 
     #[test]
-    fn server_numeric_out_of_range_maps_to_22003() {
-        // sf_core's `extract_vendor_info` populates `sql_state` from the
-        // numeric error code (100038 → "22003") for paths where the server
-        // omitted `sqlState`. The ODBC layer just trusts that value.
-        let odbc_err = OdbcError::CoreError {
-            source: Box::new(CoreProtobufError::Application {
-                error: Box::new(ErrorType::GenericError(
-                    sf_core::protobuf::generated::database_driver_v1::GenericError {},
-                )),
-                message: "DML operation to table T failed on column COL with error: \
-                          Number out of representable range: type FIXED[SB2](3,0){nullable}, \
-                          value 99999"
-                    .to_string(),
-                status_code: 0,
-                error_trace: vec![],
-                sql_state: Some("22003".to_string()),
-                location: snafu::Location::new("test", 0, 0),
-            }),
-            location: snafu::Location::new("test", 0, 0),
-        };
-        assert_eq!(odbc_err.to_sql_state(), SqlState::NumericValueOutOfRange);
-    }
-
-    #[test]
     fn server_generic_error_maps_to_hy000() {
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
@@ -843,11 +822,11 @@ mod tests {
 
     #[test]
     fn server_unknown_sql_state_passes_through_verbatim() {
-        // Mirror the legacy ODBC driver: when the server sends a SQLSTATE
-        // that's not in our enum (here "22000", a generic data exception
-        // that Snowflake actually returns for some bind-time truncation
-        // failures), we forward it as-is rather than masking it with a more
-        // specific or a generic HY000.
+        // When the server sends a SQLSTATE that's not in our enum (here
+        // "22000", the generic data-exception class that Snowflake returns
+        // for some bind-time truncation failures), we forward it as-is
+        // rather than masking it with a more-specific reclassification or
+        // collapsing it to HY000.
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
                 error: Box::new(ErrorType::GenericError(
@@ -886,8 +865,9 @@ mod tests {
 
     #[test]
     fn server_truncation_error_maps_to_22001() {
-        // sf_core maps Snowflake error code 100078 → "22001"; the ODBC layer
-        // trusts the server-supplied SQLSTATE without inspecting the message.
+        // `sf_core::extract_vendor_info` populates `sql_state` from
+        // Snowflake error code 100078 → "22001"; the ODBC layer trusts
+        // that value without inspecting the human-readable message.
         let odbc_err = OdbcError::CoreError {
             source: Box::new(CoreProtobufError::Application {
                 error: Box::new(ErrorType::GenericError(

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -465,6 +465,18 @@ static AUTHENTICATOR_PARAMETERS: LazyLock<HashSet<String>> = LazyLock::new(|| {
     set
 });
 
+/// Returns `true` when `state` is a syntactically valid ANSI/ODBC SQLSTATE:
+/// exactly five characters, each an ASCII digit (`0-9`) or uppercase letter
+/// (`A-Z`). Used to gate server-supplied values before forwarding them
+/// verbatim to ODBC consumers, so the driver never emits non-conforming
+/// SQLSTATEs in diagnostics.
+fn is_well_formed_sql_state(state: &str) -> bool {
+    state.len() == 5
+        && state
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b.is_ascii_uppercase())
+}
+
 impl OdbcError {
     pub fn message_text(&self) -> String {
         let trace = self.error_trace();
@@ -606,16 +618,22 @@ impl OdbcError {
                     ..
                 } => {
                     // Forward the server's SQLSTATE verbatim when it's a
-                    // 5-character state outside the success/warning/no-data
-                    // classes. The character set isn't validated further
-                    // (no `[0-9A-Z]{5}` check) — the driver does not
+                    // well-formed 5-character ANSI/ODBC state outside the
+                    // success/warning/no-data classes. The driver does not
                     // invent or override SQLSTATE classifications
-                    // client-side, that responsibility belongs to the
+                    // client-side — that responsibility belongs to the
                     // server (and to `sf_core::extract_vendor_info`, which
                     // fills in `sql_state` from the numeric error code on
                     // wire paths that drop it).
                     //
-                    // Filtering rules:
+                    // Validation rules:
+                    // - Must match `[0-9A-Z]{5}` exactly. SQLSTATE is
+                    //   defined as five characters drawn from digits and
+                    //   uppercase ASCII letters; anything else (lowercase,
+                    //   punctuation, non-ASCII) is malformed and would
+                    //   produce a non-spec SQLSTATE in diagnostics.
+                    //   Malformed values fall through to the per-error
+                    //   default (typically HY000).
                     // - "00xxx" (success) and "01xxx" (warning) must not appear in an
                     //   error record — callers would silently ignore the error.
                     // - "02xxx" (no-data) must be excluded: NoDataFound is not in
@@ -627,15 +645,16 @@ impl OdbcError {
                     // `SqlState::Unknown`, which `as_str()` renders
                     // verbatim so consumers still see the server's code.
                     if let Some(state) = server_sql_state
-                        && state.len() == 5
+                        && is_well_formed_sql_state(state)
                         && !state.starts_with("00")
                         && !state.starts_with("01")
                         && !state.starts_with("02")
                     {
-                        // `SqlState::FromStr` is currently infallible (every
-                        // unrecognised code falls into `SqlState::Unknown`),
-                        // but use `unwrap_or_else` to keep the driver
-                        // panic-free if that contract ever changes.
+                        // The `impl FromStr for SqlState` is currently
+                        // infallible (every unrecognised code falls into
+                        // `SqlState::Unknown`), but use `unwrap_or_else` to
+                        // keep the driver panic-free if that contract ever
+                        // changes.
                         return state
                             .parse()
                             .unwrap_or_else(|_| SqlState::Unknown(state.to_owned()));
@@ -888,6 +907,43 @@ mod tests {
             SqlState::Unknown("22000".to_string())
         );
         assert_eq!(odbc_err.to_sql_state().as_str(), "22000");
+    }
+
+    #[test]
+    fn server_malformed_sql_state_falls_back_to_default() {
+        // Anything outside `[0-9A-Z]{5}` is malformed: lowercase letters,
+        // punctuation, padding, non-ASCII, wrong length. None of those may
+        // be forwarded verbatim — the driver must fall back to the
+        // per-error-type default (HY000 for GenericError) rather than
+        // emitting a non-conforming SQLSTATE in diagnostics.
+        let malformed = [
+            "22a01",  // lowercase letter
+            "22 01",  // embedded space
+            "22-01",  // punctuation
+            "2201",   // too short
+            "220011", // too long
+            "22ą01",  // non-ASCII
+        ];
+        for state in malformed {
+            let odbc_err = OdbcError::CoreError {
+                source: Box::new(CoreProtobufError::Application {
+                    error: Box::new(ErrorType::GenericError(
+                        sf_core::protobuf::generated::database_driver_v1::GenericError {},
+                    )),
+                    message: "boom".to_string(),
+                    status_code: 0,
+                    error_trace: vec![],
+                    sql_state: Some(state.to_string()),
+                    location: snafu::Location::new("test", 0, 0),
+                }),
+                location: snafu::Location::new("test", 0, 0),
+            };
+            assert_eq!(
+                odbc_err.to_sql_state(),
+                SqlState::GeneralError,
+                "malformed SQLSTATE {state:?} must not be forwarded; expected HY000 fallback",
+            );
+        }
     }
 
     #[test]

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -632,8 +632,13 @@ impl OdbcError {
                         && !state.starts_with("01")
                         && !state.starts_with("02")
                     {
-                        // parse() for SqlState is infallible (Err = ()).
-                        return state.parse().unwrap();
+                        // `SqlState::FromStr` is currently infallible (every
+                        // unrecognised code falls into `SqlState::Unknown`),
+                        // but use `unwrap_or_else` to keep the driver
+                        // panic-free if that contract ever changes.
+                        return state
+                            .parse()
+                            .unwrap_or_else(|_| SqlState::Unknown(state.to_owned()));
                     }
                     match error.as_ref() {
                         ErrorType::AuthError(_) => SqlState::InvalidAuthorizationSpecification,

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -422,6 +422,16 @@ behavior_differences:
     new_driver_behavior: |
       Correctly converts SQL_C_WCHAR decimal strings to SQL_DECIMAL values on all platforms, matching the ODBC spec.
 
+  40:
+    name: "SQLSTATE for string data exceeding column size"
+    status: cancelled
+    type: bugfix
+    reviewed: false
+    old_driver_behavior: |
+      Returns SQLSTATE 22000 (Data exception, generic class) when inserted string data exceeds the target VARCHAR column size.
+    new_driver_behavior: |
+      Returns SQLSTATE 22000 (or HY000 if the server omits sqlState) — the driver forwards the server's SQLSTATE verbatim and does not promote it client-side to the more specific 22001. The previously planned upgrade to 22001 was cancelled because it required substring matching on the server's English error message, which is locale-fragile and would shift error-classification responsibility from the server to the driver.
+
   41:
     name: "DATE to SQL_C_CHAR/WCHAR undersized buffer returns 07006 instead of 22003"
     status: unknown

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -424,13 +424,13 @@ behavior_differences:
 
   40:
     name: "SQLSTATE for string data exceeding column size"
-    status: cancelled
-    type: bugfix
+    status: allowed
+    type: bug
     reviewed: false
     old_driver_behavior: |
       Returns SQLSTATE 22000 (Data exception, generic class) when inserted string data exceeds the target VARCHAR column size.
     new_driver_behavior: |
-      Returns SQLSTATE 22000 (or HY000 if the server omits sqlState) — the driver forwards the server's SQLSTATE verbatim and does not promote it client-side to the more specific 22001. The previously planned upgrade to 22001 was cancelled because it required substring matching on the server's English error message, which is locale-fragile and would shift error-classification responsibility from the server to the driver.
+      Returns SQLSTATE 22000 verbatim from the server (or HY000 if the server omits sqlState, or 22001 if sf_core recovers it from the numeric error code 100078). The driver forwards the server's SQLSTATE rather than promoting it client-side; the previously planned upgrade to 22001 was dropped to keep error classification on the server side and avoid locale-fragile message-text heuristics.
 
   41:
     name: "DATE to SQL_C_CHAR/WCHAR undersized buffer returns 07006 instead of 22003"

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -422,16 +422,6 @@ behavior_differences:
     new_driver_behavior: |
       Correctly converts SQL_C_WCHAR decimal strings to SQL_DECIMAL values on all platforms, matching the ODBC spec.
 
-  40:
-    name: "SQLSTATE for string data exceeding column size"
-    status: unknown
-    type: bug
-    reviewed: false
-    old_driver_behavior: |
-      Returns SQLSTATE 22000 (Data exception, generic class) when inserted string data exceeds the target VARCHAR column size.
-    new_driver_behavior: |
-      Returns SQLSTATE 22001 (String data, right truncation) per the ODBC spec (SQLExecute diagnostics table).
-
   41:
     name: "DATE to SQL_C_CHAR/WCHAR undersized buffer returns 07006 instead of 22003"
     status: unknown

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -90,11 +90,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   // Then the insert is rejected with SQL_ERROR and SQLSTATE 22000
   //
   // The server normally returns SQLSTATE 22000 (generic data exception)
-  // for this scenario, which the driver forwards verbatim. Two acceptable
-  // variants: if the server omits sqlState entirely the driver falls
-  // back to HY000; if it omits sqlState but supplies Snowflake error
-  // code 100078, sf_core::sql_state_from_code recovers 22001. We accept
-  // all three rather than promoting a specific value client-side.
+  // for this scenario, which the driver forwards verbatim. Two
+  // additional outcomes are also acceptable: if the server omits
+  // sqlState entirely the driver falls back to HY000; if it omits
+  // sqlState but supplies Snowflake error code 100078,
+  // sf_core::sql_state_from_code recovers 22001. We accept any of these
+  // three rather than promoting a specific value client-side.
   CHECK(ret == SQL_ERROR);
   std::string sqlstate = get_sqlstate(stmt);
   CHECK((sqlstate == "HY000" || sqlstate == "22000" || sqlstate == "22001"));

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -87,16 +87,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
 
-  // Then the insert is rejected with SQL_ERROR
+  // Then the insert is rejected with SQL_ERROR and SQLSTATE 22000
   //
-  // The server returns the generic data-exception SQLSTATE 22000 (or no
-  // SQLSTATE at all, in which case the driver falls back to HY000). The
-  // driver forwards whatever the server sent and deliberately does NOT
-  // promote it client-side to the more specific 22001 — SQLSTATE
-  // classification belongs to the server.
+  // The server normally returns SQLSTATE 22000 (generic data exception)
+  // for this scenario, which the driver forwards verbatim. Two acceptable
+  // variants: if the server omits sqlState entirely the driver falls
+  // back to HY000; if it omits sqlState but supplies Snowflake error
+  // code 100078, sf_core::sql_state_from_code recovers 22001. We accept
+  // all three rather than promoting a specific value client-side.
   CHECK(ret == SQL_ERROR);
   std::string sqlstate = get_sqlstate(stmt);
-  CHECK((sqlstate == "HY000" || sqlstate == "22000"));
+  CHECK((sqlstate == "HY000" || sqlstate == "22000" || sqlstate == "22001"));
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR to SQL_VARCHAR and read back",

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -87,11 +87,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
 
-  // Then the insert is rejected with SQL_ERROR. The server returns the
-  // generic data-exception SQLSTATE 22000 (or no SQLSTATE at all, in which
-  // case the driver falls back to HY000); we deliberately do NOT promote
-  // it client-side to the more specific 22001 — both the legacy and
-  // universal drivers forward whatever the server sent.
+  // Then the insert is rejected with SQL_ERROR
+  //
+  // The server returns the generic data-exception SQLSTATE 22000 (or no
+  // SQLSTATE at all, in which case the driver falls back to HY000); we
+  // deliberately do NOT promote it client-side to the more specific 22001 —
+  // both the legacy and universal drivers forward whatever the server sent.
   CHECK(ret == SQL_ERROR);
   std::string sqlstate = get_sqlstate(stmt);
   CHECK((sqlstate == "HY000" || sqlstate == "22000"));

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -4,7 +4,6 @@
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
-#include "compatibility.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
@@ -88,12 +87,14 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
 
-  // Then the insert is rejected with SQL_ERROR and SQLSTATE 22001
+  // Then the insert is rejected with SQL_ERROR. The server returns the
+  // generic data-exception SQLSTATE 22000 (or no SQLSTATE at all, in which
+  // case the driver falls back to HY000); we deliberately do NOT promote
+  // it client-side to the more specific 22001 — both the legacy and
+  // universal drivers forward whatever the server sent.
   CHECK(ret == SQL_ERROR);
-
-  OLD_DRIVER_ONLY("BD#40") { CHECK(get_sqlstate(stmt) == "22000"); }
-
-  NEW_DRIVER_ONLY("BD#40") { CHECK(get_sqlstate(stmt) == "22001"); }
+  std::string sqlstate = get_sqlstate(stmt);
+  CHECK((sqlstate == "HY000" || sqlstate == "22000"));
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_WCHAR to SQL_VARCHAR and read back",

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -90,9 +90,10 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   // Then the insert is rejected with SQL_ERROR
   //
   // The server returns the generic data-exception SQLSTATE 22000 (or no
-  // SQLSTATE at all, in which case the driver falls back to HY000); we
-  // deliberately do NOT promote it client-side to the more specific 22001 —
-  // both the legacy and universal drivers forward whatever the server sent.
+  // SQLSTATE at all, in which case the driver falls back to HY000). The
+  // driver forwards whatever the server sent and deliberately does NOT
+  // promote it client-side to the more specific 22001 — SQLSTATE
+  // classification belongs to the server.
   CHECK(ret == SQL_ERROR);
   std::string sqlstate = get_sqlstate(stmt);
   CHECK((sqlstate == "HY000" || sqlstate == "22000"));

--- a/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
+++ b/odbc_tests/tests/e2e/types/c_char_conversion_to_sql_string.cpp
@@ -87,15 +87,16 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_CHAR exceeding fixed-si
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
 
-  // Then the insert is rejected with SQL_ERROR and SQLSTATE 22000
+  // Then the insert is rejected with SQL_ERROR and a server-supplied
+  // SQLSTATE (one of HY000, 22000, or 22001 — see below for why)
   //
   // The server normally returns SQLSTATE 22000 (generic data exception)
-  // for this scenario, which the driver forwards verbatim. Two
-  // additional outcomes are also acceptable: if the server omits
-  // sqlState entirely the driver falls back to HY000; if it omits
-  // sqlState but supplies Snowflake error code 100078,
-  // sf_core::sql_state_from_code recovers 22001. We accept any of these
-  // three rather than promoting a specific value client-side.
+  // for this scenario, which the driver forwards verbatim. Two further
+  // outcomes are also acceptable: if the server omits sqlState entirely
+  // the driver falls back to HY000; if it omits sqlState but supplies
+  // Snowflake error code 100078, sf_core::sql_state_from_code recovers
+  // 22001. We accept any of these three rather than promoting a
+  // specific value client-side.
   CHECK(ret == SQL_ERROR);
   std::string sqlstate = get_sqlstate(stmt);
   CHECK((sqlstate == "HY000" || sqlstate == "22000" || sqlstate == "22001"));

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -580,9 +580,9 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 ///      code, which covers paths (async-poll, query-monitoring) that drop
 ///      `sqlState` on the wire but keep the error code.
 ///
-/// We deliberately do NOT inspect the human-readable message text — that
-/// matches the legacy ODBC driver's contract (server-supplied SQLSTATE or
-/// nothing) and avoids locale-fragile, false-positive-prone heuristics.
+/// We deliberately do NOT inspect the human-readable message text:
+/// classification belongs to the server, and substring matching on
+/// English error messages is locale-fragile and false-positive-prone.
 ///
 /// Centralising this here means downstream consumers (ODBC, JDBC, ADBC) can
 /// rely on `sql_state` as the single source of truth for error

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -15,6 +15,7 @@ use crate::apis::database_driver_v1::{
 };
 use crate::protobuf::generated::database_driver_v1::*;
 use crate::rest::snowflake::error::SfError;
+use crate::rest::snowflake::sql_state::sql_state_from_code;
 use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use error_trace::ErrorTrace;
@@ -573,10 +574,16 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 /// code is the user-facing error number.  Login errors use client-side error codes
 /// (mapped by the Python layer) so the server code is NOT surfaced here.
 ///
+/// When the server omits `sqlState` from its response (notably the async-poll
+/// and query-monitoring paths) but supplies a known numeric error code, the
+/// SQLSTATE is filled in from `sql_state_from_code` so downstream consumers
+/// (ODBC, JDBC, ADBC) can rely on `sql_state` as the single source of truth
+/// for error classification.
+///
 /// NOTE: currently handles `QueryFailed` and `AsyncQuery` variants only.
 /// New query-related error variants should be added here as they are introduced.
 fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
-    match error {
+    let (code, sql_state) = match error {
         ApiError::Query {
             source: RestError::QueryFailed {
                 code, sql_state, ..
@@ -592,7 +599,14 @@ fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
             ..
         } => (Some(*code), None),
         _ => (None, None),
-    }
+    };
+
+    let sql_state = sql_state.or_else(|| {
+        code.and_then(sql_state_from_code)
+            .map(|s| s.to_owned())
+    });
+
+    (code, sql_state)
 }
 
 fn extract_query_id(error: &ApiError) -> Option<String> {
@@ -756,5 +770,98 @@ impl<T> ToProtobuf<T> for Result<T, ApiError> {
     #[allow(clippy::result_large_err)]
     fn to_protobuf(self) -> Result<T, DriverException> {
         self.map_err(to_driver_exception)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::snowflake::error::SfError;
+    use snafu::Location;
+
+    fn loc() -> Location {
+        Location::new("test", 0, 0)
+    }
+
+    fn query_failed(code: Option<i32>, sql_state: Option<&str>) -> ApiError {
+        ApiError::Query {
+            location: loc(),
+            source: RestError::QueryFailed {
+                message: "test".to_owned(),
+                code,
+                sql_state: sql_state.map(|s| s.to_owned()),
+                query_id: None,
+                location: loc(),
+            },
+        }
+    }
+
+    fn async_query(code: i32) -> ApiError {
+        ApiError::Query {
+            location: loc(),
+            source: RestError::AsyncQuery {
+                location: loc(),
+                source: SfError::SnowflakeBody {
+                    code,
+                    message: "test".to_owned(),
+                    location: loc(),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn query_failed_passes_through_server_sql_state() {
+        let err = query_failed(Some(1003), Some("42000"));
+        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+    }
+
+    #[test]
+    fn server_sql_state_wins_over_lookup_table() {
+        // If the server provides "22000", trust it even though our table maps
+        // 100038 → "22003". The wire value is authoritative.
+        let err = query_failed(Some(100038), Some("22000"));
+        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22000".to_owned())));
+    }
+
+    #[test]
+    fn query_failed_falls_back_to_lookup_when_sql_state_missing() {
+        let err = query_failed(Some(100038), None);
+        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22003".to_owned())));
+
+        let err = query_failed(Some(100078), None);
+        assert_eq!(extract_vendor_info(&err), (Some(100078), Some("22001".to_owned())));
+
+        let err = query_failed(Some(1003), None);
+        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+    }
+
+    #[test]
+    fn unknown_code_with_no_sql_state_stays_none() {
+        let err = query_failed(Some(999_999), None);
+        assert_eq!(extract_vendor_info(&err), (Some(999_999), None));
+    }
+
+    #[test]
+    fn missing_code_and_sql_state_stays_none() {
+        let err = query_failed(None, None);
+        assert_eq!(extract_vendor_info(&err), (None, None));
+    }
+
+    #[test]
+    fn async_query_path_now_supplies_sql_state() {
+        // Previously this path returned (Some(code), None) unconditionally —
+        // the regression this fix is targeting.
+        let err = async_query(1003);
+        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+
+        let err = async_query(100038);
+        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22003".to_owned())));
+    }
+
+    #[test]
+    fn async_query_unknown_code_keeps_sql_state_none() {
+        let err = async_query(424_242);
+        assert_eq!(extract_vendor_info(&err), (Some(424_242), None));
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -574,14 +574,23 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 /// code is the user-facing error number.  Login errors use client-side error codes
 /// (mapped by the Python layer) so the server code is NOT surfaced here.
 ///
-/// When the server omits `sqlState` from its response (notably the async-poll
-/// and query-monitoring paths) but supplies a known numeric error code, the
-/// SQLSTATE is filled in from `sql_state_from_code` so downstream consumers
-/// (ODBC, JDBC, ADBC) can rely on `sql_state` as the single source of truth
-/// for error classification.
+/// SQLSTATE resolution order (first hit wins):
+///   1. The `sqlState` the server included in its response (verbatim).
+///   2. `sql_state_from_code` lookup against the numeric Snowflake error
+///      code, which covers paths (async-poll, query-monitoring) that drop
+///      `sqlState` on the wire but keep the error code.
+///
+/// We deliberately do NOT inspect the human-readable message text — that
+/// matches the legacy ODBC driver's contract (server-supplied SQLSTATE or
+/// nothing) and avoids locale-fragile, false-positive-prone heuristics.
+///
+/// Centralising this here means downstream consumers (ODBC, JDBC, ADBC) can
+/// rely on `sql_state` as the single source of truth for error
+/// classification.
 ///
 /// NOTE: currently handles `QueryFailed` and `AsyncQuery` variants only.
-/// New query-related error variants should be added here as they are introduced.
+/// New query-related error variants should be added here as they are
+/// introduced.
 fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
     let (code, sql_state) = match error {
         ApiError::Query {
@@ -601,10 +610,7 @@ fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
         _ => (None, None),
     };
 
-    let sql_state = sql_state.or_else(|| {
-        code.and_then(sql_state_from_code)
-            .map(|s| s.to_owned())
-    });
+    let sql_state = sql_state.or_else(|| code.and_then(sql_state_from_code).map(|s| s.to_owned()));
 
     (code, sql_state)
 }
@@ -813,7 +819,10 @@ mod tests {
     #[test]
     fn query_failed_passes_through_server_sql_state() {
         let err = query_failed(Some(1003), Some("42000"));
-        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(1003), Some("42000".to_owned()))
+        );
     }
 
     #[test]
@@ -821,19 +830,31 @@ mod tests {
         // If the server provides "22000", trust it even though our table maps
         // 100038 → "22003". The wire value is authoritative.
         let err = query_failed(Some(100038), Some("22000"));
-        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22000".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(100038), Some("22000".to_owned()))
+        );
     }
 
     #[test]
     fn query_failed_falls_back_to_lookup_when_sql_state_missing() {
         let err = query_failed(Some(100038), None);
-        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22003".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(100038), Some("22003".to_owned()))
+        );
 
         let err = query_failed(Some(100078), None);
-        assert_eq!(extract_vendor_info(&err), (Some(100078), Some("22001".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(100078), Some("22001".to_owned()))
+        );
 
         let err = query_failed(Some(1003), None);
-        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(1003), Some("42000".to_owned()))
+        );
     }
 
     #[test]
@@ -853,10 +874,16 @@ mod tests {
         // Previously this path returned (Some(code), None) unconditionally —
         // the regression this fix is targeting.
         let err = async_query(1003);
-        assert_eq!(extract_vendor_info(&err), (Some(1003), Some("42000".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(1003), Some("42000".to_owned()))
+        );
 
         let err = async_query(100038);
-        assert_eq!(extract_vendor_info(&err), (Some(100038), Some("22003".to_owned())));
+        assert_eq!(
+            extract_vendor_info(&err),
+            (Some(100038), Some("22003".to_owned()))
+        );
     }
 
     #[test]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -6,6 +6,7 @@ pub mod heartbeat;
 mod native_okta;
 pub mod query_request;
 pub mod query_response;
+pub mod sql_state;
 pub mod telemetry;
 
 use std::collections::HashMap;

--- a/sf_core/src/rest/snowflake/sql_state.rs
+++ b/sf_core/src/rest/snowflake/sql_state.rs
@@ -1,0 +1,68 @@
+//! Fallback Snowflake error-code → ANSI SQLSTATE lookup.
+//!
+//! The Snowflake server normally returns an explicit `sqlState` field on the
+//! query-failure response (see `query_response::Data::sql_state`), and that
+//! value is forwarded verbatim through `RestError::QueryFailed::sql_state`
+//! and onto `DriverException::sql_state`.
+//!
+//! However, a few code paths receive only the numeric error code and never an
+//! `sqlState` string — for example:
+//!
+//! - The async polling path constructs `RestError::QueryFailed { sql_state:
+//!   None, .. }` from `SfError::SnowflakeBody { code, .. }` (see
+//!   `apis::database_driver_v1::error::map_async_query_error`).
+//! - The query-monitoring response (`snowflake_query_status`) emits
+//!   `error_code` without a SQLSTATE.
+//!
+//! Without a SQLSTATE on the wire, downstream consumers (ODBC, JDBC, ADBC)
+//! lose the ability to classify the error and fall back to a generic
+//! `HY000` / `08000`. This table fills that gap by mapping the small set of
+//! well-known Snowflake error codes whose ANSI SQLSTATE is stable to the
+//! corresponding string, so the rest of the stack can keep treating
+//! `sql_state` as the single source of truth.
+//!
+//! The table is intentionally narrow: only codes whose mapping is unambiguous
+//! and stable across server versions belong here. Add a new entry when a new
+//! code is observed in production telemetry and confirmed against the
+//! Snowflake error registry — and add a unit test alongside it.
+
+/// Look up the ANSI SQLSTATE string for a Snowflake server error code.
+///
+/// Returns `None` for codes that have no canonical SQLSTATE mapping; callers
+/// should treat that as "leave `sql_state` unset" and let the consumer apply
+/// its own default (typically `HY000`).
+pub fn sql_state_from_code(code: i32) -> Option<&'static str> {
+    match code {
+        // SQL compilation error — syntax, unresolved identifier, type mismatch.
+        // Matches the server's own `sqlState` for this code, included here as
+        // a safety net for paths (async poll, monitoring) where the server
+        // omits the field.
+        1003 => Some("42000"),
+        // Numeric value out of representable range for the target column type.
+        // e.g. "Number out of representable range: type FIXED[SB2](3,0), value 99999".
+        100038 => Some("22003"),
+        // String length exceeds the column's declared maximum and would be
+        // truncated. e.g. "String 'hello world' is too long and would be truncated".
+        100078 => Some("22001"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_codes_map_to_expected_sqlstate() {
+        assert_eq!(sql_state_from_code(1003), Some("42000"));
+        assert_eq!(sql_state_from_code(100038), Some("22003"));
+        assert_eq!(sql_state_from_code(100078), Some("22001"));
+    }
+
+    #[test]
+    fn unknown_code_returns_none() {
+        assert_eq!(sql_state_from_code(0), None);
+        assert_eq!(sql_state_from_code(-1), None);
+        assert_eq!(sql_state_from_code(999_999), None);
+    }
+}

--- a/sf_core/src/rest/snowflake/sql_state.rs
+++ b/sf_core/src/rest/snowflake/sql_state.rs
@@ -44,7 +44,18 @@ pub fn sql_state_from_code(code: i32) -> Option<&'static str> {
         // String length exceeds the column's declared maximum and would be
         // truncated. e.g. "String 'hello world' is too long and would be truncated".
         100078 => Some("22001"),
-        _ => None,
+        _ => {
+            // Surface unmapped codes so we can grow this table as new ones
+            // appear in production telemetry. Logged at `debug` because this
+            // function is on a hot error path and we don't want to spam
+            // operator logs for every unknown code; bumping verbosity is
+            // sufficient when investigating an HY000 fallback.
+            tracing::debug!(
+                snowflake_error_code = code,
+                "no SQLSTATE mapping for Snowflake error code; consider adding it to sql_state_from_code"
+            );
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Move SQLSTATE classification for `GenericError`/`InternalError` payloads down from the ODBC layer into `sf_core`, so every consumer (ODBC today, JDBC/ADBC tomorrow) gets a consistent `sql_state` on the wire instead of having to re-derive it from English error text.

## Why

Today `odbc/src/api/error.rs` carries `sql_state_from_server_message`, a substring-match heuristic on the server's English message:

```rust
fn sql_state_from_server_message(message: &str) -> SqlState {
    if message.contains("SQL compilation error") { ... }
    else if message.contains("out of representable range") { ... }
    else if message.contains("too long and would be truncated") { ... }
    else { SqlState::GeneralError }
}
```

It exists because some core paths drop the server-supplied `sqlState`:

- `RestError::AsyncQuery { source: SfError::SnowflakeBody { code, .. } }` is mapped in `extract_vendor_info` to `(Some(*code), None)` — code preserved, SQLSTATE thrown away.
- `snowflake_query_status` constructs `QueryFailed { sql_state: None, .. }` even when it has a numeric `code`.

Sniffing English text is fragile (any docs/i18n tweak silently regresses the SQLSTATE) and pushes the same lookup table into every future driver binding.

## What

- New `sf_core::rest::snowflake::sql_state::sql_state_from_code(code: i32) -> Option<&'static str>` mapping the small set of well-known Snowflake error codes to ANSI SQLSTATE strings (1003 → `42000`, 100038 → `22003`, 100078 → `22001`). Documented as a fallback table; codes are added incrementally with tests.
- `extract_vendor_info` now falls back to that lookup whenever the wire response carried a recognised numeric code but no `sqlState`. Server-supplied `sqlState` still wins — the lookup only fills the gap.
- `odbc/src/api/error.rs`: delete `sql_state_from_server_message` and its branch; the ODBC layer now trusts the SQLSTATE forwarded by `sf_core` and returns `HY000` for genuinely opaque errors.
- Tests updated to encode the new contract (sf_core supplies the SQLSTATE, ODBC trusts it) plus a regression guard ensuring the ODBC layer never re-introduces message-text sniffing.

## Files

- `sf_core/src/rest/snowflake/sql_state.rs` — new lookup module + unit tests.
- `sf_core/src/rest/snowflake/mod.rs` — declare the module.
- `sf_core/src/protobuf/apis/database_driver_v1/converter.rs` — wire lookup into `extract_vendor_info`; add tests for sync/async paths and override semantics.
- `odbc/src/api/error.rs` — drop heuristic, update tests, add regression guard.

## Test plan

- [x] `cargo test -p sf_core --lib` — 572 passed.
- [x] `cargo test -p odbc --lib` — 1021 passed.
- [x] `cargo clippy -p sf_core -p odbc --tests -- -D warnings` — clean.
- [ ] CI green.
- [ ] Spot-check on an integration test that intentionally trips a `100038` / `100078` server error via the async-poll path and verify `SQLGetDiagRec` now returns `22003` / `22001` instead of `HY000`.

## Follow-ups

- Add more codes to `sql_state_from_code` as production telemetry surfaces them (e.g. lock-timeout, statement-cancelled, division-by-zero). Each addition gets a unit test alongside.
- Consider plumbing `vendor_code` from `DriverException` into `CoreProtobufError::Application` so the ODBC layer can also return it via `SQLGetDiagField(SQL_DIAG_NATIVE)` for non-login errors. Out of scope here.