### PR TITLE
SNOW-3450792: freezable proxy for post-close access to connection state

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -405,6 +405,14 @@ message ConnectionGetParameterResponse {
   optional string value = 1;
 }
 
+message ConnectionGetAllParametersRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionGetAllParametersResponse {
+  map<string, string> parameters = 1;
+}
+
 message ConnectionValidateOptionsRequest {
   ConnectionHandle conn_handle = 1;
 }
@@ -806,6 +814,8 @@ service DatabaseDriver {
   // gets cached session parameter. Cache is updated with subset of connection parameters
   // (chosen by server, included in HTTP response) after each query
   rpc ConnectionGetParameter(ConnectionGetParameterRequest) returns (ConnectionGetParameterResponse);
+  // gets all resolved session parameters at once
+  rpc ConnectionGetAllParameters(ConnectionGetAllParametersRequest) returns (ConnectionGetAllParametersResponse);
   // pre-flight validation of connection options - reports all issues at once
   rpc ConnectionValidateOptions(ConnectionValidateOptionsRequest) returns (ConnectionValidateOptionsResponse);
   // Fetch the result of a previously executed query by Snowflake Query ID

--- a/python/src/snowflake/connector/_internal/freezable_proxy.py
+++ b/python/src/snowflake/connector/_internal/freezable_proxy.py
@@ -1,0 +1,88 @@
+"""Proxies that cache connection state at close time for post-close access."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .protobuf_gen.database_driver_v1_pb2 import (
+    ConnectionGetAllParametersRequest,
+    ConnectionGetInfoRequest,
+    ConnectionGetInfoResponse,
+    ConnectionGetParameterRequest,
+)
+
+
+class FreezableProxy:
+    """Dict-like proxy that fetches live values while open and serves cached values after freeze().
+
+    Subclasses implement _fetch_one (single key) and _fetch_all (bulk snapshot).
+    Call freeze() before releasing the underlying handles.
+    """
+
+    def __init__(self, db_api: Any, conn_handle: Any) -> None:
+        self._db_api = db_api
+        self._conn_handle = conn_handle
+        self._cache: dict[str, Any] | None = None
+
+    def freeze(self) -> None:
+        """Take a snapshot and release references to db_api/conn_handle."""
+        if self._cache is None:
+            self._cache = self._fetch_all()
+            self._db_api = None
+            self._conn_handle = None
+
+    def _fetch_one(self, key: str) -> Any:
+        raise NotImplementedError
+
+    def _fetch_all(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def __getitem__(self, key: str) -> Any:
+        if self._cache is not None:
+            return self._cache.get(key)
+        return self._fetch_one(key)
+
+
+class SessionParametersProxy(FreezableProxy):
+    """Proxy for Snowflake session parameters (case-insensitive keys)."""
+
+    def _fetch_one(self, name: str) -> str | None:
+        request = ConnectionGetParameterRequest(conn_handle=self._conn_handle, key=name)
+        response = self._db_api.connection_get_parameter(request)
+        return response.value if response.value else None
+
+    def _fetch_all(self) -> dict[str, str]:
+        request = ConnectionGetAllParametersRequest(conn_handle=self._conn_handle)
+        response = self._db_api.connection_get_all_parameters(request)
+        return {k.upper(): v for k, v in response.parameters.items()}
+
+    def __getitem__(self, name: str) -> str | None:
+        if self._cache is not None:
+            return self._cache.get(name.upper())
+        return self._fetch_one(name)
+
+
+class ConnectionInfoProxy(FreezableProxy):
+    """Proxy for any field in ConnectionGetInfoResponse.
+
+    Supports all proto fields (role, database, schema, account, warehouse,
+    user, host, port, session_id, server_url, session_token, master_token).
+    While unfrozen, every field access triggers a connection_get_info RPC.
+    This matches the pre-proxy behavior where each property did its own RPC.
+    """
+
+    def _fetch_info(self, include_master_token: bool = False) -> ConnectionGetInfoResponse:
+        request = ConnectionGetInfoRequest(
+            conn_handle=self._conn_handle,
+            include_master_token=include_master_token,
+        )
+        result: ConnectionGetInfoResponse = self._db_api.connection_get_info(request)
+        return result
+
+    def _fetch_one(self, field: str) -> Any:
+        info = self._fetch_info()
+        return getattr(info, field) if info.HasField(field) else None  # type: ignore[arg-type]
+
+    def _fetch_all(self) -> dict[str, Any]:
+        info = self._fetch_info(include_master_token=True)
+        return {desc.name: value for desc, value in info.ListFields()}

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -19,18 +19,29 @@ from functools import cached_property
 from io import StringIO
 from typing import Any, TypeVar, cast
 
-from snowflake.connector._internal.config_utils import create_config_settings_from_dict, pop_typed_kwarg
-from snowflake.connector._internal.errorcode import ER_CONNECTION_IS_CLOSED, ER_INVALID_VALUE
-from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+from ._internal._private_key_helper import normalize_private_key
+from ._internal.api_client.client_api import database_driver_client
+from ._internal.binding_converters import ParamStyle
+from ._internal.config_utils import create_config_settings_from_dict, pop_typed_kwarg
+from ._internal.decorators import api_telemetry, backward_compatibility, internal_api, pep249
+from ._internal.errorcode import ER_CONNECTION_IS_CLOSED, ER_INVALID_VALUE
+from ._internal.errorhandler import ErrorHandlerMixin
+from ._internal.extras import check_dependency
+from ._internal.extras import numpy as np
+from ._internal.freezable_proxy import ConnectionInfoProxy, SessionParametersProxy
+from ._internal.logout_config_mapping import (
+    LogoutConfig,
+    LogoutOptionKeys,
+)
+from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
     DatabaseHandle,
     WrapperIdentity,
 )
-from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
+from ._internal.protobuf_gen.database_driver_v1_services import (
     ConnectionCloseRequest,
     ConnectionGetInfoRequest,
     ConnectionGetInfoResponse,
-    ConnectionGetParameterRequest,
     ConnectionGetQueryStatusRequest,
     ConnectionGetQueryStatusResponse,
     ConnectionHeartbeatRequest,
@@ -44,20 +55,8 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_services impo
     DatabaseNewRequest,
     DatabaseReleaseRequest,
 )
-from snowflake.connector._internal.sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS
-
-from ._internal._private_key_helper import normalize_private_key
-from ._internal.api_client.client_api import database_driver_client
-from ._internal.binding_converters import ParamStyle
-from ._internal.decorators import api_telemetry, backward_compatibility, internal_api, pep249
-from ._internal.errorhandler import ErrorHandlerMixin
-from ._internal.extras import check_dependency
-from ._internal.extras import numpy as np
-from ._internal.logout_config_mapping import (
-    LogoutConfig,
-    LogoutOptionKeys,
-)
 from ._internal.snowflake_restful import SnowflakeRestful
+from ._internal.sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS
 from ._internal.text_utils import split_statements
 from .constants import QueryStatus
 from .cursor import CursorInstance, CursorType, DictCursor, SnowflakeCursor
@@ -224,6 +223,9 @@ class Connection(ErrorHandlerMixin):
 
         self._connect()
 
+        self._session_parameters = SessionParametersProxy(self.db_api, self.conn_handle)
+        self._connection_info = ConnectionInfoProxy(self.db_api, self.conn_handle)
+
         _sensitive_keys = {"password", "private_key", "passcode", "private_key_password", "private_key_file_pwd"}
         self.kwargs = {k: ("***" if k in _sensitive_keys else v) for k, v in kwargs.items()}
         self._close_lock = threading.Lock()
@@ -324,6 +326,9 @@ class Connection(ErrorHandlerMixin):
         # even while another thread's logout is still in-flight.
         if self.is_closed():
             return
+
+        self._session_parameters.freeze()
+        self._connection_info.freeze()
 
         # Lock guards ONLY the handle swap — prevents concurrent double-release.
         with self._close_lock:
@@ -578,9 +583,7 @@ class Connection(ErrorHandlerMixin):
         Returns:
             str | None: The parameter value, or None if not found
         """
-        request = ConnectionGetParameterRequest(conn_handle=self.conn_handle, key=name)
-        response = self.db_api.connection_get_parameter(request)
-        return response.value if response.value else None
+        return self._session_parameters[name]
 
     @property
     def paramstyle(self) -> ParamStyle:
@@ -656,7 +659,7 @@ class Connection(ErrorHandlerMixin):
 
     @internal_api
     def _get_connection_info(self, include_master_token: bool = False) -> ConnectionGetInfoResponse:
-        """Refresh connection details for connection"""
+        """Return connection details from Core."""
         return self.db_api.connection_get_info(
             ConnectionGetInfoRequest(
                 conn_handle=self.conn_handle,
@@ -704,50 +707,42 @@ class Connection(ErrorHandlerMixin):
     @property
     def role(self) -> str | None:
         """The current role in use for the session."""
-        info = self._get_connection_info()
-        return info.role if info.HasField("role") else None
+        return cast("str | None", self._connection_info["role"])
 
     @property
     def database(self) -> str | None:
         """The current database in use for the session."""
-        info = self._get_connection_info()
-        return info.database if info.HasField("database") else None
+        return cast("str | None", self._connection_info["database"])
 
     @property
     def schema(self) -> str | None:
         """The current schema in use for the session."""
-        info = self._get_connection_info()
-        return info.schema if info.HasField("schema") else None
+        return cast("str | None", self._connection_info["schema"])
 
     @property
     def account(self) -> str | None:
         """The Snowflake account name used by this connection."""
-        info = self._get_connection_info()
-        return info.account if info.HasField("account") else None
+        return cast("str | None", self._connection_info["account"])
 
     @property
     def warehouse(self) -> str | None:
         """The current warehouse in use for the session."""
-        info = self._get_connection_info()
-        return info.warehouse if info.HasField("warehouse") else None
+        return cast("str | None", self._connection_info["warehouse"])
 
     @property
     def user(self) -> str | None:
         """The user name used for authentication."""
-        info = self._get_connection_info()
-        return info.user if info.HasField("user") else None
+        return cast("str | None", self._connection_info["user"])
 
     @property
     def host(self) -> str | None:
         """The host name of the Snowflake instance."""
-        info = self._get_connection_info()
-        return info.host if info.HasField("host") else None
+        return cast("str | None", self._connection_info["host"])
 
     @property
     def port(self) -> int | None:
         """The port number of the Snowflake instance."""
-        info = self._get_connection_info()
-        return info.port if info.HasField("port") else None
+        return cast("int | None", self._connection_info["port"])
 
     @property
     def region(self) -> str | None:
@@ -757,10 +752,10 @@ class Connection(ErrorHandlerMixin):
     @property
     def session_id(self) -> int:
         """The Snowflake session ID for this connection."""
-        info = self._get_connection_info()
-        if not info.HasField("session_id"):
+        value = cast("int | None", self._connection_info["session_id"])
+        if value is None:
             raise InterfaceError(msg="Session ID is not available; connection may not be initialized")
-        return info.session_id
+        return value
 
     @property
     def login_timeout(self) -> int | None:

--- a/python/tests/e2e/types/test_timestamp_ltz.py
+++ b/python/tests/e2e/types/test_timestamp_ltz.py
@@ -2,10 +2,14 @@
 
 TIMESTAMP_LTZ (Local Time Zone) stores timestamp with local timezone.
 Values are stored in UTC and converted to the session timezone on retrieval.
-Python type: datetime with tzinfo set (not None).
+Python type: datetime with tzinfo set to the session timezone.
 
-All SQL string literals use explicit '+00:00' UTC offset so that expected
-values are deterministic regardless of the Snowflake session timezone.
+The session timezone is explicitly set to America/New_York (a non-UTC zone)
+so that tests verify the driver actually propagates the session timezone
+to the result rather than silently falling back to UTC.
+
+SQL string literals use explicit '+00:00' UTC offsets so input values are
+deterministic; expected values are expressed in America/New_York.
 """
 
 from __future__ import annotations
@@ -13,18 +17,14 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import pytz
 
 from ...conftest import with_paramstyle
-from .utils import assert_datetime_type, assert_sequential_values, batch_insert
+from .utils import assert_datetime_type, assert_sequential_values, assert_timezone, batch_insert
 
 
-# =============================================================================
-# EXPECTED DATETIME VALUES (UTC)
-# =============================================================================
-TS_2024_JAN = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
-TS_2024_JUN = datetime(2024, 6, 20, 14, 45, 30, tzinfo=timezone.utc)
-TS_EPOCH = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-TS_WITH_MICROSECONDS = datetime(2024, 1, 15, 10, 30, 0, 123456, tzinfo=timezone.utc)
+SESSION_TZ_NAME = "America/New_York"
+SESSION_TZ = pytz.timezone(SESSION_TZ_NAME)
 
 # =============================================================================
 # SQL STRING REPRESENTATIONS (with explicit UTC offset)
@@ -35,25 +35,35 @@ TS_EPOCH_STR = "1970-01-01 00:00:00 +00:00"
 TS_WITH_MICROSECONDS_STR = "2024-01-15 10:30:00.123456 +00:00"
 
 # =============================================================================
+# EXPECTED DATETIME VALUES in America/New_York
+# Constructed from the UTC instants then converted to the session timezone.
+# Jan 15 is EST (UTC-5): 10:30 UTC -> 05:30 EST
+# Jun 20 is EDT (UTC-4): 14:45:30 UTC -> 10:45:30 EDT
+# Epoch is EST (UTC-5): 00:00 UTC -> 1969-12-31 19:00 EST
+# =============================================================================
+TS_2024_JAN = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc).astimezone(SESSION_TZ)
+TS_2024_JUN = datetime(2024, 6, 20, 14, 45, 30, tzinfo=timezone.utc).astimezone(SESSION_TZ)
+TS_EPOCH = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc).astimezone(SESSION_TZ)
+TS_WITH_MICROSECONDS = datetime(2024, 1, 15, 10, 30, 0, 123456, tzinfo=timezone.utc).astimezone(SESSION_TZ)
+
+# =============================================================================
 # LARGE RESULT SET
 # =============================================================================
 LARGE_RESULT_SET_SIZE = 50_000
-SEQUENTIAL_BASE = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+SEQUENTIAL_BASE_UTC = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-
-def to_utc(values):
-    """Convert datetime values to UTC, preserving None."""
-    return [v.astimezone(timezone.utc) if v is not None else None for v in values]
+pytestmark = pytest.mark.skip_universal(reason="SNOW-3450792 - session timezone is not respected")
 
 
 def sequential_timestamp(i):
-    """Transform index to expected sequential UTC timestamp."""
-    return SEQUENTIAL_BASE + timedelta(seconds=i)
+    """Transform index to expected sequential timestamp in session timezone."""
+    return (SEQUENTIAL_BASE_UTC + timedelta(seconds=i)).astimezone(SESSION_TZ)
 
 
-def compare_ts_utc(actual, expected):
-    """Compare timestamps by converting actual to UTC."""
-    return actual.astimezone(timezone.utc) == expected
+@pytest.fixture(autouse=True)
+def _set_session_timezone(cursor):
+    """Set session timezone to a non-UTC zone for all tests in this module."""
+    cursor.execute(f"ALTER SESSION SET TIMEZONE = '{SESSION_TZ_NAME}'")
 
 
 class TestTimestampLtzTypeCasting:
@@ -70,7 +80,7 @@ class TestTimestampLtzTypeCasting:
         assert_datetime_type(result)
 
         # And Values should have timezone info
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_timezone(result, expected_tz=SESSION_TZ_NAME)
 
 
 class TestTimestampLtzLiteral:
@@ -101,8 +111,9 @@ class TestTimestampLtzLiteral:
         result = execute_query(f"SELECT {select_cols}", single_row=True)
 
         # Then Result should contain timestamps <expected_values>
-        assert_datetime_type(result, require_tzinfo=True)
-        assert tuple(to_utc(result)) == expected_values
+        assert_datetime_type(result)
+        assert_timezone(result, expected_tz=SESSION_TZ_NAME)
+        assert tuple(result) == expected_values
 
     def test_should_handle_null_values_for_timestamp_ltz(self, execute_query):
         # Given Snowflake client is logged in
@@ -115,8 +126,9 @@ class TestTimestampLtzLiteral:
         )
 
         # Then Result should contain [2024-01-15 10:30:00 UTC, NULL]
-        assert_datetime_type(result, can_be_none=True, require_tzinfo=True)
-        assert tuple(to_utc(result)) == (TS_2024_JAN, None)
+        assert_datetime_type(result, can_be_none=True)
+        assert_timezone(result, expected_tz=SESSION_TZ_NAME, can_be_none=True)
+        assert result == (TS_2024_JAN, None)
 
     def test_should_download_large_result_set_with_multiple_chunks_for_timestamp_ltz(self, execute_query):
         # Given Snowflake client is logged in
@@ -135,8 +147,9 @@ class TestTimestampLtzLiteral:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00 UTC
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=True)
-        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp, compare=compare_ts_utc)
+        assert_datetime_type(values)
+        assert_timezone(values, expected_tz=SESSION_TZ_NAME)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp)
 
 
 class TestTimestampLtzTable:
@@ -169,8 +182,9 @@ class TestTimestampLtzTable:
         result = [row[0] for row in rows]
 
         # Then Result should contain timestamps <expected_values>
-        assert_datetime_type(result, can_be_none=can_be_none, require_tzinfo=True)
-        assert to_utc(result) == expected_values
+        assert_datetime_type(result, can_be_none=can_be_none)
+        assert_timezone(result, expected_tz=SESSION_TZ_NAME, can_be_none=can_be_none)
+        assert result == expected_values
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table_for_timestamp_ltz(
         self, execute_query, tmp_schema
@@ -193,8 +207,9 @@ class TestTimestampLtzTable:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00 UTC
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=True)
-        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp, compare=compare_ts_utc)
+        assert_datetime_type(values)
+        assert_timezone(values, expected_tz=SESSION_TZ_NAME)
+        assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp)
 
 
 @with_paramstyle("qmark")
@@ -218,7 +233,8 @@ class TestTimestampLtzBinding:
         )
 
         # Then Result should contain the bound timestamps
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
+        assert_timezone(result, expected_tz=SESSION_TZ_NAME)
         assert len(result) == 2
 
     def test_should_select_null_timestamp_ltz_using_parameter_binding(self, execute_query):
@@ -256,4 +272,5 @@ class TestTimestampLtzBinding:
         null_results = [r for r in result if r is None]
         assert len(non_null_results) == 2
         assert len(null_results) == 1
-        assert_datetime_type(non_null_results, require_tzinfo=True)
+        assert_datetime_type(non_null_results)
+        assert_timezone(non_null_results, expected_tz=SESSION_TZ_NAME)

--- a/python/tests/e2e/types/test_timestamp_ntz.py
+++ b/python/tests/e2e/types/test_timestamp_ntz.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from ...conftest import with_paramstyle
-from .utils import assert_datetime_type, assert_sequential_values, batch_insert
+from .utils import assert_datetime_type, assert_sequential_values, assert_timezone, batch_insert
 
 
 # =============================================================================
@@ -58,9 +58,9 @@ class TestTimestampNtzTypeCasting:
         result = execute_query(f"SELECT '{TS_2024_JAN_STR}'::TIMESTAMP_NTZ", single_row=True)
 
         # Then All values should be returned as appropriate type
-        assert_datetime_type(result, require_tzinfo=False)
+        assert_datetime_type(result)
         # And Values should not have timezone info
-        assert result[0].tzinfo is None
+        assert_timezone(result, expected_tz=None)
 
 
 class TestTimestampNtzLiteral:
@@ -85,8 +85,8 @@ class TestTimestampNtzLiteral:
         # Then Result should contain timestamps <expected_values>
         assert tuple(result) == expected_values
         # And Values should not have timezone info
-        assert_datetime_type(result, require_tzinfo=False)
-        assert all(v.tzinfo is None for v in result)
+        assert_datetime_type(result)
+        assert_timezone(result, expected_tz=None)
 
     def test_should_handle_null_values_for_timestamp_ntz(self, execute_query):
         # Given Snowflake client is logged in
@@ -99,7 +99,8 @@ class TestTimestampNtzLiteral:
         )
 
         # Then Result should contain [2024-01-15 10:30:00, NULL]
-        assert_datetime_type(result, can_be_none=True, require_tzinfo=False)
+        assert_datetime_type(result, can_be_none=True)
+        assert_timezone(result, expected_tz=None, can_be_none=True)
         assert tuple(result) == (TS_2024_JAN, None)
 
     def test_should_download_large_result_set_with_multiple_chunks_for_timestamp_ntz(self, execute_query):
@@ -119,8 +120,8 @@ class TestTimestampNtzLiteral:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=False)
-        assert all(v.tzinfo is None for v in values)
+        assert_datetime_type(values)
+        assert_timezone(values, expected_tz=None)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp)
 
 
@@ -154,8 +155,8 @@ class TestTimestampNtzTable:
         # Then Result should contain timestamps <expected_values>
         assert result == expected_values
         # And Values should not have timezone info
-        assert_datetime_type(result, can_be_none=can_be_none, require_tzinfo=False)
-        assert all(v.tzinfo is None for v in result if v is not None)
+        assert_datetime_type(result, can_be_none=can_be_none)
+        assert_timezone(result, expected_tz=None, can_be_none=can_be_none)
 
     def test_should_download_large_result_set_with_multiple_chunks_from_table_for_timestamp_ntz(
         self, execute_query, tmp_schema
@@ -178,8 +179,8 @@ class TestTimestampNtzTable:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=False)
-        assert all(v.tzinfo is None for v in values)
+        assert_datetime_type(values)
+        assert_timezone(values, expected_tz=None)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp)
 
 
@@ -207,8 +208,8 @@ class TestTimestampNtzBinding:
         # Then Result should contain [2024-01-15 10:30:00, 2024-06-20 14:45:30]
         assert tuple(result) == (TS_2024_JAN, TS_2024_JUN)
         # And Values should not have timezone info
-        assert_datetime_type(result, require_tzinfo=False)
-        assert all(v.tzinfo is None for v in result)
+        assert_datetime_type(result)
+        assert_timezone(result, expected_tz=None)
 
     def test_should_return_null_when_selecting_timestamp_ntz_using_parameter_binding_with_null_value(
         self, execute_query
@@ -243,7 +244,7 @@ class TestTimestampNtzBinding:
         result = [row[0] for row in rows]
 
         # Then SELECT should return the inserted values in ascending order
-        assert_datetime_type([r for r in result if r is not None], require_tzinfo=False)
+        assert_datetime_type([r for r in result if r is not None])
         assert result == [TS_2024_JAN, TS_2024_JUN, None]
 
     @pytest.mark.parametrize(
@@ -293,9 +294,9 @@ class TestTimestampNtzAliases:
             result = execute_query(f"SELECT '{TS_2024_JAN_STR}'::{type_name}", single_row=True)
 
             # Then All values should be returned as appropriate type
-            assert_datetime_type(result, require_tzinfo=False)
+            assert_datetime_type(result)
             # And Values should not have timezone info
-            assert result[0].tzinfo is None
+            assert_timezone(result, expected_tz=None)
         finally:
             execute_query("ALTER SESSION UNSET TIMESTAMP_TYPE_MAPPING")
 
@@ -313,7 +314,7 @@ class TestTimestampNtzAliases:
             result = execute_query(f"SELECT '{TS_2024_JAN_STR}'::TIMESTAMP", single_row=True)
 
             # Then All values should be returned as appropriate type
-            assert_datetime_type(result, require_tzinfo=True)
+            assert_datetime_type(result)
             # And Values should have timezone info
             assert result[0].tzinfo is not None
         finally:
@@ -348,5 +349,5 @@ class TestTimestampNtzPrecision:
         # Then Result should contain [<expected>]
         assert result[0] == expected
         # And Values should not have timezone info
-        assert_datetime_type(result, require_tzinfo=False)
-        assert result[0].tzinfo is None
+        assert_datetime_type(result)
+        assert_timezone(result, expected_tz=None)

--- a/python/tests/e2e/types/test_timestamp_tz.py
+++ b/python/tests/e2e/types/test_timestamp_tz.py
@@ -5,6 +5,9 @@ Unlike TIMESTAMP_LTZ (which converts to session timezone on retrieval), TZ keeps
 exact offset that was stored. Unlike TIMESTAMP_NTZ, TZ always has tzinfo.
 Python type: datetime with pytz.FixedOffset tzinfo matching the stored offset.
 
+The session timezone is explicitly set to America/New_York (a non-UTC zone)
+so that tests prove offset preservation is independent of the session timezone.
+
 All SQL string literals include explicit timezone offsets to exercise offset preservation.
 """
 
@@ -17,6 +20,8 @@ import pytest
 from ...conftest import with_paramstyle
 from .utils import assert_datetime_type, assert_sequential_values, batch_insert
 
+
+SESSION_TZ_NAME = "America/New_York"
 
 # =============================================================================
 # EXPECTED DATETIME VALUES (with timezone offsets)
@@ -59,6 +64,17 @@ def compare_ts_utc(actual, expected):
     return actual.astimezone(timezone.utc) == expected
 
 
+@pytest.fixture(autouse=True)
+def _set_session_timezone(cursor):
+    """Set session timezone to a non-UTC zone for all tests in this module.
+
+    TIMESTAMP_TZ preserves the original per-row offset, so the session
+    timezone must NOT affect the returned offsets.  Using a non-UTC zone
+    proves that offset preservation is independent of the session timezone.
+    """
+    cursor.execute(f"ALTER SESSION SET TIMEZONE = '{SESSION_TZ_NAME}'")
+
+
 class TestTimestampTzTypeCasting:
     """Tests for TIMESTAMP_TZ type casting to appropriate type."""
 
@@ -73,7 +89,7 @@ class TestTimestampTzTypeCasting:
         assert_datetime_type(result)
 
         # And Values should have timezone info
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
 
 
 class TestTimestampTzLiteral:
@@ -99,7 +115,7 @@ class TestTimestampTzLiteral:
         result = execute_query(f"SELECT {select_cols}", single_row=True)
 
         # Then Result should contain timestamps <expected_values>
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
         assert tuple(to_utc(result)) == tuple(to_utc(expected_values))
 
         # And Values should have timezone info
@@ -157,7 +173,7 @@ class TestTimestampTzLiteral:
         result = execute_query(f"SELECT '{query_str}'::TIMESTAMP_TZ", single_row=True)
 
         # Then Result should contain timestamps <expected_values>
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
         assert result[0].astimezone(timezone.utc) == expected.astimezone(timezone.utc)
 
         # And Values should have timezone info
@@ -174,7 +190,7 @@ class TestTimestampTzLiteral:
         )
 
         # Then Result should contain [2024-01-15 10:30:00 +05:00, NULL]
-        assert_datetime_type(result, can_be_none=True, require_tzinfo=True)
+        assert_datetime_type(result, can_be_none=True)
         assert to_utc(result) == [TS_2024_JAN.astimezone(timezone.utc), None]
 
     def test_should_download_large_result_set_with_multiple_chunks_for_timestamp_tz(self, execute_query):
@@ -194,7 +210,7 @@ class TestTimestampTzLiteral:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00 +00:00
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=True)
+        assert_datetime_type(values)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp, compare=compare_ts_utc)
 
 
@@ -229,7 +245,7 @@ class TestTimestampTzTable:
         result = [row[0] for row in rows]
 
         # Then Result should contain timestamps <expected_values>
-        assert_datetime_type(result, can_be_none=can_be_none, require_tzinfo=True)
+        assert_datetime_type(result, can_be_none=can_be_none)
         assert to_utc(result) == to_utc(expected_values)
 
         # And Values should have timezone info
@@ -258,7 +274,7 @@ class TestTimestampTzTable:
 
         # Then Result should contain 50000 sequentially increasing timestamps from 2024-01-01 00:00:00 +00:00
         values = [row[0] for row in rows]
-        assert_datetime_type(values, require_tzinfo=True)
+        assert_datetime_type(values)
         assert_sequential_values(values, LARGE_RESULT_SET_SIZE, transform=sequential_timestamp, compare=compare_ts_utc)
 
 
@@ -285,7 +301,7 @@ class TestTimestampTzBinding:
         )
 
         # Then Result should contain the bound timestamps
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
         assert len(result) == 2
 
         # And Values should have timezone info
@@ -327,7 +343,7 @@ class TestTimestampTzBinding:
         null_results = [r for r in result if r is None]
         assert len(non_null_results) == 2
         assert len(null_results) == 1
-        assert_datetime_type(non_null_results, require_tzinfo=True)
+        assert_datetime_type(non_null_results)
 
 
 class TestTimestampTzPrecision:
@@ -360,5 +376,5 @@ class TestTimestampTzPrecision:
         assert result[0].microsecond == expected.microsecond
 
         # And Values should have timezone info
-        assert_datetime_type(result, require_tzinfo=True)
+        assert_datetime_type(result)
         assert result[0].tzinfo is not None

--- a/python/tests/e2e/types/utils.py
+++ b/python/tests/e2e/types/utils.py
@@ -42,20 +42,30 @@ def assert_type(values: Iterable, expected_type: type, can_be_none: bool = False
         )
 
 
-def assert_datetime_type(values: Iterable, can_be_none: bool = False, require_tzinfo: bool = False) -> None:
-    """Assert all values are datetime instances.
-
-    Args:
-        values: Iterable of values to check.
-        can_be_none: If True, None values are allowed.
-        require_tzinfo: If True, datetime values must have timezone info (tzinfo is not None).
-    """
+def assert_datetime_type(values: Iterable, can_be_none: bool = False) -> None:
+    """Assert all values are datetime instances."""
     for i, value in enumerate(values):
         if can_be_none and value is None:
             continue
         assert isinstance(value, datetime), f"Value at index {i} should be datetime, got {type(value).__name__}"
-        if require_tzinfo:
+
+
+def assert_timezone(values: Iterable, expected_tz: str | None, can_be_none: bool = False) -> None:
+    """Assert all values have the expected timezone.
+
+    When expected_tz is set, every value must carry matching tzinfo.
+    When expected_tz is None, every value must be naive (tzinfo is None).
+    """
+    for i, value in enumerate(values):
+        if can_be_none and value is None:
+            continue
+        if expected_tz:
             assert value.tzinfo is not None, f"Value at index {i} should have timezone info (tzinfo is None)"
+            assert value.tzinfo.zone == expected_tz, (
+                f"Value at index {i}: expected tz '{expected_tz}', got '{value.tzinfo.zone}'"
+            )
+        else:
+            assert value.tzinfo is None, f"Value at index {i} should not have timezone info, got {value.tzinfo}"
 
 
 def assert_float_equal(actual: float, expected: float | None, msg: str = "") -> None:

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -160,6 +160,35 @@ class TestClosedConnection:
         assert error.sfqid == sfqid
         assert error.errno == -1
 
+    def test_connection_info_properties_on_closed_connection(self, connection_factory):
+        conn = connection_factory()
+        role = conn.role
+        database = conn.database
+        schema = conn.schema
+        warehouse = conn.warehouse
+        user = conn.user
+        account = conn.account
+        host = conn.host
+        port = conn.port
+        session_id = conn.session_id
+
+        conn.close()
+
+        assert conn.role == role
+        assert conn.database == database
+        assert conn.schema == schema
+        assert conn.warehouse == warehouse
+        assert conn.user == user
+        assert conn.account == account
+        assert conn.host == host
+        assert conn.port == port
+        assert conn.session_id == session_id
+
+    def test_session_parameters_on_closed_connection(self, connection_factory):
+        conn = connection_factory(session_parameters={"TIMEZONE": "America/Los_Angeles"})
+        conn.close()
+        assert conn._session_parameters["TIMEZONE"] == "America/Los_Angeles"
+
 
 class TestConnectionMethods:
     """Test Connection object methods."""

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1327,6 +1327,49 @@ impl DatabaseDriverV1 {
         .await
     }
 
+    pub async fn connection_get_all_parameters(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<HashMap<String, String>, ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let conn = conn_ptr.lock().await;
+                let mut result = HashMap::new();
+
+                for (k, v) in conn.connection_seed.iter() {
+                    if let Some(s) = setting_as_display_string(v) {
+                        result.insert(k.to_uppercase(), s);
+                    }
+                }
+                if let Some(resolved) = &conn.resolved_connect {
+                    for (k, v) in resolved.iter() {
+                        if let Some(s) = setting_as_display_string(v) {
+                            result.insert(k.to_uppercase(), s);
+                        }
+                    }
+                }
+                for (k, v) in conn.session_overrides.iter() {
+                    if let Some(s) = setting_as_display_string(v) {
+                        result.insert(k.to_uppercase(), s);
+                    }
+                }
+
+                let cache = conn.session_parameters.read().await;
+                for (k, v) in cache.iter() {
+                    if !v.is_empty() {
+                        result.insert(k.clone(), v.clone());
+                    }
+                }
+
+                Ok(result)
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .fail(),
+        }
+    }
+
     pub async fn connection_get_parameter(
         &self,
         conn_handle: Handle,
@@ -2385,6 +2428,37 @@ mod tests {
             !valid,
             "heartbeat should return false on uninitialized connection"
         );
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_get_all_parameters_returns_empty_by_default() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+
+        let params = ds.connection_get_all_parameters(handle).await.unwrap();
+        assert!(params.is_empty());
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_get_all_parameters_returns_cached_values() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+
+        if let Some(c) = ds.connections.get_obj(handle) {
+            let conn = c.lock().await;
+            let mut cache = conn.session_parameters.write().await;
+            cache.insert("TIMEZONE".into(), "America/Los_Angeles".into());
+            cache.insert("QUERY_TAG".into(), "test_tag".into());
+        }
+
+        let params = ds.connection_get_all_parameters(handle).await.unwrap();
+        assert_eq!(params.get("TIMEZONE").unwrap(), "America/Los_Angeles");
+        assert_eq!(params.get("QUERY_TAG").unwrap(), "test_tag");
+        assert_eq!(params.len(), 2);
 
         ds.connection_release(handle).unwrap();
     }

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -483,6 +483,25 @@ impl DatabaseDriver for DatabaseDriverImpl {
     }
 
     #[instrument(
+        name = "DatabaseDriverV1::connection_get_all_parameters",
+        skip(self, input)
+    )]
+    async fn connection_get_all_parameters(
+        &self,
+        input: ConnectionGetAllParametersRequest,
+    ) -> Result<ConnectionGetAllParametersResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        let parameters = self
+            .driver
+            .connection_get_all_parameters(conn_handle.into())
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionGetAllParametersResponse { parameters })
+    }
+
+    #[instrument(
         name = "DatabaseDriverV1::connection_validate_options",
         skip(self, input)
     )]


### PR DESCRIPTION
Introduce FreezableProxy pattern that snapshots session parameters and
connection info at close() time so properties (role, database, schema,
session_parameters, etc.) remain accessible after the connection is
released. Adds ConnectionGetAllParameters RPC to bulk-fetch all resolved
session parameters across the full fallback chain (cache, session
overrides, resolved config, connection seed).