### PR TITLE
SNOW-3441376: Add ODBC x86_32 Windows MSI installer and builds

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -297,11 +297,12 @@ jobs:
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+            cargo_extra: "--features vendored-openssl"
           - os: windows-latest
             name: Windows x86
             driver_lib: sfodbc32.dll
             cargo_target: i686-pc-windows-msvc
-            cargo_extra: "--no-default-features"
+            cargo_extra: "--no-default-features --features vendored-openssl"
     runs-on: ${{ matrix.os }}
     name: build_odbc_driver (${{ matrix.name }})
     steps:
@@ -325,16 +326,6 @@ jobs:
           brew install unixodbc go
           echo "ODBC_PREFIX=$(brew --prefix unixodbc)" >> $GITHUB_ENV
 
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          if (!(Test-Path "C:\Program Files\OpenSSL\lib\VC\x64\MD")) {
-            choco install openssl -y --no-progress
-          }
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\x64\MD" >> $env:GITHUB_ENV
-
       - name: Install Rust target
         if: matrix.cargo_target
         run: rustup target add ${{ matrix.cargo_target }}
@@ -349,15 +340,9 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo build --package odbc
 
-      - name: Build ODBC driver (Windows x64)
-        if: runner.os == 'Windows' && !matrix.cargo_target
-        run: cargo build --package odbc
-        env:
-          RUSTFLAGS: "-C linker=rust-lld"
-
-      - name: Build ODBC driver (Windows x86)
-        if: runner.os == 'Windows' && matrix.cargo_target
-        run: cargo build --package odbc ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}
+      - name: Build ODBC driver (Windows)
+        if: runner.os == 'Windows'
+        run: cargo build --package odbc ${{ matrix.cargo_extra }} ${{ matrix.cargo_target && format('--target {0}', matrix.cargo_target) || '' }}
         env:
           RUSTFLAGS: "-C linker=rust-lld"
 

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -724,11 +724,25 @@ jobs:
             config: release
             cargo_target: x86_64-pc-windows-msvc
             cargo_profile: "--release"
+            cargo_extra: ""
           - name: Windows x64 Debug
             arch: x64
             config: debug
             cargo_target: x86_64-pc-windows-msvc
             cargo_profile: ""
+            cargo_extra: ""
+          - name: Windows x86 Release
+            arch: x86
+            config: release
+            cargo_target: i686-pc-windows-msvc
+            cargo_profile: "--release"
+            cargo_extra: "--no-default-features"
+          - name: Windows x86 Debug
+            arch: x86
+            config: debug
+            cargo_target: i686-pc-windows-msvc
+            cargo_profile: ""
+            cargo_extra: "--no-default-features"
     runs-on: windows-latest
     name: build_msi (${{ matrix.name }})
     steps:
@@ -758,8 +772,12 @@ jobs:
           New-Item -ItemType Directory -Force -Path .cargo-cache/git | Out-Null
           New-Item -ItemType Directory -Force -Path .cargo-target-msi | Out-Null
 
+      - name: Install Rust target
+        if: matrix.cargo_target != 'x86_64-pc-windows-msvc'
+        run: rustup target add ${{ matrix.cargo_target }}
+
       - name: Build ODBC driver
-        run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl --target ${{ matrix.cargo_target }}
+        run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}
         env:
           RUSTFLAGS: "-C linker=rust-lld"
           CARGO_HOME: ${{ github.workspace }}/.cargo-cache

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -501,7 +501,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-zlib-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v1
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v2
           restore-keys: |
             ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-
 
@@ -578,7 +578,8 @@ jobs:
           New-Item -ItemType Directory -Force -Path $env:CCACHE_DIR | Out-Null
           New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
 
-          Invoke-Checked "vcpkg install zlib:${{ matrix.vcpkg_triplet }}" { vcpkg install zlib:${{ matrix.vcpkg_triplet }} }
+          $triplet = "${{ matrix.vcpkg_triplet }}"
+          Invoke-Checked "vcpkg install" { vcpkg install zlib:$triplet openssl:$triplet }
 
       - name: Setup MSVC environment (Windows)
         if: runner.os == 'Windows'
@@ -747,7 +748,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-zlib-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v1
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v2
 
       - name: Save Homebrew cache (macOS)
         if: always() && runner.os == 'macOS' && steps.brew-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -297,6 +297,11 @@ jobs:
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+          - os: windows-latest
+            name: Windows x86
+            driver_lib: sfodbc32.dll
+            cargo_target: i686-pc-windows-msvc
+            cargo_extra: "--no-default-features"
     runs-on: ${{ matrix.os }}
     name: build_odbc_driver (${{ matrix.name }})
     steps:
@@ -330,6 +335,10 @@ jobs:
           echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
           echo "OPENSSL_LIB_DIR=C:\Program Files\OpenSSL\lib\VC\x64\MD" >> $env:GITHUB_ENV
 
+      - name: Install Rust target
+        if: matrix.cargo_target
+        run: rustup target add ${{ matrix.cargo_target }}
+
       - name: Build ODBC driver (Linux)
         if: runner.os == 'Linux'
         run: cargo build --package odbc
@@ -340,11 +349,25 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo build --package odbc
 
-      - name: Build ODBC driver (Windows)
-        if: runner.os == 'Windows'
+      - name: Build ODBC driver (Windows x64)
+        if: runner.os == 'Windows' && !matrix.cargo_target
         run: cargo build --package odbc
         env:
           RUSTFLAGS: "-C linker=rust-lld"
+
+      - name: Build ODBC driver (Windows x86)
+        if: runner.os == 'Windows' && matrix.cargo_target
+        run: cargo build --package odbc ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}
+        env:
+          RUSTFLAGS: "-C linker=rust-lld"
+
+      - name: Rename x86 driver DLL
+        if: matrix.cargo_target == 'i686-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $dir = "target/${{ matrix.cargo_target }}/debug"
+          Rename-Item "$dir/sfodbc.dll" "sfodbc32.dll"
+          if (Test-Path "$dir/sfodbc.pdb") { Rename-Item "$dir/sfodbc.pdb" "sfodbc32.pdb" }
 
       - name: Save Rust cache
         if: always()
@@ -361,8 +384,8 @@ jobs:
       - name: Upload ODBC driver
         uses: actions/upload-artifact@v4
         with:
-          name: odbc-driver-${{ matrix.os }}
-          path: target/debug/${{ matrix.driver_lib }}
+          name: odbc-driver-${{ matrix.name }}
+          path: ${{ matrix.cargo_target && format('target/{0}/debug', matrix.cargo_target) || 'target/debug' }}/${{ matrix.driver_lib }}
 
   odbc_tests:
     needs: [detect-changes, build_odbc_driver]
@@ -374,44 +397,81 @@ jobs:
           - os: ubuntu-latest
             name: Linux x64
             driver_lib: libsfodbc.so
+            driver_artifact: Linux x64
             cloud_provider: aws
           - os: ubuntu-latest
             name: Linux x64 (JSON)
             driver_lib: libsfodbc.so
+            driver_artifact: Linux x64
             cloud_provider: aws
             result_format: json
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
+            driver_artifact: macOS ARM64
             cloud_provider: aws
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+            driver_artifact: Windows x64
             cloud_provider: aws
+            msvc_arch: amd64
+            vcpkg_triplet: x64-windows
+          - os: windows-latest
+            name: Windows x86
+            driver_lib: sfodbc32.dll
+            driver_artifact: Windows x86
+            cloud_provider: aws
+            msvc_arch: x86
+            vcpkg_triplet: x86-windows
           - os: ubuntu-latest
             name: Linux x64
             driver_lib: libsfodbc.so
+            driver_artifact: Linux x64
             cloud_provider: gcp
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
+            driver_artifact: macOS ARM64
             cloud_provider: gcp
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+            driver_artifact: Windows x64
             cloud_provider: gcp
+            msvc_arch: amd64
+            vcpkg_triplet: x64-windows
+          - os: windows-latest
+            name: Windows x86
+            driver_lib: sfodbc32.dll
+            driver_artifact: Windows x86
+            cloud_provider: gcp
+            msvc_arch: x86
+            vcpkg_triplet: x86-windows
           - os: ubuntu-latest
             name: Linux x64
             driver_lib: libsfodbc.so
+            driver_artifact: Linux x64
             cloud_provider: azure
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
+            driver_artifact: macOS ARM64
             cloud_provider: azure
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
+            driver_artifact: Windows x64
             cloud_provider: azure
+            msvc_arch: amd64
+            vcpkg_triplet: x64-windows
+          - os: windows-latest
+            name: Windows x86
+            driver_lib: sfodbc32.dll
+            driver_artifact: Windows x86
+            cloud_provider: azure
+            msvc_arch: x86
+            vcpkg_triplet: x86-windows
     runs-on: ${{ matrix.os }}
     name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     steps:
@@ -421,7 +481,7 @@ jobs:
       - name: Download pre-built ODBC driver
         uses: actions/download-artifact@v4
         with:
-          name: odbc-driver-${{ matrix.os }}
+          name: odbc-driver-${{ matrix.driver_artifact }}
           path: target/debug
 
       - name: Make driver executable (Unix)
@@ -452,9 +512,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-zlib-v1
+          key: ${{ runner.os }}-vcpkg-zlib-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v1
           restore-keys: |
-            ${{ runner.os }}-vcpkg-
+            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-
 
       # Cache Homebrew bottle downloads to avoid re-fetching unixodbc/ccache on every run
       # (brew install on GHA macOS runners is ~2-3 min uncached, <15s with bottles cached).
@@ -529,7 +589,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path $env:CCACHE_DIR | Out-Null
           New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
 
-          Invoke-Checked "vcpkg install zlib:${{ matrix.vcpkg_triplet || 'x64-windows' }}" { vcpkg install zlib:${{ matrix.vcpkg_triplet || 'x64-windows' }} }
+          Invoke-Checked "vcpkg install zlib:${{ matrix.vcpkg_triplet }}" { vcpkg install zlib:${{ matrix.vcpkg_triplet }} }
 
       - name: Setup MSVC environment (Windows)
         if: runner.os == 'Windows'
@@ -546,11 +606,12 @@ jobs:
           # inspect $LASTEXITCODE before any pipeline resets it: piping `cmd /c ... | ForEach-Object`
           # would succeed as a pipeline even if vcvarsall.bat failed, leaving later steps running
           # without cl.exe / link.exe on PATH.
-          $vcvarsOutput = cmd /c "`"$vcvars`" amd64 && set" 2>&1
+          $msvcArch = "${{ matrix.msvc_arch || 'amd64' }}"
+          $vcvarsOutput = cmd /c "`"$vcvars`" $msvcArch && set" 2>&1
           if ($LASTEXITCODE -ne 0) {
             Write-Host "vcvarsall.bat output:"
             $vcvarsOutput | ForEach-Object { Write-Host $_ }
-            throw "vcvarsall.bat amd64 failed with exit code $LASTEXITCODE"
+            throw "vcvarsall.bat $msvcArch failed with exit code $LASTEXITCODE"
           }
           # Propagate env vars to BOTH:
           #   - $env:GITHUB_ENV: visible to subsequent steps in the job (the point of this step)
@@ -697,7 +758,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-zlib-v1
+          key: ${{ runner.os }}-vcpkg-zlib-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v1
 
       - name: Save Homebrew cache (macOS)
         if: always() && runner.os == 'macOS' && steps.brew-cache.outputs.cache-hit != 'true'
@@ -796,6 +857,14 @@ jobs:
         with:
           path: .cargo-target-msi
           key: ${{ runner.os }}-${{ matrix.arch }}-rust-msi-${{ matrix.config }}-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rename x86 driver DLL
+        if: matrix.arch == 'x86'
+        shell: pwsh
+        run: |
+          $dir = ".cargo-target-msi/${{ matrix.cargo_target }}/${{ matrix.config }}"
+          Rename-Item "$dir/sfodbc.dll" "sfodbc32.dll"
+          if (Test-Path "$dir/sfodbc.pdb") { Rename-Item "$dir/sfodbc.pdb" "sfodbc32.pdb" }
 
       - name: Compute ODBC version
         id: odbc-version

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -355,8 +355,8 @@ jobs:
         shell: pwsh
         run: |
           $dir = "target/${{ matrix.cargo_target }}/debug"
-          Rename-Item "$dir/sfodbc.dll" "sfodbc32.dll"
-          if (Test-Path "$dir/sfodbc.pdb") { Rename-Item "$dir/sfodbc.pdb" "sfodbc32.pdb" }
+          Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
+          if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
 
       - name: Save Rust cache
         if: always()
@@ -853,8 +853,8 @@ jobs:
         shell: pwsh
         run: |
           $dir = ".cargo-target-msi/${{ matrix.cargo_target }}/${{ matrix.config }}"
-          Rename-Item "$dir/sfodbc.dll" "sfodbc32.dll"
-          if (Test-Path "$dir/sfodbc.pdb") { Rename-Item "$dir/sfodbc.pdb" "sfodbc32.pdb" }
+          Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
+          if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
 
       - name: Compute ODBC version
         id: odbc-version

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -291,18 +291,22 @@ jobs:
           - os: ubuntu-latest
             name: Linux x64
             driver_lib: libsfodbc.so
+            cache_key: odbc
           - os: macos-latest
             name: macOS ARM64
             driver_lib: libsfodbc.dylib
+            cache_key: odbc
           - os: windows-latest
             name: Windows x64
             driver_lib: sfodbc.dll
             cargo_extra: "--features vendored-openssl"
+            cache_key: odbc-x64
           - os: windows-latest
             name: Windows x86
             driver_lib: sfodbc32.dll
             cargo_target: i686-pc-windows-msvc
             cargo_extra: "--no-default-features --features vendored-openssl"
+            cache_key: odbc-x86
     runs-on: ${{ matrix.os }}
     name: build_odbc_driver (${{ matrix.name }})
     steps:
@@ -314,7 +318,7 @@ jobs:
         uses: ./.github/actions/cargo-cache
         with:
           mode: restore
-          shared-key: "odbc"
+          shared-key: ${{ matrix.cache_key }}
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -362,7 +366,7 @@ jobs:
         uses: ./.github/actions/cargo-cache
         with:
           mode: save
-          shared-key: "odbc"
+          shared-key: ${{ matrix.cache_key }}
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -482,18 +482,18 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: odbc_tests/cmake-build/_deps
-          key: ${{ runner.os }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-test-deps-
+            ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-test-deps-
 
       - name: Restore ccache
         id: ccache
         uses: actions/cache/restore@v5
         with:
           path: .ccache
-          key: ${{ runner.os }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-ccache-odbc-
+            ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-ccache-odbc-
 
       - name: Restore vcpkg binary cache (Windows)
         if: runner.os == 'Windows'
@@ -722,7 +722,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: odbc_tests/cmake-build/_deps
-          key: ${{ runner.os }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-test-deps-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
 
       - name: Save ccache
         if: always() && steps.ccache.outputs.cache-hit != 'true'
@@ -735,7 +735,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .ccache
-          key: ${{ runner.os }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+          key: ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
 
       - name: Save vcpkg binary cache (Windows)
         if: always() && runner.os == 'Windows' && steps.vcpkg-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -394,8 +394,93 @@ jobs:
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
+  test_windows_x86:
+    needs: detect-changes
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
+    runs-on: windows-latest
+    name: test (Windows x86)
+    env:
+      E2E_TLS_SERVER: https://snowflakecomputing.com
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Add i686 target
+        run: rustup target add i686-pc-windows-msvc
+
+      - name: Restore Rust cache
+        id: rust-cache
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: "x86-core-test"
+
+      - name: Setup MSVC x86 environment
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          if not "%VSCMD_ARG_TGT_ARCH%"=="x86" (
+            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'x86'
+            exit /b 1
+          )
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Build sf_core (x86)
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+          :: Verify the DLL is 32-bit (machine type 14C = x86)
+          dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "14C" >nul
+          if %ERRORLEVEL% neq 0 (
+            echo ERROR: sf_core.dll is not x86
+            dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "machine"
+            exit /b 1
+          )
+
+      - name: Run sf_core tests (x86)
+        id: run_rust_tests_x86
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
+
+      - name: Rerun tests (Windows x86)
+        if: steps.run_rust_tests_x86.outcome == 'failure' && github.event_name == 'merge_group'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
+
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
+      - name: Save Rust cache
+        if: always()
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: save
+          shared-key: "x86-core-test"
+          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
   rust-core-status:
-    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips]
+    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -415,13 +500,15 @@ jobs:
              [[ "${{ needs.clippy.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.build-without-protobuf.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.test_windows_arm64_nonfips.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.test_windows_arm64_nonfips.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test_windows_x86.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Rust Core tests were RUN and FAILED or CANCELLED"
             echo "  - format: ${{ needs.format.result }}"
             echo "  - clippy: ${{ needs.clippy.result }}"
             echo "  - build-without-protobuf: ${{ needs.build-without-protobuf.result }}"
             echo "  - test: ${{ needs.test.result }}"
             echo "  - test_windows_arm64_nonfips: ${{ needs.test_windows_arm64_nonfips.result }}"
+            echo "  - test_windows_x86: ${{ needs.test_windows_x86.result }}"
             exit 1
           fi
           

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -415,27 +415,23 @@ jobs:
           mode: restore
           shared-key: "x86-core-test"
 
-      - name: Setup MSVC x86 environment
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-          if not "%VSCMD_ARG_TGT_ARCH%"=="x86" (
-            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'x86'
-            exit /b 1
-          )
-
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
-      - name: Build sf_core (x86)
+      - name: Build and test
+        id: run_rust_tests_x86
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+
           cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
           :: Verify the DLL is 32-bit (machine type 14C = x86)
           dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "14C" >nul
           if %ERRORLEVEL% neq 0 (
@@ -444,13 +440,6 @@ jobs:
             exit /b 1
           )
 
-      - name: Run sf_core tests (x86)
-        id: run_rust_tests_x86
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
 
       - name: Rerun tests (Windows x86)

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -8,7 +8,7 @@ name = "sfodbc"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-sf_core = { path = "../sf_core" }
+sf_core = { path = "../sf_core", default-features = false, features = ["protobuf"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 snafu = "0.8.7"
@@ -29,6 +29,8 @@ rust-ini = "0.21.3"
 # Forwarded to sf_core so that libsfodbc.so includes compiled-in perf spans.
 # Only used by performance tests.
 [features]
+default = ["sonic-json"]
+sonic-json = ["sf_core/sonic-json"]
 perf_timing = ["sf_core/perf_timing"]
 vendored-openssl = ["sf_core/vendored-openssl"]
 

--- a/odbc/installer/win/package.ps1
+++ b/odbc/installer/win/package.ps1
@@ -92,8 +92,9 @@ $WixVersion = ($versionParts[0..2]) -join '.'
 
 # --- Driver DLL ---
 $DriverBinDir = (Resolve-Path $DriverBinDir).Path
-if (-not (Test-Path (Join-Path $DriverBinDir "sfodbc.dll"))) {
-    throw "sfodbc.dll not found in $DriverBinDir. Build the driver first."
+$driverDll = if ($Arch -eq "x86") { "sfodbc32.dll" } else { "sfodbc.dll" }
+if (-not (Test-Path (Join-Path $DriverBinDir $driverDll))) {
+    throw "$driverDll not found in $DriverBinDir. Build the driver first."
 }
 
 # --- VC++ Redistributable ---

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Product Id="*"
-		Name="Snowflake ODBC RS Driver $(var.FullVersion) PrPr (x86)"
+		Name="Snowflake ODBC UD $(var.FullVersion) PrPr (x86)"
 		Language="1033"
 		Version="$(var.ProductVersion)"
 		Manufacturer="Snowflake Computing"
@@ -13,8 +13,8 @@
 			InstallScope="perMachine"
 			Manufacturer="Snowflake Computing"
 			Platform="x86"
-			Description="Snowflake ODBC RS Driver $(var.FullVersion) Private Preview (32-bit)"
-			Comments="Installs the Snowflake ODBC RS Driver (Private Preview) built on Universal Driver." />
+			Description="Snowflake ODBC UD $(var.FullVersion) Private Preview (32-bit)"
+			Comments="Installs the Snowflake ODBC Driver (Private Preview) built on Universal Driver." />
 
 		<Media Id="1" Cabinet="odbc32.cab" EmbedCab="yes" />
 		<MajorUpgrade AllowDowngrades="yes" />
@@ -77,19 +77,19 @@
 		<!-- ================================================================ -->
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFilesFolder">
-				<Directory Id="INSTALLDIR" Name="Snowflake ODBC RS Driver">
+				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
 					<Directory Id="BinDir" Name="Bin" />
 					<Directory Id="IncludeDir" Name="include" />
 					<Directory Id="RedistDir" Name="Redistributable" />
 				</Directory>
 			</Directory>
 			<Directory Id="PersonalFolder">
-				<Directory Id="SnowflakeODBCRSDriverLogs" Name="Snowflake ODBC RS Driver">
+				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
 					<Directory Id="LogDir" Name="log">
 						<Component Id="LogDir" Guid="CD48DCFD-56C5-4BAC-AE02-0635C488499E" Win64="no">
 						<CreateFolder />
 							<RemoveFolder Id="LogDir" On="uninstall" />
-							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCRSDriverLogs" On="uninstall" />
+							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
 						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
 							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
 						</Component>
@@ -136,14 +136,14 @@
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
-				<RegistryValue Type="string" Name="SnowflakeDSIIDriver" Value="Installed" />
+				<RegistryValue Type="string" Name="Snowflake ODBC UD" Value="Installed" />
 			</RegistryKey>
 			<RegistryKey Root="HKLM"
-				Key="SOFTWARE\ODBC\ODBCINST.INI\SnowflakeDSIIDriver"
+				Key="SOFTWARE\ODBC\ODBCINST.INI\Snowflake ODBC UD"
 				ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc32.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc32.dll" />
-				<RegistryValue Type="string" Name="Description" Value="Snowflake DSII" />
+				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
 			</RegistryKey>
 			</Component>
 		</DirectoryRef>
@@ -151,7 +151,7 @@
 		<!-- ================================================================ -->
 		<!-- Feature tree                                                       -->
 		<!-- ================================================================ -->
-		<Feature Id="MainApplication" Title="Snowflake ODBC RS Driver" Level="1">
+		<Feature Id="MainApplication" Title="Snowflake ODBC UD" Level="1">
 			<ComponentRef Id="sfodbc32.dll" />
 			<ComponentRef Id="sf_odbc.h" />
 			<ComponentRef Id="RegistryEntries" />

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -144,6 +144,13 @@
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc32.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc32.dll" />
 				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
+				<RegistryValue Type="string" Name="DriverODBCVer" Value="03.52" />
+				<RegistryValue Type="string" Name="CompanyName" Value="Snowflake Computing" />
+				<RegistryValue Type="string" Name="ConnectFunctions" Value="YYY" />
+				<RegistryValue Type="string" Name="APILevel" Value="1" />
+				<RegistryValue Type="string" Name="SQLLevel" Value="1" />
+				<RegistryValue Type="string" Name="FileUsage" Value="0" />
+				<RegistryValue Type="string" Name="CPTimeout" Value="60" />
 			</RegistryKey>
 			</Component>
 		</DirectoryRef>

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -69,7 +69,7 @@
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
 				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog"
-				Value="ReturnI"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
+				Value="Return"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
 		</UI>
 
 		<!-- ================================================================ -->

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+	<Product Id="*"
+		Name="Snowflake ODBC RS Driver $(var.FullVersion) PrPr (x86)"
+		Language="1033"
+		Version="$(var.ProductVersion)"
+		Manufacturer="Snowflake Computing"
+		UpgradeCode="C22845FB-6D0B-45A8-B914-CED965D221B1">
+
+		<Package Id="*"
+			InstallerVersion="405"
+			Compressed="yes"
+			InstallScope="perMachine"
+			Manufacturer="Snowflake Computing"
+			Platform="x86"
+			Description="Snowflake ODBC RS Driver $(var.FullVersion) Private Preview (32-bit)"
+			Comments="Installs the Snowflake ODBC RS Driver (Private Preview) built on Universal Driver." />
+
+		<Media Id="1" Cabinet="odbc32.cab" EmbedCab="yes" />
+		<MajorUpgrade AllowDowngrades="yes" />
+		<Property Id="REBOOT" Value="ReallySuppress" />
+
+		<!-- ================================================================ -->
+		<!-- Branding                                                          -->
+		<!-- ================================================================ -->
+		<WixVariable Id="WixUIDialogBmp" Value="resources\snowflake_msi_background.png" />
+		<WixVariable Id="WixUIBannerBmp" Value="resources\snowflake_msi_banner.png" />
+		<Icon Id="icon.ico" SourceFile="resources\snowflake_msi.ico" />
+		<Property Id="ARPPRODUCTICON" Value="icon.ico" />
+		<Property Id="ARPHELPLINK" Value="https://docs.snowflake.net/manuals/user-guide/odbc.html" />
+		<Property Id="ARPURLINFOABOUT">https://www.snowflake.com/</Property>
+
+		<!-- ================================================================ -->
+		<!-- Install directory UI                                              -->
+		<!-- ================================================================ -->
+		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+		<UIRef Id="WixUI_InstallDir" />
+		<UI>
+			<UIRef Id="WixUI_InstallDir" />
+			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
+			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+		</UI>
+
+		<!-- ================================================================ -->
+		<!-- VC++ Redistributable detection and optional install                -->
+		<!-- ================================================================ -->
+		<Property Id="VCREDIST2015INSTALLED">
+			<RegistrySearch Id="VCREDIST2015SEARCH"
+				Root="HKLM"
+				Key="Software\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
+				Name="Installed"
+				Type="raw"
+				Win64="no" />
+		</Property>
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT" After="AppSearch"
+			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it.">
+			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+		</SetProperty>
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" After="AppSearch"
+			Value="Install VC++ 2015-2022 Redistributable">
+			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+		</SetProperty>
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
+			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+		</SetProperty>
+		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x86.exe" After="CostFinalize" Sequence="ui" />
+		<CustomAction Id="Install_vc_redist" BinaryKey="WixCA" DllEntry="WixShellExec" />
+		<UI>
+			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
+				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
+			<Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog"
+				Value="ReturnI"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
+		</UI>
+
+		<!-- ================================================================ -->
+		<!-- Directory layout                                                  -->
+		<!-- ================================================================ -->
+		<Directory Id="TARGETDIR" Name="SourceDir">
+			<Directory Id="ProgramFilesFolder">
+				<Directory Id="INSTALLDIR" Name="Snowflake ODBC RS Driver">
+					<Directory Id="BinDir" Name="Bin" />
+					<Directory Id="IncludeDir" Name="include" />
+					<Directory Id="RedistDir" Name="Redistributable" />
+				</Directory>
+			</Directory>
+			<Directory Id="PersonalFolder">
+				<Directory Id="SnowflakeODBCRSDriverLogs" Name="Snowflake ODBC RS Driver">
+					<Directory Id="LogDir" Name="log">
+						<Component Id="LogDir" Guid="CD48DCFD-56C5-4BAC-AE02-0635C488499E" Win64="no">
+						<CreateFolder />
+							<RemoveFolder Id="LogDir" On="uninstall" />
+							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCRSDriverLogs" On="uninstall" />
+						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
+							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
+						</Component>
+					</Directory>
+				</Directory>
+			</Directory>
+		</Directory>
+
+		<!-- ================================================================ -->
+		<!-- Files: driver DLL                                                 -->
+		<!-- ================================================================ -->
+		<DirectoryRef Id="BinDir">
+			<Component Id="sfodbc32.dll" Guid="E487E93A-284A-43C8-A6E9-AB54599C0C3A" Win64="no">
+				<File Id="sfodbc32.dll" KeyPath="yes"
+					Source="$(var.DriverBinDir)\sfodbc32.dll" />
+			</Component>
+		</DirectoryRef>
+
+		<!-- ================================================================ -->
+		<!-- Files: public header                                              -->
+		<!-- ================================================================ -->
+		<DirectoryRef Id="IncludeDir">
+			<Component Id="sf_odbc.h" Guid="18554A74-79EC-4401-BCFE-06F3DD7EE19F" Win64="no">
+				<File Id="sf_odbc.h" KeyPath="yes"
+					Source="$(var.SourceDir)\odbc\include\sf_odbc.h" />
+			</Component>
+		</DirectoryRef>
+
+		<!-- ================================================================ -->
+		<!-- Files: VC++ Redistributable                                       -->
+		<!-- ================================================================ -->
+		<DirectoryRef Id="RedistDir">
+			<Component Id="vc_redist.x86.exe" Guid="A412FAFC-E3C8-4FE9-9DC4-257C303098F2" Win64="no">
+			<File Id="vc_redist.x86.exe" KeyPath="yes"
+					Source="$(var.VCRedistDir)\vc_redist.x86.exe" />
+			</Component>
+		</DirectoryRef>
+
+		<!-- ================================================================ -->
+		<!-- ODBC driver registration                                          -->
+		<!-- ================================================================ -->
+		<DirectoryRef Id="TARGETDIR">
+			<Component Id="RegistryEntries" Guid="EFCE448E-AA82-4829-BBFD-2EE34F00B487" Win64="no">
+			<RegistryKey Root="HKLM"
+				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
+				ForceCreateOnInstall="yes">
+				<RegistryValue Type="string" Name="SnowflakeDSIIDriver" Value="Installed" />
+			</RegistryKey>
+			<RegistryKey Root="HKLM"
+				Key="SOFTWARE\ODBC\ODBCINST.INI\SnowflakeDSIIDriver"
+				ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc32.dll" KeyPath="yes" />
+				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc32.dll" />
+				<RegistryValue Type="string" Name="Description" Value="Snowflake DSII" />
+			</RegistryKey>
+			</Component>
+		</DirectoryRef>
+
+		<!-- ================================================================ -->
+		<!-- Feature tree                                                       -->
+		<!-- ================================================================ -->
+		<Feature Id="MainApplication" Title="Snowflake ODBC RS Driver" Level="1">
+			<ComponentRef Id="sfodbc32.dll" />
+			<ComponentRef Id="sf_odbc.h" />
+			<ComponentRef Id="RegistryEntries" />
+			<ComponentRef Id="LogDir" />
+		</Feature>
+
+		<Feature Id="VCRedist" Title="Visual C++ Runtime" AllowAdvertise="yes" Display="expand" Level="1">
+			<ComponentRef Id="vc_redist.x86.exe" />
+		</Feature>
+
+	</Product>
+</Wix>

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -1330,25 +1330,7 @@ pub unsafe extern "system" fn DllMain(
 mod setup {
     use std::ptr;
 
-    #[cfg_attr(
-        target_arch = "x86",
-        link(
-            name = "odbccp32",
-            kind = "raw-dylib",
-            import_name_type = "undecorated"
-        )
-    )]
-    #[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
-    unsafe extern "system" {
-        fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> i32;
-        fn SQLRemoveDSNFromIniW(lpszDSN: *const u16) -> i32;
-        fn SQLWritePrivateProfileStringW(
-            lpszSection: *const u16,
-            lpszEntry: *const u16,
-            lpszString: *const u16,
-            lpszFilename: *const u16,
-        ) -> i32;
-    }
+    use crate::setup_common::{self, SQLRemoveDSNFromIniW, to_wide};
 
     #[link(name = "kernel32")]
     unsafe extern "system" {
@@ -1366,10 +1348,6 @@ mod setup {
     const ODBC_ADD_DSN: u16 = 1;
     const ODBC_CONFIG_DSN: u16 = 2;
     const ODBC_REMOVE_DSN: u16 = 3;
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        s.encode_utf16().chain(std::iter::once(0)).collect()
-    }
 
     /// Convert a Windows ANSI code page byte slice to a Rust String.
     unsafe fn acp_to_string(bytes: &[u8]) -> String {
@@ -1463,35 +1441,6 @@ mod setup {
             .map(|(_, v)| v.as_str())
     }
 
-    unsafe fn write_dsn_silent(dsn: &str, driver: &str, attrs: &[(String, String)]) -> bool {
-        let dsn_w = to_wide(dsn);
-        let driver_w = to_wide(driver);
-        if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
-            return false;
-        }
-        let odbc_ini = to_wide("odbc.ini");
-        let mut ok = true;
-        for (key, value) in attrs {
-            if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
-                continue;
-            }
-            let key_w = to_wide(key);
-            let val_w = to_wide(value);
-            if unsafe {
-                SQLWritePrivateProfileStringW(
-                    dsn_w.as_ptr(),
-                    key_w.as_ptr(),
-                    val_w.as_ptr(),
-                    odbc_ini.as_ptr(),
-                )
-            } == 0
-            {
-                ok = false;
-            }
-        }
-        ok
-    }
-
     unsafe fn config_dsn_impl(
         hwnd_parent: *mut core::ffi::c_void,
         f_request: u16,
@@ -1510,8 +1459,6 @@ mod setup {
                 let dsn = find_dsn(attrs).unwrap_or("");
                 let is_add = f_request == ODBC_ADD_DSN;
 
-                // Show dialog when a parent window is provided (ODBC Administrator).
-                // Fall back to silent mode for programmatic DSN creation (null hwnd).
                 if !hwnd_parent.is_null() {
                     unsafe {
                         crate::setup_dialog::show_config_dialog(
@@ -1523,7 +1470,7 @@ mod setup {
                         )
                     }
                 } else if !dsn.is_empty() {
-                    unsafe { write_dsn_silent(dsn, driver, attrs) }
+                    unsafe { setup_common::write_dsn_values(dsn, driver, attrs) }
                 } else {
                     false
                 }

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -11,14 +11,14 @@ use odbc_sys as sql;
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLAllocEnv(output_handle: *mut sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLAllocEnv(output_handle: *mut sql::Handle) -> sql::RetCode {
     api::handle_allocation::sql_alloc_handle(sql::HandleType::Env, 0 as sql::Handle, output_handle)
         .to_sql_code()
 }
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLAllocConnect(
+pub unsafe extern "system" fn SQLAllocConnect(
     environment_handle: sql::Handle,
     output_handle: *mut sql::Handle,
 ) -> sql::RetCode {
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn SQLAllocConnect(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLAllocHandle(
+pub unsafe extern "system" fn SQLAllocHandle(
     handle_type: sql::HandleType,
     input_handle: sql::Handle,
     output_handle: *mut sql::Handle,
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn SQLAllocHandle(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLExecDirect(
+pub unsafe extern "system" fn SQLExecDirect(
     statement_handle: sql::Handle,
     statement_text: *const sql::Char,
     text_length: sql::Integer,
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn SQLExecDirect(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLExecDirectW(
+pub unsafe extern "system" fn SQLExecDirectW(
     statement_handle: sql::Handle,
     statement_text: *const sql::WChar,
     text_length: sql::Integer,
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn SQLExecDirectW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLFreeHandle(
+pub unsafe extern "system" fn SQLFreeHandle(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> sql::RetCode {
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn SQLFreeHandle(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLFreeStmt(
+pub unsafe extern "system" fn SQLFreeStmt(
     statement_handle: sql::Handle,
     option: sql::USmallInt,
 ) -> sql::RetCode {
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn SQLFreeStmt(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLCloseCursor(statement_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLCloseCursor(statement_handle: sql::Handle) -> sql::RetCode {
     if statement_handle.is_null() {
         return sql::SqlReturn::INVALID_HANDLE.0;
     }
@@ -142,7 +142,7 @@ pub unsafe extern "C" fn SQLCloseCursor(statement_handle: sql::Handle) -> sql::R
 /// cross-thread. Same-thread cancel must clear_diag_info and post its own
 /// diagnostic records per spec. Only cross-thread cancel skips diagnostics.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCode {
     if statement_handle.is_null() {
         return sql::SqlReturn::INVALID_HANDLE.0;
     }
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCod
 /// SQLSTATE HY092 per the ODBC 3.8 spec. Any truly unknown handle
 /// type returns `SQL_INVALID_HANDLE`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLCancelHandle(
+pub unsafe extern "system" fn SQLCancelHandle(
     handle_type: sql::HandleType,
     handle: sql::Handle,
 ) -> sql::RetCode {
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn SQLCancelHandle(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLConnect(
+pub unsafe extern "system" fn SQLConnect(
     connection_handle: sql::Handle,
     server_name: *const sql::Char,
     name_length1: sql::SmallInt,
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn SQLConnect(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLConnectW(
+pub unsafe extern "system" fn SQLConnectW(
     connection_handle: sql::Handle,
     server_name: *const sql::WChar,
     name_length1: sql::SmallInt,
@@ -257,7 +257,7 @@ pub unsafe extern "C" fn SQLConnectW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetEnvAttr(
+pub unsafe extern "system" fn SQLSetEnvAttr(
     environment_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn SQLSetEnvAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetEnvAttr(
+pub unsafe extern "system" fn SQLGetEnvAttr(
     environment_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn SQLGetEnvAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetInfo(
+pub unsafe extern "system" fn SQLGetInfo(
     connection_handle: sql::Handle,
     info_type: sql::USmallInt,
     info_value_ptr: sql::Pointer,
@@ -323,7 +323,7 @@ pub unsafe extern "C" fn SQLGetInfo(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetInfoW(
+pub unsafe extern "system" fn SQLGetInfoW(
     connection_handle: sql::Handle,
     info_type: sql::USmallInt,
     info_value_ptr: sql::Pointer,
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn SQLGetInfoW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetConnectAttr(
+pub unsafe extern "system" fn SQLSetConnectAttr(
     connection_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -375,7 +375,7 @@ pub unsafe extern "C" fn SQLSetConnectAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetConnectAttrW(
+pub unsafe extern "system" fn SQLSetConnectAttrW(
     connection_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn SQLSetConnectAttrW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetConnectAttr(
+pub unsafe extern "system" fn SQLGetConnectAttr(
     connection_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn SQLGetConnectAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetConnectAttrW(
+pub unsafe extern "system" fn SQLGetConnectAttrW(
     connection_handle: sql::Handle,
     attribute: sql::Integer,
     value: sql::Pointer,
@@ -469,7 +469,7 @@ pub unsafe extern "C" fn SQLGetConnectAttrW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDriverConnect(
+pub unsafe extern "system" fn SQLDriverConnect(
     connection_handle: sql::Handle,
     _window_handle: sql::Handle,
     in_connection_string: *const sql::Char,
@@ -491,7 +491,7 @@ pub unsafe extern "C" fn SQLDriverConnect(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDriverConnectW(
+pub unsafe extern "system" fn SQLDriverConnectW(
     connection_handle: sql::Handle,
     _window_handle: sql::Handle,
     in_connection_string: *const sql::WChar,
@@ -513,13 +513,13 @@ pub unsafe extern "C" fn SQLDriverConnectW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDisconnect(connection_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLDisconnect(connection_handle: sql::Handle) -> sql::RetCode {
     api::connection::disconnect(connection_handle).to_sql_code()
 }
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLFetch(statement_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLFetch(statement_handle: sql::Handle) -> sql::RetCode {
     api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
     let mut warnings = vec![];
     let result = api::data::fetch(statement_handle, &mut warnings);
@@ -535,7 +535,7 @@ pub unsafe extern "C" fn SQLFetch(statement_handle: sql::Handle) -> sql::RetCode
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLFetchScroll(
+pub unsafe extern "system" fn SQLFetchScroll(
     statement_handle: sql::Handle,
     fetch_orientation: sql::SmallInt,
     _fetch_offset: sql::Len,
@@ -555,7 +555,7 @@ pub unsafe extern "C" fn SQLFetchScroll(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLExtendedFetch(
+pub unsafe extern "system" fn SQLExtendedFetch(
     statement_handle: sql::Handle,
     fetch_orientation: sql::SmallInt,
     fetch_offset: sql::Len,
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn SQLExtendedFetch(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetData(
+pub unsafe extern "system" fn SQLGetData(
     statement_handle: sql::Handle,
     col_or_param_num: sql::USmallInt,
     target_type: CDataType,
@@ -615,7 +615,7 @@ pub unsafe extern "C" fn SQLGetData(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLColAttribute(
+pub unsafe extern "system" fn SQLColAttribute(
     statement_handle: sql::Handle,
     column_number: sql::USmallInt,
     field_identifier: sql::USmallInt,
@@ -648,7 +648,7 @@ pub unsafe extern "C" fn SQLColAttribute(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLColAttributeW(
+pub unsafe extern "system" fn SQLColAttributeW(
     statement_handle: sql::Handle,
     column_number: sql::USmallInt,
     field_identifier: sql::USmallInt,
@@ -681,7 +681,7 @@ pub unsafe extern "C" fn SQLColAttributeW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDescribeCol(
+pub unsafe extern "system" fn SQLDescribeCol(
     statement_handle: sql::Handle,
     column_number: sql::USmallInt,
     column_name: *mut sql::Char,
@@ -718,7 +718,7 @@ pub unsafe extern "C" fn SQLDescribeCol(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDescribeColW(
+pub unsafe extern "system" fn SQLDescribeColW(
     statement_handle: sql::Handle,
     column_number: sql::USmallInt,
     column_name: *mut sql::WChar,
@@ -755,7 +755,7 @@ pub unsafe extern "C" fn SQLDescribeColW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLNumResultCols(
+pub unsafe extern "system" fn SQLNumResultCols(
     statement_handle: sql::Handle,
     column_count_ptr: *mut sql::SmallInt,
 ) -> sql::RetCode {
@@ -768,7 +768,7 @@ pub unsafe extern "C" fn SQLNumResultCols(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLNumParams(
+pub unsafe extern "system" fn SQLNumParams(
     statement_handle: sql::Handle,
     param_count_ptr: *mut sql::SmallInt,
 ) -> sql::RetCode {
@@ -781,7 +781,7 @@ pub unsafe extern "C" fn SQLNumParams(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLDescribeParam(
+pub unsafe extern "system" fn SQLDescribeParam(
     statement_handle: sql::Handle,
     parameter_number: sql::USmallInt,
     data_type_ptr: *mut sql::SmallInt,
@@ -805,7 +805,7 @@ pub unsafe extern "C" fn SQLDescribeParam(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLRowCount(
+pub unsafe extern "system" fn SQLRowCount(
     statement_handle: sql::Handle,
     row_count_ptr: *mut sql::Len,
 ) -> sql::RetCode {
@@ -818,7 +818,7 @@ pub unsafe extern "C" fn SQLRowCount(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLBindParameter(
+pub unsafe extern "system" fn SQLBindParameter(
     statement_handle: sql::Handle,
     parameter_number: sql::USmallInt,
     input_output_type: sql::SmallInt,
@@ -850,7 +850,7 @@ pub unsafe extern "C" fn SQLBindParameter(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLPrepare(
+pub unsafe extern "system" fn SQLPrepare(
     statement_handle: sql::Handle,
     statement_text: *const sql::Char,
     text_length: sql::Integer,
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn SQLPrepare(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLPrepareW(
+pub unsafe extern "system" fn SQLPrepareW(
     statement_handle: sql::Handle,
     statement_text: *const sql::WChar,
     text_length: sql::Integer,
@@ -878,7 +878,7 @@ pub unsafe extern "C" fn SQLPrepareW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLExecute(statement_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLExecute(statement_handle: sql::Handle) -> sql::RetCode {
     api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
     let result = api::statement::execute(statement_handle);
     api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
@@ -888,7 +888,7 @@ pub unsafe extern "C" fn SQLExecute(statement_handle: sql::Handle) -> sql::RetCo
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDiagRec(
+pub unsafe extern "system" fn SQLGetDiagRec(
     handle_type: sql::HandleType,
     handle: sql::Handle,
     rec_number: sql::SmallInt,
@@ -918,7 +918,7 @@ pub unsafe extern "C" fn SQLGetDiagRec(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDiagRecW(
+pub unsafe extern "system" fn SQLGetDiagRecW(
     handle_type: sql::HandleType,
     handle: sql::Handle,
     rec_number: sql::SmallInt,
@@ -948,7 +948,7 @@ pub unsafe extern "C" fn SQLGetDiagRecW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDiagField(
+pub unsafe extern "system" fn SQLGetDiagField(
     handle_type: sql::HandleType,
     handle: sql::Handle,
     rec_number: sql::SmallInt,
@@ -971,7 +971,7 @@ pub unsafe extern "C" fn SQLGetDiagField(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDiagFieldW(
+pub unsafe extern "system" fn SQLGetDiagFieldW(
     handle_type: sql::HandleType,
     handle: sql::Handle,
     rec_number: sql::SmallInt,
@@ -995,7 +995,7 @@ pub unsafe extern "C" fn SQLGetDiagFieldW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLBindCol(
+pub unsafe extern "system" fn SQLBindCol(
     statement_handle: sql::Handle,
     column_number: sql::USmallInt,
     target_type: CDataType,
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn SQLBindCol(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetStmtAttr(
+pub unsafe extern "system" fn SQLSetStmtAttr(
     statement_handle: sql::Handle,
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
@@ -1044,7 +1044,7 @@ pub unsafe extern "C" fn SQLSetStmtAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetStmtAttrW(
+pub unsafe extern "system" fn SQLSetStmtAttrW(
     statement_handle: sql::Handle,
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
@@ -1071,7 +1071,7 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetStmtAttr(
+pub unsafe extern "system" fn SQLGetStmtAttr(
     statement_handle: sql::Handle,
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
@@ -1103,7 +1103,7 @@ pub unsafe extern "C" fn SQLGetStmtAttr(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetStmtAttrW(
+pub unsafe extern "system" fn SQLGetStmtAttrW(
     statement_handle: sql::Handle,
     attribute: sql::Integer,
     value_ptr: sql::Pointer,
@@ -1135,7 +1135,7 @@ pub unsafe extern "C" fn SQLGetStmtAttrW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLMoreResults(statement_handle: sql::Handle) -> sql::RetCode {
+pub unsafe extern "system" fn SQLMoreResults(statement_handle: sql::Handle) -> sql::RetCode {
     if statement_handle.is_null() {
         return sql::SqlReturn::INVALID_HANDLE.0;
     }
@@ -1148,7 +1148,7 @@ pub unsafe extern "C" fn SQLMoreResults(statement_handle: sql::Handle) -> sql::R
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLNativeSql(
+pub unsafe extern "system" fn SQLNativeSql(
     connection_handle: sql::Handle,
     in_statement_text: *const sql::Char,
     text_length1: sql::Integer,
@@ -1182,7 +1182,7 @@ pub unsafe extern "C" fn SQLNativeSql(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLNativeSqlW(
+pub unsafe extern "system" fn SQLNativeSqlW(
     connection_handle: sql::Handle,
     in_statement_text: *const sql::WChar,
     text_length1: sql::Integer,
@@ -1216,7 +1216,7 @@ pub unsafe extern "C" fn SQLNativeSqlW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDescField(
+pub unsafe extern "system" fn SQLGetDescField(
     descriptor_handle: sql::Handle,
     rec_number: sql::SmallInt,
     field_identifier: sql::SmallInt,
@@ -1237,7 +1237,7 @@ pub unsafe extern "C" fn SQLGetDescField(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLGetDescFieldW(
+pub unsafe extern "system" fn SQLGetDescFieldW(
     descriptor_handle: sql::Handle,
     rec_number: sql::SmallInt,
     field_identifier: sql::SmallInt,
@@ -1259,7 +1259,7 @@ pub unsafe extern "C" fn SQLGetDescFieldW(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetDescField(
+pub unsafe extern "system" fn SQLSetDescField(
     descriptor_handle: sql::Handle,
     rec_number: sql::SmallInt,
     field_identifier: sql::SmallInt,
@@ -1279,7 +1279,7 @@ pub unsafe extern "C" fn SQLSetDescField(
 /// # Safety
 /// This function is called by the ODBC driver manager.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SQLSetDescFieldW(
+pub unsafe extern "system" fn SQLSetDescFieldW(
     descriptor_handle: sql::Handle,
     rec_number: sql::SmallInt,
     field_identifier: sql::SmallInt,

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -475,6 +475,7 @@ pub unsafe extern "system" fn SQLDriverConnect(
     in_connection_string: *const sql::Char,
     in_string_length: sql::SmallInt,
     _out_connection_string: *mut sql::Char,
+    _buffer_length: sql::SmallInt,
     _out_string_length: *mut sql::SmallInt,
     _driver_completion: sql::SmallInt,
 ) -> sql::RetCode {
@@ -497,6 +498,7 @@ pub unsafe extern "system" fn SQLDriverConnectW(
     in_connection_string: *const sql::WChar,
     in_string_length: sql::SmallInt,
     _out_connection_string: *mut sql::WChar,
+    _buffer_length: sql::SmallInt,
     _out_string_length: *mut sql::SmallInt,
     _driver_completion: sql::SmallInt,
 ) -> sql::RetCode {

--- a/odbc/src/lib.rs
+++ b/odbc/src/lib.rs
@@ -4,6 +4,8 @@ mod api;
 pub mod c_api;
 mod conversion;
 #[cfg(target_os = "windows")]
+mod setup_common;
+#[cfg(target_os = "windows")]
 mod setup_dialog;
 
 extern crate sf_core;

--- a/odbc/src/setup_common.rs
+++ b/odbc/src/setup_common.rs
@@ -1,0 +1,117 @@
+//! Shared helpers for the ODBC Setup/Config entrypoints (`c_api::setup`)
+//! and the interactive dialog (`setup_dialog`).
+//!
+//! Everything here talks to `odbccp32.dll` (the ODBC Installer API) and
+//! performs DSN registry reads/writes.
+
+#![cfg(target_os = "windows")]
+
+// ---------------------------------------------------------------------------
+// odbccp32.dll — ODBC Installer API (raw-dylib, no import lib needed)
+// ---------------------------------------------------------------------------
+#[cfg_attr(
+    target_arch = "x86",
+    link(
+        name = "odbccp32",
+        kind = "raw-dylib",
+        import_name_type = "undecorated"
+    )
+)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
+unsafe extern "system" {
+    pub(crate) fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> i32;
+    pub(crate) fn SQLRemoveDSNFromIniW(lpszDSN: *const u16) -> i32;
+    pub(crate) fn SQLWritePrivateProfileStringW(
+        lpszSection: *const u16,
+        lpszEntry: *const u16,
+        lpszString: *const u16,
+        lpszFilename: *const u16,
+    ) -> i32;
+    pub(crate) fn SQLGetPrivateProfileStringW(
+        lpszSection: *const u16,
+        lpszEntry: *const u16,
+        lpszDefault: *const u16,
+        lpszRetBuffer: *mut u16,
+        cchRetBuffer: i32,
+        lpszFilename: *const u16,
+    ) -> i32;
+    pub(crate) fn SQLValidDSNW(lpszDSN: *const u16) -> i32;
+}
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+pub(crate) fn from_wide(p: &[u16]) -> String {
+    let len = p.iter().position(|&c| c == 0).unwrap_or(p.len());
+    String::from_utf16_lossy(&p[..len])
+}
+
+// ---------------------------------------------------------------------------
+// DSN registry read/write
+// ---------------------------------------------------------------------------
+
+pub(crate) unsafe fn read_dsn_value(dsn: &str, key: &str) -> String {
+    let dsn_w = to_wide(dsn);
+    let key_w = to_wide(key);
+    let default_w = to_wide("");
+    let filename_w = to_wide("odbc.ini");
+    let mut buf = vec![0u16; 512];
+    loop {
+        let copied = unsafe {
+            SQLGetPrivateProfileStringW(
+                dsn_w.as_ptr(),
+                key_w.as_ptr(),
+                default_w.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as i32,
+                filename_w.as_ptr(),
+            )
+        } as usize;
+        if copied < buf.len().saturating_sub(1) {
+            return from_wide(&buf[..copied]);
+        }
+        buf.resize(buf.len() * 2, 0);
+    }
+}
+
+/// Write a DSN and its key/value fields to the ODBC registry.
+///
+/// Skips `DSN` and `PWD` keys (DSN is implicit in the section name;
+/// PWD must never be persisted).  Returns `false` if any write fails.
+pub(crate) unsafe fn write_dsn_values(
+    dsn: &str,
+    driver: &str,
+    fields: &[(String, String)],
+) -> bool {
+    let dsn_w = to_wide(dsn);
+    let driver_w = to_wide(driver);
+    if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
+        return false;
+    }
+    let odbc_ini = to_wide("odbc.ini");
+    let mut ok = true;
+    for (key, value) in fields {
+        if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
+            continue;
+        }
+        let key_w = to_wide(key);
+        let val_w = to_wide(value);
+        if unsafe {
+            SQLWritePrivateProfileStringW(
+                dsn_w.as_ptr(),
+                key_w.as_ptr(),
+                val_w.as_ptr(),
+                odbc_ini.as_ptr(),
+            )
+        } == 0
+        {
+            ok = false;
+        }
+    }
+    ok
+}

--- a/odbc/src/setup_dialog.rs
+++ b/odbc/src/setup_dialog.rs
@@ -10,6 +10,9 @@ use std::ptr;
 use std::sync::atomic::Ordering;
 
 use crate::c_api::DLL_HINSTANCE;
+use crate::setup_common::{
+    self, SQLValidDSNW, from_wide, read_dsn_value, to_wide, write_dsn_values,
+};
 
 // ---------------------------------------------------------------------------
 // Win32 FFI
@@ -78,36 +81,6 @@ unsafe extern "system" {
     fn MoveWindow(hWnd: HWND, X: i32, Y: i32, nWidth: i32, nHeight: i32, bRepaint: BOOL) -> BOOL;
     fn SetCursor(hCursor: *mut core::ffi::c_void) -> *mut core::ffi::c_void;
     fn LoadCursorW(hInstance: HINSTANCE, lpCursorName: *const u16) -> *mut core::ffi::c_void;
-}
-
-// odbccp32.dll (ODBC Installer API) — linked via raw-dylib so the linker
-// generates thin import stubs without requiring an import library.
-#[cfg_attr(
-    target_arch = "x86",
-    link(
-        name = "odbccp32",
-        kind = "raw-dylib",
-        import_name_type = "undecorated"
-    )
-)]
-#[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
-unsafe extern "system" {
-    fn SQLGetPrivateProfileStringW(
-        lpszSection: *const u16,
-        lpszEntry: *const u16,
-        lpszDefault: *const u16,
-        lpszRetBuffer: *mut u16,
-        cchRetBuffer: i32,
-        lpszFilename: *const u16,
-    ) -> i32;
-    fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> BOOL;
-    fn SQLWritePrivateProfileStringW(
-        lpszSection: *const u16,
-        lpszEntry: *const u16,
-        lpszString: *const u16,
-        lpszFilename: *const u16,
-    ) -> BOOL;
-    fn SQLValidDSNW(lpszDSN: *const u16) -> BOOL;
 }
 
 // odbc32.dll (ODBC Driver Manager) is loaded dynamically to avoid putting it
@@ -250,15 +223,6 @@ const FIELD_MAP: &[(i32, &str)] = &[
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn to_wide(s: &str) -> Vec<u16> {
-    s.encode_utf16().chain(std::iter::once(0)).collect()
-}
-
-fn from_wide(p: &[u16]) -> String {
-    let len = p.iter().position(|&c| c == 0).unwrap_or(p.len());
-    String::from_utf16_lossy(&p[..len])
-}
-
 #[inline]
 fn loword(v: usize) -> u16 {
     v as u16
@@ -343,59 +307,6 @@ fn sql_succeeded(rc: i16) -> bool {
 // ---------------------------------------------------------------------------
 // DSN registry read/write via ODBC installer API
 // ---------------------------------------------------------------------------
-
-unsafe fn read_dsn_value(dsn: &str, key: &str) -> String {
-    let dsn_w = to_wide(dsn);
-    let key_w = to_wide(key);
-    let default_w = to_wide("");
-    let filename_w = to_wide("odbc.ini");
-    let mut buf = vec![0u16; 512];
-    loop {
-        let copied = unsafe {
-            SQLGetPrivateProfileStringW(
-                dsn_w.as_ptr(),
-                key_w.as_ptr(),
-                default_w.as_ptr(),
-                buf.as_mut_ptr(),
-                buf.len() as i32,
-                filename_w.as_ptr(),
-            )
-        } as usize;
-        if copied < buf.len().saturating_sub(1) {
-            return String::from_utf16_lossy(&buf[..copied]);
-        }
-        buf.resize(buf.len() * 2, 0);
-    }
-}
-
-unsafe fn write_dsn_values(dsn: &str, driver: &str, fields: &[(String, String)]) -> bool {
-    let dsn_w = to_wide(dsn);
-    let driver_w = to_wide(driver);
-    if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
-        return false;
-    }
-    let odbc_ini = to_wide("odbc.ini");
-    let mut ok = true;
-    for (key, value) in fields {
-        if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
-            continue;
-        }
-        let key_w = to_wide(key);
-        let val_w = to_wide(value);
-        if unsafe {
-            SQLWritePrivateProfileStringW(
-                dsn_w.as_ptr(),
-                key_w.as_ptr(),
-                val_w.as_ptr(),
-                odbc_ini.as_ptr(),
-            )
-        } == 0
-        {
-            ok = false;
-        }
-    }
-    ok
-}
 
 // ---------------------------------------------------------------------------
 // Dialog context passed via LPARAM

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -99,7 +99,7 @@ proto_generator = { path = "../proto_generator" }
 libc = "0.2"
 
 [dev-dependencies]
-sf_core = { path = ".", features = ["test-utils"] }
+sf_core = { path = ".", default-features = false, features = ["test-utils"] }
 tokio = { version = "1.47.1", features = ["fs", "test-util"] }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["experimental_metrics_custom_reader"] }
 tempfile = "3.21.0"

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -8,7 +8,8 @@ name = "sf_core"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["protobuf"]
+default = ["protobuf", "sonic-json"]
+sonic-json = ["sonic-rs"]
 fips = ["rustls/fips"]
 protobuf = ["prost", "proto_utils"]
 vendored-openssl = ["openssl/vendored"]
@@ -82,7 +83,7 @@ urlencoding = "2.1"
 zeroize = "1.8"
 hex = "0.4"
 memchr = "2"
-sonic-rs = "0.5"
+sonic-rs = { version = "0.5", optional = true }
 sha2 = "0.10"
 clap = { version = "4.5", features = ["derive", "env"], optional = true }
 signature = "2"

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -93,8 +93,7 @@ impl ParseChunk for JsonChunkParser {
 
 /// Scans JSON chunk bytes line-by-line, dispatching each cell directly to
 /// column builders. Each line is a JSON array ending with `,\n`, e.g.
-/// `["v1","v2",null],\n`. Uses `sonic_rs::to_array_iter` for SIMD-accelerated
-/// lazy JSON parsing.
+/// `["v1","v2",null],\n`.
 fn parse_json_rows(data: &[u8], builders: &mut [ColumnBuilder]) -> Result<usize, ArrowError> {
     let mut row_count: usize = 0;
 
@@ -114,9 +113,21 @@ fn parse_json_rows(data: &[u8], builders: &mut [ColumnBuilder]) -> Result<usize,
     Ok(row_count)
 }
 
-/// Parses a single JSON row `["v1","v2",null]` from raw bytes using sonic-rs
-/// lazy array iteration. Each element is either a JSON string or `null`.
+/// Parses a single JSON row `["v1","v2",null]` from raw bytes.
+/// Uses sonic-rs SIMD-accelerated parsing when available, falls back to serde_json.
 fn scan_json_row(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
+    #[cfg(feature = "sonic-json")]
+    {
+        scan_json_row_sonic(line, builders)
+    }
+    #[cfg(not(feature = "sonic-json"))]
+    {
+        scan_json_row_serde(line, builders)
+    }
+}
+
+#[cfg(feature = "sonic-json")]
+fn scan_json_row_sonic(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
     use sonic_rs::JsonValueTrait;
 
     let expected_cols = builders.len();
@@ -144,6 +155,34 @@ fn scan_json_row(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), Arro
         return Err(ArrowError::InvalidArgumentError(format!(
             "Expected {expected_cols} columns but got {col_idx}",
         )));
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "sonic-json"))]
+fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
+    let arr: Vec<Option<String>> =
+        serde_json::from_slice(line).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+    let expected_cols = builders.len();
+    if arr.len() > expected_cols {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Row has more columns than expected ({expected_cols})",
+        )));
+    }
+    if arr.len() < expected_cols {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Expected {expected_cols} columns but got {}",
+            arr.len(),
+        )));
+    }
+
+    for (col_idx, cell) in arr.iter().enumerate() {
+        match cell {
+            None => builders[col_idx].push_null(),
+            Some(s) => builders[col_idx].push_value(s.as_bytes())?,
+        }
     }
 
     Ok(())

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -162,7 +162,7 @@ fn scan_json_row_sonic(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<()
 
 #[cfg(not(feature = "sonic-json"))]
 fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
-    let arr: Vec<Option<String>> =
+    let arr: Vec<serde_json::Value> =
         serde_json::from_slice(line).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
 
     let expected_cols = builders.len();
@@ -178,10 +178,15 @@ fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<()
         )));
     }
 
-    for (col_idx, cell) in arr.iter().enumerate() {
-        match cell {
-            None => builders[col_idx].push_null(),
-            Some(s) => builders[col_idx].push_value(s.as_bytes())?,
+    for (col_idx, value) in arr.iter().enumerate() {
+        if value.is_null() {
+            builders[col_idx].push_null();
+        } else if let Some(s) = value.as_str() {
+            builders[col_idx].push_value(s.as_bytes())?;
+        } else {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Expected string or null at column {col_idx}",
+            )));
         }
     }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -64,8 +64,8 @@ impl<'a> From<BinaryDataPtr> for DataPtr<'a> {
             .as_slice()
             .try_into()
             .expect("Pointer must be 8 bytes");
-        let ptr_value = usize::from_le_bytes(ptr_bytes);
-        let ptr = ptr_value as *const u8;
+        let ptr_value = u64::from_le_bytes(ptr_bytes);
+        let ptr = ptr_value as usize as *const u8;
         DataPtr::new(ptr, proto_ptr.length)
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -57,25 +57,31 @@ impl From<*mut FFI_ArrowArrayStream> for ArrowArrayStreamPtr {
 
 // Convert protobuf BinaryDataPtr to internal DataPtr.
 // Both represent a raw pointer + length; this avoids leaking protobuf types into core.
-impl<'a> From<BinaryDataPtr> for DataPtr<'a> {
-    fn from(proto_ptr: BinaryDataPtr) -> Self {
+impl<'a> TryFrom<BinaryDataPtr> for DataPtr<'a> {
+    type Error = String;
+
+    fn try_from(proto_ptr: BinaryDataPtr) -> Result<Self, Self::Error> {
         let ptr_bytes: [u8; 8] = proto_ptr
             .value
             .as_slice()
             .try_into()
-            .expect("Pointer must be 8 bytes");
+            .map_err(|_| format!("Pointer must be 8 bytes, got {}", proto_ptr.value.len()))?;
         let ptr_value = u64::from_le_bytes(ptr_bytes);
-        let ptr = ptr_value as usize as *const u8;
-        DataPtr::new(ptr, proto_ptr.length)
+        let ptr = usize::try_from(ptr_value)
+            .map_err(|_| format!("Serialized pointer 0x{ptr_value:X} does not fit in usize"))?
+            as *const u8;
+        Ok(DataPtr::new(ptr, proto_ptr.length))
     }
 }
 
 // Convert protobuf QueryBindings variant to internal BindingType.
-impl<'a> From<query_bindings::BindingType> for BindingType<'a> {
-    fn from(proto: query_bindings::BindingType) -> Self {
+impl<'a> TryFrom<query_bindings::BindingType> for BindingType<'a> {
+    type Error = String;
+
+    fn try_from(proto: query_bindings::BindingType) -> Result<Self, Self::Error> {
         match proto {
-            query_bindings::BindingType::Json(ptr) => BindingType::Json(ptr.into()),
-            query_bindings::BindingType::Csv(ptr) => BindingType::Csv(ptr.into()),
+            query_bindings::BindingType::Json(ptr) => Ok(BindingType::Json(ptr.try_into()?)),
+            query_bindings::BindingType::Csv(ptr) => Ok(BindingType::Csv(ptr.try_into()?)),
         }
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -779,7 +779,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let bindings_opt = input
             .bindings
             .and_then(|b| b.binding_type)
-            .map(BindingType::from);
+            .map(BindingType::try_from)
+            .transpose()
+            .map_err(|e| DriverException {
+                message: e,
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            })?;
 
         let result = self
             .driver
@@ -816,7 +822,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let bindings_opt = input
             .bindings
             .and_then(|b| b.binding_type)
-            .map(BindingType::from);
+            .map(BindingType::try_from)
+            .transpose()
+            .map_err(|e| DriverException {
+                message: e,
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            })?;
 
         let result = self
             .driver


### PR DESCRIPTION
### TL;DR

Add Windows x86 (32-bit) MSI build support and make `sonic-rs` an optional feature with a `serde_json` fallback.

### What changed?

- Added Windows x86 (i686) release and debug build matrix entries to the ODBC CI workflow, using `--no-default-features` since `sonic-rs` does not support 32-bit targets. A `rustup target add` step is included for non-x64 targets.
- Made `sonic-rs` an optional dependency in `sf_core`, gated behind a new `sonic-json` feature flag. The `sonic-json` feature is enabled by default but can be disabled (e.g., for 32-bit builds).
- Added a corresponding `sonic-json` feature to the `odbc` crate that forwards to `sf_core/sonic-json`, enabled by default.
- Introduced a `serde_json`-based fallback implementation (`scan_json_row_serde`) for JSON row parsing when `sonic-json` is not available, with compile-time dispatch via `#[cfg(feature = "sonic-json")]`.

### How to test?

The CI workflow will build and test both x64 and x86 Windows MSI targets. To test locally:
- Build with default features to exercise the `sonic-rs` SIMD path.
- Build with `--no-default-features` (plus any required features) to exercise the `serde_json` fallback path and confirm it compiles and produces correct results on a 32-bit target or environment.

### Why make this change?

`sonic-rs` relies on SIMD intrinsics that are not available on 32-bit (x86) targets, preventing compilation of the ODBC driver for Windows x86. By making `sonic-rs` optional and providing a `serde_json` fallback, 32-bit MSI builds become possible without sacrificing SIMD-accelerated parsing on supported platforms.