### PR TITLE
NO-SNOW: fix SIGABRT in logger callback during interpreter shutdown

### DIFF
--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -134,30 +134,54 @@ level_map = {
 
 
 def logger_callback(level: int, message: bytes, filename: bytes, line: int, function: bytes) -> int:
-    py_level = level_map.get(level)
-    if py_level is None:
+    # Guard against calls arriving after the Python interpreter has begun
+    # tearing down (module globals set to None, logging infrastructure gone).
+    # The Rust tracing subscriber outlives the interpreter and can fire the
+    # callback during finalization — on some Python/OS combos this causes
+    # "FATAL: exception not rethrown" (SIGABRT).  See SNOW-3416420.
+    try:
+        if sys.is_finalizing():
+            return 0
+    except BaseException:
         return 0
 
-    sf_core_logger = get_sf_core_logger()
-    # Respect the logger's configured level - skip if not enabled
-    if not sf_core_logger.isEnabledFor(py_level):
-        return 0
+    try:
+        py_level = level_map.get(level)
+        if py_level is None:
+            return 0
 
-    record = sf_core_logger.makeRecord(
-        sf_core_logger.name,
-        py_level,
-        filename.decode("utf-8"),
-        line,
-        message.decode("utf-8"),
-        (),
-        None,
-        func=function.decode("utf-8"),
-    )
-    sf_core_logger.handle(record)
+        sf_core_logger = get_sf_core_logger()
+        if not sf_core_logger.isEnabledFor(py_level):
+            return 0
+
+        record = sf_core_logger.makeRecord(
+            sf_core_logger.name,
+            py_level,
+            filename.decode("utf-8", errors="replace"),
+            line,
+            message.decode("utf-8", errors="replace"),
+            (),
+            None,
+            func=function.decode("utf-8", errors="replace"),
+        )
+        sf_core_logger.handle(record)
+    except BaseException:
+        pass
     return 0
 
 
 c_logger_callback = LOGGER_CALLBACK(logger_callback)
+
+# The Rust tracing subscriber holds a raw C function pointer to the
+# ffi_closure backing c_logger_callback.  During Py_Finalize the module
+# dict is cleared, dropping the only Python reference and freeing the
+# closure.  Rust then calls a dangling pointer → SIGABRT.
+# A manual Py_IncRef prevents the closure from ever being collected.
+# This is an intentional one-object leak (~200 bytes) that keeps the
+# trampoline valid for the lifetime of the process.
+ctypes.pythonapi.Py_IncRef.argtypes = [ctypes.py_object]
+ctypes.pythonapi.Py_IncRef.restype = None
+ctypes.pythonapi.Py_IncRef(c_logger_callback)
 
 
 def register_default_logger_callback() -> None:


### PR DESCRIPTION
## Summary

Fixes the py3.12+Linux instance of SNOW-3416420 — \`FATAL: exception not rethrown\` (SIGABRT, return code -6) during Python interpreter shutdown. This was the only version/OS combo where the crash was **not** already handled by an \`xfail\` or \`skipif\`.

## Problem

\`sf_core_init()\` passes a ctypes \`CFUNCTYPE\` callback (\`c_logger_callback\`) to the Rust core, which stores the raw C function pointer in a global \`tracing\` subscriber (\`CallbackLayer\`). This subscriber outlives the Python interpreter.

During \`Py_Finalize\`, CPython clears module dicts — setting \`c_logger_callback\` to \`None\`, which drops the **only** Python-side reference to the ffi closure. The trampoline is freed. If any Rust code then emits a \`tracing\` event (e.g. tokio runtime cleanup, connection teardown), it calls a **dangling function pointer** → SIGABRT.

This is the exact scenario the [ctypes docs](https://docs.python.org/3/library/ctypes.html#callback-functions) warn about:
> *\"Make sure you keep references to CFUNCTYPE() objects as long as they are used from C code. ctypes doesn't, and if you don't, they may be garbage collected, crashing your program when a callback is made.\"*

## Fix

Two-layer defense in \`c_api.py\`:

1. **\`Py_IncRef\` on the ctypes closure** — prevents the ffi trampoline from being freed during module cleanup. This is an intentional ~200-byte leak that keeps the C function pointer valid for the entire process lifetime.

2. **\`sys.is_finalizing()\` + \`try/except\` in \`logger_callback\`** — even with the closure alive, module globals (\`level_map\`, \`get_sf_core_logger\`) are set to \`None\` during finalization. The callback now short-circuits via \`sys.is_finalizing()\` and catches any exception so nothing ever escapes through the FFI boundary.

The existing \`xfail\` (py3.11) and \`skipif\` (py3.9/3.10) test workarounds are intentionally preserved — those versions have a different/deeper crash path during \`Py_Finalize\` that the \`Py_IncRef\` fix alone does not resolve.

## Test plan

- Validated via a temporary debug CI workflow (ubuntu-latest + py3.12) targeting \`test_close.py\` — the previously failing \`test_should_unregister_atexit_handler_when_close_called_explicitly\` now passes: https://github.com/snowflakedb/universal-driver/actions/runs/25136172727