### PR TITLE
SNOW-3447930: Wire verify_hostname into TLS Client Construction

### DIFF
--- a/sf_core/src/tls/client.rs
+++ b/sf_core/src/tls/client.rs
@@ -1,7 +1,6 @@
 use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
 use crate::tls::CrlServerCertVerifier;
 use crate::tls::config::TlsConfig;
-use crate::tls::crl_verifier::NoHostnameVerifier;
 use crate::tls::error::{
     ClientBuildSnafu, PemParseSnafu, RootStoreAddSnafu, TlsError, VerifierBuildSnafu,
 };
@@ -29,13 +28,12 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
     // Install aws-lc-rs provider (idempotent)
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-    let custom_root_store = if let Some(pem_path) = tls_config.custom_root_store_path.as_ref() {
+    let custom_pem = if let Some(pem_path) = tls_config.custom_root_store_path.as_ref() {
         tracing::debug!(
             "Loading custom root certificate store from: {}",
             pem_path.display()
         );
-        let pem_data = std::fs::read(pem_path).context(PemParseSnafu)?;
-        Some(create_root_store_from_pem(&pem_data)?)
+        Some(std::fs::read(pem_path).context(PemParseSnafu)?)
     } else {
         None
     };
@@ -43,44 +41,31 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
     // Create client based on CRL configuration
     match tls_config.crl_config.check_mode {
         CertRevocationCheckMode::Disabled => {
-            if let Some(root_store) = custom_root_store {
-                tracing::debug!("CRL disabled, applying custom root store without CRL");
-                let root_store = Arc::new(root_store);
-                let rustls_config = if tls_config.verify_hostname {
-                    ClientConfig::builder()
-                        .with_root_certificates(root_store)
-                        .with_no_client_auth()
-                } else {
-                    tracing::warn!("Hostname verification disabled (custom root store path)");
-                    let verifier = NoHostnameVerifier::new(root_store);
-                    ClientConfig::builder()
-                        .dangerous()
-                        .with_custom_certificate_verifier(Arc::new(verifier))
-                        .with_no_client_auth()
-                };
-                configure_http_client(Client::builder())
-                    .use_preconfigured_tls(rustls_config)
-                    .build()
-                    .context(ClientBuildSnafu)
+            let mut builder = configure_http_client(Client::builder());
+            if let Some(ref pem) = custom_pem {
+                tracing::debug!("CRL disabled, applying custom root store");
+                let certs = reqwest::Certificate::from_pem_bundle(pem).context(ClientBuildSnafu)?;
+                builder = builder.tls_built_in_root_certs(false);
+                for cert in certs {
+                    builder = builder.add_root_certificate(cert);
+                }
             } else {
                 tracing::debug!("CRL disabled, using default system roots");
-                if tls_config.verify_hostname {
-                    configure_http_client(Client::builder())
-                        .build()
-                        .context(ClientBuildSnafu)
-                } else {
-                    tracing::warn!("Hostname verification disabled (default roots path)");
-                    configure_http_client(Client::builder())
-                        .danger_accept_invalid_hostnames(true)
-                        .build()
-                        .context(ClientBuildSnafu)
-                }
             }
+            if !tls_config.verify_hostname {
+                tracing::warn!("Hostname verification disabled");
+                builder = builder.danger_accept_invalid_hostnames(true);
+            }
+            builder.build().context(ClientBuildSnafu)
         }
         CertRevocationCheckMode::Enabled | CertRevocationCheckMode::Advisory => {
             tracing::debug!(
                 "CRL validation enabled, creating client with full TLS handshake validation"
             );
+            let custom_root_store = match custom_pem {
+                Some(pem) => Some(create_root_store_from_pem(&pem)?),
+                None => None,
+            };
             create_crl_tls_client_with_root_store(
                 tls_config.crl_config,
                 custom_root_store,

--- a/sf_core/src/tls/client.rs
+++ b/sf_core/src/tls/client.rs
@@ -1,6 +1,7 @@
 use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
 use crate::tls::CrlServerCertVerifier;
 use crate::tls::config::TlsConfig;
+use crate::tls::crl_verifier::NoHostnameVerifier;
 use crate::tls::error::{
     ClientBuildSnafu, PemParseSnafu, RootStoreAddSnafu, TlsError, VerifierBuildSnafu,
 };
@@ -44,43 +45,72 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
         CertRevocationCheckMode::Disabled => {
             if let Some(root_store) = custom_root_store {
                 tracing::debug!("CRL disabled, applying custom root store without CRL");
-                let tls_config = ClientConfig::builder()
-                    .with_root_certificates(Arc::new(root_store))
-                    .with_no_client_auth();
+                let root_store = Arc::new(root_store);
+                let rustls_config = if tls_config.verify_hostname {
+                    ClientConfig::builder()
+                        .with_root_certificates(root_store)
+                        .with_no_client_auth()
+                } else {
+                    tracing::warn!("Hostname verification disabled (custom root store path)");
+                    let verifier = NoHostnameVerifier::new(root_store);
+                    ClientConfig::builder()
+                        .dangerous()
+                        .with_custom_certificate_verifier(Arc::new(verifier))
+                        .with_no_client_auth()
+                };
                 configure_http_client(Client::builder())
-                    .use_preconfigured_tls(tls_config)
+                    .use_preconfigured_tls(rustls_config)
                     .build()
                     .context(ClientBuildSnafu)
             } else {
                 tracing::debug!("CRL disabled, using default system roots");
-                configure_http_client(Client::builder())
-                    .build()
-                    .context(ClientBuildSnafu)
+                if tls_config.verify_hostname {
+                    configure_http_client(Client::builder())
+                        .build()
+                        .context(ClientBuildSnafu)
+                } else {
+                    tracing::warn!("Hostname verification disabled (default roots path)");
+                    configure_http_client(Client::builder())
+                        .danger_accept_invalid_hostnames(true)
+                        .build()
+                        .context(ClientBuildSnafu)
+                }
             }
         }
         CertRevocationCheckMode::Enabled | CertRevocationCheckMode::Advisory => {
             tracing::debug!(
                 "CRL validation enabled, creating client with full TLS handshake validation"
             );
-            create_crl_tls_client_with_root_store(tls_config.crl_config, custom_root_store)
+            create_crl_tls_client_with_root_store(
+                tls_config.crl_config,
+                custom_root_store,
+                tls_config.verify_hostname,
+            )
         }
     }
 }
 
 /// Create a reqwest client with custom rustls configuration and optional custom root store
-pub fn create_crl_tls_client_with_root_store(
+pub(crate) fn create_crl_tls_client_with_root_store(
     crl_config: CrlConfig,
     custom_root_store: Option<rustls::RootCertStore>,
+    verify_hostname: bool,
 ) -> Result<Client, TlsError> {
     tracing::debug!("Creating custom TLS client with CRL handshake validation");
+    if !verify_hostname {
+        tracing::warn!("Hostname verification disabled (CRL path)");
+    }
 
     // Install default crypto provider for rustls (aws-lc-rs)
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     // Create custom certificate verifier with CRL validation
-    let crl_verifier =
-        CrlServerCertVerifier::new_with_root_store(crl_config.clone(), custom_root_store)
-            .context(VerifierBuildSnafu)?;
+    let crl_verifier = CrlServerCertVerifier::new_with_root_store(
+        crl_config.clone(),
+        custom_root_store,
+        verify_hostname,
+    )
+    .context(VerifierBuildSnafu)?;
 
     // Create rustls client configuration with our custom verifier
     let tls_config = ClientConfig::builder()

--- a/sf_core/src/tls/crl_verifier.rs
+++ b/sf_core/src/tls/crl_verifier.rs
@@ -2,23 +2,106 @@ use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
 use crate::crl::validator::CrlValidator;
 use crate::crl::worker::CrlWorker;
 use crate::tls::x509_utils::load_system_root_store;
-use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::{WebPkiServerVerifier, verify_server_cert_signed_by_trust_anchor};
+use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use rustls::server::ParsedCertificate;
+use rustls::{DigitallySignedStruct, Error as TlsError, RootCertStore, SignatureScheme};
+use std::fmt;
 use std::sync::Arc;
 
+fn default_supported_algs() -> WebPkiSupportedAlgorithms {
+    rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms
+}
+
+/// Verifies the certificate chain/trust anchor but deliberately skips hostname
+/// verification. Used when `verify_hostname = false` with custom root stores
+/// (Path 2: CRL disabled + custom roots).
+pub(crate) struct NoHostnameVerifier {
+    roots: Arc<RootCertStore>,
+    supported_algs: WebPkiSupportedAlgorithms,
+}
+
+impl NoHostnameVerifier {
+    pub(crate) fn new(roots: Arc<RootCertStore>) -> Self {
+        Self {
+            roots,
+            supported_algs: default_supported_algs(),
+        }
+    }
+}
+
+impl fmt::Debug for NoHostnameVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NoHostnameVerifier")
+            .field("roots", &"...")
+            .field("supported_algs", &self.supported_algs)
+            .finish()
+    }
+}
+
+impl ServerCertVerifier for NoHostnameVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        let cert = ParsedCertificate::try_from(end_entity)?;
+        verify_server_cert_signed_by_trust_anchor(
+            &cert,
+            &self.roots,
+            intermediates,
+            now,
+            self.supported_algs.all,
+        )?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        verify_tls12_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        verify_tls13_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_algs.supported_schemes()
+    }
+}
+
 #[derive(Debug)]
-pub struct CrlServerCertVerifier {
+pub(crate) struct CrlServerCertVerifier {
+    /// Used for cert validation when `verify_hostname` is true, and always used
+    /// for TLS 1.2/1.3 signature verification and supported scheme queries
+    /// regardless of `verify_hostname`.
     webpki_verifier: Arc<WebPkiServerVerifier>,
     crl_validator: Arc<CrlValidator>,
     crl_config: CrlConfig,
+    verify_hostname: bool,
+    root_store: Arc<RootCertStore>,
+    supported_algs: WebPkiSupportedAlgorithms,
 }
 
 impl CrlServerCertVerifier {
-    pub fn new_with_root_store(
+    pub(crate) fn new_with_root_store(
         crl_config: CrlConfig,
         custom_root_store: Option<rustls::RootCertStore>,
+        verify_hostname: bool,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let root_store = match custom_root_store {
             Some(store) => store,
@@ -26,6 +109,7 @@ impl CrlServerCertVerifier {
                 .map_err(|err| -> Box<dyn std::error::Error + Send + Sync> { Box::new(err) })?,
         };
         let root_store = Arc::new(root_store);
+        let supported_algs = default_supported_algs();
         let webpki_verifier = WebPkiServerVerifier::builder(root_store.clone()).build()?;
         let crl_validator = Arc::new(CrlValidator::new_with_root_store(
             crl_config.clone(),
@@ -35,6 +119,9 @@ impl CrlServerCertVerifier {
             webpki_verifier,
             crl_validator,
             crl_config,
+            verify_hostname,
+            root_store,
+            supported_algs,
         })
     }
 }
@@ -48,15 +135,31 @@ impl ServerCertVerifier for CrlServerCertVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, TlsError> {
-        // Helper closure to re-validate a path with fixed verifier inputs
+        // Parse once before the closure to avoid redundant ASN.1 parsing per
+        // chain iteration. Unconditional so the closure never needs to panic.
+        let parsed_cert = ParsedCertificate::try_from(end_entity)?;
+
+        // Helper closure to re-validate a path with fixed verifier inputs.
+        // When verify_hostname is false, use chain-only validation (skip hostname check).
         let verify_path = |inters: &[rustls::pki_types::CertificateDer<'_>]| {
-            self.webpki_verifier.verify_server_cert(
-                end_entity,
-                inters,
-                server_name,
-                ocsp_response,
-                now,
-            )
+            if self.verify_hostname {
+                self.webpki_verifier.verify_server_cert(
+                    end_entity,
+                    inters,
+                    server_name,
+                    ocsp_response,
+                    now,
+                )
+            } else {
+                verify_server_cert_signed_by_trust_anchor(
+                    &parsed_cert,
+                    &self.root_store,
+                    inters,
+                    now,
+                    self.supported_algs.all,
+                )?;
+                Ok(ServerCertVerified::assertion())
+            }
         };
 
         // Validate the handshake path
@@ -179,7 +282,8 @@ mod tests {
             check_mode: crate::crl::config::CertRevocationCheckMode::Advisory,
             ..Default::default()
         };
-        let ver = CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store)).unwrap();
+        let ver =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store), true).unwrap();
 
         let ee_der = rustls::pki_types::CertificateDer::from(ee_cert.to_der().unwrap());
         let inter_der = rustls::pki_types::CertificateDer::from(inter_cert.to_der().unwrap());
@@ -234,7 +338,8 @@ mod tests {
             ..Default::default()
         };
         let ver =
-            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store.clone())).unwrap();
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store.clone()), true)
+                .unwrap();
         let ee_der = rustls::pki_types::CertificateDer::from(ee_cert.to_der().unwrap());
         let inter_der = rustls::pki_types::CertificateDer::from(inter_cert.to_der().unwrap());
         let server_name = ServerName::try_from("test.example.com").unwrap();
@@ -252,7 +357,8 @@ mod tests {
             allow_certificates_without_crl_url: false,
             ..Default::default()
         };
-        let ver2 = CrlServerCertVerifier::new_with_root_store(crl_cfg2, Some(root_store)).unwrap();
+        let ver2 =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg2, Some(root_store), true).unwrap();
         let res2 = ver2.verify_server_cert(
             &ee_der,
             std::slice::from_ref(&inter_der),
@@ -314,7 +420,8 @@ mod tests {
             allow_certificates_without_crl_url: true,
             ..Default::default()
         };
-        let ver = CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store)).unwrap();
+        let ver =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store), true).unwrap();
 
         // Presented intermediates include both InterA variants
         let ee_der = rustls::pki_types::CertificateDer::from(ee.to_der().unwrap());
@@ -361,7 +468,8 @@ mod tests {
             ..Default::default()
         };
         let ver =
-            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store.clone())).unwrap();
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store.clone()), true)
+                .unwrap();
 
         // Seed outcome: Inter revoked under Root
         let cfg = crate::crl::config::CrlConfig {
@@ -404,7 +512,8 @@ mod tests {
             check_mode: crate::crl::config::CertRevocationCheckMode::Enabled,
             ..Default::default()
         };
-        let ver2 = CrlServerCertVerifier::new_with_root_store(crl_cfg2, Some(root_store)).unwrap();
+        let ver2 =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg2, Some(root_store), true).unwrap();
         let res2 = ver2.verify_server_cert(
             &ee_der,
             std::slice::from_ref(&inter_der),
@@ -470,7 +579,8 @@ mod tests {
             allow_certificates_without_crl_url: true,
             ..Default::default()
         };
-        let ver = CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store)).unwrap();
+        let ver =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store), true).unwrap();
 
         let ee_der = rustls::pki_types::CertificateDer::from(ee.to_der().unwrap());
         let inters = vec![
@@ -562,7 +672,8 @@ mod tests {
             allow_certificates_without_crl_url: true,
             ..Default::default()
         };
-        let ver = CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store)).unwrap();
+        let ver =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store), true).unwrap();
 
         let ee_der = rustls::pki_types::CertificateDer::from(ee.to_der().unwrap());
         let inters = vec![
@@ -575,6 +686,78 @@ mod tests {
         assert!(
             res.is_ok(),
             "Anchored clean path should succeed even when another anchored path is revoked"
+        );
+    }
+
+    #[test]
+    fn hostname_bypass_allows_mismatched_server_name_in_advisory() {
+        th::test_setup();
+        th::clear_all_crl_caches();
+        let root_key = th::gen_key();
+        let root_cert = th::sign_cert(
+            &th::gen_req("R", &root_key),
+            &th::make_name("R"),
+            &root_key,
+            true,
+        );
+        let inter_key = th::gen_key();
+        let inter_cert = th::sign_cert(
+            &th::gen_req("I", &inter_key),
+            root_cert.subject_name(),
+            &root_key,
+            true,
+        );
+        let ee_key = th::gen_key();
+        let ee_cert = th::sign_cert(
+            &th::gen_req("E", &ee_key),
+            inter_cert.subject_name(),
+            &inter_key,
+            false,
+        );
+        let root_store = th::make_root_store(&root_cert.to_der().unwrap());
+        th::seed_not_determined(&ee_cert, &inter_cert, 5);
+
+        let crl_cfg = crate::crl::config::CrlConfig {
+            check_mode: crate::crl::config::CertRevocationCheckMode::Advisory,
+            allow_certificates_without_crl_url: true,
+            ..Default::default()
+        };
+
+        // verify_hostname=false should succeed despite mismatched server_name
+        let ver = CrlServerCertVerifier::new_with_root_store(
+            crl_cfg.clone(),
+            Some(root_store.clone()),
+            false,
+        )
+        .unwrap();
+        let ee_der = rustls::pki_types::CertificateDer::from(ee_cert.to_der().unwrap());
+        let inter_der = rustls::pki_types::CertificateDer::from(inter_cert.to_der().unwrap());
+        let mismatched_name = ServerName::try_from("wrong.host.example.com").unwrap();
+        let res = ver.verify_server_cert(
+            &ee_der,
+            std::slice::from_ref(&inter_der),
+            &mismatched_name,
+            &[],
+            UnixTime::now(),
+        );
+        assert!(
+            res.is_ok(),
+            "verify_hostname=false should skip hostname check"
+        );
+
+        // verify_hostname=true should fail with the same mismatched server_name
+        let ver2 =
+            CrlServerCertVerifier::new_with_root_store(crl_cfg, Some(root_store), true).unwrap();
+        let res2 = ver2.verify_server_cert(
+            &ee_der,
+            std::slice::from_ref(&inter_der),
+            &mismatched_name,
+            &[],
+            UnixTime::now(),
+        );
+        assert!(
+            res2.is_err(),
+            "verify_hostname=true should reject mismatched hostname"
         );
     }
 }

--- a/sf_core/src/tls/crl_verifier.rs
+++ b/sf_core/src/tls/crl_verifier.rs
@@ -4,84 +4,14 @@ use crate::crl::worker::CrlWorker;
 use crate::tls::x509_utils::load_system_root_store;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{WebPkiServerVerifier, verify_server_cert_signed_by_trust_anchor};
-use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
+use rustls::crypto::WebPkiSupportedAlgorithms;
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::server::ParsedCertificate;
 use rustls::{DigitallySignedStruct, Error as TlsError, RootCertStore, SignatureScheme};
-use std::fmt;
 use std::sync::Arc;
 
 fn default_supported_algs() -> WebPkiSupportedAlgorithms {
     rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms
-}
-
-/// Verifies the certificate chain/trust anchor but deliberately skips hostname
-/// verification. Used when `verify_hostname = false` with custom root stores
-/// (Path 2: CRL disabled + custom roots).
-pub(crate) struct NoHostnameVerifier {
-    roots: Arc<RootCertStore>,
-    supported_algs: WebPkiSupportedAlgorithms,
-}
-
-impl NoHostnameVerifier {
-    pub(crate) fn new(roots: Arc<RootCertStore>) -> Self {
-        Self {
-            roots,
-            supported_algs: default_supported_algs(),
-        }
-    }
-}
-
-impl fmt::Debug for NoHostnameVerifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NoHostnameVerifier")
-            .field("roots", &"...")
-            .field("supported_algs", &self.supported_algs)
-            .finish()
-    }
-}
-
-impl ServerCertVerifier for NoHostnameVerifier {
-    fn verify_server_cert(
-        &self,
-        end_entity: &CertificateDer<'_>,
-        intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp_response: &[u8],
-        now: UnixTime,
-    ) -> Result<ServerCertVerified, TlsError> {
-        let cert = ParsedCertificate::try_from(end_entity)?;
-        verify_server_cert_signed_by_trust_anchor(
-            &cert,
-            &self.roots,
-            intermediates,
-            now,
-            self.supported_algs.all,
-        )?;
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TlsError> {
-        verify_tls12_signature(message, cert, dss, &self.supported_algs)
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TlsError> {
-        verify_tls13_signature(message, cert, dss, &self.supported_algs)
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.supported_algs.supported_schemes()
-    }
 }
 
 #[derive(Debug)]
@@ -135,24 +65,26 @@ impl ServerCertVerifier for CrlServerCertVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, TlsError> {
-        // Parse once before the closure to avoid redundant ASN.1 parsing per
-        // chain iteration. Unconditional so the closure never needs to panic.
-        let parsed_cert = ParsedCertificate::try_from(end_entity)?;
+        // Parse only when hostname verification is disabled (chain-only path).
+        let parsed_cert: Option<ParsedCertificate<'_>> = if !self.verify_hostname {
+            Some(ParsedCertificate::try_from(end_entity)?)
+        } else {
+            None
+        };
 
         // Helper closure to re-validate a path with fixed verifier inputs.
         // When verify_hostname is false, use chain-only validation (skip hostname check).
-        let verify_path = |inters: &[rustls::pki_types::CertificateDer<'_>]| {
-            if self.verify_hostname {
-                self.webpki_verifier.verify_server_cert(
-                    end_entity,
-                    inters,
-                    server_name,
-                    ocsp_response,
-                    now,
-                )
-            } else {
+        let verify_path = |inters: &[CertificateDer<'_>]| match &parsed_cert {
+            None => self.webpki_verifier.verify_server_cert(
+                end_entity,
+                inters,
+                server_name,
+                ocsp_response,
+                now,
+            ),
+            Some(cert) => {
                 verify_server_cert_signed_by_trust_anchor(
-                    &parsed_cert,
+                    cert,
                     &self.root_store,
                     inters,
                     now,

--- a/sf_core/src/tls/mod.rs
+++ b/sf_core/src/tls/mod.rs
@@ -9,5 +9,5 @@ pub mod x509_utils;
 
 pub use client::create_tls_client_with_config;
 pub use config::TlsConfig;
-pub use crl_verifier::CrlServerCertVerifier;
+pub(crate) use crl_verifier::CrlServerCertVerifier;
 pub use x509_utils::{crl_times, extract_skid, subject_der_hash, verify_crl_signature};

--- a/sf_core/tests/e2e/tls/handshake.rs
+++ b/sf_core/tests/e2e/tls/handshake.rs
@@ -1,4 +1,6 @@
 use std::io::Write;
+use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use rcgen::generate_simple_self_signed;
@@ -10,6 +12,61 @@ use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use wiremock::matchers::any;
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Spawns a TLS-terminating proxy backed by a wiremock `MockServer` (200 for all
+/// requests). Returns the proxy's listen address and the path to a temp PEM file
+/// containing the self-signed root certificate for "localhost".
+///
+/// The returned `tempfile::NamedTempFile` must be kept alive for the PEM path to
+/// remain valid.
+async fn spawn_tls_proxy() -> (SocketAddr, tempfile::NamedTempFile) {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let cert = generate_simple_self_signed(vec!["localhost".to_string()]).expect("cert generation");
+    let cert_pem = cert.cert.pem();
+
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der()));
+
+    let mut pem_file = tempfile::NamedTempFile::new().expect("temp file");
+    pem_file.write_all(cert_pem.as_bytes()).expect("write PEM");
+    pem_file.flush().expect("flush");
+
+    let backend = MockServer::start().await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&backend)
+        .await;
+
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("server config");
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = listener.local_addr().unwrap();
+    let backend_addr = *backend.address();
+
+    tokio::spawn(async move {
+        let _backend = backend;
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                continue;
+            };
+            let acc = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acc.accept(tcp).await else {
+                    return;
+                };
+                let Ok(mut upstream) = tokio::net::TcpStream::connect(backend_addr).await else {
+                    return;
+                };
+                let _ = tokio::io::copy_bidirectional(&mut tls, &mut upstream).await;
+            });
+        }
+    });
+
+    (proxy_addr, pem_file)
+}
 
 #[tokio::test]
 async fn should_complete_handshake_with_default_roots() {
@@ -47,53 +104,8 @@ async fn should_complete_handshake_with_custom_pem_roots() {
 
 #[tokio::test]
 async fn should_trust_custom_root_store_when_crl_disabled() {
-    // Given a self-signed certificate not in any system trust store
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    let cert = generate_simple_self_signed(vec!["localhost".to_string()]).expect("cert generation");
-    let cert_pem = cert.cert.pem();
-
-    let cert_der = CertificateDer::from(cert.cert);
-    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der()));
-
-    // And the certificate PEM is written to a temp file
-    let mut pem_file = tempfile::NamedTempFile::new().expect("temp file");
-    pem_file.write_all(cert_pem.as_bytes()).expect("write PEM");
-    pem_file.flush().expect("flush");
-
-    // And a mock HTTP backend returns 200
-    let backend = MockServer::start().await;
-    Mock::given(any())
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&backend)
-        .await;
-
-    // And a TLS proxy terminates TLS with the self-signed cert
-    let server_config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(vec![cert_der], key_der)
-        .expect("server config");
-    let acceptor = TlsAcceptor::from(Arc::new(server_config));
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-    let proxy_addr = listener.local_addr().unwrap();
-    let backend_addr = *backend.address();
-
-    tokio::spawn(async move {
-        loop {
-            let Ok((tcp, _)) = listener.accept().await else {
-                continue;
-            };
-            let acc = acceptor.clone();
-            tokio::spawn(async move {
-                let Ok(mut tls) = acc.accept(tcp).await else {
-                    return;
-                };
-                let Ok(mut upstream) = tokio::net::TcpStream::connect(backend_addr).await else {
-                    return;
-                };
-                let _ = tokio::io::copy_bidirectional(&mut tls, &mut upstream).await;
-            });
-        }
-    });
+    let (proxy_addr, pem_file) = spawn_tls_proxy().await;
+    let port = proxy_addr.port();
 
     // When a TLS client is created with custom_root_store_path and CRL disabled (default)
     let cfg = TlsConfig {
@@ -101,12 +113,51 @@ async fn should_trust_custom_root_store_when_crl_disabled() {
         ..Default::default()
     };
     let client = create_tls_client_with_config(cfg).expect("client");
-    let port = proxy_addr.port();
     let resp = client.get(format!("https://localhost:{port}")).send().await;
 
     // Then the handshake succeeds because the custom root store is applied
     assert!(
         resp.is_ok(),
         "Custom root store must be applied when CRL is disabled"
+    );
+}
+
+#[tokio::test]
+async fn should_skip_hostname_verification_when_disabled() {
+    let (proxy_addr, pem_file) = spawn_tls_proxy().await;
+    let port = proxy_addr.port();
+    let pem_path: PathBuf = pem_file.path().to_path_buf();
+
+    // When connecting as 127.0.0.1 (hostname mismatch: cert says "localhost")
+    // with verify_hostname=false and the custom root PEM
+    let cfg = TlsConfig {
+        custom_root_store_path: Some(pem_path.clone()),
+        verify_hostname: false,
+        ..Default::default()
+    };
+    let client = create_tls_client_with_config(cfg).expect("client");
+    let resp = client.get(format!("https://127.0.0.1:{port}")).send().await;
+
+    // Then the handshake succeeds despite hostname mismatch
+    assert!(
+        resp.is_ok(),
+        "verify_hostname=false should allow hostname mismatch"
+    );
+
+    // And with verify_hostname=true the same connection should fail
+    let cfg_strict = TlsConfig {
+        custom_root_store_path: Some(pem_path),
+        verify_hostname: true,
+        ..Default::default()
+    };
+    let client_strict = create_tls_client_with_config(cfg_strict).expect("client");
+    let resp_strict = client_strict
+        .get(format!("https://127.0.0.1:{port}"))
+        .send()
+        .await;
+
+    assert!(
+        resp_strict.is_err(),
+        "verify_hostname=true should reject hostname mismatch"
     );
 }

--- a/sf_core/tests/e2e/tls/handshake.rs
+++ b/sf_core/tests/e2e/tls/handshake.rs
@@ -14,10 +14,10 @@ use wiremock::matchers::any;
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Spawns a TLS-terminating proxy backed by a wiremock `MockServer` (200 for all
-/// requests). Returns the proxy's listen address and the path to a temp PEM file
-/// containing the self-signed root certificate for "localhost".
+/// requests). Returns the proxy's listen address and a `NamedTempFile` containing
+/// the self-signed root certificate PEM for "localhost".
 ///
-/// The returned `tempfile::NamedTempFile` must be kept alive for the PEM path to
+/// The returned `NamedTempFile` must be kept alive for the PEM file on disk to
 /// remain valid.
 async fn spawn_tls_proxy() -> (SocketAddr, tempfile::NamedTempFile) {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();


### PR DESCRIPTION
### TL;DR

Add optional hostname verification bypass to the TLS client, allowing connections to proceed even when the server's certificate hostname does not match the requested host.

### What changed?

A `verify_hostname` flag is now respected across all TLS client construction paths:

- **CRL disabled + custom root store**: Uses a new `NoHostnameVerifier` custom verifier that validates the certificate chain against the trust anchor but skips the hostname check.
- **CRL disabled + default system roots**: Uses reqwest's `danger_accept_invalid_hostnames(true)` when hostname verification is disabled.
- **CRL enabled/advisory**: Passes `verify_hostname` through to `CrlServerCertVerifier`, which switches between full `WebPkiServerVerifier` validation and a chain-only path (`verify_server_cert_signed_by_trust_anchor`) that omits the hostname check.

`NoHostnameVerifier` is a new `ServerCertVerifier` implementation that performs full chain and signature validation while ignoring the `ServerName`. A warning is emitted via `tracing::warn!` whenever hostname verification is disabled, regardless of path.

### How to test?

- The new unit test `hostname_bypass_allows_mismatched_server_name_in_advisory` verifies that `CrlServerCertVerifier` with `verify_hostname=false` accepts a mismatched server name, while `verify_hostname=true` rejects it.
- The new e2e test `should_skip_hostname_verification_when_disabled` spins up a TLS proxy using a self-signed certificate valid for `localhost`, then connects via `127.0.0.1` (a hostname mismatch). It asserts that `verify_hostname=false` succeeds and `verify_hostname=true` fails.

### Why make this change?

Some deployment environments require connecting to services by IP address or an alternative hostname that does not match the CN/SAN on the server certificate (e.g., internal infrastructure with self-signed or fixed certificates). This change allows hostname verification to be explicitly disabled while still enforcing certificate chain trust, giving operators a controlled escape hatch without disabling certificate validation entirely.