### PR TITLE
NO-SNOW: build cryptography from source on Windows ARM64 cleanup

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -342,6 +342,19 @@ jobs:
           name: windows-arm64-diagnostics
           path: windows-arm64-diagnostics/
           if-no-files-found: warn
+
+      # The cryptography wheel for Windows ARM64 dynamically links against the
+      # Visual C++ runtime, but the windows-11-arm runner image does not always
+      # ship with the ARM64 redistributable. Without it, `import cryptography`
+      # fails with "DLL load failed while importing _rust", which breaks the
+      # cleanup script (and any other Python tooling that touches cryptography).
+      - name: Install Visual C++ ARM64 runtime
+        if: always()
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile vc_redist.arm64.exe
+          Start-Process -FilePath .\vc_redist.arm64.exe -ArgumentList '/install','/quiet','/norestart' -Wait
+
       - name: Cleanup test PATs
         if: always()
         continue-on-error: true

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -343,24 +343,45 @@ jobs:
           path: windows-arm64-diagnostics/
           if-no-files-found: warn
 
-      # The cryptography wheel for Windows ARM64 dynamically links against the
-      # Visual C++ runtime, but the windows-11-arm runner image does not always
-      # ship with the ARM64 redistributable. Without it, `import cryptography`
-      # fails with "DLL load failed while importing _rust", which breaks the
-      # cleanup script (and any other Python tooling that touches cryptography).
-      - name: Install Visual C++ ARM64 runtime
+      # snowflake-connector-python pulls in `cryptography`, which has no working
+      # pre-built Windows ARM64 wheel (pyca/cryptography#14216 dropped official
+      # arm64 wheel publishing in early 2026). We follow the same pattern as
+      # test-python.yml and build cryptography from source against vcpkg's
+      # static OpenSSL — Rust toolchain is already on the runner. The cache key
+      # is intentionally identical to the one used in test-python.yml /
+      # build-python-release.yml so we hit their cache when it's warm.
+      - name: Restore vcpkg ARM64 static OpenSSL cache (for cryptography)
         if: always()
-        shell: pwsh
+        id: vcpkg-static-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: C:\vcpkg\installed\arm64-windows-static-md
+          key: windows-11-arm-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
+
+      - name: Install ARM64 static OpenSSL via vcpkg (cache miss)
+        if: always() && steps.vcpkg-static-cache.outputs.cache-hit != 'true'
+        shell: cmd
         run: |
-          Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile vc_redist.arm64.exe
-          Start-Process -FilePath .\vc_redist.arm64.exe -ArgumentList '/install','/quiet','/norestart' -Wait
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          vcpkg install openssl:arm64-windows-static-md
+
+      - name: Save vcpkg ARM64 static OpenSSL cache (cache miss)
+        if: always() && steps.vcpkg-static-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: C:\vcpkg\installed\arm64-windows-static-md
+          key: windows-11-arm-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
       - name: Cleanup test PATs
         if: always()
         continue-on-error: true
         shell: bash
+        env:
+          OPENSSL_DIR: C:\vcpkg\installed\arm64-windows-static-md
+          OPENSSL_LIB_DIR: C:\vcpkg\installed\arm64-windows-static-md\lib
+          OPENSSL_STATIC: "1"
         run: |
-          python -m pip install snowflake-connector-python -q
+          python -m pip install --no-binary cryptography snowflake-connector-python -q
           python scripts/cleanup_test_pats.py \
             --parameter-path "${{ github.workspace }}/parameters.json"
 


### PR DESCRIPTION
## Summary

The `Cleanup test PATs` step in the **Windows ARM64, non-FIPS** Rust core CI job has been silently failing (it has `continue-on-error: true`) with:

```
ImportError: DLL load failed while importing _rust: The specified module could not be found.
```

Original example: [run 24998968454, job 73203543194](https://github.com/snowflakedb/universal-driver/actions/runs/24998968454/job/73203543194?pr=973#step:14:38).

### Root cause

The legacy `snowflake-connector-python` (which the cleanup script uses to call `ALTER USER ... REMOVE PROGRAMMATIC ACCESS TOKEN`) pulls in `cryptography` as a transitive dep, and **`cryptography` no longer publishes working pre-built Windows ARM64 wheels** ([pyca/cryptography#14216](https://github.com/pyca/cryptography/pull/14216), [#14168](https://github.com/pyca/cryptography/issues/14168) — dropped in early 2026). Pip ends up with a wheel whose `_rust.pyd` cannot be loaded on `windows-11-arm`, regardless of which VC++ runtime is installed.

This is not a new problem — `test-python.yml` and `build-python-release.yml` already hit it for our own e2e tests that import `cryptography`, and they solve it the same way: build cryptography from source against vcpkg's `arm64-windows-static-md` OpenSSL, since the Rust toolchain is already on the runner.

### Change

Apply the same pattern to the cleanup step in `test-rust-core.yml`:

1. Restore the `arm64-windows-static-md` OpenSSL vcpkg cache, fall back to a vcpkg install on miss, save on miss.
2. Run cleanup with `OPENSSL_DIR` / `OPENSSL_LIB_DIR` / `OPENSSL_STATIC=1` set and `pip install --no-binary cryptography snowflake-connector-python`.
3. Cache key is intentionally identical to the one used in `test-python.yml` / `build-python-release.yml` (`windows-11-arm-vcpkg-openssl-static-md-${VCPKG_VER}`) so the cache is shared — when those workflows have run on the same `VCPKG_VER`, this step is essentially free.

The earlier commit on this branch tried to fix it by installing the ARM64 VC++ Redistributable, which turned out to be irrelevant (the wheel itself is unusable). That commit's logic is replaced by this one.

### Why not pin `cryptography`?

- We don't depend on it directly — `snowflake-connector-python` does, so we'd have to override its dep resolution every release.
- Per pyca/cryptography#14168, even when arm64 wheels existed they were missing for some Python versions (3.12/3.13). The hosted runner is on Python 3.13.13. Wheel coverage for the pinned version is not guaranteed.
- Source-build matches what the rest of this repo already does and stays robust to upstream version drift.

The cleanup step keeps `continue-on-error: true` (this PR is purely about making it actually succeed; not changing failure semantics).

## Test plan

- [ ] Re-run the Rust Core CI on this PR and confirm the new `Restore vcpkg ARM64 static OpenSSL cache (for cryptography)` step hits the existing cache (it should — `test-python.yml` populates the same key on every PR).
- [ ] Confirm `Cleanup test PATs` on `test (Windows ARM64, non-FIPS)` exits 0 — no more `DLL load failed` error in step 14 output.
- [ ] Sanity-check on the Snowflake side that PATs from this build (`UD_*_GHA_<run_number>_*`) were removed.