### PR TITLE
Add INTERVAL type support to JSON result format parser

### DIFF
--- a/python/tests/e2e/types/test_interval.py
+++ b/python/tests/e2e/types/test_interval.py
@@ -86,39 +86,39 @@ class TestIntervalTypeCasting:
 class TestIntervalJsonResultFormat:
     """Tests for INTERVAL types with JSON result format."""
 
-    def test_should_select_interval_year_to_month_literal_with_json_result_format(self, execute_query):
+    # TODO: Remove this test once all e2e tests run on both Arrow and JSON result formats.
+    def test_should_select_interval_year_to_month_literal_with_json_result_format(self, connection_factory):
         # Given Snowflake client is logged in
         pass
 
         # And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
-        try:
-            execute_query("ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = 'JSON'")
+        with connection_factory(session_parameters={"PYTHON_CONNECTOR_QUERY_RESULT_FORMAT": "JSON"}) as conn:
+            with conn.cursor() as cursor:
+                # When Query "SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym" is executed
+                cursor.execute("SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym")
+                row = cursor.fetchone()
 
-            # When Query "SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym" is executed
-            result = execute_query("SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym", single_row=True)
+                # Then the result should contain expected INTERVAL YEAR TO MONTH value '1-2'
+                assert row is not None
+                assert isinstance(row[0], str), f"Expected str, got {type(row[0])}"
+                assert row[0] == "+1-02"
 
-            # Then the result should contain expected INTERVAL YEAR TO MONTH value '1-2'
-            assert_type(result, str)
-            assert result == ("+1-02",)
-        finally:
-            execute_query("ALTER SESSION UNSET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT")
-
-    def test_should_select_interval_day_to_second_literal_with_json_result_format(self, execute_query):
+    # TODO: Remove this test once all e2e tests run on both Arrow and JSON result formats.
+    def test_should_select_interval_day_to_second_literal_with_json_result_format(self, connection_factory):
         # Given Snowflake client is logged in
         pass
 
         # And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
-        try:
-            execute_query("ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = 'JSON'")
+        with connection_factory(session_parameters={"PYTHON_CONNECTOR_QUERY_RESULT_FORMAT": "JSON"}) as conn:
+            with conn.cursor() as cursor:
+                # When Query "SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt" is executed
+                cursor.execute("SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt")
+                row = cursor.fetchone()
 
-            # When Query "SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt" is executed
-            result = execute_query("SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt", single_row=True)
-
-            # Then the result should contain expected INTERVAL DAY TO SECOND value '3 4:5:6.789000'
-            assert_type(result, timedelta)
-            assert result == (timedelta(days=3, hours=4, minutes=5, seconds=6, microseconds=789000),)
-        finally:
-            execute_query("ALTER SESSION UNSET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT")
+                # Then the result should contain expected INTERVAL DAY TO SECOND value '3 4:5:6.789000'
+                assert row is not None
+                assert isinstance(row[0], timedelta), f"Expected timedelta, got {type(row[0])}"
+                assert row[0] == timedelta(days=3, hours=4, minutes=5, seconds=6, microseconds=789000)
 
 
 # =============================================================================

--- a/python/tests/e2e/types/test_interval.py
+++ b/python/tests/e2e/types/test_interval.py
@@ -79,6 +79,49 @@ class TestIntervalTypeCasting:
 
 
 # =============================================================================
+# JSON RESULT FORMAT
+# =============================================================================
+
+
+class TestIntervalJsonResultFormat:
+    """Tests for INTERVAL types with JSON result format."""
+
+    def test_should_select_interval_year_to_month_literal_with_json_result_format(self, execute_query):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
+        try:
+            execute_query("ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = 'JSON'")
+
+            # When Query "SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym" is executed
+            result = execute_query("SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym", single_row=True)
+
+            # Then the result should contain expected INTERVAL YEAR TO MONTH value '1-2'
+            assert_type(result, str)
+            assert result == ("+1-02",)
+        finally:
+            execute_query("ALTER SESSION UNSET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT")
+
+    def test_should_select_interval_day_to_second_literal_with_json_result_format(self, execute_query):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
+        try:
+            execute_query("ALTER SESSION SET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = 'JSON'")
+
+            # When Query "SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt" is executed
+            result = execute_query("SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt", single_row=True)
+
+            # Then the result should contain expected INTERVAL DAY TO SECOND value '3 4:5:6.789000'
+            assert_type(result, timedelta)
+            assert result == (timedelta(days=3, hours=4, minutes=5, seconds=6, microseconds=789000),)
+        finally:
+            execute_query("ALTER SESSION UNSET PYTHON_CONNECTOR_QUERY_RESULT_FORMAT")
+
+
+# =============================================================================
 # SELECT LITERALS
 # =============================================================================
 

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -191,6 +191,32 @@ pub fn create_field_with_type(
             });
             Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
         }
+        RowType::IntervalYearMonth {
+            name,
+            nullable,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "INTERVAL_YEAR_MONTH".to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Int64), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
+        RowType::IntervalDayTime {
+            name,
+            nullable,
+            scale,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert("logicalType".to_string(), "INTERVAL_DAY_TIME".to_string());
+            metadata.insert("scale".to_string(), scale.to_string());
+            Ok(
+                Field::new(name, data_type.unwrap_or(DataType::Int64), *nullable)
+                    .with_metadata(metadata),
+            )
+        }
         RowType::Variant { name, nullable } => {
             let mut metadata = HashMap::new();
             metadata.insert("logicalType".to_string(), "VARIANT".to_string());

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -239,6 +239,12 @@ pub(super) enum ColumnBuilder {
         mant_builder: arrow::array::BinaryBuilder,
         nulls: arrow::array::BooleanBufferBuilder,
     },
+    /// INTERVAL_YEAR_MONTH: total months as Int64
+    IntervalYearMonth {
+        builder: arrow::array::PrimitiveBuilder<Int64Type>,
+    },
+    /// INTERVAL_DAY_TIME: nanoseconds, i64 with promotion to Decimal128 for large values
+    IntervalDayTime { storage: FixedStorage },
 }
 
 impl ColumnBuilder {
@@ -322,6 +328,14 @@ impl ColumnBuilder {
                 mant_builder: arrow::array::BinaryBuilder::with_capacity(capacity, capacity * 8),
                 nulls: arrow::array::BooleanBufferBuilder::new(capacity),
             },
+            RowType::IntervalYearMonth { .. } => ColumnBuilder::IntervalYearMonth {
+                builder: arrow::array::PrimitiveBuilder::<Int64Type>::with_capacity(capacity),
+            },
+            RowType::IntervalDayTime { .. } => ColumnBuilder::IntervalDayTime {
+                storage: FixedStorage::I64 {
+                    builder: arrow::array::PrimitiveBuilder::<Int64Type>::with_capacity(capacity),
+                },
+            },
         }
     }
 
@@ -380,6 +394,11 @@ impl ColumnBuilder {
                 mant_builder.append_value(&[] as &[u8]);
                 nulls.append(false);
             }
+            ColumnBuilder::IntervalYearMonth { builder } => builder.append_null(),
+            ColumnBuilder::IntervalDayTime { storage } => match storage {
+                FixedStorage::I64 { builder } => builder.append_null(),
+                FixedStorage::I128 { builder } => builder.append_null(),
+            },
         }
     }
 
@@ -514,6 +533,33 @@ impl ColumnBuilder {
                 mant_builder.append_value(mantissa);
                 nulls.append(true);
             }
+            ColumnBuilder::IntervalYearMonth { builder } => {
+                let v: i64 = parse_int_bytes(cell)?;
+                builder.append_value(v);
+            }
+            ColumnBuilder::IntervalDayTime { storage } => match storage {
+                FixedStorage::I64 { builder } => {
+                    if cell.len() <= 18 {
+                        let v: i64 = parse_int_bytes(cell)?;
+                        builder.append_value(v);
+                    } else {
+                        let v128: i128 = parse_int_bytes(cell)?;
+                        if let Ok(v) = i64::try_from(v128) {
+                            builder.append_value(v);
+                        } else {
+                            let mut decimal_builder = convert_i64_to_decimal128(builder);
+                            decimal_builder.append_value(v128);
+                            *storage = FixedStorage::I128 {
+                                builder: decimal_builder,
+                            };
+                        }
+                    }
+                }
+                FixedStorage::I128 { builder } => {
+                    let v: i128 = parse_int_bytes(cell)?;
+                    builder.append_value(v);
+                }
+            },
         }
         Ok(())
     }
@@ -684,6 +730,27 @@ impl ColumnBuilder {
                 );
                 Ok((field, Arc::new(struct_arr)))
             }
+            ColumnBuilder::IntervalYearMonth { mut builder } => Ok((
+                create_field(row_type).map_err(err)?,
+                Arc::new(builder.finish()),
+            )),
+            ColumnBuilder::IntervalDayTime { storage } => match storage {
+                FixedStorage::I64 { mut builder, .. } => Ok((
+                    create_field_with_type(row_type, Some(DataType::Int64)).map_err(err)?,
+                    Arc::new(builder.finish()),
+                )),
+                FixedStorage::I128 { mut builder } => {
+                    let arr = builder
+                        .finish()
+                        .with_precision_and_scale(38, 0)
+                        .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+                    Ok((
+                        create_field_with_type(row_type, Some(DataType::Decimal128(38, 0)))
+                            .map_err(err)?,
+                        Arc::new(arr),
+                    ))
+                }
+            },
         }
     }
 }

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -54,6 +54,16 @@ pub enum RowType {
         name: String,
         nullable: bool,
     },
+    IntervalYearMonth {
+        name: String,
+        nullable: bool,
+        scale: u64,
+    },
+    IntervalDayTime {
+        name: String,
+        nullable: bool,
+        scale: u64,
+    },
     Variant {
         name: String,
         nullable: bool,
@@ -162,6 +172,22 @@ impl RowType {
         RowType::Decfloat {
             name: name.to_string(),
             nullable,
+        }
+    }
+
+    pub fn interval_year_month(name: &str, nullable: bool, scale: u64) -> Self {
+        RowType::IntervalYearMonth {
+            name: name.to_string(),
+            nullable,
+            scale,
+        }
+    }
+
+    pub fn interval_day_time(name: &str, nullable: bool, scale: u64) -> Self {
+        RowType::IntervalDayTime {
+            name: name.to_string(),
+            nullable,
+            scale,
         }
     }
 

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -630,6 +630,18 @@ impl TryFrom<&RowType> for query_types::RowType {
                 ))
             }
             "DECFLOAT" => Ok(query_types::RowType::decfloat(&name, nullable)),
+            "INTERVAL_YEAR_MONTH" => {
+                let scale = value.scale.unwrap_or(9);
+                Ok(query_types::RowType::interval_year_month(
+                    &name, nullable, scale,
+                ))
+            }
+            "INTERVAL_DAY_TIME" => {
+                let scale = value.scale.unwrap_or(9);
+                Ok(query_types::RowType::interval_day_time(
+                    &name, nullable, scale,
+                ))
+            }
             "OBJECT" => Ok(query_types::RowType::object(&name, nullable)),
             "ARRAY" => Ok(query_types::RowType::array(&name, nullable)),
             "VARIANT" => Ok(query_types::RowType::variant(&name, nullable)),

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -173,6 +173,13 @@ fn metadata_keys_to_exclude(logical_type: &str) -> &'static [&'static str] {
             "scale",
             "physicalType",
         ],
+        "INTERVAL_YEAR_MONTH" | "INTERVAL_DAY_TIME" => &[
+            "finalType",
+            "charLength",
+            "byteLength",
+            "precision",
+            "physicalType",
+        ],
         _ => &[],
     }
 }
@@ -219,10 +226,13 @@ fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
         .get("logicalType")
         .unwrap_or_else(|| panic!("logicalType metadata key missing for field {}", left.name()));
 
-    // FIXED columns may use different integer widths (e.g. Arrow-native Int8
-    // vs JSON-converted Int64). Accept any integer/decimal pair.
-    let is_fixed = logical_type == "FIXED";
-    if !is_fixed {
+    // FIXED and INTERVAL columns may use different integer widths (e.g.
+    // Arrow-native Int16 vs JSON-converted Int64). Accept any integer/decimal pair.
+    let is_integer_flexible = matches!(
+        logical_type.as_str(),
+        "FIXED" | "INTERVAL_YEAR_MONTH" | "INTERVAL_DAY_TIME"
+    );
+    if !is_integer_flexible {
         assert_eq!(
             discriminant(left.data_type()),
             discriminant(right.data_type()),
@@ -272,11 +282,12 @@ fn assert_fields_match(left: &FieldRef, right: &FieldRef) {
                 .zip(right_fields.iter())
                 .for_each(|(a, j)| assert_fields_match(a, j));
         }
-        (left_dt, right_dt) if is_fixed => {
+        (left_dt, right_dt) if is_integer_flexible => {
             assert!(
                 is_integer_or_decimal(left_dt) && is_integer_or_decimal(right_dt),
-                "FIXED field '{}' has non-numeric types: left={:?}, right={:?}",
+                "Integer-flexible field '{}' (logicalType={}) has non-numeric types: left={:?}, right={:?}",
                 left.name(),
+                logical_type,
                 left_dt,
                 right_dt
             );

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -126,6 +126,44 @@ fn should_return_decfloat_as_arrow_even_if_json_result_set_is_returned() {
 }
 
 #[test]
+fn should_return_interval_year_month_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_interval_ym (\
+            ym_zero INTERVAL YEAR TO MONTH,\
+            ym_pos INTERVAL YEAR TO MONTH,\
+            ym_neg INTERVAL YEAR TO MONTH,\
+            ym_max INTERVAL YEAR TO MONTH,\
+            ym_min INTERVAL YEAR TO MONTH)",
+        "INSERT INTO json_result_set_interval_ym SELECT \
+            '0-0'::INTERVAL YEAR TO MONTH, \
+            '1-2'::INTERVAL YEAR TO MONTH, \
+            '-1-3'::INTERVAL YEAR TO MONTH, \
+            '999999999-11'::INTERVAL YEAR TO MONTH, \
+            '-999999999-11'::INTERVAL YEAR TO MONTH",
+        "SELECT * FROM json_result_set_interval_ym",
+    )
+}
+
+#[test]
+fn should_return_interval_day_time_as_arrow_even_if_json_result_set_is_returned() {
+    run_arrow_and_json_and_match(
+        "CREATE OR REPLACE TABLE json_result_set_interval_dt (\
+            dt_zero INTERVAL DAY TO SECOND,\
+            dt_pos INTERVAL DAY TO SECOND,\
+            dt_neg INTERVAL DAY TO SECOND,\
+            dt_large INTERVAL DAY TO SECOND,\
+            dt_large_neg INTERVAL DAY TO SECOND)",
+        "INSERT INTO json_result_set_interval_dt SELECT \
+            '0 0:0:0.0'::INTERVAL DAY TO SECOND, \
+            '12 3:4:5.678'::INTERVAL DAY TO SECOND, \
+            '-1 2:3:4.567'::INTERVAL DAY TO SECOND, \
+            '99999 23:59:59.999999'::INTERVAL DAY TO SECOND, \
+            '-99999 23:59:59.999999'::INTERVAL DAY TO SECOND",
+        "SELECT * FROM json_result_set_interval_dt",
+    )
+}
+
+#[test]
 fn should_return_variant_as_arrow_even_if_json_result_set_is_returned() {
     run_arrow_and_json_and_match(
         "CREATE OR REPLACE TABLE json_result_set_variant (\

--- a/tests/definitions/shared/types/interval.feature
+++ b/tests/definitions/shared/types/interval.feature
@@ -53,6 +53,26 @@ Feature: INTERVAL datatype handling
     Then all INTERVAL values should be returned as appropriate type for the driver
 
   # ============================================================================
+  #                         JSON result format
+  # ============================================================================
+
+  # TODO: Remove once all e2e tests run on both Arrow and JSON result formats.
+  @python_e2e
+  Scenario: should select interval year to month literal with JSON result format
+    Given Snowflake client is logged in
+    And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
+    When Query "SELECT '1-2'::INTERVAL YEAR TO MONTH AS ym" is executed
+    Then the result should contain expected INTERVAL YEAR TO MONTH value '1-2'
+
+  # TODO: Remove once all e2e tests run on both Arrow and JSON result formats.
+  @python_e2e
+  Scenario: should select interval day to second literal with JSON result format
+    Given Snowflake client is logged in
+    And Session parameter PYTHON_CONNECTOR_QUERY_RESULT_FORMAT is set to JSON
+    When Query "SELECT '3 4:5:6.789'::INTERVAL DAY TO SECOND AS dt" is executed
+    Then the result should contain expected INTERVAL DAY TO SECOND value '3 4:5:6.789000'
+
+  # ============================================================================
   # SELECT LITERALS
   # ============================================================================
 


### PR DESCRIPTION
## Summary
- Recognize `INTERVAL_YEAR_MONTH` and `INTERVAL_DAY_TIME` type strings in the JSON result set parser (previously unrecognized, causing errors when Snowflake returns JSON format)
- Add JSON-to-Arrow column builders for both interval types, with i64→Decimal128 promotion for large day-time nanosecond values
- Add Arrow field creation with proper `logicalType` and `scale` metadata
- Add integration tests comparing Arrow vs JSON result sets for both interval types
- Add Python e2e test stubs and Gherkin scenarios for JSON result format coverage

## Test plan
- [x] Rust integration tests `should_return_interval_year_month_as_arrow_even_if_json_result_set_is_returned` and `should_return_interval_day_time_as_arrow_even_if_json_result_set_is_returned` pass against live Snowflake
- [x] All 17 existing JSON result set integration tests continue to pass
- [ ] Python e2e interval tests with JSON result format (scenarios added, require CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)