### PR TITLE
NO-SNOW: Split Jenkins pipeline into VPN tests and build matrix jobs

### DIFF
--- a/ci/Jenkinsfile.build-matrix
+++ b/ci/Jenkinsfile.build-matrix
@@ -1,16 +1,9 @@
 /*
-Jenkinsfile template for use in a multibranch pipeline
+Jenkinsfile for the cross-platform build matrix.
+Runs independently from the VPN E2E / revocation tests defined in ci/Jenkinsfile.vpn-tests.
 */
 
 @Library('pipeline-utils') _
-import com.snowflake.DevEnvUtils
-
-def e2eDockerSetup(String image) {
-  new DevEnvUtils().withSfCli {
-    sh "sf artifact oci auth"
-  }
-  sh label: 'Docker Pull', script: "docker pull ${image}"
-}
 
 def getAgentLabel(platform) {
   switch (platform) {
@@ -252,218 +245,6 @@ pipeline {
     cron(env.BRANCH_NAME == 'main' ? 'H H/6 * * *' : '')
   }
   stages {
-
-        stage('Tests') {
-          parallel {
-            stage('Rust Core VPN E2E Tests') {
-              agent { label 'build-node-extra-large' }
-              environment {
-                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
-                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
-              }
-              steps {
-                script {
-                  e2eDockerSetup(E2E_DOCKER_IMAGE)
-                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
-                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
-                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
-                    }
-                    // Refresh dnf metadata before yum install — Rocky Linux rotates
-                    // metadata hashes weekly, breaking pre-built Docker images that
-                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
-                    // for full rationale.
-                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
-                    sh label: 'Install system dependencies', script: 'yum install -y unzip'
-
-                    try {
-                      sh label: 'Rust Core VPN E2E tests', script: '''
-                        set +x
-                        export PARAMETER_PATH=$(pwd)/parameters.json
-                        cargo test --package sf_core -- --ignored
-                      '''
-                    } finally {
-                      sh label: 'Cleanup test PATs', script: '''
-                        set +x
-                        pip3 install snowflake-connector-python -q 2>/dev/null || true
-                        python3 scripts/cleanup_env.py \
-                          --parameter-path $(pwd)/parameters.json \
-                          --build-tag "JNK_${BUILD_NUMBER}" || true
-                      '''
-                    }
-                  }
-                }
-              }
-            }
-
-            stage('ODBC VPN E2E Tests') {
-              agent { label 'build-node-extra-large' }
-              environment {
-                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
-                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
-              }
-              steps {
-                script {
-                  e2eDockerSetup(E2E_DOCKER_IMAGE)
-                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
-                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
-                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
-                    }
-                    // Refresh dnf metadata before yum install — Rocky Linux rotates
-                    // metadata hashes weekly, breaking pre-built Docker images that
-                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
-                    // for full rationale.
-                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
-                    sh label: 'Install system dependencies', script: 'yum install -y unzip'
-
-                    try {
-                      sh label: 'ODBC VPN E2E tests', script: '''
-                        set +x
-                        cargo build
-                        source /opt/rh/gcc-toolset-11/enable
-                        cd odbc_tests
-                        mkdir -p cmake-build
-                        cmake -B cmake-build \
-                            -D ODBC_LIBRARY="/usr/lib64/libodbc.so" \
-                            -D ODBC_INCLUDE_DIR="/usr/include" \
-                            -D DRIVER_TYPE=NEW \
-                            .
-                        cmake --build cmake-build -- -j $(nproc)
-
-                        WORKSPACE_ROOT=$(pwd)/..
-                        export DRIVER_PATH=${WORKSPACE_ROOT}/target/debug/libsfodbc.so
-                        export PARAMETER_PATH=${WORKSPACE_ROOT}/parameters.json
-                        ctest -j 1 -C Debug --test-dir cmake-build --output-on-failure -R "native_okta" --no-tests=error
-                      '''
-                    } finally {
-                      sh label: 'Cleanup test PATs', script: '''
-                        set +x
-                        pip3 install snowflake-connector-python -q 2>/dev/null || true
-                        python3 scripts/cleanup_env.py \
-                          --parameter-path $(pwd)/parameters.json \
-                          --build-tag "JNK_${BUILD_NUMBER}" || true
-                      '''
-                    }
-                  }
-                }
-              }
-            }
-
-            stage('Python VPN E2E Tests') {
-              agent { label 'build-node-extra-large' }
-              environment {
-                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
-                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
-              }
-              steps {
-                script {
-                  e2eDockerSetup(E2E_DOCKER_IMAGE)
-                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
-                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
-                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
-                    }
-                    // Refresh dnf metadata before yum install — Rocky Linux rotates
-                    // metadata hashes weekly, breaking pre-built Docker images that
-                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
-                    // for full rationale.
-                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
-                    sh label: 'Install system dependencies', script: '''
-                      yum install -y unzip \
-                        libffi-devel openssl-devel zlib-devel bzip2-devel \
-                        readline-devel sqlite-devel xz-devel
-                    '''
-
-                    try {
-                      sh label: 'Setup Python 3.13', script: '''
-                        set +x
-                        source /opt/rh/gcc-toolset-11/enable
-                        export CC=gcc CXX=g++
-                        curl -fsSL https://pyenv.run | bash
-                        export PYENV_ROOT="$HOME/.pyenv"
-                        export PATH="$PYENV_ROOT/bin:$PATH"
-                        eval "$(pyenv init -)"
-                        pyenv install 3.13 -s
-                        pyenv global 3.13
-                        pip install hatch
-                      '''
-
-                      sh label: 'Build Python wheel', script: '''
-                        set +x
-                        source /opt/rh/gcc-toolset-11/enable
-                        export CC=gcc CXX=g++
-                        export PYENV_ROOT="$HOME/.pyenv"
-                        export PATH="$PYENV_ROOT/bin:$PATH"
-                        eval "$(pyenv init -)"
-                        cd python
-                        hatch build -t wheel
-                      '''
-
-                      sh label: 'Python VPN E2E tests (test.py3.13)', script: '''
-                        set +x
-                        export PYENV_ROOT="$HOME/.pyenv"
-                        export PATH="$PYENV_ROOT/bin:$PATH"
-                        eval "$(pyenv init -)"
-                        export PARAMETER_PATH=$(pwd)/parameters.json
-                        cd python
-                        hatch run test.py3.13:install-wheel
-                        hatch run test.py3.13:pytest tests/e2e/authentication/test_native_okta.py -m require_vpn
-                        hatch env remove test.py3.13
-                      '''
-
-                      sh label: 'Python VPN E2E tests (reference)', script: '''
-                        set +x
-                        export PYENV_ROOT="$HOME/.pyenv"
-                        export PATH="$PYENV_ROOT/bin:$PATH"
-                        eval "$(pyenv init -)"
-                        export PARAMETER_PATH=$(pwd)/parameters.json
-                        cd python
-                        hatch run reference:test -- -m require_vpn
-                        hatch env remove reference
-                      '''
-                    } finally {
-                      sh label: 'Cleanup test PATs', script: '''
-                        set +x
-                        pip3 install snowflake-connector-python -q 2>/dev/null || true
-                        python3 scripts/cleanup_env.py \
-                          --parameter-path $(pwd)/parameters.json \
-                          --build-tag "JNK_${BUILD_NUMBER}" || true
-                      '''
-                    }
-                  }
-                }
-              }
-            }
-
-            stage('Revocation Validation') {
-              agent { label 'build-node-extra-large' }
-              environment {
-                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
-              }
-              steps {
-                script {
-                  e2eDockerSetup(E2E_DOCKER_IMAGE)
-                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
-                    withCredentials([
-                      usernamePassword(credentialsId: 'jenkins-snowflakedb-github-app',
-                        usernameVariable: 'GITHUB_USER',
-                        passwordVariable: 'GITHUB_TOKEN')
-                    ]) {
-                      sh '''\
-                        |#!/bin/bash -e
-                        |chmod +x "$WORKSPACE/ci/test_revocation.sh"
-                        |"$WORKSPACE/ci/test_revocation.sh"
-                      '''.stripMargin()
-                    }
-                  }
-                }
-              }
-              // No `post` block: ci/test_revocation.sh produces no artifacts (no HTML
-              // report, no archived JSON). The framework's stdout + the script's compact
-              // summary in the Jenkins console log are the entire audit trail. The stage's
-              // pass/fail status comes from the script's exit code, which Jenkins already
-              // surfaces as the stage status — no further annotation needed.
-            }
-          }
-        }
         stage('Build Matrix') {
           matrix {
             axes {
@@ -505,8 +286,8 @@ pipeline {
                       }
                       // catchError below demotes build/test/upload failures to UNSTABLE
                       // instead of FAILURE. A FAILED stage would halt the pipeline and
-                      // skip downstream Tests; UNSTABLE marks the build yellow but lets
-                      // VPN E2E Tests and Revocation Validation continue to run.
+                      // skip downstream stages; UNSTABLE marks the build yellow but lets
+                      // other matrix cells continue to run.
                       // Each platform still reports individual pass/fail on the UI.
                       stage('build (docker)') {
                         steps {
@@ -587,7 +368,7 @@ pipeline {
                     }
                   }
                   // See comment above on Docker Build: catchError demotes failures to
-                  // UNSTABLE so a broken platform build here doesn't block Tests.
+                  // UNSTABLE so a broken platform build here doesn't block other cells.
                   stage('build (node)') {
                     steps {
                       // Clear prior-run artifact so the upload guard keys off a fresh

--- a/ci/Jenkinsfile.vpn-tests
+++ b/ci/Jenkinsfile.vpn-tests
@@ -1,0 +1,241 @@
+/*
+Jenkinsfile for VPN E2E tests and revocation validation.
+The cross-platform build matrix lives in a separate job: ci/Jenkinsfile.build-matrix.
+*/
+
+@Library('pipeline-utils') _
+import com.snowflake.DevEnvUtils
+
+def e2eDockerSetup(String image) {
+  new DevEnvUtils().withSfCli {
+    sh "sf artifact oci auth"
+  }
+  sh label: 'Docker Pull', script: "docker pull ${image}"
+}
+
+pipeline {
+  //Various labels available: https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/2443215263/Agent+labels+in+jenkins
+  agent none
+  options { timestamps()
+            disableResume() //REQUIRED SECTION - We must use this property, else PRs can get in stuck state for any controller restart
+            buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '50')) // REQUIRED SECTION - retention policy must be set
+            timeout(time: 1, unit: 'HOURS') // REQUIRED SECTION - timeout must be set
+          }
+  triggers {
+    cron(env.BRANCH_NAME == 'main' ? 'H H/6 * * *' : '')
+  }
+  stages {
+
+        stage('Tests') {
+          parallel {
+            stage('Rust Core VPN E2E Tests') {
+              agent { label 'build-node-extra-large' }
+              environment {
+                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
+                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
+              }
+              steps {
+                script {
+                  e2eDockerSetup(E2E_DOCKER_IMAGE)
+                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
+                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
+                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
+                    }
+                    // Refresh dnf metadata before yum install — Rocky Linux rotates
+                    // metadata hashes weekly, breaking pre-built Docker images that
+                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
+                    // for full rationale.
+                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
+                    sh label: 'Install system dependencies', script: 'yum install -y unzip'
+
+                    try {
+                      sh label: 'Rust Core VPN E2E tests', script: '''
+                        set +x
+                        export PARAMETER_PATH=$(pwd)/parameters.json
+                        cargo test --package sf_core -- --ignored
+                      '''
+                    } finally {
+                      sh label: 'Cleanup test PATs', script: '''
+                        set +x
+                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                        python3 scripts/cleanup_env.py \
+                          --parameter-path $(pwd)/parameters.json \
+                          --build-tag "JNK_${BUILD_NUMBER}" || true
+                      '''
+                    }
+                  }
+                }
+              }
+            }
+
+            stage('ODBC VPN E2E Tests') {
+              agent { label 'build-node-extra-large' }
+              environment {
+                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
+                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
+              }
+              steps {
+                script {
+                  e2eDockerSetup(E2E_DOCKER_IMAGE)
+                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
+                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
+                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
+                    }
+                    // Refresh dnf metadata before yum install — Rocky Linux rotates
+                    // metadata hashes weekly, breaking pre-built Docker images that
+                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
+                    // for full rationale.
+                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
+                    sh label: 'Install system dependencies', script: 'yum install -y unzip'
+
+                    try {
+                      sh label: 'ODBC VPN E2E tests', script: '''
+                        set +x
+                        cargo build
+                        source /opt/rh/gcc-toolset-11/enable
+                        cd odbc_tests
+                        mkdir -p cmake-build
+                        cmake -B cmake-build \
+                            -D ODBC_LIBRARY="/usr/lib64/libodbc.so" \
+                            -D ODBC_INCLUDE_DIR="/usr/include" \
+                            -D DRIVER_TYPE=NEW \
+                            .
+                        cmake --build cmake-build -- -j $(nproc)
+
+                        WORKSPACE_ROOT=$(pwd)/..
+                        export DRIVER_PATH=${WORKSPACE_ROOT}/target/debug/libsfodbc.so
+                        export PARAMETER_PATH=${WORKSPACE_ROOT}/parameters.json
+                        ctest -j 1 -C Debug --test-dir cmake-build --output-on-failure -R "native_okta" --no-tests=error
+                      '''
+                    } finally {
+                      sh label: 'Cleanup test PATs', script: '''
+                        set +x
+                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                        python3 scripts/cleanup_env.py \
+                          --parameter-path $(pwd)/parameters.json \
+                          --build-tag "JNK_${BUILD_NUMBER}" || true
+                      '''
+                    }
+                  }
+                }
+              }
+            }
+
+            stage('Python VPN E2E Tests') {
+              agent { label 'build-node-extra-large' }
+              environment {
+                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
+                PARAMS_CREDENTIAL_ID = 'sfctest0-parameters-secret'
+              }
+              steps {
+                script {
+                  e2eDockerSetup(E2E_DOCKER_IMAGE)
+                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
+                    withCredentials([string(credentialsId: PARAMS_CREDENTIAL_ID, variable: 'PARAMETERS_SECRET')]) {
+                      sh label: 'Decode Secrets', script: './scripts/decode_secrets.sh'
+                    }
+                    // Refresh dnf metadata before yum install — Rocky Linux rotates
+                    // metadata hashes weekly, breaking pre-built Docker images that
+                    // ship with stale dnf caches. See Jenkinsfile.coverage installSystemDeps
+                    // for full rationale.
+                    sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
+                    sh label: 'Install system dependencies', script: '''
+                      yum install -y unzip \
+                        libffi-devel openssl-devel zlib-devel bzip2-devel \
+                        readline-devel sqlite-devel xz-devel
+                    '''
+
+                    try {
+                      sh label: 'Setup Python 3.13', script: '''
+                        set +x
+                        source /opt/rh/gcc-toolset-11/enable
+                        export CC=gcc CXX=g++
+                        curl -fsSL https://pyenv.run | bash
+                        export PYENV_ROOT="$HOME/.pyenv"
+                        export PATH="$PYENV_ROOT/bin:$PATH"
+                        eval "$(pyenv init -)"
+                        pyenv install 3.13 -s
+                        pyenv global 3.13
+                        pip install hatch
+                      '''
+
+                      sh label: 'Build Python wheel', script: '''
+                        set +x
+                        source /opt/rh/gcc-toolset-11/enable
+                        export CC=gcc CXX=g++
+                        export PYENV_ROOT="$HOME/.pyenv"
+                        export PATH="$PYENV_ROOT/bin:$PATH"
+                        eval "$(pyenv init -)"
+                        cd python
+                        hatch build -t wheel
+                      '''
+
+                      sh label: 'Python VPN E2E tests (test.py3.13)', script: '''
+                        set +x
+                        export PYENV_ROOT="$HOME/.pyenv"
+                        export PATH="$PYENV_ROOT/bin:$PATH"
+                        eval "$(pyenv init -)"
+                        export PARAMETER_PATH=$(pwd)/parameters.json
+                        cd python
+                        hatch run test.py3.13:install-wheel
+                        hatch run test.py3.13:pytest tests/e2e/authentication/test_native_okta.py -m require_vpn
+                        hatch env remove test.py3.13
+                      '''
+
+                      sh label: 'Python VPN E2E tests (reference)', script: '''
+                        set +x
+                        export PYENV_ROOT="$HOME/.pyenv"
+                        export PATH="$PYENV_ROOT/bin:$PATH"
+                        eval "$(pyenv init -)"
+                        export PARAMETER_PATH=$(pwd)/parameters.json
+                        cd python
+                        hatch run reference:test -- -m require_vpn
+                        hatch env remove reference
+                      '''
+                    } finally {
+                      sh label: 'Cleanup test PATs', script: '''
+                        set +x
+                        pip3 install snowflake-connector-python -q 2>/dev/null || true
+                        python3 scripts/cleanup_env.py \
+                          --parameter-path $(pwd)/parameters.json \
+                          --build-tag "JNK_${BUILD_NUMBER}" || true
+                      '''
+                    }
+                  }
+                }
+              }
+            }
+
+            stage('Revocation Validation') {
+              agent { label 'build-node-extra-large' }
+              environment {
+                E2E_DOCKER_IMAGE = 'artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual/docker/rhel8-universal-driver-coverage:3'
+              }
+              steps {
+                script {
+                  e2eDockerSetup(E2E_DOCKER_IMAGE)
+                  docker.image(E2E_DOCKER_IMAGE).inside('-u root') {
+                    withCredentials([
+                      usernamePassword(credentialsId: 'jenkins-snowflakedb-github-app',
+                        usernameVariable: 'GITHUB_USER',
+                        passwordVariable: 'GITHUB_TOKEN')
+                    ]) {
+                      sh '''\
+                        |#!/bin/bash -e
+                        |chmod +x "$WORKSPACE/ci/test_revocation.sh"
+                        |"$WORKSPACE/ci/test_revocation.sh"
+                      '''.stripMargin()
+                    }
+                  }
+                }
+              }
+              // No `post` block: ci/test_revocation.sh produces no artifacts (no HTML
+              // report, no archived JSON). The framework's stdout + the script's compact
+              // summary in the Jenkins console log are the entire audit trail. The stage's
+              // pass/fail status comes from the script's exit code, which Jenkins already
+              // surfaces as the stage status — no further annotation needed.
+            }
+          }
+        }
+  }
+}


### PR DESCRIPTION
## Summary
- Split the single Jenkins pipeline (`ci/Jenkinsfile`) into two independent jobs:
  - `ci/Jenkinsfile.vpn-tests` — VPN E2E tests (Rust Core, ODBC, Python) and revocation validation
  - `ci/Jenkinsfile.build-matrix` — 10-platform cross-compilation build matrix
- The two jobs now run independently and in parallel instead of sequentially

## Context
The VPN tests and build matrix were previously a single sequential pipeline. A build matrix failure would block VPN tests, making us overlook potential issues with authentication.

Companion change in jenkins_utils: https://github.com/snowflake-eng/jenkins_utils/pull/27745

## Tests
New jobs after being rebuild with dsl_seed are visible in "Checks" tab of this PR
 * Matrix (unstable as it's used to be): https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/universal-driver-build-matrix/job/PR-976/6/pipeline-overview/
  * VPN tests (passing): https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/universal-driver-vpn-tests/job/PR-976/6/pipeline-overview/