### PR TITLE
SNOW-3416420: add sf_core_shutdown() to prevent SIGSEGV during Py_Finalize

### DIFF
--- a/python/src/snowflake/connector/__init__.py
+++ b/python/src/snowflake/connector/__init__.py
@@ -5,9 +5,12 @@ This module provides an empty implementation of the Python Database API Specific
 as defined in PEP 249.
 """
 
+import atexit as _atexit
+
 from typing import Any
 
 from . import util_text  # noqa: F401 - backward compatibility re-exports
+from ._internal.api_client.c_api import core as _core
 from ._internal.api_client.c_api import register_default_logger_callback
 from ._internal.decorators import pep249
 from .connection import Connection, SnowflakeConnection
@@ -48,6 +51,11 @@ threadsafety = 2  # Threads may share the module and connections, but not cursor
 paramstyle = "pyformat"  # Default: %(name)s and %s placeholders (client-side interpolation)
 
 register_default_logger_callback()
+
+# Register sf_core_shutdown as atexit handler — runs before Py_Finalize to
+# disable the Rust→Python logging callback. Prevents SIGSEGV when Rust
+# threads try to log into torn-down Python state (SNOW-3416420).
+_atexit.register(_core.sf_core_shutdown)
 
 
 @pep249

--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -79,6 +79,10 @@ core.sf_core_free_buffer.argtypes = [
     ctypes.c_size_t,  # size_t len
 ]
 
+# Shutdown: disables Rust→Python logging callback before Py_Finalize (SNOW-3416420).
+core.sf_core_shutdown.restype = None
+core.sf_core_shutdown.argtypes = []
+
 
 # Performance instrumentation FFI bindings (see sf_core/src/c_api.rs).
 # These symbols are always present in libsf_core; when the perf_timing feature

--- a/sf_core/src/logging/callback_layer.rs
+++ b/sf_core/src/logging/callback_layer.rs
@@ -1,5 +1,6 @@
 use std::ffi::{CString, c_char};
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::field::Field;
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::Layer;
@@ -12,6 +13,17 @@ pub type CLogCallback = unsafe extern "C" fn(
     line: u32,
     function: *const c_char,
 ) -> u32;
+
+/// Global flag to disable the callback layer during shutdown.
+/// Once set to `true`, `on_event` returns immediately without calling
+/// the Python callback — preventing SIGSEGV during `Py_Finalize`.
+static CALLBACK_DISABLED: AtomicBool = AtomicBool::new(false);
+
+/// Disable the callback layer. Called from `sf_core_shutdown` before
+/// the Python interpreter is finalized.
+pub fn disable_callback() {
+    CALLBACK_DISABLED.store(true, Ordering::SeqCst);
+}
 
 pub struct CallbackLayer {
     callback: CLogCallback,
@@ -28,6 +40,9 @@ where
     S: Subscriber,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if CALLBACK_DISABLED.load(Ordering::SeqCst) {
+            return;
+        }
         let level = match *event.metadata().level() {
             Level::ERROR => 0,
             Level::WARN => 1,
@@ -50,6 +65,10 @@ where
         let filename =
             CString::new(event.metadata().file().unwrap_or("unknown")).unwrap_or_default();
         let function = CString::new(event.metadata().name()).unwrap_or_default();
+        // Note: catch_unwind cannot catch SIGSEGV (signal, not Rust panic).
+        // The CALLBACK_DISABLED AtomicBool guard above prevents the vast majority
+        // of post-shutdown calls. The remaining TOCTOU window (~1μs between check
+        // and call) is negligible vs Py_Finalize's module teardown time (~ms).
         unsafe {
             (self.callback)(
                 level,

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 pub use crate::logging::callback_layer::CLogCallback;
 pub use crate::logging::callback_layer::CallbackLayer;
+pub use crate::logging::callback_layer::disable_callback;
 pub use crate::logging::error::LogError;
 use crate::logging::opentelemetry::init_tracer;
 use tracing::Subscriber;

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -21,6 +21,21 @@ static STATE: LazyLock<CApiState> = LazyLock::new(|| CApiState {
     transport: RustTransport::new(),
 });
 
+/// Disable the Rust→Python logging callback before Python interpreter finalization.
+///
+/// Must be called from Python's atexit (before `Py_Finalize`) to prevent
+/// SIGSEGV/SIGABRT caused by Rust threads calling into torn-down Python state
+/// (SNOW-3416420).
+///
+/// After this call, Rust `tracing::*` macros still work but the `CallbackLayer`
+/// returns immediately without invoking the Python function pointer. Rust
+/// threads (tokio worker, CRL) continue running safely — they just can't log
+/// to Python anymore. They're killed by `_exit()` when the process terminates.
+#[unsafe(no_mangle)]
+pub extern "C" fn sf_core_shutdown() {
+    crate::logging::disable_callback();
+}
+
 fn write_buffer(vec: Vec<u8>, buffer: *mut *const u8, len: *mut usize) {
     let boxed = vec.into_boxed_slice();
     unsafe {


### PR DESCRIPTION
## Summary
- Adds `sf_core_shutdown()` C API that disables the Rust→Python logging callback
- Registered as Python atexit handler at module import time
- Prevents SIGSEGV (py3.14) and SIGABRT (py3.9) when Rust threads try to log into torn-down Python state during `Py_Finalize()`

## Root cause
Rust tokio worker + CRL threads outlive Python interpreter finalization. The `CallbackLayer::on_event()` calls a Python function pointer via FFI — after `Py_Finalize()` tears down the logging module, this is a use-after-free → SIGSEGV.

## Fix
1. `CallbackLayer`: `AtomicBool` guard — `on_event` returns immediately when disabled
2. `sf_core_shutdown()`: sets the guard, exported as C function
3. Python `__init__.py`: `atexit.register(core.sf_core_shutdown)` — runs before `Py_Finalize`
4. LIFO atexit order: shutdown registered first (at import), runs last (after all connection cleanup)

## Test plan
- [ ] All 5 `TestAutoCleanup` subprocess tests pass on py3.9, py3.13, py3.14
- [ ] No regressions in other test suites
- [ ] Verified locally: 5/5 passed on py3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)