### PR TITLE
SNOW-3098562: Determine if statement should have results based on its type

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -1167,6 +1167,16 @@ pub fn get_info<E: OdbcEncoding>(
             }
             Ok(())
         }
+        InfoType::DbmsName => {
+            write_string_bytes::<E>(
+                "Snowflake",
+                info_value_ptr as *mut E::Char,
+                buffer_length,
+                string_length_ptr,
+                None,
+            );
+            Ok(())
+        }
         InfoType::DriverOdbcVer => {
             write_string_bytes::<E>(
                 "03.00",

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod environment;
 pub mod error;
 pub mod handle_allocation;
 pub mod handle_registry;
+pub mod query_type;
 pub mod runtime;
 pub mod sql_state;
 pub mod statement;

--- a/odbc/src/api/query_type.rs
+++ b/odbc/src/api/query_type.rs
@@ -7,10 +7,20 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct QueryType(i64);
 
-impl QueryType {
-    // Full taxonomy is public API; not every id is referenced internally.
-    #![allow(dead_code)]
+/// Result-set behavior that the ODBC layer should produce for a statement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResultKind {
+    /// Opens a cursor. `SQLNumResultCols > 0`, `SQLFetch` yields rows.
+    Cursor,
+    /// No cursor; `SQLRowCount` reports an update count. DML only.
+    UpdateCount,
+    /// No cursor, no update count (`SQLRowCount` returns -1). DDL/TCL/acks.
+    NoResult,
+}
 
+// Full taxonomy is public API; not every id is referenced internally.
+#[allow(dead_code)]
+impl QueryType {
     pub const UNKNOWN: Self = Self(0x0000);
     pub const SELECT: Self = Self(0x1000);
     pub const EXPLAIN: Self = Self(0x2000);
@@ -21,6 +31,9 @@ impl QueryType {
     pub const DESCRIBE: Self = Self(0x4500);
     pub const LIST_FILES: Self = Self(0x4701);
     pub const DDL: Self = Self(0x6000);
+    /// `MANAGE_PATS` — DDL-family statement that returns a browsable result set.
+    /// Preserved as an explicit exception because it doesn't fit the DDL default.
+    pub const MANAGE_PATS: Self = Self(0x6244);
     pub const STAGE_FILE_OPERATIONS: Self = Self(0x7000);
     pub const GET_FILES: Self = Self(0x7101);
     pub const PUT_FILES: Self = Self(0x7102);
@@ -64,8 +77,37 @@ impl QueryType {
             || self == Self::EXPLAIN
             || self == Self::CALL
             || self == Self::COPY
+            || self == Self::MANAGE_PATS
             || self.is_syscmd_with_result_set()
             || self.is_stage_operation()
+    }
+
+    /// Families we explicitly know produce no cursor and no update count.
+    /// Used as the middle step in [`Self::result_kind`] so that ids the driver
+    /// hasn't catalogued yet default to `Cursor` rather than silently dropping
+    /// result data.
+    fn is_known_no_result(self) -> bool {
+        self.belongs_to(Self::DDL)
+            || self.belongs_to(Self::MISC_QUERY_TYPES)
+            || self.belongs_to(Self::MULTI_STMT)
+    }
+
+    /// Which ODBC state should the driver produce for a statement of this type.
+    ///
+    /// Precedence: `has_result_set` → `is_dml` → `is_known_no_result`.  Any id
+    /// that falls out the bottom (including `UNKNOWN` and ids the driver
+    /// doesn't recognise yet) defaults to `Cursor` so new Snowflake statement
+    /// types don't silently lose their result data.
+    pub fn result_kind(self) -> ResultKind {
+        if self.has_result_set() {
+            ResultKind::Cursor
+        } else if self.is_dml() {
+            ResultKind::UpdateCount
+        } else if self.is_known_no_result() {
+            ResultKind::NoResult
+        } else {
+            ResultKind::Cursor
+        }
     }
 }
 
@@ -148,5 +190,63 @@ mod tests {
         let future = QueryType::from_raw(Some(0xBEEF));
         assert!(!future.is_dml());
         assert!(!future.has_result_set());
+    }
+
+    #[test]
+    fn manage_pats_has_result_set() {
+        // 0x6244 belongs to the DDL family via the level-3 mask but produces a
+        // browsable result set (e.g. SHOW PATS).  Verified as an explicit
+        // exception in `has_result_set()`.
+        assert!(QueryType::MANAGE_PATS.belongs_to(QueryType::DDL));
+        assert!(QueryType::MANAGE_PATS.has_result_set());
+        assert_eq!(QueryType::MANAGE_PATS.result_kind(), ResultKind::Cursor);
+    }
+
+    #[test]
+    fn result_kind_update_count_for_plain_dml() {
+        // DML family excluding COPY — plain INSERT/UPDATE/DELETE/MERGE land
+        // on the `UpdateCount` branch.
+        assert_eq!(QueryType::DML.result_kind(), ResultKind::UpdateCount);
+    }
+
+    #[test]
+    fn result_kind_cursor_for_copy_even_though_its_dml() {
+        // COPY belongs to DML but also opens a cursor; `Cursor` must win.
+        assert_eq!(QueryType::COPY.result_kind(), ResultKind::Cursor);
+    }
+
+    #[test]
+    fn result_kind_cursor_for_select_and_friends() {
+        assert_eq!(QueryType::SELECT.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::EXPLAIN.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::CALL.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::SHOW.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::DESCRIBE.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::LIST_FILES.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::GET_FILES.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::PUT_FILES.result_kind(), ResultKind::Cursor);
+    }
+
+    #[test]
+    fn result_kind_no_result_for_ddl_and_tcl() {
+        assert_eq!(QueryType::DDL.result_kind(), ResultKind::NoResult);
+        assert_eq!(QueryType::BEGIN.result_kind(), ResultKind::NoResult);
+        assert_eq!(QueryType::COMMIT.result_kind(), ResultKind::NoResult);
+        assert_eq!(QueryType::END.result_kind(), ResultKind::NoResult);
+        assert_eq!(QueryType::SET.result_kind(), ResultKind::NoResult);
+        assert_eq!(QueryType::MULTI_STMT.result_kind(), ResultKind::NoResult);
+    }
+
+    #[test]
+    fn result_kind_cursor_for_unknown_or_absent_id() {
+        // Defensive default: an id the driver doesn't recognise yet (or a
+        // missing `statementTypeId` on the wire) should open a cursor so
+        // future statement types don't silently drop their result data.
+        assert_eq!(QueryType::UNKNOWN.result_kind(), ResultKind::Cursor);
+        assert_eq!(QueryType::from_raw(None).result_kind(), ResultKind::Cursor);
+        assert_eq!(
+            QueryType::from_raw(Some(0xBEEF)).result_kind(),
+            ResultKind::Cursor
+        );
     }
 }

--- a/odbc/src/api/query_type.rs
+++ b/odbc/src/api/query_type.rs
@@ -1,0 +1,152 @@
+//! Snowflake `statementTypeId` taxonomy.
+//!
+//! Specific ids are explicit constants; hierarchical matching uses level-2 (`0xff00`) and level-3
+//! (`0xf000`) bit-masks so subtypes (e.g. `COPY = 0x3600`) `belongs_to`
+//! their parent family (`DML = 0x3000`).
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QueryType(i64);
+
+impl QueryType {
+    // Full taxonomy is public API; not every id is referenced internally.
+    #![allow(dead_code)]
+
+    pub const UNKNOWN: Self = Self(0x0000);
+    pub const SELECT: Self = Self(0x1000);
+    pub const EXPLAIN: Self = Self(0x2000);
+    pub const DML: Self = Self(0x3000);
+    pub const COPY: Self = Self(0x3600);
+    pub const SYSCMD: Self = Self(0x4000);
+    pub const SHOW: Self = Self(0x4400);
+    pub const DESCRIBE: Self = Self(0x4500);
+    pub const LIST_FILES: Self = Self(0x4701);
+    pub const DDL: Self = Self(0x6000);
+    pub const STAGE_FILE_OPERATIONS: Self = Self(0x7000);
+    pub const GET_FILES: Self = Self(0x7101);
+    pub const PUT_FILES: Self = Self(0x7102);
+    pub const REMOVE_FILES: Self = Self(0x7103);
+    pub const MISC_QUERY_TYPES: Self = Self(0x8000);
+    pub const BEGIN: Self = Self(0x8101);
+    pub const END: Self = Self(0x8102);
+    pub const COMMIT: Self = Self(0x8103);
+    pub const SET: Self = Self(0x8104);
+    pub const CALL: Self = Self(0x9000);
+    pub const MULTI_STMT: Self = Self(0xA000);
+
+    const LEVEL_2_MASK: i64 = 0xff00;
+    const LEVEL_3_MASK: i64 = 0xf000;
+
+    pub fn from_raw(id: Option<i64>) -> Self {
+        Self(id.unwrap_or(0))
+    }
+
+    pub fn belongs_to(self, family: Self) -> bool {
+        family.0 == self.0
+            || family.0 == (self.0 & Self::LEVEL_2_MASK)
+            || family.0 == (self.0 & Self::LEVEL_3_MASK)
+    }
+
+    pub fn is_dml(self) -> bool {
+        self.belongs_to(Self::DML)
+    }
+
+    fn is_stage_operation(self) -> bool {
+        self == Self::LIST_FILES || self.belongs_to(Self::STAGE_FILE_OPERATIONS)
+    }
+
+    fn is_syscmd_with_result_set(self) -> bool {
+        self == Self::SHOW || self == Self::DESCRIBE || self == Self::LIST_FILES
+    }
+
+    /// Whether this statement produces a browsable result set (cursor).
+    pub fn has_result_set(self) -> bool {
+        self == Self::SELECT
+            || self == Self::EXPLAIN
+            || self == Self::CALL
+            || self == Self::COPY
+            || self.is_syscmd_with_result_set()
+            || self.is_stage_operation()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_is_neither_dml_nor_cursor() {
+        let qt = QueryType::from_raw(None);
+        assert_eq!(qt, QueryType::UNKNOWN);
+        assert!(!qt.is_dml());
+        assert!(!qt.has_result_set());
+    }
+
+    #[test]
+    fn copy_belongs_to_dml_via_level3_mask() {
+        assert!(QueryType::COPY.belongs_to(QueryType::DML));
+        assert!(QueryType::COPY.is_dml());
+    }
+
+    #[test]
+    fn tcl_subtypes_belong_to_misc_via_level3_mask() {
+        assert!(QueryType::BEGIN.belongs_to(QueryType::MISC_QUERY_TYPES));
+        assert!(QueryType::COMMIT.belongs_to(QueryType::MISC_QUERY_TYPES));
+        assert!(QueryType::SET.belongs_to(QueryType::MISC_QUERY_TYPES));
+    }
+
+    #[test]
+    fn tcl_has_no_result_set() {
+        assert!(!QueryType::BEGIN.has_result_set());
+        assert!(!QueryType::COMMIT.has_result_set());
+        assert!(!QueryType::END.has_result_set());
+        assert!(!QueryType::SET.has_result_set());
+    }
+
+    #[test]
+    fn ddl_is_neither_dml_nor_cursor() {
+        let qt = QueryType::DDL;
+        assert!(!qt.is_dml());
+        assert!(!qt.has_result_set());
+    }
+
+    #[test]
+    fn select_explain_call_have_result_sets() {
+        assert!(QueryType::SELECT.has_result_set());
+        assert!(QueryType::EXPLAIN.has_result_set());
+        assert!(QueryType::CALL.has_result_set());
+    }
+
+    #[test]
+    fn syscmd_subtypes_are_cursors_parent_is_not() {
+        assert!(QueryType::SHOW.has_result_set());
+        assert!(QueryType::DESCRIBE.has_result_set());
+        assert!(QueryType::LIST_FILES.has_result_set());
+        // The SYSCMD family parent itself is not whitelisted by old ODBC.
+        assert!(!QueryType::SYSCMD.has_result_set());
+    }
+
+    #[test]
+    fn stage_operations_have_result_sets() {
+        assert!(QueryType::GET_FILES.has_result_set());
+        assert!(QueryType::PUT_FILES.has_result_set());
+        assert!(QueryType::REMOVE_FILES.has_result_set());
+        assert!(QueryType::STAGE_FILE_OPERATIONS.has_result_set());
+    }
+
+    #[test]
+    fn copy_is_cursor_and_dml() {
+        // COPY is classified as DML by family but also opens a cursor.
+        assert!(QueryType::COPY.is_dml());
+        assert!(QueryType::COPY.has_result_set());
+    }
+
+    #[test]
+    fn multi_stmt_and_unrecognised_ids_classify_as_no_cursor() {
+        assert!(!QueryType::MULTI_STMT.is_dml());
+        assert!(!QueryType::MULTI_STMT.has_result_set());
+        // A synthetic future id outside every known family.
+        let future = QueryType::from_raw(Some(0xBEEF));
+        assert!(!future.is_dml());
+        assert!(!future.has_result_set());
+    }
+}

--- a/odbc/src/api/query_type.rs
+++ b/odbc/src/api/query_type.rs
@@ -63,14 +63,6 @@ impl QueryType {
         self.belongs_to(Self::DML)
     }
 
-    fn is_stage_operation(self) -> bool {
-        self == Self::LIST_FILES || self.belongs_to(Self::STAGE_FILE_OPERATIONS)
-    }
-
-    fn is_syscmd_with_result_set(self) -> bool {
-        self == Self::SHOW || self == Self::DESCRIBE || self == Self::LIST_FILES
-    }
-
     /// Whether this statement produces a browsable result set (cursor).
     pub fn has_result_set(self) -> bool {
         self == Self::SELECT
@@ -78,24 +70,16 @@ impl QueryType {
             || self == Self::CALL
             || self == Self::COPY
             || self == Self::MANAGE_PATS
-            || self.is_syscmd_with_result_set()
-            || self.is_stage_operation()
-    }
-
-    /// Families we explicitly know produce no cursor and no update count.
-    /// Used as the middle step in [`Self::result_kind`] so that ids the driver
-    /// hasn't catalogued yet default to `Cursor` rather than silently dropping
-    /// result data.
-    fn is_known_no_result(self) -> bool {
-        self.belongs_to(Self::DDL)
-            || self.belongs_to(Self::MISC_QUERY_TYPES)
-            || self.belongs_to(Self::MULTI_STMT)
+            || self == Self::SHOW
+            || self == Self::DESCRIBE
+            || self == Self::LIST_FILES
+            || self.belongs_to(Self::STAGE_FILE_OPERATIONS)
     }
 
     /// Which ODBC state should the driver produce for a statement of this type.
     ///
-    /// Precedence: `has_result_set` → `is_dml` → `is_known_no_result`.  Any id
-    /// that falls out the bottom (including `UNKNOWN` and ids the driver
+    /// Precedence: `has_result_set` → `is_dml` → explicit no-result families.
+    /// Any id that falls out the bottom (including `UNKNOWN` and ids the driver
     /// doesn't recognise yet) defaults to `Cursor` so new Snowflake statement
     /// types don't silently lose their result data.
     pub fn result_kind(self) -> ResultKind {
@@ -103,7 +87,7 @@ impl QueryType {
             ResultKind::Cursor
         } else if self.is_dml() {
             ResultKind::UpdateCount
-        } else if self.is_known_no_result() {
+        } else if self.belongs_to(Self::DDL) || self.belongs_to(Self::MISC_QUERY_TYPES) {
             ResultKind::NoResult
         } else {
             ResultKind::Cursor
@@ -116,39 +100,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unknown_is_neither_dml_nor_cursor() {
-        let qt = QueryType::from_raw(None);
-        assert_eq!(qt, QueryType::UNKNOWN);
-        assert!(!qt.is_dml());
-        assert!(!qt.has_result_set());
-    }
-
-    #[test]
     fn copy_belongs_to_dml_via_level3_mask() {
         assert!(QueryType::COPY.belongs_to(QueryType::DML));
         assert!(QueryType::COPY.is_dml());
-    }
-
-    #[test]
-    fn tcl_subtypes_belong_to_misc_via_level3_mask() {
-        assert!(QueryType::BEGIN.belongs_to(QueryType::MISC_QUERY_TYPES));
-        assert!(QueryType::COMMIT.belongs_to(QueryType::MISC_QUERY_TYPES));
-        assert!(QueryType::SET.belongs_to(QueryType::MISC_QUERY_TYPES));
-    }
-
-    #[test]
-    fn tcl_has_no_result_set() {
-        assert!(!QueryType::BEGIN.has_result_set());
-        assert!(!QueryType::COMMIT.has_result_set());
-        assert!(!QueryType::END.has_result_set());
-        assert!(!QueryType::SET.has_result_set());
-    }
-
-    #[test]
-    fn ddl_is_neither_dml_nor_cursor() {
-        let qt = QueryType::DDL;
-        assert!(!qt.is_dml());
-        assert!(!qt.has_result_set());
     }
 
     #[test]
@@ -183,22 +137,9 @@ mod tests {
     }
 
     #[test]
-    fn multi_stmt_and_unrecognised_ids_classify_as_no_cursor() {
-        assert!(!QueryType::MULTI_STMT.is_dml());
-        assert!(!QueryType::MULTI_STMT.has_result_set());
-        // A synthetic future id outside every known family.
-        let future = QueryType::from_raw(Some(0xBEEF));
-        assert!(!future.is_dml());
-        assert!(!future.has_result_set());
-    }
-
-    #[test]
     fn manage_pats_has_result_set() {
-        // 0x6244 belongs to the DDL family via the level-3 mask but produces a
-        // browsable result set (e.g. SHOW PATS).  Verified as an explicit
-        // exception in `has_result_set()`.
-        assert!(QueryType::MANAGE_PATS.belongs_to(QueryType::DDL));
-        assert!(QueryType::MANAGE_PATS.has_result_set());
+        // 0x6244 belongs to the DDL family via the level-3 mask but produces
+        // a browsable result set (e.g. SHOW PATS).
         assert_eq!(QueryType::MANAGE_PATS.result_kind(), ResultKind::Cursor);
     }
 
@@ -234,7 +175,6 @@ mod tests {
         assert_eq!(QueryType::COMMIT.result_kind(), ResultKind::NoResult);
         assert_eq!(QueryType::END.result_kind(), ResultKind::NoResult);
         assert_eq!(QueryType::SET.result_kind(), ResultKind::NoResult);
-        assert_eq!(QueryType::MULTI_STMT.result_kind(), ResultKind::NoResult);
     }
 
     #[test]

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -7,7 +7,7 @@ use crate::api::error::{
     JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcRuntimeSnafu, ReadOnlyAttributeSnafu,
     Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
 };
-use crate::api::query_type::QueryType;
+use crate::api::query_type::{QueryType, ResultKind};
 use crate::api::runtime::global;
 use crate::api::{
     ApdRecord, ConnectionState, DaeContext, ExecutionOrigin, FreeStmtOption, IpdRecord, OdbcResult,
@@ -527,22 +527,19 @@ fn create_execute_state_from_result_set(
     let stream = rs.stream.required("Stream is required")?;
     let reader = reader_from_protobuf_stream(stream)?;
     let schema = reader.schema();
-    let qt = QueryType::from_raw(statement_type_id);
 
-    let state = if qt.is_dml() && !qt.has_result_set() {
-        StatementState::DmlExecuted {
+    let state = match QueryType::from_raw(statement_type_id).result_kind() {
+        ResultKind::UpdateCount => StatementState::DmlExecuted {
             rows_affected: rows_affected.unwrap_or(0),
             schema,
             origin,
-        }
-    } else if qt.has_result_set() {
-        StatementState::QueryExecuted {
+        },
+        ResultKind::Cursor => StatementState::QueryExecuted {
             reader,
             rows_affected,
             origin,
-        }
-    } else {
-        StatementState::DdlExecuted { schema, origin }
+        },
+        ResultKind::NoResult => StatementState::DdlExecuted { schema, origin },
     };
     Ok(state)
 }

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -7,6 +7,7 @@ use crate::api::error::{
     JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcRuntimeSnafu, ReadOnlyAttributeSnafu,
     Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
 };
+use crate::api::query_type::QueryType;
 use crate::api::runtime::global;
 use crate::api::{
     ApdRecord, ConnectionState, DaeContext, ExecutionOrigin, FreeStmtOption, IpdRecord, OdbcResult,
@@ -410,20 +411,6 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     }
 }
 
-const STATEMENT_TYPE_ID_MANAGE_PATS: i64 = 0x6244;
-
-fn is_ddl_statement(statement_type_id: i64) -> bool {
-    tracing::debug!("is_ddl_statement: statement_type_id={}", statement_type_id);
-    if statement_type_id == STATEMENT_TYPE_ID_MANAGE_PATS {
-        return false;
-    }
-    (0x6000..0x7000).contains(&statement_type_id)
-}
-
-fn is_dml_statement_type(statement_type_id: Option<i64>) -> bool {
-    statement_type_id.is_some_and(|id| (0x3000..0x4000).contains(&id))
-}
-
 fn set_state(stmt: &mut Statement, state: StatementState) {
     stmt.ird.desc_count = match &state {
         StatementState::QueryExecuted { reader, .. } => {
@@ -539,26 +526,25 @@ fn create_execute_state_from_result_set(
 ) -> OdbcResult<StatementState> {
     let stream = rs.stream.required("Stream is required")?;
     let reader = reader_from_protobuf_stream(stream)?;
-    if let Some(id) = statement_type_id {
-        if is_ddl_statement(id) {
-            return Ok(StatementState::DdlExecuted {
-                schema: reader.schema(),
-                origin,
-            });
+    let schema = reader.schema();
+    let qt = QueryType::from_raw(statement_type_id);
+
+    let state = if qt.is_dml() && !qt.has_result_set() {
+        StatementState::DmlExecuted {
+            rows_affected: rows_affected.unwrap_or(0),
+            schema,
+            origin,
         }
-        if is_dml_statement_type(Some(id)) {
-            return Ok(StatementState::DmlExecuted {
-                rows_affected: rows_affected.unwrap_or(0),
-                schema: reader.schema(),
-                origin,
-            });
+    } else if qt.has_result_set() {
+        StatementState::QueryExecuted {
+            reader,
+            rows_affected,
+            origin,
         }
-    }
-    Ok(StatementState::QueryExecuted {
-        reader,
-        rows_affected,
-        origin,
-    })
+    } else {
+        StatementState::DdlExecuted { schema, origin }
+    };
+    Ok(state)
 }
 
 /// Build JSON query bindings from ODBC parameter bindings.

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -172,6 +172,8 @@ impl ConnectionAttribute {
 #[repr(u16)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InfoType {
+    /// `SQL_DBMS_NAME` (17) — name of the DBMS product (string).
+    DbmsName = 17,
     /// `SQL_CURSOR_COMMIT_BEHAVIOR` (23) — cursor behavior on commit.
     CursorCommitBehavior = 23,
     /// `SQL_CURSOR_ROLLBACK_BEHAVIOR` (24) — cursor behavior on rollback.
@@ -187,6 +189,7 @@ impl TryFrom<u16> for InfoType {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
+            17 => Ok(InfoType::DbmsName),
             23 => Ok(InfoType::CursorCommitBehavior),
             24 => Ok(InfoType::CursorRollbackBehavior),
             77 => Ok(InfoType::DriverOdbcVer),
@@ -199,6 +202,21 @@ impl TryFrom<u16> for InfoType {
                 })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod info_type_tests {
+    use super::InfoType;
+
+    #[test]
+    fn parses_dbms_name() {
+        assert_eq!(InfoType::try_from(17u16).unwrap(), InfoType::DbmsName);
+    }
+
+    #[test]
+    fn rejects_unknown_info_type() {
+        assert!(InfoType::try_from(9999u16).is_err());
     }
 }
 

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -205,21 +205,6 @@ impl TryFrom<u16> for InfoType {
     }
 }
 
-#[cfg(test)]
-mod info_type_tests {
-    use super::InfoType;
-
-    #[test]
-    fn parses_dbms_name() {
-        assert_eq!(InfoType::try_from(17u16).unwrap(), InfoType::DbmsName);
-    }
-
-    #[test]
-    fn rejects_unknown_info_type() {
-        assert!(InfoType::try_from(9999u16).is_err());
-    }
-}
-
 /// SQL_GETDATA_EXTENSIONS bitmask values.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `statement_type_id` range checks in the ODBC classifier
with an explicit `QueryType` taxonomy.

The old code used undocumented ranges (`0x6000..0x7000` = DDL, with a
`0x6244` carve-out) that didn't line up with Snowflake's real enum, and was
drifting from `sf_core`'s own DML classifier. The new module has explicit
constants per id and hierarchical `belongs_to` matching via bit-masks.

## What changes

- **New `odbc/src/api/query_type.rs`**: `QueryType` constants
  (`SELECT=0x1000`, `DML=0x3000`, `COPY=0x3600`, `DDL=0x6000`,
  `MANAGE_PATS=0x6244`, `BEGIN=0x8101`, `COMMIT=0x8103`, `CALL=0x9000`,
  `MULTI_STMT=0xA000`, …) with `belongs_to(family)` using level-2 / level-3
  masks.
- **`result_kind() → ResultKind { Cursor, UpdateCount, NoResult }`** — pure
  function the classifier consumes. Precedence: `has_result_set` →
  `is_dml` → `is_known_no_result`, with `Cursor` as the fallthrough so
  unrecognised ids don't silently drop result data.
- **`create_execute_state_from_result_set`** becomes a flat match over
  `result_kind()`. Deletes `is_ddl_statement`, `is_dml_statement_type`,
  `is_query_statement`, and the `STATEMENT_TYPE_ID_MANAGE_PATS` carve-out.

## Behavior

Preserved vs. pre-refactor:
- `MANAGE_PATS` (0x6244) → `Cursor` (now via explicit enum constant)
- Unknown / absent `statement_type_id` → `Cursor` (safe default)
- TCL (`COMMIT`/`BEGIN`/…) → no-cursor

Scope is ODBC-only — `sf_core` stays untouched so JDBC/Python can keep
their own classifications.