### PR TITLE
NO-SNOW: Add StatementParameterName registry

### DIFF
--- a/python/src/snowflake/connector/__init__.py
+++ b/python/src/snowflake/connector/__init__.py
@@ -11,7 +11,7 @@ from . import util_text  # noqa: F401 - backward compatibility re-exports
 from ._internal.api_client.c_api import register_default_logger_callback
 from ._internal.decorators import pep249
 from .connection import Connection, SnowflakeConnection
-from .constants import QueryStatus
+from .constants import QueryStatus, StatementParameterName
 from .cursor import DictCursor, SnowflakeCursor
 from .errors import (
     DatabaseError,
@@ -83,6 +83,7 @@ __all__ = [
     "Connection",
     "SnowflakeConnection",
     "QueryStatus",
+    "StatementParameterName",
     "DictCursor",
     "SnowflakeCursor",
     # Exceptions

--- a/python/src/snowflake/connector/constants.py
+++ b/python/src/snowflake/connector/constants.py
@@ -2,7 +2,6 @@
 
 from enum import Enum, unique
 
-from ._internal.type_codes import FIELD_ID_TO_NAME  # noqa: F401 - backward compatibility re-exports
 from .config_manager import CONFIG_FILE, CONNECTIONS_FILE  # noqa: F401 - backward compatibility re-exports
 
 
@@ -23,5 +22,13 @@ class QueryStatus(Enum):
     NO_DATA = 12
 
 
-# backward compatibility constant
-UTF8 = "utf-8"
+class StatementParameterName:
+    """Known statement-level parameter names.
+
+    These correspond to the statement-scoped entries in sf_core's
+    ``param_registry``.  Pass them via the ``parameters`` dict when
+    executing a statement.
+    """
+
+    MULTI_STATEMENT_COUNT = "MULTI_STATEMENT_COUNT"
+    ASYNC_EXECUTION = "ASYNC_EXECUTION"

--- a/python/src/snowflake/connector/constants.py
+++ b/python/src/snowflake/connector/constants.py
@@ -2,6 +2,7 @@
 
 from enum import Enum, unique
 
+from ._internal.type_codes import FIELD_ID_TO_NAME  # noqa: F401 - backward compatibility re-exports
 from .config_manager import CONFIG_FILE, CONNECTIONS_FILE  # noqa: F401 - backward compatibility re-exports
 
 
@@ -20,6 +21,10 @@ class QueryStatus(Enum):
     RESTARTED = 10
     BLOCKED = 11
     NO_DATA = 12
+
+
+# backward compatibility constant
+UTF8 = "utf-8"
 
 
 class StatementParameterName:


### PR DESCRIPTION
## Summary
- Adds a `StatementParameterName` constants class to `constants.py`, mirroring the two statement-scoped parameters from sf_core's `param_registry` (`MULTI_STATEMENT_COUNT`, `ASYNC_EXECUTION`)
- Exports `StatementParameterName` from the package's public API (`__init__.py`)

## Test plan
- [ ] Verify `from snowflake.connector import StatementParameterName` works
- [ ] Verify existing unit tests pass (no behavioral change)
- [ ] Verify `mypy -p snowflake.connector` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)