### PR TITLE
Pczajka/macos wheels

### DIFF
--- a/.github/actions/setup-windows-openssl/action.yml
+++ b/.github/actions/setup-windows-openssl/action.yml
@@ -33,6 +33,8 @@ runs:
       with:
         path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}
         key: vcpkg-openssl-${{ steps.triplet.outputs.value }}-${{ env.VCPKG_VER }}
+        restore-keys: |
+          vcpkg-openssl-${{ steps.triplet.outputs.value }}-
 
     - name: Install OpenSSL via vcpkg (ARM64)
       if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
@@ -48,6 +50,10 @@ runs:
 
     - name: Save vcpkg OpenSSL cache
       if: steps.cache.outputs.cache-hit != 'true'
+      continue-on-error: true
+      timeout-minutes: 10
+      env:
+        ZSTD_NBTHREADS: '2'
       uses: actions/cache/save@v5
       with:
         path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}

--- a/.github/actions/setup-windows-openssl/action.yml
+++ b/.github/actions/setup-windows-openssl/action.yml
@@ -49,7 +49,6 @@ runs:
     - name: Save vcpkg OpenSSL cache
       if: steps.cache.outputs.cache-hit != 'true'
       continue-on-error: true
-      timeout-minutes: 10
       env:
         ZSTD_NBTHREADS: '2'
       uses: actions/cache/save@v5

--- a/.github/actions/setup-windows-openssl/action.yml
+++ b/.github/actions/setup-windows-openssl/action.yml
@@ -33,8 +33,6 @@ runs:
       with:
         path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}
         key: vcpkg-openssl-${{ steps.triplet.outputs.value }}-${{ env.VCPKG_VER }}
-        restore-keys: |
-          vcpkg-openssl-${{ steps.triplet.outputs.value }}-
 
     - name: Install OpenSSL via vcpkg (ARM64)
       if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -449,3 +449,20 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: python/dist/*.whl
+
+  # ── Clean up intermediate build artifacts ──────────────────────────
+  cleanup_build_artifacts:
+    needs: [build_wheels, build_wheel]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete intermediate artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --paginate -q '.artifacts[] | select(.name == "protobuf-gen" or (.name | startswith("sf-core-"))) | .id' |
+          while read id; do
+            echo "Deleting artifact $id"
+            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
+          done

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -8,8 +8,8 @@ on:
         required: true
         description: >
           JSON object mapping platform keys to Python version arrays.
-          Example: {"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12"], "windows_x86": ["3.11","3.12"], "windows_arm": ["3.11","3.12"]}
-          Supported platforms: linux_x86, linux_aarch, windows_x86, windows_arm.
+          Example: {"linux_x86": ["3.11","3.12","3.13","3.14"], "macos_x86": ["3.11","3.12"], "windows_arm": ["3.11","3.12"]}
+          Supported platforms: linux_x86, linux_aarch, macos_x86, macos_arm, windows_x86, windows_arm.
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,6 +49,26 @@ jobs:
                   "wheel_method": "cibuildwheel",
                   "cibw_arch": "manylinux_aarch64",
                   "artifact_id": "manylinux_aarch64",
+              },
+              "macos_x86": {
+                  "target": "macos-x86_64",
+                  "os": "macos-13",
+                  "container": "",
+                  "lib_name": "libsf_core.dylib",
+                  "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
+                  "wheel_method": "cibuildwheel",
+                  "cibw_arch": "macosx_x86_64",
+                  "artifact_id": "macosx_x86_64",
+              },
+              "macos_arm": {
+                  "target": "macos-arm64",
+                  "os": "macos-latest",
+                  "container": "",
+                  "lib_name": "libsf_core.dylib",
+                  "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",
+                  "wheel_method": "cibuildwheel",
+                  "cibw_arch": "macosx_arm64",
+                  "artifact_id": "macosx_arm64",
               },
               "windows_x86": {
                   "target": "windows-x86_64",
@@ -166,6 +186,12 @@ jobs:
       - name: Build sf_core (Linux)
         if: runner.os == 'Linux'
         run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+
+      - name: Build sf_core (macOS)
+        if: runner.os == 'macOS'
+        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
 
       - name: Build sf_core (Windows x86_64)
         if: matrix.os == 'windows-latest'
@@ -303,7 +329,7 @@ jobs:
           path: python/src/snowflake/connector/_core
 
       - name: Ensure sf_core is executable
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
         run: chmod +x python/src/snowflake/connector/_core/*
 
       - name: Download pre-built protobuf code
@@ -327,8 +353,12 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >-
             SKIP_CORE_BUILD=true
             SKIP_PROTO_GENERATION=true
+          CIBW_ENVIRONMENT_MACOS: >-
+            SKIP_CORE_BUILD=true
+            SKIP_PROTO_GENERATION=true
+            MACOSX_DEPLOYMENT_TARGET=10.14
 
-      - name: Check wheels with auditwheel
+      - name: Check wheels with auditwheel (Linux)
         if: runner.os == 'Linux'
         run: |
           pip install auditwheel
@@ -340,6 +370,16 @@ jobs:
               echo "::error::Wheel $(basename $whl) does not meet manylinux_2_28 policy"
               exit 1
             fi
+          done
+
+      - name: Check wheels with delocate (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          pip install delocate
+          for whl in python/dist/*.whl; do
+            echo "=== $(basename $whl) ==="
+            delocate-listdeps "$whl"
+            delocate-wheel --require-archs ${{ contains(matrix.cibw_build, 'x86_64') && 'x86_64' || 'arm64' }} --check-archs "$whl"
           done
 
       - name: Upload wheel

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -191,7 +191,7 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.14"
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target == 'macos-arm64' && '11.0' || '10.14' }}
 
       - name: Build sf_core (Windows x86_64)
         if: matrix.os == 'windows-latest'
@@ -356,7 +356,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >-
             SKIP_CORE_BUILD=true
             SKIP_PROTO_GENERATION=true
-            MACOSX_DEPLOYMENT_TARGET=10.14
+            MACOSX_DEPLOYMENT_TARGET=${{ contains(matrix.cibw_build, 'x86_64') && '10.14' || '11.0' }}
 
       - name: Check wheels with auditwheel (Linux)
         if: runner.os == 'Linux'
@@ -379,7 +379,7 @@ jobs:
           for whl in python/dist/*.whl; do
             echo "=== $(basename $whl) ==="
             delocate-listdeps "$whl"
-            delocate-wheel --require-archs ${{ contains(matrix.cibw_build, 'x86_64') && 'x86_64' || 'arm64' }} --check-archs "$whl"
+            delocate-wheel --require-archs ${{ contains(matrix.cibw_build, 'x86_64') && 'x86_64' || 'arm64' }} --check-archs "$whl" && echo "✓ arch check passed"
           done
 
       - name: Upload wheel

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -52,7 +52,7 @@ jobs:
               },
               "macos_x86": {
                   "target": "macos-x86_64",
-                  "os": "macos-13",
+                  "os": "macos-15-intel",
                   "container": "",
                   "lib_name": "libsf_core.dylib",
                   "cargo_extra_args": "--features vendored-openssl --config profile.release.opt-level=2",

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -50,37 +50,31 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test env
-          - { os: macos-15-intel,        py: "3.10", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: macos-15-intel,        py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test-pandas env
-          - { os: macos-15-intel,        py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-15-intel,        py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test env
-          - { os: macos-latest,    py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-latest,    py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test-pandas env
-          - { os: macos-latest,    py: "3.10", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: macos-latest,    py: "3.14", hatch_env: "test-pandas", cloud_provider: "azure" }
           # Windows x86_64 — test env
-          - { os: windows-latest,  py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # Windows x86_64 — test-pandas env
-          - { os: windows-latest,  py: "3.10", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
@@ -129,14 +123,14 @@ jobs:
           path: python/dist
 
       - name: Download wheel (macOS)
-        if: runner.os == 'macOS' && matrix.py != '3.10'
+        if: runner.os == 'macOS'
         uses: actions/download-artifact@v4
         with:
           name: ${{ (matrix.os == 'macos-15-intel' && 'macosx_x86_64' || 'macosx_arm64') }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download wheel (Windows)
-        if: runner.os == 'Windows' && matrix.py != '3.10'
+        if: runner.os == 'Windows'
         uses: actions/download-artifact@v4
         with:
           name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || 'win_amd64') }}_py${{ matrix.py }}
@@ -199,7 +193,7 @@ jobs:
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
       - name: Install snowflake ud driver from wheel (Windows)
-        if: runner.os == 'Windows' && matrix.py != '3.10'
+        if: runner.os == 'Windows'
         working-directory: python
         shell: pwsh
         run: |
@@ -210,8 +204,8 @@ jobs:
           $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
-      - name: Install snowflake ud driver from sdist (Linux/macOS)
-        if: runner.os != 'Windows' && matrix.py == '3.10'
+      - name: Install snowflake ud driver from sdist
+        if: matrix.py == '3.10'
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)
@@ -220,21 +214,6 @@ jobs:
           fi
           export WHEEL_PATH="${SDISTS[0]}"
           echo "Installing sdist: $WHEEL_PATH"
-          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
-        env:
-          SKIP_CORE_BUILD: "false"
-
-      - name: Install snowflake ud driver from sdist (Windows)
-        if: runner.os == 'Windows' && matrix.py == '3.10'
-        working-directory: python
-        shell: pwsh
-        run: |
-          $sdists = @(Get-ChildItem dist/*.tar.gz)
-          if ($sdists.Count -ne 1) {
-            Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
-          }
-          $env:WHEEL_PATH = $sdists[0].FullName
-          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -317,23 +317,6 @@ jobs:
         env:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
 
-  # ── Clean up intermediate artifacts ────────────────────────────────
-  cleanup:
-    needs: [build_wheels, test, test_reference]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete intermediate build artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate -q '.artifacts[] | select(.name == "protobuf-gen" or (.name | startswith("sf-core-"))) | .id' \
-          | while read id; do
-              echo "Deleting artifact $id"
-              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-            done
-
   # ── Status gate ────────────────────────────────────────────────────
   release_status:
     needs: [build_wheels, test, test_reference]

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -323,12 +323,12 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Delete sf-core artifacts
+      - name: Delete intermediate build artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate -q '.artifacts[] | select(.name | startswith("sf-core-")) | .id' \
+            --paginate -q '.artifacts[] | select(.name == "protobuf-gen" or (.name | startswith("sf-core-"))) | .id' \
           | while read id; do
               echo "Deleting artifact $id"
               gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -50,31 +50,37 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test env
+          - { os: macos-15-intel,        py: "3.10", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: macos-15-intel,        py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test-pandas env
+          - { os: macos-15-intel,        py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: macos-15-intel,        py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-15-intel,        py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-15-intel,        py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test env
+          - { os: macos-latest,    py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-latest,    py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test-pandas env
+          - { os: macos-latest,    py: "3.10", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: macos-latest,    py: "3.14", hatch_env: "test-pandas", cloud_provider: "azure" }
           # Windows x86_64 — test env
+          - { os: windows-latest,  py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # Windows x86_64 — test-pandas env
+          - { os: windows-latest,  py: "3.10", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: windows-latest,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
@@ -123,14 +129,14 @@ jobs:
           path: python/dist
 
       - name: Download wheel (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
           name: ${{ (matrix.os == 'macos-15-intel' && 'macosx_x86_64' || 'macosx_arm64') }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download wheel (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
           name: ${{ (matrix.os == 'windows-11-arm' && 'win_arm64' || 'win_amd64') }}_py${{ matrix.py }}
@@ -193,7 +199,7 @@ jobs:
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
       - name: Install snowflake ud driver from wheel (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.py != '3.10'
         working-directory: python
         shell: pwsh
         run: |
@@ -204,8 +210,8 @@ jobs:
           $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
-      - name: Install snowflake ud driver from sdist
-        if: matrix.py == '3.10'
+      - name: Install snowflake ud driver from sdist (Linux/macOS)
+        if: runner.os != 'Windows' && matrix.py == '3.10'
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)
@@ -214,6 +220,21 @@ jobs:
           fi
           export WHEEL_PATH="${SDISTS[0]}"
           echo "Installing sdist: $WHEEL_PATH"
+          hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
+        env:
+          SKIP_CORE_BUILD: "false"
+
+      - name: Install snowflake ud driver from sdist (Windows)
+        if: runner.os == 'Windows' && matrix.py == '3.10'
+        working-directory: python
+        shell: pwsh
+        run: |
+          $sdists = @(Get-ChildItem dist/*.tar.gz)
+          if ($sdists.Count -ne 1) {
+            Write-Error "Expected exactly 1 sdist, found $($sdists.Count)"; Get-ChildItem dist/; exit 1
+          }
+          $env:WHEEL_PATH = $sdists[0].FullName
+          Write-Host "Installing sdist: $($env:WHEEL_PATH)"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
         env:
           SKIP_CORE_BUILD: "false"

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -50,21 +50,25 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test env
-          - { os: macos-13,        py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
-          - { os: macos-13,        py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
-          - { os: macos-13,        py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
-          - { os: macos-13,        py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: macos-15-intel,        py: "3.10", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: macos-15-intel,        py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: macos-15-intel,        py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: macos-15-intel,        py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: macos-15-intel,        py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
           # macOS x86_64 (Intel) — test-pandas env
-          - { os: macos-13,        py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
-          - { os: macos-13,        py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
-          - { os: macos-13,        py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
-          - { os: macos-13,        py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: macos-15-intel,        py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: macos-15-intel,        py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: macos-15-intel,        py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: macos-15-intel,        py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: macos-15-intel,        py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test env
+          - { os: macos-latest,    py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
           - { os: macos-latest,    py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
           # macOS ARM64 (Apple Silicon) — test-pandas env
+          - { os: macos-latest,    py: "3.10", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: macos-latest,    py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
           - { os: macos-latest,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp"   }
@@ -125,10 +129,10 @@ jobs:
           path: python/dist
 
       - name: Download wheel (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'macos-13' && 'macosx_x86_64' || 'macosx_arm64') }}_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'macos-15-intel' && 'macosx_x86_64' || 'macosx_arm64') }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download wheel (Windows)
@@ -206,8 +210,8 @@ jobs:
           $env:WHEEL_PATH = $wheels[0].FullName
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
-      - name: Install snowflake ud driver from sdist (Linux)
-        if: runner.os == 'Linux' && matrix.py == '3.10'
+      - name: Install snowflake ud driver from sdist (Linux/macOS)
+        if: runner.os != 'Windows' && matrix.py == '3.10'
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -14,7 +14,7 @@ jobs:
   build_wheels:
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "macos_arm": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # ── Test wheels and sdist against cloud providers ───────────────────
   # Each Python version tested once per env, cloud providers distributed evenly.
@@ -49,6 +49,26 @@ jobs:
           - { os: ubuntu-24.04-arm, py: "3.12", hatch_env: "test-pandas", cloud_provider: "gcp"   }
           - { os: ubuntu-24.04-arm, py: "3.13", hatch_env: "test-pandas", cloud_provider: "azure" }
           - { os: ubuntu-24.04-arm, py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          # macOS x86_64 (Intel) — test env
+          - { os: macos-13,        py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: macos-13,        py: "3.12", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: macos-13,        py: "3.13", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: macos-13,        py: "3.14", hatch_env: "test",        cloud_provider: "aws"   }
+          # macOS x86_64 (Intel) — test-pandas env
+          - { os: macos-13,        py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: macos-13,        py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: macos-13,        py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: macos-13,        py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          # macOS ARM64 (Apple Silicon) — test env
+          - { os: macos-latest,    py: "3.11", hatch_env: "test",        cloud_provider: "gcp"   }
+          - { os: macos-latest,    py: "3.12", hatch_env: "test",        cloud_provider: "azure" }
+          - { os: macos-latest,    py: "3.13", hatch_env: "test",        cloud_provider: "aws"   }
+          - { os: macos-latest,    py: "3.14", hatch_env: "test",        cloud_provider: "gcp"   }
+          # macOS ARM64 (Apple Silicon) — test-pandas env
+          - { os: macos-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: macos-latest,    py: "3.12", hatch_env: "test-pandas", cloud_provider: "aws"   }
+          - { os: macos-latest,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp"   }
+          - { os: macos-latest,    py: "3.14", hatch_env: "test-pandas", cloud_provider: "azure" }
           # Windows x86_64 — test env
           - { os: windows-latest,  py: "3.10", hatch_env: "test",        cloud_provider: "azure" }
           - { os: windows-latest,  py: "3.11", hatch_env: "test",        cloud_provider: "aws"   }
@@ -104,6 +124,13 @@ jobs:
           name: ${{ (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64') }}_py${{ matrix.py }}
           path: python/dist
 
+      - name: Download wheel (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ (matrix.os == 'macos-13' && 'macosx_x86_64' || 'macosx_arm64') }}_py${{ matrix.py }}
+          path: python/dist
+
       - name: Download wheel (Windows)
         if: runner.os == 'Windows' && matrix.py != '3.10'
         uses: actions/download-artifact@v4
@@ -155,8 +182,8 @@ jobs:
       - name: Install Hatch
         run: uv tool install hatch --with "virtualenv<21.0.0"
 
-      - name: Install snowflake ud driver from wheel (Linux)
-        if: runner.os == 'Linux' && matrix.py != '3.10'
+      - name: Install snowflake ud driver from wheel (Linux/macOS)
+        if: runner.os != 'Windows' && matrix.py != '3.10'
         working-directory: python
         run: |
           WHEELS=(dist/*.whl)
@@ -208,8 +235,8 @@ jobs:
         env:
           SKIP_CORE_BUILD: "false"
 
-      - name: Run tests (Linux)
-        if: runner.os == 'Linux'
+      - name: Run tests (Linux/macOS)
+        if: runner.os != 'Windows'
         working-directory: python
         run: |
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov \

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "macos_arm": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -151,6 +151,18 @@ jobs:
             py: "3.11"
             hatch_env: "test"
             cloud_provider: aws
+          - os: macos-13
+            py: "3.12"
+            hatch_env: "test"
+            cloud_provider: azure
+          - os: macos-latest
+            py: "3.14"
+            hatch_env: "test"
+            cloud_provider: gcp
+          - os: macos-latest
+            py: "3.11"
+            hatch_env: "test"
+            cloud_provider: aws
           - os: windows-latest
             py: "3.12"
             hatch_env: "test"
@@ -185,6 +197,14 @@ jobs:
             hatch_env: "test-pandas"
             cloud_provider: aws
             result_format: json
+          - os: macos-13
+            py: "3.13"
+            hatch_env: "test-pandas"
+            cloud_provider: gcp
+          - os: macos-latest
+            py: "3.12"
+            hatch_env: "test-pandas"
+            cloud_provider: azure
           - os: windows-latest
             py: "3.11"
             hatch_env: "test-pandas"
@@ -218,9 +238,9 @@ jobs:
       # dependencies regardless of which cloud provider the E2E tests target, so sharing one
       # cache per (os, py, hatch_env) triple across cloud providers avoids 3x cache duplication
       # and improves hit rates.
-      - name: Restore uv cache (Linux)
+      - name: Restore uv cache (Linux/macOS)
         id: uv-cache-linux
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
         uses: actions/cache/restore@v5
         with:
           path: /tmp/.uv-cache
@@ -250,7 +270,7 @@ jobs:
         if: matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))) }}_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'macos-13' && 'macosx_x86_64' || (matrix.os == 'macos-latest' && 'macosx_arm64' || (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))))) }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist
@@ -297,8 +317,8 @@ jobs:
       - name: Install Hatch
         run: &setup_env uv tool install hatch --with "virtualenv<21.0.0"
 
-      - name: Install snowflake ud driver from wheel (Linux)
-        if: runner.os == 'Linux' && matrix.py != '3.10'
+      - name: Install snowflake ud driver from wheel (Linux/macOS)
+        if: runner.os != 'Windows' && matrix.py != '3.10'
         working-directory: python
         run: |
           WHEELS=(dist/*.whl)
@@ -311,6 +331,7 @@ jobs:
 
       - name: Install snowflake ud driver from sdist (Linux)
         if: runner.os == 'Linux' && matrix.py == '3.10'
+        # sdist only on Linux — macOS/Windows always use wheels
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)
@@ -350,8 +371,8 @@ jobs:
         env:
           SKIP_CORE_BUILD: "false"
 
-      - name: Run tests with coverage (Linux)
-        if: runner.os == 'Linux'
+      - name: Run tests with coverage (Linux/macOS)
+        if: runner.os != 'Windows'
         id: run_python_tests_linux
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         working-directory: python
@@ -367,7 +388,7 @@ jobs:
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
           QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
 
-      - name: Rerun failed Python tests (Linux)
+      - name: Rerun failed Python tests (Linux/macOS)
         if: steps.run_python_tests_linux.outcome == 'failure' && github.event_name == 'merge_group'
         working-directory: python
         run: hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov --last-failed
@@ -427,13 +448,8 @@ jobs:
         shell: bash
         run: uv cache prune --ci
 
-      - name: Save uv cache (Linux)
-        # Skip when the exact key was already restored. Note: prefix-key fallbacks
-        # (restore-keys) do not set cache-hit=true, so saves still run after a
-        # partial restore — which is the common case after a uv.lock change.
-        if: always() && runner.os == 'Linux' && steps.uv-cache-linux.outputs.cache-hit != 'true'
-        # Cache save is best-effort — see cargo-cache action for rationale.
-        # timeout-minutes + ZSTD_NBTHREADS guard against tar+zstdmt hangs.
+      - name: Save uv cache (Linux/macOS)
+        if: always() && runner.os != 'Windows' && steps.uv-cache-linux.outputs.cache-hit != 'true'
         continue-on-error: true
         timeout-minutes: 10
         env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -177,7 +177,7 @@ jobs:
       # cache per (os, py, hatch_env) triple across cloud providers avoids 3x cache duplication
       # and improves hit rates.
       - name: Restore uv cache (Linux/macOS)
-        id: uv-cache-linux
+        id: uv-cache-unix
         if: runner.os != 'Windows'
         uses: actions/cache/restore@v5
         with:
@@ -310,7 +310,7 @@ jobs:
 
       - name: Run tests with coverage (Linux/macOS)
         if: runner.os != 'Windows'
-        id: run_python_tests_linux
+        id: run_python_tests_unix
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         working-directory: python
         run: |
@@ -326,7 +326,7 @@ jobs:
           QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
 
       - name: Rerun failed Python tests (Linux/macOS)
-        if: steps.run_python_tests_linux.outcome == 'failure' && github.event_name == 'merge_group'
+        if: steps.run_python_tests_unix.outcome == 'failure' && github.event_name == 'merge_group'
         working-directory: python
         run: hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:cov --last-failed
         env:
@@ -386,7 +386,7 @@ jobs:
         run: uv cache prune --ci
 
       - name: Save uv cache (Linux/macOS)
-        if: always() && runner.os != 'Windows' && steps.uv-cache-linux.outputs.cache-hit != 'true'
+        if: always() && runner.os != 'Windows' && steps.uv-cache-unix.outputs.cache-hit != 'true'
         continue-on-error: true
         timeout-minutes: 10
         env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -258,7 +258,7 @@ jobs:
         run: &setup_env uv tool install hatch --with "virtualenv<21.0.0"
 
       - name: Install snowflake ud driver from wheel (Linux/macOS)
-        if: runner.os != 'Windows' && matrix.py != '3.10'
+        if: runner.os != 'Windows' && matrix.wheel_artifact
         working-directory: python
         run: |
           WHEELS=(dist/*.whl)
@@ -269,9 +269,8 @@ jobs:
           echo "Installing wheel: $WHEEL_PATH"
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
-      - name: Install snowflake ud driver from sdist (Linux)
-        if: runner.os == 'Linux' && matrix.py == '3.10'
-        # sdist only on Linux — macOS/Windows always use wheels
+      - name: Install snowflake ud driver from sdist (Linux/macOS)
+        if: runner.os != 'Windows' && !matrix.wheel_artifact
         working-directory: python
         run: |
           SDISTS=(dist/*.tar.gz)
@@ -285,7 +284,7 @@ jobs:
           SKIP_CORE_BUILD: "false"
 
       - name: Install snowflake ud driver from wheel (Windows)
-        if: runner.os == 'Windows' && matrix.py != '3.10'
+        if: runner.os == 'Windows' && matrix.wheel_artifact
         working-directory: python
         shell: pwsh
         run: |
@@ -297,7 +296,7 @@ jobs:
           hatch run ${{ matrix.hatch_env }}.py${{ matrix.py }}:install-wheel
 
       - name: Install snowflake ud driver from sdist (Windows)
-        if: runner.os == 'Windows' && matrix.py == '3.10'
+        if: runner.os == 'Windows' && !matrix.wheel_artifact
         working-directory: python
         shell: pwsh
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -548,24 +548,6 @@ jobs:
             --reference ${{ github.workspace }}/reference-results/reference-${{ env.REF_MATRIX_KEY }}.json \
             --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
 
-  # ── Clean up intermediate artifacts ────────────────────────────────
-  cleanup:
-    needs: [build_wheels, python_tests]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete sf-core artifacts
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate -q '.artifacts[] | select(.name | startswith("sf-core-")) | .id' \
-          | while read id; do
-              echo "Deleting artifact $id"
-              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-            done
-
   python-status:
     needs: [detect-changes, build_wheels, packaging_tests, python_tests, python_tests_reference, python_compare_results]
     if: always()

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -151,7 +151,7 @@ jobs:
             py: "3.11"
             hatch_env: "test"
             cloud_provider: aws
-          - os: macos-13
+          - os: macos-15-intel
             py: "3.12"
             hatch_env: "test"
             cloud_provider: azure
@@ -197,7 +197,7 @@ jobs:
             hatch_env: "test-pandas"
             cloud_provider: aws
             result_format: json
-          - os: macos-13
+          - os: macos-15-intel
             py: "3.13"
             hatch_env: "test-pandas"
             cloud_provider: gcp
@@ -270,7 +270,7 @@ jobs:
         if: matrix.py != '3.10'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'macos-13' && 'macosx_x86_64' || (matrix.os == 'macos-latest' && 'macosx_arm64' || (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))))) }}_py${{ matrix.py }}
+          name: ${{ (matrix.os == 'macos-15-intel' && 'macosx_x86_64' || (matrix.os == 'macos-latest' && 'macosx_arm64' || (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))))) }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.11","3.12","3.13","3.14"], "linux_aarch": ["3.11","3.12","3.13","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "macos_arm": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.13","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.13"], "linux_aarch": ["3.11","3.14"], "macos_arm": ["3.12","3.14"], "windows_x86": ["3.11","3.12","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -132,27 +132,25 @@ jobs:
         include:
           # sdist tests (Python 3.10 — builds sf_core from source; no wheel_artifact needed)
           - { os: ubuntu-latest,     py: "3.10", hatch_env: "test",    cloud_provider: "azure" }
+          - { os: macos-latest,      py: "3.10", hatch_env: "test",    cloud_provider: "gcp"   }
+          - { os: windows-latest,    py: "3.10", hatch_env: "test",    cloud_provider: "aws"   }
           # wheel tests
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference combination — keep in sync with REFERENCE_* env vars above
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference — keep in sync with REFERENCE_* env vars above
           - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
           - { os: ubuntu-24.04-arm,  py: "3.14", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "manylinux_aarch64" }
-          - { os: ubuntu-24.04-arm,  py: "3.11", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_aarch64" }
-          - { os: macos-15-intel,    py: "3.12", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "macosx_x86_64" }
-          - { os: macos-latest,      py: "3.14", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "macosx_arm64" }
-          - { os: macos-latest,      py: "3.11", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
+          - { os: ubuntu-24.04-arm,  py: "3.11", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "manylinux_aarch64" }
+          - { os: macos-latest,      py: "3.14", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "macosx_arm64" }
+          - { os: macos-latest,      py: "3.12", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
           - { os: windows-latest,    py: "3.12", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_amd64" }
           - { os: windows-latest,    py: "3.14", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "win_amd64" }
           - { os: windows-11-arm,    py: "3.12", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "win_arm64" }
           - { os: windows-11-arm,    py: "3.11", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_arm64" }
-          - { os: windows-11-arm,    py: "3.11", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "win_arm64" }
           # test integration with Pandas
-          - { os: ubuntu-latest,     py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "manylinux_x86_64" }
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference combination — keep in sync with REFERENCE_* env vars above
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference — keep in sync with REFERENCE_* env vars above
           - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
-          - { os: macos-15-intel,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "macosx_x86_64" }
-          - { os: macos-latest,      py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure", wheel_artifact: "macosx_arm64" }
-          - { os: windows-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "win_amd64" }
-          - { os: ubuntu-24.04-arm,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure", wheel_artifact: "manylinux_aarch64" }
+          - { os: ubuntu-24.04-arm,  py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
+          - { os: macos-latest,      py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
+          - { os: windows-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "win_amd64" }
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -130,89 +130,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            py: "3.10"
-            hatch_env: "test"
-            cloud_provider: azure
-          - os: ubuntu-latest # Reference combination — keep in sync with REFERENCE_* env vars above
-            py: "3.13"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: ubuntu-latest # JSON result format test
-            py: "3.13"
-            hatch_env: "test"
-            cloud_provider: aws
-            result_format: json
-          - os: ubuntu-24.04-arm
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: ubuntu-24.04-arm
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: macos-15-intel
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: azure
-          - os: macos-latest
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: macos-latest
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: windows-latest
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: windows-latest
-            py: "3.14"
-            hatch_env: "test"
-            cloud_provider: azure
-          - os: windows-11-arm
-            py: "3.12"
-            hatch_env: "test"
-            cloud_provider: aws
-          - os: windows-11-arm
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: gcp
-          - os: windows-11-arm
-            py: "3.11"
-            hatch_env: "test"
-            cloud_provider: azure
+          # sdist tests (Python 3.10 — builds sf_core from source; no wheel_artifact needed)
+          - { os: ubuntu-latest,     py: "3.10", hatch_env: "test",    cloud_provider: "azure" }
+          # wheel tests
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference combination — keep in sync with REFERENCE_* env vars above
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
+          - { os: ubuntu-24.04-arm,  py: "3.14", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "manylinux_aarch64" }
+          - { os: ubuntu-24.04-arm,  py: "3.11", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_aarch64" }
+          - { os: macos-15-intel,    py: "3.12", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "macosx_x86_64" }
+          - { os: macos-latest,      py: "3.14", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "macosx_arm64" }
+          - { os: macos-latest,      py: "3.11", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
+          - { os: windows-latest,    py: "3.12", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_amd64" }
+          - { os: windows-latest,    py: "3.14", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "win_amd64" }
+          - { os: windows-11-arm,    py: "3.12", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "win_arm64" }
+          - { os: windows-11-arm,    py: "3.11", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_arm64" }
+          - { os: windows-11-arm,    py: "3.11", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "win_arm64" }
           # test integration with Pandas
-          - os: ubuntu-latest
-            py: "3.14"
-            hatch_env: "test-pandas"
-            cloud_provider: gcp
-          - os: ubuntu-latest # Reference combination for Pandas integration — keep in sync with REFERENCE_* env vars above
-            py: "3.13"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
-          - os: ubuntu-latest
-            py: "3.13"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
-            result_format: json
-          - os: macos-15-intel
-            py: "3.13"
-            hatch_env: "test-pandas"
-            cloud_provider: gcp
-          - os: macos-latest
-            py: "3.12"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
-          - os: windows-latest
-            py: "3.11"
-            hatch_env: "test-pandas"
-            cloud_provider: aws
-          - os: ubuntu-24.04-arm
-            py: "3.12"
-            hatch_env: "test-pandas"
-            cloud_provider: azure
+          - { os: ubuntu-latest,     py: "3.14", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "manylinux_x86_64" }
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference combination — keep in sync with REFERENCE_* env vars above
+          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
+          - { os: macos-15-intel,    py: "3.13", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "macosx_x86_64" }
+          - { os: macos-latest,      py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure", wheel_artifact: "macosx_arm64" }
+          - { os: windows-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "win_amd64" }
+          - { os: ubuntu-24.04-arm,  py: "3.12", hatch_env: "test-pandas", cloud_provider: "azure", wheel_artifact: "manylinux_aarch64" }
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:
@@ -267,10 +207,10 @@ jobs:
         run: uv python install ${{ matrix.os == 'windows-11-arm' && format('cpython-{0}-windows-aarch64-none', matrix.py) || matrix.py }}
 
       - name: Download wheel
-        if: matrix.py != '3.10'
+        if: matrix.wheel_artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ (matrix.os == 'macos-15-intel' && 'macosx_x86_64' || (matrix.os == 'macos-latest' && 'macosx_arm64' || (matrix.os == 'windows-latest' && 'win_amd64' || (matrix.os == 'windows-11-arm' && 'win_arm64' || (matrix.os == 'ubuntu-24.04-arm' && 'manylinux_aarch64' || 'manylinux_x86_64'))))) }}_py${{ matrix.py }}
+          name: ${{ matrix.wheel_artifact }}_py${{ matrix.py }}
           path: python/dist
 
       - name: Download sdist

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -247,9 +247,15 @@ class BuildHook(BuildHookInterface):
         self._apply_compile_flags(ext)
         self._apply_link_flags(ext)
 
-        # Cythonize and build
-        extensions = cythonize([ext])
-        self._run_build(extensions, src_root)
+        # Cythonize and build — chdir to self.root so relative source paths
+        # resolve correctly for both cythonize and the subsequent compilation.
+        saved_cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            extensions = cythonize([ext])
+            self._run_build(extensions, src_root)
+        finally:
+            os.chdir(saved_cwd)
 
     def _apply_compile_flags(self, ext: Extension) -> None:
         """Apply platform-specific compile flags to the extension."""
@@ -317,16 +323,7 @@ class BuildHook(BuildHookInterface):
         cmd.ensure_finalized()
         cmd.build_lib = str(src_root)
         cmd.inplace = True
-
-        # Extension sources use relative paths (see _build_extensions) so the
-        # build must run from self.root for both cythonize and compile to find
-        # the source files.
-        saved_cwd = os.getcwd()
-        os.chdir(self.root)
-        try:
-            cmd.run()
-        finally:
-            os.chdir(saved_cwd)
+        cmd.run()
 
     def _build_core(self) -> None:
         """Build the Rust core library in release mode for distribution."""

--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -7,6 +7,7 @@ from the test process do not affect the measurement.
 
 from __future__ import annotations
 
+import functools
 import platform
 import subprocess
 import sys
@@ -16,6 +17,7 @@ import pytest
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
+@functools.lru_cache(maxsize=1)
 def _is_rosetta() -> bool:
     """Detect if running x86_64 under Rosetta 2 on Apple Silicon."""
     if platform.system() != "Darwin" or platform.machine() != "x86_64":

--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -7,10 +7,29 @@ from the test process do not affect the measurement.
 
 from __future__ import annotations
 
+import platform
 import subprocess
 import sys
 
+import pytest
+
 from tests.compatibility import IS_UNIVERSAL_DRIVER
+
+
+def _is_rosetta() -> bool:
+    """Detect if running x86_64 under Rosetta 2 on Apple Silicon."""
+    if platform.system() != "Darwin" or platform.machine() != "x86_64":
+        return False
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "sysctl.proc_translated"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() == "1"
+    except Exception:
+        return False
 
 
 _IMPORT_TIME_SCRIPT = """\
@@ -31,6 +50,7 @@ _MAX_IMPORT_TIME_SECONDS = 0.4 if IS_UNIVERSAL_DRIVER else 0.6
 class TestImportTime:
     """Verify that importing snowflake.connector.connect stays within budget."""
 
+    @pytest.mark.skipif(_is_rosetta(), reason="Import timing unreliable under Rosetta 2 emulation")
     def test_import_connect_time(self):
         """Importing ``from snowflake.connector import connect`` must complete
         within the allowed time budget.

--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -39,7 +39,9 @@ _MAX_IMPORT_TIME_SECONDS = 0.4 if IS_UNIVERSAL_DRIVER else 0.6
 class TestImportTime:
     """Verify that importing snowflake.connector.connect stays within budget."""
 
-    @pytest.mark.skipif(_is_macos_x86_64(), reason="Import timing unreliable on macOS x86_64 CI runners")
+    @pytest.mark.skipif(
+        _is_macos_x86_64(), reason="Import timing unreliable on macOS x86_64 (Rosetta 2 and native Intel)"
+    )
     def test_import_connect_time(self):
         """Importing ``from snowflake.connector import connect`` must complete
         within the allowed time budget.

--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -7,7 +7,6 @@ from the test process do not affect the measurement.
 
 from __future__ import annotations
 
-import functools
 import platform
 import subprocess
 import sys
@@ -17,21 +16,9 @@ import pytest
 from tests.compatibility import IS_UNIVERSAL_DRIVER
 
 
-@functools.lru_cache(maxsize=1)
-def _is_rosetta() -> bool:
-    """Detect if running x86_64 under Rosetta 2 on Apple Silicon."""
-    if platform.system() != "Darwin" or platform.machine() != "x86_64":
-        return False
-    try:
-        result = subprocess.run(
-            ["sysctl", "-n", "sysctl.proc_translated"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout.strip() == "1"
-    except Exception:
-        return False
+def _is_macos_x86_64() -> bool:
+    """Detect if running on macOS x86_64 (native Intel or Rosetta 2)."""
+    return platform.system() == "Darwin" and platform.machine() == "x86_64"
 
 
 _IMPORT_TIME_SCRIPT = """\
@@ -52,7 +39,7 @@ _MAX_IMPORT_TIME_SECONDS = 0.4 if IS_UNIVERSAL_DRIVER else 0.6
 class TestImportTime:
     """Verify that importing snowflake.connector.connect stays within budget."""
 
-    @pytest.mark.skipif(_is_rosetta(), reason="Import timing unreliable under Rosetta 2 emulation")
+    @pytest.mark.skipif(_is_macos_x86_64(), reason="Import timing unreliable on macOS x86_64 CI runners")
     def test_import_connect_time(self):
         """Importing ``from snowflake.connector import connect`` must complete
         within the allowed time budget.


### PR DESCRIPTION
## Summary

  - Add macOS ARM64 and x86_64 wheel builds via cibuildwheel                                                                                                            
  - Add macOS test matrix entries to CI and release workflows                                                                                                
  - Replace nested ternary for artifact names with wheel_artifact matrix field                                                                                          
  - Drop macOS Intel from CI test matrix (keep in release) - it uses simulator, making the tests 2x slower                       
  - Skip import-time test on macOS x86_64 (same reason)
  - Clean up intermediate build artifacts (protobuf-gen, sf-core-*) in shared workflow                                                                                                                    
  - fixup hatch_build.py 

## per-PR test matrix:

 - add macos ARM to the matrix (intel skipped, as github workers use simulator, slowing down tests)
 - add python 3.10 (dsist installation) to per-PR test matrix
```
  test env (13 jobs):                                                                                                                                                   
   
  ┌──────────────────┬──────┬───────┬─────────────────────────┐                                                                                                         
  │        OS        │  Py  │ Cloud │          Type           │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-latest    │ 3.10 │ azure │ sdist                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤
  │ macos-latest     │ 3.10 │ gcp   │ sdist                   │                                                                                                         
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-latest   │ 3.10 │ aws   │ sdist                   │                                                                                                         
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-latest    │ 3.13 │ aws   │ wheel (Reference)       │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-latest    │ 3.13 │ aws   │ wheel (Reference, json) │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-24.04-arm │ 3.14 │ gcp   │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-24.04-arm │ 3.11 │ azure │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ macos-latest     │ 3.14 │ azure │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ macos-latest     │ 3.12 │ aws   │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-latest   │ 3.12 │ gcp   │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-latest   │ 3.14 │ azure │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-11-arm   │ 3.12 │ aws   │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-11-arm   │ 3.11 │ gcp   │ wheel                   │       
  └──────────────────┴──────┴───────┴─────────────────────────┘                                                                                                         
                                                                      
  test-pandas env (5 jobs):                                                                                                                                             
                                                                      
  ┌──────────────────┬──────┬───────┬─────────────────────────┐                                                                                                         
  │        OS        │  Py  │ Cloud │          Type           │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-latest    │ 3.13 │ aws   │ wheel (Reference)       │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤
  │ ubuntu-latest    │ 3.13 │ aws   │ wheel (Reference, json) │                                                                                                         
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ ubuntu-24.04-arm │ 3.10 │ azure │ sdist                   │                                                                                                         
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ macos-latest     │ 3.14 │ aws   │ wheel                   │       
  ├──────────────────┼──────┼───────┼─────────────────────────┤                                                                                                         
  │ windows-latest   │ 3.11 │ gcp   │ wheel                   │       
  └──────────────────┴──────┴───────┴─────────────────────────┘    
```

## Test artifact build job:
https://github.com/snowflakedb/universal-driver/actions/runs/25052489205