### PR TITLE
Add e2e test for connection string key case insensitivity

### DIFF
--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -43,6 +43,7 @@ add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)
 
 # session
 add_odbc_test(e2e_session_session_parameters session/session_parameters.cpp)
+add_odbc_test(e2e_session_connection_string_case_sensitivity session/connection_string_case_sensitivity.cpp)
 
 # types
 add_odbc_test(e2e_types_binary types/binary.cpp)

--- a/odbc_tests/tests/e2e/session/connection_string_case_sensitivity.cpp
+++ b/odbc_tests/tests/e2e/session/connection_string_case_sensitivity.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "get_data.hpp"
+#include "test_setup.hpp"
+
+/// Build a connection string with lowercase key names from the test parameters.
+static std::string get_lowercase_connection_string() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+
+  auto req = [&](const std::string& cfg, const std::string& conn) {
+    add_param_required<std::string>(ss, params, cfg, conn);
+  };
+  auto opt = [&](const std::string& cfg, const std::string& conn) {
+    add_param_optional<std::string>(ss, params, cfg, conn);
+  };
+
+  // Use all-lowercase key names instead of the usual UPPERCASE ones.
+  req("SNOWFLAKE_TEST_HOST", "server");
+  req("SNOWFLAKE_TEST_ACCOUNT", "account");
+  req("SNOWFLAKE_TEST_USER", "uid");
+  if (params.count("SNOWFLAKE_TEST_WAREHOUSE_ODBC")) {
+    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE_ODBC", "warehouse");
+  } else {
+    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE", "warehouse");
+  }
+  opt("SNOWFLAKE_TEST_ROLE", "role");
+  opt("SNOWFLAKE_TEST_SCHEMA", "schema");
+  opt("SNOWFLAKE_TEST_DATABASE", "database");
+  opt("SNOWFLAKE_TEST_PORT", "port");
+  opt("SNOWFLAKE_TEST_PROTOCOL", "protocol");
+
+  ss << "authenticator=SNOWFLAKE_JWT;";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  ss << "priv_key_file=" << get_or_create_private_key_file(params) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "priv_key_file_pwd");
+#else
+  ss << "priv_key_base64=" << test_utils::base64_encode(read_private_key(params)) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "priv_key_pwd");
+#endif
+  return ss.str();
+}
+
+/// Build a connection string with mixed-case key names.
+static std::string get_mixed_case_connection_string() {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+
+  auto req = [&](const std::string& cfg, const std::string& conn) {
+    add_param_required<std::string>(ss, params, cfg, conn);
+  };
+  auto opt = [&](const std::string& cfg, const std::string& conn) {
+    add_param_optional<std::string>(ss, params, cfg, conn);
+  };
+
+  req("SNOWFLAKE_TEST_HOST", "Server");
+  req("SNOWFLAKE_TEST_ACCOUNT", "Account");
+  req("SNOWFLAKE_TEST_USER", "Uid");
+  if (params.count("SNOWFLAKE_TEST_WAREHOUSE_ODBC")) {
+    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE_ODBC", "Warehouse");
+  } else {
+    add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE", "Warehouse");
+  }
+  opt("SNOWFLAKE_TEST_ROLE", "Role");
+  opt("SNOWFLAKE_TEST_SCHEMA", "Schema");
+  opt("SNOWFLAKE_TEST_DATABASE", "Database");
+  opt("SNOWFLAKE_TEST_PORT", "Port");
+  opt("SNOWFLAKE_TEST_PROTOCOL", "Protocol");
+
+  ss << "Authenticator=SNOWFLAKE_JWT;";
+#ifdef SNOWFLAKE_OLD_DRIVER
+  ss << "Priv_Key_File=" << get_or_create_private_key_file(params) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "Priv_Key_File_Pwd");
+#else
+  ss << "Priv_Key_Base64=" << test_utils::base64_encode(read_private_key(params)) << ";";
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_PRIVATE_KEY_PASSWORD", "Priv_Key_Pwd");
+#endif
+  return ss.str();
+}
+
+TEST_CASE("connection string keys are case-insensitive (lowercase)", "[session][case_sensitivity]") {
+  SKIP_OLD_DRIVER("", "Old driver may not support all lowercase keys");
+  // Given Snowflake ODBC connection string uses all-lowercase key names
+  Connection conn(get_lowercase_connection_string());
+
+  // When Connection is established and "SELECT 1" is executed
+  auto stmt = conn.execute_fetch("SELECT 1");
+
+  // Then the query should succeed and return 1
+  auto value = get_data<SQL_C_LONG>(stmt, 1);
+  CHECK(value == 1);
+}
+
+TEST_CASE("connection string keys are case-insensitive (mixed case)", "[session][case_sensitivity]") {
+  SKIP_OLD_DRIVER("", "Old driver may not support mixed-case keys");
+  // Given Snowflake ODBC connection string uses mixed-case key names
+  Connection conn(get_mixed_case_connection_string());
+
+  // When Connection is established and "SELECT 1" is executed
+  auto stmt = conn.execute_fetch("SELECT 1");
+
+  // Then the query should succeed and return 1
+  auto value = get_data<SQL_C_LONG>(stmt, 1);
+  CHECK(value == 1);
+}

--- a/tests/definitions/odbc/session/connection_string_case_sensitivity.feature
+++ b/tests/definitions/odbc/session/connection_string_case_sensitivity.feature
@@ -1,0 +1,18 @@
+@odbc
+Feature: Connection string key case insensitivity
+
+  Connection string keys (SERVER, UID, PWD, ACCOUNT, etc.) should be
+  matched case-insensitively so that users can write them in any
+  combination of upper, lower, or mixed case.
+
+  @odbc_e2e
+  Scenario: connection string keys are case-insensitive (lowercase)
+    Given Snowflake ODBC connection string uses all-lowercase key names
+    When Connection is established and "SELECT 1" is executed
+    Then the query should succeed and return 1
+
+  @odbc_e2e
+  Scenario: connection string keys are case-insensitive (mixed case)
+    Given Snowflake ODBC connection string uses mixed-case key names
+    When Connection is established and "SELECT 1" is executed
+    Then the query should succeed and return 1


### PR DESCRIPTION
## Summary
- Add ODBC e2e test verifying that connection string keys are case-insensitive
- Two test cases: all-lowercase keys (`server`, `uid`, `account`, ...) and mixed-case keys (`Server`, `Uid`, `Account`, ...)
- Both connect to Snowflake and run `SELECT 1` to confirm the full pipeline works end-to-end
- Includes matching feature definition file

## Test plan
- [ ] CI runs `e2e_session_connection_string_case_sensitivity` successfully
- [ ] Verify tests are skipped when running against old driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)