### PR TITLE
NO-SNOW: use p90 for import-connect timing test

### DIFF
--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -7,6 +7,7 @@ from the test process do not affect the measurement.
 
 from __future__ import annotations
 
+import math
 import subprocess
 import sys
 
@@ -38,7 +39,7 @@ class TestImportTime:
         The import is executed in fresh subprocesses so that any modules
         already loaded by the test runner have no effect on the measurement.
         The 90th percentile of multiple runs is used to reduce noise while
-        still catching slower outlier behavior.
+        still catching consistently slow runs.
         """
         times = []
         for _ in range(_NUM_RUNS):
@@ -62,7 +63,7 @@ class TestImportTime:
             times.append(elapsed)
 
         sorted_times = sorted(times)
-        p90_elapsed = sorted_times[int(0.9 * len(sorted_times)) - 1]
+        p90_elapsed = sorted_times[math.ceil(0.9 * len(sorted_times)) - 1]
         assert p90_elapsed < _MAX_IMPORT_TIME_SECONDS, (
             f"Importing snowflake.connector.connect had p90 {p90_elapsed:.3f}s "
             f"(runs: {', '.join(f'{t:.3f}s' for t in times)}), "

--- a/python/tests/integ/test_import_time.py
+++ b/python/tests/integ/test_import_time.py
@@ -24,7 +24,7 @@ elapsed = time.monotonic() - start
 print(f"{elapsed:.6f}")
 """
 
-_NUM_RUNS = 5
+_NUM_RUNS = 10
 _MAX_IMPORT_TIME_SECONDS = 0.4 if IS_UNIVERSAL_DRIVER else 0.6
 
 
@@ -37,7 +37,8 @@ class TestImportTime:
 
         The import is executed in fresh subprocesses so that any modules
         already loaded by the test runner have no effect on the measurement.
-        The mean of multiple runs is used to reduce noise.
+        The 90th percentile of multiple runs is used to reduce noise while
+        still catching slower outlier behavior.
         """
         times = []
         for _ in range(_NUM_RUNS):
@@ -60,9 +61,10 @@ class TestImportTime:
                 ) from None
             times.append(elapsed)
 
-        mean_elapsed = sum(times) / len(times)
-        assert mean_elapsed < _MAX_IMPORT_TIME_SECONDS, (
-            f"Importing snowflake.connector.connect took {mean_elapsed:.3f}s on average "
+        sorted_times = sorted(times)
+        p90_elapsed = sorted_times[int(0.9 * len(sorted_times)) - 1]
+        assert p90_elapsed < _MAX_IMPORT_TIME_SECONDS, (
+            f"Importing snowflake.connector.connect had p90 {p90_elapsed:.3f}s "
             f"(runs: {', '.join(f'{t:.3f}s' for t in times)}), "
             f"which exceeds the {_MAX_IMPORT_TIME_SECONDS}s budget"
         )


### PR DESCRIPTION
## Summary
- Update `test_import_connect_time` to assert p90 import latency instead of mean latency.
- Increase `_NUM_RUNS` from 5 to 10 to improve measurement stability.
- Update test docstring/assertion wording to reflect p90-based validation.

## Context
This adjusts the import-time performance signal to be less sensitive to single fast/slow samples while still guarding against consistently slow imports.

## Test plan
- [x] `pytest python/tests/integ/test_import_time.py -k test_import_connect_time`
- [ ] Test passes in CI environment

Local run result: test executes but fails threshold in this machine/runtime (`p90 ~= 0.499s` vs `0.4s` budget); no threshold changes were made in this PR.

Made with [Cursor](https://cursor.com)