### PR TITLE
SNOW-3441376: Add Core Windows x86_32 support

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -394,8 +394,93 @@ jobs:
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
+  test_windows_x86:
+    needs: detect-changes
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
+    runs-on: windows-latest
+    name: test (Windows x86)
+    env:
+      E2E_TLS_SERVER: https://snowflakecomputing.com
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Add i686 target
+        run: rustup target add i686-pc-windows-msvc
+
+      - name: Restore Rust cache
+        id: rust-cache
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: "x86-core-test"
+
+      - name: Setup MSVC x86 environment
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          if not "%VSCMD_ARG_TGT_ARCH%"=="x86" (
+            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'x86'
+            exit /b 1
+          )
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Build sf_core (x86)
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+          :: Verify the DLL is 32-bit (machine type 14C = x86)
+          dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "14C" >nul
+          if %ERRORLEVEL% neq 0 (
+            echo ERROR: sf_core.dll is not x86
+            dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "machine"
+            exit /b 1
+          )
+
+      - name: Run sf_core tests (x86)
+        id: run_rust_tests_x86
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
+
+      - name: Rerun tests (Windows x86)
+        if: steps.run_rust_tests_x86.outcome == 'failure' && github.event_name == 'merge_group'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
+
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_test_pats.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
+      - name: Save Rust cache
+        if: always()
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: save
+          shared-key: "x86-core-test"
+          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
   rust-core-status:
-    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips]
+    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -415,13 +500,15 @@ jobs:
              [[ "${{ needs.clippy.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.build-without-protobuf.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.test_windows_arm64_nonfips.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.test_windows_arm64_nonfips.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test_windows_x86.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Rust Core tests were RUN and FAILED or CANCELLED"
             echo "  - format: ${{ needs.format.result }}"
             echo "  - clippy: ${{ needs.clippy.result }}"
             echo "  - build-without-protobuf: ${{ needs.build-without-protobuf.result }}"
             echo "  - test: ${{ needs.test.result }}"
             echo "  - test_windows_arm64_nonfips: ${{ needs.test_windows_arm64_nonfips.result }}"
+            echo "  - test_windows_x86: ${{ needs.test_windows_x86.result }}"
             exit 1
           fi
           

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -415,27 +415,23 @@ jobs:
           mode: restore
           shared-key: "x86-core-test"
 
-      - name: Setup MSVC x86 environment
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-          if not "%VSCMD_ARG_TGT_ARCH%"=="x86" (
-            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'x86'
-            exit /b 1
-          )
-
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh
         env:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
-      - name: Build sf_core (x86)
+      - name: Build and test
+        id: run_rust_tests_x86
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+
           cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
           :: Verify the DLL is 32-bit (machine type 14C = x86)
           dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "14C" >nul
           if %ERRORLEVEL% neq 0 (
@@ -444,13 +440,6 @@ jobs:
             exit /b 1
           )
 
-      - name: Run sf_core tests (x86)
-        id: run_rust_tests_x86
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
 
       - name: Rerun tests (Windows x86)

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -1330,25 +1330,7 @@ pub unsafe extern "system" fn DllMain(
 mod setup {
     use std::ptr;
 
-    #[cfg_attr(
-        target_arch = "x86",
-        link(
-            name = "odbccp32",
-            kind = "raw-dylib",
-            import_name_type = "undecorated"
-        )
-    )]
-    #[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
-    unsafe extern "system" {
-        fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> i32;
-        fn SQLRemoveDSNFromIniW(lpszDSN: *const u16) -> i32;
-        fn SQLWritePrivateProfileStringW(
-            lpszSection: *const u16,
-            lpszEntry: *const u16,
-            lpszString: *const u16,
-            lpszFilename: *const u16,
-        ) -> i32;
-    }
+    use crate::setup_common::{self, SQLRemoveDSNFromIniW, to_wide};
 
     #[link(name = "kernel32")]
     unsafe extern "system" {
@@ -1366,10 +1348,6 @@ mod setup {
     const ODBC_ADD_DSN: u16 = 1;
     const ODBC_CONFIG_DSN: u16 = 2;
     const ODBC_REMOVE_DSN: u16 = 3;
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        s.encode_utf16().chain(std::iter::once(0)).collect()
-    }
 
     /// Convert a Windows ANSI code page byte slice to a Rust String.
     unsafe fn acp_to_string(bytes: &[u8]) -> String {
@@ -1463,35 +1441,6 @@ mod setup {
             .map(|(_, v)| v.as_str())
     }
 
-    unsafe fn write_dsn_silent(dsn: &str, driver: &str, attrs: &[(String, String)]) -> bool {
-        let dsn_w = to_wide(dsn);
-        let driver_w = to_wide(driver);
-        if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
-            return false;
-        }
-        let odbc_ini = to_wide("odbc.ini");
-        let mut ok = true;
-        for (key, value) in attrs {
-            if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
-                continue;
-            }
-            let key_w = to_wide(key);
-            let val_w = to_wide(value);
-            if unsafe {
-                SQLWritePrivateProfileStringW(
-                    dsn_w.as_ptr(),
-                    key_w.as_ptr(),
-                    val_w.as_ptr(),
-                    odbc_ini.as_ptr(),
-                )
-            } == 0
-            {
-                ok = false;
-            }
-        }
-        ok
-    }
-
     unsafe fn config_dsn_impl(
         hwnd_parent: *mut core::ffi::c_void,
         f_request: u16,
@@ -1510,8 +1459,6 @@ mod setup {
                 let dsn = find_dsn(attrs).unwrap_or("");
                 let is_add = f_request == ODBC_ADD_DSN;
 
-                // Show dialog when a parent window is provided (ODBC Administrator).
-                // Fall back to silent mode for programmatic DSN creation (null hwnd).
                 if !hwnd_parent.is_null() {
                     unsafe {
                         crate::setup_dialog::show_config_dialog(
@@ -1523,7 +1470,7 @@ mod setup {
                         )
                     }
                 } else if !dsn.is_empty() {
-                    unsafe { write_dsn_silent(dsn, driver, attrs) }
+                    unsafe { setup_common::write_dsn_values(dsn, driver, attrs) }
                 } else {
                     false
                 }

--- a/odbc/src/lib.rs
+++ b/odbc/src/lib.rs
@@ -4,6 +4,8 @@ mod api;
 pub mod c_api;
 mod conversion;
 #[cfg(target_os = "windows")]
+mod setup_common;
+#[cfg(target_os = "windows")]
 mod setup_dialog;
 
 extern crate sf_core;

--- a/odbc/src/setup_common.rs
+++ b/odbc/src/setup_common.rs
@@ -1,0 +1,117 @@
+//! Shared helpers for the ODBC Setup/Config entrypoints (`c_api::setup`)
+//! and the interactive dialog (`setup_dialog`).
+//!
+//! Everything here talks to `odbccp32.dll` (the ODBC Installer API) and
+//! performs DSN registry reads/writes.
+
+#![cfg(target_os = "windows")]
+
+// ---------------------------------------------------------------------------
+// odbccp32.dll — ODBC Installer API (raw-dylib, no import lib needed)
+// ---------------------------------------------------------------------------
+#[cfg_attr(
+    target_arch = "x86",
+    link(
+        name = "odbccp32",
+        kind = "raw-dylib",
+        import_name_type = "undecorated"
+    )
+)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
+unsafe extern "system" {
+    pub(crate) fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> i32;
+    pub(crate) fn SQLRemoveDSNFromIniW(lpszDSN: *const u16) -> i32;
+    pub(crate) fn SQLWritePrivateProfileStringW(
+        lpszSection: *const u16,
+        lpszEntry: *const u16,
+        lpszString: *const u16,
+        lpszFilename: *const u16,
+    ) -> i32;
+    pub(crate) fn SQLGetPrivateProfileStringW(
+        lpszSection: *const u16,
+        lpszEntry: *const u16,
+        lpszDefault: *const u16,
+        lpszRetBuffer: *mut u16,
+        cchRetBuffer: i32,
+        lpszFilename: *const u16,
+    ) -> i32;
+    pub(crate) fn SQLValidDSNW(lpszDSN: *const u16) -> i32;
+}
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+pub(crate) fn from_wide(p: &[u16]) -> String {
+    let len = p.iter().position(|&c| c == 0).unwrap_or(p.len());
+    String::from_utf16_lossy(&p[..len])
+}
+
+// ---------------------------------------------------------------------------
+// DSN registry read/write
+// ---------------------------------------------------------------------------
+
+pub(crate) unsafe fn read_dsn_value(dsn: &str, key: &str) -> String {
+    let dsn_w = to_wide(dsn);
+    let key_w = to_wide(key);
+    let default_w = to_wide("");
+    let filename_w = to_wide("odbc.ini");
+    let mut buf = vec![0u16; 512];
+    loop {
+        let copied = unsafe {
+            SQLGetPrivateProfileStringW(
+                dsn_w.as_ptr(),
+                key_w.as_ptr(),
+                default_w.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as i32,
+                filename_w.as_ptr(),
+            )
+        } as usize;
+        if copied < buf.len().saturating_sub(1) {
+            return from_wide(&buf[..copied]);
+        }
+        buf.resize(buf.len() * 2, 0);
+    }
+}
+
+/// Write a DSN and its key/value fields to the ODBC registry.
+///
+/// Skips `DSN` and `PWD` keys (DSN is implicit in the section name;
+/// PWD must never be persisted).  Returns `false` if any write fails.
+pub(crate) unsafe fn write_dsn_values(
+    dsn: &str,
+    driver: &str,
+    fields: &[(String, String)],
+) -> bool {
+    let dsn_w = to_wide(dsn);
+    let driver_w = to_wide(driver);
+    if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
+        return false;
+    }
+    let odbc_ini = to_wide("odbc.ini");
+    let mut ok = true;
+    for (key, value) in fields {
+        if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
+            continue;
+        }
+        let key_w = to_wide(key);
+        let val_w = to_wide(value);
+        if unsafe {
+            SQLWritePrivateProfileStringW(
+                dsn_w.as_ptr(),
+                key_w.as_ptr(),
+                val_w.as_ptr(),
+                odbc_ini.as_ptr(),
+            )
+        } == 0
+        {
+            ok = false;
+        }
+    }
+    ok
+}

--- a/odbc/src/setup_dialog.rs
+++ b/odbc/src/setup_dialog.rs
@@ -10,6 +10,9 @@ use std::ptr;
 use std::sync::atomic::Ordering;
 
 use crate::c_api::DLL_HINSTANCE;
+use crate::setup_common::{
+    self, SQLValidDSNW, from_wide, read_dsn_value, to_wide, write_dsn_values,
+};
 
 // ---------------------------------------------------------------------------
 // Win32 FFI
@@ -78,36 +81,6 @@ unsafe extern "system" {
     fn MoveWindow(hWnd: HWND, X: i32, Y: i32, nWidth: i32, nHeight: i32, bRepaint: BOOL) -> BOOL;
     fn SetCursor(hCursor: *mut core::ffi::c_void) -> *mut core::ffi::c_void;
     fn LoadCursorW(hInstance: HINSTANCE, lpCursorName: *const u16) -> *mut core::ffi::c_void;
-}
-
-// odbccp32.dll (ODBC Installer API) — linked via raw-dylib so the linker
-// generates thin import stubs without requiring an import library.
-#[cfg_attr(
-    target_arch = "x86",
-    link(
-        name = "odbccp32",
-        kind = "raw-dylib",
-        import_name_type = "undecorated"
-    )
-)]
-#[cfg_attr(not(target_arch = "x86"), link(name = "odbccp32", kind = "raw-dylib"))]
-unsafe extern "system" {
-    fn SQLGetPrivateProfileStringW(
-        lpszSection: *const u16,
-        lpszEntry: *const u16,
-        lpszDefault: *const u16,
-        lpszRetBuffer: *mut u16,
-        cchRetBuffer: i32,
-        lpszFilename: *const u16,
-    ) -> i32;
-    fn SQLWriteDSNToIniW(lpszDSN: *const u16, lpszDriver: *const u16) -> BOOL;
-    fn SQLWritePrivateProfileStringW(
-        lpszSection: *const u16,
-        lpszEntry: *const u16,
-        lpszString: *const u16,
-        lpszFilename: *const u16,
-    ) -> BOOL;
-    fn SQLValidDSNW(lpszDSN: *const u16) -> BOOL;
 }
 
 // odbc32.dll (ODBC Driver Manager) is loaded dynamically to avoid putting it
@@ -250,15 +223,6 @@ const FIELD_MAP: &[(i32, &str)] = &[
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn to_wide(s: &str) -> Vec<u16> {
-    s.encode_utf16().chain(std::iter::once(0)).collect()
-}
-
-fn from_wide(p: &[u16]) -> String {
-    let len = p.iter().position(|&c| c == 0).unwrap_or(p.len());
-    String::from_utf16_lossy(&p[..len])
-}
-
 #[inline]
 fn loword(v: usize) -> u16 {
     v as u16
@@ -343,59 +307,6 @@ fn sql_succeeded(rc: i16) -> bool {
 // ---------------------------------------------------------------------------
 // DSN registry read/write via ODBC installer API
 // ---------------------------------------------------------------------------
-
-unsafe fn read_dsn_value(dsn: &str, key: &str) -> String {
-    let dsn_w = to_wide(dsn);
-    let key_w = to_wide(key);
-    let default_w = to_wide("");
-    let filename_w = to_wide("odbc.ini");
-    let mut buf = vec![0u16; 512];
-    loop {
-        let copied = unsafe {
-            SQLGetPrivateProfileStringW(
-                dsn_w.as_ptr(),
-                key_w.as_ptr(),
-                default_w.as_ptr(),
-                buf.as_mut_ptr(),
-                buf.len() as i32,
-                filename_w.as_ptr(),
-            )
-        } as usize;
-        if copied < buf.len().saturating_sub(1) {
-            return String::from_utf16_lossy(&buf[..copied]);
-        }
-        buf.resize(buf.len() * 2, 0);
-    }
-}
-
-unsafe fn write_dsn_values(dsn: &str, driver: &str, fields: &[(String, String)]) -> bool {
-    let dsn_w = to_wide(dsn);
-    let driver_w = to_wide(driver);
-    if unsafe { SQLWriteDSNToIniW(dsn_w.as_ptr(), driver_w.as_ptr()) } == 0 {
-        return false;
-    }
-    let odbc_ini = to_wide("odbc.ini");
-    let mut ok = true;
-    for (key, value) in fields {
-        if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
-            continue;
-        }
-        let key_w = to_wide(key);
-        let val_w = to_wide(value);
-        if unsafe {
-            SQLWritePrivateProfileStringW(
-                dsn_w.as_ptr(),
-                key_w.as_ptr(),
-                val_w.as_ptr(),
-                odbc_ini.as_ptr(),
-            )
-        } == 0
-        {
-            ok = false;
-        }
-    }
-    ok
-}
 
 // ---------------------------------------------------------------------------
 // Dialog context passed via LPARAM

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -99,7 +99,7 @@ proto_generator = { path = "../proto_generator" }
 libc = "0.2"
 
 [dev-dependencies]
-sf_core = { path = ".", features = ["test-utils"] }
+sf_core = { path = ".", default-features = false, features = ["test-utils"] }
 tokio = { version = "1.47.1", features = ["fs", "test-util"] }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["experimental_metrics_custom_reader"] }
 tempfile = "3.21.0"

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -8,7 +8,8 @@ name = "sf_core"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["protobuf"]
+default = ["protobuf", "sonic-json"]
+sonic-json = ["sonic-rs"]
 fips = ["rustls/fips"]
 protobuf = ["prost", "proto_utils"]
 vendored-openssl = ["openssl/vendored"]
@@ -82,7 +83,7 @@ urlencoding = "2.1"
 zeroize = "1.8"
 hex = "0.4"
 memchr = "2"
-sonic-rs = "0.5"
+sonic-rs = { version = "0.5", optional = true }
 sha2 = "0.10"
 clap = { version = "4.5", features = ["derive", "env"], optional = true }
 signature = "2"

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -93,8 +93,7 @@ impl ParseChunk for JsonChunkParser {
 
 /// Scans JSON chunk bytes line-by-line, dispatching each cell directly to
 /// column builders. Each line is a JSON array ending with `,\n`, e.g.
-/// `["v1","v2",null],\n`. Uses `sonic_rs::to_array_iter` for SIMD-accelerated
-/// lazy JSON parsing.
+/// `["v1","v2",null],\n`.
 fn parse_json_rows(data: &[u8], builders: &mut [ColumnBuilder]) -> Result<usize, ArrowError> {
     let mut row_count: usize = 0;
 
@@ -114,9 +113,21 @@ fn parse_json_rows(data: &[u8], builders: &mut [ColumnBuilder]) -> Result<usize,
     Ok(row_count)
 }
 
-/// Parses a single JSON row `["v1","v2",null]` from raw bytes using sonic-rs
-/// lazy array iteration. Each element is either a JSON string or `null`.
+/// Parses a single JSON row `["v1","v2",null]` from raw bytes.
+/// Uses sonic-rs SIMD-accelerated parsing when available, falls back to serde_json.
 fn scan_json_row(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
+    #[cfg(feature = "sonic-json")]
+    {
+        scan_json_row_sonic(line, builders)
+    }
+    #[cfg(not(feature = "sonic-json"))]
+    {
+        scan_json_row_serde(line, builders)
+    }
+}
+
+#[cfg(feature = "sonic-json")]
+fn scan_json_row_sonic(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
     use sonic_rs::JsonValueTrait;
 
     let expected_cols = builders.len();
@@ -144,6 +155,34 @@ fn scan_json_row(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), Arro
         return Err(ArrowError::InvalidArgumentError(format!(
             "Expected {expected_cols} columns but got {col_idx}",
         )));
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "sonic-json"))]
+fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
+    let arr: Vec<Option<String>> =
+        serde_json::from_slice(line).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+    let expected_cols = builders.len();
+    if arr.len() > expected_cols {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Row has more columns than expected ({expected_cols})",
+        )));
+    }
+    if arr.len() < expected_cols {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Expected {expected_cols} columns but got {}",
+            arr.len(),
+        )));
+    }
+
+    for (col_idx, cell) in arr.iter().enumerate() {
+        match cell {
+            None => builders[col_idx].push_null(),
+            Some(s) => builders[col_idx].push_value(s.as_bytes())?,
+        }
     }
 
     Ok(())

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -162,7 +162,7 @@ fn scan_json_row_sonic(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<()
 
 #[cfg(not(feature = "sonic-json"))]
 fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<(), ArrowError> {
-    let arr: Vec<Option<String>> =
+    let arr: Vec<serde_json::Value> =
         serde_json::from_slice(line).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
 
     let expected_cols = builders.len();
@@ -178,10 +178,15 @@ fn scan_json_row_serde(line: &[u8], builders: &mut [ColumnBuilder]) -> Result<()
         )));
     }
 
-    for (col_idx, cell) in arr.iter().enumerate() {
-        match cell {
-            None => builders[col_idx].push_null(),
-            Some(s) => builders[col_idx].push_value(s.as_bytes())?,
+    for (col_idx, value) in arr.iter().enumerate() {
+        if value.is_null() {
+            builders[col_idx].push_null();
+        } else if let Some(s) = value.as_str() {
+            builders[col_idx].push_value(s.as_bytes())?;
+        } else {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Expected string or null at column {col_idx}",
+            )));
         }
     }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -64,8 +64,8 @@ impl<'a> From<BinaryDataPtr> for DataPtr<'a> {
             .as_slice()
             .try_into()
             .expect("Pointer must be 8 bytes");
-        let ptr_value = usize::from_le_bytes(ptr_bytes);
-        let ptr = ptr_value as *const u8;
+        let ptr_value = u64::from_le_bytes(ptr_bytes);
+        let ptr = ptr_value as usize as *const u8;
         DataPtr::new(ptr, proto_ptr.length)
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -57,25 +57,31 @@ impl From<*mut FFI_ArrowArrayStream> for ArrowArrayStreamPtr {
 
 // Convert protobuf BinaryDataPtr to internal DataPtr.
 // Both represent a raw pointer + length; this avoids leaking protobuf types into core.
-impl<'a> From<BinaryDataPtr> for DataPtr<'a> {
-    fn from(proto_ptr: BinaryDataPtr) -> Self {
+impl<'a> TryFrom<BinaryDataPtr> for DataPtr<'a> {
+    type Error = String;
+
+    fn try_from(proto_ptr: BinaryDataPtr) -> Result<Self, Self::Error> {
         let ptr_bytes: [u8; 8] = proto_ptr
             .value
             .as_slice()
             .try_into()
-            .expect("Pointer must be 8 bytes");
+            .map_err(|_| format!("Pointer must be 8 bytes, got {}", proto_ptr.value.len()))?;
         let ptr_value = u64::from_le_bytes(ptr_bytes);
-        let ptr = ptr_value as usize as *const u8;
-        DataPtr::new(ptr, proto_ptr.length)
+        let ptr = usize::try_from(ptr_value)
+            .map_err(|_| format!("Serialized pointer 0x{ptr_value:X} does not fit in usize"))?
+            as *const u8;
+        Ok(DataPtr::new(ptr, proto_ptr.length))
     }
 }
 
 // Convert protobuf QueryBindings variant to internal BindingType.
-impl<'a> From<query_bindings::BindingType> for BindingType<'a> {
-    fn from(proto: query_bindings::BindingType) -> Self {
+impl<'a> TryFrom<query_bindings::BindingType> for BindingType<'a> {
+    type Error = String;
+
+    fn try_from(proto: query_bindings::BindingType) -> Result<Self, Self::Error> {
         match proto {
-            query_bindings::BindingType::Json(ptr) => BindingType::Json(ptr.into()),
-            query_bindings::BindingType::Csv(ptr) => BindingType::Csv(ptr.into()),
+            query_bindings::BindingType::Json(ptr) => Ok(BindingType::Json(ptr.try_into()?)),
+            query_bindings::BindingType::Csv(ptr) => Ok(BindingType::Csv(ptr.try_into()?)),
         }
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -779,7 +779,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let bindings_opt = input
             .bindings
             .and_then(|b| b.binding_type)
-            .map(BindingType::from);
+            .map(BindingType::try_from)
+            .transpose()
+            .map_err(|e| DriverException {
+                message: e,
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            })?;
 
         let result = self
             .driver
@@ -816,7 +822,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let bindings_opt = input
             .bindings
             .and_then(|b| b.binding_type)
-            .map(BindingType::from);
+            .map(BindingType::try_from)
+            .transpose()
+            .map_err(|e| DriverException {
+                message: e,
+                status_code: StatusCode::InvalidArgument as i32,
+                ..Default::default()
+            })?;
 
         let result = self
             .driver


### PR DESCRIPTION
### TL;DR

Adds Windows x86 (32-bit) CI testing for `sf_core` and fixes compatibility issues that prevented it from building and running correctly on 32-bit targets.

### What changed?

- Added a new `test_windows_x86` CI job that builds and tests `sf_core` targeting `i686-pc-windows-msvc`, including a verification step that confirms the output DLL is 32-bit (machine type `14C`).
- Included `test_windows_x86` in the `rust-core-status` gate so failures block merges.
- Made `sonic-rs` an optional dependency behind a new `sonic-json` feature flag. When `sonic-json` is not enabled, JSON row parsing falls back to `serde_json`. This allows the crate to build on x86 Windows where `sonic-rs` (which requires SIMD intrinsics) is not available.
- Fixed a pointer width bug in `BinaryDataPtr` → `DataPtr` conversion: the raw pointer bytes are now read as `u64` before casting to `usize`, ensuring correct behavior on both 32-bit and 64-bit platforms.
- Updated the `sf_core` dev-dependency on itself to use `default-features = false` so tests don't inadvertently pull in features that break on constrained targets.

### How to test?

The new `test_windows_x86` CI job runs automatically on push or when `run_rust_core` changes are detected. It builds `sf_core` for `i686-pc-windows-msvc`, verifies the DLL is 32-bit via `dumpbin`, and then runs the full test suite against that target.

### Why make this change?

Some consumers of `sf_core` run on 32-bit Windows environments. Without explicit CI coverage, regressions on x86 targets go undetected. The `sonic-rs` dependency does not support x86 Windows, so it needed to be made optional with a `serde_json` fallback to unblock the build. The pointer cast fix was necessary to avoid undefined behavior when deserializing pointers on 32-bit platforms where `usize` is 4 bytes but the serialized pointer is stored as 8 bytes.