### PR TITLE
NO-SNOW: Replace HandleRegistry with HandleManager (two-guard model)

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -234,16 +234,22 @@ fn connect_with_params(
         options.insert("port".to_owned(), port_int.into());
     }
 
-    let dbc = conn_from_handle(connection_handle);
-    let connection = &mut dbc.connection;
-    apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
-
-    // Check before moving `options` into the RPC call below.
-    let login_timeout_in_options = options.contains_key("authentication_timeout");
-    let login_timeout_in_attrs = connection
-        .pre_connection_attrs
-        .contains_key(&ConnectionAttribute::LoginTimeout);
-    let pre_connection_attrs = connection.pre_connection_attrs.clone();
+    let dbc = conn_from_handle(connection_handle)?;
+    // Read pre-connection data under lock, then release before the async call.
+    let (pre_connection_attrs, login_timeout_in_options, login_timeout_in_attrs) = {
+        let connection = dbc.connection.lock();
+        apply_pre_connection_overrides(&connection.pre_connection_attrs, &mut options);
+        let login_timeout_in_options = options.contains_key("authentication_timeout");
+        let login_timeout_in_attrs = connection
+            .pre_connection_attrs
+            .contains_key(&ConnectionAttribute::LoginTimeout);
+        let pre_connection_attrs = connection.pre_connection_attrs.clone();
+        (
+            pre_connection_attrs,
+            login_timeout_in_options,
+            login_timeout_in_attrs,
+        )
+    };
 
     let (db_handle, conn_handle) = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
         let db_handle = c
@@ -301,7 +307,7 @@ fn connect_with_params(
 
     tracing::info!("connect_with_params: connection_init completed");
 
-    connection.state = ConnectionState::Connected {
+    dbc.connection.lock().state = ConnectionState::Connected {
         db_handle,
         conn_handle,
     };
@@ -310,7 +316,7 @@ fn connect_with_params(
     // already established (state = Connected). Use warn-and-continue rather than `?`
     // to avoid returning an error after the state was set to Connected.
     // ConnectionHandle is Copy, so conn_handle is still accessible after the move above.
-    connection.current_catalog = match global().context(OdbcRuntimeSnafu) {
+    let current_catalog = match global().context(OdbcRuntimeSnafu) {
         Ok(rt) => rt
             .block_on(async |c| {
                 let info = c
@@ -333,6 +339,7 @@ fn connect_with_params(
             None
         }
     };
+    dbc.connection.lock().current_catalog = current_catalog;
 
     Ok(())
 }
@@ -549,12 +556,15 @@ fn read_dsn_config(dsn: &str) -> OdbcResult<HashMap<String, String>> {
 pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("disconnect: disconnecting from database");
 
-    let dbc = conn_from_handle(connection_handle);
-    let connection = &mut dbc.connection;
+    let dbc = conn_from_handle(connection_handle)?;
+    let old_state = {
+        let mut connection = dbc.connection.lock();
+        std::mem::replace(&mut connection.state, ConnectionState::Disconnected)
+    };
     if let ConnectionState::Connected {
         db_handle,
         conn_handle,
-    } = std::mem::replace(&mut connection.state, ConnectionState::Disconnected)
+    } = old_state
     {
         global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
             if let Err(e) = c
@@ -610,9 +620,8 @@ pub fn native_sql<E: OdbcEncoding>(
         .fail();
     }
 
-    let dbc = conn_from_handle(connection_handle);
-    let conn = &mut dbc.connection;
-    if matches!(conn.state, ConnectionState::Disconnected) {
+    let dbc = conn_from_handle(connection_handle)?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
         return crate::api::error::DisconnectedSnafu.fail();
     }
 
@@ -655,8 +664,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
     string_length: sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let dbc = conn_from_handle(connection_handle);
-    let connection = &mut dbc.connection;
+    let dbc = conn_from_handle(connection_handle)?;
     tracing::debug!("set_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -670,6 +678,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
         }
     };
 
+    let mut connection = dbc.connection.lock();
     match attr {
         ConnectionAttribute::AccessMode => {
             let mode = AccessMode::from_raw(value_ptr as sql::UInteger).ok_or_else(|| {
@@ -692,16 +701,22 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             })?;
             // NOTE: Per ODBC spec, HY011 must be returned if a transaction is currently open.
             // Transaction state tracking requires server-side awareness — deferred to SNOW-3240589.
-            match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
+            let maybe_conn_handle = match &connection.state {
+                ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                ConnectionState::Disconnected => None,
+            };
+            match maybe_conn_handle {
+                Some(conn_handle) => {
                     let autocommit_on = matches!(val, AutocommitValue::On);
+                    drop(connection);
                     global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                         c.connection_set_autocommit(ConnectionSetAutocommitRequest {
-                            conn_handle: Some(*conn_handle),
+                            conn_handle: Some(conn_handle),
                             autocommit: autocommit_on,
                         })
                         .await
                     })?;
+                    let mut connection = dbc.connection.lock();
                     connection.cached_autocommit = val;
                     // Keep pre_connection_attrs in sync so a reconnect on the same handle
                     // re-applies the value set while connected rather than the stale pre-connect value.
@@ -710,7 +725,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                         .insert(attr, val.as_raw().to_string());
                     Ok(())
                 }
-                ConnectionState::Disconnected => {
+                None => {
                     connection.cached_autocommit = val;
                     connection
                         .pre_connection_attrs
@@ -771,6 +786,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             }
             let catalog = read_string_from_pointer::<E>(value_ptr, string_length)?;
             let catalog = catalog.trim().to_string();
+            drop(connection);
             global()
                 .context(OdbcRuntimeSnafu)?
                 .block_on(async |c| {
@@ -793,7 +809,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                         _ => e.into(),
                     }
                 })?;
-            connection.current_catalog = Some(catalog);
+            dbc.connection.lock().current_catalog = Some(catalog);
             Ok(())
         }
         ConnectionAttribute::QuietMode => {
@@ -815,8 +831,7 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::MetadataId => {
-            let val = value_ptr as sql::ULen;
-            connection.metadata_id = val != 0;
+            connection.metadata_id = value_ptr as sql::ULen != 0;
             Ok(())
         }
         ConnectionAttribute::ConnectionDead | ConnectionAttribute::AutoIpd => {
@@ -863,8 +878,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
     string_length_ptr: *mut sql::Integer,
     warnings: &mut Warnings,
 ) -> OdbcResult<()> {
-    let dbc = conn_from_handle(connection_handle);
-    let connection = &mut dbc.connection;
+    let dbc = conn_from_handle(connection_handle)?;
     tracing::debug!("get_connect_attr: attribute={attribute}");
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
@@ -875,11 +889,14 @@ pub fn get_connect_attr<E: OdbcEncoding>(
         }
     };
 
+    let connection = dbc.connection.lock();
     match attr {
         ConnectionAttribute::AccessMode => {
+            let access_mode = connection.access_mode;
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::UInteger) = connection.access_mode.as_raw();
+                    *(value_ptr as *mut sql::UInteger) = access_mode.as_raw();
                 }
             }
             if !string_length_ptr.is_null() {
@@ -893,34 +910,38 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             // Per spec: query the server for the actual autocommit state when connected;
             // fall back to the cached value if the RPC fails or the parameter is absent.
             // The cache is the authoritative source when disconnected.
-            let val: sql::UInteger = match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
-                    match get_session_parameter(conn_handle, "AUTOCOMMIT") {
-                        Ok(Some(v)) if v.eq_ignore_ascii_case("true") => {
-                            connection.cached_autocommit = AutocommitValue::On;
-                            AutocommitValue::On.as_raw()
-                        }
-                        Ok(Some(_)) => {
-                            connection.cached_autocommit = AutocommitValue::Off;
-                            AutocommitValue::Off.as_raw()
-                        }
-                        Ok(None) => {
-                            tracing::warn!(
-                                "get_connect_attr: AUTOCOMMIT session parameter missing, \
-                                 falling back to cached value"
-                            );
-                            connection.cached_autocommit.as_raw()
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "get_connect_attr: failed to read AUTOCOMMIT session parameter \
-                                 ({e}), falling back to cached value"
-                            );
-                            connection.cached_autocommit.as_raw()
-                        }
+            let maybe_conn_handle = match &connection.state {
+                ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                ConnectionState::Disconnected => None,
+            };
+            let cached = connection.cached_autocommit;
+            drop(connection);
+            let val: sql::UInteger = match maybe_conn_handle {
+                Some(conn_handle) => match get_session_parameter(&conn_handle, "AUTOCOMMIT") {
+                    Ok(Some(v)) if v.eq_ignore_ascii_case("true") => {
+                        dbc.connection.lock().cached_autocommit = AutocommitValue::On;
+                        AutocommitValue::On.as_raw()
                     }
-                }
-                ConnectionState::Disconnected => connection.cached_autocommit.as_raw(),
+                    Ok(Some(_)) => {
+                        dbc.connection.lock().cached_autocommit = AutocommitValue::Off;
+                        AutocommitValue::Off.as_raw()
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            "get_connect_attr: AUTOCOMMIT session parameter missing, \
+                                 falling back to cached value"
+                        );
+                        cached.as_raw()
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "get_connect_attr: failed to read AUTOCOMMIT session parameter \
+                                 ({e}), falling back to cached value"
+                        );
+                        cached.as_raw()
+                    }
+                },
+                None => cached.as_raw(),
             };
             if !value_ptr.is_null() {
                 unsafe {
@@ -945,6 +966,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 }),
                 None => DEFAULT_LOGIN_TIMEOUT_SECS.parse().unwrap(),
             };
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = timeout;
@@ -958,6 +980,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::TxnIsolation => {
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = SQL_TXN_READ_COMMITTED;
@@ -977,9 +1000,14 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 }
                 .fail();
             }
-            let database = match &connection.state {
-                ConnectionState::Connected { conn_handle, .. } => {
-                    let conn_handle = *conn_handle;
+            let maybe_conn_handle = match &connection.state {
+                ConnectionState::Connected { conn_handle, .. } => Some(*conn_handle),
+                ConnectionState::Disconnected => None,
+            };
+            let cached_catalog = connection.current_catalog.clone();
+            drop(connection);
+            let database = match maybe_conn_handle {
+                Some(conn_handle) => {
                     match global().context(OdbcRuntimeSnafu).and_then(|rt| {
                         rt.block_on(async |c| {
                             let info = c
@@ -993,7 +1021,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                         })
                     }) {
                         Ok(db) => {
-                            connection.current_catalog = db.clone();
+                            dbc.connection.lock().current_catalog = db.clone();
                             db
                         }
                         Err(e) => {
@@ -1001,7 +1029,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                                 "get_connect_attr: failed to fetch current catalog from server: \
                                  {e:?}; falling back to cached value"
                             );
-                            connection.current_catalog.clone()
+                            cached_catalog
                         }
                     }
                 }
@@ -1009,7 +1037,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 // Per ODBC spec the catalog is indeterminate before connecting;
                 // returning an error would break applications that probe this attribute
                 // before calling SQLConnect.
-                ConnectionState::Disconnected => connection.current_catalog.clone(),
+                None => cached_catalog,
             };
             let database_str = database.as_deref().unwrap_or("");
             write_string_bytes_i32::<E>(
@@ -1022,17 +1050,21 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::QuietMode => {
+            let quiet_mode = connection.quiet_mode;
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::Pointer) = connection.quiet_mode;
+                    *(value_ptr as *mut sql::Pointer) = quiet_mode;
                 }
             }
             Ok(())
         }
         ConnectionAttribute::PacketSize => {
+            let packet_size = connection.packet_size;
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::UInteger) = connection.packet_size;
+                    *(value_ptr as *mut sql::UInteger) = packet_size;
                 }
             }
             if !string_length_ptr.is_null() {
@@ -1043,6 +1075,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::ConnectionTimeout => {
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = 0;
@@ -1056,10 +1089,11 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::ConnectionDead => {
-            let dead = match &connection.state {
+            let dead = match connection.state {
                 ConnectionState::Connected { .. } => SQL_CD_FALSE,
                 ConnectionState::Disconnected => SQL_CD_TRUE,
             };
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = dead;
@@ -1073,6 +1107,7 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::AutoIpd => {
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
                     *(value_ptr as *mut sql::UInteger) = SQL_FALSE;
@@ -1086,9 +1121,11 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             Ok(())
         }
         ConnectionAttribute::MetadataId => {
+            let metadata_id = connection.metadata_id;
+            drop(connection);
             if !value_ptr.is_null() {
                 unsafe {
-                    *(value_ptr as *mut sql::ULen) = connection.metadata_id as sql::ULen;
+                    *(value_ptr as *mut sql::ULen) = metadata_id as sql::ULen;
                 }
             }
             if !string_length_ptr.is_null() {
@@ -1106,9 +1143,11 @@ pub fn get_connect_attr<E: OdbcEncoding>(
                 .pre_connection_attrs
                 .get(&attr)
                 .map(|s| s.as_str())
-                .unwrap_or("");
+                .unwrap_or("")
+                .to_owned();
+            drop(connection);
             write_string_bytes_i32::<E>(
-                value,
+                &value,
                 value_ptr as *mut E::Char,
                 buffer_length,
                 string_length_ptr,
@@ -1116,10 +1155,13 @@ pub fn get_connect_attr<E: OdbcEncoding>(
             );
             Ok(())
         }
-        ConnectionAttribute::PrivKey => UnsupportedAttributeSnafu {
-            attribute: attr.as_raw(),
+        ConnectionAttribute::PrivKey => {
+            drop(connection);
+            UnsupportedAttributeSnafu {
+                attribute: attr.as_raw(),
+            }
+            .fail()
         }
-        .fail(),
     }
 }
 
@@ -1134,7 +1176,7 @@ pub fn get_info<E: OdbcEncoding>(
 ) -> OdbcResult<()> {
     tracing::debug!("get_info: connection_handle={connection_handle:?}, info_type={info_type}");
 
-    let _conn = conn_from_handle(connection_handle);
+    let _conn = conn_from_handle(connection_handle)?;
 
     let info_type = InfoType::try_from(info_type)?;
     tracing::debug!("get_info: info_type={info_type:?}");

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -294,12 +294,11 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
     };
 
     let mut cache = FetchConverterCache::new();
-    let numeric_settings = unsafe { stmt.conn() }.connection.numeric_settings;
-
     // Fast path: a single-row fetch propagates the conversion error to
     // the caller instead of just marking the row as Error.
     if array_size == 1 && bind_offset_ptr.is_null() {
         advance_cursor(&mut stmt.state)?;
+        let numeric_settings = stmt.conn()?.connection.lock().numeric_settings;
         cache.refresh_if_needed(stmt, &numeric_settings)?;
         if !rows_fetched_ptr.is_null() {
             unsafe { *rows_fetched_ptr = 1 };
@@ -341,6 +340,7 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
 
     let mut rows_fetched: usize = 0;
     let mut has_error = false;
+    let numeric_settings = stmt.conn()?.connection.lock().numeric_settings;
 
     // Column-major block-cursor loop. Each iteration advances into the
     // next row and then processes as many rows as fit in the current
@@ -744,14 +744,13 @@ pub fn get_data(
                 datetime_interval_precision: ard_binding
                     .and_then(|b| b.datetime_interval_precision),
             };
+            let settings = stmt.conn()?.connection.lock().numeric_settings;
             let conversion_warnings = read_arrow_value(
                 &binding,
                 array_ref,
                 field,
                 *batch_idx,
-                // SAFETY: conn pointer is valid for the statement's lifetime;
-                // no mutable reference to the Connection exists in this scope.
-                &unsafe { stmt.conn() }.connection.numeric_settings,
+                &settings,
                 &mut offset,
             )
             .context(ConversionSnafu)?;

--- a/odbc/src/api/diagnostic.rs
+++ b/odbc/src/api/diagnostic.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     api::{
-        Dbc, Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
+        Environment, OdbcError, OdbcResult, SqlState, Statement, conn_from_handle,
         encoding::{OdbcEncoding, write_string_bytes, write_string_chars},
         env_from_handle,
         error::{
@@ -180,12 +180,12 @@ impl WithDiagnosticInfo for Environment {
     }
 }
 
-impl WithDiagnosticInfo for Dbc {
+impl WithDiagnosticInfo for crate::api::Connection {
     fn get_diag_info(&self) -> &DiagnosticInfo {
-        &self.connection.diagnostic_info
+        &self.diagnostic_info
     }
     fn get_diag_info_mut(&mut self) -> &mut DiagnosticInfo {
-        &mut self.connection.diagnostic_info
+        &mut self.diagnostic_info
     }
 }
 
@@ -259,8 +259,14 @@ pub fn clear_diag_info(handle_type: sql::HandleType, handle: sql::Handle) {
         guard.get_diag_info_mut().clear();
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        dbc.connection.lock().get_diag_info_mut().clear();
+        return;
+    }
     let t: &mut dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
         _ => return,
@@ -273,7 +279,6 @@ fn from_handle_type_non_env<'a>(
     handle: sql::Handle,
 ) -> Option<&'a mut dyn WithDiagnosticInfo> {
     match handle_type {
-        sql::HandleType::Dbc => Some(conn_from_handle(handle)),
         sql::HandleType::Stmt => Some(stmt_from_handle(handle)),
         sql::HandleType::Desc => Some(desc_diag_from_handle(handle)),
         _ => {
@@ -326,6 +331,17 @@ pub fn set_diag_info_from_warnings(
         }
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        let mut conn = dbc.connection.lock();
+        let diagnostic_info = conn.get_diag_info_mut();
+        for warning in warnings {
+            diagnostic_info.add_record(from_warning(warning));
+        }
+        return;
+    }
     if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         let diagnostic_info = t.get_diag_info_mut();
         for warning in warnings {
@@ -357,6 +373,13 @@ pub fn set_diag_info_from_result(
         add_from_result(guard.get_diag_info_mut());
         return;
     }
+    if handle_type == sql::HandleType::Dbc {
+        let Ok(dbc) = conn_from_handle(handle) else {
+            return;
+        };
+        add_from_result(dbc.connection.lock().get_diag_info_mut());
+        return;
+    }
     if let Some(t) = from_handle_type_non_env(handle_type, handle) {
         add_from_result(t.get_diag_info_mut());
     }
@@ -371,8 +394,11 @@ pub fn get_diag_info(
         let guard = env.environment.lock();
         return Ok(guard.get_diag_info().clone());
     }
+    if handle_type == sql::HandleType::Dbc {
+        let dbc = conn_from_handle(handle)?;
+        return Ok(dbc.connection.lock().get_diag_info().clone());
+    }
     let t: &dyn WithDiagnosticInfo = match handle_type {
-        sql::HandleType::Dbc => conn_from_handle(handle),
         sql::HandleType::Stmt => stmt_from_handle(handle),
         sql::HandleType::Desc => desc_diag_from_handle(handle),
         _ => return InvalidHandleSnafu.fail(),

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -66,9 +66,9 @@ pub fn alloc_connection(env_id: HandleId) -> OdbcResult<sql::Handle> {
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
     let dbc = conn_from_handle(input_handle)?;
+    let mut connection = dbc.connection.lock();
     // Extract needed data under a short-lived lock; release before the async call.
     let (conn_handle, metadata_id) = {
-        let connection = dbc.connection.lock();
         match &connection.state {
             ConnectionState::Connected {
                 db_handle: _,
@@ -86,6 +86,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
         })
         .await
     })?;
+
     let stmt_handle = response
         .stmt_handle
         .required("Statement handle is required")?;
@@ -105,26 +106,23 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
     stmt_mut.apd.stmt = raw_ptr;
     stmt_mut.ipd.stmt = raw_ptr;
 
-    {
-        let mut connection = dbc.connection.lock();
-        // Defensive prune: in correct code free_statement removes each entry before
-        // dropping the Arc, so Weaks here are always upgradeable. This retain is a
-        // safety net against a future bug in the removal logic, not a routine cleanup.
-        connection.child_statements.retain(|(w, raw_ptr)| {
-            if w.upgrade().is_some() {
-                return true;
-            }
-            // A dead Weak means free_statement dropped the Arc without removing the
-            // child_statements entry — this is a bug. Log it so leaks are visible.
-            tracing::error!(
-                "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
-                 server-side statement handle may have leaked"
-            );
-            false
-        });
-        connection.child_statements.push((weak, raw_ptr));
-    }
-    Ok(raw_ptr as *mut Statement)
+    // Defensive prune: in correct code free_statement removes each entry before
+    // dropping the Arc, so Weaks here are always upgradeable. This retain is a
+    // safety net against a future bug in the removal logic, not a routine cleanup.
+    connection.child_statements.retain(|(w, raw_ptr)| {
+        if w.upgrade().is_some() {
+            return true;
+        }
+        // A dead Weak means free_statement dropped the Arc without removing the
+        // child_statements entry — this is a bug. Log it so leaks are visible.
+        tracing::error!(
+            "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
+                server-side statement handle may have leaked"
+        );
+        false
+    });
+    connection.child_statements.push((weak, raw_ptr));
+    return Ok(raw_ptr as *mut Statement);
 }
 
 /// Free an environment handle

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -67,7 +67,6 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
     tracing::info!("Allocating new statement handle");
     let dbc = conn_from_handle(input_handle)?;
     let mut connection = dbc.connection.lock();
-    // Extract needed data under a short-lived lock; release before the async call.
     let (conn_handle, metadata_id) = {
         match &connection.state {
             ConnectionState::Connected {
@@ -122,7 +121,7 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> 
         false
     });
     connection.child_statements.push((weak, raw_ptr));
-    return Ok(raw_ptr as *mut Statement);
+    Ok(raw_ptr as *mut Statement)
 }
 
 /// Free an environment handle

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -1,4 +1,3 @@
-use crate::api::env_from_handle;
 use crate::api::error::{
     ConnectionStillConnectedSnafu, DisconnectedSnafu, EnvironmentHasConnectionsSnafu,
     InvalidHandleSnafu, OdbcRuntimeSnafu, Required,
@@ -22,7 +21,7 @@ use tracing;
 pub fn alloc_environment() -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new environment handle");
     env_allocated().context(OdbcRuntimeSnafu)?;
-    let env = Arc::new(Env {
+    let env = Env {
         environment: Mutex::new(Environment {
             odbc_version: 3,
             connection_pooling: sql::AttrConnectionPooling::Off,
@@ -30,17 +29,21 @@ pub fn alloc_environment() -> OdbcResult<sql::Handle> {
             diagnostic_info: DiagnosticInfo::default(),
             connections: vec![],
         }),
-    });
+    };
     let handle = global().context(OdbcRuntimeSnafu)?.env_registry.add(env)?;
     Ok(handle.into())
 }
 
 /// Allocate a new connection handle
-pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
+pub fn alloc_connection(env_id: HandleId) -> OdbcResult<sql::Handle> {
     tracing::info!("Allocating new connection handle");
-    let dbc = Box::new(Dbc {
-        env: Arc::downgrade(&env),
-        connection: Connection {
+    let env_guard = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .get(env_id)?;
+    let dbc = Dbc {
+        env_id,
+        connection: Mutex::new(Connection {
             state: ConnectionState::Disconnected,
             diagnostic_info: DiagnosticInfo::default(),
             pre_connection_attrs: Default::default(),
@@ -52,105 +55,103 @@ pub fn alloc_connection(env: Arc<Env>) -> OdbcResult<*mut Dbc> {
             cached_autocommit: crate::api::types::AutocommitValue::On,
             current_catalog: None,
             metadata_id: false,
-        },
-    });
-    let ptr = Box::into_raw(dbc);
-    env.environment.lock().connections.push(ptr);
-    Ok(ptr)
+        }),
+    };
+    let dbc_handle = global().context(OdbcRuntimeSnafu)?.dbc_registry.add(dbc)?;
+    env_guard.environment.lock().connections.push(dbc_handle);
+    Ok(dbc_handle.into())
 }
 
 /// Allocate a new statement handle
 pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<*mut Statement> {
     tracing::info!("Allocating new statement handle");
-    let conn = conn_from_handle(input_handle);
-    let connection = &mut conn.connection;
-    match &mut connection.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let metadata_id = connection.metadata_id;
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_new(StatementNewRequest {
-                    conn_handle: Some(*conn_handle),
-                })
-                .await
-            })?;
-            let stmt_handle = response
-                .stmt_handle
-                .required("Statement handle is required")?;
+    let dbc = conn_from_handle(input_handle)?;
+    // Extract needed data under a short-lived lock; release before the async call.
+    let (conn_handle, metadata_id) = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected {
+                db_handle: _,
+                conn_handle,
+            } => (*conn_handle, connection.metadata_id),
+            ConnectionState::Disconnected => {
+                tracing::error!("Cannot allocate statement: connection is disconnected");
+                return DisconnectedSnafu.fail();
+            }
+        }
+    };
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_new(StatementNewRequest {
+            conn_handle: Some(conn_handle),
+        })
+        .await
+    })?;
+    let stmt_handle = response
+        .stmt_handle
+        .required("Statement handle is required")?;
 
-            // Statement is Send but not Sync (conn is *mut Connection with no synchronisation).
-            // Arc is used for reference-counted ownership and Weak tracking on Connection;
-            // the Arc is converted to a raw pointer immediately — it is never cloned and
-            // never shared across threads. Rc cannot be used because Connection: Send.
-            #[allow(clippy::arc_with_non_send_sync)]
-            let stmt = Arc::new(Statement::new(conn as *mut Dbc, stmt_handle, metadata_id));
-            // Defensive prune: in correct code free_statement removes each entry before
-            // dropping the Arc, so Weaks here are always upgradeable. This retain is a
-            // safety net against a future bug in the removal logic, not a routine cleanup.
-            conn.connection.child_statements.retain(|(w, raw_ptr)| {
-                if w.upgrade().is_some() {
-                    return true;
-                }
-                // A dead Weak means free_statement dropped the Arc without removing the
-                // child_statements entry — this is a bug. Log it so leaks are visible.
-                tracing::error!(
-                    "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
-                     server-side statement handle may have leaked"
-                );
-                false
-            });
-            let weak = Arc::downgrade(&stmt);
-            // Transfer ownership to a raw pointer used as the opaque ODBC handle.
-            // Store the same pointer in child_statements so free_connection can call
-            // Arc::from_raw with a pointer that satisfies its documented contract.
-            let raw_ptr = Arc::into_raw(stmt);
-            // Set descriptor back-pointers now that the Statement has a stable heap address.
-            let stmt_mut = unsafe { &mut *(raw_ptr as *mut Statement) };
-            stmt_mut.ard.stmt = raw_ptr;
-            stmt_mut.ird.stmt = raw_ptr;
-            stmt_mut.apd.stmt = raw_ptr;
-            stmt_mut.ipd.stmt = raw_ptr;
-            conn.connection.child_statements.push((weak, raw_ptr));
-            Ok(raw_ptr as *mut Statement)
-        }
-        ConnectionState::Disconnected => {
-            tracing::error!("Cannot allocate statement: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
+    let conn_id = HandleId::from(input_handle);
+    #[allow(clippy::arc_with_non_send_sync)]
+    let stmt = Arc::new(Statement::new(conn_id, stmt_handle, metadata_id));
+    let weak = Arc::downgrade(&stmt);
+    // Transfer ownership to a raw pointer used as the opaque ODBC handle.
+    // Store the same pointer in child_statements so free_connection can call
+    // Arc::from_raw with a pointer that satisfies its documented contract.
+    let raw_ptr = Arc::into_raw(stmt);
+    // Set descriptor back-pointers now that the Statement has a stable heap address.
+    let stmt_mut = unsafe { &mut *(raw_ptr as *mut Statement) };
+    stmt_mut.ard.stmt = raw_ptr;
+    stmt_mut.ird.stmt = raw_ptr;
+    stmt_mut.apd.stmt = raw_ptr;
+    stmt_mut.ipd.stmt = raw_ptr;
+
+    {
+        let mut connection = dbc.connection.lock();
+        // Defensive prune: in correct code free_statement removes each entry before
+        // dropping the Arc, so Weaks here are always upgradeable. This retain is a
+        // safety net against a future bug in the removal logic, not a routine cleanup.
+        connection.child_statements.retain(|(w, raw_ptr)| {
+            if w.upgrade().is_some() {
+                return true;
+            }
+            // A dead Weak means free_statement dropped the Arc without removing the
+            // child_statements entry — this is a bug. Log it so leaks are visible.
+            tracing::error!(
+                "alloc_statement: defensive prune found dead Weak (raw_ptr={raw_ptr:p}); \
+                 server-side statement handle may have leaked"
+            );
+            false
+        });
+        connection.child_statements.push((weak, raw_ptr));
     }
+    Ok(raw_ptr as *mut Statement)
 }
 
 /// Free an environment handle
 pub fn free_environment(handle: sql::Handle) -> OdbcResult<()> {
     let handle_id = HandleId::from(handle);
-    let env_removal_guard = global()
+    let delete_guard = global()
         .context(OdbcRuntimeSnafu)?
         .env_registry
-        .remove(handle_id)?;
-    let environment = env_removal_guard.environment.lock();
+        .get_for_delete(handle_id)?;
+    let environment = delete_guard.value().environment.lock();
     if !environment.connections.is_empty() {
         return EnvironmentHasConnectionsSnafu.fail();
     }
     drop(environment);
-    env_removal_guard.complete();
+    delete_guard.delete();
     env_freed().context(OdbcRuntimeSnafu)?;
     Ok(())
 }
 
-fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
+fn cleanup_connection(dbc: &Dbc) -> OdbcResult<()> {
     // Release any outstanding statements whose ODBC handles were never freed.
     // Each Weak still in child_statements corresponds to an Arc::into_raw that was
     // never reclaimed by free_statement (strong count = 1, held by the raw ODBC handle).
     // Reconstruct the Arc to take back that ownership, then release the server resource.
-    let conn = unsafe { &mut *conn };
-    let connection = &mut conn.connection;
-    let stmts: Vec<_> = connection.child_statements.drain(..).collect();
+    let stmts: Vec<_> = dbc.connection.lock().child_statements.drain(..).collect();
     for (w, raw_ptr) in stmts {
         // Safety: raw_ptr was obtained via Arc::into_raw in alloc_statement.
-        // (Note: Arc::as_ptr and Arc::into_raw are NOT equivalent — as_ptr does not transfer
-        // strong-count ownership; into_raw does. Only into_raw satisfies Arc::from_raw's contract.)
         // free_statement removes its child_statements entry before dropping the Arc, so any
         // entry still present here means the ODBC handle was never freed — strong count == 1.
         // Guard: verify the Weak is still live before dereferencing raw_ptr. A dead Weak means
@@ -182,18 +183,6 @@ fn cleanup_connection(conn: *mut Dbc) -> OdbcResult<()> {
             Err(e) => tracing::warn!("free_connection: runtime unavailable: {e:?}"),
         }
     }
-
-    unsafe {
-        drop(Box::from_raw(conn as *mut Dbc));
-    }
-    Ok(())
-}
-
-fn remove_connection_from_env(conn: *mut Dbc) -> OdbcResult<()> {
-    let dbc = unsafe { &mut *conn };
-    let env = dbc.env()?;
-    let mut environment = env.environment.lock();
-    environment.connections.retain(|c| *c != conn);
     Ok(())
 }
 
@@ -204,13 +193,36 @@ pub fn free_connection(handle: sql::Handle) -> OdbcResult<()> {
     }
 
     tracing::info!("Freeing connection handle");
-    let dbc = handle as *mut Dbc;
-    let conn = unsafe { &*dbc };
-    if matches!(conn.connection.state, ConnectionState::Connected { .. }) {
+    let handle_id = HandleId::from(handle);
+    let delete_guard = global()
+        .context(OdbcRuntimeSnafu)?
+        .dbc_registry
+        .get_for_delete(handle_id)?;
+    let dbc = delete_guard.value();
+
+    if matches!(
+        dbc.connection.lock().state,
+        ConnectionState::Connected { .. }
+    ) {
         return ConnectionStillConnectedSnafu.fail();
     }
-    remove_connection_from_env(dbc)?;
-    cleanup_connection(dbc)
+
+    // Remove from parent env's connections list.
+    let env_id = dbc.env_id;
+    let env_guard = global()
+        .context(OdbcRuntimeSnafu)?
+        .env_registry
+        .get(env_id)?;
+    env_guard
+        .environment
+        .lock()
+        .connections
+        .retain(|id| *id != handle_id);
+    drop(env_guard);
+
+    cleanup_connection(dbc)?;
+    delete_guard.delete();
+    Ok(())
 }
 
 /// Free a statement handle
@@ -236,12 +248,12 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
     });
     if release_result.is_ok() {
         // Release succeeded — remove the bookkeeping entry and drop the Arc.
-        // Arc<Statement> doesn't implement DerefMut, so use conn_ptr() (takes &self via Arc::Deref)
-        // to get an independent &mut Connection.
-        unsafe { &mut *stmt.conn_ptr() }
-            .connection
-            .child_statements
-            .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
+        if let Ok(dbc) = stmt.conn() {
+            dbc.connection
+                .lock()
+                .child_statements
+                .retain(|(_, raw_ptr)| *raw_ptr != handle as *const Statement);
+        }
         drop(stmt);
     } else {
         // Release failed — forget the Arc so the raw pointer in child_statements stays valid
@@ -274,9 +286,9 @@ pub fn sql_alloc_handle(
                 "Allocating new dbc: SQLAllocHandle: handle_type={:?}",
                 handle_type
             );
-            let env = env_from_handle(input_handle)?;
-            let handle = alloc_connection(env)?;
-            unsafe { *output_handle = handle as sql::Handle };
+            let env_id = HandleId::from(input_handle);
+            let handle = alloc_connection(env_id)?;
+            unsafe { *output_handle = handle };
             Ok(())
         }
         sql::HandleType::Stmt => {

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
-use parking_lot::{ArcMutexGuard, Mutex, RawMutex, RwLock};
+use parking_lot::{ArcRwLockReadGuard, ArcRwLockWriteGuard, Mutex, RawRwLock, RwLock};
 
+use crate::api::OdbcResult;
 use crate::api::error::InvalidHandleSnafu;
-use crate::api::{Env, OdbcResult};
 use odbc_sys as sql;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -28,106 +26,111 @@ impl From<sql::Handle> for HandleId {
     }
 }
 
-pub struct RemovalGuard<T: Send + Sync + Clone> {
-    value: Option<T>,
-    guard: ArcMutexGuard<RawMutex, Option<T>>,
+struct AllocState {
+    free_ids: Vec<usize>,
+    next_id: usize,
 }
 
-impl<T: Send + Sync + Clone> RemovalGuard<T> {
-    pub fn complete(mut self) -> T {
-        self.value
-            .take()
-            .expect("complete called on already-completed RemovalGuard")
-    }
+pub struct HandleManager<T> {
+    slots: Mutex<Vec<Arc<RwLock<Option<T>>>>>,
+    alloc: Arc<Mutex<AllocState>>,
 }
 
-impl<T: Send + Sync + Clone> Drop for RemovalGuard<T> {
-    fn drop(&mut self) {
-        if let Some(value) = self.value.take() {
-            *self.guard = Some(value);
-        }
-    }
-}
-
-impl<T: Send + Sync + Clone> Deref for RemovalGuard<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        self.value
-            .as_ref()
-            .expect("deref on completed RemovalGuard")
-    }
-}
-
-// TODO Reclaim ids when handles are removed
-pub struct HandleRegistry<T: Send + Sync + Clone> {
-    handles: RwLock<HashMap<HandleId, Arc<Mutex<Option<T>>>>>,
-    next_id: AtomicUsize,
-}
-
-impl<T: Send + Sync + Clone> HandleRegistry<T> {
-    fn next_id(&self) -> HandleId {
-        HandleId {
-            id: self.next_id.fetch_add(1, Ordering::Relaxed),
-        }
-    }
-
+impl<T> HandleManager<T> {
     pub fn new() -> Self {
         Self {
-            handles: RwLock::new(HashMap::new()),
-            next_id: AtomicUsize::new(1),
+            slots: Mutex::new(Vec::new()),
+            alloc: Arc::new(Mutex::new(AllocState {
+                free_ids: Vec::new(),
+                next_id: 1,
+            })),
         }
     }
 
-    pub fn add(&self, handle: T) -> OdbcResult<HandleId> {
-        let mut handles = self.handles.write();
-        let id = self.next_id();
-        handles.insert(id, Arc::new(Mutex::new(Some(handle))));
-        Ok(id)
-    }
+    pub fn add(&self, value: T) -> OdbcResult<HandleId> {
+        let mut alloc = self.alloc.lock();
+        let id = alloc.free_ids.pop().unwrap_or_else(|| {
+            let id = alloc.next_id;
+            alloc.next_id += 1;
+            id
+        });
+        drop(alloc);
 
-    pub fn get(&self, id: HandleId) -> OdbcResult<T> {
-        let mutex = self
-            .handles
-            .read()
-            .get(&id)
-            .cloned()
-            .ok_or_else(|| InvalidHandleSnafu.build())?;
-        let value = mutex.lock();
-        value
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| InvalidHandleSnafu.build())
-    }
-
-    pub fn remove(&self, id: HandleId) -> OdbcResult<RemovalGuard<T>> {
-        let handle = self
-            .handles
-            .read()
-            .get(&id)
-            .cloned()
-            .ok_or_else(|| InvalidHandleSnafu.build())?;
-        let mut guard = handle.lock_arc();
-        let value_opt = guard.take();
-        if value_opt.is_some() {
-            return Ok(RemovalGuard {
-                value: value_opt,
-                guard,
-            });
+        let mut slots = self.slots.lock();
+        let idx = id - 1; // IDs are 1-based
+        if idx >= slots.len() {
+            slots.resize_with(idx + 1, || Arc::new(RwLock::new(None)));
         }
-        InvalidHandleSnafu.fail()
+        slots[idx] = Arc::new(RwLock::new(Some(value)));
+        Ok(HandleId { id })
     }
 
-    #[allow(dead_code)]
-    pub fn cleanup(&self, ids: &[HandleId]) -> OdbcResult<()> {
-        let mut handles = self.handles.write();
-        for id in ids {
-            handles.remove(id);
+    pub fn get(&self, id: HandleId) -> OdbcResult<HandleGuard<T>> {
+        let slot = {
+            let slots = self.slots.lock();
+            let idx = id.id.wrapping_sub(1);
+            slots
+                .get(idx)
+                .cloned()
+                .ok_or_else(|| InvalidHandleSnafu.build())?
+        };
+        let guard = slot.read_arc();
+        if guard.is_none() {
+            return Err(InvalidHandleSnafu.build());
         }
-        Ok(())
+        Ok(HandleGuard { guard })
+    }
+
+    pub fn get_for_delete(&self, id: HandleId) -> OdbcResult<DeleteGuard<T>> {
+        let slot = {
+            let slots = self.slots.lock();
+            let idx = id.id.wrapping_sub(1);
+            slots
+                .get(idx)
+                .cloned()
+                .ok_or_else(|| InvalidHandleSnafu.build())?
+        };
+        let guard = slot.write_arc();
+        if guard.is_none() {
+            return Err(InvalidHandleSnafu.build());
+        }
+        Ok(DeleteGuard {
+            guard,
+            id,
+            alloc: Arc::clone(&self.alloc),
+        })
     }
 }
 
-pub type EnvironmentHandleRegistry = HandleRegistry<Arc<Env>>;
+pub struct HandleGuard<T> {
+    guard: ArcRwLockReadGuard<RawRwLock, Option<T>>,
+}
+
+impl<T> Deref for HandleGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: Read lock guarantees no concurrent write can set this to None.
+        // Only get_for_delete (write lock) can set None, and our read lock prevents that.
+        self.guard.as_ref().unwrap()
+    }
+}
+
+pub struct DeleteGuard<T> {
+    guard: ArcRwLockWriteGuard<RawRwLock, Option<T>>,
+    id: HandleId,
+    alloc: Arc<Mutex<AllocState>>,
+}
+
+impl<T> DeleteGuard<T> {
+    pub fn value(&self) -> &T {
+        self.guard.as_ref().unwrap()
+    }
+
+    pub fn delete(mut self) {
+        *self.guard = None;
+        self.alloc.lock().free_ids.push(self.id.id);
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -142,30 +145,50 @@ mod tests {
     }
 
     #[test]
-    fn registry_add_get_remove() {
-        let registry: HandleRegistry<i32> = HandleRegistry::new();
-        let id = registry.add(42).unwrap();
-        assert_eq!(registry.get(id).unwrap(), 42);
-        assert_eq!(registry.remove(id).unwrap().complete(), 42);
-        assert!(registry.get(id).is_err());
+    fn manager_add_get() {
+        let mgr: HandleManager<i32> = HandleManager::new();
+        let id = mgr.add(42).unwrap();
+        assert_eq!(*mgr.get(id).unwrap(), 42);
     }
 
     #[test]
-    fn registry_cleanup() {
-        let registry: HandleRegistry<i32> = HandleRegistry::new();
-        let id1 = registry.add(1).unwrap();
-        let id2 = registry.add(2).unwrap();
-        let id3 = registry.add(3).unwrap();
-        registry.cleanup(&[id1, id3]).unwrap();
-        assert!(registry.get(id1).is_err());
-        assert_eq!(registry.get(id2).unwrap(), 2);
-        assert!(registry.get(id3).is_err());
+    fn manager_get_for_delete_and_delete() {
+        let mgr: HandleManager<i32> = HandleManager::new();
+        let id = mgr.add(42).unwrap();
+        let guard = mgr.get_for_delete(id).unwrap();
+        assert_eq!(*guard.value(), 42);
+        guard.delete();
+        assert!(mgr.get(id).is_err());
     }
 
     #[test]
-    fn registry_ids_start_at_one() {
-        let registry: HandleRegistry<i32> = HandleRegistry::new();
-        let id = registry.add(1).unwrap();
+    fn manager_delete_guard_drop_restores() {
+        let mgr: HandleManager<i32> = HandleManager::new();
+        let id = mgr.add(42).unwrap();
+        {
+            let _guard = mgr.get_for_delete(id).unwrap();
+            // drop without calling delete()
+        }
+        assert_eq!(*mgr.get(id).unwrap(), 42);
+    }
+
+    #[test]
+    fn manager_id_recycling() {
+        let mgr: HandleManager<i32> = HandleManager::new();
+        let id1 = mgr.add(1).unwrap();
+        let id2 = mgr.add(2).unwrap();
+        mgr.get_for_delete(id1).unwrap().delete();
+        // Next add should reuse id1's slot
+        let id3 = mgr.add(3).unwrap();
+        assert_eq!(id3, id1);
+        assert_eq!(*mgr.get(id3).unwrap(), 3);
+        assert_eq!(*mgr.get(id2).unwrap(), 2);
+    }
+
+    #[test]
+    fn manager_ids_start_at_one() {
+        let mgr: HandleManager<i32> = HandleManager::new();
+        let id = mgr.add(1).unwrap();
         assert_eq!(id, HandleId { id: 1 });
     }
 }

--- a/odbc/src/api/handle_registry.rs
+++ b/odbc/src/api/handle_registry.rs
@@ -61,7 +61,7 @@ impl<T> HandleManager<T> {
         if idx >= slots.len() {
             slots.resize_with(idx + 1, || Arc::new(RwLock::new(None)));
         }
-        slots[idx] = Arc::new(RwLock::new(Some(value)));
+        *slots[idx].write() = Some(value);
         Ok(HandleId { id })
     }
 

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -6,7 +6,7 @@ use sf_core::protobuf::apis::database_driver_v1::{
 };
 use snafu::{Location, ResultExt, Snafu};
 
-use crate::api::handle_registry::EnvironmentHandleRegistry;
+use crate::api::handle_registry::HandleManager;
 
 /// Holds the shared tokio runtime and driver client used by all ODBC
 /// environments in this process.
@@ -22,7 +22,8 @@ use crate::api::handle_registry::EnvironmentHandleRegistry;
 pub struct OdbcGlobals {
     runtime: tokio::runtime::Runtime,
     client: DatabaseDriverClient,
-    pub env_registry: EnvironmentHandleRegistry,
+    pub env_registry: HandleManager<crate::api::Env>,
+    pub dbc_registry: HandleManager<crate::api::Dbc>,
 }
 
 impl OdbcGlobals {
@@ -99,7 +100,8 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
         guard.globals = Some(OdbcGlobals {
             runtime,
             client,
-            env_registry: EnvironmentHandleRegistry::new(),
+            env_registry: HandleManager::new(),
+            dbc_registry: HandleManager::new(),
         });
     }
     guard.env_count += 1;

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -75,13 +75,10 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     }
 
     // Validate connection before committing to NeedData state.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    match &mut dbc.connection.state {
-        ConnectionState::Disconnected => {
-            tracing::error!("exec_direct: connection is disconnected");
-            return DisconnectedSnafu.fail();
-        }
-        ConnectionState::Connected { .. } => {}
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("exec_direct: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
 
     // exec-direct supersedes any prior SQLPrepare on this handle; clear the
@@ -113,48 +110,46 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         return DaeRequiredSnafu.fail();
     }
 
-    // Re-borrow connection for execution.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let (bindings, _json_owner) =
-                apply_parameter_bindings(&stmt.apd, &stmt.ipd, false, None)?;
-            let stmt_handle = stmt.stmt_handle;
-
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
-            // _cancel_token.cancelled() to support cross-thread SQLCancel.
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: statement_text.to_string(),
-                })
-                .await?;
-
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                })
-                .await
-            });
-
-            tracing::info!("exec_direct: response={:?}", response);
-            let response = response?;
-
-            update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
-            apply_execute_response(stmt, response, ExecutionOrigin::Direct)?;
-            Ok(())
+    // Get conn_handle for execution under lock, then release before async call.
+    let conn_handle = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+            ConnectionState::Disconnected => {
+                tracing::error!("exec_direct: connection is disconnected");
+                return DisconnectedSnafu.fail();
+            }
         }
-        ConnectionState::Disconnected => {
-            tracing::error!("exec_direct: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
-    }
+    };
+    let (bindings, _json_owner) = apply_parameter_bindings(&stmt.apd, &stmt.ipd, false, None)?;
+    let stmt_handle = stmt.stmt_handle;
+
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
+    // _cancel_token.cancelled() to support cross-thread SQLCancel.
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: statement_text.to_string(),
+        })
+        .await?;
+
+        c.statement_execute_query(StatementExecuteQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            bindings,
+        })
+        .await
+    });
+
+    tracing::info!("exec_direct: response={:?}", response);
+    let response = response?;
+
+    let mut settings = dbc.connection.lock().numeric_settings;
+    update_numeric_settings(&conn_handle, &mut settings)?;
+    dbc.connection.lock().numeric_settings = settings;
+    apply_execute_response(stmt, response, ExecutionOrigin::Direct)?;
+    Ok(())
 }
 
 use crate::conversion::NumericSettings;
@@ -244,77 +239,68 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
         return CursorAlreadyOpenSnafu.fail();
     }
 
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let connection = &mut dbc.connection;
-    match &mut connection.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle: _,
-        } => {
-            tracing::debug!("prepare: query = {query}");
-
-            let stmt_handle = stmt.stmt_handle;
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wire _cancel_token into tokio::select!
-            // alongside the RPC future to support cancellation.
-            let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: query.to_string(),
-                })
-                .await?;
-
-                c.statement_prepare(StatementPrepareRequest {
-                    stmt_handle: Some(stmt_handle),
-                })
-                .await
-            })?;
-
-            let result = prepare_result.result.required("Result is required")?;
-            let stream_ptr = result.stream.required("Stream is required")?;
-            let reader = reader_from_protobuf_stream(stream_ptr)?;
-            let schema = reader.schema();
-            stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
-
-            if result.number_of_binds < 0 {
-                tracing::warn!(
-                    "prepare: server reported negative bind count ({}), treating as 0",
-                    result.number_of_binds
-                );
-            }
-            let raw_bind_count = result.number_of_binds.max(0);
-            let param_count = u16::try_from(raw_bind_count).map_err(|_| {
-                crate::api::error::CountFieldIncorrectSnafu {
-                    reason: format!(
-                        "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
-                        u16::MAX
-                    ),
-                }
-                .build()
-            })?;
-            stmt.prepared_param_count = Some(param_count);
-            let max_varchar = connection.numeric_settings.max_varchar_size;
-            stmt.ipd.records.retain(|&k, _| k <= param_count);
-            for i in 1..=param_count {
-                stmt.ipd
-                    .records
-                    .entry(i)
-                    .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
-            }
-            tracing::info!(
-                "prepare: auto-IPD populated {param_count} parameter markers (from server)"
-            );
-
-            stmt.state.set(StatementState::Prepared { schema });
-            tracing::info!("prepare: Successfully prepared statement");
-            Ok(())
-        }
-        ConnectionState::Disconnected => {
-            tracing::error!("prepare: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("prepare: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
+
+    tracing::debug!("prepare: query = {query}");
+
+    let stmt_handle = stmt.stmt_handle;
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wire _cancel_token into tokio::select!
+    // alongside the RPC future to support cancellation.
+    let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_set_sql_query(StatementSetSqlQueryRequest {
+            stmt_handle: Some(stmt_handle),
+            query: query.to_string(),
+        })
+        .await?;
+
+        c.statement_prepare(StatementPrepareRequest {
+            stmt_handle: Some(stmt_handle),
+        })
+        .await
+    })?;
+
+    let result = prepare_result.result.required("Result is required")?;
+    let stream_ptr = result.stream.required("Stream is required")?;
+    let reader = reader_from_protobuf_stream(stream_ptr)?;
+    let schema = reader.schema();
+    stmt.ird.desc_count = schema.fields().len() as sql::SmallInt;
+
+    if result.number_of_binds < 0 {
+        tracing::warn!(
+            "prepare: server reported negative bind count ({}), treating as 0",
+            result.number_of_binds
+        );
+    }
+    let raw_bind_count = result.number_of_binds.max(0);
+    let param_count = u16::try_from(raw_bind_count).map_err(|_| {
+        crate::api::error::CountFieldIncorrectSnafu {
+            reason: format!(
+                "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
+                u16::MAX
+            ),
+        }
+        .build()
+    })?;
+    stmt.prepared_param_count = Some(param_count);
+    let max_varchar = dbc.connection.lock().numeric_settings.max_varchar_size;
+    stmt.ipd.records.retain(|&k, _| k <= param_count);
+    for i in 1..=param_count {
+        stmt.ipd
+            .records
+            .entry(i)
+            .or_insert_with(|| IpdRecord::with_varchar_size(max_varchar));
+    }
+    tracing::info!("prepare: auto-IPD populated {param_count} parameter markers (from server)");
+
+    stmt.state.set(StatementState::Prepared { schema });
+    tracing::info!("prepare: Successfully prepared statement");
+    Ok(())
 }
 
 /// Execute a prepared statement
@@ -343,14 +329,10 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let is_prepared = origin.is_prepared();
 
     // Validate connection before committing to NeedData state.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Disconnected => {
-            tracing::error!("execute: connection is disconnected");
-            return DisconnectedSnafu.fail();
-        }
-        ConnectionState::Connected { .. } => {}
+    let dbc = stmt.conn()?;
+    if matches!(dbc.connection.lock().state, ConnectionState::Disconnected) {
+        tracing::error!("execute: connection is disconnected");
+        return DisconnectedSnafu.fail();
     }
 
     let dae_params = find_dae_params(&stmt.apd, stmt.prepared_param_count);
@@ -372,43 +354,38 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         return DaeRequiredSnafu.fail();
     }
 
-    // Re-borrow connection for execution.
-    let dbc = unsafe { &mut *stmt.conn_ptr() };
-    let conn = &mut dbc.connection;
-    match &mut conn.state {
-        ConnectionState::Connected {
-            db_handle: _,
-            conn_handle,
-        } => {
-            let (bindings, _json_owner) = apply_parameter_bindings(
-                &stmt.apd,
-                &stmt.ipd,
-                is_prepared,
-                stmt.prepared_param_count,
-            )?;
-
-            stmt.cancel_token = CancellationToken::new();
-            let _cancel_token = stmt.cancel_token.clone();
-            // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
-            // _cancel_token.cancelled() to support cross-thread SQLCancel.
-            let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt.stmt_handle),
-                    bindings,
-                })
-                .await
-            })?;
-
-            tracing::info!("execute: Successfully executed statement");
-            update_numeric_settings(conn_handle, &mut conn.numeric_settings)?;
-            apply_execute_response(stmt, response, origin)?;
-            Ok(())
+    // Get conn_handle for execution under lock, then release before async call.
+    let conn_handle = {
+        let connection = dbc.connection.lock();
+        match &connection.state {
+            ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+            ConnectionState::Disconnected => {
+                tracing::error!("execute: connection is disconnected");
+                return DisconnectedSnafu.fail();
+            }
         }
-        ConnectionState::Disconnected => {
-            tracing::error!("execute: connection is disconnected");
-            DisconnectedSnafu.fail()
-        }
-    }
+    };
+    let (bindings, _json_owner) =
+        apply_parameter_bindings(&stmt.apd, &stmt.ipd, is_prepared, stmt.prepared_param_count)?;
+
+    stmt.cancel_token = CancellationToken::new();
+    let _cancel_token = stmt.cancel_token.clone();
+    // TODO(SNOW-3258922): Wrap RPC in tokio::select! with
+    // _cancel_token.cancelled() to support cross-thread SQLCancel.
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.statement_execute_query(StatementExecuteQueryRequest {
+            stmt_handle: Some(stmt.stmt_handle),
+            bindings,
+        })
+        .await
+    })?;
+
+    tracing::info!("execute: Successfully executed statement");
+    let mut settings = dbc.connection.lock().numeric_settings;
+    update_numeric_settings(&conn_handle, &mut settings)?;
+    dbc.connection.lock().numeric_settings = settings;
+    apply_execute_response(stmt, response, origin)?;
+    Ok(())
 }
 
 fn set_state(stmt: &mut Statement, state: StatementState) {

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1,8 +1,6 @@
 use crate::api::bitmask::Bitmask;
-use crate::api::error::{
-    ConnectionHasNoEnvironmentSnafu, InvalidDescriptorKindSnafu, OdbcRuntimeSnafu,
-};
-use crate::api::handle_registry::HandleId;
+use crate::api::error::{InvalidDescriptorKindSnafu, OdbcRuntimeSnafu};
+use crate::api::handle_registry::{HandleGuard, HandleId};
 use crate::api::runtime::global;
 use crate::api::{OdbcError, diagnostic::DiagnosticInfo};
 use crate::conversion::Binding;
@@ -15,7 +13,7 @@ use sf_core::protobuf::generated::database_driver_v1::{
 };
 use snafu::ResultExt;
 use std::collections::HashMap;
-use std::sync::{Arc, Weak};
+use std::sync::Weak;
 
 use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -895,7 +893,7 @@ pub struct Environment {
     pub connection_pooling: sql::AttrConnectionPooling,
     pub connection_pool_match: sql::AttrCpMatch,
     pub diagnostic_info: DiagnosticInfo,
-    pub connections: Vec<*mut Dbc>,
+    pub connections: Vec<HandleId>,
 }
 
 pub enum ConnectionState {
@@ -912,16 +910,8 @@ pub enum ConnectionState {
 pub type PreConnectionAttributes = HashMap<ConnectionAttribute, String>;
 
 pub struct Dbc {
-    pub connection: Connection,
-    pub env: Weak<Env>,
-}
-
-impl Dbc {
-    pub fn env(&self) -> Result<Arc<Env>, OdbcError> {
-        self.env
-            .upgrade()
-            .ok_or(ConnectionHasNoEnvironmentSnafu.build())
-    }
+    pub connection: Mutex<Connection>,
+    pub env_id: HandleId,
 }
 
 pub struct Connection {
@@ -955,13 +945,11 @@ pub struct Connection {
     pub metadata_id: bool,
 }
 
-// Safety: Send is required so that the async runtime can transfer ownership of the
-// Connection allocation between threads (e.g. when a Tokio task completes on a
-// different thread than it started). All ODBC API access remains serialised on the
-// single caller thread — the raw-pointer DBC handle is never shared across threads.
-// `*const Statement` inside `child_statements` is `!Send`, but Connection is never
-// accessed concurrently, so this is safe.
+// Safety: `*const Statement` inside `child_statements` is `!Send` and `!Sync`, but access to
+// Connection is always serialised through the Mutex<Connection> in Dbc, and ODBC
+// guarantees that a single connection handle is only used from one thread at a time.
 unsafe impl Send for Connection {}
+unsafe impl Sync for Connection {}
 
 /// Application Parameter Descriptor (APD) record.
 ///
@@ -1245,9 +1233,8 @@ impl GetDataState {
 }
 
 pub struct Statement {
-    /// Raw pointer to the owning connection. Valid for the entire lifetime of this Statement
-    /// (the connection always outlives its statements). Access via `conn()` / `conn_ptr()`.
-    conn: *mut Dbc,
+    /// ID of the parent connection handle. Looked up via the global dbc_registry.
+    conn_id: HandleId,
     pub stmt_handle: StatementHandle,
     pub state: State<StatementState>,
     pub ard: ArdDescriptor,
@@ -1284,21 +1271,16 @@ pub struct Statement {
     pub cancel_token: CancellationToken,
 }
 
-/// Safety: Statement is always accessed on the single ODBC thread that holds the handle.
-// The conn raw pointer is valid for the Statement's lifetime (Connection outlives Statement).
-// `Send` allows moving the allocation across threads (e.g. when the runtime hands the raw
-// Arc pointer back on an arbitrary thread). `Sync` is NOT implemented: sharing `&Statement`
-// across threads is unsound because `conn` is a `*mut Connection` with no synchronisation.
-// Connection itself uses `unsafe impl Send` to suppress auto-trait checks on the
-// `Vec<(Weak<Statement>, *const Statement)>` field, so `Statement: Sync` is not required
-// for `Connection: Send`.
+// Safety: `Send` allows moving the Statement allocation across threads when the Arc is
+// handed back on an arbitrary thread.
 unsafe impl Send for Statement {}
+unsafe impl Sync for Statement {}
 
 impl Statement {
     /// Construct a new Statement for the given connection.
-    pub fn new(conn: *mut Dbc, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
+    pub fn new(conn_id: HandleId, stmt_handle: StatementHandle, metadata_id: bool) -> Self {
         Self {
-            conn,
+            conn_id,
             stmt_handle,
             state: StatementState::Created.into(),
             ard: ArdDescriptor::new(),
@@ -1319,49 +1301,32 @@ impl Statement {
         }
     }
 
-    /// Borrow the owning connection.
+    /// Look up the parent connection via the global dbc_registry.
     ///
-    /// # Safety
-    /// The caller must ensure the Connection outlives this borrow and no other
-    /// mutable reference to the Connection exists simultaneously.
-    pub unsafe fn conn(&self) -> &Dbc {
-        debug_assert!(
-            !self.conn.is_null(),
-            "Statement::conn: connection pointer is null"
-        );
-        unsafe { &*self.conn }
-    }
-
-    /// Return the raw connection pointer without creating a Rust borrow on `self`.
-    ///
-    /// Use this when you need both a `&mut Connection` and access to other
-    /// `Statement` fields in the same scope — the raw pointer carries no borrow
-    /// on `self`, so the borrow checker treats the resulting `&mut Connection`
-    /// as independent.
-    ///
-    /// # Safety
-    /// The caller must ensure that no live `conn()` borrow (or any other `&Connection`
-    /// derived from this statement) exists while the returned pointer is dereferenced
-    /// mutably. Having both an active `&Connection` and a `&mut Connection` pointing
-    /// to the same allocation is undefined behaviour.
-    pub(crate) unsafe fn conn_ptr(&self) -> *mut Dbc {
-        self.conn
+    /// Returns an error if the parent connection has already been freed.
+    pub fn conn(&self) -> OdbcResult<HandleGuard<Dbc>> {
+        global()
+            .context(OdbcRuntimeSnafu)?
+            .dbc_registry
+            .get(self.conn_id)
     }
 }
 
 // Helper functions for handle conversion
-pub fn env_from_handle(handle: sql::Handle) -> OdbcResult<Arc<Env>> {
+pub fn env_from_handle(handle: sql::Handle) -> OdbcResult<HandleGuard<Env>> {
     let handle_id = HandleId::from(handle);
-    let env = global()
+    global()
         .context(OdbcRuntimeSnafu)?
         .env_registry
-        .get(handle_id)?;
-    Ok(env)
+        .get(handle_id)
 }
 
-pub fn conn_from_handle<'a>(handle: sql::Handle) -> &'a mut Dbc {
-    let conn_ptr = handle as *mut Dbc;
-    unsafe { conn_ptr.as_mut().unwrap() }
+pub fn conn_from_handle(handle: sql::Handle) -> OdbcResult<HandleGuard<Dbc>> {
+    let handle_id = HandleId::from(handle);
+    global()
+        .context(OdbcRuntimeSnafu)?
+        .dbc_registry
+        .get(handle_id)
 }
 
 pub fn stmt_from_handle<'a>(handle: sql::Handle) -> &'a mut Statement {

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -945,11 +945,10 @@ pub struct Connection {
     pub metadata_id: bool,
 }
 
-// Safety: `*const Statement` inside `child_statements` is `!Send` and `!Sync`, but access to
-// Connection is always serialised through the Mutex<Connection> in Dbc, and ODBC
-// guarantees that a single connection handle is only used from one thread at a time.
+// Safety: `*const Statement` inside `child_statements` is `!Send`, but access to Connection
+// is always serialised through the Mutex<Connection> in Dbc, and ODBC guarantees that a
+// single connection handle is only used from one thread at a time.
 unsafe impl Send for Connection {}
-unsafe impl Sync for Connection {}
 
 /// Application Parameter Descriptor (APD) record.
 ///

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -146,11 +146,9 @@ pub fn col_attribute<E: OdbcEncoding>(
 
     match desc_field {
         DescField::Type | DescField::ConciseType => {
-            // SAFETY: conn pointer is valid for the statement's lifetime;
-            // no mutable reference to the Connection exists in this scope.
-            let sql_type =
-                sql_type_from_field(field, &unsafe { stmt.conn() }.connection.numeric_settings)
-                    .context(ConversionSnafu)?;
+            let dbc = stmt.conn()?;
+            let settings = dbc.connection.lock().numeric_settings;
+            let sql_type = sql_type_from_field(field, &settings).context(ConversionSnafu)?;
             if !numeric_attribute_ptr.is_null() {
                 unsafe {
                     std::ptr::write(numeric_attribute_ptr, sql_type.0 as sql::Len);
@@ -250,10 +248,8 @@ pub fn describe_col<E: OdbcEncoding>(
     }
 
     let field = schema.field(col_idx);
-    // SAFETY: conn pointer is valid for the statement's lifetime;
-    // no mutable reference to the Connection exists in this scope.
-    let dbc = unsafe { stmt.conn() };
-    let numeric_settings = &dbc.connection.numeric_settings;
+    let dbc = stmt.conn()?;
+    let numeric_settings = dbc.connection.lock().numeric_settings;
 
     let name = field.name();
     write_string_chars::<E>(
@@ -265,17 +261,18 @@ pub fn describe_col<E: OdbcEncoding>(
     );
 
     if !data_type_ptr.is_null() {
-        let sql_type = sql_type_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let sql_type = sql_type_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(data_type_ptr, sql_type.0 as sql::SmallInt) };
     }
 
     if !column_size_ptr.is_null() {
-        let col_size = column_size_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let col_size = column_size_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(column_size_ptr, col_size) };
     }
 
     if !decimal_digits_ptr.is_null() {
-        let digits = decimal_digits_from_field(field, numeric_settings).context(ConversionSnafu)?;
+        let digits =
+            decimal_digits_from_field(field, &numeric_settings).context(ConversionSnafu)?;
         unsafe { std::ptr::write(decimal_digits_ptr, digits) };
     }
 

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1591,7 +1591,7 @@ pub enum RestError {
 }
 #[derive(Debug, Snafu, error_trace::ErrorTrace)]
 pub enum SnowflakeResponseError {
-    #[snafu(display("Failed to parse Snowflake response"))]
+    #[snafu(display("Failed to parse Snowflake response {source}"))]
     ResponseFormat {
         source: serde_json::Error,
         #[snafu(implicit)]


### PR DESCRIPTION
## Summary

- Replaces `HandleRegistry<T>` with `HandleManager<T>` using a two-guard model: `HandleGuard<T>` (read, multiple concurrent) and `DeleteGuard<T>` (write, exclusive with rollback-on-drop)
- Migrates Env and Dbc handles to new ownership model — `HandleManager` owns handles directly (no more `Arc<Env>` / `Weak<Dbc>`)
- `Dbc.env` changed from `Weak<Env>` to `env_id: HandleId`; `Environment.connections` changed from `Vec<Arc<Dbc>>` to `Vec<HandleId>`
- Wraps `Connection` in `Mutex<Connection>` inside `Dbc`, eliminating all `unsafe { &mut *(Arc::as_ptr(&dbc) as *mut Dbc) }` patterns
- Adds temporary `unsafe impl Sync` for `Connection` and `Statement` (removed in follow-up PRs via interior mutability)

## Context

This is PR 1 of 4 implementing the new handle management design. Follow-up PRs:
- **PR 2** — Migrate statements to HandleManager
- **PR 3** — SQLCancel with active_cancel  
- **PR 4** — Descriptor handle lookup
- **PRs 5-7** — Remove unsafe Send/Sync (Statement → Connection → Environment)

Builds on top of #910 (env handle migration).

## Files changed

| File | Change |
|---|---|
| `handle_registry.rs` | Full rewrite: `HandleManager<T>`, `HandleGuard<T>`, `DeleteGuard<T>` with ID recycling via crossbeam channel |
| `odbc_types.rs` | `Dbc.env` → `env_id: HandleId`, `Connection` in `Mutex`, guard-based `conn_from_handle`/`env_from_handle` |
| `handle_allocation.rs` | Rewritten alloc/free for Env and Dbc using HandleManager |
| `connection.rs` | All connection access via `dbc.connection.lock()` |
| `statement.rs` | `stmt.conn()?` returns `HandleGuard<Dbc>` |
| `diagnostic.rs` | Separate Dbc diagnostic path using lock |
| `runtime.rs` | `OdbcGlobals` uses `HandleManager<Env>`, `HandleManager<Dbc>` |
| `utils.rs` | Connection access via lock for numeric settings |

## Test plan

- [x] All 1025 unit tests pass
- [ ] CI passes (clippy, fmt, cargo check)
- [ ] E2E tests pass