### PR TITLE
SNOW-3098562: Sanitize errors - drop trace suffix

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -18,7 +18,7 @@ use sf_core::protobuf::generated::database_driver_v1::{
     MissingParameter as ProtoMissingParameter, driver_error::ErrorType,
 };
 
-use error_trace::{ErrorTrace, format_error_trace};
+use error_trace::ErrorTrace;
 use sf_core::protobuf::generated::database_driver_v1::DriverException as ProtoDriverException;
 use snafu::{Location, Snafu, location};
 
@@ -487,14 +487,12 @@ fn is_well_formed_sql_state(state: &str) -> bool {
 impl OdbcError {
     pub fn message_text(&self) -> String {
         let trace = self.error_trace();
-        let error_message = self.structured_message().unwrap_or_else(|| {
+        self.structured_message().unwrap_or_else(|| {
             trace
                 .last()
                 .map(|entry| entry.message.clone())
                 .unwrap_or_default()
-        });
-        let trace_text = format_error_trace(&trace);
-        format!("{}\nTrace:\n{}", error_message, trace_text)
+        })
     }
 
     /// Extract a user-facing message from structured protobuf error fields

--- a/odbc_tests/tests/e2e/authentication/native_okta.cpp
+++ b/odbc_tests/tests/e2e/authentication/native_okta.cpp
@@ -131,6 +131,6 @@ TEST_CASE("should fail native okta authentication with wrong okta url", "[native
   // Then Connection fails with authentication error
   REQUIRE(records.size() >= 1);
   CHECK(records[0].sqlState == "28000");
-  CHECK_THAT(records[0].messageText,
-             ContainsSubstring("does not match configured Okta URL") || ContainsSubstring("Native Okta SSO failed"));
+  CHECK_THAT(records[0].messageText, ContainsSubstring("does not match configured Okta URL") ||
+                                         ContainsSubstring("Snowflake authenticator-request (logical failure)"));
 }

--- a/odbc_tests/tests/integration/authentication/private_key_auth.cpp
+++ b/odbc_tests/tests/integration/authentication/private_key_auth.cpp
@@ -84,7 +84,7 @@ void verify_connection_fails_with_missing_private_key_error(ConnectionHandleWrap
     CHECK(records[0].sqlState == "01S00");
     CHECK(records[0].nativeError == 0);
     CHECK_THAT(records[0].messageText,
-               ContainsSubstring("Missing required parameter: 'private_key' or 'private_key_file'"));
+               ContainsSubstring("Missing required parameter: private_key or private_key_file"));
   }
 }
 


### PR DESCRIPTION
Sanitize `OdbcError::message_text()` — drop internal trace suffix

`OdbcError::message_text()` was appending `\nTrace:\n{format_error_trace(&trace)}` to every diagnostic message returned via `SQLGetDiagRec` / `SQLGetDiagField`. This change drops that suffix and returns just the
  server-supplied error text (or the last trace entry's message as a fallback).

## Why

ODBC convention for `SQL_DIAG_MESSAGE_TEXT` is the data-source error message — that's what `snowflake-odbc`, mysqlodbc and psqlodbc all return. The trace suffix:

  1. **Leaks driver internals** (Rust source paths, line numbers, intermediate state) into every application-visible error.
  2. **Breaks clients with conservative error buffers.** Concretely: `tdodbc` crashes the worker process on the kilobyte-scale message. That's the client's bug, but a long multi-line `MessageText` is hostile by default.
  3. **Surprises callers porting from `snowflake-odbc`** because the string shape (multi-line, trailing `Trace:` block) differs from every other driver they've used.

If the trace needs to be exposed through a public API in the future, the spec-correct path is a vendor-specific `SQLGetDiagField` extension — not appending to `MessageText`.