### PR TITLE
SNOW-2872430: Add configurable prefetch threads via CLIENT_PREFETCH_THREADS

### DIFF
--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -2,8 +2,8 @@ use super::ColumnMetadata;
 use crate::arrow_utils::ArrowUtilsError;
 use crate::arrow_utils::{boxed_arrow_reader, create_schema};
 use crate::chunks::{
-    ChunkError, DEFAULT_PREFETCH_THREADS, arrow_prefetch_reader, empty_reader,
-    json_prefetch_reader, schema_only_reader, single_chunk_reader,
+    ChunkError, PrefetchConfig, arrow_prefetch_reader, empty_reader, json_prefetch_reader,
+    schema_only_reader, single_chunk_reader,
 };
 use crate::file_manager;
 use crate::file_manager::{DownloadResult, UploadResult, download_files, upload_files};
@@ -28,11 +28,12 @@ pub struct QueryResult {
 pub async fn process_query_response(
     data: &query_response::Data,
     http_client: &Client,
+    prefetch_config: &PrefetchConfig,
 ) -> Result<QueryResult, QueryResponseProcessingError> {
     match data.command {
         Some(ref command) => perform_put_get(command.clone(), data).await,
         None => {
-            let reader = read_batches(data.to_rowset_data(), http_client.clone())
+            let reader = read_batches(data.to_rowset_data(), http_client.clone(), prefetch_config)
                 .await
                 .context(BatchReadingSnafu)?;
             Ok(QueryResult { reader })
@@ -81,6 +82,7 @@ async fn perform_put_get(
 async fn read_batches<'a>(
     data: query_response::RowsetData<'a>,
     http_client: Client,
+    prefetch_config: &PrefetchConfig,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ReadBatchesError> {
     tracing::debug!("read_batches called {:?}", data);
     match data {
@@ -91,12 +93,11 @@ async fn read_batches<'a>(
             initial_base64_opt,
             chunk_download_data,
         } => {
-            // Handle chunk download case without base64 data
             arrow_prefetch_reader(
                 initial_base64_opt,
                 chunk_download_data.into(),
                 http_client.clone(),
-                DEFAULT_PREFETCH_THREADS,
+                prefetch_config,
             )
             .await
             .context(ChunkReadingSnafu)
@@ -113,7 +114,7 @@ async fn read_batches<'a>(
                 row_types,
                 Vec::new(),
                 http_client.clone(),
-                DEFAULT_PREFETCH_THREADS,
+                prefetch_config,
             )
             .await
             .context(ChunkReadingSnafu)
@@ -131,7 +132,7 @@ async fn read_batches<'a>(
                 row_types,
                 chunk_download_data,
                 http_client.clone(),
-                DEFAULT_PREFETCH_THREADS,
+                prefetch_config,
             )
             .await
             .context(ChunkReadingSnafu)

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -92,16 +92,14 @@ async fn read_batches<'a>(
         query_response::RowsetData::ArrowMultiChunk {
             initial_base64_opt,
             chunk_download_data,
-        } => {
-            arrow_prefetch_reader(
-                initial_base64_opt,
-                chunk_download_data.into(),
-                http_client.clone(),
-                prefetch_config,
-            )
-            .await
-            .context(ChunkReadingSnafu)
-        }
+        } => arrow_prefetch_reader(
+            initial_base64_opt,
+            chunk_download_data.into(),
+            http_client.clone(),
+            prefetch_config,
+        )
+        .await
+        .context(ChunkReadingSnafu),
         query_response::RowsetData::SchemaOnly { rowtype } => {
             let row_types = parse_row_types(rowtype)?;
             schema_only_reader(&row_types).context(ChunkReadingSnafu)

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -9,7 +9,7 @@ use super::validation::{
     ValidationIssue, ValidationSeverity, canonicalize_setting_key, resolve_options,
     validate_statement_option_write,
 };
-use crate::chunks::{ChunkDownloadData, ChunkFormatKind};
+use crate::chunks::{ChunkDownloadData, ChunkFormatKind, PrefetchConfig};
 use crate::config::ParamStore;
 use crate::config::param_registry::ParamKey;
 use crate::config::param_registry::param_names;
@@ -452,15 +452,18 @@ impl DatabaseDriverV1 {
 
         let descriptor = response_to_descriptor(&response.data);
 
+        let prefetch_config = resolve_prefetch_config(&conn_arc).await;
+
         // Build the Arrow stream eagerly — this handles all result formats
         // (Arrow, JSON, PUT/GET file transfers) via process_query_response.
         // Skip for multi-statement parents (they only contain metadata).
         let prebuilt_stream = if super::multistatement::is_multistatement(&response.data) {
             None
         } else {
-            let query_result = process_query_response(&response.data, &http_client)
-                .await
-                .context(QueryResponseProcessingSnafu)?;
+            let query_result =
+                process_query_response(&response.data, &http_client, &prefetch_config)
+                    .await
+                    .context(QueryResponseProcessingSnafu)?;
             Some(Box::new(FFI_ArrowArrayStream::new(query_result.reader)))
         };
 
@@ -805,6 +808,22 @@ fn put_get_columns(command: Option<&str>) -> Vec<ColumnMetadata> {
     }
 }
 
+/// Read the `CLIENT_PREFETCH_THREADS` session parameter from the connection
+/// and build a [`PrefetchConfig`].
+async fn resolve_prefetch_config(conn: &Arc<Mutex<Connection>>) -> PrefetchConfig {
+    let conn_guard = conn.lock().await;
+    let threads = conn_guard
+        .session_parameters
+        .read()
+        .await
+        .get(param_names::CLIENT_PREFETCH_THREADS.as_str())
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(crate::chunks::DEFAULT_PREFETCH_THREADS);
+    PrefetchConfig {
+        prefetch_threads: threads,
+    }
+}
+
 /// Fetch a query result from Snowflake by query_id via the connection,
 /// returning the raw response `Data` for further processing.
 async fn fetch_query_response_data(
@@ -866,9 +885,10 @@ async fn fetch_and_resolve_result_set(
     query_id: &str,
 ) -> Result<ResolvedResultSet, ApiError> {
     let (data, http_client) = fetch_query_response_data(conn_ptr, query_id).await?;
+    let prefetch_config = resolve_prefetch_config(conn_ptr).await;
 
     let descriptor = response_to_descriptor(&data);
-    let query_result = process_query_response(&data, &http_client)
+    let query_result = process_query_response(&data, &http_client, &prefetch_config)
         .await
         .context(QueryResponseProcessingSnafu)?;
     let stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));

--- a/sf_core/src/chunks/mod.rs
+++ b/sf_core/src/chunks/mod.rs
@@ -25,14 +25,29 @@ use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use snafu::{OptionExt, ResultExt};
 
-pub const DEFAULT_PREFETCH_THREADS: usize = 8;
+pub const DEFAULT_PREFETCH_THREADS: usize = 4;
+
+/// Configuration for the chunk prefetch pipeline.
+#[derive(Debug, Clone)]
+pub struct PrefetchConfig {
+    /// Number of concurrent chunk download+parse tasks.
+    pub prefetch_threads: usize,
+}
+
+impl Default for PrefetchConfig {
+    fn default() -> Self {
+        Self {
+            prefetch_threads: DEFAULT_PREFETCH_THREADS,
+        }
+    }
+}
 
 pub async fn json_prefetch_reader(
     initial_rowset: &[Vec<Option<String>>],
     row_types: Vec<RowType>,
     chunk_download_data: Vec<ChunkDownloadData>,
     client: Client,
-    prefetch_concurrency: usize,
+    config: &PrefetchConfig,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let initial_reader = convert_string_rowset_to_arrow_reader(initial_rowset, &row_types)?;
     let downloader = HttpChunkDownloader { client };
@@ -44,7 +59,7 @@ pub async fn json_prefetch_reader(
         chunk_download_data.into(),
         downloader,
         parser,
-        prefetch_concurrency,
+        config.prefetch_threads,
     )
     .await
 }
@@ -53,7 +68,7 @@ pub async fn arrow_prefetch_reader(
     initial_base64_opt: Option<&str>,
     mut chunk_download_data: VecDeque<ChunkDownloadData>,
     client: Client,
-    prefetch_concurrency: usize,
+    config: &PrefetchConfig,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let initial_reader = if let Some(initial_base64) = initial_base64_opt {
         let bytes = BASE64.decode(initial_base64).context(Base64DecodingSnafu)?;
@@ -74,7 +89,7 @@ pub async fn arrow_prefetch_reader(
         chunk_download_data,
         downloader,
         parser,
-        prefetch_concurrency,
+        config.prefetch_threads,
     )
     .await
 }

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -96,6 +96,8 @@ pub mod param_names {
     pub const LOGOUT_REQUEST_TIMEOUT_SECONDS: ParamKey = ParamKey("logout_request_timeout_seconds");
     // Application identity
     pub const CLIENT_APP_ID: ParamKey = ParamKey("client_app_id");
+    // Prefetch configuration
+    pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
 }
 
 /// Which API layer owns writes for a parameter.
@@ -807,6 +809,21 @@ static PARAM_DEFS: &[ParamDef] = &[
         description: "Exact number of statements in a multi-statement query",
         deprecated_by: None,
         scope: ParamScope::Statement,
+        used_at_connect: false,
+        mutable_after_connect: true,
+    },
+    // ── Prefetch ───────────────────────────────────────────────────────
+    ParamDef {
+        canonical_name: param_names::CLIENT_PREFETCH_THREADS.as_str(),
+        aliases: &["CLIENT_PREFETCH_THREADS"],
+        value_type: ValueType::Int,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Int(4)),
+        sensitive: false,
+        description: "Number of concurrent chunk prefetch threads for result set downloading",
+        deprecated_by: None,
+        scope: ParamScope::Session,
         used_at_connect: false,
         mutable_after_connect: true,
     },


### PR DESCRIPTION
## Summary

- Introduces `PrefetchConfig` struct in `sf_core::chunks` replacing hardcoded concurrency constant
- Adds `CLIENT_PREFETCH_THREADS` session parameter to param registry (default 4, mutable after connect)
- Reads the parameter from connection session params at query execution time via `resolve_prefetch_config()`
- Threads config through `process_query_response` → `read_batches` → arrow/json prefetch readers

## Test plan

- [ ] Verify default behavior unchanged (4 threads, was previously 8 — intentional reduction)
- [ ] Test setting `CLIENT_PREFETCH_THREADS` via session parameter and confirming it affects prefetch concurrency
- [ ] Run existing distributed fetch / chunk prefetch tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)