### PR TITLE
ci: extract setup-msvc composite action; fix Windows x86 test on windows-2025-vs2026

### DIFF
--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -1,0 +1,93 @@
+name: Setup MSVC
+description: >
+  Locate Visual Studio via vswhere, source vcvarsall.bat for the requested
+  target architecture, and propagate the resulting environment to subsequent
+  steps. Fails fast if the toolchain isn't actually on PATH afterwards.
+
+  This exists because hard-coding e.g.
+  `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`
+  silently breaks whenever GitHub rolls out a new runner image with a different
+  VS major version (e.g. the windows-2025 -> windows-2025-vs2026 migration that
+  shipped only VS 2026). `cmd`'s `call` to a missing .bat does NOT fail, which
+  produces a cryptic `'dumpbin' is not recognized` error after a successful
+  Rust-auto-detected build instead of failing fast.
+
+inputs:
+  arch:
+    description: >
+      Architecture argument passed to vcvarsall.bat. Examples: x86, x64, amd64,
+      arm64, x86_arm64, amd64_arm64. The action verifies that
+      VSCMD_ARG_TGT_ARCH ends up matching the target portion of this value.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Locate MSVC and source vcvarsall.bat
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $arch = "${{ inputs.arch }}"
+
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) {
+          throw "vswhere.exe not found at $vswhere"
+        }
+
+        $installPath = & $vswhere -latest -property installationPath
+        if (-not $installPath) {
+          throw "vswhere could not locate a Visual Studio installation"
+        }
+
+        $vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvarsall.bat"
+        if (-not (Test-Path $vcvars)) {
+          throw "vcvarsall.bat not found at $vcvars"
+        }
+
+        # Capture vcvarsall output to a variable BEFORE inspecting $LASTEXITCODE.
+        # Piping `cmd /c ... | ForEach-Object` would succeed as a pipeline even if
+        # vcvarsall.bat itself failed, leaving later steps running without cl.exe
+        # or link.exe on PATH. See test-odbc.yml's Setup MSVC step for the same
+        # rationale.
+        $vcvarsOutput = cmd /c "`"$vcvars`" $arch && set" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "vcvarsall.bat output:"
+          $vcvarsOutput | ForEach-Object { Write-Host $_ }
+          throw "vcvarsall.bat $arch failed with exit code $LASTEXITCODE"
+        }
+
+        # Propagate every env var vcvarsall set to BOTH:
+        #   - $env:GITHUB_ENV     -> visible to subsequent steps in the job
+        #   - the current process -> so the post-condition checks below see
+        #                            the freshly-updated PATH (writes to
+        #                            GITHUB_ENV are buffered and only applied
+        #                            at step boundary).
+        $vcvarsOutput | ForEach-Object {
+          if ($_ -match '^([^=]+)=(.*)$') {
+            $name = $Matches[1]
+            $value = $Matches[2]
+            "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            [System.Environment]::SetEnvironmentVariable($name, $value, 'Process')
+          }
+        }
+
+        # vcvarsall.bat can exit 0 with a broken environment (missing components,
+        # wrong host arch). Verify the toolchain is actually usable so the next
+        # build step fails here with a clear message instead of producing a
+        # confusing missing-tool / linker error 3 minutes into the build.
+        foreach ($tool in @('cl.exe', 'link.exe', 'dumpbin.exe')) {
+          if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+            throw "MSVC environment setup completed but $tool is not on PATH (requested arch: $arch)"
+          }
+        }
+
+        # vcvarsall arch grammar is `[host_]target`: `x86`, `x64`, `arm64`,
+        # `amd64_arm64`, `x86_arm64`, etc. VSCMD_ARG_TGT_ARCH is set to the
+        # target portion using x64 (not amd64) terminology.
+        $expectedTgt = ($arch -split '_')[-1]
+        if ($expectedTgt -eq 'amd64') { $expectedTgt = 'x64' }
+        if ($env:VSCMD_ARG_TGT_ARCH -ne $expectedTgt) {
+          throw "VSCMD_ARG_TGT_ARCH is '$($env:VSCMD_ARG_TGT_ARCH)', expected '$expectedTgt' for arch '$arch'"
+        }
+
+        Write-Host "MSVC ready: VS at $installPath, target arch $env:VSCMD_ARG_TGT_ARCH"

--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -4,14 +4,6 @@ description: >
   target architecture, and propagate the resulting environment to subsequent
   steps. Fails fast if the toolchain isn't actually on PATH afterwards.
 
-  This exists because hard-coding e.g.
-  `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`
-  silently breaks whenever GitHub rolls out a new runner image with a different
-  VS major version (e.g. the windows-2025 -> windows-2025-vs2026 migration that
-  shipped only VS 2026). `cmd`'s `call` to a missing .bat does NOT fail, which
-  produces a cryptic `'dumpbin' is not recognized` error after a successful
-  Rust-auto-detected build instead of failing fast.
-
 inputs:
   arch:
     description: >

--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -47,8 +47,7 @@ runs:
         # Capture vcvarsall output to a variable BEFORE inspecting $LASTEXITCODE.
         # Piping `cmd /c ... | ForEach-Object` would succeed as a pipeline even if
         # vcvarsall.bat itself failed, leaving later steps running without cl.exe
-        # or link.exe on PATH. See test-odbc.yml's Setup MSVC step for the same
-        # rationale.
+        # or link.exe on PATH.
         $vcvarsOutput = cmd /c "`"$vcvars`" $arch && set" 2>&1
         if ($LASTEXITCODE -ne 0) {
           Write-Host "vcvarsall.bat output:"

--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -56,12 +56,6 @@ runs:
           throw "vcvarsall.bat $arch failed with exit code $LASTEXITCODE"
         }
 
-        # Propagate every env var vcvarsall set to BOTH:
-        #   - $env:GITHUB_ENV     -> visible to subsequent steps in the job
-        #   - the current process -> so the post-condition checks below see
-        #                            the freshly-updated PATH (writes to
-        #                            GITHUB_ENV are buffered and only applied
-        #                            at step boundary).
         $vcvarsOutput | ForEach-Object {
           if ($_ -match '^([^=]+)=(.*)$') {
             $name = $Matches[1]

--- a/.github/actions/setup-windows-openssl/action.yml
+++ b/.github/actions/setup-windows-openssl/action.yml
@@ -34,12 +34,16 @@ runs:
         path: C:\vcpkg\installed\${{ steps.triplet.outputs.value }}
         key: vcpkg-openssl-${{ steps.triplet.outputs.value }}-${{ env.VCPKG_VER }}
 
+    - name: Setup MSVC environment (ARM64, for vcpkg build)
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
+      uses: ./.github/actions/setup-msvc
+      with:
+        arch: arm64
+
     - name: Install OpenSSL via vcpkg (ARM64)
       if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
       shell: cmd
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-        vcpkg install openssl:${{ steps.triplet.outputs.value }}
+      run: vcpkg install openssl:${{ steps.triplet.outputs.value }}
 
     - name: Install OpenSSL via vcpkg (x86_64)
       if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'x86_64'

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -430,6 +430,11 @@ jobs:
         with:
           arch: arm64
 
+      - name: Setup MSVC environment (ARM64)
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: arm64
+
       # ── sf_core build ──
       - name: Restore Rust cache
         id: rust-cache
@@ -441,9 +446,7 @@ jobs:
 
       - name: Build sf_core
         shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
+        run: cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
 
       - name: Place sf_core in python package
         shell: pwsh
@@ -478,12 +481,12 @@ jobs:
         run: uv python install cpython-${{ matrix.py }}-windows-aarch64-none
 
       # ── Build ──
+      # MSVC env from the earlier setup-msvc step persists across steps via
+      # GITHUB_ENV, so no separate `call vcvarsall.bat` is needed here.
       - name: Build python wheel
         working-directory: ./python
         shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          uv run --python ${{ matrix.py }} --with hatch --with cython --with setuptools --with "virtualenv<21.0.0" hatch build
+        run: uv run --python ${{ matrix.py }} --with hatch --with cython --with setuptools --with "virtualenv<21.0.0" hatch build
 
       - name: Inspect wheel
         working-directory: ./python

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -317,20 +317,17 @@ jobs:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
+      - name: Setup MSVC environment (ARM64)
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: arm64
+
       - name: Build and test
         id: run_rust_tests_windows_arm64
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
-          :: Set up ARM64 MSVC environment
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          :: Guard: verify MSVC env targets ARM64
-          if not "%VSCMD_ARG_TGT_ARCH%"=="arm64" (
-            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'arm64'
-            exit /b 1
-          )
 
           cargo build --package sf_core --target aarch64-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
@@ -354,14 +351,8 @@ jobs:
         run: |
           :: Full re-setup (not just cargo test) so reruns work even if the first run failed
           :: before reaching cargo test (e.g., build failure, DLL copy missed). Matches the
-          :: first-run steps above.
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          :: first-run steps above. The MSVC env from setup-msvc above persists across steps.
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          if not "%VSCMD_ARG_TGT_ARCH%"=="arm64" (
-            echo ERROR: VSCMD_ARG_TGT_ARCH is '%VSCMD_ARG_TGT_ARCH%', expected 'arm64'
-            exit /b 1
-          )
 
           cargo build --package sf_core --target aarch64-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
@@ -413,12 +404,16 @@ jobs:
           path: C:\vcpkg\installed\arm64-windows-static-md
           key: windows-11-arm-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
+      - name: Setup MSVC environment (ARM64, for vcpkg static OpenSSL build)
+        if: always() && steps.vcpkg-static-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: arm64
+
       - name: Install ARM64 static OpenSSL via vcpkg (cache miss)
         if: always() && steps.vcpkg-static-cache.outputs.cache-hit != 'true'
         shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
-          vcpkg install openssl:arm64-windows-static-md
+        run: vcpkg install openssl:arm64-windows-static-md
 
       - name: Save vcpkg ARM64 static OpenSSL cache (cache miss)
         if: always() && steps.vcpkg-static-cache.outputs.cache-hit != 'true'
@@ -486,43 +481,17 @@ jobs:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
-      # Locate vcvarsall.bat dynamically via vswhere instead of hard-coding the
-      # VS 2022 path. The `windows-latest` image is being migrated from
-      # `windows-2025` to `windows-2025-vs2026` (rollout completing 2026-05-12),
-      # which only ships VS 2026, so the old hard-coded VS 2022 path silently
-      # disappears. `call` to a missing .bat does NOT fail in cmd, which is why
-      # the previous version produced an empty MSVC env and a confusing
-      # `'dumpbin' is not recognized` error rather than failing fast.
-      - name: Locate MSVC (vswhere)
-        id: vswhere
-        shell: cmd
-        run: |
-          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VS_INSTALL=%%i"
-          if not defined VS_INSTALL (
-            echo ERROR: vswhere could not locate a Visual Studio installation
-            exit /b 1
-          )
-          if not exist "%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat" (
-            echo ERROR: vcvarsall.bat not found at "%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat"
-            exit /b 1
-          )
-          echo VCVARSALL=%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat>> %GITHUB_ENV%
+      - name: Setup MSVC environment (x86)
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: x86
 
       - name: Build and test
         id: run_rust_tests_x86
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
-          call "%VCVARSALL%" x86
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          :: Guard: vcvarsall.bat can succeed silently with a broken env, so
-          :: confirm the toolchain is actually on PATH before relying on it.
-          where dumpbin >nul 2>&1
-          if %ERRORLEVEL% neq 0 (
-            echo ERROR: dumpbin not on PATH after vcvarsall.bat x86
-            exit /b 1
-          )
 
           cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
@@ -541,7 +510,6 @@ jobs:
         if: steps.run_rust_tests_x86.outcome == 'failure' && github.event_name == 'merge_group'
         shell: cmd
         run: |
-          call "%VCVARSALL%" x86
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
 

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -486,13 +486,43 @@ jobs:
           PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
         shell: bash
 
+      # Locate vcvarsall.bat dynamically via vswhere instead of hard-coding the
+      # VS 2022 path. The `windows-latest` image is being migrated from
+      # `windows-2025` to `windows-2025-vs2026` (rollout completing 2026-05-12),
+      # which only ships VS 2026, so the old hard-coded VS 2022 path silently
+      # disappears. `call` to a missing .bat does NOT fail in cmd, which is why
+      # the previous version produced an empty MSVC env and a confusing
+      # `'dumpbin' is not recognized` error rather than failing fast.
+      - name: Locate MSVC (vswhere)
+        id: vswhere
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VS_INSTALL=%%i"
+          if not defined VS_INSTALL (
+            echo ERROR: vswhere could not locate a Visual Studio installation
+            exit /b 1
+          )
+          if not exist "%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat" (
+            echo ERROR: vcvarsall.bat not found at "%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat"
+            exit /b 1
+          )
+          echo VCVARSALL=%VS_INSTALL%\VC\Auxiliary\Build\vcvarsall.bat>> %GITHUB_ENV%
+
       - name: Build and test
         id: run_rust_tests_x86
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          call "%VCVARSALL%" x86
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+
+          :: Guard: vcvarsall.bat can succeed silently with a broken env, so
+          :: confirm the toolchain is actually on PATH before relying on it.
+          where dumpbin >nul 2>&1
+          if %ERRORLEVEL% neq 0 (
+            echo ERROR: dumpbin not on PATH after vcvarsall.bat x86
+            exit /b 1
+          )
 
           cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
@@ -511,7 +541,7 @@ jobs:
         if: steps.run_rust_tests_x86.outcome == 'failure' && github.event_name == 'merge_group'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          call "%VCVARSALL%" x86
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
 


### PR DESCRIPTION
## Why

`test (Windows x86)` (in `test-rust-core.yml`) has been failing on every PR and on `main` since **2026-05-05 ~12:30 UTC** with:

```
'dumpbin' is not recognized as an internal or external command,
operable program or batch file.
##[error]Process completed with exit code 255.
```

The job hard-coded the path to VS 2022's `vcvarsall.bat`. GitHub started redirecting `windows-latest` (`windows-2025`) to `windows-2025-vs2026` on 2026-05-05 (rollout completes 2026-05-12); that image only ships VS 2026, so the hard-coded path silently disappears. `cmd`'s `call` to a missing `.bat` does **not** fail, so the job continues with an empty MSVC environment. `cargo build` still succeeds (Rust auto-detects MSVC via the registry), then `dumpbin` blows up because the toolchain isn't on `PATH`.

The Windows x86 job and the `dumpbin` check were introduced in #987 (commit 2a741ec, 2026-05-04). The job was green for ~24 hours before GitHub's runner rollout broke it.

## What changed

A code review of the initial fix flagged that:

1. The same hard-coded `vcvarsall.bat` path appeared in **five** other places across the repo, all carrying the same time bomb (they only stay green because `windows-11-arm` hasn't been migrated yet).
2. The repo already has a more thorough MSVC setup pattern in `test-odbc.yml`, but it was a one-off pwsh blob — there was no shared building block.

This PR consolidates everything into a single composite action.

### New: `./.github/actions/setup-msvc`

Reusable composite action with input `arch` (e.g. `x86`, `x64`, `arm64`, `amd64_arm64`). It:

- Locates Visual Studio dynamically via `vswhere -latest -property installationPath` — works across VS major versions, no hard-coded paths.
- Sources `vcvarsall.bat`, captures its output to a variable, and inspects `$LASTEXITCODE` **before** the pipeline resets it (a piped `cmd /c ... | ForEach-Object` would mask a real failure).
- Propagates every env var `vcvarsall` set to **both** `$GITHUB_ENV` (visible to subsequent steps in the job) **and** the current PowerShell process (so the in-step post-condition checks see the freshly-updated `PATH`).
- Verifies `cl.exe`, `link.exe`, and `dumpbin.exe` are all on `PATH`, and that `VSCMD_ARG_TGT_ARCH` matches the requested target (handles cross-compile syntax like `amd64_arm64`).
- Fails fast with a clear, named error if any precondition isn't met. `vcvarsall.bat` can exit 0 with a broken environment (missing components, wrong host arch); without these checks the next build step fails several minutes later with a confusing missing-tool / linker error.

### Call sites migrated

All five hard-coded `Microsoft Visual Studio\2022\Enterprise\...\vcvarsall.bat` paths in the repo are now gone:

| File | Step | Before | After |
|---|---|---|---|
| `test-rust-core.yml` | `test_windows_x86` → Build and test | inline `call "...vcvarsall.bat" x86` | `uses: ./.github/actions/setup-msvc` (`arch: x86`) |
| `test-rust-core.yml` | `test_windows_x86` → Rerun tests | inline `call ...` | env from prior step (`$GITHUB_ENV` persists) |
| `test-rust-core.yml` | `test_windows_arm64_nonfips` → Build and test | inline `call "...vcvarsall.bat" arm64` | `uses: ./.github/actions/setup-msvc` (`arch: arm64`) |
| `test-rust-core.yml` | `test_windows_arm64_nonfips` → Rerun tests | inline `call ...` | env from prior step |
| `test-rust-core.yml` | `test_windows_arm64_nonfips` → Install ARM64 static OpenSSL | inline `call ...` | `uses: ./.github/actions/setup-msvc` (cache-miss-only) |
| `_build-python-wheels.yml` | `build_wheel` (Windows ARM64) → Build sf_core | inline `call ...` | `uses: ./.github/actions/setup-msvc` (`arch: arm64`) |
| `_build-python-wheels.yml` | `build_wheel` (Windows ARM64) → Build python wheel | inline `call ...` | env from prior step |
| `setup-windows-openssl/action.yml` | `Install OpenSSL via vcpkg (ARM64)` | inline `call ...` | `uses: ./.github/actions/setup-msvc` (cache-miss-only) |

The redundant per-step inline guards (`if not "%VSCMD_ARG_TGT_ARCH%"=="arm64"`, `where dumpbin >nul`) are dropped — the composite action enforces them once, centrally, for all consumers.

### Net effect on `test-rust-core.yml`

`66 lines removed, 33 lines added` for the workflow itself; `+93 / -0` for the new composite action. Each Windows job is now significantly smaller and reads as: setup MSVC → build → assert arch → test.

## Out of scope (intentional)

- **`test-odbc.yml`**'s `Setup MSVC environment (Windows)` step does the same vswhere dance plus ODBC-specific CMake-PATH re-prepending. Consolidating it onto the new action is a separate refactor and would expand the blast radius of this PR. Filed as a TODO follow-up.

## Why the cleanup matters even though only x86 is currently broken

The four non-x86 sites only stay green today because `windows-11-arm` hasn't yet had a similar VS-version refresh. Same trigger, same silent-`call`-no-op failure mode. Fixing them now removes the time bomb and cuts code duplication in the same change.

## Test plan

- [x] `test (Windows x86)` is green on this PR (the breakage being fixed).
- [ ] `test (Windows ARM64, non-FIPS)` remains green (now driven through the new action).
- [ ] Python ARM64 wheel build (`_build-python-wheels.yml::build_wheel` on `windows-11-arm`) remains green (now driven through the new action; only triggered when wheel-building paths run).
- [ ] `setup-windows-openssl` ARM64 path (cache-miss-only, exercised on cold runners) remains green.