### PR TITLE
SNOW-3447929: Custom Root store not ignored when CRL is disabled

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -474,6 +474,7 @@ fn fetch_impl(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcRes
 /// Advance `batch_idx` by `delta` rows within the current `RecordBatch`.
 /// Returns `OdbcError::InternalError` if advancing would cross the batch
 /// boundary or the statement is not in the `Fetching` state.
+#[allow(clippy::result_large_err)]
 fn bump_batch_idx(state: &mut crate::api::State<StatementState>, delta: usize) -> OdbcResult<()> {
     if delta == 0 {
         return Ok(());

--- a/sf_core/src/apis/database_driver_v1/error.rs
+++ b/sf_core/src/apis/database_driver_v1/error.rs
@@ -39,7 +39,8 @@ pub enum ApiError {
     Login {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Failed to lock connection"))]
     ConnectionLocking {
@@ -58,7 +59,8 @@ pub enum ApiError {
     },
     #[snafu(display("TLS client creation failed: {source}"))]
     TlsClientCreation {
-        source: TlsError,
+        #[snafu(source(from(TlsError, Box::new)))]
+        source: Box<TlsError>,
         #[snafu(implicit)]
         location: Location,
     },
@@ -83,7 +85,8 @@ pub enum ApiError {
     SessionRefresh {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Statement error: {source}"))]
     Statement {
@@ -95,7 +98,8 @@ pub enum ApiError {
     Query {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("HTTP request failed: {context}: {source}"))]
     HttpRequest {
@@ -108,7 +112,8 @@ pub enum ApiError {
     TokenRequest {
         #[snafu(implicit)]
         location: Location,
-        source: RestError,
+        #[snafu(source(from(RestError, Box::new)))]
+        source: Box<RestError>,
     },
     #[snafu(display("Master token expired, full re-authentication required"))]
     MasterTokenExpired {

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -549,19 +549,18 @@ fn to_driver_error(error: &ApiError) -> DriverError {
         ApiError::InvalidArgument { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
         },
-        ApiError::Login {
-            source: RestError::LoginError { message, code, .. },
-            ..
-        } => DriverError {
-            error_type: Some(driver_error::ErrorType::LoginError(LoginError {
-                message: message.clone(),
-                code: *code,
-            })),
-        },
-        ApiError::Login { source, .. } => DriverError {
-            error_type: Some(driver_error::ErrorType::AuthError(AuthenticationError {
-                detail: source.to_string(),
-            })),
+        ApiError::Login { source, .. } => match source.as_ref() {
+            RestError::LoginError { message, code, .. } => DriverError {
+                error_type: Some(driver_error::ErrorType::LoginError(LoginError {
+                    message: message.clone(),
+                    code: *code,
+                })),
+            },
+            _ => DriverError {
+                error_type: Some(driver_error::ErrorType::AuthError(AuthenticationError {
+                    detail: source.to_string(),
+                })),
+            },
         },
         ApiError::ConnectionLocking { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::InternalError(InternalError {})),
@@ -704,20 +703,16 @@ fn to_driver_error(error: &ApiError) -> DriverError {
 /// introduced.
 fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
     let (code, sql_state) = match error {
-        ApiError::Query {
-            source: RestError::QueryFailed {
+        ApiError::Query { source, .. } => match source.as_ref() {
+            RestError::QueryFailed {
                 code, sql_state, ..
-            },
-            ..
-        } => (*code, sql_state.clone()),
-        ApiError::Query {
-            source:
-                RestError::AsyncQuery {
-                    source: SfError::SnowflakeBody { code, .. },
-                    ..
-                },
-            ..
-        } => (Some(*code), None),
+            } => (*code, sql_state.clone()),
+            RestError::AsyncQuery {
+                source: SfError::SnowflakeBody { code, .. },
+                ..
+            } => (Some(*code), None),
+            _ => (None, None),
+        },
         _ => (None, None),
     };
 
@@ -728,10 +723,10 @@ fn extract_vendor_info(error: &ApiError) -> (Option<i32>, Option<String>) {
 
 fn extract_query_id(error: &ApiError) -> Option<String> {
     match error {
-        ApiError::Query {
-            source: RestError::QueryFailed { query_id, .. },
-            ..
-        } => query_id.clone(),
+        ApiError::Query { source, .. } => match source.as_ref() {
+            RestError::QueryFailed { query_id, .. } => query_id.clone(),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -786,11 +781,10 @@ fn to_driver_exception(error: ApiError) -> DriverException {
             ..
         } => StatusCode::InvalidParameterValue,
         ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
-        ApiError::Login {
-            source: RestError::LoginError { .. },
-            ..
-        } => StatusCode::LoginError,
-        ApiError::Login { .. } => StatusCode::AuthenticationError,
+        ApiError::Login { source, .. } => match source.as_ref() {
+            RestError::LoginError { .. } => StatusCode::LoginError,
+            _ => StatusCode::AuthenticationError,
+        },
         ApiError::ConnectionLocking { .. } => StatusCode::InternalError,
         ApiError::StatementLocking { .. } => StatusCode::InternalError,
         ApiError::DatabaseLocking { .. } => StatusCode::InternalError,
@@ -909,27 +903,27 @@ mod tests {
     fn query_failed(code: Option<i32>, sql_state: Option<&str>) -> ApiError {
         ApiError::Query {
             location: loc(),
-            source: RestError::QueryFailed {
+            source: Box::new(RestError::QueryFailed {
                 message: "test".to_owned(),
                 code,
                 sql_state: sql_state.map(|s| s.to_owned()),
                 query_id: None,
                 location: loc(),
-            },
+            }),
         }
     }
 
     fn async_query(code: i32) -> ApiError {
         ApiError::Query {
             location: loc(),
-            source: RestError::AsyncQuery {
+            source: Box::new(RestError::AsyncQuery {
                 location: loc(),
                 source: SfError::SnowflakeBody {
                     code,
                     message: "test".to_owned(),
                     location: loc(),
                 },
-            },
+            }),
         }
     }
 

--- a/sf_core/src/tls/client.rs
+++ b/sf_core/src/tls/client.rs
@@ -42,15 +42,21 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
     // Create client based on CRL configuration
     match tls_config.crl_config.check_mode {
         CertRevocationCheckMode::Disabled => {
-            tracing::debug!("CRL validation disabled, creating standard client");
-            if custom_root_store.is_some() {
-                tracing::warn!(
-                    "Custom root store specified but CRL validation disabled - custom roots will be ignored"
-                );
+            if let Some(root_store) = custom_root_store {
+                tracing::debug!("CRL disabled, applying custom root store without CRL");
+                let tls_config = ClientConfig::builder()
+                    .with_root_certificates(Arc::new(root_store))
+                    .with_no_client_auth();
+                configure_http_client(Client::builder())
+                    .use_preconfigured_tls(tls_config)
+                    .build()
+                    .context(ClientBuildSnafu)
+            } else {
+                tracing::debug!("CRL disabled, using default system roots");
+                configure_http_client(Client::builder())
+                    .build()
+                    .context(ClientBuildSnafu)
             }
-            configure_http_client(Client::builder())
-                .build()
-                .context(ClientBuildSnafu)
         }
         CertRevocationCheckMode::Enabled | CertRevocationCheckMode::Advisory => {
             tracing::debug!(

--- a/sf_core/tests/e2e/tls/handshake.rs
+++ b/sf_core/tests/e2e/tls/handshake.rs
@@ -1,5 +1,15 @@
+use std::io::Write;
+use std::sync::Arc;
+
+use rcgen::generate_simple_self_signed;
+use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use sf_core::tls::config::TlsConfig;
 use sf_core::tls::create_tls_client_with_config;
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+use wiremock::matchers::any;
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
 async fn should_complete_handshake_with_default_roots() {
@@ -30,7 +40,73 @@ async fn should_complete_handshake_with_custom_pem_roots() {
         // When GET request is sent to the server URL
         let resp = client.get(server_url).send().await;
 
-        // Then the request attempt should complete (success or error acceptable in CI)
-        let _ = resp; // don't assert strict success; we haven't validated that our custom roots is valid
+        // Then the request attempt should be successful
+        assert!(resp.is_ok(), "Custom PEM roots should enable TLS handshake");
     }
+}
+
+#[tokio::test]
+async fn should_trust_custom_root_store_when_crl_disabled() {
+    // Given a self-signed certificate not in any system trust store
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let cert = generate_simple_self_signed(vec!["localhost".to_string()]).expect("cert generation");
+    let cert_pem = cert.cert.pem();
+
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der()));
+
+    // And the certificate PEM is written to a temp file
+    let mut pem_file = tempfile::NamedTempFile::new().expect("temp file");
+    pem_file.write_all(cert_pem.as_bytes()).expect("write PEM");
+    pem_file.flush().expect("flush");
+
+    // And a mock HTTP backend returns 200
+    let backend = MockServer::start().await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&backend)
+        .await;
+
+    // And a TLS proxy terminates TLS with the self-signed cert
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("server config");
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = listener.local_addr().unwrap();
+    let backend_addr = *backend.address();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                continue;
+            };
+            let acc = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acc.accept(tcp).await else {
+                    return;
+                };
+                let Ok(mut upstream) = tokio::net::TcpStream::connect(backend_addr).await else {
+                    return;
+                };
+                let _ = tokio::io::copy_bidirectional(&mut tls, &mut upstream).await;
+            });
+        }
+    });
+
+    // When a TLS client is created with custom_root_store_path and CRL disabled (default)
+    let cfg = TlsConfig {
+        custom_root_store_path: Some(pem_file.path().to_path_buf()),
+        ..Default::default()
+    };
+    let client = create_tls_client_with_config(cfg).expect("client");
+    let port = proxy_addr.port();
+    let resp = client.get(format!("https://localhost:{port}")).send().await;
+
+    // Then the handshake succeeds because the custom root store is applied
+    assert!(
+        resp.is_ok(),
+        "Custom root store must be applied when CRL is disabled"
+    );
 }


### PR DESCRIPTION
### TL;DR

Fix custom root store being silently ignored when CRL validation is disabled.

### What changed?

When CRL validation is disabled and a custom root store path is provided, the TLS client now correctly applies the custom root certificates instead of falling back to system roots. Previously, the custom root store was ignored in this case, and a warning was logged. Now the client branches on whether a custom root store is present: if one is provided, it builds a `ClientConfig` using those roots; otherwise, it falls back to the default system roots.

The existing test for custom PEM roots has been strengthened to assert a successful response rather than silently discarding the result.

A new end-to-end test (`should_trust_custom_root_store_when_crl_disabled`) has been added to verify this behavior. It spins up a local TLS proxy using a self-signed certificate not in any system trust store, writes the certificate to a temp file, and confirms that a client configured with that cert as a custom root can complete the TLS handshake successfully.

### How to test?

Run the TLS handshake end-to-end tests:

```
cargo test -p sf_core --test e2e tls::handshake
```

All three tests should pass:
- `should_complete_handshake_with_default_roots`
- `should_complete_handshake_with_custom_pem_roots`
- `should_trust_custom_root_store_when_crl_disabled`

### Why make this change?

Users who configure a custom root store path expect their custom CA certificates to be trusted regardless of whether CRL checking is enabled. The previous behavior silently discarded the custom root store when CRL was disabled, causing TLS handshake failures against servers using privately-signed certificates in environments where CRL checking is not needed.