### PR TITLE
fix(odbc): support TIMESTAMP_TZ parameter binding with offset round-trip

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -616,7 +616,8 @@ impl OdbcError {
                 }
                 JsonBindingError::InvalidBooleanValue { .. }
                 | JsonBindingError::InvalidNumericLiteral { .. }
-                | JsonBindingError::InvalidHexLiteral { .. } => {
+                | JsonBindingError::InvalidHexLiteral { .. }
+                | JsonBindingError::InvalidCharacterValueForCast { .. } => {
                     SqlState::InvalidCharacterValueForCast
                 }
                 _ => SqlState::GeneralError,
@@ -822,7 +823,8 @@ impl ErrorTrace for CoreProtobufError {
 mod tests {
     use super::*;
     use crate::conversion::error::{
-        BindingNumericOutOfRangeSnafu, InvalidBooleanValueSnafu, InvalidNumericLiteralSnafu,
+        BindingNumericOutOfRangeSnafu, DatetimeFieldOverflowSnafu, InvalidBooleanValueSnafu,
+        InvalidCharacterValueForCastSnafu, InvalidNumericLiteralSnafu,
         NumericMagnitudeOverflowSnafu, UnsupportedCDataTypeSnafu, UnsupportedParameterTypeSnafu,
     };
 
@@ -1060,5 +1062,51 @@ mod tests {
             odbc_err.to_sql_state(),
             SqlState::RestrictedDataTypeAttributeViolation
         );
+    }
+
+    /// Pins the SQLSTATE for the "string didn't match the expected format
+    /// for the SQL target" path -- 22018, the same class as
+    /// `InvalidNumericLiteral` / `InvalidBooleanValue`. Used by
+    /// `parse_tz_string_with_fallback` for SQL_C_CHAR / SQL_C_WCHAR bound
+    /// to SQL_SF_TIMESTAMP_TZ when the input lacks both an offset suffix
+    /// and a parseable offset-less shape. See PR #1005 review on
+    /// `timestamp.rs:643`.
+    #[test]
+    fn invalid_character_value_for_cast_maps_to_22018() {
+        let json_err = InvalidCharacterValueForCastSnafu {
+            c_type: crate::api::CDataType::Char,
+            value: "not-a-timestamp".to_string(),
+            expected_format: "YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM",
+        }
+        .build();
+        let odbc_err = OdbcError::JsonBinding {
+            source: json_err,
+            location: snafu::Location::new("test", 0, 0),
+        };
+        assert_eq!(
+            odbc_err.to_sql_state(),
+            SqlState::InvalidCharacterValueForCast
+        );
+    }
+
+    /// Pins the SQLSTATE for "the parsed datetime overflowed the wire
+    /// format's representable range" -- 22008, distinct from 22018 (parse
+    /// failure on the input string) and 07006 (the binding shape itself
+    /// was wrong). Triggered by `write_timestamp_tz_json` when
+    /// `timestamp_nanos_opt()` returns `None`. See PR #1005 review on
+    /// `timestamp.rs:643`.
+    #[test]
+    fn datetime_field_overflow_maps_to_22008() {
+        let json_err = DatetimeFieldOverflowSnafu {
+            reason: "TIMESTAMP_TZ UTC instant 9999-12-31 23:59:59 exceeds the i64 \
+                     nanosecond epoch range supported by the wire format"
+                .to_string(),
+        }
+        .build();
+        let odbc_err = OdbcError::JsonBinding {
+            source: json_err,
+            location: snafu::Location::new("test", 0, 0),
+        };
+        assert_eq!(odbc_err.to_sql_state(), SqlState::DatetimeFieldOverflow);
     }
 }

--- a/odbc/src/conversion/error.rs
+++ b/odbc/src/conversion/error.rs
@@ -259,6 +259,31 @@ pub enum JsonBindingError {
         location: Location,
     },
 
+    /// The character input failed to parse against the format(s) the SQL
+    /// target type accepts. Use this for bind paths where the C buffer
+    /// holds a string that doesn't match the spec-prescribed grammar for
+    /// the target -- e.g. SQL_C_CHAR / SQL_C_WCHAR bound to
+    /// SQL_SF_TIMESTAMP_TZ with neither a `+/-HH:MM` offset suffix nor an
+    /// offset-less `YYYY-MM-DD HH:MM:SS[.fff]` shape. Maps to SQLSTATE
+    /// 22018 ("Invalid character value for cast specification"), the same
+    /// class as `InvalidNumericLiteral` / `InvalidBooleanValue`, so apps
+    /// that switch on the SQLSTATE class can distinguish "bad input data"
+    /// from 07006 ("unsupported binding shape").
+    ///
+    /// `value` is truncated to a safe length before storage so an
+    /// adversarial caller can't blow up diagnostic-record buffers; the
+    /// `expected_format` is a static template the user can compare against.
+    #[snafu(display(
+        "Invalid character value for cast: {c_type:?} input {value:?} does not match expected format {expected_format:?}"
+    ))]
+    InvalidCharacterValueForCast {
+        c_type: CDataType,
+        value: String,
+        expected_format: &'static str,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Binding value out of range: {reason}"))]
     BindingNumericOutOfRange {
         reason: String,

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -28,7 +28,7 @@ use super::interval::{
 use super::number::{NumericSqlType, SnowflakeNumber};
 use super::real::SnowflakeReal;
 use super::time::SnowflakeTime;
-use super::timestamp::{SnowflakeTimestampLtz, SnowflakeTimestampNtz};
+use super::timestamp::{SnowflakeTimestampLtz, SnowflakeTimestampNtz, SnowflakeTimestampTz};
 use super::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use super::varchar::SnowflakeVarchar;
 
@@ -222,22 +222,18 @@ fn make_converter(binding: &ParameterBinding) -> Result<Box<dyn ParamConverter>,
             Some(TimestampSubtype::Ltz) => Ok(Box::new(JsonParamConverter {
                 snowflake_type: SnowflakeTimestampLtz { scale: 9 },
             })),
-            Some(TimestampSubtype::Tz) => {
-                // Faithfully binding TIMESTAMP_TZ requires preserving the
-                // offset (legacy emits `<epoch_ns> <offset_minutes>`), which
-                // the new driver doesn't emit yet. A clear error -- mapped to
-                // SQLSTATE 07006 by `JsonBindingError -> SqlState` -- is
-                // safer than silently dropping the offset and storing a
-                // wrong instant.
-                tracing::error!(
-                    "TIMESTAMP_TZ parameter binding is not supported yet; \
-                     binding the offset is required to avoid a lossy conversion."
-                );
-                UnsupportedParameterTypeSnafu {
-                    sql_type: *sql_type,
-                }
-                .fail()
-            }
+            // TZ binding emits the legacy two-token wire format
+            // `"<epoch_nanoseconds> <offset_minutes_plus_1440>"` so the
+            // server stores the original instant *and* its timezone
+            // offset. SQL_C_TYPE_TIMESTAMP / SQL_C_BINARY binds (no
+            // offset field) are serialised as UTC + offset 0, matching
+            // the legacy Python connector's handling of naive
+            // `datetime` values bound to TIMESTAMP_TZ. SQL_C_CHAR /
+            // SQL_C_WCHAR binds parse a `+/-HH:MM` suffix from the
+            // string and preserve that offset on the wire.
+            Some(TimestampSubtype::Tz) => Ok(Box::new(JsonParamConverter {
+                snowflake_type: SnowflakeTimestampTz { scale: 9 },
+            })),
         },
 
         // SQL_INTERVAL_* parameter types route through dedicated
@@ -1908,11 +1904,11 @@ mod tests {
     }
 
     #[test]
-    fn tz_vendor_code_is_explicitly_rejected() {
-        // TIMESTAMP_TZ binding requires preserving the offset; the new driver
-        // doesn't emit it yet, so it must reject the bind rather than silently
-        // store a wrong instant. See PR D / the legacy "<epoch_ns> <offset>"
-        // wire format.
+    fn tz_vendor_code_routes_to_timestamp_tz_logical_type() -> TestResult {
+        // SQL_C_TYPE_TIMESTAMP has no offset field; the converter treats the
+        // wall-clock as UTC (offset = 0) and emits the legacy two-token wire
+        // format. The logical type must be TimestampTz so the server stores
+        // the value with the offset side-channel rather than as plain NTZ.
         let ts = sql::Timestamp {
             year: 2024,
             month: 6,
@@ -1929,10 +1925,44 @@ mod tests {
             0,
             std::ptr::null_mut(),
         );
-        assert!(matches!(
-            make_converter(&binding),
-            Err(JsonBindingError::UnsupportedParameterType { .. })
-        ));
+        // Restack note: HEAD originally asserted that TZ binding errored
+        // out (because pre-#1005 the driver explicitly rejected the
+        // subtype). Now that #1005 wires `Some(TimestampSubtype::Tz)`
+        // to a real `SnowflakeTimestampTz` converter, the test verifies
+        // the wire-format the converter actually emits.
+        let (ty, value) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::TimestampTz);
+        let s = value.as_str().expect("TZ JSON value should be a string");
+        // Wire token shape: "<epoch_nanos> <offset_minutes_plus_1440>".
+        let parts: Vec<&str> = s.split(' ').collect();
+        assert_eq!(parts.len(), 2, "expected `<epoch_ns> <offset>`, got {s}");
+        // Naive struct -> offset 0 -> wire token = bias = 1440.
+        assert_eq!(parts[1], "1440");
+        Ok(())
+    }
+
+    #[test]
+    fn tz_vendor_code_with_char_input_parses_offset_suffix() -> TestResult {
+        // SQL_C_CHAR with a `+/-HH:MM` suffix: the offset must round-trip into
+        // the second wire token (signed offset + 1440 bias).
+        let s = b"2024-01-15 14:30:45 +05:30";
+        let mut ind: sql::Len = s.len() as sql::Len;
+        let binding = make_binding(
+            CDataType::Char,
+            SQL_SF_TIMESTAMP_TZ,
+            s.as_ptr() as sql::Pointer,
+            s.len() as sql::Len,
+            &mut ind as *mut sql::Len,
+        );
+        let (ty, value) = convert_binding(&binding)?;
+        assert_eq!(ty, SnowflakeLogicalType::TimestampTz);
+        let wire = value.as_str().unwrap();
+        let parts: Vec<&str> = wire.split(' ').collect();
+        // 2024-01-15 14:30:45 +05:30 -> 09:00:45 UTC -> 1705309245000000000 ns
+        // offset 330 + 1440 = 1770
+        assert_eq!(parts[0], "1705309245000000000");
+        assert_eq!(parts[1], "1770");
+        Ok(())
     }
 
     // -- end-to-end pipeline tests -------------------------------------------

--- a/odbc/src/conversion/timestamp.rs
+++ b/odbc/src/conversion/timestamp.rs
@@ -9,8 +9,9 @@ use serde_json::Value;
 use crate::api::CDataType;
 use crate::api::ParameterBinding;
 use crate::conversion::error::{
-    BindingNumericOutOfRangeSnafu, InvalidDatetimeValueSnafu, JsonBindingError,
-    NumericValueOutOfRangeSnafu, UnsupportedCDataTypeSnafu,
+    BindingNumericOutOfRangeSnafu, DatetimeFieldOverflowSnafu, InvalidCharacterValueForCastSnafu,
+    InvalidDatetimeValueSnafu, JsonBindingError, NumericValueOutOfRangeSnafu,
+    UnsupportedCDataTypeSnafu,
 };
 use crate::conversion::error::{
     InvalidArrowValueSnafu, ReadArrowError, UnsupportedOdbcTypeSnafu, WriteOdbcError,
@@ -617,6 +618,16 @@ fn write_timestamp_json_wallclock(value: NaiveDateTime) -> Result<Value, JsonBin
 // -> datetime without timezone converts to UTC".
 // =============================================================================
 
+/// Static template used in both diagnostics and unit tests, so a future
+/// change to the accepted grammar updates the user-facing message and the
+/// pinning test in lockstep.
+const TZ_CHAR_EXPECTED_FORMAT: &str = "YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM";
+
+/// Cap a (potentially adversarial / huge) bound string before stashing it on
+/// a diagnostic record. ODBC diagnostic message buffers are bounded and
+/// callers shouldn't be able to blow them up by binding a 1 MB literal.
+const TZ_CHAR_MAX_DIAG_LEN: usize = 64;
+
 /// Read a TIMESTAMP_TZ value from a parameter binding. Captures both the UTC
 /// instant and the offset so `write_timestamp_tz_json` can emit the legacy
 /// two-token wire format.
@@ -628,8 +639,13 @@ fn write_timestamp_json_wallclock(value: NaiveDateTime) -> Result<Value, JsonBin
 /// - `SQL_C_CHAR` / `SQL_C_WCHAR`: parse `YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM`;
 ///   if no offset suffix is present, fall back to the offset-less parser and
 ///   treat as UTC (offset = 0). A genuinely unparseable string surfaces as
-///   `UnsupportedCDataType` (mapped to SQLSTATE HY000) so the caller learns
-///   the bind failed instead of silently storing the Unix epoch.
+///   `InvalidCharacterValueForCast` (mapped to SQLSTATE 22018), carrying a
+///   truncated copy of the input plus the expected format so the caller
+///   learns *what* was rejected and *why*. This is distinct from the 07006
+///   ("Restricted data type attribute violation") that signals an
+///   unsupported binding *shape*, and from 22008 ("Datetime field overflow")
+///   that the JSON writer emits when the parsed instant exceeds the
+///   nanosecond epoch range.
 fn read_timestamp_tz_odbc(binding: &ParameterBinding) -> Result<TzInstant, JsonBindingError> {
     match binding.value_type {
         CDataType::Char => {
@@ -654,8 +670,9 @@ fn read_timestamp_tz_odbc(binding: &ParameterBinding) -> Result<TzInstant, JsonB
 }
 
 /// Try `YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM` first, then fall back to the
-/// offset-less formats (treated as UTC). Returns `UnsupportedCDataType` if
-/// neither parse succeeds.
+/// offset-less formats (treated as UTC). Returns
+/// `InvalidCharacterValueForCast` (SQLSTATE 22018) if neither shape parses,
+/// carrying a truncated copy of the input and the expected format template.
 fn parse_tz_string_with_fallback(
     s: &str,
     c_type: CDataType,
@@ -674,13 +691,29 @@ fn parse_tz_string_with_fallback(
             utc,
             offset_minutes: 0,
         })
-        .map_err(|_| UnsupportedCDataTypeSnafu { c_type }.build())
+        .map_err(|_| {
+            InvalidCharacterValueForCastSnafu {
+                c_type,
+                value: s.chars().take(TZ_CHAR_MAX_DIAG_LEN).collect::<String>(),
+                expected_format: TZ_CHAR_EXPECTED_FORMAT,
+            }
+            .build()
+        })
 }
 
 fn write_timestamp_tz_json(value: TzInstant) -> Result<Value, JsonBindingError> {
+    // `timestamp_nanos_opt` returns `None` only when the UTC instant would
+    // overflow `i64` nanoseconds (~year 1677 to year 2262 outside this).
+    // That's exactly what 22008 ("Datetime field overflow") describes per
+    // ODBC Appendix D, so reusing the existing variant is more spec-correct
+    // than the previous `UnsupportedCDataType` catch-all (which would have
+    // surfaced as 07006 "Restricted data type attribute violation").
     let epoch_nanos = value.utc.and_utc().timestamp_nanos_opt().ok_or_else(|| {
-        UnsupportedCDataTypeSnafu {
-            c_type: CDataType::TypeTimestamp,
+        DatetimeFieldOverflowSnafu {
+            reason: format!(
+                "TIMESTAMP_TZ UTC instant {} exceeds the i64 nanosecond epoch range supported by the wire format",
+                value.utc
+            ),
         }
         .build()
     })?;
@@ -1007,5 +1040,131 @@ mod format_timestamp_string_into_tests {
             format_timestamp_string_into(&dt, &mut buf).expect("format_timestamp_string_into"),
             "0001-01-01 00:00:00"
         );
+    }
+}
+
+#[cfg(test)]
+mod parse_tz_string_with_fallback_tests {
+    use super::*;
+    use crate::conversion::error::JsonBindingError;
+
+    #[test]
+    fn unparseable_string_returns_invalid_character_value_for_cast() {
+        // The new error path: a string that matches none of the accepted
+        // formats must surface as `InvalidCharacterValueForCast` so the
+        // outer `to_sql_state` mapping returns 22018, not the previous
+        // 07006 from the catch-all `UnsupportedCDataType`. See PR #1005
+        // review on `timestamp.rs:643`.
+        let err = parse_tz_string_with_fallback("not-a-timestamp", CDataType::Char)
+            .expect_err("garbage input must not parse");
+        match err {
+            JsonBindingError::InvalidCharacterValueForCast {
+                c_type,
+                value,
+                expected_format,
+                ..
+            } => {
+                assert!(matches!(c_type, CDataType::Char));
+                assert_eq!(value, "not-a-timestamp");
+                assert_eq!(expected_format, TZ_CHAR_EXPECTED_FORMAT);
+            }
+            other => panic!("expected InvalidCharacterValueForCast, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn long_input_is_truncated_in_diagnostic() {
+        // Diagnostic-record buffers are bounded; pin the truncation
+        // contract so an adversarial caller can't blow them up by binding
+        // a megabyte literal. The expected format is static, so we only
+        // need to assert on `value.len()` here.
+        let huge = "x".repeat(1024);
+        let err = parse_tz_string_with_fallback(&huge, CDataType::WChar)
+            .expect_err("garbage input must not parse");
+        match err {
+            JsonBindingError::InvalidCharacterValueForCast { value, .. } => {
+                assert_eq!(
+                    value.len(),
+                    TZ_CHAR_MAX_DIAG_LEN,
+                    "diagnostic value must be truncated to TZ_CHAR_MAX_DIAG_LEN"
+                );
+            }
+            other => panic!("expected InvalidCharacterValueForCast, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offset_suffix_parses_and_preserves_offset() {
+        // Sanity check that the happy path still works alongside the new
+        // error path -- a valid `+05:30` suffix yields the right
+        // `offset_minutes` and the offset-applied UTC instant.
+        let ti = parse_tz_string_with_fallback("2024-03-15 14:30:45 +05:30", CDataType::Char)
+            .expect("valid TZ string parses");
+        assert_eq!(ti.offset_minutes, 5 * 60 + 30);
+        // 14:30 +05:30 -> 09:00 UTC
+        assert_eq!(
+            ti.utc.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2024-03-15 09:00:45"
+        );
+    }
+
+    #[test]
+    fn offsetless_input_falls_back_to_utc() {
+        // Backward-compat path: a string with no offset suffix is treated
+        // as UTC. A regression that flipped this to a parse failure would
+        // break every legacy app that binds a naive timestamp string to a
+        // TZ column.
+        let ti = parse_tz_string_with_fallback("2024-03-15 14:30:45", CDataType::Char)
+            .expect("offset-less input must parse as UTC");
+        assert_eq!(ti.offset_minutes, 0);
+        assert_eq!(
+            ti.utc.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2024-03-15 14:30:45"
+        );
+    }
+}
+
+#[cfg(test)]
+mod write_timestamp_tz_json_tests {
+    use super::*;
+
+    #[test]
+    fn out_of_range_instant_returns_datetime_field_overflow() {
+        // `chrono::NaiveDateTime::and_utc().timestamp_nanos_opt()` returns
+        // `None` outside roughly 1677-09-21..2262-04-11 because it can't
+        // fit in `i64` nanoseconds. This must surface as 22008 (Datetime
+        // field overflow), not the previous 07006 from the catch-all
+        // `UnsupportedCDataType`. See PR #1005 review on `timestamp.rs:643`.
+        let out_of_range = NaiveDate::from_ymd_opt(9999, 12, 31)
+            .and_then(|d| d.and_hms_opt(23, 59, 59))
+            .expect("constant inputs");
+        let err = write_timestamp_tz_json(TzInstant {
+            utc: out_of_range,
+            offset_minutes: 0,
+        })
+        .expect_err("year 9999 cannot fit in i64 nanoseconds");
+        assert!(
+            matches!(err, JsonBindingError::DatetimeFieldOverflow { .. }),
+            "expected DatetimeFieldOverflow, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn in_range_instant_emits_two_token_wire_format() {
+        // Sanity check that the happy path still works -- the format is
+        // `<epoch_ns> <offset_minutes + 1440>`. A regression that reorders
+        // tokens or drops the bias would be caught by this unit test
+        // before it hit the wire.
+        let dt = NaiveDate::from_ymd_opt(2024, 3, 15)
+            .and_then(|d| d.and_hms_opt(9, 0, 45))
+            .expect("constant inputs");
+        let v = write_timestamp_tz_json(TzInstant {
+            utc: dt,
+            offset_minutes: 5 * 60 + 30,
+        })
+        .expect("in-range UTC instant serialises");
+        // 2024-03-15T09:00:45 UTC == 1710493245 epoch seconds == 1710493245000000000 ns.
+        // 330 + 1440 = 1770.
+        assert_eq!(v, Value::String("1710493245000000000 1770".to_string()));
     }
 }

--- a/odbc/src/conversion/timestamp.rs
+++ b/odbc/src/conversion/timestamp.rs
@@ -2,7 +2,7 @@ use std::io::{Cursor, Write as _};
 
 use arrow::array::{Array, PrimitiveArray, StructArray};
 use arrow::datatypes::{Int32Type, Int64Type};
-use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use odbc_sys as sql;
 use serde_json::Value;
 
@@ -22,6 +22,30 @@ use crate::conversion::traits::Binding;
 use crate::conversion::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
 use crate::conversion::warning::{Warning, Warnings};
 use crate::conversion::{ReadArrowType, SnowflakeType, WriteODBCType};
+
+/// Wire-protocol bias for TIMESTAMP_TZ offset minutes.
+///
+/// The Snowflake server expects the JSON `value` for a TIMESTAMP_TZ binding
+/// in the form `"<epoch_nanoseconds> <offset_minutes_plus_1440>"`. The 1440
+/// (= 24 * 60) bias keeps the second token non-negative for any legal
+/// timezone offset and matches the legacy 3.16.0 ODBC and Python connectors.
+const TZ_OFFSET_BIAS_MINUTES: i32 = 1440;
+
+/// A TIMESTAMP_TZ value carrying both the UTC instant and its original
+/// timezone offset in minutes.
+///
+/// `utc` is the wall-clock representation **at UTC** (`offset_minutes == 0`
+/// means "this naive datetime is already UTC"). `offset_minutes` records the
+/// offset that produced the *local* wall-clock the user originally saw, so
+/// CHAR/WCHAR formatting and JSON binding can reconstruct it without losing
+/// information. `SQL_C_TYPE_TIMESTAMP` reads ignore `offset_minutes` because
+/// the ODBC struct has no field to store it (matches the spec rule that
+/// "datetime with timezone -> datetime without timezone" converts to UTC).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TzInstant {
+    pub utc: NaiveDateTime,
+    pub offset_minutes: i32,
+}
 
 // =============================================================================
 // Arrow reading helpers
@@ -156,28 +180,25 @@ fn read_scaled_timestamp(
         })
 }
 
-/// Read a TIMESTAMP_TZ value from a StructArray.
+/// Read a TIMESTAMP_TZ value (UTC instant + original offset) from a StructArray.
 ///
 /// Snowflake uses different StructArray layouts depending on the declared scale:
 ///   - Scale 6-9: 3 columns `{epoch_sec: Int64, fraction_nanos: Int32, tz_offset_min: Int32}`
 ///   - Scale 0-5: 2 columns `{epoch_scaled: Int64, tz_offset_min: Int32}`
 ///
-/// In both cases, the epoch value already represents the UTC instant. The
-/// `tz_offset_min` column carries the original timezone offset in minutes but
-/// is intentionally **not** applied to the returned `NaiveDateTime`. This
-/// matches the old driver behavior: `SQL_TIMESTAMP_STRUCT` has no field for
-/// timezone, so callers always receive the UTC wall-clock time. When values
-/// are fetched as `SQL_C_CHAR`/`SQL_C_WCHAR` through this Arrow-based
-/// conversion path, the formatted string likewise reflects the UTC instant and
-/// does not include the original timezone offset. Applications that need to
-/// preserve or reconstruct the original offset must obtain it by other means
-/// (for example, by reading the offset column explicitly or using an API that
-/// exposes the server-formatted string with offset).
+/// In both cases the epoch value already represents the UTC instant; the
+/// `tz_offset_min` column carries the original timezone offset (Snowflake
+/// pre-biases by +1440 on the wire, so we subtract here to recover the signed
+/// offset in minutes). The offset is preserved alongside the UTC datetime so
+/// downstream conversions can reconstruct the local wall-clock for
+/// `SQL_C_CHAR`/`SQL_C_WCHAR` (with `+/-HH:MM` suffix) without losing
+/// information. `SQL_C_TYPE_TIMESTAMP` ignores the offset because the ODBC
+/// struct has no field to store it.
 fn read_struct_timestamp_tz(
     array: &StructArray,
     row_idx: usize,
     scale: u32,
-) -> Result<NaiveDateTime, ReadArrowError> {
+) -> Result<TzInstant, ReadArrowError> {
     if array.is_null(row_idx) {
         return Err(ReadArrowError::NullValue {
             location: snafu::location!(),
@@ -185,9 +206,8 @@ fn read_struct_timestamp_tz(
     }
 
     let num_columns = array.num_columns();
-
-    if num_columns == 3 {
-        read_struct_timestamp(array, row_idx)
+    let utc = if num_columns == 3 {
+        read_struct_timestamp(array, row_idx)?
     } else if num_columns == 2 {
         let epoch_array = array
             .column(0)
@@ -212,13 +232,36 @@ fn read_struct_timestamp_tz(
                     ),
                 }
                 .build()
-            })
+            })?
     } else {
-        InvalidArrowValueSnafu {
+        return InvalidArrowValueSnafu {
             reason: format!("TIMESTAMP_TZ struct has {num_columns} columns, expected 2 or 3"),
         }
-        .fail()
-    }
+        .fail();
+    };
+
+    // Offset always lives in the last column. The wire value is the
+    // signed offset in minutes plus 1440 (Snowflake's positive-only
+    // encoding); subtract the bias here so callers see the true offset.
+    let offset_col_idx = num_columns - 1;
+    let offset_array = array
+        .column(offset_col_idx)
+        .as_any()
+        .downcast_ref::<PrimitiveArray<Int32Type>>()
+        .ok_or_else(|| {
+            InvalidArrowValueSnafu {
+                reason: format!(
+                    "TIMESTAMP_TZ struct column {offset_col_idx} is not Int32 (expected tz_offset_min)"
+                ),
+            }
+            .build()
+        })?;
+    let offset_minutes = offset_array.value(row_idx) - TZ_OFFSET_BIAS_MINUTES;
+
+    Ok(TzInstant {
+        utc,
+        offset_minutes,
+    })
 }
 
 // =============================================================================
@@ -561,11 +604,98 @@ fn write_timestamp_json_wallclock(value: NaiveDateTime) -> Result<Value, JsonBin
 }
 
 // =============================================================================
-// Macro to generate the trait impls shared by NTZ, LTZ, and TZ.
+// TIMESTAMP_TZ-specific helpers
+//
+// TZ differs from NTZ/LTZ on two axes:
+//   1. CHAR/WCHAR formatting must include a `+/-HH:MM` offset suffix so the
+//      value is round-trippable as text (NTZ/LTZ have no offset to emit).
+//   2. JSON binding must emit `<epoch_nanos> <offset_minutes + 1440>` so the
+//      server stores the original instant *and* its offset (NTZ/LTZ only need
+//      the epoch).
+// `SQL_C_TYPE_TIMESTAMP` reads/writes intentionally drop the offset because
+// the ODBC struct can't carry it -- the spec rule is "datetime with timezone
+// -> datetime without timezone converts to UTC".
+// =============================================================================
+
+/// Read a TIMESTAMP_TZ value from a parameter binding. Captures both the UTC
+/// instant and the offset so `write_timestamp_tz_json` can emit the legacy
+/// two-token wire format.
+///
+/// Bind paths:
+/// - `SQL_C_TYPE_TIMESTAMP` / `SQL_C_BINARY`: the struct has no offset field,
+///   so we treat the wall-clock as UTC (offset = 0). Matches the legacy
+///   Python connector's treatment of a naive `datetime` bound to TIMESTAMP_TZ.
+/// - `SQL_C_CHAR` / `SQL_C_WCHAR`: parse `YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM`;
+///   if no offset suffix is present, fall back to the offset-less parser and
+///   treat as UTC (offset = 0). A genuinely unparseable string surfaces as
+///   `UnsupportedCDataType` (mapped to SQLSTATE HY000) so the caller learns
+///   the bind failed instead of silently storing the Unix epoch.
+fn read_timestamp_tz_odbc(binding: &ParameterBinding) -> Result<TzInstant, JsonBindingError> {
+    match binding.value_type {
+        CDataType::Char => {
+            let s = read_char_str(binding)?;
+            parse_tz_string_with_fallback(s.trim(), binding.value_type)
+        }
+        CDataType::WChar => {
+            let s = read_wchar_str(binding)?;
+            parse_tz_string_with_fallback(s.trim(), binding.value_type)
+        }
+        _ => {
+            // Reuse the existing offset-less reader (handles
+            // SQL_C_TYPE_TIMESTAMP, SQL_C_BINARY, etc.) and treat the
+            // result as UTC + offset 0.
+            let utc = read_timestamp_odbc(binding)?;
+            Ok(TzInstant {
+                utc,
+                offset_minutes: 0,
+            })
+        }
+    }
+}
+
+/// Try `YYYY-MM-DD HH:MM:SS[.fff] +/-HH:MM` first, then fall back to the
+/// offset-less formats (treated as UTC). Returns `UnsupportedCDataType` if
+/// neither parse succeeds.
+fn parse_tz_string_with_fallback(
+    s: &str,
+    c_type: CDataType,
+) -> Result<TzInstant, JsonBindingError> {
+    for fmt in &["%Y-%m-%d %H:%M:%S%.f %:z", "%Y-%m-%d %H:%M:%S%.f%:z"] {
+        if let Ok(dt) = DateTime::<FixedOffset>::parse_from_str(s, fmt) {
+            return Ok(TzInstant {
+                utc: dt.naive_utc(),
+                offset_minutes: dt.offset().local_minus_utc() / 60,
+            });
+        }
+    }
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f"))
+        .map(|utc| TzInstant {
+            utc,
+            offset_minutes: 0,
+        })
+        .map_err(|_| UnsupportedCDataTypeSnafu { c_type }.build())
+}
+
+fn write_timestamp_tz_json(value: TzInstant) -> Result<Value, JsonBindingError> {
+    let epoch_nanos = value.utc.and_utc().timestamp_nanos_opt().ok_or_else(|| {
+        UnsupportedCDataTypeSnafu {
+            c_type: CDataType::TypeTimestamp,
+        }
+        .build()
+    })?;
+    let biased_offset = value.offset_minutes + TZ_OFFSET_BIAS_MINUTES;
+    Ok(Value::String(format!("{epoch_nanos} {biased_offset}")))
+}
+
+// =============================================================================
+// Macro to generate the trait impls shared by NTZ, LTZ, and (potentially) TZ.
 //
 // The variation across variants is:
 //   - The struct reader for StructArray (NTZ/LTZ use `read_struct_timestamp`;
-//     TZ uses `read_struct_timestamp_tz` which needs `self.scale`).
+//     the `tz` arm exists for completeness but the live `SnowflakeTimestampTz`
+//     hand-writes its own impls because `Representation = TzInstant`, which
+//     the macro's `@common` arm can't express).
 //   - The `SnowflakeLogicalType` returned by `sf_type()`.
 //   - The wire-format encoding in `write_json` (NTZ/TZ use epoch nanoseconds;
 //     LTZ uses a bare wall-clock literal string and tags `type=TEXT` so the
@@ -698,11 +828,7 @@ pub(crate) struct SnowflakeTimestampNtz {
     pub(crate) scale: u32,
 }
 
-impl_snowflake_timestamp!(
-    SnowflakeTimestampNtz,
-    standard,
-    SnowflakeLogicalType::TimestampNtz
-);
+impl_snowflake_timestamp!(SnowflakeTimestampNtz, standard, SnowflakeLogicalType::TimestampNtz);
 
 pub(crate) struct SnowflakeTimestampLtz {
     pub(crate) scale: u32,
@@ -743,7 +869,91 @@ pub(crate) struct SnowflakeTimestampTz {
     pub(crate) scale: u32,
 }
 
-impl_snowflake_timestamp!(SnowflakeTimestampTz, tz, SnowflakeLogicalType::TimestampTz);
+impl SnowflakeType for SnowflakeTimestampTz {
+    type Representation<'a> = TzInstant;
+}
+
+impl ReadArrowType<StructArray> for SnowflakeTimestampTz {
+    fn read_arrow_type<'a>(
+        &self,
+        array: &'a StructArray,
+        row_idx: usize,
+    ) -> Result<Self::Representation<'a>, ReadArrowError> {
+        read_struct_timestamp_tz(array, row_idx, self.scale)
+    }
+}
+
+// TZ never actually arrives as a flat Int64 array in practice -- Snowflake
+// always sends it as a Struct with the offset column. The trait impl exists
+// only to satisfy `make_timestamp_converter!`, which compiles a flat-Int64
+// branch for every timestamp type. If TZ ever did show up flat, treating the
+// epoch as UTC + offset 0 is the safe fallback (matches what NTZ does).
+impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTimestampTz {
+    fn read_arrow_type<'a>(
+        &self,
+        array: &'a PrimitiveArray<Int64Type>,
+        row_idx: usize,
+    ) -> Result<Self::Representation<'a>, ReadArrowError> {
+        let utc = read_scaled_timestamp(array, row_idx, self.scale)?;
+        Ok(TzInstant {
+            utc,
+            offset_minutes: 0,
+        })
+    }
+}
+
+impl WriteODBCType for SnowflakeTimestampTz {
+    fn sql_type(&self) -> sql::SqlDataType {
+        sql::SqlDataType::TIMESTAMP
+    }
+
+    fn column_size(&self) -> sql::ULen {
+        if self.scale == 0 {
+            19
+        } else {
+            20 + self.scale as sql::ULen
+        }
+    }
+
+    fn decimal_digits(&self) -> sql::SmallInt {
+        self.scale as sql::SmallInt
+    }
+
+    fn write_odbc_type(
+        &self,
+        snowflake_value: Self::Representation<'_>,
+        binding: &Binding,
+        get_data_offset: &mut Option<usize>,
+    ) -> Result<Warnings, WriteOdbcError> {
+        // TZ -> ODBC fetch path drops the offset and renders the UTC instant.
+        // This matches the legacy 3.16.0 driver's default behavior (which only
+        // emits +/-HH:MM when TIMESTAMP_TZ_OUTPUT_FORMAT explicitly contains
+        // TZH/TZM tokens) and the ODBC spec rule "datetime with timezone ->
+        // datetime without timezone drops the offset". The original offset
+        // is still preserved on the bind side via `write_timestamp_tz_json`,
+        // so the value round-trips correctly when written *to* the server.
+        write_timestamp_to_odbc(&snowflake_value.utc, binding, get_data_offset)
+    }
+}
+
+impl ReadODBC for SnowflakeTimestampTz {
+    fn read_odbc<'a>(
+        &self,
+        binding: &'a ParameterBinding,
+    ) -> Result<Self::Representation<'a>, JsonBindingError> {
+        read_timestamp_tz_odbc(binding)
+    }
+}
+
+impl WriteJson for SnowflakeTimestampTz {
+    fn write_json(&self, value: Self::Representation<'_>) -> Result<Value, JsonBindingError> {
+        write_timestamp_tz_json(value)
+    }
+
+    fn sf_type(&self) -> SnowflakeLogicalType {
+        SnowflakeLogicalType::TimestampTz
+    }
+}
 
 #[cfg(test)]
 mod format_timestamp_string_into_tests {

--- a/odbc/src/conversion/timestamp.rs
+++ b/odbc/src/conversion/timestamp.rs
@@ -861,7 +861,11 @@ pub(crate) struct SnowflakeTimestampNtz {
     pub(crate) scale: u32,
 }
 
-impl_snowflake_timestamp!(SnowflakeTimestampNtz, standard, SnowflakeLogicalType::TimestampNtz);
+impl_snowflake_timestamp!(
+    SnowflakeTimestampNtz,
+    standard,
+    SnowflakeLogicalType::TimestampNtz
+);
 
 pub(crate) struct SnowflakeTimestampLtz {
     pub(crate) scale: u32,

--- a/odbc/src/conversion/timestamp_tests.rs
+++ b/odbc/src/conversion/timestamp_tests.rs
@@ -428,10 +428,16 @@ mod tests {
         assert_eq!(&buffer[..19], b"2023-06-15 10:30:45");
     }
 
-    fn make_tz_struct_array_3col(epoch: i64, fraction: i32, tz_offset: i32) -> StructArray {
+    /// Build a 3-column TIMESTAMP_TZ Arrow struct as Snowflake sends it on the
+    /// wire. `offset_minutes` is the *signed* offset in minutes (e.g. -480 for
+    /// UTC-08:00); the helper applies the +1440 bias the server actually puts
+    /// in the column so tests can read naturally.
+    fn make_tz_struct_array_3col(epoch: i64, fraction: i32, offset_minutes: i32) -> StructArray {
         let epoch_col: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![Some(epoch)]));
         let frac_col: ArrayRef = Arc::new(PrimitiveArray::<Int32Type>::from(vec![Some(fraction)]));
-        let tz_col: ArrayRef = Arc::new(PrimitiveArray::<Int32Type>::from(vec![Some(tz_offset)]));
+        let tz_col: ArrayRef = Arc::new(PrimitiveArray::<Int32Type>::from(vec![Some(
+            offset_minutes + 1440,
+        )]));
         StructArray::from(vec![
             (
                 Arc::new(ArrowField::new("epoch", DataType::Int64, false)),
@@ -440,6 +446,28 @@ mod tests {
             (
                 Arc::new(ArrowField::new("fraction", DataType::Int32, false)),
                 frac_col,
+            ),
+            (
+                Arc::new(ArrowField::new("tz_offset", DataType::Int32, false)),
+                tz_col,
+            ),
+        ])
+    }
+
+    /// Build a 2-column TIMESTAMP_TZ Arrow struct (the layout Snowflake uses
+    /// for scales 0-5, where epoch and fraction are pre-combined into a single
+    /// scaled Int64). `offset_minutes` is the signed offset; the helper
+    /// applies the +1440 server bias.
+    fn make_tz_struct_array_2col(scaled_epoch: i64, offset_minutes: i32) -> StructArray {
+        let epoch_col: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![Some(scaled_epoch)]));
+        let tz_col: ArrayRef = Arc::new(PrimitiveArray::<Int32Type>::from(vec![Some(
+            offset_minutes + 1440,
+        )]));
+        StructArray::from(vec![
+            (
+                Arc::new(ArrowField::new("epoch", DataType::Int64, false)),
+                epoch_col,
             ),
             (
                 Arc::new(ArrowField::new("tz_offset", DataType::Int32, false)),
@@ -461,15 +489,45 @@ mod tests {
         let sn = tz(9);
         let array = make_tz_struct_array_3col(1_700_000_000, 0, 0);
         let value = sn.read_arrow_type(&array, 0).unwrap();
-        assert_eq!(value.and_utc().timestamp(), 1_700_000_000);
+        assert_eq!(value.utc.and_utc().timestamp(), 1_700_000_000);
+        assert_eq!(value.offset_minutes, 0);
+    }
+
+    #[test]
+    fn read_tz_3col_struct_preserves_offset() {
+        // Positive offset: e.g. UTC+05:30 (India) is +330 minutes.
+        let sn = tz(9);
+        let array = make_tz_struct_array_3col(1_700_000_000, 0, 330);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value.utc.and_utc().timestamp(), 1_700_000_000);
+        assert_eq!(value.offset_minutes, 330);
+    }
+
+    #[test]
+    fn read_tz_3col_struct_preserves_negative_offset() {
+        // Negative offset: e.g. UTC-08:00 (PST) is -480 minutes. Server biases
+        // by +1440 so the wire value is 960; we recover -480 here.
+        let sn = tz(9);
+        let array = make_tz_struct_array_3col(1_700_000_000, 0, -480);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value.offset_minutes, -480);
     }
 
     #[test]
     fn read_tz_2col_struct_valid() {
         let sn = tz(0);
-        let array = make_struct_array(1_700_000_000, 0);
+        let array = make_tz_struct_array_2col(1_700_000_000, 0);
         let value = sn.read_arrow_type(&array, 0).unwrap();
-        assert_eq!(value.and_utc().timestamp(), 1_700_000_000);
+        assert_eq!(value.utc.and_utc().timestamp(), 1_700_000_000);
+        assert_eq!(value.offset_minutes, 0);
+    }
+
+    #[test]
+    fn read_tz_2col_struct_preserves_offset() {
+        let sn = tz(0);
+        let array = make_tz_struct_array_2col(1_700_000_000, 330);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value.offset_minutes, 330);
     }
 
     #[test]
@@ -516,20 +574,43 @@ mod tests {
     }
 
     #[test]
-    fn sql_type_is_timestamp_for_all_variants() {
+    fn sql_type_returns_standard_timestamp_for_all_variants() {
+        // Per the MS ODBC spec, `SQLDescribeCol` reports the standard
+        // `SQL_TYPE_TIMESTAMP` (93) for all three variants (matches legacy
+        // 3.16.0). Applications distinguish NTZ/LTZ/TZ via
+        // `SQLColAttribute(SQL_DESC_TYPE_NAME)`.
         assert_eq!(ntz(0).sql_type(), sql::SqlDataType::TIMESTAMP);
         assert_eq!(ltz(3).sql_type(), sql::SqlDataType::TIMESTAMP);
         assert_eq!(tz(9).sql_type(), sql::SqlDataType::TIMESTAMP);
     }
 
     #[test]
-    fn column_size_scale_0_is_19() {
+    fn column_size_ntz_scale_0_is_19() {
         assert_eq!(ntz(0).column_size(), 19);
     }
 
     #[test]
-    fn column_size_scale_9_is_29() {
+    fn column_size_ntz_scale_9_is_29() {
         assert_eq!(ntz(9).column_size(), 29); // 20 + 9
+    }
+
+    #[test]
+    fn column_size_ltz_matches_ntz() {
+        // LTZ has the same wall-clock string layout as NTZ on the wire (no
+        // offset suffix), so it shares NTZ's scale-aware column size.
+        assert_eq!(ltz(0).column_size(), 19);
+        assert_eq!(ltz(9).column_size(), 29);
+    }
+
+    #[test]
+    fn column_size_tz_matches_ntz() {
+        // TZ shares NTZ's scale-aware column size: the default fetch path
+        // drops the offset and renders the bare timestamp, matching legacy
+        // and the ODBC "datetime with timezone -> datetime without timezone"
+        // rule.
+        assert_eq!(tz(0).column_size(), 19);
+        assert_eq!(tz(3).column_size(), 23);
+        assert_eq!(tz(9).column_size(), 29);
     }
 
     #[test]
@@ -595,5 +676,188 @@ mod tests {
             v,
             serde_json::Value::String("1710513045123456789".to_string())
         );
+    }
+    // ---- TZ-specific write/read/json round-trip tests ------------------------
+    //
+    // The helpers under test live in timestamp.rs; we exercise them here through
+    // the public `WriteODBCType` / `ReadODBC` / `WriteJson` traits to keep the
+    // tests resilient against private function renames.
+
+    use crate::api::ParameterBinding;
+    use crate::conversion::traits::{ReadODBC, WriteJson};
+
+    fn make_naive(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+            .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f"))
+            .expect("valid timestamp literal in test")
+    }
+
+    fn tz_value(utc: &str, offset_minutes: i32) -> crate::conversion::timestamp::TzInstant {
+        crate::conversion::timestamp::TzInstant {
+            utc: make_naive(utc),
+            offset_minutes,
+        }
+    }
+
+    #[test]
+    fn write_tz_char_drops_offset_and_renders_utc() {
+        // TZ -> SQL_C_CHAR drops the offset suffix on the fetch path: the
+        // legacy 3.16.0 driver only emits `+/-HH:MM` when
+        // TIMESTAMP_TZ_OUTPUT_FORMAT explicitly contains TZH/TZM tokens, and
+        // the ODBC spec says "datetime with timezone -> datetime without
+        // timezone" should anchor on UTC. Positive offset case.
+        let sn = tz(9);
+        let mut buffer = [0u8; 64];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        let warnings = sn
+            .write_odbc_type(tz_value("2024-01-15 09:00:45", 330), &binding, &mut None)
+            .unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(&buffer[..str_len as usize], b"2024-01-15 09:00:45");
+    }
+
+    #[test]
+    fn write_tz_char_negative_offset_still_renders_utc() {
+        let sn = tz(9);
+        let mut buffer = [0u8; 64];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        sn.write_odbc_type(tz_value("2024-01-15 22:30:45", -480), &binding, &mut None)
+            .unwrap();
+        assert_eq!(&buffer[..str_len as usize], b"2024-01-15 22:30:45");
+    }
+
+    #[test]
+    fn write_tz_char_zero_offset_renders_utc() {
+        let sn = tz(9);
+        let mut buffer = [0u8; 64];
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_char_buffer(CDataType::Char, &mut buffer, &mut str_len);
+        sn.write_odbc_type(tz_value("2024-01-15 14:30:45", 0), &binding, &mut None)
+            .unwrap();
+        assert_eq!(&buffer[..str_len as usize], b"2024-01-15 14:30:45");
+    }
+
+    #[test]
+    fn write_tz_type_timestamp_returns_utc_ignoring_offset() {
+        // `SQL_C_TYPE_TIMESTAMP` has no offset field; the spec requires returning
+        // the UTC wall-clock. The `+05:30` info is intentionally dropped.
+        let sn = tz(9);
+        let mut value = sql::Timestamp::default();
+        let mut str_len: sql::Len = 0;
+        let binding =
+            binding_for_value::<sql::Timestamp>(CDataType::TypeTimestamp, &mut value, &mut str_len);
+        sn.write_odbc_type(tz_value("2024-01-15 09:00:45", 330), &binding, &mut None)
+            .unwrap();
+        assert_eq!(value.year, 2024);
+        assert_eq!(value.hour, 9);
+        assert_eq!(value.minute, 0);
+        assert_eq!(value.second, 45);
+    }
+
+    /// Build a `ParameterBinding` over a borrowed byte buffer + indicator slot,
+    /// suitable for exercising the `read_odbc` path on string inputs.
+    fn tz_param_binding(s: &mut [u8], str_len: &mut sql::Len) -> ParameterBinding {
+        // Restack note: the NTZ/LTZ/TZ vendor-code normalisation in
+        // `bind_parameter` (PR #1004) flattens the on-record
+        // `sql_data_type` to the standard `SQL_TYPE_TIMESTAMP` and
+        // stashes the actual subtype on `sf_subtype`. Mirror that
+        // contract in the helper so the readback path under test sees
+        // the same shape it would in production.
+        ParameterBinding {
+            sql_data_type: sql::SqlDataType::TIMESTAMP,
+            value_type: CDataType::Char,
+            parameter_value_ptr: s.as_mut_ptr() as sql::Pointer,
+            buffer_length: s.len() as sql::Len,
+            str_len_or_ind_ptr: str_len as *mut sql::Len,
+            sf_subtype: Some(crate::api::TimestampSubtype::Tz),
+        }
+    }
+
+    #[test]
+    fn read_tz_char_parses_offset_suffix() {
+        // `read_odbc` must recover the offset from the trailing `+/-HH:MM` so
+        // the JSON binding can re-emit it on the wire.
+        let sn = tz(9);
+        let mut s = b"2024-01-15 14:30:45 +05:30".to_vec();
+        let mut str_len: sql::Len = s.len() as sql::Len;
+        let binding = tz_param_binding(&mut s, &mut str_len);
+        let value = sn.read_odbc(&binding).unwrap();
+        assert_eq!(value.utc, make_naive("2024-01-15 09:00:45"));
+        assert_eq!(value.offset_minutes, 330);
+    }
+
+    #[test]
+    fn read_tz_char_negative_offset() {
+        let sn = tz(9);
+        let mut s = b"2024-01-15 14:30:45 -08:00".to_vec();
+        let mut str_len: sql::Len = s.len() as sql::Len;
+        let binding = tz_param_binding(&mut s, &mut str_len);
+        let value = sn.read_odbc(&binding).unwrap();
+        assert_eq!(value.utc, make_naive("2024-01-15 22:30:45"));
+        assert_eq!(value.offset_minutes, -480);
+    }
+
+    #[test]
+    fn read_tz_char_without_offset_falls_back_to_utc() {
+        // Spec-grey-area: bare timestamps with no offset are treated as UTC
+        // (matches legacy Python connector for naive datetimes bound to TZ).
+        let sn = tz(9);
+        let mut s = b"2024-01-15 14:30:45".to_vec();
+        let mut str_len: sql::Len = s.len() as sql::Len;
+        let binding = tz_param_binding(&mut s, &mut str_len);
+        let value = sn.read_odbc(&binding).unwrap();
+        assert_eq!(value.utc, make_naive("2024-01-15 14:30:45"));
+        assert_eq!(value.offset_minutes, 0);
+    }
+
+    #[test]
+    fn read_tz_char_unparseable_returns_error() {
+        // Genuinely garbage input must surface an error so the bind fails
+        // visibly rather than silently storing the Unix epoch.
+        let sn = tz(9);
+        let mut s = b"not a timestamp".to_vec();
+        let mut str_len: sql::Len = s.len() as sql::Len;
+        let binding = tz_param_binding(&mut s, &mut str_len);
+        assert!(sn.read_odbc(&binding).is_err());
+    }
+
+    #[test]
+    fn write_tz_json_emits_two_token_format() {
+        // Wire format: `<epoch_nanos> <offset_minutes + 1440>`. Server
+        // subtracts the bias to recover the signed offset; legacy Python and
+        // ODBC drivers use the same encoding.
+        let sn = tz(9);
+        let json = sn.write_json(tz_value("2024-01-15 09:00:45", 330)).unwrap();
+        // 2024-01-15 09:00:45 UTC -> epoch_nanos = 1705309245000000000
+        // offset 330 + 1440 = 1770
+        assert_eq!(
+            json,
+            serde_json::Value::String("1705309245000000000 1770".into())
+        );
+    }
+
+    #[test]
+    fn write_tz_json_negative_offset_stays_positive_on_wire() {
+        // -480 + 1440 = 960; the bias guarantees the second token is always
+        // non-negative for any legal offset.
+        let sn = tz(9);
+        let json = sn
+            .write_json(tz_value("2024-01-15 22:30:45", -480))
+            .unwrap();
+        let s = json.as_str().unwrap();
+        let parts: Vec<&str> = s.split(' ').collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[1], "960");
+    }
+
+    #[test]
+    fn write_tz_json_zero_offset_emits_bias() {
+        // Naive bind path (offset = 0 -> wire token = 1440).
+        let sn = tz(9);
+        let json = sn.write_json(tz_value("2024-01-15 14:30:45", 0)).unwrap();
+        let s = json.as_str().unwrap();
+        assert!(s.ends_with(" 1440"), "expected bias-only suffix, got {s}");
     }
 }

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -553,3 +553,15 @@ behavior_differences:
       Applications that switch on SQLDescribeParam's data type code with cases for 1..=12 / 91..=95 / 101..=113 (the standard ODBC type codes) will no longer fall through to an unknown-type branch when the upstream code happens to bind via the vendor opt-in. Applications that explicitly test for the 2000/2001/2002 vendor codes after SQLBindParameter must update to test SQLColAttribute(SQL_DESC_TYPE_NAME) instead.
     description: |
       The MS ODBC specification for SQLDescribeParam describes returning standard SQL type codes (1..=12, 91..=95, 101..=113). The vendor codes 2000/2001/2002 are an *input-only* aliasing on SQLBindParameter; leaking them through SQLDescribeParam violates the spec contract.
+
+  51:
+    name: "SQL_SF_TIMESTAMP_TZ accepts SQL_C_TYPE_TIMESTAMP and SQL_C_CHAR-with-offset bindings"
+    status: unknown
+    type: enhancement
+    reviewed: false
+    old_driver_behavior: |
+      SQLBindParameter with ParameterType=SQL_SF_TIMESTAMP_TZ (vendor code 2001) rejects both SQL_C_TYPE_TIMESTAMP (naive datetime) and SQL_C_CHAR strings carrying a `+/-HH:MM` offset suffix. Both cases fail at SQLExecute with SQLSTATE HY000 / NativeError 40620 ("Logic error during conversion"). Applications wanting to bind a TIMESTAMP_TZ value have no first-class path through the legacy driver and must fall back to SQL_TYPE_TIMESTAMP (which routes to TIMESTAMP_NTZ) or rely on session TIMEZONE to convert via TIMESTAMP_LTZ.
+    new_driver_behavior: |
+      Both bindings succeed with spec-aligned semantics. SQL_C_TYPE_TIMESTAMP -> SQL_SF_TIMESTAMP_TZ stores the wall-clock at UTC (offset = 0 on the wire), matching the Python connector's behavior for naive `datetime` values bound to TIMESTAMP_TZ. SQL_C_CHAR (and SQL_C_WCHAR) with a trailing `+/-HH:MM` offset is parsed and emitted in the legacy `<epoch_ns> <offset_minutes_plus_1440>` two-token wire format, so the server stores the exact instant alongside the original offset. The vendor code 2001 sits in the ODBC vendor-specific range, where the driver is free to define behavior; the new semantics are spec-permitted and additive over the legacy 40620 error path.
+    impact: |
+      Migration is forward-compatible: any application that previously caught the legacy 40620 will now find these bindings succeed with predictable, spec-conformant results. Applications that intentionally relied on the failure (e.g. as a feature gate) should switch to validating their bind path explicitly. Round-tripping a non-UTC TIMESTAMP_TZ via SQLBindParameter is now possible without falling through TIMESTAMP_LTZ + session TIMEZONE.

--- a/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
+++ b/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
@@ -306,13 +306,16 @@ TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_CHAR with offset suffix and round-tri
   // above only proves the UTC instant is right, which a buggy
   // implementation that always emitted `offset=0` (and let the server
   // derive UTC from session-TZ shenanigans) would also satisfy. Pinning
-  // the formatted readback here closes that gap end-to-end -- a
-  // regression that drops the offset on the wire reverts to
-  // `2024-03-15 09:00:45 +00:00` and fails this assertion. See PR #1005
-  // review on `timestamp_vendor_bindparam.cpp:223`.
-  auto str_stmt = conn.execute_fetch(
-      "SELECT TO_VARCHAR(ts, 'YYYY-MM-DD HH24:MI:SS TZH:TZM') FROM ts_tz_char_bind WHERE id = 1");
-  CHECK(get_data<SQL_C_CHAR>(str_stmt, 1) == "2024-03-15 09:00:45 +05:30");
+  // the formatted readback here closes that gap end-to-end: with the
+  // offset preserved on the wire, `TO_VARCHAR(..., 'TZH:TZM')` shows the
+  // wall-clock interpreted *in the stored offset* (= the original bind
+  // input) plus the offset annotation. A regression that drops the
+  // offset on the wire instead surfaces as `2024-03-15 09:00:45 +00:00`
+  // (UTC instant + zeroed offset) and fails this assertion. See PR
+  // #1005 review on `timestamp_vendor_bindparam.cpp:223`.
+  auto str_stmt =
+      conn.execute_fetch("SELECT TO_VARCHAR(ts, 'YYYY-MM-DD HH24:MI:SS TZH:TZM') FROM ts_tz_char_bind WHERE id = 1");
+  CHECK(get_data<SQL_C_CHAR>(str_stmt, 1) == "2024-03-15 14:30:45 +05:30");
 }
 
 TEST_CASE("SQLDescribeParam returns SQL_TYPE_TIMESTAMP (93) after binding with vendor codes",

--- a/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
+++ b/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
@@ -198,6 +198,15 @@ TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_TYPE_TIMESTAMP into a TIMESTAMP_TZ co
   // the legacy Python connector's behavior for naive `datetime` values bound
   // to TIMESTAMP_TZ. Applications that need to preserve a non-UTC offset must
   // bind via SQL_C_CHAR / SQL_C_WCHAR with a `+/-HH:MM` suffix instead.
+  //
+  // The legacy 3.16.0 ODBC driver REJECTS this binding with SQLSTATE HY000 /
+  // NativeError 40620 ("Logic error during conversion") rather than accepting
+  // the naive value. The new driver implements the spec/Python-connector
+  // semantics; documenting the divergence in BehaviorDifferences.yaml under
+  // BD#51 and skipping on the reference driver here.
+  SKIP_OLD_DRIVER("BD#51",
+                  "Legacy driver returns 40620 for SQL_C_TYPE_TIMESTAMP -> SQL_SF_TIMESTAMP_TZ; new driver "
+                  "accepts and binds as UTC (offset=0) per Python connector parity");
 
   // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_TZ column
   Connection conn;
@@ -247,6 +256,15 @@ TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_CHAR with offset suffix and round-tri
   // SQL_C_CHAR with a `+/-HH:MM` suffix. The driver parses the offset, emits
   // the legacy `<epoch_ns> <offset_minutes_plus_1440>` two-token wire format,
   // and the server stores the original instant alongside the offset.
+  //
+  // The legacy 3.16.0 ODBC driver REJECTS this binding with SQLSTATE HY000 /
+  // NativeError 40620 ("Logic error during conversion") — it does not parse
+  // the `+/-HH:MM` suffix from SQL_C_CHAR for vendor TZ. The new driver
+  // implements offset parsing per the universal driver design. Documented
+  // under BD#51; skip on the reference driver.
+  SKIP_OLD_DRIVER("BD#51",
+                  "Legacy driver returns 40620 for SQL_C_CHAR with `+/-HH:MM` -> SQL_SF_TIMESTAMP_TZ; new "
+                  "driver parses and preserves the offset on wire");
 
   // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_TZ column
   Connection conn;

--- a/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
+++ b/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
@@ -300,6 +300,19 @@ TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_CHAR with offset suffix and round-tri
   CHECK(ts_out.hour == 9);
   CHECK(ts_out.minute == 0);
   CHECK(ts_out.second == 45);
+
+  // And The server-side rendering of the TZ value preserves *both* the
+  // wall-clock and the original `+05:30` offset on the wire. The check
+  // above only proves the UTC instant is right, which a buggy
+  // implementation that always emitted `offset=0` (and let the server
+  // derive UTC from session-TZ shenanigans) would also satisfy. Pinning
+  // the formatted readback here closes that gap end-to-end -- a
+  // regression that drops the offset on the wire reverts to
+  // `2024-03-15 09:00:45 +00:00` and fails this assertion. See PR #1005
+  // review on `timestamp_vendor_bindparam.cpp:223`.
+  auto str_stmt = conn.execute_fetch(
+      "SELECT TO_VARCHAR(ts, 'YYYY-MM-DD HH24:MI:SS TZH:TZM') FROM ts_tz_char_bind WHERE id = 1");
+  CHECK(get_data<SQL_C_CHAR>(str_stmt, 1) == "2024-03-15 09:00:45 +05:30");
 }
 
 TEST_CASE("SQLDescribeParam returns SQL_TYPE_TIMESTAMP (93) after binding with vendor codes",

--- a/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
+++ b/odbc_tests/tests/e2e/types/timestamp_vendor_bindparam.cpp
@@ -18,7 +18,6 @@
 #include "compatibility.hpp"
 #include "conversion_checks.hpp"
 #include "get_data.hpp"
-#include "get_diag_rec.hpp"
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 #include "snowflake_odbc_constants.hpp"
@@ -192,25 +191,17 @@ TEST_CASE("SQL_SF_TIMESTAMP_LTZ wall-clock is interpreted in the session timezon
   CHECK(get_data<SQL_C_CHAR>(wc_stmt, 1) == "2024-03-15 14:30:45.123456789 +0530");
 }
 
-TEST_CASE("SQL_SF_TIMESTAMP_TZ binding is rejected with SQLSTATE 07006",
-          "[timestamp_tz][bind_fetch][vendor_codes][.skip]") {
-  // SKIPPED: this test pins the *current gap* — the new driver rejects TZ
-  // binds because it doesn't yet emit the `<epoch_ns> <offset_minutes>`
-  // two-token wire format the legacy driver uses. A follow-up PR will add
-  // the offset round-trip and flip the assertion to a positive round-trip
-  // check. Skipping (rather than deleting) preserves the table setup,
-  // SQLBindParameter call, and SQLExecute scaffolding for that follow-up
-  // to reuse.
-  SKIP("Pending follow-up PR that adds TIMESTAMP_TZ binding (offset round-trip).");
-
-  // Faithfully binding TIMESTAMP_TZ requires preserving the offset (legacy
-  // emits `<epoch_ns> <offset_minutes>`), which the new driver doesn't yet
-  // emit. The driver therefore rejects the bind with `Restricted data type
-  // attribute violation` (07006) at SQLExecute time rather than silently
-  // dropping the offset.
+TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_TYPE_TIMESTAMP into a TIMESTAMP_TZ column as UTC",
+          "[timestamp_tz][bind_fetch][vendor_codes]") {
+  // SQL_TIMESTAMP_STRUCT has no offset field, so binding it to a TIMESTAMP_TZ
+  // column treats the wall-clock as UTC (offset = 0 on the wire). This matches
+  // the legacy Python connector's behavior for naive `datetime` values bound
+  // to TIMESTAMP_TZ. Applications that need to preserve a non-UTC offset must
+  // bind via SQL_C_CHAR / SQL_C_WCHAR with a `+/-HH:MM` suffix instead.
 
   // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_TZ column
   Connection conn;
+  conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   Schema::use_temp_session_schema(conn);
   conn.execute("CREATE TEMPORARY TABLE ts_tz_vendor (id INT, ts TIMESTAMP_TZ)");
   auto stmt = conn.createStatement();
@@ -232,16 +223,65 @@ TEST_CASE("SQL_SF_TIMESTAMP_TZ binding is rejected with SQLSTATE 07006",
   ts_in.minute = 30;
   ts_in.second = 45;
   SQLLEN ts_ind = 0;
-  // SQLBindParameter itself accepts the vendor type; rejection happens when
-  // the driver actually serialises the binding during SQLExecute.
   ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_SF_TIMESTAMP_TZ, 35, 9, &ts_in,
                          sizeof(ts_in), &ts_ind);
   REQUIRE_ODBC_SUCCESS(ret, stmt);
-
-  // Then SQLExecute fails with SQLSTATE 07006
   ret = SQLExecute(stmt.getHandle());
-  REQUIRE(ret == SQL_ERROR);
-  CHECK(get_sqlstate(stmt) == "07006");
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then The fetched UTC wall-clock matches the inserted naive value (session
+  // TIMEZONE = UTC, so SQL_C_TYPE_TIMESTAMP read returns the same components).
+  auto select_stmt = conn.execute_fetch("SELECT ts FROM ts_tz_vendor WHERE id = 1");
+  auto ts_out = check_no_truncation<SQL_C_TYPE_TIMESTAMP>(select_stmt, 1);
+  CHECK(ts_out.year == 2024);
+  CHECK(ts_out.month == 3);
+  CHECK(ts_out.day == 15);
+  CHECK(ts_out.hour == 14);
+  CHECK(ts_out.minute == 30);
+  CHECK(ts_out.second == 45);
+}
+
+TEST_CASE("SQL_SF_TIMESTAMP_TZ binds SQL_C_CHAR with offset suffix and round-trips the offset",
+          "[timestamp_tz][bind_fetch][vendor_codes]") {
+  // Spec-correct path for binding a TIMESTAMP_TZ value with a non-UTC offset:
+  // SQL_C_CHAR with a `+/-HH:MM` suffix. The driver parses the offset, emits
+  // the legacy `<epoch_ns> <offset_minutes_plus_1440>` two-token wire format,
+  // and the server stores the original instant alongside the offset.
+
+  // Given Snowflake client is logged in and a temporary table with a TIMESTAMP_TZ column
+  Connection conn;
+  conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
+  Schema::use_temp_session_schema(conn);
+  conn.execute("CREATE TEMPORARY TABLE ts_tz_char_bind (id INT, ts TIMESTAMP_TZ)");
+  auto stmt = conn.createStatement();
+
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO ts_tz_char_bind VALUES (?, ?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER id = 1;
+  SQLLEN id_ind = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &id, 0, &id_ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When A SQL_C_CHAR ISO-8601 string with a `+05:30` suffix is bound with the vendor TZ ParameterType
+  std::string ts_in = "2024-03-15 14:30:45 +05:30";
+  SQLLEN ts_ind = static_cast<SQLLEN>(ts_in.size());
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_SF_TIMESTAMP_TZ, 35, 0,
+                         const_cast<char*>(ts_in.data()), static_cast<SQLLEN>(ts_in.size()), &ts_ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then The fetched UTC wall-clock matches the offset-applied instant: the
+  // `+05:30` suffix moved 14:30:45 back to 09:00:45 UTC before storage.
+  auto select_stmt = conn.execute_fetch("SELECT ts FROM ts_tz_char_bind WHERE id = 1");
+  auto ts_out = check_no_truncation<SQL_C_TYPE_TIMESTAMP>(select_stmt, 1);
+  CHECK(ts_out.year == 2024);
+  CHECK(ts_out.month == 3);
+  CHECK(ts_out.day == 15);
+  CHECK(ts_out.hour == 9);
+  CHECK(ts_out.minute == 0);
+  CHECK(ts_out.second == 45);
 }
 
 TEST_CASE("SQLDescribeParam returns SQL_TYPE_TIMESTAMP (93) after binding with vendor codes",


### PR DESCRIPTION
## Summary

Lifts the explicit `SQL_SF_TIMESTAMP_TZ` rejection introduced in the previous PR and routes the vendor code to a new `SnowflakeTimestampTz` binding path that **preserves the original timezone offset** on the wire.

### What changes

- `SnowflakeTimestampTz` now uses a `TzInstant { utc, offset_minutes }` representation so the offset survives the read/bind boundary.
- The TZ Arrow read path (struct + flat layouts) extracts `tz_offset_min` and applies the legacy `+1440` bias.
- The bind path accepts both `SQL_C_TYPE_TIMESTAMP` (treated as UTC, offset = 0; matches the legacy Python connector for naive `datetime`) and `SQL_C_CHAR` / `SQL_C_WCHAR` strings with an optional `+/-HH:MM` suffix.
- `WriteJson` for TZ emits the legacy two-token wire format `"<epoch_ns> <offset_minutes_plus_1440>"` so the server stores the correct instant **and** offset.

### Out of scope (intentionally)

- TZ -> `SQL_C_CHAR/WCHAR` **fetch** rendering. The driver continues to emit the bare UTC wall-clock with no offset suffix, matching the legacy 3.16.0 driver's default `TIMESTAMP_TZ_OUTPUT_FORMAT` and the ODBC spec rule "datetime with timezone -> datetime without timezone drops the offset". A future PR can add session-format-aware rendering when the format string contains TZH/TZM tokens.

## Test plan

- Unit tests cover the new `TzInstant`-based read/write/JSON helpers (offset extraction, JSON wire format with `+1440` bias, CHAR/WCHAR bind parsing, struct-as-UTC fallback).
- The e2e `timestamp_vendor_bindparam.cpp` TZ tests are unskipped and flipped to positive round-trips:
  - Naive `SQL_C_TYPE_TIMESTAMP` bind stores the wall-clock as UTC.
  - `SQL_C_CHAR` bind with a `+05:30` suffix has the offset applied before storage and round-trips correctly through `SELECT`.
- [ ] CI green