### PR TITLE
Extend OTel instrumentation with child spans from sf_core

### DIFF
--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -117,28 +117,34 @@ def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory
 
     message = entry["message"]
 
-    # Event attributes (from record_api_call) + inherited connection-span
-    # attributes. `snowflake.session.id` comes from the login mapping
-    # (tests/wiremock/mappings/auth/login_success_jwt.json -> sessionId).
-    # The `code.*`, `busy_ns`, `idle_ns`, `thread.id` attributes are
-    # auto-populated by `tracing::info_span!` at
-    # sf_core/src/apis/database_driver_v1/connection.rs where the
-    # "connection" span is created.
+    # Event attributes (from record_api_call) + bounded wrapper_api_usage
+    # span attributes. `snowflake.session.id` is stamped on the span from
+    # the login mapping (tests/wiremock/mappings/auth/login_success_jwt.json
+    # -> sessionId). The `code.*`, `busy_ns`, `idle_ns`, `thread.id`
+    # attributes are auto-populated by `tracing::info_span!` at the FFI
+    # entry-point where the per-call wrapper_api_usage span is opened.
     expected_exact = {
         "type": "api_call",
         "api_method": "Connection.cursor",
         "snowflake.session.id": 12345,
-        "code.filepath": "sf_core/src/apis/database_driver_v1/connection.rs",
-        "code.namespace": "sf_core::apis::database_driver_v1::connection",
+        "db.system": "snowflake",
+        "event_kind": "event",
     }
     for key, expected in expected_exact.items():
-        actual = message.get(key)
-        # Normalize path separators for cross-platform compatibility (Windows uses backslashes)
-        if key == "code.filepath" and isinstance(actual, str):
-            actual = actual.replace("\\", "/")
-        assert actual == expected, (
+        assert message.get(key) == expected, (
             f"api_call message[{key!r}] expected {expected!r}, got {message.get(key)!r}. Full message: {message}"
         )
+
+    # Verify code-location and timing attributes are present and well-typed.
+    # We do NOT pin `code.filepath` / `code.namespace` to a specific path —
+    # it's auto-populated by tracing and changes whenever the FFI entry-point
+    # moves, which is purely a refactor concern unrelated to telemetry behavior.
+    assert isinstance(message.get("code.filepath"), str) and message["code.filepath"], (
+        f"code.filepath must be a non-empty string, got: {message.get('code.filepath')!r}"
+    )
+    assert isinstance(message.get("code.namespace"), str) and message["code.namespace"], (
+        f"code.namespace must be a non-empty string, got: {message.get('code.namespace')!r}"
+    )
 
     numeric_attrs = {"code.lineno", "busy_ns", "idle_ns", "thread.id"}
     for key in numeric_attrs:
@@ -148,10 +154,9 @@ def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory
 
     # Guard against the event silently gaining or losing attributes: the
     # api_call message is the union of the exact and numeric attribute
-    # sets above — nothing more, nothing less.
-    assert set(message.keys()) == set(expected_exact.keys()) | numeric_attrs, (
-        f"Unexpected api_call message keys: {sorted(message.keys())}"
-    )
+    # sets above plus code.filepath / code.namespace.
+    expected_keys = set(expected_exact.keys()) | numeric_attrs | {"code.filepath", "code.namespace"}
+    assert set(message.keys()) == expected_keys, f"Unexpected api_call message keys: {sorted(message.keys())}"
 
 
 def _jwt_private_key_params() -> dict:

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1,10 +1,11 @@
 use snafu::{OptionExt, ResultExt};
 use std::future::Future;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 use tokio::sync::RwLock as AsyncRwLock;
+use tracing::Instrument;
 
 use super::Setting;
 use super::async_query_registry::AsyncQueryRegistry;
@@ -345,6 +346,11 @@ impl DatabaseDriverV1 {
                     )
                     .await;
 
+                    // Populate the lock-free session id cache so entry-point
+                    // methods can stamp `snowflake.session.id` on their spans
+                    // without taking the connection mutex.
+                    conn.session_id_cache.store(session_id, Ordering::Relaxed);
+
                     // Telemetry setup: check if the server has opted this session
                     // into in-band telemetry and a session registry is configured,
                     // then register the session so spans tagged with this
@@ -389,21 +395,18 @@ impl DatabaseDriverV1 {
                             .as_ref()
                             .map(crate::telemetry::environment::EnvironmentInfo::with_wrapper)
                             .unwrap_or_else(crate::telemetry::environment::EnvironmentInfo::detect);
-                        // Long-lived connection span carries all telemetry events
-                        // (session_init, api_usage, wrapper_error) for this session.
-                        // Events are exported when the span ends on connection release.
-                        let conn_span =
-                            tracing::info_span!("connection", "snowflake.session.id" = session_id,);
-
-                        // Record session_init as an event on the connection span.
-                        // We enter the span so the OpenTelemetryLayer captures the
-                        // tracing event as an OTel span event.
-                        {
-                            let _guard = conn_span.enter();
-                            crate::telemetry::record_session_init(&env_info);
-                        }
-
-                        conn.telemetry_span = Some(conn_span);
+                        // Bounded `session_init` span: an event-carrier span whose
+                        // sole purpose is to attach `snowflake.session.id` to the
+                        // session_init OTEL event. It does NOT measure connection_init
+                        // duration — login has already completed by the time this span
+                        // opens. Each subsequent driver operation emits its own bounded
+                        // span tagged with the same session id; they share no trace_id
+                        // with this span.
+                        // TODO: instrument the surrounding connection_init future so we
+                        // capture login duration + Status::Error on failure.
+                        let init_span = crate::snowflake_op_span!("session_init", Some(session_id));
+                        let _guard = init_span.enter();
+                        crate::telemetry::record_session_init(&env_info);
                     }
 
                     if keep_alive {
@@ -440,45 +443,35 @@ impl DatabaseDriverV1 {
         }
     }
 
-    /// Return the per-connection telemetry span if available.
+    /// Flush all telemetry for this connection and clean up the session registry.
     ///
-    /// Callers enter this span and record OTel events (via
-    /// `telemetry::record_api_call` / `record_exception`). The span
-    /// carries `snowflake.session.id` for routing by the shared exporter.
-    pub async fn telemetry_span(&self, handle: Handle) -> Option<tracing::Span> {
-        let conn_ptr = self.connections.get_obj(handle)?;
-        let conn = conn_ptr.lock().await;
-        conn.telemetry_span.clone()
-    }
-
-    /// End the connection span and deregister from the shared telemetry
-    /// session registry. Must be called while session tokens are still alive
-    /// (before logout/cleanup) so the exporter can authenticate the POST.
-    /// Idempotent: no-op if the span was already taken.
+    /// Order matters:
+    /// 1. Flush per-session buffered spans — awaited export to `/telemetry/send`
+    ///    while session tokens are still alive for authentication.
+    /// 2. Remove the session from the exporter registry so it no longer resolves.
+    ///
+    /// Must be called while session tokens are still alive (before logout).
+    /// Idempotent. Each driver operation emits a bounded span that ends when the
+    /// operation returns, so there is no long-lived parent span to drop here.
     pub async fn flush_connection_telemetry(&self, conn_handle: Handle) {
         let Some(conn_ptr) = self.connections.get_obj(conn_handle) else {
             return;
         };
-        let (span, tokens_arc) = {
-            let mut conn = conn_ptr.lock().await;
-            (conn.telemetry_span.take(), conn.tokens.clone())
+        let tokens_arc = {
+            let conn = conn_ptr.lock().await;
+            conn.tokens.clone()
         };
-        // Mutex dropped before reading the tokens RwLock to avoid deadlock.
         let session_id = tokens_arc.read().await.as_ref().map(|t| t.session_id);
 
-        // Drop the tracing span — this ends the underlying OTel span.
-        // SimpleSpanProcessor calls the exporter synchronously via
-        // futures_executor::block_on.  The exporter spawns the HTTP
-        // POST on the tokio runtime and awaits the JoinHandle, so by
-        // the time drop() returns the telemetry has been sent.
-        drop(span);
-        if let Some(id) = session_id
-            && let Some(sessions) = self.telemetry_sessions()
-        {
-            sessions
-                .write()
-                .unwrap_or_else(|e| e.into_inner())
-                .remove(&id);
+        if let Some(id) = session_id {
+            self.flush_telemetry_session(id).await;
+
+            if let Some(sessions) = self.telemetry_sessions() {
+                sessions
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&id);
+            }
         }
     }
 
@@ -808,10 +801,12 @@ pub struct Connection {
     pub final_session_names: RwLock<FinalSessionNames>,
     /// Wrapper identity for telemetry, set once via ConnectionInit.
     pub wrapper_identity: Option<WrapperIdentity>,
-    /// Long-lived connection span carrying `snowflake.session.id`.
-    /// Telemetry events (session_init, api_usage, wrapper_error) are
-    /// recorded as OTel events on this span; it is ended on release.
-    pub(crate) telemetry_span: Option<tracing::Span>,
+    /// Snowflake session id, populated from `tokens.session_id` immediately after
+    /// `connection_init` succeeds. Stored as `AtomicI64` so entry-point methods
+    /// can resolve it lock-free when stamping `snowflake.session.id` on their
+    /// telemetry spans. `0` means "not yet populated"; resolvers must treat `0`
+    /// as `None` to avoid colliding with a real session id of zero.
+    pub(crate) session_id_cache: AtomicI64,
     /// Handle to the per-connection heartbeat background task (if keep-alive is enabled).
     pub(crate) heartbeat_handle: Option<HeartbeatHandle>,
 }
@@ -842,7 +837,7 @@ impl Connection {
             logout_config: LogoutConfig::default(),
             final_session_names: RwLock::new(FinalSessionNames::default()),
             wrapper_identity: None,
-            telemetry_span: None,
+            session_id_cache: AtomicI64::new(0),
             heartbeat_handle: None,
         }
     }
@@ -1825,51 +1820,59 @@ impl DatabaseDriverV1 {
     /// Returns `true` if the session is valid, `false` otherwise.
     /// Automatically attempts one token refresh on 401 (session expired).
     pub async fn connection_heartbeat(&self, conn_handle: Handle) -> Result<bool, ApiError> {
-        let conn_ptr = self
-            .connections
-            .get_obj(conn_handle)
-            .context(InvalidArgumentSnafu {
-                argument: "Connection handle not found".to_string(),
-            })?;
+        let session_id = self.session_id_for_conn(conn_handle).await;
+        async {
+            let conn_ptr = self
+                .connections
+                .get_obj(conn_handle)
+                .context(InvalidArgumentSnafu {
+                    argument: "Connection handle not found".to_string(),
+                })?;
 
-        let mut ctx = match RefreshContext::from_arc(&conn_ptr).await {
-            Ok(ctx) => ctx,
-            Err(_) => return Ok(false),
-        };
-
-        let server_url = match url::Url::parse(&ctx.server_url) {
-            Ok(u) => u,
-            Err(_) => return Ok(false),
-        };
-
-        let mut last_error: Option<RestError> = None;
-
-        loop {
-            let token = match ctx.refresh_token(last_error.take()).await {
-                Ok(t) => t,
+            let mut ctx = match RefreshContext::from_arc(&conn_ptr).await {
+                Ok(ctx) => ctx,
                 Err(_) => return Ok(false),
             };
 
-            match heartbeat::send_heartbeat(
-                &ctx.http_client,
-                &server_url,
-                &ctx.client_info,
-                token.reveal(),
-            )
-            .await
-            {
-                Ok(()) => return Ok(true),
-                Err(
-                    e @ RestError::InvalidSnowflakeResponse {
-                        source: SnowflakeResponseError::SessionExpired { .. },
-                        ..
-                    },
-                ) => {
-                    last_error = Some(e);
-                }
+            let server_url = match url::Url::parse(&ctx.server_url) {
+                Ok(u) => u,
                 Err(_) => return Ok(false),
+            };
+
+            let mut last_error: Option<RestError> = None;
+
+            loop {
+                let token = match ctx.refresh_token(last_error.take()).await {
+                    Ok(t) => t,
+                    Err(_) => return Ok(false),
+                };
+
+                match heartbeat::send_heartbeat(
+                    &ctx.http_client,
+                    &server_url,
+                    &ctx.client_info,
+                    token.reveal(),
+                )
+                .await
+                {
+                    Ok(()) => return Ok(true),
+                    Err(
+                        e @ RestError::InvalidSnowflakeResponse {
+                            source: SnowflakeResponseError::SessionExpired { .. },
+                            ..
+                        },
+                    ) => {
+                        last_error = Some(e);
+                    }
+                    Err(_) => return Ok(false),
+                }
             }
         }
+        .instrument(crate::snowflake_op_span!(
+            "connection_heartbeat",
+            session_id
+        ))
+        .await
     }
 
     /// Execute a token request (ISSUE/RENEW) using the connection's master token.

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -346,11 +346,11 @@ impl DatabaseDriverV1 {
                     )
                     .await;
 
-                    // Publish the session id to the parallel `session_ids`
-                    // map on `DatabaseDriverV1` so entry-point methods can
-                    // stamp `snowflake.session.id` on their spans without
-                    // taking the connection mutex.
-                    self.register_session_id(conn_handle, session_id);
+                    // Cache the session id on the Connection so entry-point
+                    // methods can stamp `snowflake.session.id` on their spans
+                    // by reading the field under the same mutex they already
+                    // take to do their work.
+                    conn.session_id = Some(session_id);
 
                     // Telemetry setup: check if the server has opted this session
                     // into in-band telemetry and a session registry is configured,
@@ -455,11 +455,7 @@ impl DatabaseDriverV1 {
     /// Idempotent. Each driver operation emits a bounded span that ends when the
     /// operation returns, so there is no long-lived parent span to drop here.
     pub async fn flush_connection_telemetry(&self, conn_handle: Handle) {
-        // Read the session id from the parallel cache without locking the
-        // connection mutex. After flushing we drop the entry so a later
-        // operation on a re-used handle id can never resolve to a stale
-        // session.
-        let session_id = self.session_id_for_conn(conn_handle);
+        let session_id = self.session_id_for_conn(conn_handle).await;
 
         if let Some(id) = session_id {
             self.flush_telemetry_session(id).await;
@@ -471,8 +467,6 @@ impl DatabaseDriverV1 {
                     .remove(&id);
             }
         }
-
-        self.deregister_session_id(conn_handle);
     }
 
     pub async fn connection_set_option(
@@ -801,6 +795,11 @@ pub struct Connection {
     pub final_session_names: RwLock<FinalSessionNames>,
     /// Wrapper identity for telemetry, set once via ConnectionInit.
     pub wrapper_identity: Option<WrapperIdentity>,
+    /// Snowflake session id, populated from `tokens.session_id` once
+    /// `connection_init` succeeds. Read by entry-point methods (under the
+    /// connection mutex) to stamp `snowflake.session.id` on telemetry spans.
+    /// `None` until login completes; cleared on connection release.
+    pub(crate) session_id: Option<i64>,
     /// Handle to the per-connection heartbeat background task (if keep-alive is enabled).
     pub(crate) heartbeat_handle: Option<HeartbeatHandle>,
 }
@@ -831,6 +830,7 @@ impl Connection {
             logout_config: LogoutConfig::default(),
             final_session_names: RwLock::new(FinalSessionNames::default()),
             wrapper_identity: None,
+            session_id: None,
             heartbeat_handle: None,
         }
     }
@@ -1813,7 +1813,7 @@ impl DatabaseDriverV1 {
     /// Returns `true` if the session is valid, `false` otherwise.
     /// Automatically attempts one token refresh on 401 (session expired).
     pub async fn connection_heartbeat(&self, conn_handle: Handle) -> Result<bool, ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle);
+        let session_id = self.session_id_for_conn(conn_handle).await;
         async {
             let conn_ptr = self
                 .connections

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1,7 +1,7 @@
 use snafu::{OptionExt, ResultExt};
 use std::future::Future;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 use tokio::sync::RwLock as AsyncRwLock;
@@ -346,10 +346,11 @@ impl DatabaseDriverV1 {
                     )
                     .await;
 
-                    // Populate the lock-free session id cache so entry-point
-                    // methods can stamp `snowflake.session.id` on their spans
-                    // without taking the connection mutex.
-                    conn.session_id_cache.store(session_id, Ordering::Relaxed);
+                    // Publish the session id to the parallel `session_ids`
+                    // map on `DatabaseDriverV1` so entry-point methods can
+                    // stamp `snowflake.session.id` on their spans without
+                    // taking the connection mutex.
+                    self.register_session_id(conn_handle, session_id);
 
                     // Telemetry setup: check if the server has opted this session
                     // into in-band telemetry and a session registry is configured,
@@ -454,14 +455,11 @@ impl DatabaseDriverV1 {
     /// Idempotent. Each driver operation emits a bounded span that ends when the
     /// operation returns, so there is no long-lived parent span to drop here.
     pub async fn flush_connection_telemetry(&self, conn_handle: Handle) {
-        let Some(conn_ptr) = self.connections.get_obj(conn_handle) else {
-            return;
-        };
-        let tokens_arc = {
-            let conn = conn_ptr.lock().await;
-            conn.tokens.clone()
-        };
-        let session_id = tokens_arc.read().await.as_ref().map(|t| t.session_id);
+        // Read the session id from the parallel cache without locking the
+        // connection mutex. After flushing we drop the entry so a later
+        // operation on a re-used handle id can never resolve to a stale
+        // session.
+        let session_id = self.session_id_for_conn(conn_handle);
 
         if let Some(id) = session_id {
             self.flush_telemetry_session(id).await;
@@ -473,6 +471,8 @@ impl DatabaseDriverV1 {
                     .remove(&id);
             }
         }
+
+        self.deregister_session_id(conn_handle);
     }
 
     pub async fn connection_set_option(
@@ -801,12 +801,6 @@ pub struct Connection {
     pub final_session_names: RwLock<FinalSessionNames>,
     /// Wrapper identity for telemetry, set once via ConnectionInit.
     pub wrapper_identity: Option<WrapperIdentity>,
-    /// Snowflake session id, populated from `tokens.session_id` immediately after
-    /// `connection_init` succeeds. Stored as `AtomicI64` so entry-point methods
-    /// can resolve it lock-free when stamping `snowflake.session.id` on their
-    /// telemetry spans. `0` means "not yet populated"; resolvers must treat `0`
-    /// as `None` to avoid colliding with a real session id of zero.
-    pub(crate) session_id_cache: AtomicI64,
     /// Handle to the per-connection heartbeat background task (if keep-alive is enabled).
     pub(crate) heartbeat_handle: Option<HeartbeatHandle>,
 }
@@ -837,7 +831,6 @@ impl Connection {
             logout_config: LogoutConfig::default(),
             final_session_names: RwLock::new(FinalSessionNames::default()),
             wrapper_identity: None,
-            session_id_cache: AtomicI64::new(0),
             heartbeat_handle: None,
         }
     }
@@ -1820,7 +1813,7 @@ impl DatabaseDriverV1 {
     /// Returns `true` if the session is valid, `false` otherwise.
     /// Automatically attempts one token refresh on 401 (session expired).
     pub async fn connection_heartbeat(&self, conn_handle: Handle) -> Result<bool, ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle).await;
+        let session_id = self.session_id_for_conn(conn_handle);
         async {
             let conn_ptr = self
                 .connections

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
@@ -75,18 +75,6 @@ pub struct DatabaseDriverV1 {
     pub(super) connections: HandleManager<Mutex<Connection>>,
     pub(super) statements: HandleManager<Mutex<Statement>>,
     pub(super) results: HandleManager<Mutex<ResultSet>>,
-    /// Cached `connection_handle.id → Snowflake session_id` populated on login
-    /// and removed on connection release. Keeping this off the `Connection`
-    /// struct (which is behind a `tokio::Mutex`) lets entry-point methods
-    /// resolve the session id without taking the connection mutex — the only
-    /// writers are login / logout, so reads under the parallel `RwLock` are
-    /// uncontended in normal operation.
-    pub(super) session_ids: RwLock<HashMap<u64, i64>>,
-    /// Cached `statement_handle.id → owning connection_handle.id` populated
-    /// when a statement is created and removed on statement release. Lets
-    /// statement-scoped entry points map to their connection's session id
-    /// without locking the statement mutex.
-    pub(super) stmt_to_conn: RwLock<HashMap<u64, u64>>,
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
@@ -111,8 +99,6 @@ impl DatabaseDriverV1 {
             connections: HandleManager::new(),
             statements: HandleManager::new(),
             results: HandleManager::new(),
-            session_ids: RwLock::new(HashMap::new()),
-            stmt_to_conn: RwLock::new(HashMap::new()),
             token_cache: once_cell::sync::OnceCell::new(),
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),
@@ -126,73 +112,28 @@ impl DatabaseDriverV1 {
         self.log_manager.as_ref().map(|lm| lm.telemetry_sessions())
     }
 
-    /// Record a connection's Snowflake session id. Called once on successful
-    /// login so subsequent entry-point methods can stamp `snowflake.session.id`
-    /// on their telemetry spans without locking the connection mutex.
-    pub(crate) fn register_session_id(&self, conn_handle: Handle, session_id: i64) {
-        self.session_ids
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(conn_handle.id, session_id);
+    /// Resolve the Snowflake session id for a connection handle by reading
+    /// `Connection::session_id` under the connection mutex. Returns `None`
+    /// when the handle is unknown, login has not completed, or the connection
+    /// has been released.
+    pub(crate) async fn session_id_for_conn(&self, conn_handle: Handle) -> Option<i64> {
+        let conn_ptr = self.connections.get_obj(conn_handle)?;
+        let conn = conn_ptr.lock().await;
+        conn.session_id
     }
 
-    /// Forget a connection's session id. Called during connection release so a
-    /// re-used handle id never resolves to a stale session.
-    pub(crate) fn deregister_session_id(&self, conn_handle: Handle) {
-        self.session_ids
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&conn_handle.id);
-    }
-
-    /// Resolve the Snowflake session id for a connection handle. Returns
-    /// `None` when login has not populated the cache (or after release). Reads
-    /// take only the parallel-map's read lock — does **not** touch the
-    /// connection mutex, so it can be called while a query is executing on
-    /// the same connection without contending.
-    pub(crate) fn session_id_for_conn(&self, conn_handle: Handle) -> Option<i64> {
-        self.session_ids
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(&conn_handle.id)
-            .copied()
-    }
-
-    /// Record a statement's owning connection handle id. Called when the
-    /// statement is created so [`Self::session_id_for_stmt`] can resolve
-    /// without locking the statement mutex.
-    pub(crate) fn register_stmt_conn(&self, stmt_handle: Handle, conn_handle: Handle) {
-        self.stmt_to_conn
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(stmt_handle.id, conn_handle.id);
-    }
-
-    /// Forget a statement's owning connection mapping. Called on statement
-    /// release so a re-used handle id never resolves to a stale connection.
-    pub(crate) fn deregister_stmt_conn(&self, stmt_handle: Handle) {
-        self.stmt_to_conn
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&stmt_handle.id);
-    }
-
-    /// Resolve the Snowflake session id for a statement handle by reading the
-    /// parallel `stmt → conn_handle` map then the parallel `conn_handle →
-    /// session_id` map. Same lock-free properties as
-    /// [`Self::session_id_for_conn`] — no statement / connection mutex taken.
-    pub(crate) fn session_id_for_stmt(&self, stmt_handle: Handle) -> Option<i64> {
-        let conn_handle_id = self
-            .stmt_to_conn
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(&stmt_handle.id)
-            .copied()?;
-        self.session_ids
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(&conn_handle_id)
-            .copied()
+    /// Resolve the Snowflake session id for a statement handle by traversing
+    /// to its owning connection. Acquires the statement mutex to read the
+    /// `Arc<Mutex<Connection>>`, then the connection mutex to read its
+    /// cached `session_id`.
+    pub(crate) async fn session_id_for_stmt(&self, stmt_handle: Handle) -> Option<i64> {
+        let stmt_ptr = self.statements.get_obj(stmt_handle)?;
+        let conn_arc = {
+            let stmt = stmt_ptr.lock().await;
+            stmt.conn.clone()
+        };
+        let conn = conn_arc.lock().await;
+        conn.session_id
     }
 
     /// Flush buffered telemetry spans for a specific session.

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
 
 use tokio::sync::Mutex;
 
@@ -76,6 +75,18 @@ pub struct DatabaseDriverV1 {
     pub(super) connections: HandleManager<Mutex<Connection>>,
     pub(super) statements: HandleManager<Mutex<Statement>>,
     pub(super) results: HandleManager<Mutex<ResultSet>>,
+    /// Cached `connection_handle.id → Snowflake session_id` populated on login
+    /// and removed on connection release. Keeping this off the `Connection`
+    /// struct (which is behind a `tokio::Mutex`) lets entry-point methods
+    /// resolve the session id without taking the connection mutex — the only
+    /// writers are login / logout, so reads under the parallel `RwLock` are
+    /// uncontended in normal operation.
+    pub(super) session_ids: RwLock<HashMap<u64, i64>>,
+    /// Cached `statement_handle.id → owning connection_handle.id` populated
+    /// when a statement is created and removed on statement release. Lets
+    /// statement-scoped entry points map to their connection's session id
+    /// without locking the statement mutex.
+    pub(super) stmt_to_conn: RwLock<HashMap<u64, u64>>,
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
@@ -100,6 +111,8 @@ impl DatabaseDriverV1 {
             connections: HandleManager::new(),
             statements: HandleManager::new(),
             results: HandleManager::new(),
+            session_ids: RwLock::new(HashMap::new()),
+            stmt_to_conn: RwLock::new(HashMap::new()),
             token_cache: once_cell::sync::OnceCell::new(),
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),
@@ -113,34 +126,73 @@ impl DatabaseDriverV1 {
         self.log_manager.as_ref().map(|lm| lm.telemetry_sessions())
     }
 
-    /// Resolve the Snowflake session id for a connection handle by reading
-    /// `Connection::session_id_cache` (lock-free `AtomicI64`). Returns `None`
-    /// when the handle is unknown or login has not yet populated the cache.
-    /// `0` is treated as "not populated" — never as a valid session id —
-    /// because routing telemetry on `0` could collide with another tenant.
-    pub(crate) async fn session_id_for_conn(&self, conn_handle: Handle) -> Option<i64> {
-        let conn_ptr = self.connections.get_obj(conn_handle)?;
-        let conn = conn_ptr.lock().await;
-        match conn.session_id_cache.load(Ordering::Relaxed) {
-            0 => None,
-            id => Some(id),
-        }
+    /// Record a connection's Snowflake session id. Called once on successful
+    /// login so subsequent entry-point methods can stamp `snowflake.session.id`
+    /// on their telemetry spans without locking the connection mutex.
+    pub(crate) fn register_session_id(&self, conn_handle: Handle, session_id: i64) {
+        self.session_ids
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(conn_handle.id, session_id);
     }
 
-    /// Resolve the Snowflake session id for a statement handle by traversing
-    /// to its owning connection's cached session id (see
-    /// [`Self::session_id_for_conn`]).
-    pub(crate) async fn session_id_for_stmt(&self, stmt_handle: Handle) -> Option<i64> {
-        let stmt_ptr = self.statements.get_obj(stmt_handle)?;
-        let conn_arc = {
-            let stmt = stmt_ptr.lock().await;
-            stmt.conn.clone()
-        };
-        let conn = conn_arc.lock().await;
-        match conn.session_id_cache.load(Ordering::Relaxed) {
-            0 => None,
-            id => Some(id),
-        }
+    /// Forget a connection's session id. Called during connection release so a
+    /// re-used handle id never resolves to a stale session.
+    pub(crate) fn deregister_session_id(&self, conn_handle: Handle) {
+        self.session_ids
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&conn_handle.id);
+    }
+
+    /// Resolve the Snowflake session id for a connection handle. Returns
+    /// `None` when login has not populated the cache (or after release). Reads
+    /// take only the parallel-map's read lock — does **not** touch the
+    /// connection mutex, so it can be called while a query is executing on
+    /// the same connection without contending.
+    pub(crate) fn session_id_for_conn(&self, conn_handle: Handle) -> Option<i64> {
+        self.session_ids
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&conn_handle.id)
+            .copied()
+    }
+
+    /// Record a statement's owning connection handle id. Called when the
+    /// statement is created so [`Self::session_id_for_stmt`] can resolve
+    /// without locking the statement mutex.
+    pub(crate) fn register_stmt_conn(&self, stmt_handle: Handle, conn_handle: Handle) {
+        self.stmt_to_conn
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(stmt_handle.id, conn_handle.id);
+    }
+
+    /// Forget a statement's owning connection mapping. Called on statement
+    /// release so a re-used handle id never resolves to a stale connection.
+    pub(crate) fn deregister_stmt_conn(&self, stmt_handle: Handle) {
+        self.stmt_to_conn
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&stmt_handle.id);
+    }
+
+    /// Resolve the Snowflake session id for a statement handle by reading the
+    /// parallel `stmt → conn_handle` map then the parallel `conn_handle →
+    /// session_id` map. Same lock-free properties as
+    /// [`Self::session_id_for_conn`] — no statement / connection mutex taken.
+    pub(crate) fn session_id_for_stmt(&self, stmt_handle: Handle) -> Option<i64> {
+        let conn_handle_id = self
+            .stmt_to_conn
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&stmt_handle.id)
+            .copied()?;
+        self.session_ids
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&conn_handle_id)
+            .copied()
     }
 
     /// Flush buffered telemetry spans for a specific session.

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use tokio::sync::Mutex;
 
@@ -8,7 +9,7 @@ use super::database::Database;
 use super::result_set::ResultSet;
 use super::statement::Statement;
 use crate::fs_adapter::{FsAdapter, RealFs};
-use crate::handle_manager::HandleManager;
+use crate::handle_manager::{Handle, HandleManager};
 use crate::logging::LogManager;
 use crate::telemetry::platform_detection::{DetectionConfig, detect_platforms};
 use crate::telemetry::snowflake_exporter::SessionRegistry;
@@ -110,6 +111,43 @@ impl DatabaseDriverV1 {
     /// Returns the session registry if telemetry was configured via `DriverProviders`.
     pub(super) fn telemetry_sessions(&self) -> Option<&SessionRegistry> {
         self.log_manager.as_ref().map(|lm| lm.telemetry_sessions())
+    }
+
+    /// Resolve the Snowflake session id for a connection handle by reading
+    /// `Connection::session_id_cache` (lock-free `AtomicI64`). Returns `None`
+    /// when the handle is unknown or login has not yet populated the cache.
+    /// `0` is treated as "not populated" — never as a valid session id —
+    /// because routing telemetry on `0` could collide with another tenant.
+    pub(crate) async fn session_id_for_conn(&self, conn_handle: Handle) -> Option<i64> {
+        let conn_ptr = self.connections.get_obj(conn_handle)?;
+        let conn = conn_ptr.lock().await;
+        match conn.session_id_cache.load(Ordering::Relaxed) {
+            0 => None,
+            id => Some(id),
+        }
+    }
+
+    /// Resolve the Snowflake session id for a statement handle by traversing
+    /// to its owning connection's cached session id (see
+    /// [`Self::session_id_for_conn`]).
+    pub(crate) async fn session_id_for_stmt(&self, stmt_handle: Handle) -> Option<i64> {
+        let stmt_ptr = self.statements.get_obj(stmt_handle)?;
+        let conn_arc = {
+            let stmt = stmt_ptr.lock().await;
+            stmt.conn.clone()
+        };
+        let conn = conn_arc.lock().await;
+        match conn.session_id_cache.load(Ordering::Relaxed) {
+            0 => None,
+            id => Some(id),
+        }
+    }
+
+    /// Flush buffered telemetry spans for a specific session.
+    pub(super) async fn flush_telemetry_session(&self, session_id: i64) {
+        if let Some(ref lm) = self.log_manager {
+            lm.flush_session(session_id).await;
+        }
     }
 
     pub fn token_cache(&self) -> Result<&KeyringTokenCache, TokenCacheError> {

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -93,9 +93,6 @@ impl DatabaseDriverV1 {
             Some(conn_ptr) => {
                 let stmt = Mutex::new(Statement::new(conn_ptr));
                 let handle = self.statements.add_handle(stmt);
-                // Publish stmt → conn handle mapping so telemetry can resolve
-                // the owning session id without locking the statement mutex.
-                self.register_stmt_conn(handle, conn_handle);
                 Ok(handle)
             }
             None => InvalidArgumentSnafu {
@@ -107,10 +104,7 @@ impl DatabaseDriverV1 {
 
     pub fn statement_release(&self, stmt_handle: Handle) -> Result<(), ApiError> {
         match self.statements.delete_handle(stmt_handle) {
-            true => {
-                self.deregister_stmt_conn(stmt_handle);
-                Ok(())
-            }
+            true => Ok(()),
             false => InvalidArgumentSnafu {
                 argument: "Failed to release statement handle".to_string(),
             }
@@ -208,7 +202,7 @@ pub struct PrepareResult {
 
 impl DatabaseDriverV1 {
     pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
-        let session_id = self.session_id_for_stmt(stmt_handle);
+        let session_id = self.session_id_for_stmt(stmt_handle).await;
         async {
             let result = self
                 .execute_query_internal(stmt_handle, None, Some(true), None)
@@ -256,7 +250,7 @@ impl DatabaseDriverV1 {
         bindings: Option<BindingType<'a>>,
         timeout_seconds: Option<u32>,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        let session_id = self.session_id_for_stmt(stmt_handle);
+        let session_id = self.session_id_for_stmt(stmt_handle).await;
         self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds)
             .instrument(crate::snowflake_op_span!(
                 "statement_execute_query",
@@ -450,7 +444,7 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle);
+        let session_id = self.session_id_for_conn(conn_handle).await;
         async {
             let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
                 InvalidArgumentSnafu {
@@ -500,7 +494,7 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<(), ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle);
+        let session_id = self.session_id_for_conn(conn_handle).await;
         async {
             let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
                 InvalidArgumentSnafu {

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -1,5 +1,6 @@
 use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::sync::Mutex;
+use tracing::Instrument;
 
 use super::connection::{Connection, RefreshContext, with_valid_session};
 use super::error::*;
@@ -201,39 +202,44 @@ pub struct PrepareResult {
 
 impl DatabaseDriverV1 {
     pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
-        let result = self
-            .execute_query_internal(stmt_handle, None, Some(true), None)
-            .await?;
+        let session_id = self.session_id_for_stmt(stmt_handle).await;
+        async {
+            let result = self
+                .execute_query_internal(stmt_handle, None, Some(true), None)
+                .await?;
 
-        // Multi-statement query prepare is not supported.
-        let ExecuteQueryResult::Single(rs_info) = result else {
-            return Err(InvalidArgumentSnafu {
-                argument: "Multi-statement queries cannot be prepared".to_string(),
-            }
-            .build());
-        };
-        let stream = self.result_set_get_stream(rs_info.handle).await?;
-        self.result_set_release(rs_info.handle)?;
+            // Multi-statement query prepare is not supported.
+            let ExecuteQueryResult::Single(rs_info) = result else {
+                return Err(InvalidArgumentSnafu {
+                    argument: "Multi-statement queries cannot be prepared".to_string(),
+                }
+                .build());
+            };
+            let stream = self.result_set_get_stream(rs_info.handle).await?;
+            self.result_set_release(rs_info.handle)?;
 
-        let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Statement handle not found".to_string(),
-            }
-            .build()
-        })?;
-        // TODO: re-lock the statement to just copy the query
-        //       consider to carry query text in ExecuteQueryResult to avoid the re-lock
-        let stmt = stmt_ptr.lock().await;
-        let query = stmt.query.clone().unwrap_or_default();
+            let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
+                InvalidArgumentSnafu {
+                    argument: "Statement handle not found".to_string(),
+                }
+                .build()
+            })?;
+            // TODO: re-lock the statement to just copy the query
+            //       consider to carry query text in ExecuteQueryResult to avoid the re-lock
+            let stmt = stmt_ptr.lock().await;
+            let query = stmt.query.clone().unwrap_or_default();
 
-        Ok(PrepareResult {
-            stream,
-            query_id: rs_info.descriptor.query_id,
-            columns: rs_info.descriptor.columns,
-            number_of_binds: rs_info.descriptor.number_of_binds,
-            query,
-            sql_state: rs_info.descriptor.sql_state,
-        })
+            Ok(PrepareResult {
+                stream,
+                query_id: rs_info.descriptor.query_id,
+                columns: rs_info.descriptor.columns,
+                number_of_binds: rs_info.descriptor.number_of_binds,
+                query,
+                sql_state: rs_info.descriptor.sql_state,
+            })
+        }
+        .instrument(crate::snowflake_op_span!("statement_prepare", session_id))
+        .await
     }
 }
 
@@ -244,7 +250,12 @@ impl DatabaseDriverV1 {
         bindings: Option<BindingType<'a>>,
         timeout_seconds: Option<u32>,
     ) -> Result<ExecuteQueryResult, ApiError> {
+        let session_id = self.session_id_for_stmt(stmt_handle).await;
         self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds)
+            .instrument(crate::snowflake_op_span!(
+                "statement_execute_query",
+                session_id
+            ))
             .await
     }
 
@@ -433,41 +444,49 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Connection handle not found".to_string(),
+        let session_id = self.session_id_for_conn(conn_handle).await;
+        async {
+            let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
+                InvalidArgumentSnafu {
+                    argument: "Connection handle not found".to_string(),
+                }
+                .build()
+            })?;
+
+            let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
+            let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
+
+            if let Some(multi) = multistatement::try_into_multi_result(&data, descriptor.clone()) {
+                return Ok(multi);
             }
-            .build()
-        })?;
 
-        let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
-        let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
-
-        if let Some(multi) = multistatement::try_into_multi_result(&data, descriptor.clone()) {
-            return Ok(multi);
-        }
-
-        let rowset_data = match data.command.as_deref() {
-            Some(command) => {
-                let use_s3_regional_url_session_param = conn_ptr
-                    .lock()
+            let rowset_data = match data.command.as_deref() {
+                Some(command) => {
+                    let use_s3_regional_url_session_param = conn_ptr
+                        .lock()
+                        .await
+                        .use_s3_regional_url_session_param()
+                        .await;
+                    perform_put_get_transfer(
+                        command,
+                        &data,
+                        &self.wrapper_presets,
+                        None,
+                        use_s3_regional_url_session_param,
+                    )
                     .await
-                    .use_s3_regional_url_session_param()
-                    .await;
-                perform_put_get_transfer(
-                    command,
-                    &data,
-                    &self.wrapper_presets,
-                    None,
-                    use_s3_regional_url_session_param,
-                )
-                .await
-                .context(QueryResponseProcessingSnafu)?
-            }
-            None => data.into_rowset_data(),
-        };
-        let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
-        Ok(self.build_execute_result(rowset_data, descriptor, reader_ctx))
+                    .context(QueryResponseProcessingSnafu)?
+                }
+                None => data.into_rowset_data(),
+            };
+            let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
+            Ok(self.build_execute_result(rowset_data, descriptor, reader_ctx))
+        }
+        .instrument(crate::snowflake_op_span!(
+            "connection_get_query_result",
+            session_id
+        ))
+        .await
     }
 
     pub async fn connection_abort_query(
@@ -475,23 +494,32 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<(), ApiError> {
-        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Connection handle not found".to_string(),
-            }
-            .build()
-        })?;
+        let session_id = self.session_id_for_conn(conn_handle).await;
+        async {
+            let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
+                InvalidArgumentSnafu {
+                    argument: "Connection handle not found".to_string(),
+                }
+                .build()
+            })?;
 
-        let (query_parameters, http_client, _) = query_context(&conn_ptr).await?;
+            let (query_parameters, http_client, _) = query_context(&conn_ptr).await?;
 
-        with_valid_session(&conn_ptr, |token| {
-            let http_client = &http_client;
-            let query_parameters = &query_parameters;
-            let query_id = &query_id;
-            async move {
-                snowflake_abort_query(http_client, query_parameters, token.reveal(), query_id).await
-            }
-        })
+            with_valid_session(&conn_ptr, |token| {
+                let http_client = &http_client;
+                let query_parameters = &query_parameters;
+                let query_id = &query_id;
+                async move {
+                    snowflake_abort_query(http_client, query_parameters, token.reveal(), query_id)
+                        .await
+                }
+            })
+            .await
+        }
+        .instrument(crate::snowflake_op_span!(
+            "connection_abort_query",
+            session_id
+        ))
         .await
     }
 }

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -93,6 +93,9 @@ impl DatabaseDriverV1 {
             Some(conn_ptr) => {
                 let stmt = Mutex::new(Statement::new(conn_ptr));
                 let handle = self.statements.add_handle(stmt);
+                // Publish stmt → conn handle mapping so telemetry can resolve
+                // the owning session id without locking the statement mutex.
+                self.register_stmt_conn(handle, conn_handle);
                 Ok(handle)
             }
             None => InvalidArgumentSnafu {
@@ -104,7 +107,10 @@ impl DatabaseDriverV1 {
 
     pub fn statement_release(&self, stmt_handle: Handle) -> Result<(), ApiError> {
         match self.statements.delete_handle(stmt_handle) {
-            true => Ok(()),
+            true => {
+                self.deregister_stmt_conn(stmt_handle);
+                Ok(())
+            }
             false => InvalidArgumentSnafu {
                 argument: "Failed to release statement handle".to_string(),
             }
@@ -202,7 +208,7 @@ pub struct PrepareResult {
 
 impl DatabaseDriverV1 {
     pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
-        let session_id = self.session_id_for_stmt(stmt_handle).await;
+        let session_id = self.session_id_for_stmt(stmt_handle);
         async {
             let result = self
                 .execute_query_internal(stmt_handle, None, Some(true), None)
@@ -250,7 +256,7 @@ impl DatabaseDriverV1 {
         bindings: Option<BindingType<'a>>,
         timeout_seconds: Option<u32>,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        let session_id = self.session_id_for_stmt(stmt_handle).await;
+        let session_id = self.session_id_for_stmt(stmt_handle);
         self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds)
             .instrument(crate::snowflake_op_span!(
                 "statement_execute_query",
@@ -444,7 +450,7 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<ExecuteQueryResult, ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle).await;
+        let session_id = self.session_id_for_conn(conn_handle);
         async {
             let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
                 InvalidArgumentSnafu {
@@ -494,7 +500,7 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         query_id: String,
     ) -> Result<(), ApiError> {
-        let session_id = self.session_id_for_conn(conn_handle).await;
+        let session_id = self.session_id_for_conn(conn_handle);
         async {
             let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
                 InvalidArgumentSnafu {

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::{Layer, Registry};
 use crate::fs_adapter::{FsAdapter, RealFs};
 use crate::telemetry::os_details::detect_os_details;
 use crate::telemetry::snowflake_exporter::SessionRegistry;
+use crate::telemetry::snowflake_processor::SessionFlushHandle;
 
 use super::error::{InitSnafu, LogError};
 use super::{EmptyLayer, LoggingConfig};
@@ -28,6 +29,7 @@ pub struct LogManager {
     #[allow(dead_code)]
     telemetry_provider: opentelemetry_sdk::trace::SdkTracerProvider,
     telemetry_sessions: SessionRegistry,
+    session_flusher: Option<SessionFlushHandle>,
     os_details: once_cell::sync::OnceCell<Option<HashMap<String, String>>>,
     fs: Arc<dyn FsAdapter>,
     /// Process-wide default for `log_query_text` parsed from `sf.odbc.ini` /
@@ -43,6 +45,16 @@ impl LogManager {
     /// Returns the session registry shared with the Snowflake telemetry exporter.
     pub fn telemetry_sessions(&self) -> &SessionRegistry {
         &self.telemetry_sessions
+    }
+
+    /// Flush buffered telemetry spans for a specific session.
+    /// Called during connection release before the connection span is dropped.
+    /// Awaits the export so it completes while session tokens are still alive
+    /// (see [`crate::telemetry::snowflake_processor::SessionFlushHandle::flush_session`]).
+    pub async fn flush_session(&self, session_id: i64) {
+        if let Some(ref flusher) = self.session_flusher {
+            flusher.flush_session(session_id).await;
+        }
     }
 
     /// Lazily detects and caches OS details (e.g. `/etc/os-release` on Linux).
@@ -83,6 +95,7 @@ impl LogManager {
         Self {
             telemetry_provider: opentelemetry_sdk::trace::SdkTracerProvider::builder().build(),
             telemetry_sessions: SessionRegistry::default(),
+            session_flusher: None,
             os_details: once_cell::sync::OnceCell::new(),
             fs,
             log_query_text: None,
@@ -114,16 +127,18 @@ impl LogManager {
         let log_query_text = config.log_query_text;
         let log_query_parameters = config.log_query_parameters;
         let error_trace_enabled = config.error_trace_enabled;
-        let provider = Self::try_init(config, None::<EmptyLayer>, Some(sessions.clone()))?
-            .ok_or_else(|| {
-                InitSnafu {
-                    message: "provider is always Some when sessions are provided",
-                }
-                .build()
-            })?;
+        let (provider, flusher) =
+            Self::try_init(config, None::<EmptyLayer>, Some(sessions.clone()))?;
+        let provider = provider.ok_or_else(|| {
+            InitSnafu {
+                message: "provider is always Some when sessions are provided",
+            }
+            .build()
+        })?;
         Ok(Self {
             telemetry_provider: provider,
             telemetry_sessions: sessions,
+            session_flusher: flusher,
             os_details: once_cell::sync::OnceCell::new(),
             fs: Arc::new(RealFs),
             log_query_text,
@@ -146,16 +161,17 @@ impl LogManager {
         let log_query_text = config.log_query_text;
         let log_query_parameters = config.log_query_parameters;
         let error_trace_enabled = config.error_trace_enabled;
-        let provider =
-            Self::try_init(config, Some(app_sink), Some(registry.clone()))?.ok_or_else(|| {
-                InitSnafu {
-                    message: "provider is always Some when registry is Some",
-                }
-                .build()
-            })?;
+        let (provider, flusher) = Self::try_init(config, Some(app_sink), Some(registry.clone()))?;
+        let provider = provider.ok_or_else(|| {
+            InitSnafu {
+                message: "provider is always Some when registry is Some",
+            }
+            .build()
+        })?;
         Ok(Self {
             telemetry_provider: provider,
             telemetry_sessions: registry,
+            session_flusher: flusher,
             os_details: once_cell::sync::OnceCell::new(),
             fs: Arc::new(RealFs),
             log_query_text,
@@ -205,7 +221,13 @@ impl LogManager {
         config: LoggingConfig,
         app_sink: Option<L>,
         registry: Option<SessionRegistry>,
-    ) -> Result<Option<opentelemetry_sdk::trace::SdkTracerProvider>, LogError>
+    ) -> Result<
+        (
+            Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+            Option<SessionFlushHandle>,
+        ),
+        LogError,
+    >
     where
         L: Layer<Registry> + Send + Sync + 'static,
     {
@@ -221,20 +243,21 @@ impl LogManager {
             layers.push(OpenTelemetryLayer::new(super::opentelemetry::init_tracer()?).boxed());
         }
 
-        let (snowflake_layer, provider) = if let Some(sessions) = registry {
+        let (snowflake_layer, provider, flush_handle) = if let Some(sessions) = registry {
             let exporter =
                 crate::telemetry::snowflake_exporter::SnowflakeInBandExporter::new(sessions);
+            let (processor, flush_handle) =
+                crate::telemetry::snowflake_processor::SnowflakeSpanProcessor::new(exporter);
             let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-                .with_simple_exporter(exporter)
+                .with_span_processor(processor)
                 .build();
             let tracer = provider.tracer("snowflake.telemetry");
-            let layer =
-                OpenTelemetryLayer::new(tracer).with_filter(tracing_subscriber::filter::filter_fn(
-                    |metadata| metadata.name() == "connection" || metadata.is_event(),
-                ));
-            (Some(layer), Some(provider))
+            // No filter — the processor handles routing and drops
+            // spans that cannot be resolved to a session.
+            let layer = OpenTelemetryLayer::new(tracer);
+            (Some(layer), Some(provider), Some(flush_handle))
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         if let Some(layer) = snowflake_layer {
@@ -263,7 +286,7 @@ impl LogManager {
             .build()
         })?;
 
-        Ok(provider)
+        Ok((provider, flush_handle))
     }
 
     fn build_core_layer(config: &LoggingConfig) -> Result<BoxedLayer, LogError> {
@@ -436,5 +459,19 @@ mod tests {
             !config.open_telemetry,
             "default opentelemetry should be false"
         );
+    }
+
+    #[test]
+    fn with_none_subscriber_exposes_session_registry() {
+        let lm = LogManager::with_none_subscriber(Arc::new(crate::fs_adapter::RealFs));
+        let guard = lm.telemetry_sessions().read().unwrap();
+        assert!(guard.is_empty(), "session registry should start empty");
+    }
+
+    #[tokio::test]
+    async fn flush_session_is_noop_without_flusher() {
+        let lm = LogManager::with_none_subscriber(Arc::new(crate::fs_adapter::RealFs));
+        // session_flusher is None for with_none_subscriber — should not panic
+        lm.flush_session(42).await;
     }
 }

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use opentelemetry::trace::TracerProvider;
+use tracing::Level;
 use tracing::level_filters::LevelFilter;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -252,9 +253,14 @@ impl LogManager {
                 .with_span_processor(processor)
                 .build();
             let tracer = provider.tracer("snowflake.telemetry");
-            // No filter — the processor handles routing and drops
-            // spans that cannot be resolved to a session.
-            let layer = OpenTelemetryLayer::new(tracer);
+            // Restrict the OpenTelemetryLayer to spans emitted by sf_core itself.
+            // Without this filter every span from tokio, hyper, tower, tonic, …
+            // would flow through `SnowflakeSpanProcessor::on_end`, take the
+            // per-session buffers mutex, scan attributes for `snowflake.session.id`
+            // (always absent), and be dropped — pure overhead on the hot path.
+            let layer = OpenTelemetryLayer::new(tracer).with_filter(
+                tracing_subscriber::filter::Targets::new().with_target("sf_core", Level::TRACE),
+            );
             (Some(layer), Some(provider), Some(flush_handle))
         } else {
             (None, None, None)

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -914,7 +914,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        let session_id = self.driver.session_id_for_conn(handle).await;
+        let session_id = self.driver.session_id_for_conn(handle);
         let span = crate::snowflake_op_span!("wrapper_api_usage", session_id);
         let _guard = span.enter();
         crate::telemetry::record_api_call(&input.api_method);
@@ -933,7 +933,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        let session_id = self.driver.session_id_for_conn(handle).await;
+        let session_id = self.driver.session_id_for_conn(handle);
         let span = crate::snowflake_op_span!("wrapper_error", session_id);
         let _guard = span.enter();
         crate::telemetry::record_exception(&input.exception_type, &input.error_source);

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -914,10 +914,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        if let Some(conn_span) = self.driver.telemetry_span(handle).await {
-            let _guard = conn_span.enter();
-            crate::telemetry::record_api_call(&input.api_method);
-        }
+        let session_id = self.driver.session_id_for_conn(handle).await;
+        let span = crate::snowflake_op_span!("wrapper_api_usage", session_id);
+        let _guard = span.enter();
+        crate::telemetry::record_api_call(&input.api_method);
 
         Ok(TelemetrySendResponse {})
     }
@@ -933,10 +933,10 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        if let Some(conn_span) = self.driver.telemetry_span(handle).await {
-            let _guard = conn_span.enter();
-            crate::telemetry::record_exception(&input.exception_type, &input.error_source);
-        }
+        let session_id = self.driver.session_id_for_conn(handle).await;
+        let span = crate::snowflake_op_span!("wrapper_error", session_id);
+        let _guard = span.enter();
+        crate::telemetry::record_exception(&input.exception_type, &input.error_source);
 
         Ok(TelemetrySendResponse {})
     }

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -914,7 +914,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        let session_id = self.driver.session_id_for_conn(handle);
+        let session_id = self.driver.session_id_for_conn(handle).await;
         let span = crate::snowflake_op_span!("wrapper_api_usage", session_id);
         let _guard = span.enter();
         crate::telemetry::record_api_call(&input.api_method);
@@ -933,7 +933,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
 
-        let session_id = self.driver.session_id_for_conn(handle);
+        let session_id = self.driver.session_id_for_conn(handle).await;
         let span = crate::snowflake_op_span!("wrapper_error", session_id);
         let _guard = span.enter();
         crate::telemetry::record_exception(&input.exception_type, &input.error_source);

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -14,9 +14,11 @@ pub mod platform_detection;
 
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-/// Span attribute key for the Snowflake session id. Carried on every span
-/// the driver emits so the exporter can route it to the correct session
-/// without relying on parent-child trace relationships.
+/// Span attribute key for the Snowflake session id. Read by the exporter to
+/// route spans to the right session. The [`snowflake_op_span!`] macro stamps
+/// the same string as a literal field name (it has to — `tracing::info_span!`
+/// requires field names at macro-expansion time, not runtime values), so any
+/// rename here must be mirrored in the macro.
 pub const SESSION_ID_FIELD: &str = "snowflake.session.id";
 
 /// Build a bounded span for a single FFI / driver operation tagged with the
@@ -31,6 +33,8 @@ pub const SESSION_ID_FIELD: &str = "snowflake.session.id";
 /// `event_kind = "span"` is stamped so downstream consumers can distinguish
 /// per-operation span records from event records (`session_init`, `api_call`,
 /// `exception`) that share the same `/telemetry/send` payload shape.
+///
+/// The `"snowflake.session.id"` literal must match [`SESSION_ID_FIELD`].
 #[macro_export]
 macro_rules! snowflake_op_span {
     ($name:expr, $session_id:expr) => {

--- a/sf_core/src/telemetry/mod.rs
+++ b/sf_core/src/telemetry/mod.rs
@@ -6,18 +6,53 @@ pub mod types;
 pub mod serialization;
 #[doc(hidden)]
 pub mod snowflake_exporter;
+#[doc(hidden)]
+pub mod snowflake_processor;
 
 pub mod os_details;
 pub mod platform_detection;
 
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+/// Span attribute key for the Snowflake session id. Carried on every span
+/// the driver emits so the exporter can route it to the correct session
+/// without relying on parent-child trace relationships.
+pub const SESSION_ID_FIELD: &str = "snowflake.session.id";
+
+/// Build a bounded span for a single FFI / driver operation tagged with the
+/// owning session id. Each entry-point method opens one of these and lets it
+/// end with the operation — there is no long-lived parent span.
+///
+/// `$session_id` must be `Option<i64>`. When `None` (handle unknown, login
+/// not yet completed, mid-teardown) the macro returns `Span::none()` so the
+/// span is silently disabled rather than stamped with a sentinel that could
+/// collide with a real session id and route telemetry to the wrong tenant.
+///
+/// `event_kind = "span"` is stamped so downstream consumers can distinguish
+/// per-operation span records from event records (`session_init`, `api_call`,
+/// `exception`) that share the same `/telemetry/send` payload shape.
+#[macro_export]
+macro_rules! snowflake_op_span {
+    ($name:expr, $session_id:expr) => {
+        match $session_id {
+            ::std::option::Option::Some(id) => ::tracing::info_span!(
+                $name,
+                "db.system" = "snowflake",
+                "snowflake.session.id" = id,
+                "event_kind" = "span",
+            ),
+            ::std::option::Option::None => ::tracing::Span::none(),
+        }
+    };
+}
+
 /// Record a session_init event on the **current** tracing span.
 ///
-/// The caller must have entered the connection span before calling this.
-/// Uses `OpenTelemetrySpanExt::add_event` (rather than `tracing::event!`)
-/// because events with dotted field names (e.g. `service.name`) are not
-/// supported by the `event!` macro, and because
+/// The caller must have entered a span tagged with `snowflake.session.id`
+/// (e.g. one built by [`snowflake_op_span!`]) before calling this. Uses
+/// `OpenTelemetrySpanExt::add_event` (rather than `tracing::event!`) because
+/// events with dotted field names (e.g. `service.name`) are not supported by
+/// the `event!` macro, and because
 /// `Span::current().context().span().add_event(...)` operates on a detached
 /// `SpanRef` and does not mutate the underlying tracing span.
 pub fn record_session_init(env: &environment::EnvironmentInfo) {

--- a/sf_core/src/telemetry/serialization.rs
+++ b/sf_core/src/telemetry/serialization.rs
@@ -1,5 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use opentelemetry::KeyValue;
+use opentelemetry::trace::Status;
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
 use opentelemetry_sdk::trace::SpanData;
 use serde_json::{Value, json};
@@ -15,24 +17,39 @@ pub fn spans_to_snowflake_payload(spans: &[SpanData]) -> Value {
 fn span_to_log_entries(span: &SpanData) -> Vec<Value> {
     let mut entries = Vec::new();
 
-    if span.events.is_empty() {
-        // No events — emit the span itself as a single log entry (e.g. session_init
-        // when emitted as a standalone span for backward compatibility).
-        entries.push(attrs_to_log_entry(
-            &span.name,
-            &span.attributes,
-            span.start_time,
-        ));
-    } else {
-        // Each event on the span becomes its own log entry. The span's
-        // attributes are inherited so every entry carries session_id etc.
-        for event in span.events.iter() {
-            let mut attrs: Vec<opentelemetry::KeyValue> = span.attributes.clone();
-            for kv in &event.attributes {
-                attrs.push(kv.clone());
-            }
-            entries.push(attrs_to_log_entry(&event.name, &attrs, event.timestamp));
+    // Events on the span (wrapper api_call, exception, session_init) —
+    // each becomes its own log entry, inheriting span attributes. We override
+    // `event_kind` to "event" so downstream consumers can distinguish event
+    // records from span records that happen to share the same payload shape.
+    for event in span.events.iter() {
+        let mut attrs: Vec<KeyValue> = span
+            .attributes
+            .iter()
+            .filter(|kv| kv.key.as_str() != "event_kind")
+            .cloned()
+            .collect();
+        attrs.push(KeyValue::new("event_kind", "event"));
+        for kv in &event.attributes {
+            attrs.push(kv.clone());
         }
+        entries.push(attrs_to_log_entry(&event.name, &attrs, event.timestamp));
+    }
+
+    // Operation spans (sf_core entry-points like execute_query, heartbeat)
+    // have no events — emit the span itself as a log entry with duration
+    // and status. The span's `event_kind="span"` attribute carries through.
+    if span.events.is_empty() {
+        let mut attrs = span.attributes.clone();
+        if let Ok(duration) = span.end_time.duration_since(span.start_time) {
+            attrs.push(KeyValue::new("duration_ms", duration.as_millis() as i64));
+        }
+        if let Status::Error { description } = &span.status {
+            attrs.push(KeyValue::new("status", "ERROR"));
+            if !description.is_empty() {
+                attrs.push(KeyValue::new("status_description", description.to_string()));
+            }
+        }
+        entries.push(attrs_to_log_entry(&span.name, &attrs, span.start_time));
     }
 
     entries
@@ -205,5 +222,59 @@ mod tests {
 
         let payload = spans_to_snowflake_payload(&[span]);
         assert_eq!(payload["logs"][0]["message"]["login_timeout"], 30);
+    }
+
+    #[test]
+    fn child_span_includes_duration_ms() {
+        // Child span: no events, 1 second duration (end - start = 1000ms)
+        let span = make_test_span("statement_execute_query", vec![]);
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        let entry = &payload["logs"][0];
+        assert_eq!(entry["message"]["type"], "statement_execute_query");
+        assert_eq!(entry["message"]["duration_ms"], 1000);
+    }
+
+    #[test]
+    fn child_span_ok_status_has_no_error_fields() {
+        let span = make_test_span("connection_heartbeat", vec![]);
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        let msg = &payload["logs"][0]["message"];
+        assert!(
+            msg.get("status").is_none(),
+            "OK span should not have status field"
+        );
+    }
+
+    #[test]
+    fn child_span_error_status_includes_description() {
+        let mut span = make_test_span("statement_execute_query", vec![]);
+        span.status = Status::Error {
+            description: "SQL compilation error".into(),
+        };
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        let msg = &payload["logs"][0]["message"];
+        assert_eq!(msg["status"], "ERROR");
+        assert_eq!(msg["status_description"], "SQL compilation error");
+        // duration_ms still present
+        assert_eq!(msg["duration_ms"], 1000);
+    }
+
+    #[test]
+    fn child_span_error_empty_description() {
+        let mut span = make_test_span("statement_execute_query", vec![]);
+        span.status = Status::Error {
+            description: "".into(),
+        };
+
+        let payload = spans_to_snowflake_payload(&[span]);
+        let msg = &payload["logs"][0]["message"];
+        assert_eq!(msg["status"], "ERROR");
+        assert!(
+            msg.get("status_description").is_none(),
+            "empty description should be omitted"
+        );
     }
 }

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -12,10 +12,8 @@ use crate::config::rest_parameters::QueryParameters;
 use crate::rest::snowflake::SessionTokens;
 use crate::rest::snowflake::telemetry as rest;
 
+use super::SESSION_ID_FIELD;
 use super::serialization;
-
-/// Span attribute key used to route telemetry to the correct session.
-const SESSION_ID_ATTR: &str = "snowflake.session.id";
 
 /// Shared registry mapping session IDs to their exporter sessions.
 /// Connections register on init, deregister on release.
@@ -88,7 +86,7 @@ async fn send_with_token(session: &ExporterSession, payload: &serde_json::Value)
 pub(crate) fn extract_session_id(attrs: &[KeyValue]) -> Option<i64> {
     use opentelemetry::Value;
     attrs.iter().find_map(|kv| {
-        if kv.key.as_str() == SESSION_ID_ATTR {
+        if kv.key.as_str() == SESSION_ID_FIELD {
             match &kv.value {
                 Value::I64(id) => Some(*id),
                 Value::String(s) => s.as_str().parse::<i64>().ok(),
@@ -232,7 +230,7 @@ mod tests {
     fn make_test_span(session_id: Option<i64>) -> SpanData {
         let mut attributes = vec![];
         if let Some(id) = session_id {
-            attributes.push(KeyValue::new(SESSION_ID_ATTR, id.to_string()));
+            attributes.push(KeyValue::new(SESSION_ID_FIELD, id.to_string()));
         }
 
         SpanData {
@@ -359,13 +357,13 @@ mod tests {
 
     #[test]
     fn extract_session_id_handles_i64_value() {
-        let attrs = vec![KeyValue::new(SESSION_ID_ATTR, 42i64)];
+        let attrs = vec![KeyValue::new(SESSION_ID_FIELD, 42i64)];
         assert_eq!(extract_session_id(&attrs), Some(42));
     }
 
     #[test]
     fn extract_session_id_handles_string_value() {
-        let attrs = vec![KeyValue::new(SESSION_ID_ATTR, "99")];
+        let attrs = vec![KeyValue::new(SESSION_ID_FIELD, "99")];
         assert_eq!(extract_session_id(&attrs), Some(99));
     }
 

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -38,10 +38,9 @@ impl std::fmt::Debug for ExporterSession {
 
 /// Custom OTel exporter that sends telemetry to Snowflake's in-band `/telemetry/send` endpoint.
 ///
-/// Uses a shared session registry to route spans to the correct connection based on
-/// the `snowflake.session.id` span attribute. Spans without this attribute are silently
-/// dropped — this is the security/privacy boundary ensuring only explicitly tagged spans
-/// are sent to Snowflake.
+/// Routes spans by the `snowflake.session.id` attribute every driver operation
+/// stamps on its own bounded span. Spans that lack the attribute are silently
+/// dropped — they don't belong to a Snowflake session.
 ///
 /// All errors are treated as non-fatal — telemetry must never break the user's workflow.
 #[derive(Debug, Clone)]
@@ -86,7 +85,7 @@ async fn send_with_token(session: &ExporterSession, payload: &serde_json::Value)
 
 /// Extract the `snowflake.session.id` attribute value from a span's attributes.
 /// Handles both I64 (from tracing i64 fields) and String representations.
-fn extract_session_id(attrs: &[KeyValue]) -> Option<i64> {
+pub(crate) fn extract_session_id(attrs: &[KeyValue]) -> Option<i64> {
     use opentelemetry::Value;
     attrs.iter().find_map(|kv| {
         if kv.key.as_str() == SESSION_ID_ATTR {
@@ -117,11 +116,11 @@ impl SpanExporter for SnowflakeInBandExporter {
             }
 
             let do_export = move || async move {
-                // Group spans by session_id. Spans without the attribute are dropped.
+                // Group spans by session_id from the span attribute.
                 let mut by_session: HashMap<i64, Vec<SpanData>> = HashMap::new();
                 for span in batch {
-                    if let Some(session_id) = extract_session_id(&span.attributes) {
-                        by_session.entry(session_id).or_default().push(span);
+                    if let Some(id) = extract_session_id(&span.attributes) {
+                        by_session.entry(id).or_default().push(span);
                     }
                 }
 

--- a/sf_core/src/telemetry/snowflake_processor.rs
+++ b/sf_core/src/telemetry/snowflake_processor.rs
@@ -1,0 +1,399 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use opentelemetry::Context;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
+
+use super::snowflake_exporter::{SnowflakeInBandExporter, extract_session_id};
+
+/// Number of buffered spans per session before an automatic flush.
+const FLUSH_THRESHOLD: usize = 50;
+
+type SharedBuffers = Arc<Mutex<HashMap<i64, Vec<SpanData>>>>;
+
+/// Custom [`SpanProcessor`] that buffers spans per session and flushes
+/// when a threshold is reached or when explicitly requested on connection
+/// release.
+///
+/// Unlike `SimpleSpanProcessor` (which exports every span immediately),
+/// this batches spans per session and sends them together, reducing the
+/// number of HTTP calls to `/telemetry/send`.
+///
+/// Spans are routed by the `snowflake.session.id` attribute the driver
+/// stamps on each operation span. Spans that lack the attribute are
+/// dropped — they don't belong to a Snowflake session.
+#[derive(Debug)]
+pub struct SnowflakeSpanProcessor {
+    exporter: Mutex<SnowflakeInBandExporter>,
+    buffers: SharedBuffers,
+}
+
+/// Cloneable handle for flushing a specific session's buffered spans.
+///
+/// Shared with `DatabaseDriverV1` so connection release can flush
+/// remaining spans before the connection span is dropped.
+#[derive(Debug, Clone)]
+pub struct SessionFlushHandle {
+    exporter: SnowflakeInBandExporter,
+    buffers: SharedBuffers,
+}
+
+/// Bounded wait for the awaited flush path. Prevents a hung
+/// `/telemetry/send` endpoint from blocking `connection_close` indefinitely.
+/// Sized to accommodate p99 latency in degraded regions (observed 3-4s).
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
+impl SessionFlushHandle {
+    /// Drain and export all buffered spans for the given session.
+    /// Called during connection release, before session tokens are cleared
+    /// and before the connection span is dropped.
+    ///
+    /// Awaits the HTTP POST so the export completes while session tokens are
+    /// still alive for authentication. If the exporter exceeds
+    /// [`FLUSH_TIMEOUT`], the in-flight export future is cancelled and the
+    /// buffered spans for this session are dropped — telemetry is best-effort
+    /// and we prefer losing a batch to stalling `connection_close`. A detached
+    /// spawn retry is intentionally not used because the `Vec<SpanData>` has
+    /// already been moved into the cancelled future.
+    pub async fn flush_session(&self, session_id: i64) {
+        let spans = {
+            let mut bufs = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
+            bufs.remove(&session_id).unwrap_or_default()
+        };
+        if spans.is_empty() {
+            return;
+        }
+        do_export_await(&self.exporter, spans).await;
+    }
+}
+
+use opentelemetry_sdk::trace::SpanExporter;
+
+/// Spawn the exporter on the tokio runtime and return immediately.
+///
+/// Used from [`SnowflakeSpanProcessor::on_end`], which is called synchronously
+/// from within `Span::end`. We must not block the span-end hot path, so this
+/// path is fire-and-forget and telemetry export is best-effort.
+fn do_export_spawn(exporter: &SnowflakeInBandExporter, spans: Vec<SpanData>) {
+    let exporter_clone = exporter.clone();
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            if let Err(e) = SpanExporter::export(&exporter_clone, spans).await {
+                tracing::debug!(error = %e, "Snowflake telemetry export failed");
+            }
+        });
+    }
+}
+
+/// Await the exporter with [`FLUSH_TIMEOUT`] bound. Used by
+/// [`SessionFlushHandle::flush_session`] on connection release so the POST
+/// completes while session tokens are still alive. On timeout the in-flight
+/// export future is cancelled and the spans are dropped (the `Vec<SpanData>`
+/// was moved into that future). A slow/hung endpoint therefore cannot stall
+/// `connection_close`; the trade-off is losing at most one per-session batch.
+async fn do_export_await(exporter: &SnowflakeInBandExporter, spans: Vec<SpanData>) {
+    let exporter_clone = exporter.clone();
+    match tokio::time::timeout(FLUSH_TIMEOUT, SpanExporter::export(&exporter_clone, spans)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "Snowflake telemetry export failed");
+        }
+        Err(_elapsed) => {
+            tracing::debug!(
+                timeout_secs = FLUSH_TIMEOUT.as_secs(),
+                "Snowflake telemetry flush timed out; continuing"
+            );
+        }
+    }
+}
+
+impl SnowflakeSpanProcessor {
+    /// Create a processor and a [`SessionFlushHandle`] that shares the
+    /// same buffers. The handle is used by connection release to flush
+    /// remaining spans for a session.
+    pub fn new(exporter: SnowflakeInBandExporter) -> (Self, SessionFlushHandle) {
+        let buffers: SharedBuffers = Arc::new(Mutex::new(HashMap::new()));
+        let flush_handle = SessionFlushHandle {
+            exporter: exporter.clone(),
+            buffers: Arc::clone(&buffers),
+        };
+        let processor = Self {
+            exporter: Mutex::new(exporter),
+            buffers,
+        };
+        (processor, flush_handle)
+    }
+}
+
+impl SpanProcessor for SnowflakeSpanProcessor {
+    fn on_start(&self, _span: &mut Span, _cx: &Context) {
+        // Nothing to do on span start.
+    }
+
+    fn on_end(&self, span: SpanData) {
+        if !span.span_context.is_sampled() {
+            return;
+        }
+
+        let Some(session_id) = extract_session_id(&span.attributes) else {
+            return;
+        };
+
+        let flush = {
+            let mut bufs = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
+            let buf = bufs.entry(session_id).or_default();
+            buf.push(span);
+            buf.len() >= FLUSH_THRESHOLD
+        };
+
+        if flush {
+            let spans = {
+                let mut bufs = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
+                bufs.remove(&session_id).unwrap_or_default()
+            };
+            if !spans.is_empty() {
+                do_export_spawn(
+                    &self.exporter.lock().unwrap_or_else(|e| e.into_inner()),
+                    spans,
+                );
+            }
+        }
+    }
+
+    /// Best-effort spawn flush on tracer-provider shutdown.
+    ///
+    /// The `SpanProcessor` trait requires a sync `force_flush`, so we cannot
+    /// await the exporter here. The authoritative flush path that guarantees
+    /// the POST completes while session tokens are still alive is
+    /// [`SessionFlushHandle::flush_session`], called from
+    /// `flush_connection_telemetry` on connection release.
+    fn force_flush(&self) -> OTelSdkResult {
+        let all_spans: Vec<(i64, Vec<SpanData>)> = {
+            let mut bufs = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
+            bufs.drain().collect()
+        };
+        let exporter = self.exporter.lock().unwrap_or_else(|e| e.into_inner());
+        for (_session_id, spans) in all_spans {
+            if !spans.is_empty() {
+                do_export_spawn(&exporter, spans);
+            }
+        }
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        self.force_flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::InstrumentationScope;
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::{
+        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    };
+    use std::sync::RwLock;
+    use std::time::UNIX_EPOCH;
+
+    use super::super::snowflake_exporter::SessionRegistry;
+
+    fn make_test_span(session_id: Option<i64>, trace_id_hex: &str) -> SpanData {
+        let mut attributes = vec![];
+        if let Some(id) = session_id {
+            attributes.push(KeyValue::new("snowflake.session.id", id.to_string()));
+        }
+
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_hex(trace_id_hex).unwrap(),
+                SpanId::from_hex("0102030405060708").unwrap(),
+                TraceFlags::SAMPLED,
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            span_kind: SpanKind::Internal,
+            name: "test_span".into(),
+            start_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000000000),
+            end_time: UNIX_EPOCH + std::time::Duration::from_millis(1700000001000),
+            attributes,
+            dropped_attributes_count: 0,
+            events: Default::default(),
+            links: Default::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    fn make_processor() -> (SnowflakeSpanProcessor, SessionFlushHandle) {
+        let sessions: SessionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let exporter = SnowflakeInBandExporter::new(sessions);
+        SnowflakeSpanProcessor::new(exporter)
+    }
+
+    #[test]
+    fn span_without_session_id_is_dropped() {
+        let (processor, _flush) = make_processor();
+        let span = make_test_span(None, "0102030405060708090a0b0c0d0e0f10");
+        processor.on_end(span);
+
+        let bufs = processor.buffers.lock().unwrap();
+        assert!(bufs.is_empty(), "unresolvable span should be dropped");
+    }
+
+    #[test]
+    fn span_with_session_id_is_buffered() {
+        let (processor, _flush) = make_processor();
+        let span = make_test_span(Some(1), "0102030405060708090a0b0c0d0e0f10");
+        processor.on_end(span);
+
+        let bufs = processor.buffers.lock().unwrap();
+        assert_eq!(bufs.get(&1).map(|v| v.len()), Some(1));
+    }
+
+    #[test]
+    fn flush_threshold_drains_buffer() {
+        let (processor, _flush) = make_processor();
+
+        for _ in 0..FLUSH_THRESHOLD {
+            let span = make_test_span(Some(1), "0102030405060708090a0b0c0d0e0f10");
+            processor.on_end(span);
+        }
+
+        // Buffer should be drained after reaching threshold
+        // (export may fail because no session is registered, but buffer is cleared)
+        let bufs = processor.buffers.lock().unwrap();
+        assert!(
+            bufs.get(&1).map(|v| v.len()).unwrap_or(0) == 0,
+            "buffer should be drained at threshold"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_session_drains_specific_session() {
+        let (processor, flush_handle) = make_processor();
+
+        // Buffer spans for two sessions
+        for _ in 0..5 {
+            processor.on_end(make_test_span(Some(1), "0102030405060708090a0b0c0d0e0f10"));
+            processor.on_end(make_test_span(Some(2), "0102030405060708090a0b0c0d0e0f10"));
+        }
+
+        {
+            let bufs = processor.buffers.lock().unwrap();
+            assert_eq!(bufs.get(&1).map(|v| v.len()), Some(5));
+            assert_eq!(bufs.get(&2).map(|v| v.len()), Some(5));
+        }
+
+        // Flush only session 1
+        flush_handle.flush_session(1).await;
+
+        let bufs = processor.buffers.lock().unwrap();
+        assert!(bufs.get(&1).is_none(), "session 1 should be fully drained");
+        assert_eq!(
+            bufs.get(&2).map(|v| v.len()),
+            Some(5),
+            "session 2 should be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_session_on_empty_is_noop() {
+        let (_processor, flush_handle) = make_processor();
+        // Should not panic
+        flush_handle.flush_session(999).await;
+    }
+
+    /// Regression guard for SNOW-flush-before-logout: `flush_session` must
+    /// drain the buffer synchronously *before* returning its awaited future.
+    /// If the implementation reverted to a fire-and-forget spawn, the buffer
+    /// would still contain spans after the `.await` returns — and in
+    /// production the export would race `cleanup_connection`'s token clear.
+    #[tokio::test]
+    async fn flush_session_drains_buffer_before_returning() {
+        let (processor, flush_handle) = make_processor();
+        for _ in 0..3 {
+            processor.on_end(make_test_span(Some(7), "0102030405060708090a0b0c0d0e0f10"));
+        }
+        assert_eq!(
+            processor.buffers.lock().unwrap().get(&7).map(|v| v.len()),
+            Some(3)
+        );
+
+        // The handle has no registered session, so the exporter call is a no-op
+        // and returns Ok immediately — we only assert the drain ordering here.
+        flush_handle.flush_session(7).await;
+
+        assert!(
+            processor.buffers.lock().unwrap().get(&7).is_none(),
+            "flush_session must drain the per-session buffer before returning"
+        );
+    }
+
+    /// Regression guard: `flush_session` must bound its wait. If the exporter
+    /// were to hang, the timeout path must allow the caller to continue.
+    /// We exercise this by running `flush_session` under `tokio::time::timeout`
+    /// set larger than `FLUSH_TIMEOUT` — if the implementation dropped the
+    /// timeout, a hung exporter would trip our outer timeout first.
+    #[tokio::test]
+    async fn flush_session_completes_within_bounded_window() {
+        let (_processor, flush_handle) = make_processor();
+        // Empty buffer: the export is skipped, so this only verifies the
+        // structural contract (method is async + returns promptly).
+        let outer = Duration::from_secs(FLUSH_TIMEOUT.as_secs() + 5);
+        tokio::time::timeout(outer, flush_handle.flush_session(1))
+            .await
+            .expect("flush_session must complete within bounded window");
+    }
+
+    #[test]
+    fn force_flush_drains_all() {
+        let (processor, _flush) = make_processor();
+
+        for _ in 0..10 {
+            processor.on_end(make_test_span(Some(1), "0102030405060708090a0b0c0d0e0f10"));
+            processor.on_end(make_test_span(Some(2), "0102030405060708090a0b0c0d0e0f10"));
+        }
+
+        let result = processor.force_flush();
+        assert!(result.is_ok());
+
+        let bufs = processor.buffers.lock().unwrap();
+        assert!(bufs.is_empty(), "all buffers should be drained");
+    }
+
+    #[test]
+    fn unsampled_span_is_ignored() {
+        let (processor, _flush) = make_processor();
+
+        let span = SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap(),
+                SpanId::from_hex("0102030405060708").unwrap(),
+                TraceFlags::default(), // NOT sampled
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            span_kind: SpanKind::Internal,
+            name: "test".into(),
+            start_time: UNIX_EPOCH,
+            end_time: UNIX_EPOCH,
+            attributes: vec![KeyValue::new("snowflake.session.id", "1")],
+            dropped_attributes_count: 0,
+            events: Default::default(),
+            links: Default::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        };
+
+        processor.on_end(span);
+
+        let bufs = processor.buffers.lock().unwrap();
+        assert!(bufs.is_empty(), "unsampled span should be ignored");
+    }
+}


### PR DESCRIPTION
## Summary

Bring sf_core telemetry in line with OpenTelemetry's per-operation span model.
Each FFI entry-point opens its own bounded span tagged with `db.system="snowflake"`
and `snowflake.session.id`. The exporter routes spans to the correct session
by reading that attribute — no parent-child registries, no shared connection
trace_id.

This unblocks distributed context propagation: when a wrapper caller has an
active OTEL context (e.g. inside an HTTP handler span), our spans attach to
the caller's trace via standard tracing-subscriber semantics, instead of
forcing every operation under a long-lived connection-scoped trace.

### Span surface

- `session_init` — event-carrier; opens after login, attaches the
  `session_init` OTEL event with environment metadata.
- `statement_execute_query`, `statement_prepare`
- `connection_get_query_result`, `connection_abort_query`, `connection_heartbeat`
- `wrapper_api_usage`, `wrapper_error` — per-call spans for the FFI methods
  that record `api_call` / `exception` OTEL events from the wrapper layer.

### Implementation

- **`snowflake_op_span!` macro** — takes `Option<i64>` and returns
  `Span::none()` when no session id is resolvable, so unknown-handle telemetry
  is silently dropped instead of stamped with a sentinel that could collide
  with a real session id and route to the wrong tenant.
- **`SnowflakeSpanProcessor`** — buffers spans per session, flushes at 50 per
  session or on `flush_connection_telemetry` (called during connection release
  with a bounded 5 s timeout).
- **`SnowflakeInBandExporter`** — groups spans by `snowflake.session.id`
  attribute and POSTs each session's batch to `/telemetry/send` with the
  active session token.
- **`Connection::session_id_cache: AtomicI64`** — populated on login; entry
  points read it lock-free via `DatabaseDriverV1::session_id_for_conn` /
  `session_id_for_stmt`. `0` is a sentinel for "not populated" — never a real id.
- **Serialization** — span events carry `event_kind="event"`; empty operation
  spans carry `event_kind="span"` plus `duration_ms` and
  `status`/`status_description`. Downstream consumers can filter on `event_kind`
  rather than enumerating every span name.

### What the Snowflake backend receives

Same flat JSON shape; `event_kind` distinguishes span records from event records:

```json
{"logs": [
  {"message": {"type": "session_init", "event_kind": "event", "service.name": "snowflake-python", "snowflake.session.id": 12345, ...}, "timestamp": "..."},
  {"message": {"type": "api_call", "event_kind": "event", "api_method": "Connection.cursor", "snowflake.session.id": 12345, ...}, "timestamp": "..."},
  {"message": {"type": "statement_execute_query", "event_kind": "span", "duration_ms": 342, "snowflake.session.id": 12345, ...}, "timestamp": "..."},
  {"message": {"type": "connection_heartbeat", "event_kind": "span", "duration_ms": 2, "snowflake.session.id": 12345, ...}, "timestamp": "..."}
]}
```

### Not yet instrumented

- `statement_execute_async` — lifetime `'a` on `bindings` prevents the
  async-block-capture pattern; needs core logic extraction.
- `connection_set_autocommit`, `connection_use_database`,
  `connection_token_request`, `connection_get_query_status`,
  `connection_send_http_request`.
- The `session_init` span only wraps the event recording — it does **not**
  capture login duration. Instrumenting the full `connection_init` future
  (so login latency / failures become part of the span) is left as a follow-up.
- Accept caller OTEL context from wrappers so driver spans nest under the
  caller's app span.

## Test plan

- [x] sf_core `cargo test --lib` — 891 passed
- [x] sf_core telemetry integration tests — 26 passed
- [x] Python integ against local SUT — 439 passed, 1 unrelated env failure
      (`TIMESTAMP_NTZ` cursor-description; reproduces on main)
- [x] Python e2e — 744 passed; remaining failures are env (numpy/pandas
      missing, `SNOWFLAKE` db absent on local SUT)
- [x] `test_api_usage_telemetry_sent_on_cursor_creation` updated to assert
      the new `db.system` and `event_kind` attributes; no longer pins
      `code.filepath` / `code.namespace` to a specific path.
- [x] All pre-commit hooks pass (rustfmt, clippy, cargo check, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)