### PR TITLE
SNOW-3416420: skip atexit subprocess tests on py3.10

### DIFF
--- a/python/tests/e2e/session/test_close.py
+++ b/python/tests/e2e/session/test_close.py
@@ -456,8 +456,8 @@ class TestLogoutRetryBehavior:
 
 @pytest.mark.skip_reference(reason="subprocess imports Connection (not SnowflakeConnection)")
 @pytest.mark.skipif(
-    sys.version_info[:2] == (3, 9),
-    reason="SNOW-3416420: Rust tokio runtime teardown crashes during Py_Finalize on py3.9",
+    sys.version_info[:2] in ((3, 9), (3, 10)),
+    reason="SNOW-3416420: Rust log callback fires into dead Python interpreter during Py_Finalize",
 )
 class TestAutoCleanup:
     """Auto-cleanup deprecation tests.


### PR DESCRIPTION
## Summary
- Skip `TestAutoCleanup` on py3.10 (same SIGABRT as py3.9)
- Root cause: Rust log callback fires into dead Python interpreter during `Py_Finalize`
- Fix in PR #1011 (`sf_core_shutdown` atexit handler)

## Test plan
- [ ] CI py3.10 no longer fails on atexit tests
- [ ] Other Python versions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)