### PR TITLE
NO-SNOW: Move test validator to end of checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,6 @@ repos:
         # to avoid huge diffs in case we need to upgrade nanoarrow
         exclude: ^python/src/snowflake/connector/_internal/nanoarrow_cpp/
         language: system
-    -   id: tests-format-validator
-        name: Tests format validator
-        description: Validate that test implementations match Gherkin feature scenarios
-        entry: ./tests/tests_format_validator/run_validator.sh
-        pass_filenames: false
-        language: system
     -   id: python-checks
         name: Python code checks (ruff + mypy)
         description: Run linting, formatting, and type checks on changed Python files
@@ -70,4 +64,10 @@ repos:
         entry: python3 odbc_tests/validate_behavior_differences.py
         pass_filenames: false
         files: ^odbc_tests/BehaviorDifferences\.yaml$
+        language: system
+    -   id: tests-format-validator
+        name: Tests format validator
+        description: Validate that test implementations match Gherkin feature scenarios
+        entry: ./tests/tests_format_validator/run_validator.sh
+        pass_filenames: false
         language: system


### PR DESCRIPTION
By moving this check to end we can obtain a feedback faster. The check is one of slowest in precommit.