### PR TITLE
NO-SNOW: Migrate ODBC version metadata from version.sh to Cargo.toml

### DIFF
--- a/.github/workflows/test-jdbc.yml
+++ b/.github/workflows/test-jdbc.yml
@@ -96,7 +96,7 @@ jobs:
           GRADLE_TEST_RETRY_COUNT: ${{ github.event_name == 'merge_group' && '2' || '' }}
 
       - name: Upload NEW driver test artifacts
-        if: always()
+        if: always() && matrix.result_format == 'default'
         uses: actions/upload-artifact@v4
         with:
           name: jdbc-tests-artifacts

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -1089,8 +1089,8 @@ jobs:
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake_odbc_ud-universal-macos
-          path: build/snowflake_odbc_ud-*.dmg
+          name: snowflake-odbc-ud-macos-universal
+          path: build/snowflake-odbc-ud-*.dmg
 
   odbc-status:
     needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, build_msi, build_dmg]

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -904,7 +904,7 @@ jobs:
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-odbc-ud-msi-${{ matrix.config }}-${{ matrix.arch }}
+          name: snowflake-odbc-ud-${{ matrix.config }}-${{ matrix.arch }}
           path: build/snowflake-odbc-ud-*.msi
 
   build_rpm:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -893,29 +893,18 @@ jobs:
           Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
           if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
 
-      - name: Compute ODBC version
-        id: odbc-version
-        shell: pwsh
-        run: |
-          $versionLine = Get-Content "odbc\version.sh" -Raw
-          if ($versionLine -match 'BASE_VERSION=(\S+)') { $base = $Matches[1] } else { throw "Could not parse BASE_VERSION" }
-          $hash = (git rev-parse --short HEAD)
-          $version = "${base}-${hash}"
-          echo "version=$version" >> $env:GITHUB_OUTPUT
-
       - name: Build MSI installer
         shell: pwsh
         run: |
           .\odbc\installer\win\package.ps1 `
             -DriverBinDir ".cargo-target-msi\${{ matrix.cargo_target }}\${{ matrix.config }}" `
             -Arch ${{ matrix.arch }} `
-            -BuildConfig ${{ matrix.config }} `
-            -Version "${{ steps.odbc-version.outputs.version }}"
+            -BuildConfig ${{ matrix.config }}
 
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-odbc-ud-${{ steps.odbc-version.outputs.version }}-${{ matrix.config }}-${{ matrix.arch }}
+          name: snowflake-odbc-ud-msi-${{ matrix.config }}-${{ matrix.arch }}
           path: build/snowflake-odbc-ud-*.msi
 
   build_rpm:
@@ -1091,12 +1080,6 @@ jobs:
           path: .cargo-target-dmg
           key: ${{ runner.os }}-universal-rust-dmg-release-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Compute ODBC version
-        id: odbc-version
-        run: |
-          source ./odbc/version.sh
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Package DMG
         run: ./odbc/installer/mac/package.sh
         env:
@@ -1106,7 +1089,7 @@ jobs:
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake_odbc_ud-${{ steps.odbc-version.outputs.version }}-universal-macos
+          name: snowflake_odbc_ud-universal-macos
           path: build/snowflake_odbc_ud-*.dmg
 
   odbc-status:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -942,29 +942,18 @@ jobs:
           Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
           if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
 
-      - name: Compute ODBC version
-        id: odbc-version
-        shell: pwsh
-        run: |
-          $versionLine = Get-Content "odbc\version.sh" -Raw
-          if ($versionLine -match 'BASE_VERSION=(\S+)') { $base = $Matches[1] } else { throw "Could not parse BASE_VERSION" }
-          $hash = (git rev-parse --short HEAD)
-          $version = "${base}-${hash}"
-          echo "version=$version" >> $env:GITHUB_OUTPUT
-
       - name: Build MSI installer
         shell: pwsh
         run: |
           .\odbc\installer\win\package.ps1 `
             -DriverBinDir ".cargo-target-msi\${{ matrix.cargo_target }}\${{ matrix.config }}" `
             -Arch ${{ matrix.arch }} `
-            -BuildConfig ${{ matrix.config }} `
-            -Version "${{ steps.odbc-version.outputs.version }}"
+            -BuildConfig ${{ matrix.config }}
 
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-odbc-ud-${{ steps.odbc-version.outputs.version }}-${{ matrix.config }}-${{ matrix.arch }}
+          name: snowflake-odbc-ud-msi-${{ matrix.config }}-${{ matrix.arch }}
           path: build/snowflake-odbc-ud-*.msi
 
   build_rpm:
@@ -1140,12 +1129,6 @@ jobs:
           path: .cargo-target-dmg
           key: ${{ runner.os }}-universal-rust-dmg-release-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Compute ODBC version
-        id: odbc-version
-        run: |
-          source ./odbc/version.sh
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Package DMG
         run: ./odbc/installer/mac/package.sh
         env:
@@ -1155,7 +1138,7 @@ jobs:
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake_odbc_ud-${{ steps.odbc-version.outputs.version }}-universal-macos
+          name: snowflake_odbc_ud-universal-macos
           path: build/snowflake_odbc_ud-*.dmg
 
   odbc-status:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -953,7 +953,7 @@ jobs:
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-odbc-ud-msi-${{ matrix.config }}-${{ matrix.arch }}
+          name: snowflake-odbc-ud-${{ matrix.config }}-${{ matrix.arch }}
           path: build/snowflake-odbc-ud-*.msi
 
   build_rpm:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -1138,8 +1138,8 @@ jobs:
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake_odbc_ud-universal-macos
-          path: build/snowflake_odbc_ud-*.dmg
+          name: snowflake-odbc-ud-macos-universal
+          path: build/snowflake-odbc-ud-*.dmg
 
   odbc-status:
     needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, build_msi, build_dmg]

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -3,6 +3,18 @@ name = "odbc"
 version = "4.0.0"
 edition = "2024"
 
+[package.metadata.odbc]
+# ODBC API conformance level reported by SQLGetInfo(SQL_DRIVER_ODBC_VER) and
+# registered as DriverODBCVer with unixODBC / the Windows ODBC registry.
+# Format is "MM.mm" (e.g. "03.80").
+odbc_api_version = "03.80"
+# Snowflake ODBC UD release version used as the RPM / DMG / MSI artifact
+# version and embedded in the Windows DLL VERSIONINFO resource. The git
+# short SHA is appended at packaging time to produce the full release string.
+# Format is "<major>.<minor>.<patch>" (e.g. "0.0.1").
+# This is to be removed and the package.version used after moving into the PuPr
+odbc_preview_version = "0.0.1"
+
 [lib]
 name = "sfodbc"
 crate-type = ["cdylib", "rlib"]

--- a/odbc/build.rs
+++ b/odbc/build.rs
@@ -1,6 +1,11 @@
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../build_common.rs"));
 
 fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let odbc_api_version = read_odbc_metadata(&manifest_dir, "odbc_api_version");
+    println!("cargo:rustc-env=SF_ODBC_API_VER={odbc_api_version}");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
     #[cfg(not(target_os = "windows"))]
     {
         emit_loader_rpaths();
@@ -10,12 +15,11 @@ fn main() {
     // This avoids the PE/COFF 65535 export symbol limit.
     #[cfg(target_os = "windows")]
     {
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let manifest_path = std::path::Path::new(&manifest_dir);
         let def_path = manifest_path.join("exports.def");
         println!("cargo:rustc-cdylib-link-arg=/DEF:{}", def_path.display());
 
-        let (major, minor, patch) = parse_base_version(&manifest_dir);
+        let (major, minor, patch) = parse_odbc_preview_version(&manifest_dir);
         let commit_hash = resolve_commit_hash();
 
         let target_arch =
@@ -40,7 +44,6 @@ fn main() {
         )
         .expect("failed to write version_generated.h");
 
-        println!("cargo:rerun-if-changed=version.sh");
         println!("cargo:rerun-if-changed=exports.def");
         println!("cargo:rerun-if-changed=src/setup/resource.rc");
         println!("cargo:rerun-if-changed=src/setup/resource.h");
@@ -60,32 +63,66 @@ fn main() {
     }
 }
 
-#[cfg(target_os = "windows")]
-fn parse_base_version(manifest_dir: &str) -> (u32, u32, u32) {
-    let version_sh = std::fs::read_to_string(std::path::Path::new(manifest_dir).join("version.sh"))
-        .expect("failed to read version.sh");
-    for line in version_sh.lines() {
-        if let Some(val) = line.strip_prefix("BASE_VERSION=") {
-            let trimmed = val.trim();
-            let parts: Vec<&str> = trimmed.split('.').collect();
-            assert!(
-                parts.len() == 3,
-                "invalid BASE_VERSION in version.sh: expected <major>.<minor>.<patch>, got `{trimmed}`"
-            );
-            return (
-                parts[0]
-                    .parse()
-                    .unwrap_or_else(|_| panic!("invalid major version in `{trimmed}`")),
-                parts[1]
-                    .parse()
-                    .unwrap_or_else(|_| panic!("invalid minor version in `{trimmed}`")),
-                parts[2]
-                    .parse()
-                    .unwrap_or_else(|_| panic!("invalid patch version in `{trimmed}`")),
-            );
+fn read_odbc_metadata(manifest_dir: &str, key: &str) -> String {
+    const SECTION: &str = "[package.metadata.odbc]";
+
+    let cargo_toml_path = std::path::Path::new(manifest_dir).join("Cargo.toml");
+    let cargo_toml = std::fs::read_to_string(&cargo_toml_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", cargo_toml_path.display()));
+
+    let mut in_section = false;
+    for line in cargo_toml.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_section = trimmed == SECTION;
+            continue;
         }
+        if !in_section {
+            continue;
+        }
+        let Some(rhs) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let rhs = rhs.trim_start();
+        let Some(rhs) = rhs.strip_prefix('=') else {
+            continue;
+        };
+        let value = rhs.trim();
+        let value = value.split('#').next().unwrap_or(value).trim();
+        if let Some(stripped) = value
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| value.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        {
+            return stripped.to_string();
+        }
+        panic!("`{key}` in {SECTION} must be a quoted string, got `{value}`");
     }
-    panic!("BASE_VERSION not found in version.sh")
+    panic!(
+        "`{key}` not found in {SECTION} of {}",
+        cargo_toml_path.display()
+    );
+}
+
+#[cfg(target_os = "windows")]
+fn parse_odbc_preview_version(manifest_dir: &str) -> (u32, u32, u32) {
+    let raw = read_odbc_metadata(manifest_dir, "odbc_preview_version");
+    let parts: Vec<&str> = raw.split('.').collect();
+    assert!(
+        parts.len() == 3,
+        "invalid odbc_preview_version: expected <major>.<minor>.<patch>, got `{raw}`"
+    );
+    (
+        parts[0]
+            .parse()
+            .unwrap_or_else(|_| panic!("invalid major version in `{raw}`")),
+        parts[1]
+            .parse()
+            .unwrap_or_else(|_| panic!("invalid minor version in `{raw}`")),
+        parts[2]
+            .parse()
+            .unwrap_or_else(|_| panic!("invalid patch version in `{raw}`")),
+    )
 }
 
 #[cfg(target_os = "windows")]

--- a/odbc/installer/mac/package.sh
+++ b/odbc/installer/mac/package.sh
@@ -71,8 +71,7 @@ cp odbc/include/sf_odbc.h "$STAGE_DIR$INSTALL_DIR/include/"
 # stage the postinstall alongside the iODBC ini templates the postinstall
 # renders at install time. __ODBC_API_VERSION__ is baked into the odbcinst
 # template here so the customer's machine doesn't need access to Cargo.toml;
-# the remaining placeholders (__DRIVER_PATH__, __SF_ACCOUNT__) are resolved
-# by the postinstall.
+# the remaining placeholders are resolved by the postinstall.
 cp "$SCRIPTS_DIR/postinstall" "$SCRIPTS_STAGE_DIR/postinstall"
 chmod +x "$SCRIPTS_STAGE_DIR/postinstall"
 sed "s/__ODBC_API_VERSION__/${ODBC_API_VERSION}/g" \
@@ -81,8 +80,8 @@ cp "$TEMPLATES_DIR/odbc.ini.template" "$SCRIPTS_STAGE_DIR/odbc.ini.template"
 
 mkdir -p "$BUILD_DIR"
 
-PKG_NAME="snowflake_odbc_ud-${VERSION}-universal.pkg"
-DMG_NAME="snowflake_odbc_ud-${VERSION}-universal.dmg"
+PKG_NAME="snowflake-odbc-ud-${VERSION}-universal.pkg"
+DMG_NAME="snowflake-odbc-ud-${VERSION}-universal.dmg"
 
 echo "=== Building pkg: $PKG_NAME ==="
 pkgbuild \

--- a/odbc/installer/mac/package.sh
+++ b/odbc/installer/mac/package.sh
@@ -14,12 +14,35 @@
 #
 set -euxo pipefail
 
-source ./odbc/version.sh
+read_odbc_metadata() {
+    local key="$1"
+    awk -v key="$key" '
+        /^\[package\.metadata\.odbc\][[:space:]]*$/ { in_section = 1; next }
+        /^\[/                                       { in_section = 0 }
+        in_section && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+            line = $0
+            sub(/^[^"]*"/, "", line)
+            sub(/".*$/,    "", line)
+            print line
+            exit
+        }
+    ' odbc/Cargo.toml
+}
+
+BASE_VERSION=$(read_odbc_metadata odbc_preview_version)
+ODBC_API_VERSION=$(read_odbc_metadata odbc_api_version)
+if [[ -z "$BASE_VERSION" || -z "$ODBC_API_VERSION" ]]; then
+    echo "Failed to read odbc_preview_version / odbc_api_version from [package.metadata.odbc] in odbc/Cargo.toml"
+    exit 1
+fi
+COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
+VERSION="${BASE_VERSION}-${COMMIT_HASH}"
 
 INSTALL_DIR="/opt/snowflake/snowflakeodbcud"
 PKG_IDENTIFIER="net.snowflake.odbc-ud"
 BUILD_DIR=build
 SCRIPTS_DIR=odbc/installer/mac/scripts
+TEMPLATES_DIR=odbc/installer/shared/templates
 
 DRIVER_X86_64="${DRIVER_X86_64:-target/x86_64-apple-darwin/release/libsfodbc.dylib}"
 DRIVER_ARM64="${DRIVER_ARM64:-target/aarch64-apple-darwin/release/libsfodbc.dylib}"
@@ -32,7 +55,8 @@ for f in "$DRIVER_X86_64" "$DRIVER_ARM64"; do
 done
 
 STAGE_DIR=$(mktemp -d)
-trap 'rm -rf "$STAGE_DIR"' EXIT
+SCRIPTS_STAGE_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGE_DIR" "$SCRIPTS_STAGE_DIR"' EXIT
 
 echo "=== Creating universal binary ==="
 mkdir -p "$STAGE_DIR$INSTALL_DIR/lib"
@@ -42,6 +66,18 @@ lipo -info "$STAGE_DIR$INSTALL_DIR/lib/libsfodbc.dylib"
 echo "=== Staging additional files ==="
 mkdir -p "$STAGE_DIR$INSTALL_DIR/include"
 cp odbc/include/sf_odbc.h "$STAGE_DIR$INSTALL_DIR/include/"
+
+# pkgbuild --scripts packages everything in the directory it points at, so
+# stage the postinstall alongside the iODBC ini templates the postinstall
+# renders at install time. __ODBC_API_VERSION__ is baked into the odbcinst
+# template here so the customer's machine doesn't need access to Cargo.toml;
+# the remaining placeholders (__DRIVER_PATH__, __SF_ACCOUNT__) are resolved
+# by the postinstall.
+cp "$SCRIPTS_DIR/postinstall" "$SCRIPTS_STAGE_DIR/postinstall"
+chmod +x "$SCRIPTS_STAGE_DIR/postinstall"
+sed "s/__ODBC_API_VERSION__/${ODBC_API_VERSION}/g" \
+    "$TEMPLATES_DIR/odbcinst.ini.template" > "$SCRIPTS_STAGE_DIR/odbcinst.ini.template"
+cp "$TEMPLATES_DIR/odbc.ini.template" "$SCRIPTS_STAGE_DIR/odbc.ini.template"
 
 mkdir -p "$BUILD_DIR"
 
@@ -54,7 +90,7 @@ pkgbuild \
     --version "$VERSION" \
     --install-location "$INSTALL_DIR" \
     --root "$STAGE_DIR$INSTALL_DIR" \
-    --scripts "$SCRIPTS_DIR" \
+    --scripts "$SCRIPTS_STAGE_DIR" \
     "$BUILD_DIR/$PKG_NAME"
 
 echo "=== Creating DMG: $DMG_NAME ==="

--- a/odbc/installer/mac/scripts/postinstall
+++ b/odbc/installer/mac/scripts/postinstall
@@ -3,11 +3,21 @@
 # Post-install script for the Snowflake ODBC UD macOS pkg.
 # Registers the driver with the iODBC Driver Manager.
 #
+# Driver registration and DSN content live in ini section templates installed
+# alongside the driver. odbc/installer/unix/package.sh substitutes
+# __ODBC_API_VERSION__ at packaging time from [package.metadata.odbc] in
+# odbc/Cargo.toml; the remaining placeholders are substituted here at install time.
+#
 
 INSTALL_DIR="/opt/snowflake/snowflakeodbcud"
 DRIVER_PATH="$INSTALL_DIR/lib/libsfodbc.dylib"
 
-if [ -n "$SUDO_USER" ]; then
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# pkg postinstall scripts run as root. Resolve the invoking user's home so the
+# driver and DSN land in the per-user iODBC config (~/Library/ODBC/), which is
+# the macOS convention.
+if [ -n "${SUDO_USER:-}" ]; then
     USER_HOME=$(dscl . -read /Users/"$SUDO_USER" NFSHomeDirectory | awk '{print $2}')
 else
     USER_HOME="$HOME"
@@ -15,25 +25,63 @@ fi
 
 ODBC_DIR="$USER_HOME/Library/ODBC"
 ODBCINST_FILE="$ODBC_DIR/odbcinst.ini"
+ODBC_FILE="$ODBC_DIR/odbc.ini"
+
+if [ -z "${SF_ACCOUNT:-}" ]; then
+    echo "[WARN] SF_ACCOUNT is not set, please manually update $ODBC_FILE after installation"
+    SF_ACCOUNT=SF_ACCOUNT
+fi
 
 mkdir -p "$ODBC_DIR"
 
-DRIVER_ENTRY="[Snowflake ODBC UD]
-Driver=$DRIVER_PATH
-Description=Snowflake ODBC UD"
+render_template() {
+    sed \
+        -e "s|__DRIVER_PATH__|${DRIVER_PATH}|g" \
+        -e "s|__SF_ACCOUNT__|${SF_ACCOUNT}|g" \
+        "$1"
+}
 
-if [ -f "$ODBCINST_FILE" ]; then
-    if grep -q "\[Snowflake ODBC UD\]" "$ODBCINST_FILE"; then
-        echo "Snowflake ODBC UD already registered in $ODBCINST_FILE, updating..."
-        sed -i '' '/\[Snowflake ODBC UD\]/,/^\[/{/^\[Snowflake ODBC UD\]/d;/^Driver=/d;/^Description=/d;/^$/d;}' "$ODBCINST_FILE"
+# Replace (or append) a named ini section so re-running the installer with
+# updated driver metadata leaves the file well-formed instead of accreting
+# duplicate keys. The section content includes the [section] header line; the
+# section name is parsed from it so callers don't have to repeat themselves.
+write_ini_section() {
+    local target_file="$1" section_content="$2"
+
+    local section_name
+    section_name=$(printf '%s\n' "$section_content" \
+        | head -n 1 \
+        | sed -e 's/^\[//' -e 's/\]$//')
+    if [ -z "$section_name" ]; then
+        echo "Section content must start with a [section] header" >&2
+        return 1
     fi
-fi
 
-echo "" >> "$ODBCINST_FILE"
-echo "$DRIVER_ENTRY" >> "$ODBCINST_FILE"
+    local tmp
+    tmp=$(mktemp)
+
+    if [ -f "$target_file" ]; then
+        awk -v header="[$section_name]" '
+            $0 == header { skip = 1; next }
+            /^\[/        { skip = 0 }
+            !skip
+        ' "$target_file" > "$tmp"
+    fi
+
+    if [ -s "$tmp" ] && [ "$(tail -n 1 "$tmp")" != "" ]; then
+        printf '\n' >> "$tmp"
+    fi
+    printf '%s\n' "$section_content" >> "$tmp"
+
+    mv "$tmp" "$target_file"
+}
+
+write_ini_section "$ODBCINST_FILE" "$(render_template "$SCRIPT_DIR/odbcinst.ini.template")"
+write_ini_section "$ODBC_FILE"     "$(render_template "$SCRIPT_DIR/odbc.ini.template")"
 
 echo "Snowflake ODBC UD registered in $ODBCINST_FILE"
+echo "Default Snowflake DSN written to $ODBC_FILE"
 
-if [ -n "$SUDO_UID" ]; then
-    chown -R "$SUDO_UID":"$SUDO_GID" "$ODBC_DIR"
+if [ -n "${SUDO_UID:-}" ]; then
+    chown -R "$SUDO_UID":"${SUDO_GID:-$SUDO_UID}" "$ODBC_DIR"
 fi

--- a/odbc/installer/mac/scripts/postinstall
+++ b/odbc/installer/mac/scripts/postinstall
@@ -1,12 +1,13 @@
 #!/bin/bash
 #
 # Post-install script for the Snowflake ODBC UD macOS pkg.
-# Registers the driver with the iODBC Driver Manager.
+# Registers the driver and a default DSN with the iODBC Driver Manager.
 #
 # Driver registration and DSN content live in ini section templates installed
-# alongside the driver. odbc/installer/unix/package.sh substitutes
+# alongside this script. odbc/installer/mac/package.sh substitutes
 # __ODBC_API_VERSION__ at packaging time from [package.metadata.odbc] in
-# odbc/Cargo.toml; the remaining placeholders are substituted here at install time.
+# odbc/Cargo.toml; the remaining placeholders are substituted here at install
+# time.
 #
 
 INSTALL_DIR="/opt/snowflake/snowflakeodbcud"
@@ -33,6 +34,13 @@ if [ -z "${SF_ACCOUNT:-}" ]; then
 fi
 
 mkdir -p "$ODBC_DIR"
+
+parse_section_header() {
+    head -n 1 "$1" | sed -e 's/^\[//' -e 's/\]$//'
+}
+
+DRIVER_NAME=$(parse_section_header "$SCRIPT_DIR/odbcinst.ini.template")
+DSN_NAME=$(parse_section_header "$SCRIPT_DIR/odbc.ini.template")
 
 render_template() {
     sed \
@@ -76,8 +84,66 @@ write_ini_section() {
     mv "$tmp" "$target_file"
 }
 
+upsert_ini_kv() {
+    local target_file="$1" section="$2" key="$3" value="$4"
+
+    local tmp
+    tmp=$(mktemp)
+
+    if [ -f "$target_file" ]; then
+        awk -v section="[$section]" -v key="$key" -v value="$value" '
+            BEGIN { in_section = 0; seen_section = 0; updated = 0 }
+            /^\[/ {
+                if (in_section && !updated) {
+                    print key "=" value
+                    updated = 1
+                }
+                in_section = ($0 == section) ? 1 : 0
+                if (in_section) seen_section = 1
+                print
+                next
+            }
+            in_section {
+                eq = index($0, "=")
+                if (eq > 0) {
+                    line_key = substr($0, 1, eq - 1)
+                    sub(/[[:space:]]+$/, "", line_key)
+                    if (line_key == key) {
+                        if (!updated) {
+                            print key "=" value
+                            updated = 1
+                        }
+                        next
+                    }
+                }
+                print
+                next
+            }
+            { print }
+            END {
+                if (!seen_section) {
+                    if (NR > 0) print ""
+                    print section
+                    print key "=" value
+                } else if (!updated) {
+                    print key "=" value
+                }
+            }
+        ' "$target_file" > "$tmp"
+    else
+        printf '%s\n%s=%s\n' "[$section]" "$key" "$value" > "$tmp"
+    fi
+
+    mv "$tmp" "$target_file"
+}
+
 write_ini_section "$ODBCINST_FILE" "$(render_template "$SCRIPT_DIR/odbcinst.ini.template")"
 write_ini_section "$ODBC_FILE"     "$(render_template "$SCRIPT_DIR/odbc.ini.template")"
+
+# Maintain the iODBC index sections so SQLDrivers() / SQLDataSources() and
+# tools like ODBC Manager.app see our driver and DSN.
+upsert_ini_kv "$ODBCINST_FILE" "ODBC Drivers"      "$DRIVER_NAME" "Installed"
+upsert_ini_kv "$ODBC_FILE"     "ODBC Data Sources" "$DSN_NAME"    "$DRIVER_NAME"
 
 echo "Snowflake ODBC UD registered in $ODBCINST_FILE"
 echo "Default Snowflake DSN written to $ODBC_FILE"

--- a/odbc/installer/shared/templates/odbc.ini.template
+++ b/odbc/installer/shared/templates/odbc.ini.template
@@ -1,0 +1,8 @@
+[snowflake]
+Description=SnowflakeDB
+Driver=Snowflake ODBC UD
+Locale=en-US
+SERVER=__SF_ACCOUNT__.snowflakecomputing.com
+PORT=443
+SSL=on
+ACCOUNT=__SF_ACCOUNT__

--- a/odbc/installer/shared/templates/odbcinst.ini.template
+++ b/odbc/installer/shared/templates/odbcinst.ini.template
@@ -1,0 +1,7 @@
+[Snowflake ODBC UD]
+APILevel=1
+ConnectFunctions=YYY
+Description=Snowflake ODBC UD
+Driver=__DRIVER_PATH__
+DriverODBCVer=__ODBC_API_VERSION__
+SQLLevel=1

--- a/odbc/installer/unix/after_install.sh
+++ b/odbc/installer/unix/after_install.sh
@@ -5,33 +5,30 @@
 #
 # Registers the driver with unixODBC and creates a template DSN.
 #
+# Driver registration and DSN content live in ini section templates installed
+# alongside the driver. odbc/installer/unix/package.sh substitutes
+# __ODBC_API_VERSION__ at packaging time from [package.metadata.odbc] in
+# odbc/Cargo.toml; the remaining placeholders are substituted here at install time.
+#
+
+ODBC_DIR=/usr/lib64/snowflake/odbc
+DRIVER_PATH=$ODBC_DIR/lib/libsfodbc.so
+TEMPLATES_DIR=$ODBC_DIR/templates
 
 if [[ -z "$SF_ACCOUNT" ]]; then
     echo "[WARN] SF_ACCOUNT is not set, please manually update the odbc.ini file after installation"
     SF_ACCOUNT=SF_ACCOUNT
 fi
 
-ODBC_DIR=/usr/lib64/snowflake/odbc
+render_template() {
+    sed \
+        -e "s|__DRIVER_PATH__|${DRIVER_PATH}|g" \
+        -e "s|__SF_ACCOUNT__|${SF_ACCOUNT}|g" \
+        "$1"
+}
 
 echo "Adding driver info to odbcinst.ini..."
-odbcinst -i -d -r <<ODBCINST_INI
-[Snowflake ODBC UD]
-APILevel=1
-ConnectFunctions=YYY
-Description=Snowflake ODBC UD
-Driver=$ODBC_DIR/lib/libsfodbc.so
-DriverODBCVer=03.52
-SQLLevel=1
-ODBCINST_INI
+render_template "$TEMPLATES_DIR/odbcinst.ini.template" | odbcinst -i -d -r
 
 echo "Adding connect info to odbc.ini..."
-odbcinst -i -s -l -r <<ODBC_INI
-[snowflake]
-Description=SnowflakeDB
-Driver=Snowflake ODBC UD
-Locale=en-US
-SERVER=$SF_ACCOUNT.snowflakecomputing.com
-PORT=443
-SSL=on
-ACCOUNT=$SF_ACCOUNT
-ODBC_INI
+render_template "$TEMPLATES_DIR/odbc.ini.template" | odbcinst -i -s -l -r

--- a/odbc/installer/unix/package.sh
+++ b/odbc/installer/unix/package.sh
@@ -13,7 +13,29 @@
 #
 set -euxo pipefail
 
-source ./odbc/version.sh
+read_odbc_metadata() {
+    local key="$1"
+    awk -v key="$key" '
+        /^\[package\.metadata\.odbc\][[:space:]]*$/ { in_section = 1; next }
+        /^\[/                                       { in_section = 0 }
+        in_section && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+            line = $0
+            sub(/^[^"]*"/, "", line)
+            sub(/".*$/,    "", line)
+            print line
+            exit
+        }
+    ' odbc/Cargo.toml
+}
+
+BASE_VERSION=$(read_odbc_metadata odbc_preview_version)
+ODBC_API_VERSION=$(read_odbc_metadata odbc_api_version)
+if [[ -z "$BASE_VERSION" || -z "$ODBC_API_VERSION" ]]; then
+    echo "Failed to read odbc_preview_version / odbc_api_version from [package.metadata.odbc] in odbc/Cargo.toml"
+    exit 1
+fi
+COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
+VERSION="${BASE_VERSION}-${COMMIT_HASH}"
 
 echo "=== Platform: $PLATFORM ==="
 
@@ -49,12 +71,18 @@ ODBC_DIR=/usr/lib64/snowflake/odbc
 STAGE_DIR=$(mktemp -d)
 trap 'rm -rf "$STAGE_DIR"' EXIT
 RPM_SCRIPTS_DIR=odbc/installer/unix
+TEMPLATES_DIR=odbc/installer/shared/templates
 
 echo "=== Staging files in $STAGE_DIR ==="
 mkdir -p "$STAGE_DIR$ODBC_DIR/lib"
 mkdir -p "$STAGE_DIR$ODBC_DIR/include"
+mkdir -p "$STAGE_DIR$ODBC_DIR/templates"
 cp "$DRIVER_SO" "$STAGE_DIR$ODBC_DIR/lib/"
 cp odbc/include/sf_odbc.h "$STAGE_DIR$ODBC_DIR/include/"
+
+sed "s/__ODBC_API_VERSION__/${ODBC_API_VERSION}/g" \
+    "$TEMPLATES_DIR/odbcinst.ini.template" > "$STAGE_DIR$ODBC_DIR/templates/odbcinst.ini.template"
+cp "$TEMPLATES_DIR/odbc.ini.template" "$STAGE_DIR$ODBC_DIR/templates/odbc.ini.template"
 
 RPM_NAME="snowflake-odbc-ud-${VERSION}.${SYSTEM_ARCH}.rpm"
 mkdir -p "$BUILD_DIR"

--- a/odbc/installer/win/package.ps1
+++ b/odbc/installer/win/package.ps1
@@ -23,7 +23,8 @@
 
 .PARAMETER Version
     Version string for the product (e.g. 0.0.1-abc1234).
-    Defaults to BASE_VERSION from odbc/version.sh with the git short hash appended.
+    Defaults to [package.metadata.odbc] odbc_preview_version from odbc/Cargo.toml
+    with the git short hash appended.
 
 .PARAMETER OutputDir
     Directory where the resulting MSI will be placed. Created if it doesn't exist.
@@ -72,13 +73,18 @@ foreach ($tool in @("candle.exe", "light.exe")) {
 }
 
 # --- Version ---
-if (-not $Version) {
-    $versionLine = Get-Content (Join-Path $SourceDir "odbc\version.sh") -Raw
-    if ($versionLine -match 'BASE_VERSION=(\S+)') {
-        $baseVersion = $Matches[1]
-    } else {
-        throw "Could not parse BASE_VERSION from odbc/version.sh"
+$cargoTomlContent = Get-Content (Join-Path $SourceDir "odbc\Cargo.toml") -Raw
+
+function Read-OdbcMetadata([string]$Key) {
+    $pattern = '(?m)^\[package\.metadata\.odbc\][^\[]*?' + [regex]::Escape($Key) + '\s*=\s*"([^"]+)"'
+    if ($cargoTomlContent -match $pattern) {
+        return $Matches[1]
     }
+    throw "Could not parse [package.metadata.odbc] $Key from odbc/Cargo.toml"
+}
+
+if (-not $Version) {
+    $baseVersion = Read-OdbcMetadata 'odbc_preview_version'
     $commitHash = "unknown"
     if (Get-Command git -ErrorAction SilentlyContinue) {
         $commitHash = (git -C $SourceDir rev-parse --short HEAD 2>$null)
@@ -89,6 +95,8 @@ if (-not $Version) {
 $versionParts = ($Version -replace '-.*', '').Split('.')
 while ($versionParts.Count -lt 3) { $versionParts += "0" }
 $WixVersion = ($versionParts[0..2]) -join '.'
+
+$OdbcApiVer = Read-OdbcMetadata 'odbc_api_version'
 
 # --- Driver DLL ---
 $DriverBinDir = (Resolve-Path $DriverBinDir).Path
@@ -145,13 +153,14 @@ $OutputDir = (Resolve-Path $OutputDir).Path
 $configSuffix = if ($BuildConfig -eq "debug") { "-debug" } else { "" }
 
 Write-Host "=== Building Snowflake ODBC Driver MSI ==="
-Write-Host "  Architecture : $Arch"
-Write-Host "  Config       : $BuildConfig"
-Write-Host "  Version      : $Version (MSI ProductVersion: $WixVersion)"
-Write-Host "  Driver dir   : $DriverBinDir"
-Write-Host "  VCRedist dir : $VCRedistDir"
-Write-Host "  Source dir   : $SourceDir"
-Write-Host "  Output dir   : $OutputDir"
+Write-Host "  Architecture     : $Arch"
+Write-Host "  Config           : $BuildConfig"
+Write-Host "  Version          : $Version (MSI ProductVersion: $WixVersion)"
+Write-Host "  ODBC API version : $OdbcApiVer"
+Write-Host "  Driver dir       : $DriverBinDir"
+Write-Host "  VCRedist dir     : $VCRedistDir"
+Write-Host "  Source dir       : $SourceDir"
+Write-Host "  Output dir       : $OutputDir"
 
 $ObjDir = Join-Path $OutputDir "wixobj"
 New-Item -ItemType Directory -Force -Path $ObjDir | Out-Null
@@ -167,6 +176,7 @@ Write-Host "`n--- Compiling WiX source ---"
     -arch $candleArch `
     -dProductVersion="$WixVersion" `
     -dFullVersion="$Version" `
+    -dOdbcApiVer="$OdbcApiVer" `
     -dDriverBinDir="$DriverBinDir" `
     -dVCRedistDir="$VCRedistDir" `
     -dSourceDir="$SourceDir" `

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -144,7 +144,7 @@
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc.dll" />
 				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
-				<RegistryValue Type="string" Name="DriverODBCVer" Value="03.52" />
+				<RegistryValue Type="string" Name="DriverODBCVer" Value="$(var.OdbcApiVer)" />
 				<RegistryValue Type="string" Name="CompanyName" Value="Snowflake Computing" />
 				<RegistryValue Type="string" Name="ConnectFunctions" Value="YYY" />
 				<RegistryValue Type="string" Name="APILevel" Value="1" />

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -144,7 +144,7 @@
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc32.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc32.dll" />
 				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
-				<RegistryValue Type="string" Name="DriverODBCVer" Value="03.52" />
+				<RegistryValue Type="string" Name="DriverODBCVer" Value="$(var.OdbcApiVer)" />
 				<RegistryValue Type="string" Name="CompanyName" Value="Snowflake Computing" />
 				<RegistryValue Type="string" Name="ConnectFunctions" Value="YYY" />
 				<RegistryValue Type="string" Name="APILevel" Value="1" />

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -29,6 +29,7 @@ const SQL_FALSE: sql::UInteger = 0;
 
 const ODBC_DRIVER_NAME: &str = "ODBC";
 const ODBC_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const ODBC_API_VERSION: &str = env!("SF_ODBC_API_VER");
 
 /// Default login timeout in seconds, matching the old driver's S_DEFAULT_LOGIN_TIMEOUT.
 /// Used as the Okta SAML retry budget when neither the connection string nor
@@ -1206,7 +1207,7 @@ pub fn get_info<E: OdbcEncoding>(
         }
         InfoType::DriverOdbcVer => {
             write_string_bytes::<E>(
-                "03.00",
+                ODBC_API_VERSION,
                 info_value_ptr as *mut E::Char,
                 buffer_length,
                 string_length_ptr,

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -29,6 +29,7 @@ const SQL_FALSE: sql::UInteger = 0;
 
 const ODBC_DRIVER_NAME: &str = "ODBC";
 const ODBC_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const ODBC_API_VERSION: &str = env!("SF_ODBC_API_VER");
 
 /// Default login timeout in seconds, matching the old driver's S_DEFAULT_LOGIN_TIMEOUT.
 /// Used as the Okta SAML retry budget when neither the connection string nor
@@ -1215,7 +1216,7 @@ pub fn get_info<E: OdbcEncoding>(
             // claim: every API the driver currently implements is
             // available at that level.
             write_string_bytes::<E>(
-                "03.80",
+                ODBC_API_VERSION,
                 info_value_ptr as *mut E::Char,
                 buffer_length,
                 string_length_ptr,

--- a/odbc/version.sh
+++ b/odbc/version.sh
@@ -1,3 +1,0 @@
-BASE_VERSION=0.0.1
-COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
-export VERSION="${BASE_VERSION}-${COMMIT_HASH}"

--- a/tests/performance/drivers/Dockerfile.sf_core_builder
+++ b/tests/performance/drivers/Dockerfile.sf_core_builder
@@ -77,6 +77,7 @@ COPY sf_mini_core/src/ ./sf_mini_core/src/
 COPY sf_mini_core_static/src/ ./sf_mini_core_static/src/
 COPY proto_utils/src/ ./proto_utils/src/
 COPY odbc/src/ ./odbc/src/
+COPY odbc/build.rs ./odbc/build.rs
 COPY proto_generator/src/ ./proto_generator/src/
 COPY jdbc_bridge/src/ ./jdbc_bridge/src/
 COPY error_trace/src/ ./error_trace/src/


### PR DESCRIPTION
### TL;DR

Consolidate ODBC versioning into `Cargo.toml` and replace `version.sh` with structured metadata under `[package.metadata.odbc]`.

### What changed?

- Removed `odbc/version.sh` and replaced it with two new keys in `[package.metadata.odbc]` inside `odbc/Cargo.toml`:
  - `odbc_preview_version` — the base release version (e.g. `0.0.1`) used for RPM/DMG/MSI artifact naming and the Windows DLL `VERSIONINFO` resource.
  - `odbc_api_version` — the ODBC API conformance level (e.g. `03.80`) reported by `SQLGetInfo(SQL_DRIVER_ODBC_VER)` and registered in the Windows ODBC registry and unixODBC.
- `build.rs` now reads both keys from `Cargo.toml` via a new `read_odbc_metadata` helper, exposes `SF_ODBC_API_VER` as a compile-time env var, and uses it in `connection.rs` instead of a hardcoded string.
- Packaging scripts (`package.sh` for macOS and Linux, `package.ps1` for Windows) now parse both keys directly from `Cargo.toml` instead of sourcing `version.sh`.
- Introduced shared ini templates under `odbc/installer/shared/templates/` (`odbcinst.ini.template` and `odbc.ini.template`) with placeholders (`__DRIVER_PATH__`, `__SF_ACCOUNT__`, `__ODBC_API_VERSION__`) that are resolved at packaging or install time.
- The macOS `postinstall` script was rewritten to use the shared templates and now also writes a default DSN to `odbc.ini` in addition to registering the driver in `odbcinst.ini`. It uses robust `write_ini_section` and `upsert_ini_kv` helpers to avoid duplicate entries on reinstall.
- The Linux `after_install.sh` script now renders the shared templates via `render_template` and pipes them to `odbcinst` instead of using inline heredocs.
- CI artifact names for MSI and DMG no longer embed the version string, simplifying artifact references.
- `DriverODBCVer` in both WiX installer sources (`snowflake_odbc_x64.wxs`, `snowflake_odbc_x86.wxs`) is now driven by the `OdbcApiVer` variable sourced from `Cargo.toml` rather than a hardcoded `03.52`.

### How to test?

- Build the ODBC driver and verify `SQLGetInfo(SQL_DRIVER_ODBC_VER)` returns `03.80`.
- Run the macOS packaging script and confirm the `.pkg` and `.dmg` are produced with the correct version, and that installing the `.pkg` correctly populates both `~/Library/ODBC/odbcinst.ini` and `~/Library/ODBC/odbc.ini`. Re-run the installer and verify no duplicate sections appear.
- Run the Linux packaging script and confirm the RPM is produced and that `after_install.sh` correctly registers the driver and DSN via `odbcinst`.
- Run the Windows packaging script and confirm the MSI is produced and that the registry entries contain `DriverODBCVer=03.80`.
- Verify CI artifact uploads succeed with the new simplified artifact names.

### Why make this change?

`version.sh` was a shell-only artifact that required separate parsing logic in every packaging script and CI step, and the ODBC API version was hardcoded in multiple places independently. Centralizing both values in `Cargo.toml` under `[package.metadata.odbc]` makes them the single source of truth, eliminates the shell-script dependency, and ensures the API version reported at runtime, embedded in the Windows DLL, and registered with driver managers is always consistent.