### PR TITLE
Add retry strategy for S3 PUT/GET

### DIFF
--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -1,17 +1,28 @@
 use super::types::{
     EncryptedFileMetadata, MaterialDescription, PreparedUpload, StageInfo, UploadStatus,
 };
+use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use snafu::{Location, ResultExt, Snafu};
+use std::time::Duration;
 
 // AWS SDK imports
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::Credentials;
+use aws_sdk_s3::config::retry::RetryConfig as AwsRetryConfig;
+use aws_sdk_s3::config::timeout::TimeoutConfig as AwsTimeoutConfig;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
 
 const SNOWFLAKE_UPLOAD_PROVIDER: &str = "snowflake-upload";
 const SNOWFLAKE_DOWNLOAD_PROVIDER: &str = "snowflake-download";
 const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
+
+/// Per-attempt HTTP timeout applied to every S3 SDK operation.
+///
+/// Matches the Azure/GCS transfer timeout (300s). The retry budget
+/// (`max_elapsed` in `s3_retry_policy`) must exceed this so at least one
+/// full attempt can complete.
+const REQUEST_TIMEOUT_SECS: u64 = 300;
 
 // TODO: streaming instead of loading the whole file into memory
 
@@ -157,6 +168,64 @@ pub async fn download_from_s3(
     Ok((data, digest, file_metadata))
 }
 
+/// Returns a retry policy tuned for S3 file-transfer operations.
+///
+/// Mirrors the shape and budget of the GCS/Azure policies so that cross-cloud
+/// behavior is consistent: 6 attempts, exponential backoff from 1s to 16s,
+/// and a total retry budget of 600s (2× `REQUEST_TIMEOUT_SECS`) so at least
+/// one full-timeout attempt can complete before the budget expires.
+///
+/// The AWS SDK's standard retry strategy already covers transient transport
+/// errors, 5xx server errors, and throttling (429, SlowDown). 403 is left to
+/// the SDK's defaults: unlike GCS/Azure (where 403 commonly means "token not
+/// yet propagated" / "SAS clock skew"), S3 returns 403 for genuine AccessDenied
+/// and retrying is rarely productive — `create_s3_client` is called per
+/// operation, so an expired STS token surfaces as a non-retryable 403 and the
+/// caller can re-fetch credentials via a new PUT/GET parse.
+pub(crate) fn s3_retry_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 6,
+        backoff: BackoffConfig {
+            base: Duration::from_secs(1),
+            factor: 2.0,
+            cap: Duration::from_secs(16),
+            jitter: Jitter::None,
+        },
+        // Must exceed REQUEST_TIMEOUT_SECS (300s) to allow at least one full
+        // request + retries. 600s accommodates ~2 full-timeout attempts plus backoff.
+        max_elapsed: Duration::from_secs(600),
+        per_request_timeout: Some(Duration::from_secs(REQUEST_TIMEOUT_SECS)),
+        extra_retryable_statuses: Vec::new(),
+        ..RetryPolicy::default()
+    }
+}
+
+/// Translates the driver's `RetryPolicy` into the AWS SDK's `RetryConfig`.
+///
+/// The SDK owns the retry loop for S3, so we hand it our knobs — attempt count
+/// and backoff bounds — and let it classify errors. AWS's standard mode already
+/// retries transient transport faults, 5xx, and throttling (429, SlowDown)
+/// with exponential backoff and jitter.
+fn to_aws_retry_config(policy: &RetryPolicy) -> AwsRetryConfig {
+    AwsRetryConfig::standard()
+        .with_max_attempts(policy.max_attempts)
+        .with_initial_backoff(policy.backoff.base)
+        .with_max_backoff(policy.backoff.cap)
+}
+
+/// Builds the SDK's `TimeoutConfig` from our policy.
+///
+/// - `operation_attempt_timeout` bounds a single try (so retries are actually
+///   triggered on stuck connections rather than hanging forever).
+/// - `operation_timeout` bounds the total retry budget.
+fn to_aws_timeout_config(policy: &RetryPolicy) -> AwsTimeoutConfig {
+    let mut builder = AwsTimeoutConfig::builder().operation_timeout(policy.max_elapsed);
+    if let Some(per_attempt) = policy.per_request_timeout {
+        builder = builder.operation_attempt_timeout(per_attempt);
+    }
+    builder.build()
+}
+
 async fn create_s3_client(
     stage_info: &StageInfo,
     provider_name: &'static str,
@@ -178,9 +247,12 @@ async fn create_s3_client(
         provider_name,
     );
 
+    let policy = s3_retry_policy();
     let config = aws_config::defaults(BehaviorVersion::latest())
         .credentials_provider(credentials)
         .region(Region::new(stage_info.region.clone()))
+        .retry_config(to_aws_retry_config(&policy))
+        .timeout_config(to_aws_timeout_config(&policy))
         .load()
         .await;
 
@@ -282,4 +354,62 @@ pub enum DownloadFileError {
         #[snafu(implicit)]
         location: Location,
     },
+}
+
+// --- Unit tests ---
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn s3_retry_policy_max_attempts_matches_gcs_and_azure() {
+        let policy = s3_retry_policy();
+        assert_eq!(policy.max_attempts, 6);
+    }
+
+    #[test]
+    fn s3_retry_policy_backoff_bounds() {
+        let policy = s3_retry_policy();
+        assert_eq!(policy.backoff.base, Duration::from_secs(1));
+        assert_eq!(policy.backoff.cap, Duration::from_secs(16));
+        assert_eq!(policy.backoff.factor, 2.0);
+    }
+
+    #[test]
+    fn s3_retry_policy_max_elapsed_exceeds_request_timeout() {
+        let policy = s3_retry_policy();
+        assert!(
+            policy.max_elapsed > Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            "retry budget must exceed a single request timeout"
+        );
+        assert_eq!(policy.max_elapsed, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn s3_retry_policy_has_per_request_timeout() {
+        let policy = s3_retry_policy();
+        assert_eq!(
+            policy.per_request_timeout,
+            Some(Duration::from_secs(REQUEST_TIMEOUT_SECS)),
+            "per_request_timeout must be set so the SDK cancels stuck attempts"
+        );
+    }
+
+    #[test]
+    fn to_aws_retry_config_translates_policy() {
+        let policy = s3_retry_policy();
+        let aws = to_aws_retry_config(&policy);
+        assert_eq!(aws.max_attempts(), policy.max_attempts);
+        assert_eq!(aws.initial_backoff(), policy.backoff.base);
+        assert_eq!(aws.max_backoff(), policy.backoff.cap);
+    }
+
+    #[test]
+    fn to_aws_timeout_config_sets_attempt_and_operation_timeouts() {
+        let policy = s3_retry_policy();
+        let cfg = to_aws_timeout_config(&policy);
+        assert_eq!(cfg.operation_timeout(), Some(policy.max_elapsed));
+        assert_eq!(cfg.operation_attempt_timeout(), policy.per_request_timeout);
+    }
 }


### PR DESCRIPTION
  Aligns S3 file-transfer behavior with GCS and Azure, which already go through  
  RetryPolicy + HTTP-retry helpers. Until now, S3 made a single attempt and      
  surfaced any transient error straight to the caller.                           
                                                                                 
##  What changed                                              
                                                                                 
  - New s3_retry_policy() in sf_core/src/file_manager/s3_transfer.rs, returning
  the same RetryPolicy shape used by gcs_retry_policy() and azure_retry_policy():
   6 attempts, 1s→16s exponential backoff, 600s total budget, 300s per-attempt   
  timeout.                                                                       
  - Policy is translated into the AWS SDK's native RetryConfig + TimeoutConfig
  (via two small helpers) and attached to aws_config::defaults(...) in        
  create_s3_client. The SDK's standard retry mode then handles transient         
  transport faults, 5xx, and throttling (429, SlowDown) with backoff and jitter.
  - 403 intentionally left off the retryable set — on S3 it's genuine            
  AccessDenied, unlike GCS/Azure where 403 often means token propagation / SAS
  clock skew.                                                                    
             
##  Test plan                                                                      
                                                                                 
  - 6 new unit tests cover the policy values and the RetryPolicy → AWS SDK
  translation.                                                                   
  - Full e2e PUT/GET suite against real S3 (sfctest0, 33 tests) passes before and
   after the change with no regressions in runtime. 