### PR TITLE
SNOW-3441375: Change driver naming to Snowflake ODBC UD

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -801,8 +801,8 @@ jobs:
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake_odbc_rs-${{ steps.odbc-version.outputs.version }}-${{ matrix.config }}-${{ matrix.arch }}
-          path: build/snowflake_odbc_rs-*.msi
+          name: snowflake_odbc_ud-${{ steps.odbc-version.outputs.version }}-${{ matrix.config }}-${{ matrix.arch }}
+          path: build/snowflake_odbc_ud-*.msi
 
   build_rpm:
     # RPM packaging is independent: it builds the driver from scratch in its own Docker image

--- a/odbc/installer/unix/after_install.sh
+++ b/odbc/installer/unix/after_install.sh
@@ -15,10 +15,10 @@ ODBC_DIR=/usr/lib64/snowflake/odbc
 
 echo "Adding driver info to odbcinst.ini..."
 odbcinst -i -d -r <<ODBCINST_INI
-[SnowflakeDSIIDriver]
+[SnowflakeODBCUDDriver]
 APILevel=1
 ConnectFunctions=YYY
-Description=Snowflake DSII
+Description=Snowflake ODBC UD
 Driver=$ODBC_DIR/lib/libsfodbc.so
 DriverODBCVer=03.52
 SQLLevel=1
@@ -28,7 +28,7 @@ echo "Adding connect info to odbc.ini..."
 odbcinst -i -s -l -r <<ODBC_INI
 [snowflake]
 Description=SnowflakeDB
-Driver=SnowflakeDSIIDriver
+Driver=SnowflakeODBCUDDriver
 Locale=en-US
 SERVER=$SF_ACCOUNT.snowflakecomputing.com
 PORT=443

--- a/odbc/installer/unix/before_remove.sh
+++ b/odbc/installer/unix/before_remove.sh
@@ -6,7 +6,7 @@
 # Unregisters the driver and DSN from unixODBC.
 #
 
-odbcinst -u -d -n SnowflakeDSIIDriver || true
+odbcinst -u -d -n SnowflakeODBCUDDriver || true
 
 SYSTEM_DSN_PATH=$(odbcinst -j | grep "SYSTEM DATA SOURCES" | sed -n -e 's/SYSTEM DATA SOURCES: //p')
 OLD_ODBC_INI=${ODBCINI-}

--- a/odbc/installer/win/package.ps1
+++ b/odbc/installer/win/package.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    Builds a Snowflake ODBC RS Driver MSI installer using the WiX Toolset v3.
+    Builds a Snowflake ODBC Driver MSI installer using the WiX Toolset v3.
 
 .DESCRIPTION
     Invokes candle.exe (compiler) and light.exe (linker) from the WiX Toolset
-    to produce an MSI installer for the Snowflake ODBC RS Driver.
+    to produce an MSI installer for the Snowflake ODBC Driver.
 
 .PARAMETER DriverBinDir
     Directory containing the built sfodbc.dll (e.g. target\release).
@@ -125,7 +125,7 @@ New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 $OutputDir = (Resolve-Path $OutputDir).Path
 $configSuffix = if ($BuildConfig -eq "debug") { "-debug" } else { "" }
 
-Write-Host "=== Building Snowflake ODBC RS Driver MSI ==="
+Write-Host "=== Building Snowflake ODBC Driver MSI ==="
 Write-Host "  Architecture : $Arch"
 Write-Host "  Config       : $BuildConfig"
 Write-Host "  Version      : $Version (MSI ProductVersion: $WixVersion)"
@@ -138,7 +138,7 @@ $ObjDir = Join-Path $OutputDir "wixobj"
 New-Item -ItemType Directory -Force -Path $ObjDir | Out-Null
 
 $WixObj = Join-Path $ObjDir "snowflake_odbc_${Arch}${configSuffix}.wixobj"
-$MsiFile = Join-Path $OutputDir "snowflake_odbc_rs-${Version}${configSuffix}-${Arch}.msi"
+$MsiFile = Join-Path $OutputDir "snowflake_odbc_ud-${Version}${configSuffix}-${Arch}.msi"
 
 $candleArch = if ($Arch -eq "x64") { "x64" } else { "x86" }
 

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -89,7 +89,7 @@
 						<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD" Win64="yes">
 						<CreateFolder />
 							<RemoveFolder Id="LogDir" On="uninstall" />
-							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCRSDriverLogs" On="uninstall" />
+							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
 						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
 							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
 						</Component>

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Product Id="*"
-		Name="Snowflake ODBC RS Driver $(var.FullVersion) PrPr (x64)"
+		Name="Snowflake ODBC UD $(var.FullVersion) PrPr (x64)"
 		Language="1033"
 		Version="$(var.ProductVersion)"
 		Manufacturer="Snowflake Computing"
@@ -13,8 +13,8 @@
 			InstallScope="perMachine"
 			Manufacturer="Snowflake Computing"
 			Platform="x64"
-			Description="Snowflake ODBC RS Driver $(var.FullVersion) Private Preview (64-bit)"
-			Comments="Installs the Snowflake ODBC RS Driver (Private Preview) built on Universal Driver." />
+			Description="Snowflake ODBC UD $(var.FullVersion) Private Preview (64-bit)"
+			Comments="Installs the Snowflake ODBC Driver (Private Preview) built on Universal Driver." />
 
 		<Media Id="1" Cabinet="odbc64.cab" EmbedCab="yes" />
 		<MajorUpgrade AllowDowngrades="yes" />
@@ -77,14 +77,14 @@
 		<!-- ================================================================ -->
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFiles64Folder">
-				<Directory Id="INSTALLDIR" Name="Snowflake ODBC RS Driver">
+				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
 					<Directory Id="BinDir" Name="Bin" />
 					<Directory Id="IncludeDir" Name="include" />
 					<Directory Id="RedistDir" Name="Redistributable" />
 				</Directory>
 			</Directory>
 			<Directory Id="PersonalFolder">
-				<Directory Id="SnowflakeODBCRSDriverLogs" Name="Snowflake ODBC RS Driver">
+				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
 					<Directory Id="LogDir" Name="log">
 						<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD" Win64="yes">
 						<CreateFolder />
@@ -136,14 +136,14 @@
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
-				<RegistryValue Type="string" Name="SnowflakeDSIIDriver" Value="Installed" />
+				<RegistryValue Type="string" Name="Snowflake ODBC UD" Value="Installed" />
 			</RegistryKey>
 			<RegistryKey Root="HKLM"
-				Key="SOFTWARE\ODBC\ODBCINST.INI\SnowflakeDSIIDriver"
+				Key="SOFTWARE\ODBC\ODBCINST.INI\Snowflake ODBC UD"
 				ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc.dll" />
-				<RegistryValue Type="string" Name="Description" Value="Snowflake DSII" />
+				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
 			</RegistryKey>
 			</Component>
 		</DirectoryRef>
@@ -151,7 +151,7 @@
 		<!-- ================================================================ -->
 		<!-- Feature tree                                                       -->
 		<!-- ================================================================ -->
-		<Feature Id="MainApplication" Title="Snowflake ODBC RS Driver" Level="1">
+		<Feature Id="MainApplication" Title="Snowflake ODBC UD" Level="1">
 			<ComponentRef Id="sfodbc.dll" />
 			<ComponentRef Id="sf_odbc.h" />
 			<ComponentRef Id="RegistryEntries" />


### PR DESCRIPTION
### TL;DR

Rename the ODBC driver from `SnowflakeDSIIDriver` / `ODBC RS` branding to `SnowflakeODBCUDDriver` / `ODBC UD` across installer scripts, WiX configuration, and CI artifacts.

### What changed?

- The Windows MSI artifact and output file are now named `snowflake_odbc_ud-*` instead of `snowflake_odbc_rs-*`.
- The driver registry key and ODBC registration name changed from `SnowflakeDSIIDriver` to `Snowflake ODBC UD` on Windows, and from `SnowflakeDSIIDriver` to `SnowflakeODBCUDDriver` on Unix.
- The Windows install directory was renamed from `Snowflake ODBC RS Driver` to `SnowflakeODBCUDDriver`, and the logs directory from `Snowflake ODBC RS Driver` to `Snowflake ODBC UD`.
- The WiX product name, description, and feature title were updated to reflect the `ODBC UD` branding.
- Unix `after_install.sh` and `before_remove.sh` scripts now register and unregister the driver under the new `SnowflakeODBCUDDriver` name.
- The `package.ps1` synopsis and description were updated to remove references to "RS Driver".

### How to test?

- Run the Windows packaging script (`package.ps1`) and verify the output MSI is named `snowflake_odbc_ud-<version>-<arch>.msi`.
- Install the MSI and confirm the driver appears in the ODBC Data Source Administrator under `Snowflake ODBC UD`.
- On a Linux system, run the RPM/DEB installer and verify `odbcinst -q -d` lists `SnowflakeODBCUDDriver`.
- Trigger the CI workflow and confirm the uploaded artifact is named `snowflake_odbc_ud-*`.

### Why make this change?

The driver is being rebranded from the legacy `DSII`/`RS` naming convention to `UD` (Universal Driver) to better reflect the underlying architecture and align with updated product naming standards.