### PR TITLE
SNOW-2912540: python - pandas-specific type test suite driven by Gherkin definitions

### DIFF
--- a/python/tests/e2e/pandas/types/test_number.py
+++ b/python/tests/e2e/pandas/types/test_number.py
@@ -1,0 +1,530 @@
+"""NUMBER type tests for Universal Driver -- pandas consumer.
+
+Mirrors every scenario in ``tests/definitions/shared/types/number.feature``
+using ``cursor.fetch_pandas_all()`` / ``cursor.fetch_pandas_batches()``.
+
+Arrow -> pandas numeric behavior (default, ``arrow_number_to_decimal=False``):
+
+* ``scale == 0``, precision <= 18  -> numpy integer
+* ``scale == 0``, precision > 18   -> ``Decimal`` (decimal128 -> object)
+* ``scale > 0``                    -> ``float64``
+
+Tests that need lossless 38-digit decimals with scale > 0 explicitly set
+``arrow_number_to_decimal = True``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tests.conftest import with_paramstyle
+from tests.e2e.pandas.utils import (
+    NULL_FLOAT,
+    assert_dtypes,
+    enable_decimal_mode,
+    execute_and_fetch,
+    execute_and_fetch_multiple_batches,
+    get_column,
+    get_row,
+    is_float,
+    is_integer,
+    is_object,
+)
+from tests.e2e.types.utils import assert_sequential_values, floats_equal
+
+
+# Test constants ported from tests/e2e/types/test_number.py
+NUMBER_TYPE_SYNONYMS = ["NUMBER", "DECIMAL", "NUMERIC"]
+number_type_parametrize = pytest.mark.parametrize("num_type", NUMBER_TYPE_SYNONYMS)
+
+NUMBER_38_DIGITS_INT = 12345678901234567890123456789012345678
+NUMBER_38_DIGITS_SCALE2 = Decimal("123456789012345678901234567890123456.78")
+NUMBER_38_DIGITS_SCALE10 = Decimal("1234567890123456789012345678.1234567890")
+NUMBER_38_DIGITS_SCALE37 = Decimal("1.2345678901234567890123456789012345678")
+
+NUMBER_5_2_MAX = 999.99
+NUMBER_5_2_MIN = -999.99
+NUMBER_8_0_MAX = 99999999
+NUMBER_8_0_MIN = -99999999
+NUMBER_38_0_MAX = 99999999999999999999999999999999999999
+NUMBER_38_0_MIN = -99999999999999999999999999999999999999
+NUMBER_38_37_MIN_POSITIVE = Decimal("0.0000000000000000000000000000000000001")
+
+LARGE_RESULT_SET_SIZE = 30_000
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPandasNumberTypeCasting:
+    """Type-casting coverage for the NUMBER family via fetch_pandas_all."""
+
+    @number_type_parametrize
+    def test_should_cast_number_values_to_appropriate_type_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT 0::<type>(10,0), 123::<type>(10,0), 0.00::<type>(10,2), 123.45::<type>(10,2)" is executed
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT 0::{num_type}(10,0), 123::{num_type}(10,0), 0.00::{num_type}(10,2), 123.45::{num_type}(10,2)",
+        )
+
+        # Then All values should be returned as appropriate type matching [0, 123, 0.00, 123.45]
+        assert_dtypes(df, [is_integer, is_integer, is_float, is_float])
+        assert get_row(df, 0) == [0, 123, 0.0, 123.45]
+
+
+class TestFetchPandasNumberLiteral:
+    """SELECT-with-literal coverage via fetch_pandas_all."""
+
+    @number_type_parametrize
+    def test_should_select_number_literals_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT 0::<type>(10,0), -456::<type>(10,0), 1.50::<type>(10,2),
+        # -123.45::<type>(10,2), 123.456::<type>(15,3), -789.012::<type>(15,3)" is executed
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT 0::{num_type}(10,0), -456::{num_type}(10,0), "
+            f"1.50::{num_type}(10,2), -123.45::{num_type}(10,2), "
+            f"123.456::{num_type}(15,3), -789.012::{num_type}(15,3)",
+        )
+
+        # Then Result should contain [0, -456, 1.50, -123.45, 123.456, -789.012]
+        assert_dtypes(df, [is_integer, is_integer, is_float, is_float, is_float, is_float])
+        assert get_row(df, 0) == [0, -456, 1.50, -123.45, 123.456, -789.012]
+
+    @number_type_parametrize
+    def test_should_handle_high_precision_values_from_literals_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT 12345678901234567890123456789012345678::<type>(38,0),
+        # 123456789012345678901234567890123456.78::<type>(38,2),
+        # 1234567890123456789012345678.1234567890::<type>(38,10),
+        # 0.0000000000000000000000000000000000001::<type>(38,37)" is executed
+        enable_decimal_mode(cursor)
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT {NUMBER_38_DIGITS_INT}::{num_type}(38,0), "
+            f"{NUMBER_38_DIGITS_SCALE2}::{num_type}(38,2), "
+            f"{NUMBER_38_DIGITS_SCALE10}::{num_type}(38,10), "
+            f"{NUMBER_38_37_MIN_POSITIVE}::{num_type}(38,37)",
+        )
+
+        # Then Result should contain [12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78,
+        # 1234567890123456789012345678.1234567890,
+        # 0.0000000000000000000000000000000000001]
+        assert_dtypes(df, [is_object, is_object, is_object, is_object])
+        assert get_row(df, 0) == [
+            NUMBER_38_DIGITS_INT,
+            NUMBER_38_DIGITS_SCALE2,
+            NUMBER_38_DIGITS_SCALE10,
+            NUMBER_38_37_MIN_POSITIVE,
+        ]
+
+    @number_type_parametrize
+    def test_should_handle_scale_and_precision_boundaries_from_literals_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT 999.99::<type>(5,2), -999.99::<type>(5,2),
+        # 99999999::<type>(8,0), -99999999::<type>(8,0)" is executed
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT {NUMBER_5_2_MAX}::{num_type}(5,2), {NUMBER_5_2_MIN}::{num_type}(5,2), "
+            f"{NUMBER_8_0_MAX}::{num_type}(8,0), {NUMBER_8_0_MIN}::{num_type}(8,0)",
+        )
+
+        # Then Result should contain [999.99, -999.99, 99999999, -99999999]
+        assert_dtypes(df, [is_float, is_float, is_integer, is_integer])
+        assert get_row(df, 0) == [NUMBER_5_2_MAX, NUMBER_5_2_MIN, NUMBER_8_0_MAX, NUMBER_8_0_MIN]
+
+    @number_type_parametrize
+    def test_should_handle_high_precision_boundaries_from_literals_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT 99999999999999999999999999999999999999::<type>(38,0),
+        # -99999999999999999999999999999999999999::<type>(38,0)" is executed
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT {NUMBER_38_0_MAX}::{num_type}(38,0), {NUMBER_38_0_MIN}::{num_type}(38,0)",
+        )
+
+        # Then Result should contain max and min 38-digit integers
+        assert_dtypes(df, [is_object, is_object])
+        assert get_row(df, 0) == [NUMBER_38_0_MAX, NUMBER_38_0_MIN]
+
+    @number_type_parametrize
+    def test_should_handle_null_values_from_literals_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT NULL::<type>(10,0), 42::<type>(10,0), NULL::<type>(10,2), 42.50::<type>(10,2)" is executed
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT NULL::{num_type}(10,0), 42::{num_type}(10,0), NULL::{num_type}(10,2), 42.50::{num_type}(10,2)",
+        )
+
+        # Then Result should contain [NULL, 42, NULL, 42.50]
+        assert_dtypes(df, [is_float, is_integer, is_float, is_float])
+        assert get_row(df, 0) == pytest.approx([NULL_FLOAT, 42, NULL_FLOAT, 42.5], nan_ok=True)
+
+    @number_type_parametrize
+    def test_should_download_large_result_set_with_multiple_chunks_from_generator_for_number_and_synonyms(
+        self, cursor, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT seq8()::<type>(38,0), (seq8() + 0.12345)::<type>(20,5)
+        # FROM TABLE(GENERATOR(ROWCOUNT => 30000)) v" is executed
+        combined = execute_and_fetch_multiple_batches(
+            cursor,
+            f"WITH base AS ("
+            f"  SELECT ROW_NUMBER() OVER (ORDER BY seq8()) - 1 as rn "
+            f"  FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+            f") "
+            f"SELECT rn::{num_type}(38,0), (rn + 0.12345)::{num_type}(15,5) FROM base "
+            f"ORDER BY 1",
+        )
+
+        # Then Result should contain 30000 rows with sequential integers in column 1
+        # and sequential decimals starting from 0.12345 in column 2
+        col0 = get_column(combined, 0)
+        col1 = get_column(combined, 1)
+        assert_sequential_values(col0, LARGE_RESULT_SET_SIZE)
+        assert_sequential_values(
+            col1,
+            LARGE_RESULT_SET_SIZE,
+            transform=lambda i: float(i) + 0.12345,
+            compare=floats_equal,
+        )
+
+
+class TestFetchPandasNumberTable:
+    """Table-based scenarios via fetch_pandas_all."""
+
+    @number_type_parametrize
+    def test_should_select_numbers_from_table_with_multiple_scales_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3), <type>(20,5)) exists
+        table_name = f"{tmp_schema}.pd_number_table_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} ("
+            f"col_scale0 {num_type}(10,0), "
+            f"col_scale2 {num_type}(10,2), "
+            f"col_scale3 {num_type}(15,3), "
+            f"col_scale5 {num_type}(20,5))"
+        )
+        # And Row (123, 123.45, 123.456, 12345.67890) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (123, 123.45, 123.456, 12345.67890)")
+        # And Row (-456, -67.89, -789.012, -98765.43210) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (-456, -67.89, -789.012, -98765.43210)")
+        # And Row (0, 0.00, 0.000, 0.00000) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (0, 0.00, 0.000, 0.00000)")
+        # And Row (999999, 999.99, 1000.500, 123456.78901) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (999999, 999.99, 1000.500, 123456.78901)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name} ORDER BY col_scale0")
+
+        # Then Result should contain 4 rows with expected values
+        assert_dtypes(df, [is_integer, is_float, is_float, is_float])
+        assert get_row(df, 0) == pytest.approx([-456, -67.89, -789.012, -98765.43210])
+        assert get_row(df, 1) == pytest.approx([0, 0.0, 0.0, 0.0])
+        assert get_row(df, 2) == pytest.approx([123, 123.45, 123.456, 12345.67890])
+        assert get_row(df, 3) == pytest.approx([999999, 999.99, 1000.500, 123456.78901])
+
+    @number_type_parametrize
+    def test_should_handle_high_precision_values_from_table_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(38,0), <type>(38,2), <type>(38,10), <type>(38,37)) exists
+        table_name = f"{tmp_schema}.pd_precision_table_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} ("
+            f"col_38_0 {num_type}(38,0), "
+            f"col_38_2 {num_type}(38,2), "
+            f"col_38_10 {num_type}(38,10), "
+            f"col_38_37 {num_type}(38,37))"
+        )
+        # And Row (12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78,
+        # 1234567890123456789012345678.1234567890,
+        # 1.2345678901234567890123456789012345678) is inserted
+        execute_query(
+            f"INSERT INTO {table_name} VALUES ("
+            f"{NUMBER_38_DIGITS_INT}, {NUMBER_38_DIGITS_SCALE2}, "
+            f"{NUMBER_38_DIGITS_SCALE10}, {NUMBER_38_DIGITS_SCALE37})"
+        )
+
+        # When Query "SELECT * FROM <table>" is executed
+        enable_decimal_mode(cursor)
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name}")
+
+        # Then Result should contain [12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78,
+        # 1234567890123456789012345678.1234567890,
+        # 1.2345678901234567890123456789012345678]
+        assert_dtypes(df, [is_object, is_object, is_object, is_object])
+        assert get_row(df, 0) == [
+            NUMBER_38_DIGITS_INT,
+            NUMBER_38_DIGITS_SCALE2,
+            NUMBER_38_DIGITS_SCALE10,
+            NUMBER_38_DIGITS_SCALE37,
+        ]
+
+    @number_type_parametrize
+    def test_should_handle_scale_and_precision_boundaries_from_table_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(5,2), <type>(8,0)) exists
+        table_name = f"{tmp_schema}.pd_boundary_table_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} (col_5_2 {num_type}(5,2), col_8_0 {num_type}(8,0))"
+        )
+        # And Row (999.99, 99999999) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({NUMBER_5_2_MAX}, {NUMBER_8_0_MAX})")
+        # And Row (-999.99, -99999999) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({NUMBER_5_2_MIN}, {NUMBER_8_0_MIN})")
+        # And Row (123.45, 12345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (123.45, 12345678)")
+        # And Row (0.01, 0) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (0.01, 0)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name} ORDER BY col_5_2")
+
+        # Then Result should contain 4 rows with expected boundary values
+        assert_dtypes(df, [is_float, is_integer])
+        assert get_row(df, 0) == pytest.approx([NUMBER_5_2_MIN, NUMBER_8_0_MIN])
+        assert get_row(df, 1) == pytest.approx([0.01, 0])
+        assert get_row(df, 2) == pytest.approx([123.45, 12345678])
+        assert get_row(df, 3) == pytest.approx([NUMBER_5_2_MAX, NUMBER_8_0_MAX])
+
+    @number_type_parametrize
+    def test_should_handle_high_precision_boundaries_from_table_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(38,0), <type>(38,37)) exists
+        table_name = f"{tmp_schema}.pd_high_prec_boundary_table_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} (col_38_0 {num_type}(38,0), col_38_37 {num_type}(38,37))"
+        )
+        # And Row (99999999999999999999999999999999999999, 1.2345678901234567890123456789012345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({NUMBER_38_0_MAX}, {NUMBER_38_DIGITS_SCALE37})")
+        # And Row (-99999999999999999999999999999999999999, -1.2345678901234567890123456789012345678) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({NUMBER_38_0_MIN}, {-NUMBER_38_DIGITS_SCALE37})")
+        # And Row (12345678901234567890123456789012345678, 0.0000000000000000000000000000000000001) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES ({NUMBER_38_DIGITS_INT}, {NUMBER_38_37_MIN_POSITIVE})")
+
+        # When Query "SELECT * FROM <table>" is executed
+        enable_decimal_mode(cursor)
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name} ORDER BY col_38_0")
+
+        # Then Result should contain 3 rows with expected high precision boundary values
+        assert_dtypes(df, [is_object, is_object])
+        assert get_row(df, 0) == [NUMBER_38_0_MIN, -NUMBER_38_DIGITS_SCALE37]
+        assert get_row(df, 1) == [NUMBER_38_DIGITS_INT, NUMBER_38_37_MIN_POSITIVE]
+        assert get_row(df, 2) == [NUMBER_38_0_MAX, NUMBER_38_DIGITS_SCALE37]
+
+    @number_type_parametrize
+    def test_should_handle_null_values_from_table_with_multiple_scales_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(10,0), <type>(10,2), <type>(15,3)) exists
+        table_name = f"{tmp_schema}.pd_null_table_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} ("
+            f"col_10_0 {num_type}(10,0), "
+            f"col_10_2 {num_type}(10,2), "
+            f"col_15_3 {num_type}(15,3))"
+        )
+        # And Row (NULL, NULL, NULL) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL, NULL, NULL)")
+        # And Row (123, 123.45, 123.456) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (123, 123.45, 123.456)")
+        # And Row (NULL, NULL, NULL) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (NULL, NULL, NULL)")
+        # And Row (-456, -67.89, -789.012) is inserted
+        execute_query(f"INSERT INTO {table_name} VALUES (-456, -67.89, -789.012)")
+
+        # When Query "SELECT * FROM <table>" is executed
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name}")
+
+        # Then Result should contain 4 rows with 2 NULL rows and 2 non-NULL rows with expected values
+        assert_dtypes(df, [is_float, is_float, is_float])
+        assert get_row(df, 0) == pytest.approx([NULL_FLOAT, NULL_FLOAT, NULL_FLOAT], nan_ok=True)
+        assert get_row(df, 1) == pytest.approx([123.0, 123.45, 123.456])
+        assert get_row(df, 2) == pytest.approx([NULL_FLOAT, NULL_FLOAT, NULL_FLOAT], nan_ok=True)
+        assert get_row(df, 3) == pytest.approx([-456.0, -67.89, -789.012])
+
+    @number_type_parametrize
+    def test_should_download_large_result_set_from_table_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(38,0), <type>(20,5)) exists with 30000 sequential rows,
+        # from 0 to 29999 in the first column and from 0.12345 to 29999.12345 in the second column
+        table_name = f"{tmp_schema}.pd_large_table_{num_type.lower()}"
+        execute_query(f"CREATE OR REPLACE TEMPORARY TABLE {table_name} (col1 {num_type}(38,0), col2 {num_type}(15,5))")
+        execute_query(
+            f"INSERT INTO {table_name} "
+            f"WITH base AS ("
+            f"  SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 as rn "
+            f"  FROM TABLE(GENERATOR(ROWCOUNT => {LARGE_RESULT_SET_SIZE}))"
+            f") "
+            f"SELECT rn::{num_type}(38,0), (rn + 0.12345)::{num_type}(15,5) FROM base"
+        )
+
+        # When Query "SELECT * FROM <table>" is executed
+        combined = execute_and_fetch_multiple_batches(cursor, f"SELECT * FROM {table_name} ORDER BY 1")
+
+        # Then Result should contain 30000 rows with sequential integers in column 1
+        # and sequential decimals starting from 0.12345 in column 2
+        col0 = get_column(combined, 0)
+        col1 = get_column(combined, 1)
+        assert_sequential_values(col0, LARGE_RESULT_SET_SIZE)
+        assert_sequential_values(
+            col1,
+            LARGE_RESULT_SET_SIZE,
+            transform=lambda i: float(i) + 0.12345,
+            compare=floats_equal,
+        )
+
+
+@with_paramstyle("qmark")
+class TestFetchPandasNumberBinding:
+    """Parameter-binding scenarios via fetch_pandas_all."""
+
+    @number_type_parametrize
+    def test_should_select_number_using_parameter_binding_for_number_and_synonyms(self, cursor, num_type):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT ?::<type>(10,0), ?::<type>(10,0), ?::<type>(10,2),
+        # ?::<type>(10,2), ?::<type>(10,0)" is executed with bound values [123, -456, 12.34, -56.78, NULL]
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT ?::{num_type}(10,0), ?::{num_type}(10,0), "
+            f"?::{num_type}(10,2), ?::{num_type}(10,2), ?::{num_type}(10,0)",
+            params=(123, -456, 12.34, -56.78, None),
+        )
+
+        # Then Result should contain [123, -456, 12.34, -56.78, NULL]
+        assert_dtypes(df, [is_integer, is_integer, is_float, is_float, is_float])
+        assert get_row(df, 0) == pytest.approx([123, -456, 12.34, -56.78, NULL_FLOAT], nan_ok=True)
+
+    @number_type_parametrize
+    def test_should_select_high_precision_number_using_parameter_binding_for_number_and_synonyms(
+        self, cursor, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query "SELECT ?::<type>(38,0), ?::<type>(38,2)" is executed
+        # with bound values [12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78]
+        enable_decimal_mode(cursor)
+        df = execute_and_fetch(
+            cursor,
+            f"SELECT ?::{num_type}(38,0), ?::{num_type}(38,2)",
+            params=(NUMBER_38_DIGITS_INT, NUMBER_38_DIGITS_SCALE2),
+        )
+
+        # Then Result should contain [12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78]
+        assert_dtypes(df, [is_object, is_object])
+        assert get_row(df, 0) == [NUMBER_38_DIGITS_INT, NUMBER_38_DIGITS_SCALE2]
+
+    @number_type_parametrize
+    def test_should_insert_number_using_parameter_binding_for_number_and_synonyms(
+        self, execute_query, executemany_insert, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(10,0), <type>(10,2)) exists
+        table_name = f"{tmp_schema}.pd_number_bind_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} (col_int {num_type}(10,0), col_dec {num_type}(10,2))"
+        )
+
+        # When Rows (0, 0.00), (123, 123.45), (-456, -67.89), (999999, 999.99), (NULL, NULL) are inserted using binding
+        test_data = [
+            (0, 0.00),
+            (123, 123.45),
+            (-456, -67.89),
+            (999999, 999.99),
+            (None, None),
+        ]
+        executemany_insert(table_name, f"INSERT INTO {table_name} VALUES (?, ?)", test_data)
+
+        # Then Result should contain 5 rows with expected values
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name} ORDER BY col_int")
+        assert_dtypes(df, [is_float, is_float])
+        assert get_row(df, 0) == pytest.approx([-456.0, -67.89])
+        assert get_row(df, 1) == pytest.approx([0.0, 0.0])
+        assert get_row(df, 2) == pytest.approx([123.0, 123.45])
+        assert get_row(df, 3) == pytest.approx([999999.0, 999.99])
+        assert get_row(df, 4) == pytest.approx([NULL_FLOAT, NULL_FLOAT], nan_ok=True)
+
+    @number_type_parametrize
+    def test_should_insert_high_precision_number_using_parameter_binding_for_number_and_synonyms(
+        self, execute_query, cursor, tmp_schema, num_type
+    ):
+        # Given Snowflake client is logged in
+        pass
+
+        # And Table with columns (<type>(38,0), <type>(38,2)) exists
+        table_name = f"{tmp_schema}.pd_high_prec_bind_{num_type.lower()}"
+        execute_query(
+            f"CREATE OR REPLACE TEMPORARY TABLE {table_name} (col_38_0 {num_type}(38,0), col_38_2 {num_type}(38,2))"
+        )
+
+        # When Rows (12345678901234567890123456789012345678,
+        # 123456789012345678901234567890123456.78),
+        # (99999999999999999999999999999999999999, 0.01),
+        # (-99999999999999999999999999999999999999, -0.01) are inserted using binding
+        test_data = [
+            (NUMBER_38_DIGITS_INT, NUMBER_38_DIGITS_SCALE2),
+            (NUMBER_38_0_MAX, Decimal("0.01")),
+            (NUMBER_38_0_MIN, Decimal("-0.01")),
+        ]
+        for row in test_data:
+            execute_query(f"INSERT INTO {table_name} VALUES (?, ?)", row)
+
+        # Then Result should contain 3 rows with expected values keeping the precision
+        enable_decimal_mode(cursor)
+        df = execute_and_fetch(cursor, f"SELECT * FROM {table_name} ORDER BY col_38_0")
+        assert_dtypes(df, [is_object, is_object])
+        assert get_row(df, 0) == [NUMBER_38_0_MIN, Decimal("-0.01")]
+        assert get_row(df, 1) == [NUMBER_38_DIGITS_INT, NUMBER_38_DIGITS_SCALE2]
+        assert get_row(df, 2) == [NUMBER_38_0_MAX, Decimal("0.01")]

--- a/python/tests/e2e/pandas/utils.py
+++ b/python/tests/e2e/pandas/utils.py
@@ -1,0 +1,60 @@
+"""Shared helpers for pandas type tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tests.compatibility import is_old_driver
+
+
+is_bool = pd.api.types.is_bool_dtype
+is_integer = pd.api.types.is_integer_dtype
+is_float = pd.api.types.is_float_dtype
+is_object = pd.api.types.is_object_dtype
+is_datetime64 = pd.api.types.is_datetime64_dtype
+is_datetime64_ns = pd.api.types.is_datetime64_ns_dtype
+is_datetime64_tz = pd.api.types.is_datetime64tz_dtype
+is_timedelta = pd.api.types.is_timedelta64_dtype
+is_string = pd.api.types.is_string_dtype
+
+NULL_FLOAT = float("nan")
+
+
+def enable_decimal_mode(cursor) -> None:
+    """Enable exact decimal representation for high-precision scale > 0 columns.
+
+    Only needed for tests that assert lossless 38-digit values with scale > 0;
+    all other tests rely on the default float64 conversion.
+    """
+    if is_old_driver():
+        cursor.connection.arrow_number_to_decimal_setter = True
+    else:
+        cursor.connection.arrow_number_to_decimal = True
+
+
+def execute_and_fetch(cursor, sql: str, params=None) -> pd.DataFrame:
+    cursor.execute(sql, params)
+    return cursor.fetch_pandas_all()
+
+
+def execute_and_fetch_multiple_batches(cursor, sql: str, params=None) -> pd.DataFrame:
+    cursor.execute(sql, params)
+    batches = list(cursor.fetch_pandas_batches())
+    assert batches, "expected at least one pandas batch"
+    return pd.concat(batches, ignore_index=True)
+
+
+def assert_dtypes(df: pd.DataFrame, expected: list) -> None:
+    assert df.shape[1] == len(expected), f"Column count mismatch: {df.shape[1]} vs {len(expected)}"
+    for i, (dtype, check) in enumerate(zip(df.dtypes, expected)):
+        assert check(dtype), f"Column {i} ({df.columns[i]}): dtype {dtype} failed {check.__name__}"
+
+
+def get_row(df: pd.DataFrame, idx: int) -> list:
+    # use list() instead of .tolist(), as tolist() converts np/pandas types to native python types
+    return list(df.iloc[idx])
+
+
+def get_column(df: pd.DataFrame, idx: int) -> list:
+    # use list() instead of .tolist(), as tolist() converts np/pandas types to native python types
+    return list(df.iloc[:, idx])

--- a/tests/tests_format_validator/Cargo.lock
+++ b/tests/tests_format_validator/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -182,9 +182,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -315,18 +315,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -343,6 +353,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -400,8 +419,48 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "toml",
  "walkdir",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -549,6 +608,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/tests/tests_format_validator/Cargo.toml
+++ b/tests/tests_format_validator/Cargo.toml
@@ -23,6 +23,7 @@ convert_case = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+toml = "1.1"
 
 [dev-dependencies]
 tempfile = "3.21"

--- a/tests/tests_format_validator/README.md
+++ b/tests/tests_format_validator/README.md
@@ -1,6 +1,6 @@
 # Tests Format Validator
 
-Validates that Gherkin feature files have corresponding test implementations across all supported languages.
+Validates that Gherkin feature files have corresponding test implementations across all supported languages. Runs as a pre-commit hook (`tests-format-validator`) on every commit.
 
 ## Feature file location
 
@@ -41,6 +41,68 @@ Feature: Python datetime handling
   Scenario: Handle timezone-aware datetime
 ```
 
+## Alignment Targets
+
+In addition to the tag-based validation above, the validator supports **alignment targets** — direct pairings between a features directory and a test directory that bypass the tag system. This is useful for secondary test suites (e.g., framework-specific tests) that cover the same Gherkin scenarios as the primary suite but live in a different directory.
+
+Targets are defined in `alignment_targets.toml`:
+
+```toml
+[[target]]
+name     = "pandas-types"
+language = "python"
+features = "tests/definitions/shared/types"
+tests    = "python/tests/e2e/pandas/types"
+```
+
+Each target pairs every `.feature` file in the `features` directory with the corresponding test file in the `tests` directory (matched by stem: `boolean.feature` ↔ `test_boolean.py`). The validator then checks:
+- Every scenario in the feature has a matching test method
+- Every test method maps back to a scenario (no orphans)
+- Step comments inside each test method match the Gherkin steps
+
+## Writing Tests That Pass Validation
+
+### Method naming
+
+Test method names must match scenario names after normalization. The normalizer strips prefixes, converts to snake_case, and removes spaces, underscores, hyphens, angle brackets, and parentheses before comparing.
+
+For **Scenario Outlines** with `<placeholder>` parameters, the angle brackets are stripped during normalization, so the placeholder name becomes part of the snake_case method name.
+
+### Step comments
+
+Every Gherkin step (`Given`, `When`, `Then`, `And`, `But`) must appear as a comment in the corresponding test method. 
+The validator compares step text after normalizing case and stripping punctuation (`"`, `'`, `,`, `.`, `:`, `;`, `!`, `?`, `(`, `)`).
+
+```python
+def test_should_cast_boolean_values_to_appropriate_type(self, cursor):
+    # Given Snowflake client is logged in      ← matches "Given Snowflake client is logged in"
+    pass
+
+    # When Query "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN" is executed
+    df = execute_and_fetch(cursor, "SELECT TRUE::BOOLEAN, FALSE::BOOLEAN, TRUE::BOOLEAN")
+
+    # Then All values should be returned as appropriate type
+    assert_dtypes(df, [np.bool_, np.bool_, np.bool_])
+
+    # And Values should match [TRUE, FALSE, TRUE]
+    assert get_row(df, 0) == [True, False, True]
+```
+
+**Multi-line step comments** are supported. A continuation line is any comment that immediately follows a step comment and does not start with a new Gherkin keyword:
+
+```python
+# When Query "SELECT -99999999999999999999999999999999999999::<type>,
+#   99999999999999999999999999999999999999::<type>" is executed
+```
+
+### Empty steps
+
+A step comment with no code between it and the next step (or end of method) is flagged as "empty".
+
+### Required When/Then
+
+Every test method must have at least one non-empty `When` and one non-empty `Then` step comment.
+
 ## Usage
 
 ```bash
@@ -68,13 +130,14 @@ cargo run -- --help
 
 - ✅ All feature files are in `tests/definitions/shared/`
 - ✅ Each scenario has corresponding test files in required languages (from scenario tags)
-- ✅ Test methods match scenario names
+- ✅ Test methods match scenario names (normalized comparison)
 - ✅ All Gherkin steps are implemented as comments in test methods
 - ✅ Tests are in correct directory (`_int` → integration/, `_e2e` → e2e/)
 - ✅ Feature-level tags are only generic (`@core`, `@python`) or exclusions (`@*_not_needed`)
 - ✅ Feature declares language but scenarios have no level tags → validation error
 - ✅ Feature has `@{language}_not_needed` but scenario has `@{language}_e2e` → validation error
 - ✅ Every test method in e2e and integration dirs has at least one non-empty `When` and `Then` step comment
+- ✅ Alignment targets: feature ↔ test file pairing, method matching, step matching
 - ⚠️ Reports orphaned test files and missing test methods
 
 ## Output
@@ -85,3 +148,13 @@ By default only failures are printed. Use `--verbose` to see all features includ
 - ❌ Missing implementations or validation failures
 - ⚠️ Issues: validation errors (wrong directory), missing methods, missing steps
 - 🔍 Orphaned tests (no Gherkin definition)
+
+## Common Failures and Fixes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| `Orphan test method (no matching scenario)` | Method name doesn't match any scenario after normalization | Rename the method to match the Gherkin scenario name exactly |
+| `Missing test method for scenario` | No test method found for a feature scenario | Add a test method with the correct name |
+| `Missing steps in '...'` | Step comments in the test don't match the feature steps | Add/fix `# When ...` / `# Then ...` comments to match the feature file text |
+| `Empty steps in '...'` | A step comment has no code between it and the next step | Add implementation code after the step comment (even `pass` counts) |
+| `Orphaned Tests Found` | Test methods exist that aren't referenced by any feature | Either add the scenario to the feature file or remove/rename the test |

--- a/tests/tests_format_validator/alignment_targets.toml
+++ b/tests/tests_format_validator/alignment_targets.toml
@@ -1,0 +1,15 @@
+# Alignment targets.
+#
+# Each [[target]] block pairs a Gherkin features directory with a
+# language-specific test directory.  The validator ensures that every
+# scenario in each paired feature has a matching test method with the
+# expected Gherkin step comments — without requiring scenario-level
+# tags in the .feature files.
+#
+# Paths are relative to the workspace root.
+
+[[target]]
+name     = "pandas-types"
+language = "python"
+features = "tests/definitions/shared/types"
+tests    = "python/tests/e2e/pandas/types"

--- a/tests/tests_format_validator/src/alignment_targets.rs
+++ b/tests/tests_format_validator/src/alignment_targets.rs
@@ -1,0 +1,342 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::feature_parser::Feature;
+use crate::step_finder::StepFinder;
+use crate::test_discovery::Language;
+use crate::utils::{clean_method_name, strings_match_normalized, to_snake_case};
+
+// ---------------------------------------------------------------------------
+// Config types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct AlignmentConfig {
+    pub target: Vec<AlignmentTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AlignmentTarget {
+    pub name: String,
+    pub language: String,
+    pub features: String,
+    pub tests: String,
+}
+
+impl AlignmentTarget {
+    fn language_enum(&self) -> Result<Language> {
+        match self.language.as_str() {
+            "python" => Ok(Language::Python),
+            "rust" => Ok(Language::Rust),
+            "jdbc" => Ok(Language::Jdbc),
+            "odbc" => Ok(Language::Odbc),
+            other => anyhow::bail!("unsupported target language: {other}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation result types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct AlignmentValidationResult {
+    pub target_name: String,
+    pub pair_results: Vec<PairResult>,
+    pub orphan_test_files: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct PairResult {
+    pub feature_file: PathBuf,
+    pub test_file: PathBuf,
+    pub missing_methods: Vec<String>,
+    pub orphan_methods: Vec<String>,
+    pub missing_steps_by_method: Vec<MethodStepResult>,
+    pub empty_steps_by_method: Vec<MethodStepResult>,
+}
+
+#[derive(Debug)]
+pub struct MethodStepResult {
+    pub method_name: String,
+    pub scenario_name: String,
+    pub issues: Vec<String>,
+}
+
+impl AlignmentValidationResult {
+    pub fn has_issues(&self) -> bool {
+        !self.orphan_test_files.is_empty()
+            || self.pair_results.iter().any(|pr| {
+                !pr.missing_methods.is_empty()
+                    || !pr.orphan_methods.is_empty()
+                    || !pr.missing_steps_by_method.is_empty()
+                    || !pr.empty_steps_by_method.is_empty()
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+pub fn load_config(workspace_root: &Path) -> Result<Option<AlignmentConfig>> {
+    let config_path = workspace_root.join("tests/tests_format_validator/alignment_targets.toml");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let config: AlignmentConfig =
+        toml::from_str(&content).with_context(|| "failed to parse alignment_targets.toml")?;
+    Ok(Some(config))
+}
+
+pub fn validate_alignment_targets(
+    workspace_root: &Path,
+    config: &AlignmentConfig,
+) -> Result<Vec<AlignmentValidationResult>> {
+    let mut results = Vec::new();
+    for target in &config.target {
+        results.push(validate_target(workspace_root, target)?);
+    }
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Per-target validation
+// ---------------------------------------------------------------------------
+
+fn validate_target(
+    workspace_root: &Path,
+    target: &AlignmentTarget,
+) -> Result<AlignmentValidationResult> {
+    let language = target.language_enum()?;
+    let features_dir = workspace_root.join(&target.features);
+    let tests_dir = workspace_root.join(&target.tests);
+
+    anyhow::ensure!(
+        features_dir.is_dir(),
+        "target '{name}': features directory does not exist: {path}",
+        name = target.name,
+        path = features_dir.display(),
+    );
+    anyhow::ensure!(
+        tests_dir.is_dir(),
+        "target '{name}': tests directory does not exist: {path}",
+        name = target.name,
+        path = tests_dir.display(),
+    );
+
+    let step_finder = StepFinder::new(language.clone());
+
+    let test_files = collect_test_files(&tests_dir, &language)?;
+    let feature_files = collect_feature_files(&features_dir)?;
+
+    let mut pair_results = Vec::new();
+    let mut orphan_test_files = Vec::new();
+    let mut matched_test_stems: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    for test_path in &test_files {
+        let test_stem = test_file_stem(test_path, &language);
+        match feature_files.iter().find(|fp| {
+            fp.file_stem()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s == test_stem)
+        }) {
+            Some(feature_path) => {
+                matched_test_stems.insert(test_stem);
+                let pr = validate_pair(&step_finder, feature_path, test_path, &language)?;
+                pair_results.push(pr);
+            }
+            None => {
+                orphan_test_files.push(test_path.clone());
+            }
+        }
+    }
+
+    Ok(AlignmentValidationResult {
+        target_name: target.name.clone(),
+        pair_results,
+        orphan_test_files,
+    })
+}
+
+fn validate_pair(
+    step_finder: &StepFinder,
+    feature_path: &Path,
+    test_path: &Path,
+    language: &Language,
+) -> Result<PairResult> {
+    let feature = Feature::parse_from_file(feature_path)
+        .with_context(|| format!("failed to parse {}", feature_path.display()))?;
+
+    let test_content = std::fs::read_to_string(test_path)
+        .with_context(|| format!("failed to read {}", test_path.display()))?;
+
+    let all_test_methods = collect_test_methods(&test_content, language)?;
+
+    let mut missing_methods = Vec::new();
+    let mut matched_methods: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    let mut missing_steps_by_method = Vec::new();
+    let mut empty_steps_by_method = Vec::new();
+
+    for scenario in &feature.scenarios {
+        let matching: Vec<&String> = all_test_methods
+            .iter()
+            .filter(|m| method_matches_scenario(m, &scenario.name))
+            .collect();
+
+        if matching.is_empty() {
+            missing_methods.push(scenario.name.clone());
+            continue;
+        }
+
+        for method_name in &matching {
+            matched_methods.insert((*method_name).clone());
+
+            let (steps, empty) =
+                step_finder.find_steps_and_empty_steps_in_method(test_path, method_name)?;
+
+            let scenario_steps: Vec<String> = scenario
+                .steps
+                .iter()
+                .map(|step| format!("{:?} {}", step.step_type, step.text))
+                .collect();
+
+            let missing: Vec<String> = scenario_steps
+                .iter()
+                .filter(|ss| !steps.iter().any(|is| steps_match(is, ss)))
+                .cloned()
+                .collect();
+
+            if !missing.is_empty() {
+                missing_steps_by_method.push(MethodStepResult {
+                    method_name: (*method_name).clone(),
+                    scenario_name: scenario.name.clone(),
+                    issues: missing,
+                });
+            }
+            if !empty.is_empty() {
+                empty_steps_by_method.push(MethodStepResult {
+                    method_name: (*method_name).clone(),
+                    scenario_name: scenario.name.clone(),
+                    issues: empty,
+                });
+            }
+        }
+    }
+
+    let orphan_methods: Vec<String> = all_test_methods
+        .into_iter()
+        .filter(|m| !matched_methods.contains(m))
+        .collect();
+
+    Ok(PairResult {
+        feature_file: feature_path.to_path_buf(),
+        test_file: test_path.to_path_buf(),
+        missing_methods,
+        orphan_methods,
+        missing_steps_by_method,
+        empty_steps_by_method,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn collect_test_files(dir: &Path, language: &Language) -> Result<Vec<PathBuf>> {
+    let ext = match language {
+        Language::Python => "py",
+        Language::Rust => "rs",
+        Language::Jdbc => "java",
+        Language::Odbc => "cpp",
+        _ => return Ok(vec![]),
+    };
+    let prefix = match language {
+        Language::Python => "test_",
+        _ => "",
+    };
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().and_then(|e| e.to_str()) == Some(ext)
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| prefix.is_empty() || n.starts_with(prefix))
+        })
+        .collect();
+
+    files.sort();
+    Ok(files)
+}
+
+fn collect_feature_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("feature"))
+        .collect();
+    files.sort();
+    Ok(files)
+}
+
+fn test_file_stem(path: &Path, language: &Language) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    match language {
+        Language::Python => stem.strip_prefix("test_").unwrap_or(stem).to_string(),
+        _ => stem.to_string(),
+    }
+}
+
+fn collect_test_methods(content: &str, language: &Language) -> Result<Vec<String>> {
+    use regex::Regex;
+    let re = match language {
+        Language::Python => Regex::new(r"def\s+(test_\w+)\s*\(")?,
+        Language::Rust => Regex::new(
+            r"#\[\s*(?:[a-zA-Z0-9_]+::)?test(?:\([^)]*\))?\s*\]\s*(?:\n\s*)*(?:async\s+)?fn\s+(\w+)\s*\(",
+        )?,
+        _ => return Ok(vec![]),
+    };
+    let mut methods: Vec<String> = re
+        .captures_iter(content)
+        .map(|c| c[1].to_string())
+        .collect();
+    methods.sort();
+    methods.dedup();
+    Ok(methods)
+}
+
+fn method_matches_scenario(method_name: &str, scenario_name: &str) -> bool {
+    let clean = clean_method_name(method_name);
+    let snake = to_snake_case(scenario_name);
+    strings_match_normalized(clean, scenario_name)
+        || strings_match_normalized(clean, &snake)
+}
+
+fn steps_match(implemented: &str, expected: &str) -> bool {
+    let normalize = |s: &str| {
+        s.to_lowercase()
+            .replace('"', "")
+            .replace('\'', "")
+            .replace(',', "")
+            .replace('.', "")
+            .replace(':', "")
+            .replace(';', "")
+            .replace('!', "")
+            .replace('?', "")
+            .replace('(', "")
+            .replace(')', "")
+            .trim()
+            .to_string()
+    };
+    normalize(implemented) == normalize(expected)
+}

--- a/tests/tests_format_validator/src/lib.rs
+++ b/tests/tests_format_validator/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod behavior_differences_processor;
 pub mod behavior_differences_utils;
+pub mod alignment_targets;
 pub mod driver_handlers;
 pub mod feature_parser;
 pub mod step_finder;

--- a/tests/tests_format_validator/src/main.rs
+++ b/tests/tests_format_validator/src/main.rs
@@ -1,5 +1,6 @@
 mod behavior_differences_processor;
 mod behavior_differences_utils;
+mod alignment_targets;
 mod driver_handlers;
 mod feature_parser;
 mod step_finder;
@@ -35,7 +36,8 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let validator = GherkinValidator::new(args.workspace, args.features)?;
+    let workspace_root = args.workspace;
+    let validator = GherkinValidator::new(workspace_root.clone(), args.features)?;
 
     if args.json {
         // JSON output mode - includes Behavior Differences processing
@@ -343,7 +345,75 @@ fn main() -> anyhow::Result<()> {
         println!("  Untagged features (TODO): {}", untagged_features.len());
     }
 
-    if has_failures || has_orphans || has_gherkin_violations {
+    // Alignment target validation (tag-agnostic alignment for extra test directories)
+    let mut has_alignment_failures = false;
+    if let Some(alignment_config) = alignment_targets::load_config(&workspace_root)? {
+        let alignment_results =
+            alignment_targets::validate_alignment_targets(&workspace_root, &alignment_config)?;
+
+        for result in &alignment_results {
+            if !result.has_issues() {
+                if args.verbose {
+                    println!("\n📦 Target '{}': ✅ all aligned", result.target_name);
+                }
+                continue;
+            }
+
+            has_alignment_failures = true;
+            println!("\n📦 Target '{}':", result.target_name);
+
+            for orphan in &result.orphan_test_files {
+                println!("  ❌ Test file has no matching feature: {}", orphan.display());
+            }
+
+            for pr in &result.pair_results {
+                let has_pair_issues = !pr.missing_methods.is_empty()
+                    || !pr.orphan_methods.is_empty()
+                    || !pr.missing_steps_by_method.is_empty()
+                    || !pr.empty_steps_by_method.is_empty();
+
+                if !has_pair_issues {
+                    if args.verbose {
+                        println!("  ✅ {}", pr.test_file.display());
+                    }
+                    continue;
+                }
+
+                println!(
+                    "  ❌ {} ↔ {}",
+                    pr.feature_file.display(),
+                    pr.test_file.display()
+                );
+
+                for m in &pr.missing_methods {
+                    println!("    ⚠️  Missing test method for scenario: {m}");
+                }
+                for m in &pr.orphan_methods {
+                    println!("    ⚠️  Orphan test method (no matching scenario): {m}");
+                }
+                for ms in &pr.missing_steps_by_method {
+                    println!(
+                        "    ⚠️  Missing steps in '{}' (scenario: {}):",
+                        ms.method_name, ms.scenario_name
+                    );
+                    for s in &ms.issues {
+                        println!("      - {s}");
+                    }
+                }
+                for es in &pr.empty_steps_by_method {
+                    println!(
+                        "    ⚠️  Empty steps in '{}' (scenario: {}):",
+                        es.method_name, es.scenario_name
+                    );
+                    for s in &es.issues {
+                        println!("      - {s}");
+                    }
+                }
+            }
+        }
+    }
+
+    if has_failures || has_orphans || has_gherkin_violations || has_alignment_failures {
         println!("❌ VALIDATION FAILED");
         std::process::exit(1);
     } else {


### PR DESCRIPTION
Extend the Rust format validator with alignment-target support that ensures extra test directories (not covered by scenario-level tags) stay in sync with their paired Gherkin feature scenarios. Add the first pandas type test suite (NUMBER) built on top of this alignment.