### PR TITLE
LogManager tests and CI keys in ini config file

### DIFF
--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -180,3 +180,14 @@ pub unsafe extern "system" fn Java_net_snowflake_client_internal_unicore_JNICore
 
     response_obj.into_raw()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_new_succeeds_without_log_manager() {
+        // LogManager::get() returns None when not initialised; construction must not panic.
+        let _bridge = JdbcBridge::new();
+    }
+}

--- a/jdbc_bridge/src/sflogger_layer.rs
+++ b/jdbc_bridge/src/sflogger_layer.rs
@@ -56,30 +56,53 @@ where
             }
         };
 
-        let logger_factory = env
-            .find_class("net/snowflake/client/internal/log/SFLoggerFactory")
-            .unwrap();
-        let logger_name = env.new_string("com.snowflake.jdbc.CoreLogger").unwrap();
-        let logger = env
+        let logger_factory =
+            match env.find_class("net/snowflake/client/internal/log/SFLoggerFactory") {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Failed to find SFLoggerFactory class: {e:?}");
+                    return;
+                }
+            };
+        let logger_name = match env.new_string("com.snowflake.jdbc.CoreLogger") {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Failed to create logger name string: {e:?}");
+                return;
+            }
+        };
+        let logger = match env
             .call_static_method(
                 logger_factory,
                 "getLogger",
                 "(Ljava/lang/String;)Lnet/snowflake/client/internal/log/SFLogger;",
                 &[(&logger_name).into()],
             )
-            .unwrap()
-            .l()
-            .unwrap();
+            .and_then(|v| v.l())
+        {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("Failed to get SFLogger instance: {e:?}");
+                return;
+            }
+        };
 
-        let java_log_msg = env.new_string(log_msg).unwrap();
+        let java_log_msg = match env.new_string(log_msg) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Failed to create log message string: {e:?}");
+                return;
+            }
+        };
 
-        env.call_method(
+        if let Err(e) = env.call_method(
             logger,
             level_str,
             "(Ljava/lang/String;Z)V",
             &[(&java_log_msg).into(), JValue::Bool(1)],
-        )
-        .unwrap();
+        ) {
+            eprintln!("Failed to call SFLogger.{level_str}: {e:?}");
+        }
     }
 }
 

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -41,6 +41,9 @@ add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)
 
+# logging
+add_odbc_test(e2e_logging_odbc_logging logging/odbc_logging.cpp)
+
 # session
 add_odbc_test(e2e_session_session_parameters session/session_parameters.cpp)
 add_odbc_test(e2e_session_connection_params session/connection_params.cpp)

--- a/odbc_tests/tests/e2e/logging/odbc_logging.cpp
+++ b/odbc_tests/tests/e2e/logging/odbc_logging.cpp
@@ -9,6 +9,7 @@
 
 #include "Connection.hpp"
 #include "EnvOverride.hpp"
+#include "compatibility.hpp"
 #include "get_data.hpp"
 
 namespace fs = std::filesystem;

--- a/odbc_tests/tests/e2e/logging/odbc_logging.cpp
+++ b/odbc_tests/tests/e2e/logging/odbc_logging.cpp
@@ -1,0 +1,66 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "EnvOverride.hpp"
+#include "get_data.hpp"
+
+namespace fs = std::filesystem;
+
+static fs::path create_temp_log_dir() {
+  auto base = fs::temp_directory_path();
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint64_t> dist;
+  auto dir = base / ("odbc_log_e2e_" + std::to_string(dist(gen)));
+  fs::create_directories(dir);
+  return dir;
+}
+
+static std::string read_all_files_in(const fs::path& dir) {
+  std::ostringstream combined;
+  if (!fs::exists(dir)) return {};
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (entry.is_regular_file()) {
+      std::ifstream in(entry.path(), std::ios::binary);
+      combined << in.rdbuf();
+    }
+  }
+  return combined.str();
+}
+
+TEST_CASE("should create log file when sf.odbc.ini configures file logging", "[logging]") {
+  // Given a temp directory for logs and an sf.odbc.ini pointing there
+  auto log_dir = create_temp_log_dir();
+  auto ini_path = log_dir / "sf.odbc.ini";
+
+  {
+    std::ofstream ini(ini_path);
+    ini << "LogLevel=DEBUG\n";
+    ini << "LogPath=" << log_dir.string() << "\n";
+    ini << "LogFile=odbc_e2e_test.log\n";
+  }
+
+  EnvOverride env_override("SF_ODBC_INI", ini_path.string());
+
+  // When a connection is established and a query is executed
+  Connection conn;
+  auto stmt = conn.execute_fetch("SELECT 1");
+  auto value = get_data<SQL_C_CHAR>(stmt, 1);
+  CHECK(value == "1");
+
+  // Then the log directory should contain a log file with connection-related output
+  auto log_contents = read_all_files_in(log_dir);
+  CHECK(!log_contents.empty());
+  CHECK(log_contents.find("connect_with_params") != std::string::npos);
+
+  // Cleanup
+  std::error_code ec;
+  fs::remove_all(log_dir, ec);
+}

--- a/odbc_tests/tests/e2e/logging/odbc_logging.cpp
+++ b/odbc_tests/tests/e2e/logging/odbc_logging.cpp
@@ -36,6 +36,7 @@ static std::string read_all_files_in(const fs::path& dir) {
 }
 
 TEST_CASE("should create log file when sf.odbc.ini configures file logging", "[logging]") {
+  SKIP_OLD_DRIVER("BD#000", "Old driver does not support file logging setup via sf.odbc.ini");
   // Given a temp directory for logs and an sf.odbc.ini pointing there
   auto log_dir = create_temp_log_dir();
   auto ini_path = log_dir / "sf.odbc.ini";

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -121,6 +121,34 @@ name = "integration_tests"
 path = "tests/integration/mod.rs"
 
 [[test]]
+name = "logging_tests"
+path = "tests/logging_tests.rs"
+
+[[test]]
+name = "logging_disabled_tests"
+path = "tests/logging_disabled_tests.rs"
+
+[[test]]
+name = "logging_toml_tests"
+path = "tests/logging_toml_tests.rs"
+
+[[test]]
+name = "logging_callback_tests"
+path = "tests/logging_callback_tests.rs"
+
+[[test]]
+name = "logging_for_odbc_tests"
+path = "tests/logging_for_odbc_tests.rs"
+
+[[test]]
+name = "logging_level_filtering_tests"
+path = "tests/logging_level_filtering_tests.rs"
+
+[[test]]
+name = "logging_custom_file_tests"
+path = "tests/logging_custom_file_tests.rs"
+
+[[test]]
 name = "e2e_tests"
 path = "tests/e2e/mod.rs"
 

--- a/sf_core/src/logging/ini_config.rs
+++ b/sf_core/src/logging/ini_config.rs
@@ -17,12 +17,12 @@ use crate::config::settings::Setting;
 /// Checks file permissions before reading (rejects group/world-writable files
 /// on Unix).
 pub fn parse_ini_file(path: &Path) -> Result<LoggingConfig, LogError> {
-    crate::config::toml_loader::check_file_permissions(path).map_err(|e| {
-        InsecurePermissionsSnafu {
-            path: path.display().to_string(),
-            reason: e.to_string(),
+    crate::config::toml_loader::check_file_permissions(path).map_err(|e| match e {
+        crate::config::ConfigError::InsecurePermissions { path, reason, .. } => {
+            InsecurePermissionsSnafu { path, reason }.build()
         }
-        .build()
+        crate::config::ConfigError::ConfigFileRead { source, .. } => IoSnafu.into_error(source),
+        other => IoSnafu.into_error(std::io::Error::other(other.to_string())),
     })?;
 
     let ini = Ini::load_from_file_noescape(path).map_err(|e| match e {
@@ -58,7 +58,7 @@ fn apply_ini_section(props: &ini::Properties) -> Result<LoggingConfig, LogError>
             "logmaxcount" => config.max_file_count = Some(parse_u32(value)?),
             "logrotation" => config.rotation = parse_rotation(value)?,
             "logenabled" => config.enabled = parse_bool(value)?,
-            _ => {}
+            other => eprintln!("ignoring unknown INI key: {other}"),
         }
     }
     Ok(config)
@@ -462,7 +462,7 @@ LOGENABLED=false
     #[test]
     fn parse_ini_file_missing_file() {
         let err = parse_ini_file(Path::new("/nonexistent/sf.odbc.ini")).unwrap_err();
-        matches!(err, LogError::Io { .. });
+        assert!(matches!(err, LogError::Io { .. }));
     }
 
     // ---- TOML section loading ----
@@ -475,6 +475,7 @@ LOGENABLED=false
         section.insert("file".into(), Setting::String("app.log".into()));
         section.insert("max_size".into(), Setting::Int(2_000_000));
         section.insert("max_count".into(), Setting::Int(3));
+        section.insert("rotation".into(), Setting::String("DAILY".into()));
         section.insert("enabled".into(), Setting::Bool(false));
         section.insert("opentelemetry".into(), Setting::Bool(true));
 
@@ -484,6 +485,7 @@ LOGENABLED=false
         assert_eq!(config.log_file_name.unwrap(), "app.log");
         assert_eq!(config.max_file_size.unwrap(), 2_000_000);
         assert_eq!(config.max_file_count.unwrap(), 3);
+        assert_eq!(config.rotation, LogRotation::Daily);
         assert!(!config.enabled);
         assert!(config.open_telemetry);
     }

--- a/sf_core/src/logging/ini_config.rs
+++ b/sf_core/src/logging/ini_config.rs
@@ -2,15 +2,16 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use ini::Ini;
+use snafu::IntoError;
 use tracing::level_filters::LevelFilter;
 
-use super::error::{ConfigParseSnafu, InsecurePermissionsSnafu, LogError};
+use super::error::{ConfigParseSnafu, InsecurePermissionsSnafu, IoSnafu, LogError};
 use super::{LogRotation, LoggingConfig};
 use crate::config::settings::Setting;
 
 /// Parse an `sf.odbc.ini`-style INI file into a [`LoggingConfig`].
 ///
-/// Supported keys (case-sensitive):
+/// Supported keys (case-insensitive):
 /// `LogLevel`, `LogPath`, `LogFile`, `LogMaxSize`, `LogMaxCount`, `LogEnabled`.
 ///
 /// Checks file permissions before reading (rejects group/world-writable files
@@ -24,11 +25,12 @@ pub fn parse_ini_file(path: &Path) -> Result<LoggingConfig, LogError> {
         .build()
     })?;
 
-    let ini = Ini::load_from_file_noescape(path).map_err(|e| {
-        ConfigParseSnafu {
-            message: format!("failed to load {}: {e}", path.display()),
+    let ini = Ini::load_from_file_noescape(path).map_err(|e| match e {
+        ini::Error::Io(io_err) => IoSnafu.into_error(io_err),
+        ini::Error::Parse(parse_err) => ConfigParseSnafu {
+            message: format!("failed to parse {}: {parse_err}", path.display()),
         }
-        .build()
+        .build(),
     })?;
     apply_ini_section(ini.general_section())
 }
@@ -48,14 +50,14 @@ pub fn parse_ini_content(content: &str) -> Result<LoggingConfig, LogError> {
 fn apply_ini_section(props: &ini::Properties) -> Result<LoggingConfig, LogError> {
     let mut config = LoggingConfig::default();
     for (key, value) in props.iter() {
-        match key {
-            "LogLevel" => config.level = parse_level(value)?,
-            "LogPath" => config.log_path = Some(PathBuf::from(value)),
-            "LogFile" => config.log_file_name = Some(value.to_string()),
-            "LogMaxSize" => config.max_file_size = Some(parse_u64(value)?),
-            "LogMaxCount" => config.max_file_count = Some(parse_u32(value)?),
-            "LogRotation" => config.rotation = parse_rotation(value)?,
-            "LogEnabled" => config.enabled = parse_bool(value)?,
+        match key.to_ascii_lowercase().as_str() {
+            "loglevel" => config.level = parse_level(value)?,
+            "logpath" => config.log_path = Some(PathBuf::from(value)),
+            "logfile" => config.log_file_name = Some(value.to_string()),
+            "logmaxsize" => config.max_file_size = Some(parse_u64(value)?),
+            "logmaxcount" => config.max_file_count = Some(parse_u32(value)?),
+            "logrotation" => config.rotation = parse_rotation(value)?,
+            "logenabled" => config.enabled = parse_bool(value)?,
             _ => {}
         }
     }
@@ -258,5 +260,308 @@ mod tests {
             err_msg.contains("Insecure file permissions"),
             "expected InsecurePermissions error, got: {err_msg}"
         );
+    }
+
+    // ---- INI content parsing ----
+
+    #[test]
+    fn parse_ini_content_all_keys() {
+        let ini = "\
+LogLevel=DEBUG
+LogPath=/var/log/snowflake
+LogFile=driver.log
+LogMaxSize=1048576
+LogMaxCount=5
+LogEnabled=true
+";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::DEBUG);
+        assert_eq!(
+            config.log_path.unwrap(),
+            PathBuf::from("/var/log/snowflake")
+        );
+        assert_eq!(config.log_file_name.unwrap(), "driver.log");
+        assert_eq!(config.max_file_size.unwrap(), 1_048_576);
+        assert_eq!(config.max_file_count.unwrap(), 5);
+        assert!(config.enabled);
+        assert!(!config.open_telemetry);
+    }
+
+    #[test]
+    fn parse_ini_content_defaults_for_missing_keys() {
+        let config = parse_ini_content("").unwrap();
+        assert_eq!(config.level, LevelFilter::INFO);
+        assert!(config.log_path.is_none());
+        assert!(config.log_file_name.is_none());
+        assert!(config.max_file_size.is_none());
+        assert!(config.max_file_count.is_none());
+        assert!(config.enabled);
+        assert!(!config.open_telemetry);
+    }
+
+    #[test]
+    fn parse_ini_content_skips_comments_and_blank_lines() {
+        let ini = "\
+# This is a comment
+; Another comment
+
+LogLevel=WARN
+; non-indented comment
+LogPath=/tmp
+";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::WARN);
+        assert_eq!(config.log_path.unwrap(), PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn parse_ini_content_trims_whitespace() {
+        let ini = "  LogLevel  =  TRACE  \n  LogFile = my_log.log  ";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::TRACE);
+        assert_eq!(config.log_file_name.unwrap(), "my_log.log");
+    }
+
+    #[test]
+    fn parse_ini_content_ignores_unknown_keys() {
+        let ini = "UnknownKey=value\nLogLevel=ERROR\nFoo=bar";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::ERROR);
+    }
+
+    #[test]
+    fn parse_ini_content_disabled() {
+        let ini = "LogEnabled=false";
+        let config = parse_ini_content(ini).unwrap();
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_bool_variants() {
+        for truthy in &["true", "1", "yes", "on", "True", "YES", "ON"] {
+            let ini = format!("LogEnabled={truthy}");
+            assert!(
+                parse_ini_content(&ini).unwrap().enabled,
+                "expected true for {truthy}"
+            );
+        }
+        for falsy in &["false", "0", "no", "off", "False", "NO", "OFF"] {
+            let ini = format!("LogEnabled={falsy}");
+            assert!(
+                !parse_ini_content(&ini).unwrap().enabled,
+                "expected false for {falsy}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_ini_content_invalid_bool() {
+        let ini = "LogEnabled=maybe";
+        let err = parse_ini_content(ini).unwrap_err();
+        assert!(format!("{err:?}").contains("Invalid boolean"));
+    }
+
+    #[test]
+    fn parse_ini_content_invalid_number() {
+        let ini = "LogMaxSize=not_a_number";
+        let err = parse_ini_content(ini).unwrap_err();
+        assert!(format!("{err:?}").contains("Invalid number"));
+    }
+
+    #[test]
+    fn parse_ini_content_invalid_level() {
+        let ini = "LogLevel=VERBOSE";
+        let err = parse_ini_content(ini).unwrap_err();
+        assert!(format!("{err:?}").contains("Unknown log level"));
+    }
+
+    #[test]
+    fn parse_ini_content_level_case_insensitive() {
+        for (input, expected) in [
+            ("off", LevelFilter::OFF),
+            ("error", LevelFilter::ERROR),
+            ("warn", LevelFilter::WARN),
+            ("warning", LevelFilter::WARN),
+            ("info", LevelFilter::INFO),
+            ("debug", LevelFilter::DEBUG),
+            ("trace", LevelFilter::TRACE),
+            ("Info", LevelFilter::INFO),
+            ("DEBUG", LevelFilter::DEBUG),
+        ] {
+            let ini = format!("LogLevel={input}");
+            let config = parse_ini_content(&ini).unwrap();
+            assert_eq!(config.level, expected, "level mismatch for input '{input}'");
+        }
+    }
+
+    // ---- Case-insensitive INI keys ----
+
+    #[test]
+    fn parse_ini_content_lowercase_keys() {
+        let ini = "\
+loglevel=DEBUG
+logpath=/var/log/snowflake
+logfile=driver.log
+logmaxsize=1048576
+logmaxcount=5
+logenabled=true
+";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::DEBUG);
+        assert_eq!(
+            config.log_path.unwrap(),
+            PathBuf::from("/var/log/snowflake")
+        );
+        assert_eq!(config.log_file_name.unwrap(), "driver.log");
+        assert_eq!(config.max_file_size.unwrap(), 1_048_576);
+        assert_eq!(config.max_file_count.unwrap(), 5);
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_uppercase_keys() {
+        let ini = "\
+LOGLEVEL=TRACE
+LOGPATH=/tmp/logs
+LOGFILE=upper.log
+LOGMAXSIZE=2097152
+LOGMAXCOUNT=3
+LOGENABLED=false
+";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::TRACE);
+        assert_eq!(config.log_path.unwrap(), PathBuf::from("/tmp/logs"));
+        assert_eq!(config.log_file_name.unwrap(), "upper.log");
+        assert_eq!(config.max_file_size.unwrap(), 2_097_152);
+        assert_eq!(config.max_file_count.unwrap(), 3);
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_mixed_case_keys() {
+        let ini = "logLevel=ERROR\nLogPATH=/tmp\nlogFILE=mixed.log\nLogMaxSIZE=512\n";
+        let config = parse_ini_content(ini).unwrap();
+        assert_eq!(config.level, LevelFilter::ERROR);
+        assert_eq!(config.log_path.unwrap(), PathBuf::from("/tmp"));
+        assert_eq!(config.log_file_name.unwrap(), "mixed.log");
+        assert_eq!(config.max_file_size.unwrap(), 512);
+    }
+
+    // ---- INI file parsing ----
+
+    #[test]
+    fn parse_ini_file_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sf.odbc.ini");
+        std::fs::write(&path, "LogLevel=DEBUG\nLogPath=/tmp/logs\n").unwrap();
+        let config = parse_ini_file(&path).unwrap();
+        assert_eq!(config.level, LevelFilter::DEBUG);
+        assert_eq!(config.log_path.unwrap(), PathBuf::from("/tmp/logs"));
+    }
+
+    #[test]
+    fn parse_ini_file_missing_file() {
+        let err = parse_ini_file(Path::new("/nonexistent/sf.odbc.ini")).unwrap_err();
+        matches!(err, LogError::Io { .. });
+    }
+
+    // ---- TOML section loading ----
+
+    #[test]
+    fn load_from_toml_section_all_fields() {
+        let mut section = HashMap::new();
+        section.insert("level".into(), Setting::String("DEBUG".into()));
+        section.insert("path".into(), Setting::String("/var/log".into()));
+        section.insert("file".into(), Setting::String("app.log".into()));
+        section.insert("max_size".into(), Setting::Int(2_000_000));
+        section.insert("max_count".into(), Setting::Int(3));
+        section.insert("enabled".into(), Setting::Bool(false));
+        section.insert("opentelemetry".into(), Setting::Bool(true));
+
+        let config = load_from_toml_section(&section);
+        assert_eq!(config.level, LevelFilter::DEBUG);
+        assert_eq!(config.log_path.unwrap(), PathBuf::from("/var/log"));
+        assert_eq!(config.log_file_name.unwrap(), "app.log");
+        assert_eq!(config.max_file_size.unwrap(), 2_000_000);
+        assert_eq!(config.max_file_count.unwrap(), 3);
+        assert!(!config.enabled);
+        assert!(config.open_telemetry);
+    }
+
+    #[test]
+    fn load_from_toml_section_empty_returns_defaults() {
+        let section = HashMap::new();
+        let config = load_from_toml_section(&section);
+        assert_eq!(config.level, LevelFilter::INFO);
+        assert!(config.log_path.is_none());
+        assert!(config.log_file_name.is_none());
+        assert!(config.max_file_size.is_none());
+        assert!(config.max_file_count.is_none());
+        assert!(config.enabled);
+        assert!(!config.open_telemetry);
+    }
+
+    #[test]
+    fn load_from_toml_section_invalid_level_keeps_default() {
+        let mut section = HashMap::new();
+        section.insert("level".into(), Setting::String("VERBOSE".into()));
+        let config = load_from_toml_section(&section);
+        assert_eq!(config.level, LevelFilter::INFO);
+    }
+
+    #[test]
+    fn load_from_toml_section_negative_size_ignored() {
+        let mut section = HashMap::new();
+        section.insert("max_size".into(), Setting::Int(-100));
+        section.insert("max_count".into(), Setting::Int(-1));
+        let config = load_from_toml_section(&section);
+        assert!(config.max_file_size.is_none());
+        assert!(config.max_file_count.is_none());
+    }
+
+    #[test]
+    fn load_from_toml_section_zero_size_ignored() {
+        let mut section = HashMap::new();
+        section.insert("max_size".into(), Setting::Int(0));
+        section.insert("max_count".into(), Setting::Int(0));
+        let config = load_from_toml_section(&section);
+        assert!(config.max_file_size.is_none());
+        assert!(config.max_file_count.is_none());
+    }
+
+    #[test]
+    fn load_from_toml_section_wrong_type_ignored() {
+        let mut section = HashMap::new();
+        section.insert("level".into(), Setting::Int(42));
+        section.insert("max_size".into(), Setting::String("big".into()));
+        let config = load_from_toml_section(&section);
+        assert_eq!(config.level, LevelFilter::INFO);
+        assert!(config.max_file_size.is_none());
+    }
+
+    // ---- find_odbc_ini ----
+
+    #[test]
+    fn find_odbc_ini_via_env_var() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sf.odbc.ini");
+        std::fs::write(&path, "LogLevel=DEBUG\n").unwrap();
+        temp_env::with_var("SF_ODBC_INI", Some(path.to_str().unwrap()), || {
+            let found = find_odbc_ini();
+            assert_eq!(found.unwrap(), path);
+        });
+    }
+
+    #[test]
+    fn find_odbc_ini_env_var_nonexistent_file() {
+        temp_env::with_var("SF_ODBC_INI", Some("/nonexistent/sf.odbc.ini"), || {
+            // Should not return the non-existent env var path; may return None
+            // or a platform path.  Just ensure it doesn't return the env var path.
+            let found = find_odbc_ini();
+            assert_ne!(
+                found.as_deref(),
+                Some(Path::new("/nonexistent/sf.odbc.ini"))
+            );
+        });
     }
 }

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -66,7 +66,12 @@ impl LogManager {
     pub fn init(config: LoggingConfig) -> Result<Self, LogError> {
         let sessions = SessionRegistry::default();
         let provider = Self::try_init(config, None::<EmptyLayer>, Some(sessions.clone()))?
-            .expect("provider is always Some when sessions are provided");
+            .ok_or_else(|| {
+                InitSnafu {
+                    message: "provider is always Some when sessions are provided",
+                }
+                .build()
+            })?;
         Ok(Self {
             telemetry_provider: provider,
             telemetry_sessions: sessions,
@@ -86,8 +91,13 @@ impl LogManager {
     where
         L: Layer<Registry> + Send + Sync + 'static,
     {
-        let provider = Self::try_init(config, Some(app_sink), Some(registry.clone()))?
-            .expect("provider is always Some when registry is Some");
+        let provider =
+            Self::try_init(config, Some(app_sink), Some(registry.clone()))?.ok_or_else(|| {
+                InitSnafu {
+                    message: "provider is always Some when registry is Some",
+                }
+                .build()
+            })?;
         Ok(Self {
             telemetry_provider: provider,
             telemetry_sessions: registry,

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -239,13 +239,111 @@ impl LogManager {
                 );
             }
 
-            Ok(tracing_subscriber::fmt::layer()
+            let fmt_layer = tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_writer(appender)
-                .with_filter(config.level)
-                .boxed())
+                .with_writer(appender);
+
+            Ok(fmt_layer.with_filter(config.level).boxed())
         } else {
             Ok(EmptyLayer.boxed())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_core_layer_disabled_returns_empty() {
+        let config = LoggingConfig {
+            enabled: false,
+            ..LoggingConfig::default()
+        };
+        assert!(LogManager::build_core_layer(&config).is_ok());
+    }
+
+    #[test]
+    fn build_core_layer_no_path_returns_empty() {
+        let config = LoggingConfig {
+            enabled: true,
+            log_path: None,
+            ..LoggingConfig::default()
+        };
+        assert!(LogManager::build_core_layer(&config).is_ok());
+    }
+
+    #[test]
+    fn build_core_layer_with_path_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = LoggingConfig {
+            enabled: true,
+            log_path: Some(dir.path().to_path_buf()),
+            ..LoggingConfig::default()
+        };
+        assert!(LogManager::build_core_layer(&config).is_ok());
+    }
+
+    #[test]
+    fn build_core_layer_with_custom_file_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = LoggingConfig {
+            enabled: true,
+            log_path: Some(dir.path().to_path_buf()),
+            log_file_name: Some("custom.log".to_string()),
+            ..LoggingConfig::default()
+        };
+        assert!(
+            LogManager::build_core_layer(&config).is_ok(),
+            "build_core_layer should succeed with a custom file name"
+        );
+    }
+
+    #[test]
+    fn build_core_layer_respects_level_filter() {
+        use tracing::level_filters::LevelFilter;
+
+        let dir = tempfile::tempdir().unwrap();
+        for level in [
+            LevelFilter::OFF,
+            LevelFilter::ERROR,
+            LevelFilter::WARN,
+            LevelFilter::INFO,
+            LevelFilter::DEBUG,
+            LevelFilter::TRACE,
+        ] {
+            let config = LoggingConfig {
+                enabled: true,
+                log_path: Some(dir.path().to_path_buf()),
+                level,
+                ..LoggingConfig::default()
+            };
+            assert!(
+                LogManager::build_core_layer(&config).is_ok(),
+                "build_core_layer should succeed for level {level:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_config_is_enabled_info_no_path() {
+        use tracing::level_filters::LevelFilter;
+
+        let config = LoggingConfig::default();
+        assert!(config.enabled, "default config should be enabled");
+        assert_eq!(
+            config.level,
+            LevelFilter::INFO,
+            "default level should be INFO"
+        );
+        assert!(config.log_path.is_none(), "default log_path should be None");
+        assert!(
+            config.log_file_name.is_none(),
+            "default log_file_name should be None"
+        );
+        assert!(
+            !config.open_telemetry,
+            "default opentelemetry should be false"
+        );
     }
 }

--- a/sf_core/tests/integration/logging/callback_sink.rs
+++ b/sf_core/tests/integration/logging/callback_sink.rs
@@ -1,0 +1,64 @@
+use std::ffi::{CStr, c_char};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::{CLogCallback, CallbackLayer, LogManager, LoggingConfig};
+use sf_core::telemetry::snowflake_exporter::SessionRegistry;
+
+struct CapturedEvent {
+    level: u32,
+    message: String,
+}
+
+static CAPTURED: Mutex<Vec<CapturedEvent>> = Mutex::new(Vec::new());
+
+unsafe extern "C" fn test_callback(
+    level: u32,
+    message: *const c_char,
+    _filename: *const c_char,
+    _line: u32,
+    _function: *const c_char,
+) -> u32 {
+    let msg = unsafe { CStr::from_ptr(message) }
+        .to_string_lossy()
+        .into_owned();
+    CAPTURED.lock().unwrap().push(CapturedEvent {
+        level,
+        message: msg,
+    });
+    0
+}
+
+/// Verify that events emitted through tracing are delivered to a C callback
+/// registered via `CallbackLayer`.
+#[test]
+fn callback_layer_delivers_events() {
+    let config = LoggingConfig::default();
+    let cb: CLogCallback = test_callback;
+    LogManager::with_app_sink(config, CallbackLayer::new(cb), SessionRegistry::default()).unwrap();
+
+    tracing::info!("callback_info_msg");
+    tracing::warn!("callback_warn_msg");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let events = CAPTURED.lock().unwrap();
+    let info_event = events
+        .iter()
+        .find(|e| e.message.contains("callback_info_msg"));
+    assert!(
+        info_event.is_some(),
+        "callback should have received INFO event"
+    );
+    assert_eq!(info_event.unwrap().level, 2, "INFO level should map to 2");
+
+    let warn_event = events
+        .iter()
+        .find(|e| e.message.contains("callback_warn_msg"));
+    assert!(
+        warn_event.is_some(),
+        "callback should have received WARN event"
+    );
+    assert_eq!(warn_event.unwrap().level, 1, "WARN level should map to 1");
+}

--- a/sf_core/tests/integration/logging/custom_file_name.rs
+++ b/sf_core/tests/integration/logging/custom_file_name.rs
@@ -1,0 +1,60 @@
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::LogManager;
+use sf_core::logging::ini_config::parse_ini_file;
+
+/// Configure `LogFile=my_custom_driver.log`, emit an event, and verify a file
+/// matching that prefix exists in the log directory.
+#[test]
+fn custom_log_file_name_is_used() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(
+        &ini_path,
+        format!(
+            "LogLevel=INFO\nLogPath={}\nLogFile=my_custom_driver.log\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let config = parse_ini_file(&ini_path).unwrap();
+    assert_eq!(
+        config.log_file_name.as_deref(),
+        Some("my_custom_driver.log")
+    );
+
+    LogManager::init(config).unwrap();
+
+    tracing::info!("custom_file_name_test_message");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let entries: Vec<_> = std::fs::read_dir(&log_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+
+    let has_custom_file = entries
+        .iter()
+        .any(|e| e.file_name().to_string_lossy().contains("my_custom_driver"));
+    assert!(
+        has_custom_file,
+        "expected a log file with prefix 'my_custom_driver' in {}, found: {:?}",
+        log_dir.display(),
+        entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+    );
+
+    let mut combined = String::new();
+    for entry in &entries {
+        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap_or_default());
+    }
+    assert!(
+        combined.contains("custom_file_name_test_message"),
+        "test message should appear in the custom-named log file"
+    );
+}

--- a/sf_core/tests/integration/logging/disabled_logging.rs
+++ b/sf_core/tests/integration/logging/disabled_logging.rs
@@ -1,0 +1,45 @@
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::LogManager;
+use sf_core::logging::ini_config::parse_ini_file;
+
+/// When `LogEnabled=false`, the LogManager initialises successfully but no
+/// test messages appear in any log file under the configured path.
+#[test]
+fn disabled_logging_produces_no_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(
+        &ini_path,
+        format!(
+            "LogEnabled=false\nLogPath={}\nLogFile=disabled.log\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let config = parse_ini_file(&ini_path).unwrap();
+    assert!(!config.enabled);
+
+    LogManager::init(config).unwrap();
+    tracing::info!("disabled_logging_test_message");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let has_test_message = std::fs::read_dir(&log_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            std::fs::read_to_string(e.path())
+                .unwrap_or_default()
+                .contains("disabled_logging_test_message")
+        });
+    assert!(
+        !has_test_message,
+        "expected no log file containing test message when logging is disabled"
+    );
+}

--- a/sf_core/tests/integration/logging/for_odbc_factory.rs
+++ b/sf_core/tests/integration/logging/for_odbc_factory.rs
@@ -1,0 +1,42 @@
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::LogManager;
+
+/// End-to-end: write a temp INI, point `SF_ODBC_INI` at it, call
+/// `LogManager::for_odbc()`, emit an event, and verify it lands in the log
+/// file.
+#[test]
+fn for_odbc_factory_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(
+        &ini_path,
+        format!(
+            "LogLevel=INFO\nLogPath={}\nLogFile=odbc_factory.log\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+
+    temp_env::with_var("SF_ODBC_INI", Some(ini_path.to_str().unwrap()), || {
+        LogManager::for_odbc();
+
+        tracing::info!("for_odbc_factory_test_message");
+
+        thread::sleep(Duration::from_millis(200));
+
+        let mut combined = String::new();
+        for entry in std::fs::read_dir(&log_dir).unwrap().filter_map(|e| e.ok()) {
+            combined.push_str(&std::fs::read_to_string(entry.path()).unwrap_or_default());
+        }
+
+        assert!(
+            combined.contains("for_odbc_factory_test_message"),
+            "expected test message in log file, got: {combined}"
+        );
+    });
+}

--- a/sf_core/tests/integration/logging/level_filtering.rs
+++ b/sf_core/tests/integration/logging/level_filtering.rs
@@ -1,0 +1,58 @@
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::LogManager;
+use sf_core::logging::ini_config::parse_ini_file;
+
+/// Configure LogLevel=WARN, emit ERROR/WARN/INFO/DEBUG events, and verify
+/// that only ERROR and WARN appear in the log file.
+#[test]
+fn warn_level_filters_info_and_debug() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(
+        &ini_path,
+        format!(
+            "LogLevel=WARN\nLogPath={}\nLogFile=level_filter.log\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let config = parse_ini_file(&ini_path).unwrap();
+    assert_eq!(config.level, tracing::level_filters::LevelFilter::WARN);
+
+    LogManager::init(config).unwrap();
+
+    tracing::error!("level_filter_error_msg");
+    tracing::warn!("level_filter_warn_msg");
+    tracing::info!("level_filter_info_msg");
+    tracing::debug!("level_filter_debug_msg");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let mut combined = String::new();
+    for entry in std::fs::read_dir(&log_dir).unwrap().filter_map(|e| e.ok()) {
+        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap_or_default());
+    }
+
+    assert!(
+        combined.contains("level_filter_error_msg"),
+        "ERROR message should appear at WARN level"
+    );
+    assert!(
+        combined.contains("level_filter_warn_msg"),
+        "WARN message should appear at WARN level"
+    );
+    assert!(
+        !combined.contains("level_filter_info_msg"),
+        "INFO message should NOT appear at WARN level"
+    );
+    assert!(
+        !combined.contains("level_filter_debug_msg"),
+        "DEBUG message should NOT appear at WARN level"
+    );
+}

--- a/sf_core/tests/integration/logging/mod.rs
+++ b/sf_core/tests/integration/logging/mod.rs
@@ -1,0 +1,1 @@
+mod odbc_logging;

--- a/sf_core/tests/integration/logging/odbc_logging.rs
+++ b/sf_core/tests/integration/logging/odbc_logging.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+use sf_core::logging::ini_config::{find_odbc_ini, parse_ini_file};
+use sf_core::logging::{LogManager, LoggingConfig};
+use tracing::level_filters::LevelFilter;
+
+/// Single-init happy path: parse a temp INI, init `LogManager`, emit events,
+/// verify the log file.
+#[test]
+fn ini_to_log_manager_happy_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(
+        &ini_path,
+        format!(
+            "LogLevel=INFO\nLogPath={}\nLogFile=test_driver.log\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let config = parse_ini_file(&ini_path).unwrap();
+    assert_eq!(config.level, LevelFilter::INFO);
+    assert_eq!(config.log_path.as_deref(), Some(log_dir.as_path()));
+    assert_eq!(config.log_file_name.as_deref(), Some("test_driver.log"));
+
+    LogManager::init(config).unwrap();
+
+    tracing::info!("happy_path_info_message");
+    tracing::warn!("happy_path_warn_message");
+    tracing::debug!("happy_path_debug_should_not_appear");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let entries: Vec<_> = std::fs::read_dir(&log_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "expected at least one log file in {}, found none",
+        log_dir.display()
+    );
+
+    let mut combined = String::new();
+    for entry in &entries {
+        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap_or_default());
+    }
+    assert!(
+        combined.contains("happy_path_info_message"),
+        "INFO message should appear in log file"
+    );
+    assert!(
+        combined.contains("happy_path_warn_message"),
+        "WARN message should appear in log file"
+    );
+    assert!(
+        !combined.contains("happy_path_debug_should_not_appear"),
+        "DEBUG message should not appear when level is INFO"
+    );
+}
+
+/// Verify `find_odbc_ini` picks up the `SF_ODBC_INI` env var.
+#[test]
+fn find_odbc_ini_resolves_env_var() {
+    let dir = tempfile::tempdir().unwrap();
+    let ini_path = dir.path().join("sf.odbc.ini");
+    std::fs::write(&ini_path, "LogLevel=WARN\n").unwrap();
+
+    temp_env::with_var("SF_ODBC_INI", Some(ini_path.to_str().unwrap()), || {
+        let found = find_odbc_ini();
+        assert_eq!(found.as_deref(), Some(ini_path.as_path()));
+    });
+}
+
+/// Verify that a non-existent INI path returns an IO error.
+#[test]
+fn parse_nonexistent_ini_returns_io_error() {
+    let result = parse_ini_file(Path::new("/nonexistent/path/sf.odbc.ini"));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, sf_core::logging::LogError::Io { .. }),
+        "expected Io error variant, got: {err:?}"
+    );
+}

--- a/sf_core/tests/integration/logging/odbc_logging.rs
+++ b/sf_core/tests/integration/logging/odbc_logging.rs
@@ -1,9 +1,8 @@
-use std::path::Path;
 use std::thread;
 use std::time::Duration;
 
+use sf_core::logging::LogManager;
 use sf_core::logging::ini_config::{find_odbc_ini, parse_ini_file};
-use sf_core::logging::{LogManager, LoggingConfig};
 use tracing::level_filters::LevelFilter;
 
 /// Single-init happy path: parse a temp INI, init `LogManager`, emit events,
@@ -81,7 +80,9 @@ fn find_odbc_ini_resolves_env_var() {
 /// Verify that a non-existent INI path returns an IO error.
 #[test]
 fn parse_nonexistent_ini_returns_io_error() {
-    let result = parse_ini_file(Path::new("/nonexistent/path/sf.odbc.ini"));
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("sf.odbc.ini");
+    let result = parse_ini_file(&missing);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(

--- a/sf_core/tests/integration/logging/toml_config.rs
+++ b/sf_core/tests/integration/logging/toml_config.rs
@@ -19,7 +19,7 @@ fn toml_log_section_with_level_filtering() {
         &config_path,
         format!(
             "[log]\nlevel = \"DEBUG\"\npath = \"{}\"\nfile = \"toml_test.log\"\n",
-            log_dir.display()
+            log_dir.display().to_string().replace('\\', "/")
         ),
     )
     .unwrap();

--- a/sf_core/tests/integration/logging/toml_config.rs
+++ b/sf_core/tests/integration/logging/toml_config.rs
@@ -1,0 +1,63 @@
+use std::thread;
+use std::time::Duration;
+
+use sf_core::config::config_manager::load_config_section_with_paths;
+use sf_core::config::path_resolver::ConfigPaths;
+use sf_core::logging::LogManager;
+use sf_core::logging::ini_config::load_from_toml_section;
+
+/// Load a `[log]` section from a TOML file, init `LogManager` at DEBUG level,
+/// and verify that DEBUG events appear but TRACE events do not.
+#[test]
+fn toml_log_section_with_level_filtering() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_dir = dir.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[log]\nlevel = \"DEBUG\"\npath = \"{}\"\nfile = \"toml_test.log\"\n",
+            log_dir.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let paths = ConfigPaths {
+        config_file: Some(config_path),
+        connections_file: None,
+    };
+    let section = load_config_section_with_paths("log", &paths)
+        .expect("load_config_section_with_paths failed")
+        .expect("[log] section should exist");
+
+    let config = load_from_toml_section(&section);
+    assert_eq!(config.level, tracing::level_filters::LevelFilter::DEBUG);
+
+    LogManager::init(config).unwrap();
+
+    tracing::debug!("toml_debug_message_should_appear");
+    tracing::trace!("toml_trace_message_should_not_appear");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let mut combined = String::new();
+    for entry in std::fs::read_dir(&log_dir).unwrap().filter_map(|e| e.ok()) {
+        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap_or_default());
+    }
+
+    assert!(
+        combined.contains("toml_debug_message_should_appear"),
+        "DEBUG message should appear in log file at DEBUG level"
+    );
+    assert!(
+        !combined.contains("toml_trace_message_should_not_appear"),
+        "TRACE message should not appear when level is DEBUG"
+    );
+}

--- a/sf_core/tests/logging_callback_tests.rs
+++ b/sf_core/tests/logging_callback_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/callback_sink.rs"]
+mod callback_sink;

--- a/sf_core/tests/logging_custom_file_tests.rs
+++ b/sf_core/tests/logging_custom_file_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/custom_file_name.rs"]
+mod custom_file_name;

--- a/sf_core/tests/logging_disabled_tests.rs
+++ b/sf_core/tests/logging_disabled_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/disabled_logging.rs"]
+mod disabled_logging;

--- a/sf_core/tests/logging_for_odbc_tests.rs
+++ b/sf_core/tests/logging_for_odbc_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/for_odbc_factory.rs"]
+mod for_odbc_factory;

--- a/sf_core/tests/logging_level_filtering_tests.rs
+++ b/sf_core/tests/logging_level_filtering_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/level_filtering.rs"]
+mod level_filtering;

--- a/sf_core/tests/logging_tests.rs
+++ b/sf_core/tests/logging_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/odbc_logging.rs"]
+mod odbc_logging;

--- a/sf_core/tests/logging_toml_tests.rs
+++ b/sf_core/tests/logging_toml_tests.rs
@@ -1,0 +1,2 @@
+#[path = "integration/logging/toml_config.rs"]
+mod toml_config;


### PR DESCRIPTION
### TL;DR

Adds comprehensive test coverage for the logging subsystem and hardens JNI/JVM error handling in the JDBC bridge.

### What changed?

- **INI config key matching is now case-insensitive.** Keys like `loglevel`, `LOGLEVEL`, and `LogLevel` are all accepted.
- **INI file I/O errors are now distinguished from parse errors.** `parse_ini_file` maps `ini::Error::Io` to `LogError::Io` and `ini::Error::Parse` to `LogError::ConfigParse` instead of collapsing both into a single message.
- **`LogConfig` derives `Debug`** to support test assertions and error reporting.
- **JNI calls in `sflogger_layer` no longer panic on failure.** All `.unwrap()` calls on JNI operations (`find_class`, `new_string`, `call_static_method`, `call_method`) are replaced with graceful error handling that prints to stderr and returns early.
- **Unit tests added inline** in `ini_config.rs` (covering INI parsing, TOML section loading, boolean/level/number parsing, case-insensitive keys, and `find_odbc_ini`) and in `log_manager.rs` (covering `build_core_layer` with various configurations and the default `LogConfig` shape).
- **A smoke test added to `jdbc_bridge`** verifying that `JdbcBridge::new()` succeeds when no `LogManager` is initialised.
- **Integration test suite for logging** introduced as separate test binaries: `logging_tests`, `logging_disabled_tests`, `logging_toml_tests`, `logging_callback_tests`, `logging_for_odbc_tests`, `logging_level_filtering_tests`, and `logging_custom_file_tests`. Each covers an end-to-end scenario including INI-to-`LogManager` happy path, disabled logging producing no output, TOML-driven level filtering, C callback delivery, `LogManager::for_odbc()` factory, WARN-level filtering, and custom log file naming.

### How to test?

Run the full test suite:

```
cargo test -p sf_core
cargo test -p jdbc_bridge
```

Individual integration test binaries can be targeted directly, e.g.:

```
cargo test --test logging_tests
cargo test --test logging_disabled_tests
cargo test --test logging_level_filtering_tests
```

### Why make this change?

The logging subsystem previously had no dedicated test coverage, making it difficult to validate behaviour across configuration sources (INI, TOML, callbacks) or catch regressions in level filtering, file naming, and disabled-logging semantics. The JNI layer also contained unchecked `.unwrap()` calls that could panic the process if the JVM was in an unexpected state. This change closes both gaps.