### PR TITLE
NO-SNOW: Fix clippy result_large_err by heap allocating error source enums

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -474,6 +474,7 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`.
 /// Returns `OdbcError::InternalError` if advancing would cross the batch
 /// boundary or the statement is not in the `Fetching` state.
+#[allow(clippy::result_large_err)]
 fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) -> OdbcResult<()> {
     if delta == 0 {
         return Ok(());

--- a/sf_core/src/apis/database_driver_v1/error.rs
+++ b/sf_core/src/apis/database_driver_v1/error.rs
@@ -39,7 +39,8 @@ pub enum ApiError {
     Login {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Failed to lock connection"))]
     ConnectionLocking {
@@ -58,7 +59,8 @@ pub enum ApiError {
     },
     #[snafu(display("TLS client creation failed: {source}"))]
     TlsClientCreation {
-        source: TlsError,
+        #[snafu(source(from(TlsError, Box::new)))]
+        source: Box<TlsError>,
         #[snafu(implicit)]
         location: Location,
     },
@@ -83,7 +85,8 @@ pub enum ApiError {
     SessionRefresh {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Statement error: {source}"))]
     Statement {
@@ -95,7 +98,8 @@ pub enum ApiError {
     Query {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("HTTP request failed: {context}: {source}"))]
     HttpRequest {
@@ -108,7 +112,8 @@ pub enum ApiError {
     TokenRequest {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Master token expired, full re-authentication required"))]
     MasterTokenExpired {

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -549,19 +549,18 @@ fn to_driver_error(error: &ApiError) -> DriverError {
         ApiError::InvalidArgument { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
         },
-        ApiError::Login {
-            source: RestError::LoginError { message, code, .. },
-            ..
-        } => DriverError {
-            error_type: Some(driver_error::ErrorType::LoginError(LoginError {
-                message: message.clone(),
-                code: *code,
-            })),
-        },
-        ApiError::Login { source, .. } => DriverError {
-            error_type: Some(driver_error::ErrorType::AuthError(AuthenticationError {
-                detail: source.to_string(),
-            })),
+        ApiError::Login { source, .. } => match source.as_ref() {
+            RestError::LoginError { message, code, .. } => DriverError {
+                error_type: Some(driver_error::ErrorType::LoginError(LoginError {
+                    message: message.clone(),
+                    code: *code,
+                })),
+            },
+            _ => DriverError {
+                error_type: Some(driver_error::ErrorType::AuthError(AuthenticationError {
+                    detail: source.to_string(),
+                })),
+            },
         },
         ApiError::ConnectionLocking { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
@@ -704,20 +703,16 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 /// introduced.
 fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
     let (code, sql_state) = match error {
-        ApiError::Query {
-            source: RestError::QueryFailed {
+        ApiError::Query { source, .. } => match source.as_ref() {
+            RestError::QueryFailed {
                 code, sql_state, ..
-            },
-            ..
-        } => (*code, sql_state.clone()),
-        ApiError::Query {
-            source:
-                RestError::AsyncQuery {
-                    source: SfError::SnowflakeBody { code, .. },
-                    ..
-                },
-            ..
-        } => (Some(*code), None),
+            } => (*code, sql_state.clone()),
+            RestError::AsyncQuery {
+                source: SfError::SnowflakeBody { code, .. },
+                ..
+            } => (Some(*code), None),
+            _ => (None, None),
+        },
         _ => (None, None),
     };
 
@@ -728,10 +723,10 @@ fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
 
 fn extract_query_id(error: &ApiError) -> Option<String> {
     match error {
-        ApiError::Query {
-            source: RestError::QueryFailed { query_id, .. },
-            ..
-        } => query_id.clone(),
+        ApiError::Query { source, .. } => match source.as_ref() {
+            RestError::QueryFailed { query_id, .. } => query_id.clone(),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -786,11 +781,10 @@ fn to_driver_exception(error: ApiError) -> DriverException {
             ..
         } => StatusCode::InvalidParameterValue,
         ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
-        ApiError::Login {
-            source: RestError::LoginError { .. },
-            ..
-        } => StatusCode::LoginError,
-        ApiError::Login { .. } => StatusCode::AuthenticationError,
+        ApiError::Login { source, .. } => match source.as_ref() {
+            RestError::LoginError { .. } => StatusCode::LoginError,
+            _ => StatusCode::AuthenticationError,
+        },
         ApiError::ConnectionLocking { .. } => StatusCode::InternalError,
         ApiError::StatementLocking { .. } => StatusCode::InternalError,
         ApiError::DatabaseLocking { .. } => StatusCode::InternalError,
@@ -909,27 +903,27 @@ mod tests {
     fn query_failed(code: Option<i32>, sql_state: Option<&str>) -> ApiError {
         ApiError::Query {
             location: loc(),
-            source: RestError::QueryFailed {
+            source: Box::new(RestError::QueryFailed {
                 message: "test".to_owned(),
                 code,
                 sql_state: sql_state.map(|s| s.to_owned()),
                 query_id: None,
                 location: loc(),
-            },
+            }),
         }
     }
 
     fn async_query(code: i32) -> ApiError {
         ApiError::Query {
             location: loc(),
-            source: RestError::AsyncQuery {
+            source: Box::new(RestError::AsyncQuery {
                 location: loc(),
                 source: SfError::SnowflakeBody {
                     code,
                     message: "test".to_owned(),
                     location: loc(),
                 },
-            },
+            }),
         }
     }
 


### PR DESCRIPTION
### TL;DR

Box large error variants in `ApiError` to reduce enum size and satisfy Clippy's `result_large_err` lint.

### What changed?

Several `source` fields in `ApiError` variants (`Login`, `TlsClientCreation`, `SessionRefresh`, `Query`, `TokenRequest`) have been changed from inline types (`RestError`, `TlsError`) to `Box<RestError>` and `Box<TlsError>`. The `snafu` attribute `#[snafu(source(from(..., Box::new)))]` is used to preserve ergonomic error conversion. Pattern matches against these variants in `converter.rs` have been updated to dereference the boxed sources via `.as_ref()`. A `#[allow(clippy::result_large_err)]` annotation was added to `bump_batch_idx` in `data.rs` where suppression is intentional.

### How to test?

Run the existing test suite, particularly the tests in `converter.rs` (e.g., `query_failed` and `async_query` helpers), to confirm error conversion and pattern matching behavior is unchanged. Verify that the build produces no new Clippy warnings related to `result_large_err`.

### Why make this change?

`RestError` and `TlsError` are large types, and embedding them directly in `ApiError` variants causes the overall enum size to grow significantly. Boxing these sources reduces the size of the `ApiError` enum, addressing the `clippy::result_large_err` lint and improving stack usage when these errors are propagated.