### PR TITLE
Update RPM naming

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -976,8 +976,8 @@ jobs:
       - name: Upload RPM
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-odbc-rpm-${{ matrix.arch }}
-          path: build/snowflake-odbc-*.rpm
+          name: snowflake-odbc-ud-rpm-${{ matrix.arch }}
+          path: build/snowflake-odbc-ud-*.rpm
 
   odbc-status:
     needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, build_msi]

--- a/odbc/installer/unix/package.sh
+++ b/odbc/installer/unix/package.sh
@@ -63,7 +63,7 @@ echo "=== Building RPM: $RPM_NAME ==="
 fpm -s dir \
     -t rpm \
     -n snowflake-odbc-ud \
-    -v "$VERSION" \
+    -v "$BASE_VERSION" \
     -C "$STAGE_DIR" \
     -p "$BUILD_DIR/$RPM_NAME" \
     -d unixODBC \

--- a/odbc/installer/unix/package.sh
+++ b/odbc/installer/unix/package.sh
@@ -56,19 +56,19 @@ mkdir -p "$STAGE_DIR$ODBC_DIR/include"
 cp "$DRIVER_SO" "$STAGE_DIR$ODBC_DIR/lib/"
 cp odbc/include/sf_odbc.h "$STAGE_DIR$ODBC_DIR/include/"
 
-RPM_NAME="snowflake-odbc-${VERSION}.${SYSTEM_ARCH}.rpm"
+RPM_NAME="snowflake-odbc-ud-${VERSION}.${SYSTEM_ARCH}.rpm"
 mkdir -p "$BUILD_DIR"
 
 echo "=== Building RPM: $RPM_NAME ==="
 fpm -s dir \
     -t rpm \
-    -n snowflake-odbc \
+    -n snowflake-odbc-ud \
     -v "$VERSION" \
     -C "$STAGE_DIR" \
     -p "$BUILD_DIR/$RPM_NAME" \
     -d unixODBC \
     --url https://www.snowflake.net/ \
-    --description "Snowflake ODBC Driver ($VERSION, Release)" \
+    --description "Snowflake ODBC UD ($VERSION, Release)" \
     --license "Commercial" \
     --vendor "Snowflake Computing, Inc." \
     --rpm-changelog "$RPM_SCRIPTS_DIR/changelog" \


### PR DESCRIPTION
### TL;DR

Renamed the RPM package from `snowflake-odbc` to `snowflake-odbc-ud` to distinguish the Unix Driver (UD) variant.

### What changed?

The RPM package name, filename, and description have been updated to include the `ud` suffix:
- RPM artifact name changed from `snowflake-odbc-rpm-<arch>` to `snowflake-odbc-ud-rpm-<arch>`
- RPM filename changed from `snowflake-odbc-*.rpm` to `snowflake-odbc-ud-*.rpm`
- Internal package name changed from `snowflake-odbc` to `snowflake-odbc-ud`
- Package description updated from "Snowflake ODBC Driver" to "Snowflake ODBC UD"

### How to test?

Run the ODBC build workflow and verify that the generated RPM artifact is named `snowflake-odbc-ud-<version>.<arch>.rpm` and is uploaded correctly under the `snowflake-odbc-ud-rpm-<arch>` artifact name.

### Why make this change?

The `ud` suffix explicitly identifies this package as the Unix Driver variant, differentiating it from other ODBC driver packages and avoiding potential naming conflicts or ambiguity during installation.