### PR TITLE
NO-SNOW: derive host from account and strip wrapper prefixes from query errors

### DIFF
--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -36,18 +36,15 @@ class TestConnectionParameters:
     These tests exercise that behavior against both drivers.
     """
 
-    def test_connect_with_account_only_no_host_or_server_url(self, connection_factory):
+    def test_connect_with_account_only_no_host_or_server_url(self, connector_adapter, monkeypatch):
         """Connection succeeds when only ``account`` is given — host/server_url are derived.
 
         Skipped when the test environment targets a non-production host (preprod,
         localhost, or a dev deployment) — derivation only yields a valid URL for
         accounts whose canonical host is ``{account}.snowflakecomputing.com``.
-
-        Passing ``None`` for host/server_url/port/protocol causes the connection
-        factory to omit those parameters entirely, forcing the driver to derive
-        them from ``account``.
         """
         from tests.config import get_test_parameters
+        from tests.connector_factory import create_connection_with_adapter
 
         test_params = get_test_parameters()
         account = test_params.get("SNOWFLAKE_TEST_ACCOUNT")
@@ -64,7 +61,23 @@ class TestConnectionParameters:
                 f"yields '{expected_host}', not the configured target."
             )
 
-        with connection_factory(host=None, server_url=None, port=None, protocol=None) as conn:
+        # Patch get_test_parameters at its import site in connector_factory to
+        # return a copy with host/server_url/port/protocol stripped. This forces
+        # the driver to derive the host from `account` alone.
+        def _stripped_params():
+            p = dict(test_params)
+            for k in (
+                "SNOWFLAKE_TEST_HOST",
+                "SNOWFLAKE_TEST_SERVER_URL",
+                "SNOWFLAKE_TEST_PORT",
+                "SNOWFLAKE_TEST_PROTOCOL",
+            ):
+                p.pop(k, None)
+            return p
+
+        monkeypatch.setattr("tests.connector_factory.get_test_parameters", _stripped_params)
+
+        with create_connection_with_adapter(connector_adapter) as conn:
             assert not conn.is_closed()
             cur = conn.cursor()
             try:

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -5,6 +5,7 @@ Integration tests for PEP 249 Connection objects.
 import uuid
 
 from io import StringIO
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -36,7 +37,7 @@ class TestConnectionParameters:
     These tests exercise that behavior against both drivers.
     """
 
-    def test_connect_with_account_only_no_host_or_server_url(self, connector_adapter, monkeypatch):
+    def test_connect_with_account_only_no_host_or_server_url(self, connector_adapter):
         """Connection succeeds when only ``account`` is given — host/server_url are derived.
 
         Skipped when the test environment targets a non-production host (preprod,
@@ -44,7 +45,7 @@ class TestConnectionParameters:
         accounts whose canonical host is ``{account}.snowflakecomputing.com``.
         """
         from tests.config import get_test_parameters
-        from tests.connector_factory import create_connection_with_adapter
+        from tests.connector_factory import setup_default_jwt_auth
 
         test_params = get_test_parameters()
         account = test_params.get("SNOWFLAKE_TEST_ACCOUNT")
@@ -61,23 +62,16 @@ class TestConnectionParameters:
                 f"yields '{expected_host}', not the configured target."
             )
 
-        # Patch get_test_parameters at its import site in connector_factory to
-        # return a copy with host/server_url/port/protocol stripped. This forces
-        # the driver to derive the host from `account` alone.
-        def _stripped_params():
-            p = dict(test_params)
-            for k in (
-                "SNOWFLAKE_TEST_HOST",
-                "SNOWFLAKE_TEST_SERVER_URL",
-                "SNOWFLAKE_TEST_PORT",
-                "SNOWFLAKE_TEST_PROTOCOL",
-            ):
-                p.pop(k, None)
-            return p
+        # Build a minimal connection params dict containing only ``account`` plus
+        # auth credentials. No host/server_url/port/protocol is supplied — the
+        # driver must derive ``host = {account}.snowflakecomputing.com``.
+        connection_params: dict[str, Any] = {
+            "account": account,
+            "user": test_params.get("SNOWFLAKE_TEST_USER"),
+        }
+        setup_default_jwt_auth(connection_params)
 
-        monkeypatch.setattr("tests.connector_factory.get_test_parameters", _stripped_params)
-
-        with create_connection_with_adapter(connector_adapter) as conn:
+        with connector_adapter.connect(**connection_params) as conn:
             assert not conn.is_closed()
             cur = conn.cursor()
             try:

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -28,6 +28,53 @@ class TestConnectionInfo:
         assert info is not None
 
 
+class TestConnectionParameters:
+    """Reference tests: minimum parameters required to establish a connection.
+
+    The old snowflake-connector-python driver accepts just ``account`` (plus
+    auth credentials) and derives the host as ``{account}.snowflakecomputing.com``.
+    These tests exercise that behavior against both drivers.
+    """
+
+    def test_connect_with_account_only_no_host_or_server_url(self, connection_factory):
+        """Connection succeeds when only ``account`` is given — host/server_url are derived.
+
+        Skipped when the test environment targets a non-production host (preprod,
+        localhost, or a dev deployment) — derivation only yields a valid URL for
+        accounts whose canonical host is ``{account}.snowflakecomputing.com``.
+
+        Passing ``None`` for host/server_url/port/protocol causes the connection
+        factory to omit those parameters entirely, forcing the driver to derive
+        them from ``account``.
+        """
+        from tests.config import get_test_parameters
+
+        test_params = get_test_parameters()
+        account = test_params.get("SNOWFLAKE_TEST_ACCOUNT")
+        if not account:
+            pytest.skip("SNOWFLAKE_TEST_ACCOUNT not configured")
+        custom_host = test_params.get("SNOWFLAKE_TEST_HOST") or ""
+        custom_server_url = test_params.get("SNOWFLAKE_TEST_SERVER_URL") or ""
+        expected_host = f"{account}.snowflakecomputing.com"
+        if (custom_host and custom_host != expected_host) or (
+            custom_server_url and expected_host not in custom_server_url
+        ):
+            pytest.skip(
+                "Test environment overrides host/server_url; account-name derivation "
+                f"yields '{expected_host}', not the configured target."
+            )
+
+        with connection_factory(host=None, server_url=None, port=None, protocol=None) as conn:
+            assert not conn.is_closed()
+            cur = conn.cursor()
+            try:
+                cur.execute("SELECT 1")
+                row = cur.fetchone()
+                assert row[0] == 1
+            finally:
+                cur.close()
+
+
 class TestConnectionInfoProperties:
     """Integration tests for Connection properties backed by _get_connection_info."""
 

--- a/python/tests/integ/test_errors.py
+++ b/python/tests/integ/test_errors.py
@@ -196,11 +196,14 @@ class TestErrorMessageFormat:
         error = excinfo.value
         msg = str(error)
         # Must start with zero-padded errno and sqlstate, e.g. "002003 (42S02): "
-        assert msg.startswith(f"{error.errno:06d} ({error.sqlstate}): "), (
-            f"Expected '<errno> (<sqlstate>): ...' prefix, got: {msg!r}"
-        )
+        prefix = f"{error.errno:06d} ({error.sqlstate}): "
+        assert msg.startswith(prefix), f"Expected '<errno> (<sqlstate>): ...' prefix, got: {msg!r}"
+        body = msg[len(prefix) :]
+        # At INFO/DEBUG log level the old driver injects "{sfqid}: " before the
+        # server message. Strip it if present so we can assert on the server text.
+        if error.sfqid and body.startswith(f"{error.sfqid}: "):
+            body = body[len(f"{error.sfqid}: ") :]
         # The body must start with the server's error class, not a wrapper.
-        body = msg[len(f"{error.errno:06d} ({error.sqlstate}): ") :]
         assert body.lower().startswith("sql compilation error"), (
             f"Expected body to start with 'SQL compilation error', got: {body!r}"
         )

--- a/python/tests/integ/test_errors.py
+++ b/python/tests/integ/test_errors.py
@@ -170,3 +170,37 @@ class TestErrorAttributes:
         with pytest.raises(Error) as excinfo:
             cursor.execute("SELEC 1")
         assert excinfo.value.__cause__ is None
+
+
+class TestErrorMessageFormat:
+    """Reference tests asserting the exact on-the-wire error message format.
+
+    The formatted message surfaced to users must match the legacy
+    snowflake-connector-python driver exactly:
+        ``{errno:06d} ({sqlstate}): {server_message}``
+    with no wrapper prefixes like ``"Query execution failed:"`` or ``"Query failed:"``.
+    """
+
+    def test_query_error_message_has_no_wrapper_prefixes(self, cursor):
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute("SELEC 1")
+        msg = str(excinfo.value)
+        assert "Query execution failed" not in msg
+        assert "Query failed:" not in msg
+
+    def test_query_error_message_format_matches_old_driver(self, cursor):
+        """End-to-end: the formatted message has the exact shape the old driver produces."""
+        table_name = f"nonexistent_table_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(DatabaseError) as excinfo:
+            cursor.execute(f"SELECT * FROM {table_name}")
+        error = excinfo.value
+        msg = str(error)
+        # Must start with zero-padded errno and sqlstate, e.g. "002003 (42S02): "
+        assert msg.startswith(f"{error.errno:06d} ({error.sqlstate}): "), (
+            f"Expected '<errno> (<sqlstate>): ...' prefix, got: {msg!r}"
+        )
+        # The body must start with the server's error class, not a wrapper.
+        body = msg[len(f"{error.errno:06d} ({error.sqlstate}): ") :]
+        assert body.lower().startswith("sql compilation error"), (
+            f"Expected body to start with 'SQL compilation error', got: {body!r}"
+        )

--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -340,6 +340,30 @@ class TestConvertProtoError:
         assert result.errno == 1003
         assert result.sqlstate == "42000"
 
+    def test_application_exception_message_has_no_wrapper_prefixes(self):
+        """Regression test: match old snowflake-connector-python error format.
+
+        Old driver produces '002003 (42S02): SQL compilation error: ...'
+        — no 'Query execution failed:' or 'Query failed:' wrapper.
+        """
+        from snowflake.connector._internal.protobuf_gen.proto_exception import (
+            ProtoApplicationException,
+        )
+
+        driver_exc = ProtoDriverException(
+            message="SQL compilation error: Object 'FOO' does not exist.",
+            status_code=STATUS_CODE_INTERNAL_ERROR,
+            vendor_code=2003,
+            sql_state="42S02",
+        )
+        proto_exc = ProtoApplicationException(driver_exc)
+
+        result = _proto_to_public_error(proto_exc)
+        msg = str(result)
+        assert "Query execution failed" not in msg
+        assert "Query failed:" not in msg
+        assert msg == "002003 (42S02): SQL compilation error: Object 'FOO' does not exist."
+
     def test_application_exception_root_cause_appended(self):
         from snowflake.connector._internal.protobuf_gen.proto_exception import (
             ProtoApplicationException,

--- a/sf_core/src/apis/database_driver_v1/error.rs
+++ b/sf_core/src/apis/database_driver_v1/error.rs
@@ -94,7 +94,7 @@ pub enum ApiError {
         location: Location,
         source: StatementError,
     },
-    #[snafu(display("Query execution failed: {source}"))]
+    #[snafu(display("{source}"))]
     Query {
         #[snafu(implicit)]
         location: Location,

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -1520,4 +1520,28 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn build_succeeds_with_account_only_no_host() {
+        use crate::config::path_resolver::ConfigPaths;
+        use crate::config::resolver;
+
+        let mut explicit = ParamStore::new();
+        explicit.insert("account".into(), Setting::String("myaccount".into()));
+        explicit.insert("user".into(), Setting::String("myuser".into()));
+        explicit.insert("password".into(), Setting::String("mypassword".into()));
+
+        let paths = ConfigPaths {
+            config_file: None,
+            connections_file: None,
+        };
+        let resolved = resolver::resolve_with_paths(&explicit, &paths).unwrap();
+        let config = ConnectionConfig::build(&resolved).unwrap();
+
+        assert_eq!(config.server.account, "myaccount");
+        assert_eq!(
+            config.server.server_url,
+            "https://myaccount.snowflakecomputing.com"
+        );
+    }
 }

--- a/sf_core/src/config/resolver.rs
+++ b/sf_core/src/config/resolver.rs
@@ -48,6 +48,29 @@ pub(crate) fn derive_account_from_host(store: &mut ParamStore) {
     );
 }
 
+/// If neither `host` nor `server_url` is explicitly set but `account` is,
+/// derive the hostname from the account identifier — matching the legacy
+/// `snowflake-connector-python` driver behavior where `account="myaccount"`
+/// yields host `"myaccount.snowflakecomputing.com"`.
+///
+/// Account identifiers that already encode a region (e.g. `"myaccount.us-east-1"`)
+/// are passed through unchanged, producing `"myaccount.us-east-1.snowflakecomputing.com"`.
+pub(crate) fn derive_host_from_account(store: &mut ParamStore) {
+    if store.get_string(param_names::HOST).is_some()
+        || store.get_string(param_names::SERVER_URL).is_some()
+    {
+        return;
+    }
+
+    let Some(account) = store.get_string(param_names::ACCOUNT) else {
+        return;
+    };
+
+    let host = format!("{account}.snowflakecomputing.com");
+    tracing::debug!(derived_host = %host, account = %account, "Derived host from account");
+    store.insert(param_names::HOST.into(), Setting::String(host));
+}
+
 /// Resolve final settings by merging explicit settings with file-based
 /// config and registry defaults.
 ///
@@ -93,6 +116,7 @@ pub fn resolve_with_paths(
     merged.extend_from(explicit);
 
     derive_account_from_host(&mut merged);
+    derive_host_from_account(&mut merged);
 
     Ok(merged)
 }
@@ -166,6 +190,72 @@ mod tests {
         derive_account_from_host(&mut store);
 
         assert_eq!(store.get(param_names::ACCOUNT), None);
+    }
+
+    // --- derive_host_from_account tests ---
+
+    #[test_case("myaccount", "myaccount.snowflakecomputing.com" ; "simple account")]
+    #[test_case("myaccount.us-east-1", "myaccount.us-east-1.snowflakecomputing.com" ; "account with region")]
+    #[test_case("myorg-myaccount", "myorg-myaccount.snowflakecomputing.com" ; "org-account format")]
+    fn derive_host_from_account_constructs_host(account: &str, expected_host: &str) {
+        let mut store = ParamStore::new();
+        store.insert(
+            param_names::ACCOUNT.into(),
+            Setting::String(account.to_owned()),
+        );
+
+        derive_host_from_account(&mut store);
+
+        assert_eq!(
+            store.get(param_names::HOST),
+            Some(&Setting::String(expected_host.to_owned())),
+        );
+    }
+
+    #[test]
+    fn derive_host_from_account_skips_when_host_present() {
+        let mut store = ParamStore::new();
+        store.insert(
+            param_names::ACCOUNT.into(),
+            Setting::String("myaccount".to_owned()),
+        );
+        store.insert(
+            param_names::HOST.into(),
+            Setting::String("custom.host.com".to_owned()),
+        );
+
+        derive_host_from_account(&mut store);
+
+        assert_eq!(
+            store.get(param_names::HOST),
+            Some(&Setting::String("custom.host.com".to_owned())),
+        );
+    }
+
+    #[test]
+    fn derive_host_from_account_skips_when_server_url_present() {
+        let mut store = ParamStore::new();
+        store.insert(
+            param_names::ACCOUNT.into(),
+            Setting::String("myaccount".to_owned()),
+        );
+        store.insert(
+            param_names::SERVER_URL.into(),
+            Setting::String("https://custom.url".to_owned()),
+        );
+
+        derive_host_from_account(&mut store);
+
+        assert_eq!(store.get(param_names::HOST), None);
+    }
+
+    #[test]
+    fn derive_host_from_account_noop_when_no_account() {
+        let mut store = ParamStore::new();
+
+        derive_host_from_account(&mut store);
+
+        assert_eq!(store.get(param_names::HOST), None);
     }
 
     fn make_paths(dir: &TempDir) -> ConfigPaths {

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -1008,4 +1008,42 @@ mod tests {
         let err = async_query(424_242);
         assert_eq!(extract_vendor_info(&err), (Some(424_242), None));
     }
+
+    #[test]
+    fn query_error_to_string_has_no_wrapper_prefixes() {
+        // Server errors should surface verbatim: no "Query execution failed:"
+        // and no "Query failed:" prefix — matching the legacy Python driver.
+        let err = ApiError::Query {
+            location: loc(),
+            source: Box::new(RestError::QueryFailed {
+                message: "SQL compilation error: Object 'FOO' does not exist.".to_owned(),
+                code: Some(2003),
+                sql_state: Some("42S02".to_owned()),
+                query_id: None,
+                location: loc(),
+            }),
+        };
+        assert_eq!(
+            err.to_string(),
+            "SQL compilation error: Object 'FOO' does not exist."
+        );
+    }
+
+    #[test]
+    fn query_error_driver_exception_message_has_no_wrapper_prefixes() {
+        // End-to-end: the DriverException.message field (what Python reads)
+        // should contain only the server error, no wrapper prefixes.
+        let err = ApiError::Query {
+            location: loc(),
+            source: Box::new(RestError::QueryFailed {
+                message: "SQL compilation error: syntax error line 1".to_owned(),
+                code: Some(1003),
+                sql_state: Some("42000".to_owned()),
+                query_id: None,
+                location: loc(),
+            }),
+        };
+        let exc = to_driver_exception(err);
+        assert_eq!(exc.message, "SQL compilation error: syntax error line 1");
+    }
 }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1600,7 +1600,7 @@ pub enum RestError {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Query failed: {message}"))]
+    #[snafu(display("{message}"))]
     QueryFailed {
         message: String,
         /// Snowflake server error code (e.g. 1003 for syntax error).


### PR DESCRIPTION
## Summary

Fixes two regressions versus the legacy `snowflake-connector-python`:

1. **Connecting with only `account` now works again.** The old driver accepts just `account` (plus auth credentials) and derives `host = {account}.snowflakecomputing.com`. The new driver rejected the connection because the Rust core required `host` or `server_url`. Added `derive_host_from_account()` in the resolver to fill in the canonical host when neither is provided.

2. **Query-error messages no longer carry a doubled prefix.** Previously:
   ```
   002003 (42S02): Query execution failed: Query failed: SQL compilation error: ...
   ```
   Now matches the old driver exactly:
   ```
   002003 (42S02): SQL compilation error: ...
   ```
   Removed the SNAFU `display` prefixes on `ApiError::Query` and `RestError::QueryFailed` so the server's error surfaces verbatim in `DriverException.message`.

Also replaces `pkgs.rustup` in `shell.nix` with `rust-overlay`. The rustup-downloaded toolchain isn't patched against nix's glibc and breaks whenever the nix store changes — `rust-overlay` gives us a properly-linked toolchain while still honoring `rust-toolchain.toml`.

## Test plan

- [x] Rust unit tests for `derive_host_from_account` (6 cases covering simple, region-embedded, org-account, and skip-when-set scenarios)
- [x] Rust integration test that exercises the full `resolver::resolve_with_paths` → `ConnectionConfig::build` pipeline with only `account`
- [x] Rust unit tests asserting exact display of `ApiError::Query` and `DriverException.message` with no wrapper prefixes
- [x] Python unit test asserting `str(error) == "002003 (42S02): SQL compilation error: ..."` (exact match)
- [x] Python integration tests (`TestConnectionParameters`, `TestErrorMessageFormat`) runnable as reference tests against both the new and legacy drivers
- [ ] Verify integration tests pass in CI against a real Snowflake account

🤖 Generated with [Claude Code](https://claude.com/claude-code)