### PR TITLE
NO-SNOW: SQLCancel with active_cancel pattern

### DIFF
--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -22,7 +22,7 @@ parking_lot = { version = "0.12.5", features = ["arc_lock"] }
 
 proto_utils = { path = "../proto_utils" }
 error_trace = { path = "../error_trace" }
-tokio = { version = "1.50.0", features = ["rt"] }
+tokio = { version = "1.50.0", features = ["rt", "macros"] }
 tokio-util = "0.7"
 rust-ini = "0.21.3"
 

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -1256,6 +1256,11 @@ pub fn cancel(statement_handle: sql::Handle) -> OdbcResult<()> {
     // TODO(SNOW-3258918): Cancel async execution.
     // Blocked by: SQLSetStmtAttr does not support SQL_ATTR_ASYNC_ENABLE.
 
+    // TODO(SNOW-3258922): Cancel execution on another thread.
+    // Blocked by: no server-side cancel RPC. When implemented,
+    // cancelling the token resolves the cancelled() future observed
+    // by the executing thread's tokio::select!, aborting the in-flight RPC.
+
     let guard = stmt_from_handle(statement_handle)?;
 
     // Path 1: cancel in-flight RPC without touching inner.

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -4,8 +4,8 @@ use crate::api::error::{
     ArrowArrayStreamReaderCreationSnafu, CursorAlreadyOpenSnafu, DaeRequiredSnafu,
     DisconnectedSnafu, InvalidBufferLengthSnafu, InvalidCursorStateSnafu, InvalidDuringDaeSnafu,
     InvalidHandleSnafu, InvalidParameterNumberSnafu, InvalidPrecisionOrScaleSnafu,
-    JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcRuntimeSnafu, ReadOnlyAttributeSnafu,
-    Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
+    JsonBindingSnafu, NoMoreDataSnafu, NullPointerSnafu, OdbcRuntimeSnafu, OperationCanceledSnafu,
+    ReadOnlyAttributeSnafu, Required, StatementNotExecutedSnafu, UnsupportedAttributeSnafu,
 };
 use crate::api::query_type::{QueryType, ResultKind};
 use crate::api::runtime::global;
@@ -110,21 +110,30 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     let (bindings, _json_owner) = apply_parameter_bindings(&inner.apd, &inner.ipd, false, None)?;
     let stmt_handle = guard.stmt_handle;
 
-    inner.cancel_token = CancellationToken::new();
-    let _cancel_token = inner.cancel_token.clone();
-    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            query: statement_text.to_string(),
-        })
-        .await?;
+    let token = CancellationToken::new();
+    *guard.active_cancel.lock() = Some(token.clone());
 
-        c.statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            bindings,
-        })
-        .await
+    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+            result = async {
+                c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: statement_text.to_string(),
+                })
+                .await?;
+
+                c.statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    bindings,
+                })
+                .await
+            } => result.map_err(Into::into),
+        }
     });
+
+    *guard.active_cancel.lock() = None;
 
     tracing::info!("exec_direct: response={:?}", response);
     let response = response?;
@@ -234,23 +243,31 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
     tracing::debug!("prepare: query = {query}");
 
     let stmt_handle = guard.stmt_handle;
-    inner.cancel_token = CancellationToken::new();
-    let _cancel_token = inner.cancel_token.clone();
-    // TODO(SNOW-3258922): Wire _cancel_token into tokio::select!
-    // alongside the RPC future to support cancellation.
+
+    let token = CancellationToken::new();
+    *guard.active_cancel.lock() = Some(token.clone());
+
     let prepare_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            query: query.to_string(),
-        })
-        .await?;
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+            result = async {
+                c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    query: query.to_string(),
+                })
+                .await?;
 
-        c.statement_prepare(StatementPrepareRequest {
-            stmt_handle: Some(stmt_handle),
-        })
-        .await
-    })?;
+                c.statement_prepare(StatementPrepareRequest {
+                    stmt_handle: Some(stmt_handle),
+                })
+                .await
+            } => result.map_err(Into::into),
+        }
+    });
 
+    *guard.active_cancel.lock() = None;
+    let prepare_result = prepare_result?;
     let result = prepare_result.result.required("Result is required")?;
     let stream_ptr = result.stream.required("Stream is required")?;
     let reader = reader_from_protobuf_stream(stream_ptr)?;
@@ -359,15 +376,26 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     )?;
 
     let stmt_handle = guard.stmt_handle;
-    inner.cancel_token = CancellationToken::new();
-    let _cancel_token = inner.cancel_token.clone();
+
+    let token = CancellationToken::new();
+    *guard.active_cancel.lock() = Some(token.clone());
+
     let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            bindings,
-        })
-        .await
-    })?;
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+            result = async {
+                c.statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    bindings,
+                })
+                .await
+            } => result.map_err(Into::into),
+        }
+    });
+
+    *guard.active_cancel.lock() = None;
+    let response = response?;
 
     tracing::info!("execute: Successfully executed statement");
     let mut settings = dbc.connection.lock().numeric_settings;
@@ -1213,27 +1241,34 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
 
 /// Cancel processing on a statement (SQLCancel).
 ///
-/// Cancels the `CancellationToken` stored in `StatementInner`.
-/// Called from `SQLCancel` in `c_api.rs`, which may be invoked from a
-/// different thread. Per ODBC 3.5 spec, cross-thread `SQLCancel` does
-/// not clear or post diagnostic records.
+/// Two-path design for safe cross-thread cancellation:
+/// - Path 1: If an RPC is in flight (`active_cancel` is `Some`), cancel the
+///   token. The executing thread observes this via `tokio::select!`. Never
+///   touches the inner Mutex.
+/// - Path 2: If no RPC is in flight (`active_cancel` is `None`), check for
+///   NeedData state and restore it. This is a single-threaded scenario.
 ///
-/// With the HandleManager, cross-thread `SQLCancel` now acquires the
-/// inner Mutex instead of aliasing raw pointers — no more UB.
+/// Per ODBC 3.5 spec, cross-thread `SQLCancel` does not clear or post
+/// diagnostic records.
 pub fn cancel(statement_handle: sql::Handle) -> OdbcResult<()> {
     tracing::debug!("cancel: statement_handle={:?}", statement_handle);
 
     // TODO(SNOW-3258918): Cancel async execution.
     // Blocked by: SQLSetStmtAttr does not support SQL_ATTR_ASYNC_ENABLE.
 
-    // TODO(SNOW-3258922): Cancel execution on another thread.
-    // Blocked by: no server-side cancel RPC. When implemented,
-    // cancelling the token resolves the cancelled() future observed
-    // by the executing thread's tokio::select!, aborting the in-flight RPC.
-
     let guard = stmt_from_handle(statement_handle)?;
-    let mut inner = guard.inner.lock();
 
+    // Path 1: cancel in-flight RPC without touching inner.
+    {
+        let active = guard.active_cancel.lock();
+        if let Some(token) = active.as_ref() {
+            token.cancel();
+            return Ok(());
+        }
+    }
+
+    // Path 2: no RPC in flight — check NeedData state (single-threaded).
+    let mut inner = guard.inner.lock();
     match inner.state.as_ref() {
         StatementState::AwaitingParamData { origin, .. }
         | StatementState::AwaitingPutData { origin, .. }
@@ -1241,12 +1276,10 @@ pub fn cancel(statement_handle: sql::Handle) -> OdbcResult<()> {
             // TODO(SNOW-3258919): Full cancel testing during NeedData.
             let restored = origin.restore_state();
             inner.state.set(restored);
-            return Ok(());
         }
         _ => {}
     }
 
-    inner.cancel_token.cancel();
     Ok(())
 }
 

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1227,9 +1227,11 @@ impl GetDataState {
     }
 }
 
-/// Outer Statement handle — immutable fields only.
+/// Outer Statement handle.
 ///
-/// All mutable state lives inside `inner: Mutex<StatementInner>`.
+/// Most mutable state lives inside `inner: Mutex<StatementInner>`.
+/// `active_cancel` is also mutable (interior mutability via its own Mutex)
+/// to allow zero-contention cross-thread cancellation without locking `inner`.
 /// The `HandleManager` stores `Statement` inside `Arc<RwLock<Option<Statement>>>`,
 /// so the outer fields are accessible through `HandleGuard::deref()` without
 /// any additional locking.

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1238,6 +1238,10 @@ pub struct Statement {
     pub conn_id: HandleId,
     pub stmt_handle: StatementHandle,
     pub inner: parking_lot::Mutex<StatementInner>,
+    /// Cancellation token for the currently in-flight RPC, if any.
+    /// `Some(token)` while a cancellable operation is running; `None` otherwise.
+    /// SQLCancel checks this without locking `inner` — zero-contention cross-thread cancel.
+    pub active_cancel: parking_lot::Mutex<Option<CancellationToken>>,
 }
 
 /// All mutable statement state, protected by `Statement::inner`.
@@ -1273,11 +1277,6 @@ pub struct StatementInner {
     pub multi_query_ids: Vec<String>,
     /// Index of the next child result to fetch in `multi_query_ids`.
     pub multi_current_idx: usize,
-    /// Cancelled by `SQLCancel` (possibly from another thread) and observed
-    /// by execution functions via `tokio::select!` when cross-thread cancel
-    /// is wired up. Replaced with a fresh token at the start of each
-    /// execution/prepare call so that stale cancels do not affect new ops.
-    pub cancel_token: CancellationToken,
 }
 
 // Safety: StatementInner contains raw pointers (descriptor fields like bind_offset_ptr,
@@ -1309,8 +1308,8 @@ impl Statement {
                 last_query_id: None,
                 multi_query_ids: Vec::new(),
                 multi_current_idx: 0,
-                cancel_token: CancellationToken::new(),
             }),
+            active_cancel: parking_lot::Mutex::new(None),
         }
     }
 

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -113,8 +113,12 @@ pub unsafe extern "system" fn SQLCloseCursor(statement_handle: sql::Handle) -> s
 /// This function is called by the ODBC driver manager.
 ///
 /// ODBC allows SQLCancel to be called from a different thread.
-/// `cancel()` accesses the `Statement` via `stmt_from_handle()` and
-/// acquires the inner Mutex for safe cross-thread access.
+/// Uses a two-path design via `Statement::active_cancel`:
+/// - Path 1 (RPC in flight): cancels the token without touching the inner
+///   Mutex. The executing thread observes cancellation via `tokio::select!`
+///   and returns HY008.
+/// - Path 2 (no RPC): locks the inner Mutex to check/restore NeedData state.
+///   This path only runs in single-threaded DAE scenarios.
 ///
 /// This function does not modify statement diagnostics. Any diagnostic
 /// information related to cancellation must be produced by the executing
@@ -133,11 +137,6 @@ pub unsafe extern "system" fn SQLCloseCursor(statement_handle: sql::Handle) -> s
 /// This means `SQLGetDiagRec` may return records from a previous call
 /// after a successful `SQLCancel`. We accept this because we currently
 /// cannot distinguish same-thread vs cross-thread callers.
-///
-/// TODO(SNOW-3258918, SNOW-3258919): When async or DAE cancel is
-/// implemented, add thread-ID tracking to distinguish same-thread vs
-/// cross-thread. Same-thread cancel must clear_diag_info and post its own
-/// diagnostic records per spec. Only cross-thread cancel skips diagnostics.
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCode {
     if statement_handle.is_null() {

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -137,6 +137,11 @@ pub unsafe extern "system" fn SQLCloseCursor(statement_handle: sql::Handle) -> s
 /// This means `SQLGetDiagRec` may return records from a previous call
 /// after a successful `SQLCancel`. We accept this because we currently
 /// cannot distinguish same-thread vs cross-thread callers.
+///
+/// TODO(SNOW-3258918, SNOW-3258919): When async or DAE cancel is
+/// implemented, add thread-ID tracking to distinguish same-thread vs
+/// cross-thread. Same-thread cancel must clear_diag_info and post its own
+/// diagnostic records per spec. Only cross-thread cancel skips diagnostics.
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn SQLCancel(statement_handle: sql::Handle) -> sql::RetCode {
     if statement_handle.is_null() {


### PR DESCRIPTION
## Summary

- Move `cancel_token` out of `StatementInner` into a separate `Mutex<Option<CancellationToken>>` (`active_cancel`) on the outer `Statement` struct
- SQLCancel checks `active_cancel` first — if an RPC is in flight, cancels the token without touching the inner Mutex (zero contention with the executing thread)
- Falls through to inner Mutex only for NeedData/DAE state restoration (single-threaded, no RPC running)
- Wire `tokio::select!` into `exec_direct_impl`, `prepare_impl`, and `execute` so cross-thread SQLCancel actually cancels in-flight RPCs (returns HY008)

### Design

Two mutually exclusive cancel paths:
1. **RPC in flight** → `active_cancel` holds `Some(token)` → SQLCancel locks `active_cancel`, calls `token.cancel()`, returns. Never touches inner Mutex.
2. **NeedData state** (no RPC) → `active_cancel` is `None` → SQLCancel falls through, acquires inner Mutex, restores state machine.

### Files changed

| File | Change |
|---|---|
| `odbc/Cargo.toml` | Add `macros` feature to tokio (for `tokio::select!`) |
| `odbc/src/api/types/odbc_types.rs` | Add `active_cancel` to `Statement`, remove `cancel_token` from `StatementInner` |
| `odbc/src/api/statement.rs` | Rewrite `cancel()` with two-path approach, wire `tokio::select!` into 3 RPC functions |
| `odbc/src/c_api.rs` | Update SQLCancel documentation |

Follows #1020 (PR 2: statement migration to HandleManager)

## Test plan

- [x] All 1067+ odbc unit tests pass
- [x] Clean build with no warnings
- [x] `cargo clippy --package odbc` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)