### PR TITLE
ci(coverage): unblock Python and Rust Core stages

### DIFF
--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -46,12 +46,15 @@ def installSystemDeps() {
     // install resilient to mirror rotation. Long-term fix: bake `unzip` into
     // the Docker image so no runtime install is needed.
     sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
-    // perl-* modules are required by the `openssl-src` crate when the
+    // perl-Time-Piece is required by the `openssl-src` crate when the
     // `vendored-openssl` feature is active (Rust Core stage runs tarpaulin
-    // with `--all-features`, which enables it). Without them the build
-    // fails with "Can't locate Time/Piece.pm in @INC" at openssl-3.x
-    // Configure time. Long-term fix: bake these into the Docker image.
-    sh label: 'Install system dependencies', script: 'yum install -y unzip perl-Time-Piece perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy perl-Pod-Html'
+    // with `--all-features`, which enables it). Without it the build fails
+    // with "Can't locate Time/Piece.pm in @INC" at openssl-3.x Configure
+    // time. Other perl modules openssl-src may use (FindBin, File::Compare,
+    // File::Copy, IPC::Cmd, Pod::Html) are already bundled in the base
+    // perl-interpreter / perl-modules packages on Rocky 8 and have no
+    // separate subpackages. Long-term fix: bake this into the Docker image.
+    sh label: 'Install system dependencies', script: 'yum install -y unzip perl-Time-Piece'
 }
 
 def decodeSecrets() {

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -46,7 +46,12 @@ def installSystemDeps() {
     // install resilient to mirror rotation. Long-term fix: bake `unzip` into
     // the Docker image so no runtime install is needed.
     sh label: 'Refresh dnf metadata', script: 'dnf clean all && dnf makecache --refresh -y'
-    sh label: 'Install system dependencies', script: 'yum install -y unzip'
+    // perl-* modules are required by the `openssl-src` crate when the
+    // `vendored-openssl` feature is active (Rust Core stage runs tarpaulin
+    // with `--all-features`, which enables it). Without them the build
+    // fails with "Can't locate Time/Piece.pm in @INC" at openssl-3.x
+    // Configure time. Long-term fix: bake these into the Docker image.
+    sh label: 'Install system dependencies', script: 'yum install -y unzip perl-Time-Piece perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy perl-Pod-Html'
 }
 
 def decodeSecrets() {
@@ -210,8 +215,17 @@ pipeline {
                                     installSystemDeps()
                                     
                                     dir('python') {
+                                        // CC/CXX override: hatch ships its own python-build-standalone
+                                        // interpreter compiled with clang, so its sysconfig reports
+                                        // CXX=clang++. The Rocky 8 coverage image only has GCC, so
+                                        // setuptools/distutils fails the C++ extension build with
+                                        // "command 'clang++' failed: No such file or directory".
+                                        // Forcing CC=gcc / CXX=g++ keeps the build on the toolchain
+                                        // that's actually present in the image.
                                         sh label: 'Build Python Package', script: '''
                                             set +x
+                                            export CC=gcc
+                                            export CXX=g++
                                             RUSTFLAGS="" hatch build -t wheel
                                         '''
 

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -384,6 +384,16 @@ pipeline {
                                         set +x
                                         export PARAMETER_PATH=$(pwd)/parameters.json
                                         export CORE_PATH=$(pwd)/target/debug/libjdbc_bridge.so
+                                        # Persist Gradle's dependency cache + wrapper distribution under the
+                                        # Jenkins workspace so they survive container teardown between builds.
+                                        # Without this every coverage run re-downloads every Maven Central /
+                                        # Gradle plugin POM/JAR, which intermittently trips Maven Central's
+                                        # rate limiter (HTTP 429 "Too Many Requests") and fails the stage.
+                                        # `$WORKSPACE` is auto-mounted into the container by Jenkins, so writes
+                                        # to this path persist on the host filesystem across builds on the same
+                                        # agent.
+                                        export GRADLE_USER_HOME="${WORKSPACE}/.gradle-cache"
+                                        mkdir -p "${GRADLE_USER_HOME}"
                                         chmod +x jdbc/gradlew
                                         cd jdbc
                                         ./gradlew test jacocoTestReport --stacktrace

--- a/ci/Jenkinsfile.coverage
+++ b/ci/Jenkinsfile.coverage
@@ -218,15 +218,26 @@ pipeline {
                                     installSystemDeps()
                                     
                                     dir('python') {
-                                        // CC/CXX override: hatch ships its own python-build-standalone
-                                        // interpreter compiled with clang, so its sysconfig reports
-                                        // CXX=clang++. The Rocky 8 coverage image only has GCC, so
-                                        // setuptools/distutils fails the C++ extension build with
-                                        // "command 'clang++' failed: No such file or directory".
-                                        // Forcing CC=gcc / CXX=g++ keeps the build on the toolchain
-                                        // that's actually present in the image.
+                                        // Compiler setup for the Cython C++ extension build:
+                                        //
+                                        // 1. Hatch ships its own python-build-standalone interpreter
+                                        //    compiled with clang, so its sysconfig reports CXX=clang++.
+                                        //    The Rocky 8 image only has GCC, so without an override
+                                        //    setuptools/distutils dies with
+                                        //    "command 'clang++' failed: No such file or directory".
+                                        //    Force CC=gcc / CXX=g++ to use the toolchain in the image.
+                                        //
+                                        // 2. python-build-standalone also injects `-march=x86-64-v4`
+                                        //    into the build flags (its interpreter targets AVX2/AVX-512).
+                                        //    The default Rocky 8 system GCC is 8.5, which only knows
+                                        //    `-march=x86-64` and rejects v4 with
+                                        //    "cc1plus: error: bad value ('x86-64-v4') for '-march=' switch".
+                                        //    Source gcc-toolset-11 (already used by the ODBC stage)
+                                        //    so that `gcc`/`g++` resolve to GCC 11, which supports
+                                        //    `-march=x86-64-v4`.
                                         sh label: 'Build Python Package', script: '''
                                             set +x
+                                            source /opt/rh/gcc-toolset-11/enable
                                             export CC=gcc
                                             export CXX=g++
                                             RUSTFLAGS="" hatch build -t wheel

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -203,6 +203,15 @@ ignore_missing_imports = true
 
 # ===== Hatch Configuration =====
 
+# Pin the isolated build environment used by `hatch build` to Python 3.10
+# so produced wheels are tagged `cp310` (matching the lowest supported
+# `requires-python`). Without this hatch picks the highest interpreter
+# available on the host (e.g. 3.14 in CI), which produces a `cp314` wheel
+# that is rejected by `hatch run test.py3.10:install-wheel` with
+# "A path dependency is incompatible with the current platform".
+[tool.hatch.envs.hatch-build]
+python = "3.10"
+
 [tool.hatch.envs.default]
 features = ["test", "dev"]
 installer = "uv"


### PR DESCRIPTION
## Summary

Both the Python and Rust Core stages of `Jenkinsfile.coverage` have been failing on every run because the Rocky 8 coverage image (`rhel8-universal-driver-coverage:3`) is missing dependencies they need. Example failure: [universal-driver-coverage PR-1054 #4](https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/universal-driver-coverage/job/PR-1054/4/console) — `Python: FAILED | Rust Core: FAILED | ODBC: FAILED | JDBC: 59.80%`.

This PR adds the missing dependencies in the same runtime-install pattern as the existing `unzip` install in `installSystemDeps()`.

### Rust Core — missing perl modules for `openssl-src`

The Rust Core stage runs `cargo tarpaulin --packages sf_core --all-features ...`, which activates the optional `vendored-openssl` feature on `sf_core`:

```toml
# sf_core/Cargo.toml
vendored-openssl = ["openssl/vendored"]
```

That makes `openssl-src` build OpenSSL 3.6.2 from source. OpenSSL 3.x's Configure script uses Perl modules (`Time::Piece`, `IPC::Cmd`, `FindBin`, …) that are not in the base Rocky 8 perl install, so the build dies with:

```
Can't locate Time/Piece.pm in @INC ... at Makefile.in line 37
BEGIN failed--compilation aborted at Makefile.in line 37
```

Fix: install `perl-Time-Piece perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy perl-Pod-Html` in `installSystemDeps()`.

### Python — clang++ vs gcc

Hatch installs its own [python-build-standalone](https://github.com/astral-sh/python-build-standalone) interpreter, which is compiled with clang. setuptools/distutils then reads `CXX` from `sysconfig.get_config_var('CXX')` and gets back `clang++`. The Rocky 8 image only has GCC, so the Cython C++ extension build dies with:

```
distutils.compilers.C.errors.CompileError: command 'clang++' failed: No such file or directory
```

Fix: export `CC=gcc CXX=g++` right before `hatch build -t wheel` so distutils overrides sysconfig and uses the GCC that's already in the image.

## Notes / follow-ups

- The Rust Core stage could alternatively drop `--all-features` and pass an explicit feature list (or the defaults), which would skip building OpenSSL from source entirely (faster + no perl dep). I went with the conservative install-the-perl-modules fix to preserve coverage semantics for the `vendored-openssl` / `fips` / `auth_mfa_e2e` / etc. feature codepaths. Worth a follow-up discussion whether `--all-features` here is intentional.
- Long-term, both sets of dependencies should be baked into the `rhel8-universal-driver-coverage` Docker image — same caveat as the existing `unzip` install in `installSystemDeps()`.
- This PR does not touch the ODBC stage. The ODBC failure in the same coverage build is a real C++ compile error in `c_to_binary_incompatible_conversions.cpp` that belongs to PR #1054 and will be addressed there.

## Test plan

- [ ] Trigger `universal-driver-coverage` against this branch and confirm the Python and Rust Core stages get past the build step (they may still report low/no coverage but should no longer fail with `clang++ not found` or `Time/Piece.pm not in @INC`).
- [ ] Confirm `dnf install` for the new perl-* packages resolves on the current Rocky 8 mirrors.


Made with [Cursor](https://cursor.com)