### PR TITLE
Add Linux aarch64 wheel builds

### DIFF
--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -36,18 +36,16 @@ jobs:
                   "container": "quay.io/pypa/manylinux_2_28_x86_64",
                   "lib_name": "libsf_core.so",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
-                  "rust_target": "",
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_x86_64",
                   "artifact_id": "manylinux_x86_64",
               },
               "linux_aarch": {
                   "target": "linux-aarch64",
-                  "os": "ubuntu-latest",
-                  "container": "",
+                  "os": "ubuntu-24.04-arm",
+                  "container": "quay.io/pypa/manylinux_2_28_aarch64",
                   "lib_name": "libsf_core.so",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
-                  "rust_target": "aarch64-unknown-linux-gnu",
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_aarch64",
                   "artifact_id": "manylinux_aarch64",
@@ -58,7 +56,6 @@ jobs:
                   "container": "",
                   "lib_name": "sf_core.dll",
                   "cargo_extra_args": "--config profile.release.opt-level=2 --config profile.release.strip=false",
-                  "rust_target": "",
                   "wheel_method": "manual",
                   "artifact_id": "win_arm64",
               },
@@ -84,7 +81,6 @@ jobs:
                       "container": p["container"],
                       "lib_name": p["lib_name"],
                       "cargo_extra_args": p["cargo_extra_args"],
-                      "rust_target": p["rust_target"],
                   })
 
               if p["wheel_method"] == "cibuildwheel":
@@ -132,7 +128,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ── Linux container setup (native builds: x86 in manylinux container) ──
+      # ── Linux container setup ──
       - name: Install Rust toolchain (container)
         if: matrix.container != ''
         run: |
@@ -142,15 +138,6 @@ jobs:
       - name: Install vendored OpenSSL build deps (container)
         if: matrix.container != ''
         run: yum install -y perl-IPC-Cmd perl-Time-Piece
-
-      # ── Linux cross-compilation setup (aarch64 on x86 host) ──
-      - name: Install cross-compilation toolchain
-        if: matrix.rust_target != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          rustup target add ${{ matrix.rust_target }}
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       # ── Windows ARM64 OpenSSL setup ──
       - name: Capture vcpkg version for cache key
@@ -190,10 +177,7 @@ jobs:
 
       - name: Build sf_core (Linux)
         if: runner.os == 'Linux'
-        run: >
-          cargo build --release --package sf_core
-          ${{ matrix.cargo_extra_args }}
-          ${{ matrix.rust_target != '' && format('--target {0}', matrix.rust_target) || '' }}
+        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
 
       - name: Build sf_core (Windows ARM64)
         if: runner.os == 'Windows'
@@ -206,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sf-core-${{ matrix.target }}
-          path: target/${{ matrix.rust_target != '' && format('{0}/release', matrix.rust_target) || 'release' }}/${{ matrix.lib_name }}
+          path: target/release/${{ matrix.lib_name }}
 
       - name: Save Rust cache
         if: always()
@@ -331,10 +315,6 @@ jobs:
         with:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen
-
-      - name: Set up QEMU
-        if: contains(matrix.cibw_build, 'aarch64')
-        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@v3.4

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -8,8 +8,8 @@ on:
         required: true
         description: >
           JSON object mapping platform keys to Python version arrays.
-          Example: {"linux_x86": ["3.10","3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}
-          Supported platforms: linux_x86, windows_arm.
+          Example: {"linux_x86": ["3.10","3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12"], "windows_arm": ["3.11","3.12"]}
+          Supported platforms: linux_x86, linux_aarch, windows_arm.
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,9 +36,21 @@ jobs:
                   "container": "quay.io/pypa/manylinux_2_28_x86_64",
                   "lib_name": "libsf_core.so",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
+                  "rust_target": "",
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_x86_64",
                   "artifact_id": "manylinux_x86_64",
+              },
+              "linux_aarch": {
+                  "target": "linux-aarch64",
+                  "os": "ubuntu-latest",
+                  "container": "",
+                  "lib_name": "libsf_core.so",
+                  "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
+                  "rust_target": "aarch64-unknown-linux-gnu",
+                  "wheel_method": "cibuildwheel",
+                  "cibw_arch": "manylinux_aarch64",
+                  "artifact_id": "manylinux_aarch64",
               },
               "windows_arm": {
                   "target": "windows-arm64",
@@ -46,6 +58,7 @@ jobs:
                   "container": "",
                   "lib_name": "sf_core.dll",
                   "cargo_extra_args": "--config profile.release.opt-level=2 --config profile.release.strip=false",
+                  "rust_target": "",
                   "wheel_method": "manual",
                   "artifact_id": "win_arm64",
               },
@@ -71,6 +84,7 @@ jobs:
                       "container": p["container"],
                       "lib_name": p["lib_name"],
                       "cargo_extra_args": p["cargo_extra_args"],
+                      "rust_target": p["rust_target"],
                   })
 
               if p["wheel_method"] == "cibuildwheel":
@@ -118,7 +132,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ── Linux container setup ──
+      # ── Linux container setup (native builds: x86 in manylinux container) ──
       - name: Install Rust toolchain (container)
         if: matrix.container != ''
         run: |
@@ -128,6 +142,15 @@ jobs:
       - name: Install vendored OpenSSL build deps (container)
         if: matrix.container != ''
         run: yum install -y perl-IPC-Cmd perl-Time-Piece
+
+      # ── Linux cross-compilation setup (aarch64 on x86 host) ──
+      - name: Install cross-compilation toolchain
+        if: matrix.rust_target != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          rustup target add ${{ matrix.rust_target }}
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       # ── Windows ARM64 OpenSSL setup ──
       - name: Capture vcpkg version for cache key
@@ -167,7 +190,10 @@ jobs:
 
       - name: Build sf_core (Linux)
         if: runner.os == 'Linux'
-        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+        run: >
+          cargo build --release --package sf_core
+          ${{ matrix.cargo_extra_args }}
+          ${{ matrix.rust_target != '' && format('--target {0}', matrix.rust_target) || '' }}
 
       - name: Build sf_core (Windows ARM64)
         if: runner.os == 'Windows'
@@ -180,7 +206,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sf-core-${{ matrix.target }}
-          path: target/release/${{ matrix.lib_name }}
+          path: target/${{ matrix.rust_target != '' && format('{0}/release', matrix.rust_target) || 'release' }}/${{ matrix.lib_name }}
 
       - name: Save Rust cache
         if: always()
@@ -306,6 +332,10 @@ jobs:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen
 
+      - name: Set up QEMU
+        if: contains(matrix.cibw_build, 'aarch64')
+        uses: docker/setup-qemu-action@v3
+
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@v3.4
         with:
@@ -314,6 +344,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_LINUX: >-
             SKIP_CORE_BUILD=true
             SKIP_PROTO_GENERATION=true

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -37,6 +37,18 @@ jobs:
           - { os: ubuntu-latest,   py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: ubuntu-latest,   py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-latest,   py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          # Linux ARM64 — test env
+          - { os: ubuntu-24.04-arm, py: "3.10", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: ubuntu-24.04-arm, py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: ubuntu-24.04-arm, py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
+          # Linux ARM64 — test-pandas env
+          - { os: ubuntu-24.04-arm, py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: ubuntu-24.04-arm, py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: ubuntu-24.04-arm, py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
           # Windows ARM64 (no test-pandas — pyarrow has no win_arm64 wheel)
           - { os: windows-11-arm,  py: "3.11", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-11-arm,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -77,7 +77,7 @@ jobs:
         if: runner.os == 'Linux' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: manylinux_x86_64_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64') }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download wheel (Windows ARM64)

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -14,7 +14,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # ── Test wheels and sdist against cloud providers ───────────────────
   # Each Python version tested once per env, cloud providers distributed evenly.

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -217,7 +217,7 @@ jobs:
         if: matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || 'manylinux_x86_64') }}_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64')) }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -162,48 +162,6 @@ jobs:
             py: "3.14"
             hatch_env: "test-pandas"
             cloud_provider: azure
-          # Linux ARM64 — test env
-          - os: ubuntu-24.04-arm
-            py: "3.10"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: ubuntu-24.04-arm
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.13"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: gcp
-          # Linux ARM64 — test-pandas env
-          - os: ubuntu-24.04-arm
-            py: "3.10"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.11"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.12"
-            hatch_env: "test-pandas"
-            cloud_provider: gcp
-          - os: ubuntu-24.04-arm
-            py: "3.13"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.14"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -116,10 +116,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: ubuntu-latest
             py: "3.10"
             hatch_env: "test"
             cloud_provider: azure
@@ -132,6 +128,14 @@ jobs:
             hatch_env: "test"
             cloud_provider: aws
             result_format: json
+          - os: ubuntu-24.04-arm
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: ubuntu-24.04-arm
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: aws
           - os: windows-11-arm
             py: "3.12"
             hatch_env: "test"
@@ -146,7 +150,7 @@ jobs:
             cloud_provider: azure
           # test integration with Pandas
           - os: ubuntu-latest
-            py: "3.10"
+            py: "3.14"
             hatch_env: "test-pandas"
             cloud_provider: gcp
           - os: ubuntu-latest # Reference combination for Pandas integration — keep in sync with REFERENCE_* env vars above
@@ -158,8 +162,8 @@ jobs:
             hatch_env: "test-pandas"
             cloud_provider: aws
             result_format: json
-          - os: ubuntu-latest
-            py: "3.14"
+          - os: ubuntu-24.04-arm
+            py: "3.12"
             hatch_env: "test-pandas"
             cloud_provider: azure
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -162,6 +162,48 @@ jobs:
             py: "3.14"
             hatch_env: "test-pandas"
             cloud_provider: azure
+          # Linux ARM64 — test env
+          - os: ubuntu-24.04-arm
+            py: "3.10"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: ubuntu-24.04-arm
+            py: "3.12"
+            hatch_env: "test"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.13"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: gcp
+          # Linux ARM64 — test-pandas env
+          - os: ubuntu-24.04-arm
+            py: "3.10"
+            hatch_env: "test-pandas"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.11"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.12"
+            hatch_env: "test-pandas"
+            cloud_provider: gcp
+          - os: ubuntu-24.04-arm
+            py: "3.13"
+            hatch_env: "test-pandas"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.14"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:


### PR DESCRIPTION
Add `linux_aarch` to wheel support matrix. It is mingled in reduced matrix on push-to-pr workflow, ensuring that:
1. each OS is tested against gcp, arm and azure
2. all versions of Python are being tested
```
  ┌─────┬──────────────────┬──────┬─────────────┬───────┬─────────────┐                                                                                                                                      
  │  #  │        OS        │  Py  │     env     │ cloud │    notes    │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 1   │ ubuntu-latest    │ 3.10 │ test        │ azure │ sdist       │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤
  │ 2   │ ubuntu-latest    │ 3.13 │ test        │ aws   │ reference   │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤
  │ 3   │ ubuntu-latest    │ 3.13 │ test        │ aws   │ JSON format │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤
  │ 4   │ ubuntu-24.04-arm │ 3.14 │ test        │ gcp   │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤
  │ 5   │ ubuntu-24.04-arm │ 3.11 │ test        │ aws   │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 6   │ windows-11-arm   │ 3.12 │ test        │ aws   │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 7   │ windows-11-arm   │ 3.11 │ test        │ gcp   │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 8   │ windows-11-arm   │ 3.11 │ test        │ azure │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 9   │ ubuntu-latest    │ 3.14 │ test-pandas │ gcp   │             │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 10  │ ubuntu-latest    │ 3.13 │ test-pandas │ aws   │ reference   │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 11  │ ubuntu-latest    │ 3.13 │ test-pandas │ aws   │ JSON format │
  ├─────┼──────────────────┼──────┼─────────────┼───────┼─────────────┤                                                                                                                                      
  │ 12  │ ubuntu-24.04-arm │ 3.12 │ test-pandas │ azure │             │
  └─────┴──────────────────┴──────┴─────────────┴───────┴─────────────┘    
  ```
  
  ## Testing:
 * ensure `manylinux_aarch` tag is enforced on the new wheel
 * try-run of full build matrix: https://github.com/snowflakedb/universal-driver/actions/runs/24984006418