### PR TITLE
Add Windows x86_64 wheel builds via cibuildwheel

### DIFF
--- a/.github/actions/setup-windows-openssl/action.yml
+++ b/.github/actions/setup-windows-openssl/action.yml
@@ -1,0 +1,66 @@
+name: Setup OpenSSL on Windows
+description: >
+  Installs OpenSSL via vcpkg on Windows with caching.
+  Supports ARM64 and x86_64, static and dynamic linking.
+
+inputs:
+  arch:
+    description: "Target architecture: arm64 or x86_64"
+    required: true
+  linkage:
+    description: "Link mode: static (static-md triplet) or dynamic (shared DLLs)"
+    required: false
+    default: "static"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve vcpkg triplet
+      id: triplet
+      shell: pwsh
+      run: |
+        $arch = if ("${{ inputs.arch }}" -eq "x86_64") { "x64" } else { "${{ inputs.arch }}" }
+        $triplet = "$arch-windows"
+        if ("${{ inputs.linkage }}" -eq "static") { $triplet += "-static-md" }
+        echo "value=$triplet" >> $env:GITHUB_OUTPUT
+
+    - name: Capture vcpkg version
+      uses: ./.github/actions/vcpkg-version
+
+    - name: Restore vcpkg OpenSSL cache
+      id: cache
+      uses: actions/cache/restore@v5
+      with:
+        path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}
+        key: vcpkg-openssl-${{ steps.triplet.outputs.value }}-${{ env.VCPKG_VER }}
+
+    - name: Install OpenSSL via vcpkg (ARM64)
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+        vcpkg install openssl:${{ steps.triplet.outputs.value }}
+
+    - name: Install OpenSSL via vcpkg (x86_64)
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'x86_64'
+      shell: pwsh
+      run: vcpkg install openssl:${{ steps.triplet.outputs.value }}
+
+    - name: Save vcpkg OpenSSL cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}
+        key: vcpkg-openssl-${{ steps.triplet.outputs.value }}-${{ env.VCPKG_VER }}
+
+    - name: Configure OpenSSL environment
+      shell: pwsh
+      run: |
+        $dir = "C:\vcpkg\installed\${{ steps.triplet.outputs.value }}"
+        echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
+        echo "OPENSSL_LIB_DIR=$dir\lib" >> $env:GITHUB_ENV
+        if ("${{ inputs.linkage }}" -eq "static") {
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+        } else {
+          echo "$dir\bin" >> $env:GITHUB_PATH
+        }

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -36,7 +36,6 @@ jobs:
                   "container": "quay.io/pypa/manylinux_2_28_x86_64",
                   "lib_name": "libsf_core.so",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
-                  "rust_target": "",
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_x86_64",
                   "artifact_id": "manylinux_x86_64",
@@ -57,7 +56,6 @@ jobs:
                   "container": "",
                   "lib_name": "sf_core.dll",
                   "cargo_extra_args": "--config profile.release.opt-level=2 --config profile.release.strip=false",
-                  "rust_target": "",
                   "wheel_method": "manual",
                   "artifact_id": "win_arm64",
               },
@@ -83,7 +81,6 @@ jobs:
                       "container": p["container"],
                       "lib_name": p["lib_name"],
                       "cargo_extra_args": p["cargo_extra_args"],
-                      "rust_target": p["rust_target"],
                   })
 
               if p["wheel_method"] == "cibuildwheel":
@@ -131,7 +128,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ── Linux container setup (native builds: x86 in manylinux container) ──
+      # ── Linux container setup ──
       - name: Install Rust toolchain (container)
         if: matrix.container != ''
         run: |
@@ -141,15 +138,6 @@ jobs:
       - name: Install vendored OpenSSL build deps (container)
         if: matrix.container != ''
         run: yum install -y perl-IPC-Cmd perl-Time-Piece
-
-      # ── Linux cross-compilation setup (aarch64 on x86 host) ──
-      - name: Install cross-compilation toolchain
-        if: matrix.rust_target != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          rustup target add ${{ matrix.rust_target }}
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       # ── Windows ARM64 OpenSSL setup ──
       - name: Capture vcpkg version for cache key
@@ -189,10 +177,7 @@ jobs:
 
       - name: Build sf_core (Linux)
         if: runner.os == 'Linux'
-        run: >
-          cargo build --release --package sf_core
-          ${{ matrix.cargo_extra_args }}
-          ${{ matrix.rust_target != '' && format('--target {0}', matrix.rust_target) || '' }}
+        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
 
       - name: Build sf_core (Windows ARM64)
         if: runner.os == 'Windows'
@@ -205,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sf-core-${{ matrix.target }}
-          path: target/${{ matrix.rust_target != '' && format('{0}/release', matrix.rust_target) || 'release' }}/${{ matrix.lib_name }}
+          path: target/release/${{ matrix.lib_name }}
 
       - name: Save Rust cache
         if: always()
@@ -333,10 +318,6 @@ jobs:
         with:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen
-
-      - name: Set up QEMU
-        if: contains(matrix.cibw_build, 'aarch64')
-        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@v3.4

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -8,8 +8,8 @@ on:
         required: true
         description: >
           JSON object mapping platform keys to Python version arrays.
-          Example: {"linux_x86": ["3.10","3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12"], "windows_arm": ["3.11","3.12"]}
-          Supported platforms: linux_x86, linux_aarch, windows_arm.
+          Example: {"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12"], "windows_x86": ["3.11","3.12"], "windows_arm": ["3.11","3.12"]}
+          Supported platforms: linux_x86, linux_aarch, windows_x86, windows_arm.
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,6 +49,16 @@ jobs:
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_aarch64",
                   "artifact_id": "manylinux_aarch64",
+              },
+              "windows_x86": {
+                  "target": "windows-x86_64",
+                  "os": "windows-latest",
+                  "container": "",
+                  "lib_name": "sf_core.dll",
+                  "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2 --config profile.release.strip=false",
+                  "wheel_method": "cibuildwheel",
+                  "cibw_arch": "win_amd64",
+                  "artifact_id": "win_amd64",
               },
               "windows_arm": {
                   "target": "windows-arm64",
@@ -141,11 +151,11 @@ jobs:
 
       # ── Windows ARM64 OpenSSL setup ──
       - name: Capture vcpkg version for cache key
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         uses: ./.github/actions/vcpkg-version
 
       - name: Cache vcpkg packages
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         id: vcpkg-cache
         uses: actions/cache@v5
         with:
@@ -153,14 +163,14 @@ jobs:
           key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
       - name: Install ARM64 OpenSSL (static) via vcpkg
-        if: runner.os == 'Windows' && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache.outputs.cache-hit != 'true'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           vcpkg install openssl:arm64-windows-static-md
 
       - name: Configure ARM64 OpenSSL (static)
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         shell: pwsh
         run: |
           echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
@@ -179,8 +189,12 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
 
+      - name: Build sf_core (Windows x86_64)
+        if: matrix.os == 'windows-latest'
+        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+
       - name: Build sf_core (Windows ARM64)
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
@@ -311,6 +325,7 @@ jobs:
           path: python/src/snowflake/connector/_core
 
       - name: Ensure sf_core is executable
+        if: runner.os == 'Linux'
         run: chmod +x python/src/snowflake/connector/_core/*
 
       - name: Download pre-built protobuf code
@@ -331,8 +346,12 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >-
             SKIP_CORE_BUILD=true
             SKIP_PROTO_GENERATION=true
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            SKIP_CORE_BUILD=true
+            SKIP_PROTO_GENERATION=true
 
       - name: Check wheels with auditwheel
+        if: runner.os == 'Linux'
         run: |
           pip install auditwheel
           for whl in python/dist/*.whl; do

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -149,33 +149,11 @@ jobs:
         if: matrix.container != ''
         run: yum install -y perl-IPC-Cmd perl-Time-Piece
 
-      # ── Windows ARM64 OpenSSL setup ──
-      - name: Capture vcpkg version for cache key
+      - name: Setup OpenSSL (Windows ARM64)
         if: matrix.os == 'windows-11-arm'
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Cache vcpkg packages
-        if: matrix.os == 'windows-11-arm'
-        id: vcpkg-cache
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install ARM64 OpenSSL (static) via vcpkg
-        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows-static-md
-
-      - name: Configure ARM64 OpenSSL (static)
-        if: matrix.os == 'windows-11-arm'
-        shell: pwsh
-        run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          arch: arm64
 
       # ── Cargo cache & build ──
       - name: Restore Rust cache
@@ -408,30 +386,10 @@ jobs:
       - name: Set up Python ${{ matrix.py }}
         run: uv python install cpython-${{ matrix.py }}-windows-aarch64-none
 
-      # ── Windows ARM64 OpenSSL (needed by cryptography dependency) ──
-      - name: Capture vcpkg version for cache key
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Cache vcpkg ARM64 static OpenSSL
-        id: vcpkg-cache
-        uses: actions/cache@v5
+      - name: Setup OpenSSL (Windows ARM64)
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\arm64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install ARM64 OpenSSL (static) via vcpkg
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows-static-md
-
-      - name: Configure ARM64 OpenSSL (static)
-        shell: pwsh
-        run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          arch: arm64
 
       # ── Build ──
       - name: Build python wheel

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -36,6 +36,7 @@ jobs:
                   "container": "quay.io/pypa/manylinux_2_28_x86_64",
                   "lib_name": "libsf_core.so",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
+                  "rust_target": "",
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_x86_64",
                   "artifact_id": "manylinux_x86_64",
@@ -56,6 +57,7 @@ jobs:
                   "container": "",
                   "lib_name": "sf_core.dll",
                   "cargo_extra_args": "--config profile.release.opt-level=2 --config profile.release.strip=false",
+                  "rust_target": "",
                   "wheel_method": "manual",
                   "artifact_id": "win_arm64",
               },
@@ -81,6 +83,7 @@ jobs:
                       "container": p["container"],
                       "lib_name": p["lib_name"],
                       "cargo_extra_args": p["cargo_extra_args"],
+                      "rust_target": p["rust_target"],
                   })
 
               if p["wheel_method"] == "cibuildwheel":
@@ -128,7 +131,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ── Linux container setup ──
+      # ── Linux container setup (native builds: x86 in manylinux container) ──
       - name: Install Rust toolchain (container)
         if: matrix.container != ''
         run: |
@@ -138,6 +141,15 @@ jobs:
       - name: Install vendored OpenSSL build deps (container)
         if: matrix.container != ''
         run: yum install -y perl-IPC-Cmd perl-Time-Piece
+
+      # ── Linux cross-compilation setup (aarch64 on x86 host) ──
+      - name: Install cross-compilation toolchain
+        if: matrix.rust_target != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          rustup target add ${{ matrix.rust_target }}
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       # ── Windows ARM64 OpenSSL setup ──
       - name: Capture vcpkg version for cache key
@@ -177,7 +189,10 @@ jobs:
 
       - name: Build sf_core (Linux)
         if: runner.os == 'Linux'
-        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+        run: >
+          cargo build --release --package sf_core
+          ${{ matrix.cargo_extra_args }}
+          ${{ matrix.rust_target != '' && format('--target {0}', matrix.rust_target) || '' }}
 
       - name: Build sf_core (Windows ARM64)
         if: runner.os == 'Windows'
@@ -190,7 +205,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sf-core-${{ matrix.target }}
-          path: target/release/${{ matrix.lib_name }}
+          path: target/${{ matrix.rust_target != '' && format('{0}/release', matrix.rust_target) || 'release' }}/${{ matrix.lib_name }}
 
       - name: Save Rust cache
         if: always()
@@ -318,6 +333,10 @@ jobs:
         with:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen
+
+      - name: Set up QEMU
+        if: contains(matrix.cibw_build, 'aarch64')
+        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@v3.4

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -14,7 +14,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # ── Test wheels and sdist against cloud providers ───────────────────
   # Each Python version tested once per env, cloud providers distributed evenly.
@@ -49,6 +49,16 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          # Windows x86_64 — test env
+          - { os: windows-latest,  py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: windows-latest,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: windows-latest,  py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: windows-latest,  py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
+          # Windows x86_64 — test-pandas env
+          - { os: windows-latest,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: windows-latest,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: windows-latest,  py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: windows-latest,  py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           # Windows ARM64 (no test-pandas — pyarrow has no win_arm64 wheel)
           - { os: windows-11-arm,  py: "3.11", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-11-arm,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
@@ -92,11 +102,11 @@ jobs:
           name: ${{ (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64') }}_py${{ matrix.py }}
           path: python/dist
 
-      - name: Download wheel (Windows ARM64)
+      - name: Download wheel (Windows)
         if: runner.os == 'Windows'
         uses: actions/download-artifact@v4
         with:
-          name: win_arm64_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || 'win_amd64') }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist
@@ -123,11 +133,11 @@ jobs:
 
       # ── Windows ARM64 OpenSSL (needed by cryptography dependency) ──
       - name: Capture vcpkg version for cache key (Windows ARM64)
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         uses: ./.github/actions/vcpkg-version
 
       - name: Restore vcpkg ARM64 static OpenSSL cache (Windows ARM64)
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         id: vcpkg-cache-test
         uses: actions/cache/restore@v5
         with:
@@ -135,7 +145,7 @@ jobs:
           key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
       - name: Install ARM64 OpenSSL (static) via vcpkg
-        if: runner.os == 'Windows' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
+        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
@@ -143,8 +153,6 @@ jobs:
 
       - name: Save vcpkg ARM64 static OpenSSL cache (Windows ARM64)
         if: runner.os == 'Windows' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
-        # Cache save is best-effort — see cargo-cache action for rationale.
-        # timeout-minutes + ZSTD_NBTHREADS guard against tar+zstdmt hangs.
         continue-on-error: true
         timeout-minutes: 10
         env:
@@ -155,7 +163,7 @@ jobs:
           key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
       - name: Configure ARM64 build environment
-        if: runner.os == 'Windows'
+        if: matrix.os == 'windows-11-arm'
         shell: pwsh
         run: |
           echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -50,11 +50,13 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
           # Windows x86_64 — test env
+          - { os: windows-latest,  py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # Windows x86_64 — test-pandas env
+          - { os: windows-latest,  py: "3.10", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
@@ -103,7 +105,7 @@ jobs:
           path: python/dist
 
       - name: Download wheel (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
           name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || 'win_amd64') }}_py${{ matrix.py }}
@@ -188,7 +190,7 @@ jobs:
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
       - name: Install snowflake ud driver from wheel (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.py != '3.10'
         working-directory: python
         shell: pwsh
         run: |
@@ -199,8 +201,8 @@ jobs:
           $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
-      - name: Install snowflake ud driver from sdist
-        if: matrix.py == '3.10'
+      - name: Install snowflake ud driver from sdist (Linux)
+        if: runner.os == 'Linux' && matrix.py == '3.10'
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)
@@ -209,6 +211,21 @@ jobs:
           fi
           export WHEEL_PATH="${SDISTS[0]}"
           echo "Installing sdist: $WHEEL_PATH"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+        env:
+          SKIP_CORE_BUILD: "false"
+
+      - name: Install snowflake ud driver from sdist (Windows)
+        if: runner.os == 'Windows' && matrix.py == '3.10'
+        working-directory: python
+        shell: pwsh
+        run: |
+          $sdists = @(Get-ChildItem dist/*.tar.gz)
+          if ($sdists.Count -ne 1) {
+            Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
+          }
+          $env:WHEEL_PATH = $sdists[0].FullName
+          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -174,6 +174,38 @@ jobs:
           echo "RUSTFLAGS=-C linker=rust-lld" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
+      # ── Windows x86_64 OpenSSL (needed for sdist builds that compile sf_core from source) ──
+      - name: Capture vcpkg version for cache key (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        uses: ./.github/actions/vcpkg-version
+
+      - name: Restore vcpkg x64 static OpenSSL cache (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        id: vcpkg-cache-x64
+        uses: actions/cache/restore@v5
+        with:
+          path: C:\vcpkg\installed\x64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Install x64 OpenSSL (static) via vcpkg
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
+        run: vcpkg install openssl:x64-windows-static-md
+
+      - name: Save vcpkg x64 static OpenSSL cache (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: C:\vcpkg\installed\x64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Configure x64 OpenSSL environment
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        shell: pwsh
+        run: |
+          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\x64-windows-static-md\lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+
       - name: Install Hatch
         run: uv tool install hatch --with "virtualenv<21.0.0"
 
@@ -224,15 +256,8 @@ jobs:
           if ($sdists.Count -ne 1) {
             Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
           }
-          # Build wheel from sdist in a short directory to avoid MSVC MAX_PATH.
-          # MSVC mirrors absolute source paths inside build temp directories,
-          # doubling UV cache's deeply nested hash paths and exceeding 260 chars.
-          New-Item -ItemType Directory -Force D:\s | Out-Null
-          tar xzf $sdists[0].FullName -C D:\s
-          $srcDir = (Get-ChildItem D:\s -Directory)[0].FullName
-          uv build --wheel $srcDir --out-dir D:\s\out
-          $env:WHEEL_PATH = (Get-ChildItem D:\s\out\*.whl)[0].FullName
-          Write-Host "Installing wheel built from sdist: $($env:WHEEL_PATH)"
+          $env:WHEEL_PATH = $sdists[0].FullName
+          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -226,6 +226,9 @@ jobs:
           }
           $env:WHEEL_PATH = $sdists[0].FullName
           Write-Host "Installing sdist: $($env:WHEEL_PATH)"
+          # Use a short cache path to avoid MSVC MAX_PATH errors when
+          # compiling C/C++ extensions from the unpacked sdist.
+          $env:UV_CACHE_DIR = "D:\uv"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -224,11 +224,15 @@ jobs:
           if ($sdists.Count -ne 1) {
             Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
           }
-          $env:WHEEL_PATH = $sdists[0].FullName
-          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
-          # Use a short cache path to avoid MSVC MAX_PATH errors when
-          # compiling C/C++ extensions from the unpacked sdist.
-          $env:UV_CACHE_DIR = "D:\uv"
+          # Build wheel from sdist in a short directory to avoid MSVC MAX_PATH.
+          # MSVC mirrors absolute source paths inside build temp directories,
+          # doubling UV cache's deeply nested hash paths and exceeding 260 chars.
+          New-Item -ItemType Directory -Force D:\s | Out-Null
+          tar xzf $sdists[0].FullName -C D:\s
+          $srcDir = (Get-ChildItem D:\s -Directory)[0].FullName
+          uv build --wheel $srcDir --out-dir D:\s\out
+          $env:WHEEL_PATH = (Get-ChildItem D:\s\out\*.whl)[0].FullName
+          Write-Host "Installing wheel built from sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -133,78 +133,24 @@ jobs:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
-      # ── Windows ARM64 OpenSSL (needed by cryptography dependency) ──
-      - name: Capture vcpkg version for cache key (Windows ARM64)
+      - name: Setup OpenSSL (Windows ARM64)
         if: matrix.os == 'windows-11-arm'
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Restore vcpkg ARM64 static OpenSSL cache (Windows ARM64)
-        if: matrix.os == 'windows-11-arm'
-        id: vcpkg-cache-test
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\arm64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install ARM64 OpenSSL (static) via vcpkg
-        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows-static-md
-
-      - name: Save vcpkg ARM64 static OpenSSL cache (Windows ARM64)
-        if: runner.os == 'Windows' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
-        continue-on-error: true
-        timeout-minutes: 10
-        env:
-          ZSTD_NBTHREADS: '2'
-        uses: actions/cache/save@v5
-        with:
-          path: C:\vcpkg\installed\arm64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+          arch: arm64
 
       - name: Configure ARM64 build environment
         if: matrix.os == 'windows-11-arm'
         shell: pwsh
         run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
           echo "RUSTFLAGS=-C linker=rust-lld" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
-      # ── Windows x86_64 OpenSSL (needed for sdist builds that compile sf_core from source) ──
-      - name: Capture vcpkg version for cache key (Windows x64)
+      - name: Setup OpenSSL (Windows x86_64)
         if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Restore vcpkg x64 static OpenSSL cache (Windows x64)
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        id: vcpkg-cache-x64
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\x64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install x64 OpenSSL (static) via vcpkg
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
-        run: vcpkg install openssl:x64-windows-static-md
-
-      - name: Save vcpkg x64 static OpenSSL cache (Windows x64)
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: C:\vcpkg\installed\x64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Configure x64 OpenSSL environment
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        shell: pwsh
-        run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\x64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          arch: x86_64
 
       - name: Install Hatch
         run: uv tool install hatch --with "virtualenv<21.0.0"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -323,6 +323,38 @@ jobs:
           echo "RUSTFLAGS=-C linker=rust-lld" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
+      # ── Windows x86_64 OpenSSL (needed for sdist builds that compile sf_core from source) ──
+      - name: Capture vcpkg version for cache key (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        uses: ./.github/actions/vcpkg-version
+
+      - name: Restore vcpkg x64 static OpenSSL cache (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        id: vcpkg-cache-x64
+        uses: actions/cache/restore@v5
+        with:
+          path: C:\vcpkg\installed\x64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Install x64 OpenSSL (static) via vcpkg
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
+        run: vcpkg install openssl:x64-windows-static-md
+
+      - name: Save vcpkg x64 static OpenSSL cache (Windows x64)
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: C:\vcpkg\installed\x64-windows-static-md
+          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Configure x64 OpenSSL environment
+        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
+        shell: pwsh
+        run: |
+          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\x64-windows-static-md\lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+
       - name: Install Hatch
         run: &setup_env uv tool install hatch --with "virtualenv<21.0.0"
 
@@ -373,15 +405,8 @@ jobs:
           if ($sdists.Count -ne 1) {
             Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
           }
-          # Build wheel from sdist in a short directory to avoid MSVC MAX_PATH.
-          # MSVC mirrors absolute source paths inside build temp directories,
-          # doubling UV cache's deeply nested hash paths and exceeding 260 chars.
-          New-Item -ItemType Directory -Force D:\s | Out-Null
-          tar xzf $sdists[0].FullName -C D:\s
-          $srcDir = (Get-ChildItem D:\s -Directory)[0].FullName
-          uv build --wheel $srcDir --out-dir D:\s\out
-          $env:WHEEL_PATH = (Get-ChildItem D:\s\out\*.whl)[0].FullName
-          Write-Host "Installing wheel built from sdist: $($env:WHEEL_PATH)"
+          $env:WHEEL_PATH = $sdists[0].FullName
+          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -275,85 +275,24 @@ jobs:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
-      # cryptography has no pre-built ARM64 Windows wheel, so uv builds it from
-      # source via maturin. Use static OpenSSL (arm64-windows-static-md) so the
-      # built _rust.pyd embeds OpenSSL rather than depending on DLLs at runtime —
-      # the same reason we use static OpenSSL for sf_core in the build_wheel job.
-
-      - name: Capture vcpkg version for cache key (Windows ARM64)
+      - name: Setup OpenSSL (Windows ARM64)
         if: matrix.os == 'windows-11-arm'
-        uses: ./.github/actions/vcpkg-version
-
-      # Share the vcpkg cache with build_wheel so OpenSSL is not rebuilt here either.
-      - name: Restore vcpkg ARM64 static OpenSSL cache (Windows ARM64)
-        if: matrix.os == 'windows-11-arm'
-        id: vcpkg-cache-test
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\arm64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install ARM64 OpenSSL (static) via vcpkg (for dependency source builds)
-        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows-static-md
-
-      - name: Save vcpkg ARM64 static OpenSSL cache (Windows ARM64)
-        if: matrix.os == 'windows-11-arm' && steps.vcpkg-cache-test.outputs.cache-hit != 'true'
-        # Cache save is best-effort — see cargo-cache action for rationale.
-        # timeout-minutes + ZSTD_NBTHREADS guard against tar+zstdmt hangs.
-        continue-on-error: true
-        timeout-minutes: 10
-        env:
-          ZSTD_NBTHREADS: '2'
-        uses: actions/cache/save@v5
-        with:
-          path: C:\vcpkg\installed\arm64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+          arch: arm64
 
       - name: Configure ARM64 build environment
         if: matrix.os == 'windows-11-arm'
         shell: pwsh
         run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
           echo "RUSTFLAGS=-C linker=rust-lld" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
-      # ── Windows x86_64 OpenSSL (needed for sdist builds that compile sf_core from source) ──
-      - name: Capture vcpkg version for cache key (Windows x64)
+      - name: Setup OpenSSL (Windows x86_64)
         if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Restore vcpkg x64 static OpenSSL cache (Windows x64)
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        id: vcpkg-cache-x64
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\x64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Install x64 OpenSSL (static) via vcpkg
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
-        run: vcpkg install openssl:x64-windows-static-md
-
-      - name: Save vcpkg x64 static OpenSSL cache (Windows x64)
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10' && steps.vcpkg-cache-x64.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: C:\vcpkg\installed\x64-windows-static-md
-          key: ${{ matrix.os }}-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
-
-      - name: Configure x64 OpenSSL environment
-        if: matrix.os == 'windows-latest' && matrix.py == '3.10'
-        shell: pwsh
-        run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\x64-windows-static-md\lib" >> $env:GITHUB_ENV
-          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          arch: x86_64
 
       - name: Install Hatch
         run: &setup_env uv tool install hatch --with "virtualenv<21.0.0"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -181,6 +181,48 @@ jobs:
             py: "3.12"
             hatch_env: "test-pandas"
             cloud_provider: azure
+          # Linux ARM64 — test env
+          - os: ubuntu-24.04-arm
+            py: "3.10"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: ubuntu-24.04-arm
+            py: "3.12"
+            hatch_env: "test"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.13"
+            hatch_env: "test"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: gcp
+          # Linux ARM64 — test-pandas env
+          - os: ubuntu-24.04-arm
+            py: "3.10"
+            hatch_env: "test-pandas"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.11"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
+          - os: ubuntu-24.04-arm
+            py: "3.12"
+            hatch_env: "test-pandas"
+            cloud_provider: gcp
+          - os: ubuntu-24.04-arm
+            py: "3.13"
+            hatch_env: "test-pandas"
+            cloud_provider: azure
+          - os: ubuntu-24.04-arm
+            py: "3.14"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -353,7 +353,7 @@ jobs:
           SKIP_CORE_BUILD: "false"
 
       - name: Install snowflake ud driver from wheel (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.py != '3.10'
         working-directory: python
         shell: pwsh
         run: |
@@ -363,6 +363,28 @@ jobs:
           }
           $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+
+      - name: Install snowflake ud driver from sdist (Windows)
+        if: runner.os == 'Windows' && matrix.py == '3.10'
+        working-directory: python
+        shell: pwsh
+        run: |
+          $sdists = @(Get-ChildItem dist/*.tar.gz)
+          if ($sdists.Count -ne 1) {
+            Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
+          }
+          # Build wheel from sdist in a short directory to avoid MSVC MAX_PATH.
+          # MSVC mirrors absolute source paths inside build temp directories,
+          # doubling UV cache's deeply nested hash paths and exceeding 260 chars.
+          New-Item -ItemType Directory -Force D:\s | Out-Null
+          tar xzf $sdists[0].FullName -C D:\s
+          $srcDir = (Get-ChildItem D:\s -Directory)[0].FullName
+          uv build --wheel $srcDir --out-dir D:\s\out
+          $env:WHEEL_PATH = (Get-ChildItem D:\s\out\*.whl)[0].FullName
+          Write-Host "Installing wheel built from sdist: $($env:WHEEL_PATH)"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+        env:
+          SKIP_CORE_BUILD: "false"
 
       - name: Run tests with coverage (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -151,6 +151,14 @@ jobs:
             py: "3.11"
             hatch_env: "test"
             cloud_provider: aws
+          - os: windows-latest
+            py: "3.12"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: windows-latest
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: azure
           - os: windows-11-arm
             py: "3.12"
             hatch_env: "test"
@@ -177,6 +185,10 @@ jobs:
             hatch_env: "test-pandas"
             cloud_provider: aws
             result_format: json
+          - os: windows-latest
+            py: "3.11"
+            hatch_env: "test-pandas"
+            cloud_provider: aws
           - os: ubuntu-24.04-arm
             py: "3.12"
             hatch_env: "test-pandas"
@@ -238,7 +250,7 @@ jobs:
         if: matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64')) }}_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))) }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -181,48 +181,6 @@ jobs:
             py: "3.12"
             hatch_env: "test-pandas"
             cloud_provider: azure
-          # Linux ARM64 — test env
-          - os: ubuntu-24.04-arm
-            py: "3.10"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: ubuntu-24.04-arm
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.13"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: gcp
-          # Linux ARM64 — test-pandas env
-          - os: ubuntu-24.04-arm
-            py: "3.10"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.11"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.12"
-            hatch_env: "test-pandas"
-            cloud_provider: gcp
-          - os: ubuntu-24.04-arm
-            py: "3.13"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
-          - os: ubuntu-24.04-arm
-            py: "3.14"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -245,45 +245,11 @@ jobs:
           mode: restore
           shared-key: "arm64-nonfips"
 
-      - name: Capture vcpkg version for cache key
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Restore vcpkg ARM64 OpenSSL cache
-        id: vcpkg-cache
-        uses: actions/cache/restore@v5
+      - name: Setup OpenSSL (Windows ARM64)
+        uses: ./.github/actions/setup-windows-openssl
         with:
-          path: C:\vcpkg\installed\arm64-windows
-          key: windows-11-arm-vcpkg-openssl-${{ env.VCPKG_VER }}
-
-      - name: Install ARM64 OpenSSL via vcpkg
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          :: Build native ARM64 OpenSSL from source. The pre-installed OpenSSL is
-          :: x64-only (no static libs, DLLs cause error 193 at runtime).
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows
-
-      - name: Save vcpkg ARM64 OpenSSL cache
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        # Cache save is best-effort — see cargo-cache action for rationale.
-        # timeout-minutes + ZSTD_NBTHREADS guard against tar+zstdmt hangs.
-        continue-on-error: true
-        timeout-minutes: 10
-        env:
-          ZSTD_NBTHREADS: '2'
-        uses: actions/cache/save@v5
-        with:
-          path: C:\vcpkg\installed\arm64-windows
-          key: windows-11-arm-vcpkg-openssl-${{ env.VCPKG_VER }}
-
-      - name: Configure OpenSSL
-        shell: pwsh
-        run: |
-          echo "OPENSSL_DIR=C:\vcpkg\installed\arm64-windows" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\vcpkg\installed\arm64-windows\lib" >> $env:GITHUB_ENV
-          # Add vcpkg bin to PATH so ARM64 OpenSSL DLLs are found at runtime
-          echo "C:\vcpkg\installed\arm64-windows\bin" >> $env:GITHUB_PATH
+          arch: arm64
+          linkage: dynamic
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -212,30 +212,36 @@ class BuildHook(BuildHookInterface):
     def _build_extensions(self) -> None:
         """Build the Cython extensions."""
         src_root = Path(self.root) / "src"
-        arrow_iterator_dir = src_root / self.ARROW_ITERATOR_DIR
-        logging_dir = src_root / self.LOGGING_DIR
+
+        # Use paths relative to self.root for Extension sources.
+        # MSVC mirrors source file paths inside build_temp for .obj output;
+        # absolute paths in a deeply nested UV cache push .obj paths past
+        # Windows' 260-char MAX_PATH limit.  Relative paths keep them short.
+        src_rel = Path("src")
+        arrow_rel = src_rel / self.ARROW_ITERATOR_DIR
+        logging_rel = src_rel / self.LOGGING_DIR
 
         # Define the extension
         ext = Extension(
             name=self.EXTENSION_NAME,
-            sources=[str(src_root / self.PYX_SOURCE)],
+            sources=[str(src_rel / self.PYX_SOURCE)],
             language="c++",
         )
 
         # Add C++ source files
         for src in self.CPP_SOURCES:
-            ext.sources.append(str(arrow_iterator_dir / src))
+            ext.sources.append(str(arrow_rel / src))
 
         # Add subdirectory sources
         for subdir, filename in self.SUBDIRECTORY_SOURCES:
-            ext.sources.append(str(arrow_iterator_dir / subdir / filename))
+            ext.sources.append(str(arrow_rel / subdir / filename))
 
         # Add logging source
-        ext.sources.append(str(logging_dir / "logging.cpp"))
+        ext.sources.append(str(logging_rel / "logging.cpp"))
 
         # Add include directories
-        ext.include_dirs.append(str(arrow_iterator_dir))
-        ext.include_dirs.append(str(logging_dir))
+        ext.include_dirs.append(str(arrow_rel))
+        ext.include_dirs.append(str(logging_rel))
 
         # Apply platform-specific flags
         self._apply_compile_flags(ext)
@@ -311,7 +317,16 @@ class BuildHook(BuildHookInterface):
         cmd.ensure_finalized()
         cmd.build_lib = str(src_root)
         cmd.inplace = True
-        cmd.run()
+
+        # Extension sources use relative paths (see _build_extensions) so the
+        # build must run from self.root for both cythonize and compile to find
+        # the source files.
+        saved_cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            cmd.run()
+        finally:
+            os.chdir(saved_cwd)
 
     def _build_core(self) -> None:
         """Build the Rust core library in release mode for distribution."""


### PR DESCRIPTION
## Summary
- Add `windows_x86` platform to the reusable wheel build workflow using **cibuildwheel**
- extract common "setup openSSL" step on Windows machines, to increase readability and reduce code redundancy
- hatch_build.py: Use relative source paths in Extension to avoid exceeding Windows' 260-char path limit during MSVC compilation.
- sf_core builds natively on `windows-latest` with `vendored-openssl` (no vcpkg needed)
- Add test + test-pandas entries for `windows-latest` in both CI and release workflows

## Reduced test matrix (CI, 15 entries)

| # | OS | Py | env | cloud | notes |
|---|-----|-----|------|-------|-------|
| 1 | ubuntu-latest | 3.10 | test | azure | sdist |
| 2 | ubuntu-latest | 3.13 | test | aws | reference |
| 3 | ubuntu-latest | 3.13 | test | aws | JSON format |
| 4 | ubuntu-24.04-arm | 3.14 | test | gcp | |
| 5 | ubuntu-24.04-arm | 3.11 | test | aws | |
| 6 | windows-latest | 3.12 | test | gcp | **new** |
| 7 | windows-latest | 3.14 | test | azure | **new** |
| 8 | windows-11-arm | 3.12 | test | aws | |
| 9 | windows-11-arm | 3.11 | test | gcp | |
| 10 | windows-11-arm | 3.11 | test | azure | |
| 11 | ubuntu-latest | 3.14 | test-pandas | gcp | |
| 12 | ubuntu-latest | 3.13 | test-pandas | aws | reference |
| 13 | ubuntu-latest | 3.13 | test-pandas | aws | JSON format |
| 14 | windows-latest | 3.11 | test-pandas | aws | **new** |
| 15 | ubuntu-24.04-arm | 3.12 | test-pandas | azure | |

**Coverage:** all 4 OSes × all 3 cloud providers, all Python versions 3.10-3.14, test + test-pandas.

## Test plan
https://github.com/snowflakedb/universal-driver/actions/runs/25046260518