### PR TITLE
NO-SNOW: Add flaky test tagging infrastructure

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -235,16 +235,18 @@ jobs:
       - name: Run Old ODBC tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         id: run_odbc_ref_tests_linux
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
-        run: ./scripts/odbc/run_tests_unix.sh
+        run: |
+          REPEAT_ARGS=${{ github.event_name == 'merge_group' && '"--repeat until-pass:2"' || '' }}
+          ./scripts/odbc/run_tests_unix.sh -LE flaky $REPEAT_ARGS
         env:
           DRIVER_PATH: /usr/lib/snowflake/odbc/lib/libSnowflake.so
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           DRIVER_TYPE: OLD
 
-      - name: Rerun failed Old ODBC tests (Linux)
-        if: steps.run_odbc_ref_tests_linux.outcome == 'failure' && github.event_name == 'merge_group'
-        run: ctest --rerun-failed -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+      - name: Run flaky Old ODBC tests (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        continue-on-error: true
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
         env:
           DRIVER_PATH: /usr/lib/snowflake/odbc/lib/libSnowflake.so
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
@@ -253,18 +255,19 @@ jobs:
       - name: Run Old ODBC tests (Windows)
         if: matrix.os == 'windows-latest'
         id: run_odbc_ref_tests_windows
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: pwsh
         run: |
           $env:DRIVER_PATH = "C:\Program Files\Snowflake ODBC Driver\Bin\SnowflakeDSII.dll"
           $env:PARAMETER_PATH = "$(pwd)\parameters.json"
           $env:DRIVER_TYPE = "OLD"
-          .\scripts\odbc\run_tests_windows.ps1
+          $repeatArgs = if ("${{ github.event_name }}" -eq "merge_group") { @("--repeat", "until-pass:2") } else { @() }
+          .\scripts\odbc\run_tests_windows.ps1 -LE flaky @repeatArgs
 
-      - name: Rerun failed Old ODBC tests (Windows)
-        if: steps.run_odbc_ref_tests_windows.outcome == 'failure' && github.event_name == 'merge_group'
+      - name: Run flaky Old ODBC tests (Windows)
+        if: matrix.os == 'windows-latest'
+        continue-on-error: true
         shell: pwsh
-        run: ctest --rerun-failed -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
         env:
           DRIVER_PATH: C:\Program Files\Snowflake ODBC Driver\Bin\SnowflakeDSII.dll
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -711,19 +711,19 @@ jobs:
 
       - name: Build and run ODBC tests (Unix)
         if: runner.os != 'Windows'
-        id: run_odbc_tests_unix
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
         run: |
           ls -l target/debug/
           export DRIVER_PATH=$(pwd)/target/debug/${{ matrix.driver_lib }}
           export PARAMETER_PATH=$(pwd)/parameters.json
           export DRIVER_TYPE=NEW
           export QUERY_RESULT_FORMAT=${{ matrix.result_format == 'json' && 'JSON' || '' }}
-          ./scripts/odbc/run_tests_unix.sh
+          REPEAT_ARGS=${{ github.event_name == 'merge_group' && '"--repeat until-pass:2"' || '' }}
+          ./scripts/odbc/run_tests_unix.sh -LE flaky $REPEAT_ARGS
 
-      - name: Rerun failed ODBC tests (Unix)
-        if: steps.run_odbc_tests_unix.outcome == 'failure' && github.event_name == 'merge_group'
-        run: ctest --rerun-failed -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+      - name: Run flaky ODBC tests (Unix)
+        if: runner.os != 'Windows'
+        continue-on-error: true
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
         env:
           DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
@@ -732,8 +732,6 @@ jobs:
 
       - name: Build and run ODBC tests (Windows)
         if: runner.os == 'Windows'
-        id: run_odbc_tests_windows
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: pwsh
         run: |
           dir target\debug\
@@ -741,12 +739,14 @@ jobs:
           $env:PARAMETER_PATH = "$PWD\parameters.json"
           $env:DRIVER_TYPE = "NEW"
           $env:QUERY_RESULT_FORMAT = "${{ matrix.result_format == 'json' && 'JSON' || '' }}"
-          .\scripts\odbc\run_tests_windows.ps1
+          $repeatArgs = if ("${{ github.event_name }}" -eq "merge_group") { @("--repeat", "until-pass:2") } else { @() }
+          .\scripts\odbc\run_tests_windows.ps1 -LE flaky @repeatArgs
 
-      - name: Rerun failed ODBC tests (Windows)
-        if: steps.run_odbc_tests_windows.outcome == 'failure' && github.event_name == 'merge_group'
+      - name: Run flaky ODBC tests (Windows)
+        if: runner.os == 'Windows'
+        continue-on-error: true
         shell: pwsh
-        run: ctest --rerun-failed -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
         env:
           DRIVER_PATH: ${{ github.workspace }}\target\debug\${{ matrix.driver_lib }}
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json

--- a/odbc_tests/CMakeLists.txt
+++ b/odbc_tests/CMakeLists.txt
@@ -53,7 +53,7 @@ function(add_odbc_test name)
     target_link_libraries(${name} PRIVATE ${CMAKE_DL_LIBS})
   endif()
   target_include_directories(${name} PRIVATE ${picojson_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/../odbc/include)
-  catch_discover_tests(${name} TEST_PREFIX "${name}: ")
+  catch_discover_tests(${name} TEST_PREFIX "${name}: " ADD_TAGS_AS_LABELS)
 endfunction()
 
 add_subdirectory(tests)

--- a/odbc_tests/tests/basic_tests/CMakeLists.txt
+++ b/odbc_tests/tests/basic_tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 4.0)
 
-add_odbc_test(basic_tests test.cpp)
+add_odbc_test(basic_tests test.cpp flaky_test.cpp)

--- a/odbc_tests/tests/basic_tests/flaky_test.cpp
+++ b/odbc_tests/tests/basic_tests/flaky_test.cpp
@@ -1,0 +1,10 @@
+#include <random>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Flaky test example - intentionally unreliable", "[odbc][flaky]") {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::bernoulli_distribution coin(0.5);
+  REQUIRE(coin(gen));
+}


### PR DESCRIPTION
## Summary

- Adds `ADD_TAGS_AS_LABELS` to `catch_discover_tests()` so Catch2 tags become CTest labels
- Main CI step excludes `[flaky]`-labeled tests via `-LE flaky`
- New non-blocking CI step runs only flaky tests via `ctest -L flaky` with `continue-on-error: true`
- In merge queue, non-flaky tests retry with `--repeat until-pass:2`
- Includes a mock flaky test (`flaky_test.cpp`) that fails ~50% of the time to validate the infrastructure

## How to mark a test as flaky

```cpp
TEST_CASE("some test", "[query][e2e][flaky]") { ... }
```

The `[flaky]` tag becomes a CTest label via `ADD_TAGS_AS_LABELS`. The main CI step uses `-LE flaky` to exclude it, and the flaky step uses `ctest -L flaky` to run only flaky tests.

## Test plan

- [x] Verify `ADD_TAGS_AS_LABELS` correctly exposes `[flaky]` as a CTest label (`ctest --print-labels`)
- [x] Verify main CI step excludes the mock flaky test
- [ ] Verify flaky CI step runs only the mock flaky test and doesn't block the build
- [ ] Verify `--repeat until-pass:2` retries in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)