### PR TITLE
feat(odbc): add Snowflake vendor TIMESTAMP type code constants

### DIFF
--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -549,6 +549,24 @@ pub enum SqlType {
     // sqlext.h
     Guid = -11, // SQL_GUID
 
+    // Snowflake-specific vendor SQL type codes for TIMESTAMP variants.
+    //
+    // Defined here so applications can pass them as the `ParameterType`
+    // argument to `SQLBindParameter` and explicitly request that a bound
+    // value round-trip as `TIMESTAMP_LTZ` / `_TZ` / `_NTZ` instead of being
+    // routed by the standard `SQL_TYPE_TIMESTAMP` (93) which has no way to
+    // distinguish the three. The values match the legacy 3.16.0 Snowflake
+    // ODBC driver (`Source/sf_odbc.h`) for application compatibility.
+    //
+    // These are *not* returned from `SQLDescribeCol` or
+    // `SQLColAttribute(SQL_DESC_CONCISE_TYPE)`: per the MS ODBC spec, those
+    // descriptors must report the standard `SQL_TYPE_TIMESTAMP` (93) for
+    // ODBC 3.x output. Applications distinguish the three subtypes via
+    // `SQLColAttribute(SQL_DESC_TYPE_NAME)`.
+    SqlSfTimestampLtz = 2000, // SQL_SF_TIMESTAMP_LTZ
+    SqlSfTimestampTz = 2001,  // SQL_SF_TIMESTAMP_TZ
+    SqlSfTimestampNtz = 2002, // SQL_SF_TIMESTAMP_NTZ
+
     // sqlext.h — ODBC 3.x interval types (100 + subcode)
     IntervalYear = 101,
     IntervalMonth = 102,
@@ -611,6 +629,9 @@ impl TryFrom<sql::SmallInt> for SqlType {
             111 => Ok(SqlType::IntervalHourToMinute),
             112 => Ok(SqlType::IntervalHourToSecond),
             113 => Ok(SqlType::IntervalMinuteToSecond),
+            2000 => Ok(SqlType::SqlSfTimestampLtz),
+            2001 => Ok(SqlType::SqlSfTimestampTz),
+            2002 => Ok(SqlType::SqlSfTimestampNtz),
             _ => {
                 tracing::error!("Invalid SQL data type: {value}");
                 Err(OdbcError::InvalidSqlDataType {

--- a/odbc_tests/common/include/snowflake_odbc_constants.hpp
+++ b/odbc_tests/common/include/snowflake_odbc_constants.hpp
@@ -1,0 +1,21 @@
+#ifndef SNOWFLAKE_ODBC_CONSTANTS_HPP
+#define SNOWFLAKE_ODBC_CONSTANTS_HPP
+
+#include <sql.h>
+#include <sqltypes.h>
+
+// Snowflake-specific vendor SQL type codes for TIMESTAMP variants. Defined in
+// the legacy 3.16.0 driver's `Source/sf_odbc.h`. These are accepted as the
+// `ParameterType` argument to `SQLBindParameter` so applications can
+// explicitly request `TIMESTAMP_LTZ` / `_TZ` / `_NTZ` round-trip behavior
+// that the standard `SQL_TYPE_TIMESTAMP` (93) cannot distinguish.
+//
+// They are NOT returned from `SQLDescribeCol` or
+// `SQLColAttribute(SQL_DESC_CONCISE_TYPE)`; those report the spec-mandated
+// `SQL_TYPE_TIMESTAMP` (93) and applications use `SQL_DESC_TYPE_NAME` to tell
+// the three subtypes apart.
+constexpr SQLSMALLINT SQL_SF_TIMESTAMP_LTZ = 2000;
+constexpr SQLSMALLINT SQL_SF_TIMESTAMP_TZ = 2001;
+constexpr SQLSMALLINT SQL_SF_TIMESTAMP_NTZ = 2002;
+
+#endif  // SNOWFLAKE_ODBC_CONSTANTS_HPP


### PR DESCRIPTION
## Summary

This PR is **infrastructure-only**. It adds the Snowflake-specific vendor TIMESTAMP type-code constants to the type system and to the C++ test header so the next PRs can route them through `SQLBindParameter`.

- `SqlType::SqlSfTimestamp{Ltz,Tz,Ntz}` enum variants (2000/2001/2002) and a matching `TryFrom<SmallInt>` arm.
- `snowflake_odbc_constants.hpp` with the same three constants for e2e tests.

## Why

The `SQL_TYPE_TIMESTAMP` (93) standard ODBC code cannot distinguish `TIMESTAMP_LTZ` / `_TZ` / `_NTZ`. Applications that need explicit subtype routing on **bind** can pass these vendor codes as the `ParameterType` argument to `SQLBindParameter` (consumed by the next PR in the stack).

These codes are deliberately **not** returned from `SQLDescribeCol` or `SQLColAttribute`: per the MS ODBC spec, those descriptors must report the standard 93 for ODBC 3.x output, and applications distinguish the three subtypes via `SQL_DESC_TYPE_NAME` (matches the legacy 3.16.0 driver).

## Test plan

- [ ] CI green (no behavior change, infrastructure-only)