### PR TITLE
NO-SNOW: Collapse if inside match to prevent clippy warning

### DIFF
--- a/odbc_trace_tool/src/generator/cpp.rs
+++ b/odbc_trace_tool/src/generator/cpp.rs
@@ -122,15 +122,11 @@ impl<'a> GenContext<'a> {
                 return;
             }
             match ht {
-                HandleType::Env => {
-                    if !implicit_envs.contains(&addr.to_string()) {
-                        implicit_envs.push(addr.to_string());
-                    }
+                HandleType::Env if !implicit_envs.contains(&addr.to_string()) => {
+                    implicit_envs.push(addr.to_string());
                 }
-                HandleType::Dbc => {
-                    if !implicit_dbcs.contains(&addr.to_string()) {
-                        implicit_dbcs.push(addr.to_string());
-                    }
+                HandleType::Dbc if !implicit_dbcs.contains(&addr.to_string()) => {
+                    implicit_dbcs.push(addr.to_string());
                 }
                 _ => {}
             }


### PR DESCRIPTION
### TL;DR

Refactored match arm conditions for implicit handle deduplication using Rust guard clauses.

### What changed?

The `match` arms for `HandleType::Env` and `HandleType::Dbc` were simplified by moving the inner `if` conditions into match guards (`if !implicit_envs.contains(...)` and `if !implicit_dbcs.contains(...)`), eliminating the nested conditional blocks.

### How to test?

Run existing tests for the ODBC trace tool's C++ code generator to verify that duplicate handle addresses are still correctly filtered from `implicit_envs` and `implicit_dbcs`.

### Why make this change?

The refactor reduces nesting and makes the intent of the code clearer by leveraging Rust's match guard syntax, resulting in more idiomatic Rust code without changing any behavior.