### PR TITLE
SNOW-2314157: scaffold OAuth core interfaces in sf_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ dependencies = [
  "crc",
  "digest",
  "libc",
- "rand",
+ "rand 0.9.2",
  "regex",
 ]
 
@@ -3229,6 +3229,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,7 +3615,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.16",
 ]
@@ -4040,7 +4060,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls 0.23.32",
@@ -4092,12 +4112,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4665,6 +4706,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4743,6 +4795,7 @@ dependencies = [
  "lru",
  "memchr",
  "num-traits",
+ "oauth2",
  "once_cell",
  "openssl",
  "opentelemetry",
@@ -4754,7 +4807,7 @@ dependencies = [
  "prost 0.14.1",
  "proto_generator",
  "proto_utils",
- "rand",
+ "rand 0.9.2",
  "rcgen",
  "reqwest",
  "rust-ini",

--- a/sf_core/Cargo.toml
+++ b/sf_core/Cargo.toml
@@ -43,6 +43,7 @@ arrow-ipc = "56.0.0"
 flate2 = "1.1.2"
 openssl = "0.10.73"
 jwt = { version = "0.16.0", features = ["openssl"] }
+oauth2 = "5"
 infer = "0.19.0"
 
 # Proto

--- a/sf_core/src/auth.rs
+++ b/sf_core/src/auth.rs
@@ -40,6 +40,15 @@ pub enum Credentials {
         passcode_in_password: bool,
         passcode: Option<SensitiveString>,
     },
+    /// Pre-acquired OAuth access token forwarded to Snowflake unchanged
+    /// (analysis §6 — legacy `AUTHENTICATOR=OAUTH` with raw `token=`).
+    /// Fields are populated by `create_credentials` in step 2.1 but are
+    /// only read once `auth_request_data` is wired in step 2.3.
+    #[allow(dead_code)]
+    OAuth {
+        username: String,
+        access_token: SensitiveString,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -171,6 +180,22 @@ pub fn create_credentials(login_parameters: &LoginParameters) -> Result<Credenti
             passcode: passcode.clone(),
             passcode_in_password: *passcode_in_password,
         }),
+        LoginMethod::OAuthAccessToken { username, token } => Ok(Credentials::OAuth {
+            username: username.clone(),
+            access_token: token.clone(),
+        }),
+        // OAuth Authorization Code and Client Credentials run their own multi-step
+        // flow (PKCE, browser/loopback, token exchange, refresh) outside of
+        // create_credentials — see analysis_feature_oauth.md §3 / §4. Mirror the
+        // NativeOkta arm above and surface a typed error rather than panicking.
+        LoginMethod::OAuthAuthorizationCode(_) => UnsupportedLoginMethodSnafu {
+            method: "OAuthAuthorizationCode",
+        }
+        .fail(),
+        LoginMethod::OAuthClientCredentials(_) => UnsupportedLoginMethodSnafu {
+            method: "OAuthClientCredentials",
+        }
+        .fail(),
     }
 }
 
@@ -181,6 +206,13 @@ pub enum AuthError {
     ))]
     UnsupportedLoginMethod {
         method: &'static str,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("OAuth flow '{flow}' is not yet wired into the login pipeline"))]
+    #[snafu(visibility(pub(crate)))]
+    OAuthFlowNotWired {
+        flow: &'static str,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -245,6 +245,78 @@ pub struct NativeOktaConfig {
     pub authentication_timeout_secs: u64,
 }
 
+/// OAuth 2.0 Authorization Code (with PKCE) flow configuration.
+///
+/// Mirrors the cross-driver configuration matrix in `analysis_feature_oauth.md` §9.
+/// All optional URL fields fall back to Snowflake-as-IdP defaults at flow time
+/// (see analysis §9 / §14): `https://{host}/oauth/authorize`,
+/// `https://{host}/oauth/token-request`, and an ephemeral `http://127.0.0.1:<random>`
+/// loopback redirect URI.
+#[derive(Debug)]
+pub struct OAuthAuthorizationCodeConfig {
+    /// Snowflake user name. Sent unchanged in the login-request body
+    /// (analysis §10.1: `LOGIN_NAME` is always set, unlike .NET's `loginName=""` quirk).
+    pub username: String,
+    /// IdP-issued client identifier. For Snowflake-as-IdP the wiring step
+    /// will substitute `LOCAL_APPLICATION` when this is empty (analysis §1, §9).
+    pub client_id: String,
+    /// IdP-issued client secret.
+    pub client_secret: SensitiveString,
+    /// Optional override for the IdP authorization endpoint.
+    /// `None` ⇒ default `https://{host}/oauth/authorize` (analysis §9).
+    pub authorization_url: Option<Url>,
+    /// Optional override for the IdP token endpoint.
+    /// `None` ⇒ default `https://{host}/oauth/token-request`. Also used to
+    /// derive the OAuth cache-key host (analysis §7.3).
+    pub token_url: Option<Url>,
+    /// Optional override for the loopback redirect URI advertised to the IdP.
+    /// `None` ⇒ ephemeral `http://127.0.0.1:<random>` (analysis §3.5; bind to
+    /// `127.0.0.1`, never `0.0.0.0` per §14 gotcha #11).
+    pub redirect_uri: Option<Url>,
+    /// OAuth scope string (space-separated). `None` ⇒ derived from role
+    /// (`session:role:<role>` per analysis §9).
+    pub scope: Option<String>,
+    /// Snowflake-as-IdP only: request single-use refresh-token rotation by
+    /// adding `enable_single_use_refresh_tokens=true` to the token body
+    /// (analysis §7.4). Defaults to `false`.
+    pub enable_single_use_refresh_tokens: bool,
+    /// Python-only escape hatch (analysis §9): disable PKCE S256.
+    /// All other drivers always run PKCE; defaults to `false` here.
+    pub disable_pkce: bool,
+    /// Enable RFC 9449 DPoP proof-of-possession on token + login requests.
+    /// Currently only JDBC has parity (analysis §5); defaults to `false`.
+    pub enable_dpop: bool,
+    /// Whether refresh tokens may be persisted to the OS-level token cache
+    /// (analysis §7.1; controls `client_store_temporary_credential`).
+    pub client_store_temporary_credential: bool,
+    /// End-to-end auth budget for the AC flow, mirroring
+    /// [`DEFAULT_AUTHENTICATION_TIMEOUT_SECS`] used by `NativeOktaConfig`.
+    pub authentication_timeout_secs: u64,
+}
+
+/// OAuth 2.0 Client Credentials flow configuration (external IdP only —
+/// Snowflake's GS does not issue tokens for `grant_type=client_credentials`,
+/// see analysis §4).
+#[derive(Debug)]
+pub struct OAuthClientCredentialsConfig {
+    /// Snowflake user name (sent in the Snowflake login-request body).
+    pub username: String,
+    /// IdP-issued client identifier (required for CC).
+    pub client_id: String,
+    /// IdP-issued client secret (required for CC).
+    pub client_secret: SensitiveString,
+    /// IdP token endpoint. **Required** for CC: there is no Snowflake default
+    /// because Snowflake-as-IdP does not support CC (analysis §4).
+    pub token_url: Url,
+    /// OAuth scope string (space-separated). `None` ⇒ derived from role.
+    pub scope: Option<String>,
+    /// Enable RFC 9449 DPoP proof-of-possession on the token + login
+    /// requests. Currently only JDBC has parity (analysis §5).
+    pub enable_dpop: bool,
+    /// End-to-end auth budget for the CC flow.
+    pub authentication_timeout_secs: u64,
+}
+
 #[derive(Debug)]
 pub enum LoginMethod {
     Password {
@@ -272,6 +344,18 @@ pub enum LoginMethod {
         username: String,
         authentication_timeout_secs: u64,
     },
+    /// Pre-acquired OAuth access token (legacy `AUTHENTICATOR=OAUTH` with
+    /// raw `token=`). The driver forwards the token to Snowflake unchanged
+    /// (analysis §6). Production wiring + parsing land in step 2.3.
+    OAuthAccessToken {
+        username: String,
+        token: SensitiveString,
+    },
+    /// OAuth 2.0 Authorization Code with PKCE (S256). Multi-step flow
+    /// orchestrated outside of `create_credentials` (analysis §3).
+    OAuthAuthorizationCode(OAuthAuthorizationCodeConfig),
+    /// OAuth 2.0 Client Credentials. External IdP only (analysis §4).
+    OAuthClientCredentials(OAuthClientCredentialsConfig),
 }
 
 impl LoginMethod {

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -6,6 +6,7 @@ mod external_browser;
 pub mod heartbeat;
 pub mod logout;
 mod native_okta;
+mod oauth;
 pub mod query_request;
 pub mod query_response;
 pub mod sql_state;
@@ -446,6 +447,17 @@ pub async fn auth_request_data(
                 data.login_name = Some(username);
                 data.token = Some(token);
                 data.authenticator = Some("PROGRAMMATIC_ACCESS_TOKEN".to_string());
+            }
+            Credentials::OAuth { .. } => {
+                // Legacy AUTHENTICATOR=OAUTH body wiring lands in step 2.3
+                // (analysis_feature_oauth.md §6 / §10.1). This skeleton
+                // surfaces a typed error so the variant remains constructible
+                // without smuggling in flow logic.
+                return crate::auth::OAuthFlowNotWiredSnafu {
+                    flow: "OAuthAccessToken",
+                }
+                .fail()
+                .context(AuthenticationSnafu);
             }
             Credentials::UserPasswordMfa {
                 username,

--- a/sf_core/src/rest/snowflake/oauth/authorization_code.rs
+++ b/sf_core/src/rest/snowflake/oauth/authorization_code.rs
@@ -1,0 +1,9 @@
+//! OAuth 2.0 Authorization Code flow with PKCE (S256).
+//!
+//! Owns the end-to-end orchestration: PKCE verifier/challenge, state
+//! parameter, browser launch, loopback HTTP redirect handling, token
+//! exchange, and refresh-token rotation. See `analysis_feature_oauth.md`
+//! §3 for the per-driver state machine and gotchas (notably §3.5 on
+//! 127.0.0.1 binding and §14 #11 on rejecting Node's `0.0.0.0`).
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/browser.rs
+++ b/sf_core/src/rest/snowflake/oauth/browser.rs
@@ -1,0 +1,6 @@
+//! OS browser launcher for the AC flow's `/authorize` redirect.
+//!
+//! Falls back to printing the URL when the platform helper is unavailable
+//! (Python's manual-paste pattern, analysis_feature_oauth.md §3.6).
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/client_credentials.rs
+++ b/sf_core/src/rest/snowflake/oauth/client_credentials.rs
@@ -1,0 +1,8 @@
+//! OAuth 2.0 Client Credentials flow (external IdP only).
+//!
+//! Snowflake-as-IdP does not currently issue tokens for
+//! `grant_type=client_credentials` (analysis_feature_oauth.md §4), so this
+//! module always requires an explicit `token_url`. Tokens obtained here are
+//! intentionally not persisted to the OS token cache (analysis §14 #12).
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/dpop.rs
+++ b/sf_core/src/rest/snowflake/oauth/dpop.rs
@@ -1,0 +1,8 @@
+//! DPoP (RFC 9449) proof-of-possession helpers.
+//!
+//! ES256 P-256 keypair, proof JWT with `jti`/`htm`/`htu`/`iat` (and
+//! optional `nonce` on `use_dpop_nonce` retry), `dpop_jkt` thumbprint on
+//! the `/authorize` request, and a bundled access-token cache row. Only
+//! JDBC has parity today (analysis_feature_oauth.md §5).
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/error.rs
+++ b/sf_core/src/rest/snowflake/oauth/error.rs
@@ -1,0 +1,20 @@
+//! Errors raised by the OAuth flow engine.
+//!
+//! Skeleton enum introduced in step 2.1; concrete variants for state
+//! mismatch, IdP failures, browser timeouts, etc. land in step 2.2 (see
+//! `analysis_feature_oauth.md` §13 for the cross-driver error taxonomy).
+
+// TODO(SNOW-OAUTH): implement in step 2.2
+
+use snafu::{Location, Snafu};
+
+/// Errors raised by the OAuth flow engine.
+#[allow(dead_code)]
+#[derive(Debug, Snafu, error_trace::ErrorTrace)]
+pub(crate) enum OAuthError {
+    #[snafu(display("OAuth flow not yet implemented"))]
+    NotImplemented {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}

--- a/sf_core/src/rest/snowflake/oauth/loopback_server.rs
+++ b/sf_core/src/rest/snowflake/oauth/loopback_server.rs
@@ -1,0 +1,7 @@
+//! Loopback HTTP server that receives the IdP's authorization-code redirect.
+//!
+//! Must bind explicitly to `127.0.0.1` (and only `::1` when the user
+//! supplies a literal IPv6 redirect URI). Do **not** replicate Node's
+//! `0.0.0.0` bind — see `analysis_feature_oauth.md` §3.5 and §14 #11.
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/mod.rs
+++ b/sf_core/src/rest/snowflake/oauth/mod.rs
@@ -1,0 +1,26 @@
+//! OAuth 2.x flow engine for Snowflake login.
+//!
+//! Houses the Authorization Code (with PKCE), Client Credentials, and
+//! pre-acquired access-token paths plus the supporting primitives (PKCE,
+//! state, loopback HTTP server, browser launcher, DPoP, token cache I/O,
+//! and the OAuth-specific error type). Cross-driver behavior, parameter
+//! names, redaction expectations, and gotchas are catalogued in
+//! `analysis_feature_oauth.md` (especially §2–§9 and §14).
+//!
+//! This file currently exposes only the empty submodule tree introduced in
+//! step 2.1 of the OAuth feature. Production logic lands in step 2.2;
+//! `LoginMethod` parsing and authenticator-string wiring land in step 2.3.
+//!
+// TODO(SNOW-OAUTH): wire `pub(crate) use` re-exports for the flow entry
+// points (authorization_code::run, client_credentials::run, token::cache I/O)
+// in step 2.2 once the production code lands.
+
+mod authorization_code;
+mod browser;
+mod client_credentials;
+mod dpop;
+mod error;
+mod loopback_server;
+mod pkce;
+mod state;
+mod token;

--- a/sf_core/src/rest/snowflake/oauth/pkce.rs
+++ b/sf_core/src/rest/snowflake/oauth/pkce.rs
@@ -1,0 +1,6 @@
+//! PKCE (RFC 7636) verifier and S256 challenge generation.
+//!
+//! Cross-driver verifier sizes converge on ≥43 URL-safe characters; see
+//! `analysis_feature_oauth.md` §3.3 for the per-driver matrix.
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/state.rs
+++ b/sf_core/src/rest/snowflake/oauth/state.rs
@@ -1,0 +1,7 @@
+//! `state` parameter generation and CSRF validation for the AC flow.
+//!
+//! Mismatch must surface the canonical "It might indicate an XSS attack"
+//! message — multiple drivers ship that exact wording and SREs grep for
+//! it (analysis_feature_oauth.md §3.4 and §14 #7).
+
+// TODO(SNOW-OAUTH): implement in step 2.2

--- a/sf_core/src/rest/snowflake/oauth/token.rs
+++ b/sf_core/src/rest/snowflake/oauth/token.rs
@@ -1,0 +1,8 @@
+//! OAuth token cache I/O and refresh-token rotation.
+//!
+//! Cache key derivation follows JDBC/Python: `{HOST_FROM_TOKEN_REQUEST_URL}:
+//! {USER}:{TYPE}` uppercased, SHA-256 hashed on Linux file backends
+//! (analysis_feature_oauth.md §7). Eviction on Snowflake error codes
+//! `390303` / `390318` is required across all drivers (§8).
+
+// TODO(SNOW-OAUTH): implement in step 2.2


### PR DESCRIPTION
Lays down the type/interface skeleton for the OAuth feature parity work
in `sf_core` (step 2.1 of the OAuth implementation plan). No production
flow logic, no parameter parsing — these land in the next two substeps.

- Add `oauth2 = "5"` (resolves to 5.0.0) dependency next to `jwt`.
- Extend `Credentials` with an `OAuth { username, access_token }`
  variant covering the legacy pre-acquired access-token path
  (analysis_feature_oauth.md §6).
- Extend `LoginMethod` with `OAuthAccessToken { username, token }`,
  `OAuthAuthorizationCode(OAuthAuthorizationCodeConfig)`, and
  `OAuthClientCredentials(OAuthClientCredentialsConfig)` variants.
  Field sets follow the cross-driver matrix in
  analysis_feature_oauth.md §9 / §14.
- Make `create_credentials()` exhaustive: `OAuthAccessToken` maps to
  `Credentials::OAuth`; AC and CC return `UnsupportedLoginMethod`
  (these run their own multi-step flow outside this function, mirroring
  the existing NativeOkta treatment).
- Add empty module skeleton at `sf_core/src/rest/snowflake/oauth/`
  with submodules for authorization_code, client_credentials, pkce,
  state, loopback_server, browser, dpop, token, and error.
- Stub `OAuthError::NotImplemented` per the snafu+ErrorTrace pattern.
- Add a transitional `AuthError::OAuthFlowNotWired { flow: &'static str }`
  variant used by `auth_request_data` to surface a typed error for the
  new `Credentials::OAuth` arm; this variant is removed/folded once the
  legacy OAuth body wiring lands in step 2.3.

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo build -p sf_core --all-targets`, and `cargo test -p sf_core --lib`
(697 passed, 0 failed) all green.