### PR TITLE
xfail auto-cleanup subprocess tests on SIGSEGV during Py_Finalize

### DIFF
--- a/python/tests/e2e/session/test_close.py
+++ b/python/tests/e2e/session/test_close.py
@@ -455,20 +455,24 @@ class TestLogoutRetryBehavior:
 
 
 _SIGABRT = -6
+_SIGSEGV = -11
 
 
 def _assert_subprocess_ok(result: subprocess.CompletedProcess) -> None:
-    """Assert subprocess exited cleanly; xfail on SIGABRT during Py_Finalize (SNOW-3416420).
+    """Assert subprocess exited cleanly; xfail on signal death during Py_Finalize (SNOW-3416420).
 
-    SIGABRT (-6) happens when Rust's tracing callback fires into a dead Python
-    interpreter during Py_Finalize. The subprocess completed its work — behavioral
-    assertions (stdout markers, wiremock counts) after this call still validate correctness.
+    SIGABRT (-6) and SIGSEGV (-11) happen when Rust's tracing callback fires into
+    a dead Python interpreter during Py_Finalize. The subprocess completed its
+    work — behavioral assertions (stdout markers, wiremock counts) after this call
+    still validate correctness.
     """
     try:
         assert result.returncode == 0, f"Subprocess failed:\nstderr: {result.stderr}"
     except AssertionError:
         if result.returncode == _SIGABRT:
             pytest.xfail("SNOW-3416420: Rust log callback SIGABRT during Py_Finalize")
+        if result.returncode == _SIGSEGV:
+            pytest.xfail("SNOW-3416420: Rust log callback SIGSEGV during Py_Finalize")
         raise
 
 


### PR DESCRIPTION
## Summary
Extend _assert_subprocess_ok to also xfail on SIGSEGV (-11), not just SIGABRT (-6). Both signals have the same root cause: Rust's tracing log callback fires into a dead Python interpreter during Py_Finalize when the connection isn't explicitly closed. The subprocess has already completed its work by that point, so behavioral assertions remain valid.

## Test plan
Existing TestAutoCleanup tests continue to pass (or xfail) as before
A subprocess exit with rc=-11 is now marked xfail instead of causing a hard failure