### PR TITLE
NO-SNOW: Account for cross thread cancel diagnostic ambiguity

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -505,6 +505,8 @@ behavior_differences:
     reviewed: false
     old_driver_behavior: |
       When SQLCancel or SQLCancelHandle is called from a different thread to cancel an in-progress SQLExecDirect, the cancel function intermittently returns SQL_ERROR with SQLSTATE HY008 (NativeError 604, "SQL execution canceled") instead of SQL_SUCCESS. This happens because the driver's internal CancelExecute() calls Statement::cancel() without a try-catch. When the server's abort-request endpoint responds with a non-success status (e.g. the query was already canceled before the REST abort completed), cancel() throws and the exception propagates to the caller.
+
+      The diagnostic record posted alongside that SQL_ERROR is also unreliable. The exception path may unwind without populating the diag list, and the in-flight SQLExecDirect on the executor thread concurrently clears the per-statement diag list at entry and posts its own HY008 at exit. A snapshot of the diag list taken on the canceling thread immediately after the cancel returns may therefore be empty, contain a single HY008 from the executor's completed SQLExecDirect, or contain a single HY008 posted by the cancel itself, depending on thread scheduling.
     new_driver_behavior: |
       Cross-thread SQLCancel and SQLCancelHandle always return SQL_SUCCESS per the ODBC specification. The cancel function posts no diagnostics of its own; only the canceled function (SQLExecDirect) returns SQL_ERROR with HY008.
     impact: |

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_handle_tests.cpp
@@ -749,8 +749,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancelHandle: Cross-thread cancel in
 
   OLD_DRIVER_ONLY("BD#47") {
     REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
-    if (ctx.cancel_result == SQL_ERROR) {
-      REQUIRE(!ctx.cancel_diag_records.empty());
+    if (ctx.cancel_result == SQL_ERROR && !ctx.cancel_diag_records.empty()) {
       REQUIRE(ctx.cancel_diag_records[0].sqlState == "HY008");
     }
   }

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
@@ -751,8 +751,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Cross-thread cancel interrup
 
   OLD_DRIVER_ONLY("BD#47") {
     REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
-    if (ctx.cancel_result == SQL_ERROR) {
-      REQUIRE(!ctx.cancel_diag_records.empty());
+    if (ctx.cancel_result == SQL_ERROR && !ctx.cancel_diag_records.empty()) {
       REQUIRE(ctx.cancel_diag_records[0].sqlState == "HY008");
     }
   }


### PR DESCRIPTION
### TL;DR

Relaxes old-driver test assertions for cross-thread cancel diagnostic records to account for race conditions where the diag list may be empty.

### What changed?

The old-driver behavior description for BD#47 was expanded to document that the diagnostic record posted alongside a SQL_ERROR return from `SQLCancel`/`SQLCancelHandle` is unreliable due to thread scheduling. Depending on timing, the diag list on the canceling thread may be empty, contain an HY008 from the executor's completed `SQLExecDirect`, or contain an HY008 posted by the cancel itself.

The corresponding test assertions in both `cancel_tests.cpp` and `cancel_handle_tests.cpp` were updated to reflect this. The previously unconditional `REQUIRE(!ctx.cancel_diag_records.empty())` check was removed, and the HY008 SQLSTATE assertion is now only evaluated when diagnostic records are actually present.

### How to test?

Run the existing cross-thread cancel test cases:
- `SQLCancel: Cross-thread cancel interrupts SQLExecDirect`
- `SQLCancelHandle: Cross-thread cancel interrupts SQLExecDirect`

These tests should now pass consistently under the old driver without intermittently failing due to an empty diag list.

### Why make this change?

The old driver's cancel path has a race condition where the diag list may not be populated when `SQLCancel`/`SQLCancelHandle` returns SQL_ERROR. The previous test assertions assumed the diag list would always be non-empty on an SQL_ERROR result, which caused flaky test failures. The assertions are now aligned with the documented unreliable behavior of the old driver.