### PR TITLE
Fix intermittent "worker crashed" failures in Python test CI

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -131,7 +131,8 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "-vv",
-    "-n auto",  # minimum 8 workers configured via pytest_xdist_auto_num_workers in conftest.py
+    # minimum 8 workers configured via pytest_xdist_auto_num_workers in conftest.py
+    "-n", "auto",
     "--max-worker-restart=4",
     "--durations=0",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -132,6 +132,7 @@ addopts = [
     "--strict-config",
     "-vv",
     "-n 16",
+    "--max-worker-restart=4",
     "--durations=0",
 ]
 # Default timeout for tests (2 minutes) - prevents hanging tests on CI

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -131,7 +131,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "-vv",
-    "-n 16",
+    "-n auto",  # minimum 8 workers configured via pytest_xdist_auto_num_workers in conftest.py
     "--max-worker-restart=4",
     "--durations=0",
 ]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -22,6 +22,14 @@ from .private_key_helper import get_test_private_key_path
 Row = tuple[Any, ...]
 
 
+_MIN_XDIST_WORKERS = 8
+
+
+def pytest_xdist_auto_num_workers(config):
+    num_cpus = os.cpu_count() or _MIN_XDIST_WORKERS
+    return max(num_cpus, _MIN_XDIST_WORKERS)
+
+
 @pytest.mark.optionalhook
 def pytest_metadata(metadata):
     metadata["Version of snowflake.connector"] = "Universal" if IS_UNIVERSAL_DRIVER else "Old"


### PR DESCRIPTION
## Summary
* Add --max-worker-restart=4 to pytest-xdist config to automatically restart crashed workers and re-queue their tests
* Addresses random/non-deterministic "worker gwN crashed" failures in CI that cause entire test runs to fail
* Lower number of concurrent workers to 8, unless host allows more ("-n auto" + config in conftest)
## Context
With -n 16 parallel workers, occasional worker crashes (due to resource pressure, native code interactions, etc.) would fail the entire test suite. pytest-xdist supports restarting crashed workers transparently — this enables that behavior with a cap of 4 restarts per session to still catch systemic issues.