### PR TITLE
NO-SNOW: Account for intermittent failures in reference driver cross thread cancel behaviour

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -497,3 +497,17 @@ behavior_differences:
       Per the MS ODBC specification ("C to SQL: Binary" appendix) the driver checks that BufferLength equals the SQL data length (sizeof(SQL_NUMERIC_STRUCT) = 19 for DECIMAL/NUMERIC, sizeof(SQL_TIME_STRUCT) = 6 for TIME, sizeof(SQL_TIMESTAMP_STRUCT) = 16 for TIMESTAMP) and forwards the raw bytes to the server. Buffers of any other length are rejected with SQLSTATE 22003, matching the spec's "Byte length of data <> SQL data length -> 22003" rule.
     impact: |
       Applications that bind a typed C struct as SQL_C_BINARY now have a portable way to insert these SQL types without separate SQL_C_NUMERIC / SQL_C_TYPE_TIMESTAMP / etc. bindings. See SNOW-3031774 (PR #833 for the Rust implementation, PR #834 for E2E coverage).
+
+  47:
+    name: "Cross-thread SQLCancel/SQLCancelHandle returns SQL_ERROR with HY008 instead of SQL_SUCCESS"
+    status: unknown
+    type: bug
+    reviewed: false
+    old_driver_behavior: |
+      When SQLCancel or SQLCancelHandle is called from a different thread to cancel an in-progress SQLExecDirect, the cancel function intermittently returns SQL_ERROR with SQLSTATE HY008 (NativeError 604, "SQL execution canceled") instead of SQL_SUCCESS. This happens because the driver's internal CancelExecute() calls Statement::cancel() without a try-catch. When the server's abort-request endpoint responds with a non-success status (e.g. the query was already canceled before the REST abort completed), cancel() throws and the exception propagates to the caller.
+    new_driver_behavior: |
+      Cross-thread SQLCancel and SQLCancelHandle always return SQL_SUCCESS per the ODBC specification. The cancel function posts no diagnostics of its own; only the canceled function (SQLExecDirect) returns SQL_ERROR with HY008.
+    impact: |
+      Applications that check the return code of SQLCancel/SQLCancelHandle in multi-threaded scenarios may see intermittent SQL_ERROR on the old driver. The cancellation itself still takes effect (the executing function returns HY008), so the functional impact is limited to the cancel call's return code.
+    description: |
+      Spec reference: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcancel-function — "When SQLCancel is successfully called to cancel a function running in another thread, the driver does not post SQL_ERROR with SQLSTATE HY008."

--- a/odbc_tests/common/include/cross_thread_cancel.hpp
+++ b/odbc_tests/common/include/cross_thread_cancel.hpp
@@ -7,7 +7,9 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <vector>
 
+#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 
 namespace odbc_test {
@@ -24,6 +26,7 @@ struct JoinGuard {
 struct CrossThreadCancel {
   std::atomic<SQLRETURN> exec_result{SQL_NO_DATA};
   SQLRETURN cancel_result = SQL_ERROR;
+  std::vector<DiagRec> cancel_diag_records;
 
   void run(const SQLHSTMT stmt, const char* query, const std::chrono::seconds pre_cancel_delay) {
     run(stmt, query, pre_cancel_delay, [](const SQLHSTMT s) { return SQLCancel(s); });
@@ -55,6 +58,7 @@ struct CrossThreadCancel {
     }
 
     cancel_result = cancel_fn(stmt);
+    cancel_diag_records = get_diag_rec(SQL_HANDLE_STMT, stmt);
   }
 };
 

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
@@ -747,7 +747,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cross-thread cancel in
   ctx.run(stmt, "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 60))", std::chrono::seconds(5),
           [](SQLHSTMT s) { return SQLCancelHandle(SQL_HANDLE_STMT, s); });
 
-  REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+  OLD_DRIVER_ONLY("BD#47") {
+    REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
+    if (ctx.cancel_result == SQL_ERROR) {
+      REQUIRE(!ctx.cancel_diag_records.empty());
+      REQUIRE(ctx.cancel_diag_records[0].sqlState == "HY008");
+    }
+  }
+  NEW_DRIVER_ONLY("BD#47") {
+    REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+  }
 
   SQLRETURN exec_ret = ctx.exec_result.load();
   REQUIRE_EXPECTED_ERROR(exec_ret, "HY008", stmt, SQL_HANDLE_STMT);
@@ -891,7 +900,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: SQL_ERROR with HY092 f
   REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt_handle()), OdbcMatchers::Succeeded());
   REQUIRE(ard != SQL_NULL_HDESC);
 
-  ret = SQLCancelHandle(SQL_HANDLE_DESC, static_cast<SQLHANDLE>(ard));
+  ret = SQLCancelHandle(SQL_HANDLE_DESC, ard);
   // The DM typically intercepts this before reaching the driver.
   // Windows DM returns SQL_ERROR with HY092 (per spec).
   // Unix DM (unixODBC) may return SQL_INVALID_HANDLE instead.

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
@@ -749,7 +749,16 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cross-thread cancel interrup
   // leaving nothing to cancel and causing the query to run to completion.
   ctx.run(stmt, "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 60))", std::chrono::seconds(5));
 
-  REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+  OLD_DRIVER_ONLY("BD#47") {
+    REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
+    if (ctx.cancel_result == SQL_ERROR) {
+      REQUIRE(!ctx.cancel_diag_records.empty());
+      REQUIRE(ctx.cancel_diag_records[0].sqlState == "HY008");
+    }
+  }
+  NEW_DRIVER_ONLY("BD#47") {
+    REQUIRE_THAT(OdbcResult(ctx.cancel_result, SQL_HANDLE_STMT, stmt), OdbcMatchers::Succeeded());
+  }
 
   SQLRETURN exec_ret = ctx.exec_result.load();
   REQUIRE_EXPECTED_ERROR(exec_ret, "HY008", stmt, SQL_HANDLE_STMT);


### PR DESCRIPTION
### TL;DR

Documents and adds test coverage for the behavior difference where cross-thread `SQLCancel`/`SQLCancelHandle` intermittently returns `SQL_ERROR` with `HY008` on the old driver instead of `SQL_SUCCESS` as required by the ODBC spec.

### What changed?

A new behavior difference entry (BD#47) was added to `BehaviorDifferences.yaml` describing the old driver bug where `SQLCancel` and `SQLCancelHandle`, when called from a different thread to cancel an in-progress `SQLExecDirect`, could intermittently return `SQL_ERROR` with SQLSTATE `HY008` instead of `SQL_SUCCESS`. This occurs because the Simba SDK DSII's `CancelExecute()` calls `Statement::cancel()` without a try-catch, allowing exceptions to propagate when the server's abort-request endpoint responds with a non-success status.

The cross-thread cancel tests in `cancel_tests.cpp` and `cancel_handle_tests.cpp` were updated to use `OLD_DRIVER_ONLY`/`NEW_DRIVER_ONLY` guards. The old driver assertion accepts either `SQL_SUCCESS` or `SQL_ERROR` (verifying `HY008` when it is an error), while the new driver assertion strictly requires `SQL_SUCCESS` per the ODBC specification.

### How to test?

Run the existing cross-thread cancel test cases:
- `SQLCancel: Cross-thread cancel interrupts` in `cancel_tests.cpp`
- `SQLCancelHandle: Cross-thread cancel in` in `cancel_handle_tests.cpp`

On the new driver, both tests should pass with `SQL_SUCCESS` returned from the cancel call. On the old driver, the tests accept either `SQL_SUCCESS` or `SQL_ERROR` with `HY008`.

### Why make this change?

The ODBC specification explicitly states that when `SQLCancel` successfully cancels a function running in another thread, the driver must not return `SQL_ERROR` with `HY008` — only the canceled function itself should report that error. The old driver violated this contract intermittently. This change documents the known deviation and ensures the new driver enforces the correct behavior.