### PR TITLE
NO-SNOW: introduce ResultSet handle with lazy stream construction

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
@@ -36,7 +36,7 @@ import net.snowflake.client.internal.core.arrow.cursor.ArrowBatchManager;
 import net.snowflake.client.internal.core.arrow.cursor.ArrowResources;
 import net.snowflake.client.internal.core.arrow.cursor.CursorState;
 import net.snowflake.client.internal.core.arrow.cursor.SchemaState;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
 import net.snowflake.client.internal.util.NotImplementedException;
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
@@ -54,7 +54,7 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
   private int fetchSize = 0;
   private int fetchDirection = FETCH_FORWARD;
 
-  public SnowflakeResultSetImpl(SnowflakeStatementImpl statement, ResultSetResponse result)
+  public SnowflakeResultSetImpl(SnowflakeStatementImpl statement, ResultSetGetStreamResponse result)
       throws SQLException {
     this.statement = statement;
     ByteString streamPointerBytes = result.getStream().getValue();

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -21,13 +21,17 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetResultSetRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementGetResultSetRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsRequest;
@@ -129,17 +133,47 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     }
   }
 
-  private ResultSetResponse fetchResultSet(String queryId) throws SQLException {
-    StatementGetResultSetRequest request =
-        StatementGetResultSetRequest.newBuilder()
-            .setStmtHandle(statementHandle)
+  private ResultSetResponse fetchResultSetByQueryId(String queryId) throws SQLException {
+    ConnectionGetResultSetRequest request =
+        ConnectionGetResultSetRequest.newBuilder()
+            .setConnHandle(connection.connectionHandle)
             .setQueryId(queryId)
             .build();
     try {
-      return ProtobufApis.databaseDriverV1.statementGetResultSet(request);
+      return ProtobufApis.databaseDriverV1.connectionGetResultSet(request);
     } catch (DatabaseDriverService.ServiceException e) {
       throw SnowflakeSQLException.fromServiceException(
           "Failed to fetch result set for query ID: " + queryId, e);
+    }
+  }
+
+  /**
+   * Fetch the Arrow stream and release the ResultSet handle.
+   *
+   * <p>{@code resultSetGetStream} takes ownership of the prebuilt stream (one-shot), so the handle
+   * is released immediately after.
+   */
+  private ResultSetGetStreamResponse fetchStreamAndRelease(ResultSetHandle handle)
+      throws SQLException {
+    ResultSetGetStreamRequest request =
+        ResultSetGetStreamRequest.newBuilder().setResultSetHandle(handle).build();
+    try {
+      ResultSetGetStreamResponse response =
+          ProtobufApis.databaseDriverV1.resultSetGetStream(request);
+      releaseResultSet(handle);
+      return response;
+    } catch (DatabaseDriverService.ServiceException e) {
+      releaseResultSet(handle);
+      throw SnowflakeSQLException.fromServiceException("Failed to fetch Arrow stream", e);
+    }
+  }
+
+  private void releaseResultSet(ResultSetHandle handle) {
+    try {
+      ProtobufApis.databaseDriverV1.resultSetRelease(
+          ResultSetReleaseRequest.newBuilder().setResultSetHandle(handle).build());
+    } catch (DatabaseDriverService.ServiceException e) {
+      logger.warn("Failed to release ResultSet handle", e);
     }
   }
 
@@ -148,22 +182,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
       applyMultiStatementResult(response.getMulti());
       return;
     }
-    ResultSetDescriptor descriptor = response.getSingle();
-    queryId = descriptor.getQueryId();
-    if (StatementTypeClassifier.producesResultSet(descriptor)) {
-      applyResultSetFromDescriptor(descriptor);
-      return;
-    }
-    // DML/DDL that returned via executeQuery() — still surface a ResultSet if the server
-    // provides a stream (matches old JDBC driver behavior)
-    ResultSetResponse resultSetResponse = fetchResultSet(descriptor.getQueryId());
-    if (resultSetResponse.hasStream() && !resultSetResponse.getStream().getValue().isEmpty()) {
-      currentResultSet = new SnowflakeResultSetImpl(this, resultSetResponse);
-      currentUpdateCount = NO_UPDATE_COUNT;
-      return;
-    }
-    currentResultSet = null;
-    currentUpdateCount = NO_UPDATE_COUNT;
+    applySingleResult(response.getSingle(), true);
   }
 
   private boolean updateExecutionStateAndReturnHasResultSet(ExecuteQueryResponse response)
@@ -172,11 +191,40 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
       applyMultiStatementResult(response.getMulti());
       return currentResultSet != null;
     }
-    ResultSetDescriptor descriptor = response.getSingle();
+    return applySingleResult(response.getSingle(), false);
+  }
+
+  /**
+   * Apply a single-statement result: set queryId, fetch stream, update
+   * currentResultSet/updateCount.
+   *
+   * @param forceResultSet when true (executeQuery path), surface a ResultSet even for DML/DDL if
+   *     the server provides a non-empty stream.
+   * @return true if the result produced a ResultSet.
+   */
+  private boolean applySingleResult(ResultSetResponse rsResponse, boolean forceResultSet)
+      throws SQLException {
+    ResultSetDescriptor descriptor = rsResponse.getResultDescriptor();
     queryId = descriptor.getQueryId();
+
     if (StatementTypeClassifier.producesResultSet(descriptor)) {
-      applyResultSetFromDescriptor(descriptor);
+      ResultSetGetStreamResponse streamResponse =
+          fetchStreamAndRelease(rsResponse.getResultSetHandle());
+      currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
+      currentUpdateCount = NO_UPDATE_COUNT;
       return true;
+    }
+
+    if (forceResultSet) {
+      // DML/DDL that returned via executeQuery() — still surface a ResultSet if the server
+      // provides a stream (matches old JDBC driver behavior)
+      ResultSetGetStreamResponse streamResponse =
+          fetchStreamAndRelease(rsResponse.getResultSetHandle());
+      if (streamResponse.hasStream() && !streamResponse.getStream().getValue().isEmpty()) {
+        currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
+        currentUpdateCount = NO_UPDATE_COUNT;
+        return true;
+      }
     }
 
     currentResultSet = null;
@@ -199,8 +247,8 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   private void applyChildResult(int index) throws SQLException {
     String childQueryId = childQueryIds.get(index);
-    ResultSetResponse resultSetResponse = fetchResultSet(childQueryId);
-    ResultSetDescriptor descriptor = resultSetResponse.getResultDescriptor();
+    ResultSetResponse rsResponse = fetchResultSetByQueryId(childQueryId);
+    ResultSetDescriptor descriptor = rsResponse.getResultDescriptor();
 
     // Use statement type from the initial multi-statement response if available,
     // otherwise fall back to the descriptor from the fetched result set.
@@ -213,18 +261,14 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     }
 
     if (producesResultSet) {
-      currentResultSet = new SnowflakeResultSetImpl(this, resultSetResponse);
+      ResultSetGetStreamResponse streamResponse =
+          fetchStreamAndRelease(rsResponse.getResultSetHandle());
+      currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
       currentUpdateCount = NO_UPDATE_COUNT;
     } else {
       currentResultSet = null;
       currentUpdateCount = StatementTypeClassifier.getUpdateCount(descriptor);
     }
-  }
-
-  private void applyResultSetFromDescriptor(ResultSetDescriptor descriptor) throws SQLException {
-    ResultSetResponse resultSetResponse = fetchResultSet(descriptor.getQueryId());
-    currentResultSet = new SnowflakeResultSetImpl(this, resultSetResponse);
-    currentUpdateCount = NO_UPDATE_COUNT;
   }
 
   private void resetExecutionState() {

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -25,9 +25,9 @@ use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use odbc_sys as sql;
 use sf_core::protobuf::generated::database_driver_v1::{
     ArrowArrayStreamPtr, BinaryDataPtr, ConfigSetting, ConnectionGetParameterRequest,
-    ConnectionHandle, ExecuteQueryResponse, QueryBindings, ResultSetResponse,
-    StatementExecuteQueryRequest, StatementGetResultSetRequest,
-    StatementHandle as StatementHandleProto, StatementPrepareRequest, StatementSetOptionsRequest,
+    ConnectionGetResultSetRequest, ConnectionHandle, ExecuteQueryResponse, QueryBindings,
+    ResultSetGetStreamRequest, ResultSetHandle, ResultSetReleaseRequest, ResultSetResponse,
+    StatementExecuteQueryRequest, StatementPrepareRequest, StatementSetOptionsRequest,
     StatementSetSqlQueryRequest, config_setting, execute_query_response, query_bindings,
 };
 use snafu::ResultExt;
@@ -179,7 +179,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     };
 
     update_numeric_settings(&conn_handle, &mut conn.numeric_settings)?;
-    apply_execute_response(&mut inner, stmt_handle, response, ExecutionOrigin::Direct)?;
+    apply_execute_response(&mut inner, conn_handle, response, ExecutionOrigin::Direct)?;
     inner.rows_returned = 0;
     // Clear any SQL text cached by a prior SQLPrepare so a subsequent
     // SQLExecute cannot inject LIMIT into stale prepared SQL.
@@ -635,7 +635,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     let mut settings = dbc.connection.lock().numeric_settings;
     update_numeric_settings(&conn_handle, &mut settings)?;
     dbc.connection.lock().numeric_settings = settings;
-    apply_execute_response(&mut inner, stmt_handle, response, origin)?;
+    apply_execute_response(&mut inner, conn_handle, response, origin)?;
     inner.rows_returned = 0;
     inner.last_sent_max_rows = Some(max_rows);
     Ok(())
@@ -656,13 +656,13 @@ fn set_state(stmt: &mut StatementInner, state: StatementState) {
 
 /// Process an `ExecuteQueryResponse` and apply the resulting state to the statement.
 ///
-/// For Single results: fetches the Arrow stream via `StatementGetResultSet`, then
-/// creates the appropriate state (DDL/DML/Query).
+/// For Single results: uses the returned ResultSetHandle to fetch the Arrow stream,
+/// then creates the appropriate state (DDL/DML/Query).
 /// For Multi results: stores child query IDs, fetches the first child result set,
 /// and sets up state for `SQLMoreResults` iteration.
 fn apply_execute_response(
     stmt: &mut StatementInner,
-    stmt_handle: sf_core::protobuf::generated::database_driver_v1::StatementHandle,
+    conn_handle: ConnectionHandle,
     response: ExecuteQueryResponse,
     origin: ExecutionOrigin,
 ) -> OdbcResult<()> {
@@ -673,11 +673,17 @@ fn apply_execute_response(
     stmt.multi_current_idx = 0;
 
     match result {
-        execute_query_response::Result::Single(descriptor) => {
+        execute_query_response::Result::Single(rs_response) => {
+            let descriptor = rs_response
+                .result_descriptor
+                .required("Descriptor is required")?;
+            let rs_handle = rs_response
+                .result_set_handle
+                .required("ResultSet handle is required")?;
             let query_id = descriptor.query_id.clone();
-            let rs = fetch_result_set(stmt_handle, &query_id)?;
-            let execute_state = create_execute_state_from_result_set(
-                rs,
+            let stream = fetch_stream_and_release(rs_handle)?;
+            let execute_state = create_execute_state_from_stream(
+                stream,
                 descriptor.statement_type_id,
                 descriptor.rows_affected,
                 origin,
@@ -719,14 +725,16 @@ fn apply_execute_response(
 
             // Fetch and apply the first child result set.
             let first_id = &stmt.multi_query_ids[0];
-            let rs = fetch_result_set(stmt_handle, first_id)?;
-            let statement_type_id = rs
-                .result_descriptor
-                .as_ref()
-                .and_then(|d| d.statement_type_id);
-            let rows_affected = rs.result_descriptor.as_ref().and_then(|d| d.rows_affected);
+            let rs = fetch_result_set_by_query_id(conn_handle, first_id)?;
+            let descriptor = rs.result_descriptor.as_ref();
+            let statement_type_id = descriptor.and_then(|d| d.statement_type_id);
+            let rows_affected = descriptor.and_then(|d| d.rows_affected);
+            let rs_handle = rs
+                .result_set_handle
+                .required("ResultSet handle is required")?;
+            let stream = fetch_stream_and_release(rs_handle)?;
             let execute_state =
-                create_execute_state_from_result_set(rs, statement_type_id, rows_affected, origin)?;
+                create_execute_state_from_stream(stream, statement_type_id, rows_affected, origin)?;
             stmt.multi_current_idx = 1;
             set_state(stmt, execute_state);
             Ok(())
@@ -734,14 +742,14 @@ fn apply_execute_response(
     }
 }
 
-/// Fetch a result set (descriptor + Arrow stream) for a given query ID.
-fn fetch_result_set(
-    stmt_handle: StatementHandleProto,
+/// Fetch a ResultSetResponse (handle + descriptor) for a given query ID via the connection.
+fn fetch_result_set_by_query_id(
+    conn_handle: ConnectionHandle,
     query_id: &str,
 ) -> OdbcResult<ResultSetResponse> {
     let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.statement_get_result_set(StatementGetResultSetRequest {
-            stmt_handle: Some(stmt_handle),
+        c.connection_get_result_set(ConnectionGetResultSetRequest {
+            conn_handle: Some(conn_handle),
             query_id: query_id.to_string(),
         })
         .await
@@ -749,13 +757,41 @@ fn fetch_result_set(
     Ok(response)
 }
 
-fn create_execute_state_from_result_set(
-    rs: ResultSetResponse,
+/// Fetch the Arrow stream from a ResultSet handle and release the handle.
+///
+/// `result_set_get_stream` takes ownership of the prebuilt stream (one-shot),
+/// so the handle is no longer useful after this call.
+fn fetch_stream_and_release(rs_handle: ResultSetHandle) -> OdbcResult<ArrowArrayStreamPtr> {
+    let stream = {
+        let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            c.result_set_get_stream(ResultSetGetStreamRequest {
+                result_set_handle: Some(rs_handle),
+            })
+            .await
+        })?;
+        response.stream.required("Stream is required")?
+    };
+    release_result_set(rs_handle);
+    Ok(stream)
+}
+
+fn release_result_set(rs_handle: ResultSetHandle) {
+    if let Ok(rt) = global() {
+        let _ = rt.block_on(async |c| {
+            c.result_set_release(ResultSetReleaseRequest {
+                result_set_handle: Some(rs_handle),
+            })
+            .await
+        });
+    }
+}
+
+fn create_execute_state_from_stream(
+    stream: ArrowArrayStreamPtr,
     statement_type_id: Option<i64>,
     rows_affected: Option<i64>,
     origin: ExecutionOrigin,
 ) -> OdbcResult<StatementState> {
-    let stream = rs.stream.required("Stream is required")?;
     let reader = reader_from_protobuf_stream(stream)?;
     let schema = reader.schema();
 
@@ -2060,15 +2096,24 @@ pub fn more_results(statement_handle: sql::Handle) -> OdbcResult<()> {
     let query_id = inner.multi_query_ids[inner.multi_current_idx].clone();
     inner.multi_current_idx += 1;
 
-    let stmt_handle = guard.stmt_handle;
-    let rs = fetch_result_set(stmt_handle, &query_id)?;
-    let statement_type_id = rs
-        .result_descriptor
-        .as_ref()
-        .and_then(|d| d.statement_type_id);
-    let rows_affected = rs.result_descriptor.as_ref().and_then(|d| d.rows_affected);
+    let dbc = guard.conn()?;
+    let conn = dbc.connection.lock();
+    let conn_handle = match &conn.state {
+        ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+        ConnectionState::Disconnected => return DisconnectedSnafu.fail(),
+    };
+    drop(conn);
+
+    let rs = fetch_result_set_by_query_id(conn_handle, &query_id)?;
+    let descriptor = rs.result_descriptor.as_ref();
+    let statement_type_id = descriptor.and_then(|d| d.statement_type_id);
+    let rows_affected = descriptor.and_then(|d| d.rows_affected);
+    let rs_handle = rs
+        .result_set_handle
+        .required("ResultSet handle is required")?;
+    let stream = fetch_stream_and_release(rs_handle)?;
     let execute_state =
-        create_execute_state_from_result_set(rs, statement_type_id, rows_affected, origin)?;
+        create_execute_state_from_stream(stream, statement_type_id, rows_affected, origin)?;
     set_state(&mut inner, execute_state);
     Ok(())
 }

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -150,8 +150,6 @@ message QueryStats {
 }
 
 // Describes one result set from a (possibly multi-statement) execution.
-// For single statements, returned inline in the execute response.
-// For multi-statement children, fetched lazily via StatementGetResultSet.
 message ResultSetDescriptor {
   string query_id = 1;
   repeated ColumnMetadata columns = 2;
@@ -159,6 +157,11 @@ message ResultSetDescriptor {
   optional int64 statement_type_id = 4;
   optional string sql_state = 5;
   optional QueryStats stats = 6;
+}
+
+message ResultSetResponse {
+  ResultSetHandle result_set_handle = 1;
+  ResultSetDescriptor result_descriptor = 2;
 }
 
 // Multi-statement execution: child query IDs and their statement types.
@@ -191,6 +194,12 @@ message ConnectionHandle {
 
 // Statement handle
 message StatementHandle {
+  int64 id = 1;
+  int64 magic = 2;
+}
+
+// ResultSet handle
+message ResultSetHandle {
   int64 id = 1;
   int64 magic = 2;
 }
@@ -470,11 +479,6 @@ message ConnectionGetQueryResultRequest {
   string query_id = 2;
 }
 
-message ResultSetResponse {
-  ResultSetDescriptor result_descriptor = 1;
-  ArrowArrayStreamPtr stream = 2;
-}
-
 message ConnectionGetResultSetRequest {
   ConnectionHandle conn_handle = 1;
   string query_id = 2;
@@ -557,18 +561,11 @@ message StatementExecuteQueryRequest {
 
 message ExecuteQueryResponse {
   oneof result {
-    // Single statement — metadata available immediately.
-    ResultSetDescriptor single = 1;
+    // Single statement — descriptor + result_set_handle for stream/chunks access.
+    ResultSetResponse single = 1;
     // Multi-statement — child query IDs only, fetch metadata lazily.
     MultiStatementResult multi = 2;
   }
-}
-
-// Fetch a result set by query_id: returns metadata + Arrow stream.
-// For multi-statement children, this triggers a lazy fetch in sf_core.
-message StatementGetResultSetRequest {
-  StatementHandle stmt_handle = 1;
-  string query_id = 2;
 }
 
 // Async query execution: submit and return immediately with query_id
@@ -626,45 +623,43 @@ message ResultChunk {
   int32 row_count = 4;
 }
 
-message ResultChunksResult {
-  repeated ResultChunk chunks = 1;
-  // Result column metadata. Required for CHUNK_FORMAT_JSON (forward verbatim on DatabaseFetchChunkRequest); ignored for CHUNK_FORMAT_ARROW_IPC.
-  repeated ColumnMetadata columns = 2;
-}
-
-// Fetch raw result chunks for a query executed on this statement.
-// query_id identifies which query's chunks to return; for single-statement
-// executions this is the query_id from ExecuteQueryResponse, for
-// multi-statement children it is one of the query_ids from MultiStatementResult.
-message StatementResultChunksRequest {
-  StatementHandle stmt_handle = 1;
-  string query_id = 2;
-}
-
-message StatementResultChunksResponse {
-  ResultChunksResult result = 1;
-}
-
-// Fetch raw result chunks by query_id using the connection (no statement handle required).
-// Useful for multi-statement children after the batch statement handle has been released.
-message ConnectionResultChunksRequest {
-  ConnectionHandle conn_handle = 1;
-  string query_id = 2;
-}
-
-message ConnectionResultChunksResponse {
-  ResultChunksResult result = 1;
-}
 
 message DatabaseFetchChunkRequest {
   DatabaseHandle db_handle = 1;
   ResultChunk chunk = 2;
-  // Required when chunk.format == CHUNK_FORMAT_JSON (forward verbatim from ResultChunksResult.columns); ignored for CHUNK_FORMAT_ARROW_IPC.
+  // Required when chunk.format == CHUNK_FORMAT_JSON (forward from ResultSetGetChunksResponse.columns); ignored for CHUNK_FORMAT_ARROW_IPC.
   repeated ColumnMetadata columns = 3;
 }
 
 message DatabaseFetchChunkResponse {
   ArrowArrayStreamPtr stream = 1;
+}
+
+// ResultSet RPCs
+
+message ResultSetGetStreamRequest {
+  ResultSetHandle result_set_handle = 1;
+}
+
+message ResultSetGetStreamResponse {
+  ArrowArrayStreamPtr stream = 1;
+}
+
+message ResultSetGetChunksRequest {
+  ResultSetHandle result_set_handle = 1;
+}
+
+message ResultSetGetChunksResponse {
+  repeated ResultChunk chunks = 1;
+  // Column metadata. Required for CHUNK_FORMAT_JSON (forward on DatabaseFetchChunkRequest); ignored for CHUNK_FORMAT_ARROW_IPC.
+  repeated ColumnMetadata columns = 2;
+}
+
+message ResultSetReleaseRequest {
+  ResultSetHandle result_set_handle = 1;
+}
+
+message ResultSetReleaseResponse {
 }
 
 // Validation issue reported during set or validate operations.
@@ -831,6 +826,7 @@ service DatabaseDriver {
   rpc ConnectionRequestToken(ConnectionTokenRequest) returns (ConnectionTokenResponse);
   // Heartbeat to validate connection and session are still alive
   rpc ConnectionHeartbeat(ConnectionHeartbeatRequest) returns (ConnectionHeartbeatResponse);
+
   // Statement operations
   rpc StatementNew(StatementNewRequest) returns (StatementNewResponse);
   rpc StatementRelease(StatementReleaseRequest) returns (StatementReleaseResponse);
@@ -840,12 +836,14 @@ service DatabaseDriver {
   rpc StatementSetOptions(StatementSetOptionsRequest) returns (StatementSetOptionsResponse);
   rpc StatementGetParameterSchema(StatementGetParameterSchemaRequest) returns (StatementGetParameterSchemaResponse);
   rpc StatementExecuteQuery(StatementExecuteQueryRequest) returns (ExecuteQueryResponse);
-  rpc StatementGetResultSet(StatementGetResultSetRequest) returns (ResultSetResponse);
   rpc StatementExecutePartitions(StatementExecutePartitionsRequest) returns (StatementExecutePartitionsResponse);
   rpc StatementReadPartition(StatementReadPartitionRequest) returns (StatementReadPartitionResponse);
-  rpc StatementResultChunks(StatementResultChunksRequest) returns (StatementResultChunksResponse);
-  rpc ConnectionResultChunks(ConnectionResultChunksRequest) returns (ConnectionResultChunksResponse);
   rpc StatementExecuteAsync(StatementExecuteAsyncRequest) returns (StatementExecuteAsyncResponse);
+
+  // ResultSet operations
+  rpc ResultSetGetStream(ResultSetGetStreamRequest) returns (ResultSetGetStreamResponse);
+  rpc ResultSetGetChunks(ResultSetGetChunksRequest) returns (ResultSetGetChunksResponse);
+  rpc ResultSetRelease(ResultSetReleaseRequest) returns (ResultSetReleaseResponse);
 
   // Config operations
   rpc ConfigLoadAllSections(ConfigLoadAllSectionsRequest) returns (ConfigLoadAllSectionsResponse);

--- a/python/src/snowflake/connector/_internal/arrow_stream_utils.py
+++ b/python/src/snowflake/connector/_internal/arrow_stream_utils.py
@@ -27,7 +27,7 @@ def release_arrow_stream(stream_ptr: int | None) -> None:
     If the stream is in a bad state (already released, corrupt), the
     ArrowStreamIterator constructor will fail.  We catch that to avoid
     propagating errors into callers that are doing best-effort cleanup
-    (e.g. _QueryResult.__del__ or reset()).
+    (e.g. from_prepare_result cleanup).
     """
     if not stream_ptr:
         return

--- a/python/src/snowflake/connector/_internal/statement_utils.py
+++ b/python/src/snowflake/connector/_internal/statement_utils.py
@@ -8,7 +8,7 @@ from .protobuf_gen.database_driver_v1_pb2 import (
     DatabaseFetchChunkResponse,
     PrepareResult,
     ResultSetDescriptor,
-    ResultSetResponse,
+    ResultSetGetStreamResponse,
     StatementHandle,
     StatementNewRequest,
     StatementReleaseRequest,
@@ -19,24 +19,6 @@ from .sqlstate import SQLSTATE_SUCCESS
 
 if TYPE_CHECKING:
     from ..connection import Connection
-
-
-def new_stmt(connection: Connection) -> StatementHandle:
-    statement_request = StatementNewRequest(conn_handle=connection.conn_handle)
-    stmt = connection.db_api.statement_new(request=statement_request)
-    return stmt.stmt_handle
-
-
-def set_query(connection: Connection, stmt_handle: StatementHandle, query: str) -> None:
-    sql_query_request = StatementSetSqlQueryRequest(stmt_handle=stmt_handle, query=query)
-    connection.db_api.statement_set_sql_query(sql_query_request)
-
-
-def release_stmt(connection: Connection, stmt_handle: StatementHandle | None) -> StatementHandle | None:
-    if stmt_handle:
-        release_request = StatementReleaseRequest(stmt_handle=stmt_handle)
-        connection.db_api.statement_release(release_request)
-    return None
 
 
 @contextmanager
@@ -56,15 +38,32 @@ def statement(connection: Connection, query: str) -> Generator[StatementHandle]:
         StatementHandle: A handle that can be passed to ``statement_execute``
         or other statement-level APIs.
     """
-    stmt_handle = new_stmt(connection)
+    stmt_handle = _new_stmt(connection)
     try:
-        set_query(connection, stmt_handle, query)
+        _set_query(connection, stmt_handle, query)
         yield stmt_handle
     finally:
-        release_stmt(connection, stmt_handle)
+        _release_stmt(connection, stmt_handle)
 
 
-def get_stream_ptr(result: DatabaseFetchChunkResponse | PrepareResult | ResultSetResponse | None) -> int:
+def _new_stmt(connection: Connection) -> StatementHandle:
+    statement_request = StatementNewRequest(conn_handle=connection.conn_handle)
+    stmt = connection.db_api.statement_new(request=statement_request)
+    return stmt.stmt_handle
+
+
+def _set_query(connection: Connection, stmt_handle: StatementHandle, query: str) -> None:
+    sql_query_request = StatementSetSqlQueryRequest(stmt_handle=stmt_handle, query=query)
+    connection.db_api.statement_set_sql_query(sql_query_request)
+
+
+def _release_stmt(connection: Connection, stmt_handle: StatementHandle | None) -> None:
+    if stmt_handle:
+        release_request = StatementReleaseRequest(stmt_handle=stmt_handle)
+        connection.db_api.statement_release(release_request)
+
+
+def get_stream_ptr(result: DatabaseFetchChunkResponse | PrepareResult | ResultSetGetStreamResponse | None) -> int:
     """Extract a C ArrowArrayStream pointer from an execute result.
 
     The pointer is stored as an 8-byte little-endian value inside

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -37,27 +37,24 @@ from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionAbortQueryRequest,
     ConnectionGetQueryResultRequest,
     ConnectionGetResultSetRequest,
-    ConnectionResultChunksRequest,
     ExecuteQueryResponse,
     MultiStatementResult,
     PrepareResult,
     QueryBindings,
-    ResultChunksResult,
     ResultSetResponse,
     StatementExecuteAsyncRequest,
     StatementExecuteQueryRequest,
-    StatementGetResultSetRequest,
     StatementHandle,
     StatementPrepareRequest,
-    StatementResultChunksRequest,
     StatementSetOptionsRequest,
 )
-from .._internal.statement_utils import new_stmt, release_stmt, set_query, statement
+from .._internal.statement_utils import statement
 from ..errors import Error, ErrorValue, InterfaceError, NotSupportedError, ProgrammingError
 from ..result_batch import ResultBatch
 from ._query_result import _MultiStatementQueryResultState, _QueryResult
 from ._query_result_waiter import QueryResultWaiter
 from ._result_metadata import QueryResultStats, ResultMetadata
+from ._result_set_wrapper import _ResultSetWrapper
 
 
 if TYPE_CHECKING:
@@ -182,9 +179,8 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         # Cursor navigation position — mutable to avoid allocation per fetchone
         self._rownumber: int = -1
 
-        # -- Statement handle (set by _execute, cleared on reset) --
-        # needed for get_result_batches as the first (inline) chunk is cached on stmt in core
-        self._stmt_handle: StatementHandle | None = None
+        # -- ResultSet guard (set by _execute, cleared on reset) --
+        self._result_set = _ResultSetWrapper(connection.db_api)
 
         # -- Multi-statement navigation (set by _handle_multi_statement_response, cleared on reset) --
         self._multi_statement: _MultiStatementQueryResultState | None = None
@@ -511,23 +507,16 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         query, bindings = self._prepare_query(operation, parameters)
 
-        stmt_handle = new_stmt(self.connection)
-        self._stmt_handle = stmt_handle
-
-        try:
-            set_query(self.connection, stmt_handle, query)
+        with statement(self.connection, query) as stmt_handle:
             if self._statement_parameters:
                 self._apply_statement_parameters(stmt_handle)
 
             response = self._execute_query(stmt_handle, bindings)
 
             if response.HasField("multi"):
-                self._handle_multi_statement_response(response.multi, stmt_handle, query)
+                self._handle_multi_statement_response(response.multi, query)
             else:
-                self._fetch_and_handle_result_set(response.single.query_id, stmt_handle, query)
-        except Exception:
-            self._stmt_handle = release_stmt(self.connection, stmt_handle)
-            raise
+                self._apply_result_set(response.single, query)
 
         self._rownumber = -1  # reset the rownumber (rownumber is not reset in reset() for backward compatibility)
         return self
@@ -560,9 +549,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             self._query_result = _QueryResult.from_programming_error(exc)
             raise
 
-    def _handle_multi_statement_response(
-        self, result: MultiStatementResult, stmt_handle: StatementHandle, query: str
-    ) -> None:
+    def _handle_multi_statement_response(self, result: MultiStatementResult, query: str) -> None:
         self._multi_statement = _MultiStatementQueryResultState.from_result(result)
 
         # Edge case: empty multi-statement result
@@ -571,33 +558,22 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             return
 
         first_qid = self._multi_statement.advance()  # always non-None: from_result() guarantees non-empty children
-        self._fetch_and_handle_result_set(first_qid, stmt_handle, query)  # type: ignore[arg-type]
+        # already populate cursor with first child query results
+        rs_response = self._fetch_result_set_by_query_id(first_qid)  # type: ignore[arg-type]
+        self._apply_result_set(rs_response, query)
 
-    def _fetch_and_handle_result_set(self, query_id: str, stmt_handle: StatementHandle, query: str) -> None:
-        # Fetch the result set (metadata + arrow stream)
-        # TODO: consider lazy results fetch (i.e., don't statement_get_result_set on execute)
-        result_set_response = self._fetch_result_set(stmt_handle, query_id)
-        self._query_result = _QueryResult.from_result_set_response(result_set_response, query)
+    def _apply_result_set(self, rs_response: ResultSetResponse, query: str | None) -> None:
+        self._result_set.replace(rs_response.result_set_handle)
+        self._query_result = _QueryResult.from_result_set_response(rs_response, query)
 
-    def _fetch_result_set(self, stmt_handle: StatementHandle, query_id: str) -> ResultSetResponse:
-        """Fetch a result set by query ID via StatementGetResultSet RPC.
-
-        Args:
-            stmt_handle: Active statement handle.
-            query_id: Query ID to fetch.
-
-        Returns:
-            ResultSetResponse containing descriptor and arrow stream.
-
-        Raises:
-            ProgrammingError: If the fetch fails.
-        """
+    def _fetch_result_set_by_query_id(self, query_id: str) -> ResultSetResponse:
+        """Fetch a ResultSetResponse (handle + descriptor) for a given query ID."""
         try:
-            request = StatementGetResultSetRequest(
-                stmt_handle=stmt_handle,
+            request = ConnectionGetResultSetRequest(
+                conn_handle=self._connection.conn_handle,
                 query_id=query_id,
             )
-            return self._connection.db_api.statement_get_result_set(request)
+            return self._connection.db_api.connection_get_result_set(request)
         except Exception as exc:
             if isinstance(exc, ProgrammingError):
                 raise
@@ -745,6 +721,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @pep249
     @api_telemetry
     @_requires_open_cursor_not_connection
+    @_with_prefetch_hook
     @_requires_fetch_mode(FetchMode.ROW)
     def fetchmany(self, size: int | None = None) -> list[Any]:
         """
@@ -800,7 +777,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
     def _create_row_iterator(self) -> ArrowStreamIterator:
         return create_row_iterator(
-            stream_ptr=self._query_result.consume_stream(),
+            stream_ptr=self._result_set.get_arrow_stream_ptr(),
             connection=self._connection,
             use_dict_result=self._use_dict_result,
             use_numpy=bool(self._connection.config.numpy),
@@ -880,13 +857,8 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         self.reset()
         self._multi_statement = ms
 
-        # TODO: consider lazy results fetch (i.e., don't statement_get_result_set on execute)
-        request = ConnectionGetResultSetRequest(
-            conn_handle=self._connection.conn_handle,
-            query_id=query_id,
-        )
-        result_set_response = self._connection.db_api.connection_get_result_set(request)
-        self._query_result = _QueryResult.from_result_set_response(result_set_response)
+        rs_response = self._fetch_result_set_by_query_id(query_id)
+        self._apply_result_set(rs_response, query=None)
         self._rownumber = -1
 
         return self
@@ -930,12 +902,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         """Exit the runtime context for the cursor."""
         self.close()
 
-    def __del__(self) -> None:
-        try:
-            release_stmt(self._connection, self._stmt_handle)
-        except Exception:
-            pass
-
     def is_closed(self) -> bool:
         """
         Check if the cursor is closed.
@@ -964,7 +930,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         """
         del self._messages[:]
         self._query_result.reset(closing=closing)
-        self._stmt_handle = release_stmt(self.connection, self._stmt_handle)
+        self._result_set.release()
         self._iterator = None
         self._fetch_mode = None
         self._binding_data = None
@@ -1081,7 +1047,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     ) -> Iterator[Table]:
         """Fetch Arrow Tables in batches."""
         iterator = create_table_iterator(
-            stream_ptr=self._query_result.consume_stream(),
+            stream_ptr=self._result_set.get_arrow_stream_ptr(),
             connection=self._connection,
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
@@ -1101,7 +1067,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     ) -> Table | None:
         """Fetch all results as a single Arrow Table."""
         iterator = create_table_iterator(
-            stream_ptr=self._query_result.consume_stream(),
+            stream_ptr=self._result_set.get_arrow_stream_ptr(),
             connection=self._connection,
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
@@ -1143,7 +1109,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @_with_prefetch_hook
     def get_result_batches(self) -> list[ResultBatch] | None:
         """Get the previously executed query's ResultBatches if available."""
-        result_chunks = self._fetch_result_chunks()
+        result_chunks = self._result_set.get_chunks()
         if result_chunks is None:
             return None
         return ResultBatch.from_chunks(
@@ -1152,27 +1118,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             self._connection,
             list(result_chunks.columns),
         )
-
-    def _fetch_result_chunks(self) -> ResultChunksResult | None:
-        if self._multi_statement is None:
-            # single stmt - we have to fetch by statement handle as the first (inline) chunk is cached on statement
-            if self._stmt_handle:  # unless no stmt handle, then no result available (not executed yet)
-                stmt_req = StatementResultChunksRequest(stmt_handle=self._stmt_handle)
-                stmt_resp = self._connection.db_api.statement_result_chunks(stmt_req)
-                if stmt_resp.HasField("result"):
-                    return stmt_resp.result
-        else:
-            # multistatement - no stmt handle - chunks are fetched by query ids
-            query_id = self._multi_statement.current_child_query_id()
-            if query_id:  # unless no query_id (e.g. iteration over stmts already finished)
-                conn_req = ConnectionResultChunksRequest(
-                    conn_handle=self._connection.conn_handle,
-                    query_id=query_id,
-                )
-                conn_resp = self._connection.db_api.connection_result_chunks(conn_req)
-                if conn_resp.HasField("result"):
-                    return conn_resp.result
-        return None
 
     # ------------------------------------------------------------------
     # Async query support
@@ -1207,26 +1152,16 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         # Handle single or multi-statement response
         if response.HasField("multi"):
-            # For async, we only support fetching the first result of multi-statement
             multi_result = response.multi
             if multi_result.query_ids:
                 first_qid = multi_result.query_ids[0]
-                result_request = ConnectionGetResultSetRequest(
-                    conn_handle=self._connection.conn_handle,
-                    query_id=first_qid,
-                )
-                result_set = self._connection.db_api.connection_get_result_set(result_request)
-                self._query_result = _QueryResult.from_result_set_response(result_set)
+                rs_response = self._fetch_result_set_by_query_id(first_qid)
+                self._apply_result_set(rs_response, query=None)
             else:
                 self._query_result = _QueryResult()
         else:
-            # Single statement
-            result_request = ConnectionGetResultSetRequest(
-                conn_handle=self._connection.conn_handle,
-                query_id=response.single.query_id,
-            )
-            result_set = self._connection.db_api.connection_get_result_set(result_request)
-            self._query_result = _QueryResult.from_result_set_response(result_set)
+            rs_response = response.single
+            self._apply_result_set(rs_response, query=None)
 
         self._rownumber = -1
 

--- a/python/src/snowflake/connector/cursor/_query_result.py
+++ b/python/src/snowflake/connector/cursor/_query_result.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from .._internal.arrow_stream_utils import release_arrow_stream
-from .._internal.errorcode import ER_NO_DATA_FOUND
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     MultiStatementResult,
     PrepareResult,
@@ -64,7 +63,9 @@ class _MultiStatementQueryResultState:
 
 
 class _QueryResult:
-    __slots__ = ("description", "sqlstate", "sfqid", "query", "stats", "rowcount", "_stream_ptr")
+    """Pure metadata about a query execution result."""
+
+    __slots__ = ("description", "sqlstate", "sfqid", "query", "stats", "rowcount")
 
     def __init__(
         self,
@@ -75,7 +76,6 @@ class _QueryResult:
         query: str | None = None,
         stats: QueryResultStats | None = None,
         rowcount: int | None = None,
-        _stream_ptr: int | None = None,
     ) -> None:
         self.description = description
         self.sqlstate = sqlstate
@@ -83,53 +83,14 @@ class _QueryResult:
         self.query = query
         self.stats = stats if stats is not None else QueryResultStats()
         self.rowcount = rowcount
-        self._stream_ptr = _stream_ptr
-
-    def __del__(self) -> None:
-        # Safety net: release the native ArrowArrayStream if it was neither
-        # consumed (via consume_stream) nor explicitly freed (via reset).
-        # This guards against leaks when a _QueryResult is replaced on the
-        # cursor (e.g. executemany loop, error paths) without a prior reset().
-        # The try/except is intentional — during interpreter shutdown, modules
-        # and builtins referenced by release_arrow_stream may already be torn
-        # down, so any call here is best-effort only.
-        try:
-            if self._stream_ptr:
-                release_arrow_stream(self._stream_ptr)
-        except Exception:
-            pass
-
-    def consume_stream(self) -> int:
-        """Take ownership of the arrow stream pointer.
-
-        Returns the stream pointer and clears it from this result.
-        After this call the stream is the caller's responsibility;
-        reset() will not attempt to release it.
-
-        Raises:
-            ProgrammingError: If no stream is available (already consumed,
-                never present, or result was from a non-query statement).
-        """
-        ptr = self._stream_ptr
-        if not ptr:
-            raise ProgrammingError(
-                msg="No results available (already consumed or not produced by this query)",
-                errno=ER_NO_DATA_FOUND,
-            )
-        self._stream_ptr = None
-        return ptr
 
     def reset(self, closing: bool = False) -> None:
-        """Release the arrow stream and optionally clear rowcount.
+        """Optionally clear the rowcount.
 
-        Only stream and rowcount are reset — description, sqlstate, sfqid,
-        query, and stats are left intact for backward compatibility (callers
-        may read them after close/reset).  They are overwritten wholesale
-        when the cursor's _query_result is replaced on the next execute().
+        Only rowcount is reset — description, sqlstate, sfqid, query, and stats
+        are left intact for backward compatibility (callers may read them after close/reset).
+        They are overwritten wholesale when the cursor's _query_result is replaced on the next execute().
         """
-        release_arrow_stream(self._stream_ptr)
-        self._stream_ptr = None
-
         if not closing:
             self.rowcount = None
 
@@ -160,14 +121,14 @@ class _QueryResult:
         response: ResultSetResponse,
         query: str | None = None,
     ) -> _QueryResult:
-        """Create _QueryResult from a ResultSetResponse.
+        """Create _QueryResult from a ResultSetResponse (metadata only).
 
         Args:
-            response: ResultSetResponse from StatementGetResultSet or ConnectionGetResultSet.
+            response: ResultSetResponse containing descriptor metadata.
             query: Optional query text (not available in proto, must be passed separately).
 
         Returns:
-            _QueryResult instance.
+            _QueryResult instance with metadata populated.
         """
         descriptor = response.result_descriptor
 
@@ -177,7 +138,6 @@ class _QueryResult:
             sfqid=descriptor.query_id if descriptor.query_id else None,
             query=query,
             rowcount=extract_rowcount(descriptor),
-            _stream_ptr=get_stream_ptr(response),
             stats=(
                 QueryResultStats.from_query_stats(descriptor.stats)
                 if descriptor.HasField("stats")

--- a/python/src/snowflake/connector/cursor/_result_set_wrapper.py
+++ b/python/src/snowflake/connector/cursor/_result_set_wrapper.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+
+from typing import TYPE_CHECKING
+
+from .._internal.errorcode import ER_NO_DATA_FOUND
+from .._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ResultSetGetChunksRequest,
+    ResultSetGetChunksResponse,
+    ResultSetGetStreamRequest,
+    ResultSetHandle,
+    ResultSetReleaseRequest,
+)
+from .._internal.statement_utils import get_stream_ptr
+from ..errors import ProgrammingError
+
+
+if TYPE_CHECKING:
+    from .._internal.protobuf_gen.database_driver_v1_services import DatabaseDriverClient
+
+logger = logging.getLogger(__name__)
+
+
+class _ResultSetWrapper:
+    """Owns a ``ResultSetHandle`` and guards against misuse.
+
+    Lifecycle: ``replace()`` releases the previous handle before adopting a
+    new one; ``release()`` frees the current handle.  ``__del__`` acts as a
+    safety net for handles that were never explicitly released.
+
+    The wrapper tracks whether the Arrow stream has already been consumed.
+    A second call to :meth:`get_arrow_stream_ptr` raises instead of
+    silently re-fetching.  (The core layer *does* support re-fetching via a
+    slow path, but the Python wrapper prevents it to catch accidental
+    double-consumption.)
+    """
+
+    __slots__ = ("_db_api", "_handle", "_stream_consumed")
+
+    def __init__(self, db_api: DatabaseDriverClient, handle: ResultSetHandle | None = None) -> None:
+        self._db_api = db_api
+        self._handle: ResultSetHandle | None = handle
+        self._stream_consumed: bool = False
+
+    # -- handle management --------------------------------------------------
+
+    def replace(self, new_handle: ResultSetHandle | None) -> None:
+        """Release the current handle (if any) and adopt *new_handle*."""
+        self._do_release()
+        self._handle = new_handle
+        self._stream_consumed = False
+
+    def release(self) -> None:
+        """Explicitly release the handle."""
+        self._do_release()
+
+    def __del__(self) -> None:
+        self._do_release()
+
+    def _do_release(self) -> None:
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+        try:
+            request = ResultSetReleaseRequest(result_set_handle=handle)
+            self._db_api.result_set_release(request)
+        except Exception:
+            logger.warning("Failed to release ResultSet handle", exc_info=True)
+
+    # -- data access --------------------------------------------------------
+
+    def get_arrow_stream_ptr(self) -> int:
+        """Fetch the Arrow stream and return the raw C pointer.
+
+        The stream can only be consumed once per result set.  A second call
+        raises ``ProgrammingError`` instead of silently hitting Snowflake.
+
+        Raises:
+            ProgrammingError: If no handle is held or the stream was already consumed.
+        """
+        if self._handle is None:
+            raise ProgrammingError(
+                msg="No results available (not produced by this query)",
+                errno=ER_NO_DATA_FOUND,
+            )
+        if self._stream_consumed:
+            raise ProgrammingError(
+                msg="No results available (arrow stream already consumed)",
+                errno=ER_NO_DATA_FOUND,
+            )
+        request = ResultSetGetStreamRequest(result_set_handle=self._handle)
+        response = self._db_api.result_set_get_stream(request)
+        self._stream_consumed = True
+        return get_stream_ptr(response)
+
+    def get_chunks(self) -> ResultSetGetChunksResponse | None:
+        """Call ``result_set_get_chunks`` on the held handle, or return ``None``.
+
+        Safe to call multiple times and independently of :meth:`get_arrow_stream_ptr` —
+        the core layer re-fetches chunk metadata from Snowflake if the cached copy
+        was already consumed.
+        """
+        if self._handle is None:
+            return None
+        request = ResultSetGetChunksRequest(result_set_handle=self._handle)
+        return self._db_api.result_set_get_chunks(request)

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -12,13 +12,20 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     DatabaseHandle,
     ExecuteQueryResponse,
     ResultSetDescriptor,
+    ResultSetHandle,
+    ResultSetResponse,
     StatementHandle,
 )
 
 
 def _make_execute_response(query_id: str = "fake-qid") -> ExecuteQueryResponse:
-    """Return an ExecuteQueryResponse with a single-statement descriptor."""
-    return ExecuteQueryResponse(single=ResultSetDescriptor(query_id=query_id))
+    """Return an ExecuteQueryResponse with a single-statement ResultSetResponse."""
+    return ExecuteQueryResponse(
+        single=ResultSetResponse(
+            result_set_handle=ResultSetHandle(id=1),
+            result_descriptor=ResultSetDescriptor(query_id=query_id),
+        )
+    )
 
 
 @pytest.fixture
@@ -39,13 +46,7 @@ def mock_db_api():
     db_api.connection_is_closed.side_effect = _connection_is_closed
     # Provide a real StatementHandle so protobuf field validation passes
     db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
-    # Mock the two-step execute flow: execute_query returns a descriptor,
-    # then get_result_set returns the result set (get_stream_ptr is patched).
     db_api.statement_execute_query.return_value = _make_execute_response()
-    db_api.statement_get_result_set.return_value = MagicMock(
-        result_descriptor=ResultSetDescriptor(query_id="fake-qid"),
-    )
-    db_api.statement_result_chunks.return_value = MagicMock(HasField=MagicMock(return_value=False))
     return db_api
 
 

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -17,6 +17,7 @@ from snowflake.connector._internal.extras import (
 )
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     ConnectionHandle,
+    ResultSetHandle,
     StatementHandle,
 )
 from snowflake.connector.constants import QueryStatus
@@ -487,12 +488,14 @@ class TestFetchmany:
         assert result == [(3,), (4,)]
 
 
-class TestStatementLifecycle:
-    """Unit tests for statement handle lifecycle (create/release).
+class TestHandleLifecycle:
+    """Unit tests for statement and ResultSet handle lifecycle.
 
-    The statement handle is kept alive after execute() so that the stream
-    and chunk metadata can be fetched lazily.  The handle is released on
-    reset(), close(), or when the next execute() replaces it.
+    Statement handles are scoped to the ``statement()`` context manager
+    inside ``_execute`` — they are always released when execute completes.
+    ResultSet handles live longer: they are held by the cursor's
+    ``_ResultSetWrapper`` and released on ``reset()``, ``close()``, or
+    when the next ``execute()`` replaces them.
     """
 
     @pytest.fixture
@@ -501,29 +504,23 @@ class TestStatementLifecycle:
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
-        handle_counter = 0
+        rs_counter = 0
 
-        def new_handle(*_args, **_kwargs):
-            nonlocal handle_counter
-            handle_counter += 1
-            resp = MagicMock()
-            resp.stmt_handle = StatementHandle(id=handle_counter)
-            return resp
+        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
 
-        conn.db_api.statement_new.side_effect = new_handle
+        def make_execute_response(*_args, **_kwargs):
+            nonlocal rs_counter
+            rs_counter += 1
+            response = MagicMock()
+            response.HasField = MagicMock(return_value=False)
+            response.single.result_set_handle = ResultSetHandle(id=rs_counter)
+            response.single.result_descriptor.query_id = "fake-qid"
+            response.single.result_descriptor.HasField = MagicMock(return_value=False)
+            response.single.result_descriptor.rows_affected = 0
+            response.single.result_descriptor.sql_state = "00000"
+            return response
 
-        execute_response = MagicMock()
-        execute_response.HasField = MagicMock(return_value=False)
-        execute_response.single.query_id = "fake-qid"
-        conn.db_api.statement_execute_query.return_value = execute_response
-
-        result_set_response = MagicMock()
-        result_set_response.result_descriptor.query_id = "fake-qid"
-        result_set_response.result_descriptor.HasField = MagicMock(return_value=False)
-        result_set_response.result_descriptor.rows_affected = 0
-        result_set_response.result_descriptor.sql_state = "00000"
-        result_set_response.stream.value = (1).to_bytes(8, "little")
-        conn.db_api.statement_get_result_set.return_value = result_set_response
+        conn.db_api.statement_execute_query.side_effect = make_execute_response
 
         return conn
 
@@ -532,46 +529,52 @@ class TestStatementLifecycle:
         """Create a cursor with the mocked connection."""
         return SnowflakeCursor(mock_connection)
 
-    def test_execute_does_not_release_handle_immediately(self, cursor, mock_connection):
-        """After execute(), the handle stays alive (owned by the cursor)."""
+    def test_statement_handle_released_after_execute(self, cursor, mock_connection):
+        """Statement handle is released within execute (context manager)."""
         cursor.execute("SELECT 1")
 
-        mock_connection.db_api.statement_release.assert_not_called()
+        mock_connection.db_api.statement_release.assert_called_once()
 
-    def test_reset_releases_handle(self, cursor, mock_connection):
-        """reset() releases the statement handle held by the cursor."""
+    def test_result_set_handle_survives_execute(self, cursor, mock_connection):
+        """After execute(), the ResultSet handle is still held (not released)."""
+        cursor.execute("SELECT 1")
+
+        mock_connection.db_api.result_set_release.assert_not_called()
+
+    def test_reset_releases_result_set_handle(self, cursor, mock_connection):
+        """reset() releases the ResultSet handle held by the cursor."""
         cursor.execute("SELECT 1")
         cursor.reset()
 
-        mock_connection.db_api.statement_release.assert_called_once()
-        released_id = mock_connection.db_api.statement_release.call_args.args[0].stmt_handle.id
+        mock_connection.db_api.result_set_release.assert_called_once()
+        released_id = mock_connection.db_api.result_set_release.call_args.args[0].result_set_handle.id
         assert released_id == 1
 
-    def test_close_releases_handle(self, cursor, mock_connection):
-        """close() releases the statement handle held by the cursor."""
+    def test_close_releases_result_set_handle(self, cursor, mock_connection):
+        """close() releases the ResultSet handle held by the cursor."""
         cursor.execute("SELECT 1")
         cursor.close()
 
-        mock_connection.db_api.statement_release.assert_called_once()
+        mock_connection.db_api.result_set_release.assert_called_once()
 
-    def test_sequential_executes_release_previous_handles(self, cursor, mock_connection):
-        """Each execute() releases the handle from the previous execution."""
+    def test_sequential_executes_release_previous_result_set_handles(self, cursor, mock_connection):
+        """Each execute() releases the ResultSet handle from the previous execution."""
         n = 5
         for i in range(n):
             cursor.execute(f"SELECT {i}")
 
-        release = mock_connection.db_api.statement_release
-        # First n-1 handles released by reset() at the start of each subsequent execute();
+        release = mock_connection.db_api.result_set_release
+        # First n-1 handles released by replace() at the start of each subsequent _apply_result_set;
         # the last handle is still alive.
         assert release.call_count == n - 1
-        released_ids = [call.args[0].stmt_handle.id for call in release.call_args_list]
+        released_ids = [call.args[0].result_set_handle.id for call in release.call_args_list]
         assert released_ids == list(range(1, n))
 
     def test_close_without_execute_does_not_release(self, cursor, mock_connection):
         """Closing a cursor that never executed should not call release."""
         cursor.close()
 
-        mock_connection.db_api.statement_release.assert_not_called()
+        mock_connection.db_api.result_set_release.assert_not_called()
 
 
 class TestSqlstate:
@@ -612,18 +615,12 @@ class TestSqlstate:
 
         descriptor.HasField = MagicMock(side_effect=has_field_impl)
 
-        # Mock ExecuteQueryResponse with single statement
+        # Mock ExecuteQueryResponse with single statement (ResultSetResponse)
         execute_response = MagicMock()
-        execute_response.single = descriptor
+        execute_response.single.result_descriptor = descriptor
+        execute_response.single.result_set_handle = ResultSetHandle(id=1)
         execute_response.HasField = MagicMock(side_effect=lambda f: f == "single")
         mock_connection.db_api.statement_execute_query.return_value = execute_response
-
-        # Mock StatementGetResultSetResponse
-        result_set_response = MagicMock()
-        result_set_response.result_descriptor = descriptor
-        result_set_response.stream = MagicMock()
-        result_set_response.stream.value = (0).to_bytes(8, byteorder="little")
-        mock_connection.db_api.statement_get_result_set.return_value = result_set_response
 
         return descriptor
 
@@ -1060,7 +1057,7 @@ class TestCreateRowIteratorNumpyFlag:
     def test_passes_numpy_true_from_connection(self, mock_connection):
         mock_connection.config.numpy = True
         cursor = SnowflakeCursor(mock_connection)
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create:
             mock_create.return_value = iter([])
@@ -1076,7 +1073,7 @@ class TestCreateRowIteratorNumpyFlag:
     def test_passes_numpy_false_from_connection(self, mock_connection):
         mock_connection.config.numpy = False
         cursor = SnowflakeCursor(mock_connection)
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_row_iterator") as mock_create:
             mock_create.return_value = iter([])
@@ -1179,7 +1176,7 @@ class TestFetchArrowBatches:
         batch1, batch2 = MagicMock(), MagicMock()
         table1, table2 = MagicMock(), MagicMock()
         self.pa.Table.from_batches.side_effect = [table1, table2]
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])):
             tables = list(cursor.fetch_arrow_batches())
@@ -1189,7 +1186,7 @@ class TestFetchArrowBatches:
         self.pa.Table.from_batches.assert_any_call([batch2])
 
     def test_yields_nothing_for_empty_stream(self, cursor):
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             tables = list(cursor.fetch_arrow_batches())
@@ -1206,7 +1203,7 @@ class TestFetchArrowBatches:
                 list(cursor.fetch_arrow_batches())
 
     def test_passes_force_microsecond_precision(self, cursor, mock_connection):
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get:
             list(cursor.fetch_arrow_batches(force_microsecond_precision=True))
@@ -1244,7 +1241,7 @@ class TestFetchArrowAll:
         batch1, batch2 = MagicMock(), MagicMock()
         mock_table = MagicMock()
         self.pa.Table.from_batches.return_value = mock_table
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([batch1, batch2])):
             result = cursor.fetch_arrow_all()
@@ -1255,7 +1252,7 @@ class TestFetchArrowAll:
     def test_returns_none_for_empty_stream(self, cursor):
         mock_iterator = MagicMock()
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator):
             result = cursor.fetch_arrow_all()
@@ -1270,7 +1267,7 @@ class TestFetchArrowAll:
         mock_iterator = MagicMock()
         mock_iterator.__iter__ = MagicMock(return_value=iter([]))
         mock_iterator.get_converted_schema.return_value = mock_schema
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=mock_iterator):
             result = cursor.fetch_arrow_all(force_return_table=True)
@@ -1280,7 +1277,7 @@ class TestFetchArrowAll:
         mock_schema.empty_table.assert_called_once()
 
     def test_returns_none_without_force_return_table(self, cursor):
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             result = cursor.fetch_arrow_all(force_return_table=False)
@@ -1288,7 +1285,7 @@ class TestFetchArrowAll:
         assert result is None
 
     def test_passes_force_microsecond_precision(self, cursor, mock_connection):
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])) as mock_get:
             cursor.fetch_arrow_all(force_microsecond_precision=True)
@@ -1429,7 +1426,7 @@ class TestFetchModeValidation:
             list(cursor.fetch_arrow_batches())
 
     def test_arrow_then_row_raises(self, cursor):
-        cursor._query_result._stream_ptr = 42
+        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
 
         with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
             cursor.fetch_arrow_all()
@@ -1528,7 +1525,6 @@ class TestReset:
             sqlstate="42601",
             sfqid="abc-123",
             query="SELECT 1",
-            _stream_ptr=0xABCD,
             rowcount=100,
         )
         cursor._iterator = iter([(1,)])
@@ -1539,7 +1535,6 @@ class TestReset:
         cursor.reset()
 
         # Cleared by reset
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
@@ -1553,14 +1548,13 @@ class TestReset:
 
     def test_reset_is_idempotent(self, cursor):
         """Calling reset() twice produces the same state as calling it once."""
-        cursor._query_result = _QueryResult(_stream_ptr=0xABCD, rowcount=42)
+        cursor._query_result = _QueryResult(rowcount=42)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 
         cursor.reset()
         cursor.reset()
 
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._fetch_mode is None
         assert cursor._query_result.rowcount is None
@@ -1570,7 +1564,6 @@ class TestReset:
         """reset() on a freshly created cursor doesn't break anything."""
         cursor.reset()
 
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor.sqlstate is None
         assert cursor._fetch_mode is None
@@ -1586,7 +1579,6 @@ class TestReset:
             sqlstate="42601",
             sfqid="abc-123",
             query="SELECT 1",
-            _stream_ptr=0xABCD,
             rowcount=100,
         )
         cursor._iterator = iter([(1,)])
@@ -1597,7 +1589,6 @@ class TestReset:
         cursor.reset(closing=True)
 
         # Cleared by reset
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._binding_data is None
         assert cursor._fetch_mode is None
@@ -1664,13 +1655,12 @@ class TestClose:
     def test_close_clears_result_state(self, cursor):
         """close() clears result-related state via reset (except description)."""
         mock_desc = [MagicMock()]
-        cursor._query_result = _QueryResult(description=mock_desc, _stream_ptr=0xABCD)
+        cursor._query_result = _QueryResult(description=mock_desc)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 
         cursor.close()
 
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._query_result.description is mock_desc
         assert cursor._fetch_mode is None
@@ -1718,7 +1708,7 @@ class TestResetIntegration:
 
     def test_close_calls_reset_with_closing_true(self, cursor):
         """close() calls reset(closing=True) to preserve rowcount."""
-        cursor._query_result = _QueryResult(rowcount=42, _stream_ptr=0xABCD)
+        cursor._query_result = _QueryResult(rowcount=42)
         cursor._iterator = iter([(1,)])
 
         cursor.close()
@@ -1726,7 +1716,6 @@ class TestResetIntegration:
         # Rowcount should be preserved
         assert cursor._query_result.rowcount == 42
         # Other state should be cleared
-        assert cursor._query_result._stream_ptr is None
         assert cursor._iterator is None
         assert cursor._closed is True
 
@@ -1734,7 +1723,6 @@ class TestResetIntegration:
         """execute() calls reset() before executing to clear old state."""
         cursor._query_result = _QueryResult(
             description=[MagicMock()],
-            _stream_ptr=0xABCD,
             rowcount=100,
         )
         cursor._iterator = iter([(1,)])
@@ -1975,18 +1963,16 @@ class TestQueryResult:
         descriptor.sql_state = overrides.get("sql_state", "")
         descriptor.stats = overrides.get("stats", None)
 
-        # Mock ConnectionGetQueryResultResponse with single statement
-        query_result_response = MagicMock()
-        query_result_response.single = descriptor
-        query_result_response.HasField = MagicMock(side_effect=lambda f: f == "single")
-        mock_connection.db_api.connection_get_query_result.return_value = query_result_response
-
-        # Mock ConnectionGetResultSetResponse
+        # Mock ResultSetResponse wrapping the descriptor
         result_set_response = MagicMock()
         result_set_response.result_descriptor = descriptor
-        result_set_response.stream = MagicMock()
-        result_set_response.stream.value = (0).to_bytes(8, byteorder="little")  # Null pointer
-        mock_connection.db_api.connection_get_result_set.return_value = result_set_response
+        result_set_response.result_set_handle = ResultSetHandle(id=99)
+
+        # Mock ConnectionGetQueryResultResponse with single statement
+        query_result_response = MagicMock()
+        query_result_response.single = result_set_response
+        query_result_response.HasField = MagicMock(side_effect=lambda f: f == "single")
+        mock_connection.db_api.connection_get_query_result.return_value = query_result_response
 
         return descriptor
 
@@ -2020,7 +2006,7 @@ class TestQueryResult:
 
     def test_query_result_resets_prior_state(self, cursor, mock_connection):
         """query_result clears iterator and fetch mode from a previous execute."""
-        cursor._query_result = _QueryResult(_stream_ptr=0xABCD)
+        cursor._query_result = _QueryResult(rowcount=99)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -5,6 +5,7 @@ use tokio::sync::Mutex;
 
 use super::connection::Connection;
 use super::database::Database;
+use super::result_set::ResultSet;
 use super::statement::Statement;
 use crate::fs_adapter::{FsAdapter, RealFs};
 use crate::handle_manager::HandleManager;
@@ -73,6 +74,7 @@ pub struct DatabaseDriverV1 {
     pub(super) databases: HandleManager<Mutex<Database>>,
     pub(super) connections: HandleManager<Mutex<Connection>>,
     pub(super) statements: HandleManager<Mutex<Statement>>,
+    pub(super) results: HandleManager<Mutex<ResultSet>>,
     token_cache: once_cell::sync::OnceCell<KeyringTokenCache>,
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
@@ -96,6 +98,7 @@ impl DatabaseDriverV1 {
             databases: HandleManager::new(),
             connections: HandleManager::new(),
             statements: HandleManager::new(),
+            results: HandleManager::new(),
             token_cache: once_cell::sync::OnceCell::new(),
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod heartbeat;
 mod logout;
 pub(crate) mod multistatement;
 mod query;
+pub(crate) mod result_set;
 pub mod spcs_token;
 pub(crate) mod statement;
 pub(crate) mod validation;
@@ -26,8 +27,9 @@ pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_sess
 pub use database::FetchChunkInput;
 pub use error::ApiError;
 pub use global_state::{DatabaseDriverV1, DriverProviders, WrapperPresets};
-pub use statement::{
-    BindingType, ColumnMetadata, DataPtr, ExecuteQueryResult, InlineData, ResolvedResultSet,
-    ResultSetDescriptor, StoredChunkInfo,
+pub use result_set::{
+    ChunkData, ChunkDataWithDescriptor, ColumnMetadata, ExecuteQueryResult, InlineData,
+    ResultSetDescriptor, ResultSetInfo,
 };
+pub use statement::{BindingType, DataPtr};
 pub use validation::{ValidationCode, ValidationIssue, ValidationSeverity};

--- a/sf_core/src/apis/database_driver_v1/multistatement.rs
+++ b/sf_core/src/apis/database_driver_v1/multistatement.rs
@@ -1,3 +1,4 @@
+use super::result_set::{ExecuteQueryResult, ResultSetDescriptor};
 use crate::rest::snowflake::query_response::Data;
 
 const STATEMENT_TYPE_MULTI: i64 = 0xA000;
@@ -5,6 +6,21 @@ const STATEMENT_TYPE_MULTI: i64 = 0xA000;
 /// Returns `true` if the response represents a multi-statement execution.
 pub fn is_multistatement(data: &Data) -> bool {
     data.statement_type_id == Some(STATEMENT_TYPE_MULTI)
+}
+
+/// If `data` is a multi-statement response, returns `ExecuteQueryResult::Multi`.
+pub fn try_into_multi_result(
+    data: &Data,
+    descriptor: ResultSetDescriptor,
+) -> Option<ExecuteQueryResult> {
+    if !is_multistatement(data) {
+        return None;
+    }
+    Some(ExecuteQueryResult::Multi {
+        parent: descriptor,
+        query_ids: child_query_ids(data),
+        statement_type_ids: child_statement_type_ids(data),
+    })
 }
 
 /// Parse comma-separated `resultIds` from a multi-statement response into individual query IDs.

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -14,7 +14,7 @@ use arrow::array::{Array, Int64Array, RecordBatchReader, StringArray};
 use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
 use reqwest::Client;
-use rest::snowflake::query_response::{self, QueryResponseError};
+use rest::snowflake::query_response::{self, QueryResponseError, RowsetData};
 use snafu::{IntoError, Location, ResultExt, Snafu};
 use std::sync::Arc;
 
@@ -35,34 +35,12 @@ const ODBC_PUT_ENCRYPTION_LITERAL: &str = "ENCRYPTED";
 /// from legacy libsnowflakeclient. See `ODBC_PUT_ENCRYPTION_LITERAL`.
 const ODBC_GET_ENCRYPTION_LITERAL: &str = "DECRYPTED";
 
-/// Result of processing a query response, containing the Arrow reader.
-pub struct QueryResult {
-    pub reader: Box<dyn RecordBatchReader + Send>,
-}
-
-pub async fn process_query_response(
+/// Executes a PUT/GET file transfer and returns a `RowsetData` variant holding the results.
+pub(super) async fn perform_put_get_transfer(
+    command: &str,
     data: &query_response::Data,
-    http_client: &Client,
-    prefetch_config: &PrefetchConfig,
-    wrapper_presets: &WrapperPresets,
-) -> Result<QueryResult, QueryResponseProcessingError> {
-    match data.command {
-        Some(ref command) => perform_put_get(command.clone(), data, wrapper_presets).await,
-        None => {
-            let reader = read_batches(data.to_rowset_data(), http_client.clone(), prefetch_config)
-                .await
-                .context(BatchReadingSnafu)?;
-            Ok(QueryResult { reader })
-        }
-    }
-}
-
-async fn perform_put_get(
-    command: String,
-    data: &query_response::Data,
-    wrapper_presets: &WrapperPresets,
-) -> Result<QueryResult, QueryResponseProcessingError> {
-    match command.as_str() {
+) -> Result<RowsetData, QueryResponseProcessingError> {
+    match command {
         "UPLOAD" => {
             let file_upload_data = data
                 .to_file_upload_data()
@@ -70,9 +48,7 @@ async fn perform_put_get(
             let upload_results = upload_files(&file_upload_data)
                 .await
                 .context(FileUploadSnafu)?;
-            let reader = upload_results_reader(upload_results, wrapper_presets)
-                .context(UploadResultsConversionSnafu)?;
-            Ok(QueryResult { reader })
+            Ok(RowsetData::Upload(upload_results))
         }
         "DOWNLOAD" => {
             let file_download_data = data.to_file_download_data().map_err(|e| {
@@ -85,9 +61,7 @@ async fn perform_put_get(
             let download_results = download_files(file_download_data)
                 .await
                 .context(FileDownloadSnafu)?;
-            let reader = download_results_reader(download_results, wrapper_presets)
-                .context(DownloadResultsConversionSnafu)?;
-            Ok(QueryResult { reader })
+            Ok(RowsetData::Download(download_results))
         }
         _ => UnsupportedCommandSnafu {
             command: command.to_string(),
@@ -96,32 +70,52 @@ async fn perform_put_get(
     }
 }
 
-async fn read_batches<'a>(
-    data: query_response::RowsetData<'a>,
+/// Builds an Arrow `RecordBatchReader` from the stored `RowsetData`.
+/// Called lazily by `result_set_get_stream`.
+pub(super) async fn build_reader_from_rowset_data(
+    data: &RowsetData,
+    http_client: Client,
+    prefetch_config: &PrefetchConfig,
+    wrapper_presets: &WrapperPresets,
+) -> Result<Box<dyn RecordBatchReader + Send>, QueryResponseProcessingError> {
+    match data {
+        RowsetData::Upload(results) => {
+            upload_results_reader(results, wrapper_presets).context(UploadResultsConversionSnafu)
+        }
+        RowsetData::Download(results) => download_results_reader(results, wrapper_presets)
+            .context(DownloadResultsConversionSnafu),
+        _ => read_batches(data, http_client, prefetch_config)
+            .await
+            .context(BatchReadingSnafu),
+    }
+}
+
+pub(super) async fn read_batches(
+    data: &RowsetData,
     http_client: Client,
     prefetch_config: &PrefetchConfig,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ReadBatchesError> {
     tracing::debug!("read_batches called {:?}", data);
     match data {
-        query_response::RowsetData::ArrowSingleChunk { chunk_base64 } => {
+        RowsetData::ArrowSingleChunk { chunk_base64 } => {
             single_chunk_reader(chunk_base64).context(ChunkReadingSnafu)
         }
-        query_response::RowsetData::ArrowMultiChunk {
+        RowsetData::ArrowMultiChunk {
             initial_base64_opt,
             chunk_download_data,
         } => arrow_prefetch_reader(
-            initial_base64_opt,
-            chunk_download_data.into(),
+            initial_base64_opt.as_deref(),
+            chunk_download_data.clone().into(),
             http_client.clone(),
             prefetch_config,
         )
         .await
         .context(ChunkReadingSnafu),
-        query_response::RowsetData::SchemaOnly { rowtype } => {
+        RowsetData::SchemaOnly { rowtype } => {
             let row_types = parse_row_types(rowtype)?;
             schema_only_reader(&row_types).context(ChunkReadingSnafu)
         }
-        query_response::RowsetData::JsonRowset { rowset, rowtype } => {
+        RowsetData::JsonRowset { rowset, rowtype } => {
             let row_types = parse_row_types(rowtype)?;
             validate_column_count(rowset, &row_types)?;
             json_prefetch_reader(
@@ -134,7 +128,7 @@ async fn read_batches<'a>(
             .await
             .context(ChunkReadingSnafu)
         }
-        query_response::RowsetData::JsonMultiChunk {
+        RowsetData::JsonMultiChunk {
             rowset,
             rowtype,
             chunk_download_data,
@@ -145,14 +139,14 @@ async fn read_batches<'a>(
             json_prefetch_reader(
                 rowset,
                 row_types,
-                chunk_download_data,
+                chunk_download_data.clone(),
                 http_client.clone(),
                 prefetch_config,
             )
             .await
             .context(ChunkReadingSnafu)
         }
-        query_response::RowsetData::NoData => Ok(empty_reader()),
+        RowsetData::NoData | RowsetData::Upload(_) | RowsetData::Download(_) => Ok(empty_reader()),
     }
 }
 
@@ -231,8 +225,8 @@ fn download_row_types(wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataTyp
 }
 
 /// Converts upload results to Arrow format
-pub fn upload_results_reader(
-    upload_results: Vec<UploadResult>,
+pub(super) fn upload_results_reader(
+    upload_results: &[UploadResult],
     wrapper_presets: &WrapperPresets,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ArrowError> {
     let schema = create_schema(&upload_row_types(wrapper_presets))
@@ -259,8 +253,8 @@ pub fn upload_results_reader(
 }
 
 /// Converts download results to Arrow format
-pub fn download_results_reader(
-    download_results: Vec<DownloadResult>,
+pub(super) fn download_results_reader(
+    download_results: &[DownloadResult],
     wrapper_presets: &WrapperPresets,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ArrowError> {
     let schema = create_schema(&download_row_types(wrapper_presets))

--- a/sf_core/src/apis/database_driver_v1/result_set.rs
+++ b/sf_core/src/apis/database_driver_v1/result_set.rs
@@ -1,0 +1,463 @@
+use std::sync::Arc;
+
+use super::connection::{Connection, RefreshContext};
+use super::error::*;
+use super::global_state::{DatabaseDriverV1, WrapperPresets};
+use super::query::build_reader_from_rowset_data;
+use crate::chunks::{ChunkDownloadData, ChunkFormatKind, PrefetchConfig};
+use crate::handle_manager::Handle;
+use crate::rest::snowflake::query_response::{Data, RowsetData, Stats};
+use crate::rest::snowflake::snowflake_get_query_result;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+use snafu::{OptionExt, ResultExt};
+use tokio::sync::Mutex;
+
+// --- Public types ---
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ColumnMetadata {
+    pub name: String,
+    pub r#type: String,
+    pub precision: Option<i64>,
+    pub scale: Option<i64>,
+    pub length: Option<i64>,
+    pub byte_length: Option<i64>,
+    pub nullable: bool,
+}
+
+/// Metadata for a single result set (maps to proto ResultSetDescriptor).
+#[derive(Clone)]
+pub struct ResultSetDescriptor {
+    pub query_id: String,
+    pub columns: Vec<ColumnMetadata>,
+    pub rows_affected: Option<i64>,
+    pub statement_type_id: Option<i64>,
+    pub sql_state: Option<String>,
+    pub stats: Option<Stats>,
+    pub number_of_binds: i32,
+}
+
+/// A result set handle paired with its descriptor.
+pub struct ResultSetInfo {
+    pub handle: Handle,
+    pub descriptor: ResultSetDescriptor,
+}
+
+/// Result of executing a query (maps to proto ExecuteQueryResponse).
+pub enum ExecuteQueryResult {
+    Single(ResultSetInfo),
+    Multi {
+        parent: ResultSetDescriptor,
+        query_ids: Vec<String>,
+        statement_type_ids: Vec<i64>,
+    },
+}
+
+#[derive(Clone)]
+pub enum InlineData {
+    /// Base64-encoded Arrow IPC stream.
+    ArrowIpc(String),
+    /// JSON rowset (rows of nullable string cells).
+    Json(Vec<Vec<Option<String>>>),
+    None,
+}
+
+#[derive(Clone)]
+pub struct ChunkData {
+    pub format: ChunkFormatKind,
+    pub inline: InlineData,
+    pub remote_chunks: Vec<ChunkDownloadData>,
+}
+
+impl From<&RowsetData> for ChunkData {
+    fn from(data: &RowsetData) -> Self {
+        match data {
+            RowsetData::ArrowSingleChunk { chunk_base64 } => ChunkData {
+                format: ChunkFormatKind::ArrowIpc,
+                inline: InlineData::ArrowIpc(chunk_base64.clone()),
+                remote_chunks: Vec::new(),
+            },
+            RowsetData::ArrowMultiChunk {
+                initial_base64_opt,
+                chunk_download_data,
+            } => ChunkData {
+                format: ChunkFormatKind::ArrowIpc,
+                inline: initial_base64_opt
+                    .as_ref()
+                    .map(|b| InlineData::ArrowIpc(b.clone()))
+                    .unwrap_or(InlineData::None),
+                remote_chunks: chunk_download_data.clone(),
+            },
+            RowsetData::JsonRowset { rowset, .. } => ChunkData {
+                format: ChunkFormatKind::Json,
+                inline: InlineData::Json(rowset.clone()),
+                remote_chunks: Vec::new(),
+            },
+            RowsetData::JsonMultiChunk {
+                rowset,
+                chunk_download_data,
+                ..
+            } => ChunkData {
+                format: ChunkFormatKind::Json,
+                inline: InlineData::Json(rowset.clone()),
+                remote_chunks: chunk_download_data.clone(),
+            },
+            RowsetData::Upload(_)
+            | RowsetData::Download(_)
+            | RowsetData::SchemaOnly { .. }
+            | RowsetData::NoData => ChunkData {
+                format: ChunkFormatKind::ArrowIpc,
+                inline: InlineData::None,
+                remote_chunks: Vec::new(),
+            },
+        }
+    }
+}
+
+pub struct ChunkDataWithDescriptor {
+    pub chunk_data: ChunkData,
+    pub descriptor: ResultSetDescriptor,
+}
+
+// --- Internal types ---
+
+/// Resources captured at result set creation time that are needed to build
+/// the Arrow stream lazily. Snapshotted up front so the stream can be
+/// constructed even after the originating connection has been closed.
+pub(super) struct ReaderContext {
+    pub http_client: reqwest::Client,
+    pub prefetch_config: PrefetchConfig,
+}
+
+/// A handle-managed result set. The Arrow stream is built lazily from the stored
+/// `RowsetData` when `result_set_get_stream` is called. Since the data is
+/// preserved, the stream can be rebuilt on each call.
+pub(super) struct ResultSet {
+    pub descriptor: ResultSetDescriptor,
+    pub data: RowsetData,
+    pub reader_ctx: ReaderContext,
+}
+
+// --- DML detection constants ---
+
+const DML_AFFECTED_ROWS_COLUMNS: &[&str] = &[
+    "number of rows updated",
+    "number of multi-joined rows updated",
+    "number of rows deleted",
+];
+const DML_AFFECTED_ROWS_COLUMN_PREFIXES: &[&str] = &["number of rows inserted"];
+
+const STATEMENT_TYPE_ID_DML: i64 = 0x3000;
+const STATEMENT_TYPE_ID_INSERT: i64 = 0x3100;
+const STATEMENT_TYPE_ID_UPDATE: i64 = 0x3200;
+const STATEMENT_TYPE_ID_DELETE: i64 = 0x3300;
+const STATEMENT_TYPE_ID_MERGE: i64 = 0x3400;
+const STATEMENT_TYPE_ID_MULTI_TABLE_INSERT: i64 = 0x3500;
+const STATEMENT_TYPE_ID_GET_FILES: i64 = 0x7101;
+const STATEMENT_TYPE_ID_PUT_FILES: i64 = 0x7102;
+
+// --- Response parsing helpers ---
+
+fn is_dml_statement(statement_type_id: Option<i64>) -> bool {
+    statement_type_id.is_some_and(|type_id| {
+        matches!(
+            type_id,
+            STATEMENT_TYPE_ID_DML
+                | STATEMENT_TYPE_ID_INSERT
+                | STATEMENT_TYPE_ID_UPDATE
+                | STATEMENT_TYPE_ID_DELETE
+                | STATEMENT_TYPE_ID_MERGE
+                | STATEMENT_TYPE_ID_MULTI_TABLE_INSERT
+        )
+    })
+}
+
+/// Calculate rows affected based on statement type.
+///
+/// Returns `Some(count)` when rows affected is known, `None` when it is not
+/// (when the statement type is unknown).
+///
+/// - For DML: Parse rowset columns to sum affected rows
+/// - For SELECT and other queries: Use total field
+/// - For unknown: Return None
+pub(super) fn calculate_rows_affected(data: &Data) -> Option<i64> {
+    if is_dml_statement(data.statement_type_id) {
+        if let (Some(rowset), Some(row_types)) = (&data.rowset, &data.row_type)
+            && !rowset.is_empty()
+            && !rowset[0].is_empty()
+        {
+            let mut affected_rows = 0i64;
+            for (idx, col) in row_types.iter().enumerate() {
+                let col_name = col.name.to_lowercase();
+                if (DML_AFFECTED_ROWS_COLUMNS.contains(&col_name.as_str())
+                    || DML_AFFECTED_ROWS_COLUMN_PREFIXES
+                        .iter()
+                        .any(|p| col_name.starts_with(p)))
+                    && let Some(Some(value)) = rowset[0].get(idx)
+                    && let Ok(count) = value.parse::<i64>()
+                {
+                    affected_rows += count;
+                }
+            }
+            return Some(affected_rows);
+        }
+        return Some(0);
+    }
+
+    data.total
+}
+
+pub(super) fn response_to_descriptor(
+    data: &Data,
+    wrapper_presets: &WrapperPresets,
+) -> ResultSetDescriptor {
+    let query_id = data.query_id.clone().unwrap_or_default();
+    let rows_affected = calculate_rows_affected(data);
+    let columns = data
+        .row_type
+        .as_ref()
+        .map(|row_types| {
+            row_types
+                .iter()
+                .map(|rt| ColumnMetadata {
+                    name: rt.name.clone(),
+                    r#type: rt
+                        .ext_type_name
+                        .as_ref()
+                        .filter(|s| !s.is_empty())
+                        .cloned()
+                        .unwrap_or_else(|| rt.type_.clone()),
+                    precision: rt.precision.map(|v| v as i64),
+                    scale: rt.scale.map(|v| v as i64),
+                    length: rt.length.map(|v| v as i64),
+                    byte_length: rt.byte_length.map(|v| v as i64),
+                    nullable: rt.nullable,
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| put_get_columns(data.command.as_deref(), wrapper_presets));
+
+    let statement_type_id = data.statement_type_id.or(match data.command.as_deref() {
+        Some("UPLOAD") => Some(STATEMENT_TYPE_ID_PUT_FILES),
+        Some("DOWNLOAD") => Some(STATEMENT_TYPE_ID_GET_FILES),
+        _ => None,
+    });
+
+    ResultSetDescriptor {
+        query_id,
+        columns,
+        rows_affected,
+        statement_type_id,
+        sql_state: data.sql_state.clone(),
+        stats: data.stats.clone(),
+        number_of_binds: data.number_of_binds.unwrap_or(0),
+    }
+}
+
+/// Return client-synthesized column metadata for PUT/GET commands,
+/// which don't include `rowType` in the Snowflake response.
+fn put_get_columns(command: Option<&str>, wrapper_presets: &WrapperPresets) -> Vec<ColumnMetadata> {
+    use super::query::{download_column_metadata, upload_column_metadata};
+    match command {
+        Some("UPLOAD") => upload_column_metadata(wrapper_presets),
+        Some("DOWNLOAD") => download_column_metadata(wrapper_presets),
+        _ => Vec::new(),
+    }
+}
+
+/// Build [`ReaderContext`] by snapshotting the HTTP client and prefetch
+/// config from an active connection.
+pub(super) async fn resolve_reader_ctx(
+    conn: &Arc<Mutex<Connection>>,
+) -> Result<ReaderContext, ApiError> {
+    let conn_guard = conn.lock().await;
+    let http_client = conn_guard
+        .http_client
+        .clone()
+        .context(ConnectionNotInitializedSnafu)?;
+    let session_params = conn_guard.session_parameters.read().await;
+    let prefetch_config = PrefetchConfig::from_session_params(&session_params);
+    Ok(ReaderContext {
+        http_client,
+        prefetch_config,
+    })
+}
+
+/// Fetch a query result from Snowflake by query_id via the connection,
+/// returning the raw response `Data` for further processing.
+pub(super) async fn fetch_query_response_data(
+    conn_ptr: &Arc<Mutex<Connection>>,
+    query_id: &str,
+) -> Result<Data, ApiError> {
+    let (query_parameters, http_client, retry_policy) = {
+        let conn = conn_ptr.lock().await;
+        (
+            conn.query_transport_parameters()?,
+            conn.http_client
+                .clone()
+                .context(ConnectionNotInitializedSnafu)?,
+            conn.retry_policy.clone(),
+        )
+    };
+
+    let response = {
+        let mut ctx = RefreshContext::from_arc(conn_ptr).await?;
+        let mut last_error = None;
+        loop {
+            let session_token = ctx.refresh_token(last_error).await?;
+            match snowflake_get_query_result(
+                &http_client,
+                &query_parameters,
+                session_token.reveal(),
+                query_id,
+                &retry_policy,
+            )
+            .await
+            {
+                Ok(response) => break response,
+                Err(err) => {
+                    last_error = Some(err);
+                }
+            }
+        }
+    };
+
+    if response.success {
+        let conn = conn_ptr.lock().await;
+        conn.update_session_params_cache(
+            "",
+            response.data.parameters.as_ref(),
+            &super::connection::FinalSessionNames {
+                database: response.data.final_database_name.clone(),
+                schema: response.data.final_schema_name.clone(),
+                warehouse: response.data.final_warehouse_name.clone(),
+                role: response.data.final_role_name.clone(),
+            },
+        )
+        .await;
+    }
+
+    Ok(response.data)
+}
+
+// --- DatabaseDriverV1 impl ---
+
+impl DatabaseDriverV1 {
+    /// Builds and returns a fresh Arrow stream for this result set.
+    ///
+    /// The stream is constructed lazily from the stored `RowsetData`.
+    /// Can be called multiple times — the source data is preserved.
+    pub async fn result_set_get_stream(
+        &self,
+        result_handle: Handle,
+    ) -> Result<Box<FFI_ArrowArrayStream>, ApiError> {
+        let rs_ptr = self.results.get_obj(result_handle).ok_or_else(|| {
+            InvalidArgumentSnafu {
+                argument: "ResultSet handle not found".to_string(),
+            }
+            .build()
+        })?;
+        let rs = rs_ptr.lock().await;
+
+        let reader = build_reader_from_rowset_data(
+            &rs.data,
+            rs.reader_ctx.http_client.clone(),
+            &rs.reader_ctx.prefetch_config,
+            &self.wrapper_presets,
+        )
+        .await
+        .context(QueryResponseProcessingSnafu)?;
+
+        Ok(Box::new(FFI_ArrowArrayStream::new(reader)))
+    }
+
+    /// Returns chunk metadata (inline data + remote chunk URLs) for this result set.
+    ///
+    /// Derives `ChunkData` from the stored `RowsetData` on demand.
+    pub async fn result_set_get_chunks(
+        &self,
+        result_handle: Handle,
+    ) -> Result<ChunkDataWithDescriptor, ApiError> {
+        let rs_ptr = self.results.get_obj(result_handle).ok_or_else(|| {
+            InvalidArgumentSnafu {
+                argument: "ResultSet handle not found".to_string(),
+            }
+            .build()
+        })?;
+        let result_set = rs_ptr.lock().await;
+
+        let chunk_data = (&result_set.data).into();
+
+        Ok(ChunkDataWithDescriptor {
+            chunk_data,
+            descriptor: result_set.descriptor.clone(),
+        })
+    }
+
+    pub fn result_set_release(&self, result_handle: Handle) -> Result<(), ApiError> {
+        if !self.results.delete_handle(result_handle) {
+            return Err(InvalidArgumentSnafu {
+                argument: "ResultSet handle not found".to_string(),
+            }
+            .build());
+        }
+        Ok(())
+    }
+
+    /// Builds an `ExecuteQueryResult` from pre-resolved `RowsetData`.
+    ///
+    /// Callers must resolve PUT/GET transfers and convert `Data` into `RowsetData`
+    /// before calling this method.
+    pub(super) fn build_execute_result(
+        &self,
+        rowset_data: RowsetData,
+        descriptor: ResultSetDescriptor,
+        reader_ctx: ReaderContext,
+    ) -> ExecuteQueryResult {
+        let result_set_handle = self.create_result_set(descriptor.clone(), rowset_data, reader_ctx);
+        ExecuteQueryResult::Single(ResultSetInfo {
+            handle: result_set_handle,
+            descriptor,
+        })
+    }
+
+    /// Creates a ResultSet and registers it in the handle manager.
+    fn create_result_set(
+        &self,
+        descriptor: ResultSetDescriptor,
+        data: RowsetData,
+        reader_ctx: ReaderContext,
+    ) -> Handle {
+        let result_set = ResultSet {
+            descriptor,
+            data,
+            reader_ctx,
+        };
+        self.results.add_handle(Mutex::new(result_set))
+    }
+
+    /// Creates a ResultSet by fetching data from Snowflake by query_id.
+    ///
+    /// This path is used for multi-statement child results and async query result
+    /// retrieval — neither of which involves PUT/GET file transfers.
+    pub async fn create_result_set_from_sfqid(
+        &self,
+        conn_handle: Handle,
+        query_id: String,
+    ) -> Result<ResultSetInfo, ApiError> {
+        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
+            InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .build()
+        })?;
+
+        let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
+        let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
+        let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
+        let handle =
+            self.create_result_set(descriptor.clone(), data.into_rowset_data(), reader_ctx);
+
+        Ok(ResultSetInfo { handle, descriptor })
+    }
+}

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -4,21 +4,23 @@ use tokio::sync::Mutex;
 use super::connection::{Connection, RefreshContext, with_valid_session};
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
-use super::query::process_query_response;
+use super::multistatement;
+use super::query::perform_put_get_transfer;
+use super::result_set::{
+    ColumnMetadata, ExecuteQueryResult, fetch_query_response_data, resolve_reader_ctx,
+    response_to_descriptor,
+};
 use super::validation::{
     ValidationIssue, ValidationSeverity, canonicalize_setting_key, resolve_options,
     validate_statement_option_write,
 };
-use crate::chunks::{ChunkDownloadData, ChunkFormatKind, PrefetchConfig};
 use crate::config::ParamStore;
 use crate::config::param_registry::ParamKey;
 use crate::config::param_registry::param_names;
 use crate::config::settings::Setting;
 use crate::handle_manager::Handle;
-use crate::rest::snowflake::query_response::{Data, Stats};
 use crate::rest::snowflake::{
-    QueryExecutionMode, QueryInput, snowflake_abort_query, snowflake_get_query_result,
-    snowflake_query_with_client,
+    QueryExecutionMode, QueryInput, snowflake_abort_query, snowflake_query_with_client,
 };
 
 use crate::config::rest_parameters::QueryParameters;
@@ -82,92 +84,6 @@ pub enum BindingType<'a> {
 /// Result returned from async query submission (non-blocking).
 pub struct AsyncExecuteResult {
     pub query_id: String,
-}
-
-/// Column names whose values are summed to compute DML rows-affected (exact match).
-const DML_AFFECTED_ROWS_COLUMNS: &[&str] = &[
-    "number of rows updated",
-    "number of multi-joined rows updated",
-    "number of rows deleted",
-];
-
-/// Column name prefixes whose values are summed to compute DML rows-affected.
-const DML_AFFECTED_ROWS_COLUMN_PREFIXES: &[&str] = &["number of rows inserted"];
-
-// Statement type ID constants for DML detection
-const STATEMENT_TYPE_ID_DML: i64 = 0x3000;
-const STATEMENT_TYPE_ID_INSERT: i64 = 0x3100;
-const STATEMENT_TYPE_ID_UPDATE: i64 = 0x3200;
-const STATEMENT_TYPE_ID_DELETE: i64 = 0x3300;
-const STATEMENT_TYPE_ID_MERGE: i64 = 0x3400;
-const STATEMENT_TYPE_ID_MULTI_TABLE_INSERT: i64 = 0x3500;
-
-// Statement type IDs for PUT / GET, mirroring `odbc::api::query_type::QueryType`.
-// Snowflake's REST response for these commands does not always carry a
-// `statementTypeId`, so `response_to_descriptor` falls back to these when
-// the `command` field indicates an UPLOAD / DOWNLOAD.
-const STATEMENT_TYPE_ID_GET_FILES: i64 = 0x7101;
-const STATEMENT_TYPE_ID_PUT_FILES: i64 = 0x7102;
-
-/// Check if a statement type ID represents a DML operation
-fn is_dml_statement(statement_type_id: Option<i64>) -> bool {
-    if let Some(type_id) = statement_type_id {
-        matches!(
-            type_id,
-            STATEMENT_TYPE_ID_DML
-                | STATEMENT_TYPE_ID_INSERT
-                | STATEMENT_TYPE_ID_UPDATE
-                | STATEMENT_TYPE_ID_DELETE
-                | STATEMENT_TYPE_ID_MERGE
-                | STATEMENT_TYPE_ID_MULTI_TABLE_INSERT
-        )
-    } else {
-        false
-    }
-}
-
-/// Calculate rows affected based on statement type.
-///
-/// Returns `Some(count)` when rows affected is known, `None` when it is not
-/// (when the statement type is unknown).
-///
-/// - For DML: Parse rowset columns to sum affected rows
-/// - For SELECT and other queries: Use total field
-/// - For unknown: Return None
-pub(crate) fn calculate_rows_affected(data: &Data) -> Option<i64> {
-    // Check if this is a DML statement
-    if is_dml_statement(data.statement_type_id) {
-        // For DML, parse the rowset to get affected rows
-        if let (Some(rowset), Some(row_types)) = (&data.rowset, &data.row_type)
-            && !rowset.is_empty()
-            && !rowset[0].is_empty()
-        {
-            let mut affected_rows = 0i64;
-
-            // Look for specific column names that indicate affected rows
-            for (idx, col) in row_types.iter().enumerate() {
-                let col_name = col.name.to_lowercase();
-
-                if (DML_AFFECTED_ROWS_COLUMNS.contains(&col_name.as_str())
-                    || DML_AFFECTED_ROWS_COLUMN_PREFIXES
-                        .iter()
-                        .any(|p| col_name.starts_with(p)))
-                    && let Some(Some(value)) = rowset[0].get(idx)
-                    && let Ok(count) = value.parse::<i64>()
-                {
-                    affected_rows += count;
-                }
-            }
-
-            return Some(affected_rows);
-        }
-        // DML with no affected rows
-        return Some(0);
-    }
-
-    // For SELECT and other queries, use total field.
-    // Return None if total is not available.
-    data.total
 }
 
 impl DatabaseDriverV1 {
@@ -288,88 +204,37 @@ impl DatabaseDriverV1 {
         let result = self
             .execute_query_internal(stmt_handle, None, Some(true), None)
             .await?;
-        let descriptor = result.into_descriptor();
 
-        // For describe_only, use prebuilt stream from execute
+        // Multi-statement query prepare is not supported.
+        let ExecuteQueryResult::Single(rs_info) = result else {
+            return Err(InvalidArgumentSnafu {
+                argument: "Multi-statement queries cannot be prepared".to_string(),
+            }
+            .build());
+        };
+        let stream = self.result_set_get_stream(rs_info.handle).await?;
+        self.result_set_release(rs_info.handle)?;
+
         let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
             InvalidArgumentSnafu {
                 argument: "Statement handle not found".to_string(),
             }
             .build()
         })?;
-        let mut stmt = stmt_ptr.lock().await;
-        let chunk_info = stmt.chunk_info.as_mut().ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "No chunk info available; execute a query first".to_string(),
-            }
-            .build()
-        })?;
-        let stream = chunk_info.prebuilt_stream.take().ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "No prebuilt stream available".to_string(),
-            }
-            .build()
-        })?;
+        // TODO: re-lock the statement to just copy the query
+        //       consider to carry query text in ExecuteQueryResult to avoid the re-lock
+        let stmt = stmt_ptr.lock().await;
         let query = stmt.query.clone().unwrap_or_default();
 
         Ok(PrepareResult {
             stream,
-            query_id: descriptor.query_id,
-            columns: descriptor.columns,
-            number_of_binds: descriptor.number_of_binds,
+            query_id: rs_info.descriptor.query_id,
+            columns: rs_info.descriptor.columns,
+            number_of_binds: rs_info.descriptor.number_of_binds,
             query,
-            sql_state: descriptor.sql_state,
+            sql_state: rs_info.descriptor.sql_state,
         })
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ColumnMetadata {
-    pub name: String,
-    pub r#type: String,
-    pub precision: Option<i64>,
-    pub scale: Option<i64>,
-    pub length: Option<i64>,
-    pub byte_length: Option<i64>,
-    pub nullable: bool,
-}
-
-/// Metadata for a single result set (maps to proto ResultSetDescriptor).
-#[derive(Clone)]
-pub struct ResultSetDescriptor {
-    pub query_id: String,
-    pub columns: Vec<ColumnMetadata>,
-    pub rows_affected: Option<i64>,
-    pub statement_type_id: Option<i64>,
-    pub sql_state: Option<String>,
-    pub stats: Option<Stats>,
-    pub number_of_binds: i32,
-}
-
-/// Result of executing a query (maps to proto ExecuteQueryResponse).
-pub enum ExecuteQueryResult {
-    Single(ResultSetDescriptor),
-    Multi {
-        parent: ResultSetDescriptor,
-        query_ids: Vec<String>,
-        statement_type_ids: Vec<i64>,
-    },
-}
-
-impl ExecuteQueryResult {
-    /// Extract the descriptor regardless of single/multi variant.
-    pub fn into_descriptor(self) -> ResultSetDescriptor {
-        match self {
-            ExecuteQueryResult::Single(d) => d,
-            ExecuteQueryResult::Multi { parent, .. } => parent,
-        }
-    }
-}
-
-/// A fully resolved result set with data (maps to proto ResultSetResponse).
-pub struct ResolvedResultSet {
-    pub descriptor: ResultSetDescriptor,
-    pub stream: Box<FFI_ArrowArrayStream>,
 }
 
 impl DatabaseDriverV1 {
@@ -452,55 +317,26 @@ impl DatabaseDriverV1 {
             .await;
         }
 
-        let descriptor = response_to_descriptor(&response.data, &self.wrapper_presets);
-
-        let prefetch_config = resolve_prefetch_config(&conn_arc).await;
-
-        // Build the Arrow stream eagerly — this handles all result formats
-        // (Arrow, JSON, PUT/GET file transfers) via process_query_response.
-        // Skip for multi-statement parents (they only contain metadata).
-        let prebuilt_stream = if super::multistatement::is_multistatement(&response.data) {
-            None
-        } else {
-            let query_result = process_query_response(
-                &response.data,
-                &http_client,
-                &prefetch_config,
-                &self.wrapper_presets,
-            )
-            .await
-            .context(QueryResponseProcessingSnafu)?;
-            Some(Box::new(FFI_ArrowArrayStream::new(query_result.reader)))
-        };
-
-        // Re-acquire lock to store results
+        // Re-acquire lock to set the state
         let mut stmt = stmt_ptr.lock().await;
-        let format = response_chunk_format(&response.data)?;
-        stmt.chunk_info = Some(StoredChunkInfo {
-            query_id: descriptor.query_id.clone(),
-            descriptor: descriptor.clone(),
-            format,
-            inline: response_inline_data(&response.data, format),
-            chunks: response.data.to_chunk_download_data().unwrap_or_default(),
-            prebuilt_stream,
-            number_of_binds: response.data.number_of_binds.unwrap_or(0),
-            stream_consumed: false,
-        });
-
         stmt.state = StatementState::Executed;
+        drop(stmt);
 
-        if super::multistatement::is_multistatement(&response.data) {
-            let query_ids = super::multistatement::child_query_ids(&response.data);
-            let statement_type_ids =
-                super::multistatement::child_statement_type_ids(&response.data);
-            Ok(ExecuteQueryResult::Multi {
-                parent: descriptor,
-                query_ids,
-                statement_type_ids,
-            })
-        } else {
-            Ok(ExecuteQueryResult::Single(descriptor))
+        let data = response.data;
+        let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
+
+        if let Some(multi) = multistatement::try_into_multi_result(&data, descriptor.clone()) {
+            return Ok(multi);
         }
+
+        let rowset_data = match data.command.as_deref() {
+            Some(command) => perform_put_get_transfer(command, &data)
+                .await
+                .context(QueryResponseProcessingSnafu)?,
+            None => data.into_rowset_data(),
+        };
+        let reader_ctx = resolve_reader_ctx(&conn_arc).await?;
+        Ok(self.build_execute_result(rowset_data, descriptor, reader_ctx))
     }
 
     /// Execute query asynchronously (non-blocking) — returns immediately with query_id.
@@ -569,48 +405,6 @@ impl DatabaseDriverV1 {
         Ok(AsyncExecuteResult { query_id })
     }
 
-    pub async fn statement_result_chunks(
-        &self,
-        stmt_handle: Handle,
-        query_id: &str,
-    ) -> Result<StoredChunkInfo, ApiError> {
-        let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Statement handle not found".to_string(),
-            }
-            .build()
-        })?;
-
-        let stmt = stmt_ptr.lock().await;
-        let chunk_info = stmt.chunk_info.as_ref().ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "No chunk info available; execute a query first".to_string(),
-            }
-            .build()
-        })?;
-
-        if !query_id.is_empty() && chunk_info.query_id != query_id {
-            return Err(InvalidArgumentSnafu {
-                argument: format!(
-                    "query_id mismatch: requested '{}' but statement has '{}'",
-                    query_id, chunk_info.query_id
-                ),
-            }
-            .build());
-        }
-
-        Ok(StoredChunkInfo {
-            query_id: chunk_info.query_id.clone(),
-            descriptor: chunk_info.descriptor.clone(),
-            format: chunk_info.format,
-            inline: chunk_info.inline.clone(),
-            chunks: chunk_info.chunks.clone(),
-            prebuilt_stream: None, // prebuilt stream is not cloneable; chunks path only
-            number_of_binds: chunk_info.number_of_binds,
-            stream_consumed: chunk_info.stream_consumed,
-        })
-    }
-
     pub async fn connection_get_query_result(
         &self,
         conn_handle: Handle,
@@ -623,54 +417,21 @@ impl DatabaseDriverV1 {
             .build()
         })?;
 
-        let (query_parameters, http_client, retry_policy) = query_context(&conn_ptr).await?;
+        let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
+        let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
 
-        let response = with_valid_session(&conn_ptr, |token| {
-            let http_client = &http_client;
-            let query_parameters = &query_parameters;
-            let query_id = &query_id;
-            let retry_policy = &retry_policy;
-            async move {
-                snowflake_get_query_result(
-                    http_client,
-                    query_parameters,
-                    token.reveal(),
-                    query_id,
-                    retry_policy,
-                )
+        if let Some(multi) = multistatement::try_into_multi_result(&data, descriptor.clone()) {
+            return Ok(multi);
+        }
+
+        let rowset_data = match data.command.as_deref() {
+            Some(command) => perform_put_get_transfer(command, &data)
                 .await
-            }
-        })
-        .await?;
-
-        if response.success {
-            let conn = conn_ptr.lock().await;
-            conn.update_session_params_cache(
-                "",
-                response.data.parameters.as_ref(),
-                &super::connection::FinalSessionNames {
-                    database: response.data.final_database_name.clone(),
-                    schema: response.data.final_schema_name.clone(),
-                    warehouse: response.data.final_warehouse_name.clone(),
-                    role: response.data.final_role_name.clone(),
-                },
-            )
-            .await;
-        }
-
-        let descriptor = response_to_descriptor(&response.data, &self.wrapper_presets);
-        if super::multistatement::is_multistatement(&response.data) {
-            let query_ids = super::multistatement::child_query_ids(&response.data);
-            let statement_type_ids =
-                super::multistatement::child_statement_type_ids(&response.data);
-            Ok(ExecuteQueryResult::Multi {
-                parent: descriptor,
-                query_ids,
-                statement_type_ids,
-            })
-        } else {
-            Ok(ExecuteQueryResult::Single(descriptor))
-        }
+                .context(QueryResponseProcessingSnafu)?,
+            None => data.into_rowset_data(),
+        };
+        let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
+        Ok(self.build_execute_result(rowset_data, descriptor, reader_ctx))
     }
 
     pub async fn connection_abort_query(
@@ -730,313 +491,11 @@ fn extract_query(stmt: &Statement) -> Result<String, ApiError> {
     })
 }
 
-/// Map the server's `queryResultFormat` onto `ChunkFormatKind`; absent field defaults to Arrow IPC, unknown values error.
-fn response_chunk_format(data: &Data) -> Result<ChunkFormatKind, ApiError> {
-    match data.query_result_format.as_deref() {
-        Some(s) if s.eq_ignore_ascii_case("json") => Ok(ChunkFormatKind::Json),
-        Some(s) if s.eq_ignore_ascii_case("arrow") => Ok(ChunkFormatKind::ArrowIpc),
-        None => Ok(ChunkFormatKind::ArrowIpc),
-        Some(other) => UnsupportedQueryResultFormatSnafu {
-            format: other.to_string(),
-        }
-        .fail(),
-    }
-}
-
-/// Extract the inline initial chunk from the response; empty/missing payloads collapse to `InlineData::None`.
-fn response_inline_data(data: &Data, format: ChunkFormatKind) -> InlineData {
-    match format {
-        ChunkFormatKind::Json => match data.rowset.as_ref() {
-            Some(rowset) if !rowset.is_empty() => InlineData::Json(rowset.clone()),
-            _ => InlineData::None,
-        },
-        ChunkFormatKind::ArrowIpc => match data.to_initial_base64_opt() {
-            Some(b) => InlineData::ArrowIpc(b.to_string()),
-            None => InlineData::None,
-        },
-    }
-}
-
-/// Extract metadata from a Snowflake query response into a `ResultSetDescriptor`.
-fn response_to_descriptor(
-    data: &Data,
-    wrapper_presets: &super::global_state::WrapperPresets,
-) -> ResultSetDescriptor {
-    let query_id = data.query_id.clone().unwrap_or_default();
-    let rows_affected = calculate_rows_affected(data);
-    let columns = data
-        .row_type
-        .as_ref()
-        .map(|row_types| {
-            row_types
-                .iter()
-                .map(|rt| ColumnMetadata {
-                    name: rt.name.clone(),
-                    r#type: rt
-                        .ext_type_name
-                        .as_ref()
-                        .filter(|s| !s.is_empty())
-                        .cloned()
-                        .unwrap_or_else(|| rt.type_.clone()),
-                    precision: rt.precision.map(|v| v as i64),
-                    scale: rt.scale.map(|v| v as i64),
-                    length: rt.length.map(|v| v as i64),
-                    byte_length: rt.byte_length.map(|v| v as i64),
-                    nullable: rt.nullable,
-                })
-                .collect()
-        })
-        .unwrap_or_else(|| put_get_columns(data.command.as_deref(), wrapper_presets));
-
-    // Snowflake's REST response for PUT / GET does not always carry a `statementTypeId`,
-    // wrapper classifiers need a client-side fallback to recognise the synthesized PUT / GET cursor.
-    // Preserve any server-provided value and only infer it from the `command` field when absent.
-    let statement_type_id = data.statement_type_id.or(match data.command.as_deref() {
-        Some("UPLOAD") => Some(STATEMENT_TYPE_ID_PUT_FILES),
-        Some("DOWNLOAD") => Some(STATEMENT_TYPE_ID_GET_FILES),
-        _ => None,
-    });
-
-    ResultSetDescriptor {
-        query_id,
-        columns,
-        rows_affected,
-        statement_type_id,
-        sql_state: data.sql_state.clone(),
-        stats: data.stats.clone(),
-        number_of_binds: data.number_of_binds.unwrap_or(0),
-    }
-}
-
-/// Return client-synthesized column metadata for PUT/GET commands,
-/// which don't include `rowType` in the Snowflake response.
-fn put_get_columns(
-    command: Option<&str>,
-    wrapper_presets: &super::global_state::WrapperPresets,
-) -> Vec<ColumnMetadata> {
-    use super::query::{download_column_metadata, upload_column_metadata};
-    match command {
-        Some("UPLOAD") => upload_column_metadata(wrapper_presets),
-        Some("DOWNLOAD") => download_column_metadata(wrapper_presets),
-        _ => Vec::new(),
-    }
-}
-
-/// Read prefetch-related session parameters from the connection
-/// and build a [`PrefetchConfig`].
-async fn resolve_prefetch_config(conn: &Arc<Mutex<Connection>>) -> PrefetchConfig {
-    let conn_guard = conn.lock().await;
-    let session_params = conn_guard.session_parameters.read().await;
-    let threads = session_params
-        .get(param_names::CLIENT_PREFETCH_THREADS.as_str())
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(crate::chunks::DEFAULT_PREFETCH_THREADS);
-    let memory_limit_mb = session_params
-        .get(param_names::CLIENT_MEMORY_LIMIT.as_str())
-        .and_then(|v| v.parse::<u32>().ok())
-        .unwrap_or(crate::chunks::DEFAULT_MEMORY_LIMIT_MB);
-    PrefetchConfig {
-        prefetch_threads: threads,
-        memory_limit_mb,
-    }
-}
-
-/// Fetch a query result from Snowflake by query_id via the connection,
-/// returning the raw response `Data` for further processing.
-async fn fetch_query_response_data(
-    conn_ptr: &Arc<Mutex<Connection>>,
-    query_id: &str,
-) -> Result<(Data, reqwest::Client), ApiError> {
-    let (query_parameters, http_client, retry_policy) = {
-        let conn = conn_ptr.lock().await;
-        (
-            conn.query_transport_parameters()?,
-            conn.http_client
-                .clone()
-                .context(ConnectionNotInitializedSnafu)?,
-            conn.retry_policy.clone(),
-        )
-    };
-
-    let response = {
-        let mut ctx = RefreshContext::from_arc(conn_ptr).await?;
-        let mut last_error = None;
-        loop {
-            let session_token = ctx.refresh_token(last_error).await?;
-            match snowflake_get_query_result(
-                &http_client,
-                &query_parameters,
-                session_token.reveal(),
-                query_id,
-                &retry_policy,
-            )
-            .await
-            {
-                Ok(result) => break Ok(result),
-                Err(e) => last_error = Some(e),
-            }
-        }
-    }?;
-
-    if response.success {
-        let conn = conn_ptr.lock().await;
-        conn.update_session_params_cache(
-            "",
-            response.data.parameters.as_ref(),
-            &super::connection::FinalSessionNames {
-                database: response.data.final_database_name.clone(),
-                schema: response.data.final_schema_name.clone(),
-                warehouse: response.data.final_warehouse_name.clone(),
-                role: response.data.final_role_name.clone(),
-            },
-        )
-        .await;
-    }
-
-    Ok((response.data, http_client))
-}
-
-/// Build a `ResolvedResultSet` from a Snowflake HTTP response by fetching the query result by query_id and building the Arrow stream.
-async fn fetch_and_resolve_result_set(
-    conn_ptr: &Arc<Mutex<Connection>>,
-    query_id: &str,
-    wrapper_presets: &super::global_state::WrapperPresets,
-) -> Result<ResolvedResultSet, ApiError> {
-    let (data, http_client) = fetch_query_response_data(conn_ptr, query_id).await?;
-    let prefetch_config = resolve_prefetch_config(conn_ptr).await;
-
-    let descriptor = response_to_descriptor(&data, wrapper_presets);
-    let query_result =
-        process_query_response(&data, &http_client, &prefetch_config, wrapper_presets)
-            .await
-            .context(QueryResponseProcessingSnafu)?;
-    let stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));
-
-    Ok(ResolvedResultSet { descriptor, stream })
-}
-
-/// Fetch chunk metadata for a query_id using the connection (no statement handle needed).
-async fn fetch_chunk_info_by_query_id(
-    conn_ptr: &Arc<Mutex<Connection>>,
-    query_id: &str,
-    wrapper_presets: &super::global_state::WrapperPresets,
-) -> Result<StoredChunkInfo, ApiError> {
-    let (data, _http_client) = fetch_query_response_data(conn_ptr, query_id).await?;
-
-    let descriptor = response_to_descriptor(&data, wrapper_presets);
-    let format = response_chunk_format(&data)?;
-
-    Ok(StoredChunkInfo {
-        query_id: descriptor.query_id.clone(),
-        descriptor,
-        format,
-        inline: response_inline_data(&data, format),
-        chunks: data.to_chunk_download_data().unwrap_or_default(),
-        prebuilt_stream: None, // prebuilt stream is not cloneable; chunks path only
-        number_of_binds: data.number_of_binds.unwrap_or(0),
-        stream_consumed: false,
-    })
-}
-
-impl DatabaseDriverV1 {
-    /// Fetch a result set by query_id using the statement's stored chunk info (fast path)
-    /// or by re-fetching from Snowflake (for multi-statement children).
-    pub async fn statement_get_result_set(
-        &self,
-        stmt_handle: Handle,
-        query_id: String,
-    ) -> Result<ResolvedResultSet, ApiError> {
-        let stmt_ptr = self.statements.get_obj(stmt_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Statement handle not found".to_string(),
-            }
-            .build()
-        })?;
-
-        let mut stmt = stmt_ptr.lock().await;
-
-        // Fast path: if the query_id matches stored chunk_info, use prebuilt stream
-        if let Some(ref mut info) = stmt.chunk_info
-            && info.query_id == query_id
-            && let Some(prebuilt) = info.prebuilt_stream.take()
-        {
-            let descriptor = info.descriptor.clone();
-            return Ok(ResolvedResultSet {
-                descriptor,
-                stream: prebuilt,
-            });
-        }
-
-        // Slow path: fetch from Snowflake by query_id (multi-statement children)
-        let conn = stmt.conn.clone();
-        drop(stmt);
-        fetch_and_resolve_result_set(&conn, &query_id, &self.wrapper_presets).await
-    }
-
-    /// Fetch a result set by query_id using the connection (stateless, always fetches from Snowflake).
-    pub async fn connection_get_result_set(
-        &self,
-        conn_handle: Handle,
-        query_id: String,
-    ) -> Result<ResolvedResultSet, ApiError> {
-        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Connection handle not found".to_string(),
-            }
-            .build()
-        })?;
-
-        fetch_and_resolve_result_set(&conn_ptr, &query_id, &self.wrapper_presets).await
-    }
-
-    /// Fetch chunk metadata by query_id using the connection (no statement handle required).
-    pub async fn connection_result_chunks(
-        &self,
-        conn_handle: Handle,
-        query_id: String,
-    ) -> Result<StoredChunkInfo, ApiError> {
-        let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
-            InvalidArgumentSnafu {
-                argument: "Connection handle not found".to_string(),
-            }
-            .build()
-        })?;
-
-        fetch_chunk_info_by_query_id(&conn_ptr, &query_id, &self.wrapper_presets).await
-    }
-}
-
-/// Inline initial chunk of a result set, if any.
-#[derive(Clone)]
-pub enum InlineData {
-    /// Base64-encoded Arrow IPC stream.
-    ArrowIpc(String),
-    /// JSON rowset (rows of nullable string cells).
-    Json(Vec<Vec<Option<String>>>),
-    None,
-}
-
-pub struct StoredChunkInfo {
-    pub query_id: String,
-    pub descriptor: ResultSetDescriptor,
-    /// Wire format reported by the server (`ARROW` or `JSON`).
-    pub format: ChunkFormatKind,
-    pub inline: InlineData,
-    pub chunks: Vec<ChunkDownloadData>,
-    /// Pre-built Arrow stream from execute. Consumed once by `statement_get_result_set`.
-    pub prebuilt_stream: Option<Box<FFI_ArrowArrayStream>>,
-    /// Number of bind parameters (only for prepared statements).
-    pub number_of_binds: i32,
-    /// Tracks whether the prebuilt stream was already consumed.
-    pub stream_consumed: bool,
-}
-
 pub struct Statement {
     pub state: StatementState,
     pub(crate) settings: ParamStore,
     pub query: Option<String>,
     pub conn: Arc<Mutex<Connection>>,
-    pub(crate) chunk_info: Option<StoredChunkInfo>,
 }
 
 #[derive(Debug, Clone)]
@@ -1052,7 +511,6 @@ impl Statement {
             state: StatementState::Initialized,
             query: None,
             conn,
-            chunk_info: None,
         }
     }
 
@@ -1273,7 +731,9 @@ fn resolve_query_bindings<'a>(
 
 #[cfg(test)]
 mod tests {
+    use super::super::result_set;
     use super::*;
+    use crate::rest::snowflake::query_response::Data;
 
     #[test]
     fn parse_bool_setting_accepts_native_bool_values() {
@@ -1766,7 +1226,7 @@ mod tests {
                 ]
             }"#,
         );
-        assert_eq!(calculate_rows_affected(&data), Some(13));
+        assert_eq!(result_set::calculate_rows_affected(&data), Some(13));
     }
 
     #[test]
@@ -1781,7 +1241,7 @@ mod tests {
                 ]
             }"#,
         );
-        assert_eq!(calculate_rows_affected(&data), Some(5));
+        assert_eq!(result_set::calculate_rows_affected(&data), Some(5));
     }
 
     #[test]
@@ -1795,7 +1255,7 @@ mod tests {
                 ]
             }"#,
         );
-        assert_eq!(calculate_rows_affected(&data), Some(0));
+        assert_eq!(result_set::calculate_rows_affected(&data), Some(0));
     }
 
     #[test]
@@ -1805,7 +1265,7 @@ mod tests {
                 "total": 42
             }"#,
         );
-        assert_eq!(calculate_rows_affected(&data), Some(42));
+        assert_eq!(result_set::calculate_rows_affected(&data), Some(42));
     }
 
     #[test]

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -416,22 +416,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Format: {format_label}");
 
-    let rowset_data = response.data.to_rowset_data();
-    match rowset_data {
-        sf_core::rest::snowflake::query_response::RowsetData::ArrowMultiChunk { .. }
-        | sf_core::rest::snowflake::query_response::RowsetData::ArrowSingleChunk { .. } => {
-            save_arrow_data(&response.data, &cli.output_dir, &tls_client).await?;
-        }
-        sf_core::rest::snowflake::query_response::RowsetData::JsonMultiChunk { .. }
-        | sf_core::rest::snowflake::query_response::RowsetData::JsonRowset { .. } => {
-            save_json_data(&response.data, &cli.output_dir, &tls_client).await?;
-        }
-        sf_core::rest::snowflake::query_response::RowsetData::SchemaOnly { .. } => {
-            return Err("Query returned schema-only (no data)".into());
-        }
-        sf_core::rest::snowflake::query_response::RowsetData::NoData => {
-            return Err("Query returned no data".into());
-        }
+    match format_label {
+        "arrow" => save_arrow_data(&response.data, &cli.output_dir, &tls_client).await?,
+        "json" => save_json_data(&response.data, &cli.output_dir, &tls_client).await?,
+        other => return Err(format!("Unsupported query result format: {other}").into()),
     }
 
     println!("Done! Chunk data saved to {:?}", cli.output_dir);

--- a/sf_core/src/chunks/mod.rs
+++ b/sf_core/src/chunks/mod.rs
@@ -47,6 +47,25 @@ impl Default for PrefetchConfig {
     }
 }
 
+impl PrefetchConfig {
+    /// Resolve from a session parameters map, falling back to defaults for
+    /// missing or unparseable values.
+    pub fn from_session_params(params: &HashMap<String, String>) -> Self {
+        let prefetch_threads = params
+            .get("CLIENT_PREFETCH_THREADS")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_PREFETCH_THREADS);
+        let memory_limit_mb = params
+            .get("CLIENT_MEMORY_LIMIT")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_MEMORY_LIMIT_MB);
+        Self {
+            prefetch_threads,
+            memory_limit_mb,
+        }
+    }
+}
+
 pub async fn json_prefetch_reader(
     initial_rowset: &[Vec<Option<String>>],
     row_types: Vec<RowType>,

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -1,12 +1,16 @@
+use crate::apis::database_driver_v1::ChunkDataWithDescriptor;
 use crate::apis::database_driver_v1::ColumnMetadata as NativeColumnMetadata;
 use crate::apis::database_driver_v1::ConnectionInfo;
 use crate::apis::database_driver_v1::ExecuteQueryResult as NativeExecuteQueryResult;
 use crate::apis::database_driver_v1::FetchChunkInput;
 use crate::apis::database_driver_v1::Handle;
-use crate::apis::database_driver_v1::ResolvedResultSet as NativeResolvedResultSet;
+use crate::apis::database_driver_v1::InlineData;
 use crate::apis::database_driver_v1::ResultSetDescriptor as NativeResultSetDescriptor;
+use crate::apis::database_driver_v1::ResultSetInfo as NativeResultSetInfo;
 use crate::apis::database_driver_v1::Setting;
-use crate::apis::database_driver_v1::error::{ConfigError, InvalidColumnMetadataSnafu, RestError};
+use crate::apis::database_driver_v1::error::{
+    ConfigError, InlineJsonEncodingSnafu, InvalidColumnMetadataSnafu, RestError,
+};
 use crate::apis::database_driver_v1::{ApiError, BindingType, DataPtr};
 use crate::apis::database_driver_v1::{
     ValidationCode as CoreValidationCode, ValidationIssue as CoreValidationIssue,
@@ -138,6 +142,24 @@ impl From<StatementHandle> for Handle {
 impl From<Handle> for StatementHandle {
     fn from(handle: Handle) -> Self {
         StatementHandle {
+            id: handle.id as i64,
+            magic: handle.magic as i64,
+        }
+    }
+}
+
+impl From<ResultSetHandle> for Handle {
+    fn from(handle: ResultSetHandle) -> Self {
+        Handle {
+            id: handle.id as u64,
+            magic: handle.magic as u64,
+        }
+    }
+}
+
+impl From<Handle> for ResultSetHandle {
+    fn from(handle: Handle) -> Self {
+        ResultSetHandle {
             id: handle.id as i64,
             magic: handle.magic as i64,
         }
@@ -288,8 +310,8 @@ impl From<NativeResultSetDescriptor> for ResultSetDescriptor {
 impl From<NativeExecuteQueryResult> for ExecuteQueryResponse {
     fn from(result: NativeExecuteQueryResult) -> Self {
         match result {
-            NativeExecuteQueryResult::Single(descriptor) => ExecuteQueryResponse {
-                result: Some(execute_query_response::Result::Single(descriptor.into())),
+            NativeExecuteQueryResult::Single(info) => ExecuteQueryResponse {
+                result: Some(execute_query_response::Result::Single(info.into())),
             },
             NativeExecuteQueryResult::Multi {
                 parent,
@@ -308,13 +330,86 @@ impl From<NativeExecuteQueryResult> for ExecuteQueryResponse {
     }
 }
 
-impl From<NativeResolvedResultSet> for ResultSetResponse {
-    fn from(result: NativeResolvedResultSet) -> Self {
-        let stream_ptr: ArrowArrayStreamPtr = Box::into_raw(result.stream).into();
-        ResultSetResponse {
-            result_descriptor: Some(result.descriptor.into()),
+impl From<Box<FFI_ArrowArrayStream>> for ResultSetGetStreamResponse {
+    fn from(stream: Box<FFI_ArrowArrayStream>) -> Self {
+        let stream_ptr: ArrowArrayStreamPtr = Box::into_raw(stream).into();
+        ResultSetGetStreamResponse {
             stream: Some(stream_ptr),
         }
+    }
+}
+
+impl From<NativeResultSetInfo> for ResultSetResponse {
+    fn from(info: NativeResultSetInfo) -> Self {
+        ResultSetResponse {
+            result_set_handle: Some(info.handle.into()),
+            result_descriptor: Some(info.descriptor.into()),
+        }
+    }
+}
+
+impl TryFrom<ChunkDataWithDescriptor> for ResultSetGetChunksResponse {
+    type Error = DriverException;
+
+    fn try_from(value: ChunkDataWithDescriptor) -> Result<Self, Self::Error> {
+        let chunk_data = value.chunk_data;
+        let descriptor = value.descriptor;
+
+        let columns: Vec<ColumnMetadata> = descriptor
+            .columns
+            .iter()
+            .cloned()
+            .map(|c| c.into())
+            .collect();
+
+        let mut chunks = Vec::new();
+
+        let inline_base64 = match &chunk_data.inline {
+            InlineData::Json(rowset) => {
+                let row_types: Vec<RowType> = descriptor
+                    .columns
+                    .iter()
+                    .map(column_metadata_to_row_type)
+                    .collect::<Result<Vec<_>, _>>()
+                    .to_protobuf()?;
+                Some(
+                    json_rowset_to_arrow_ipc_base64(rowset, &row_types)
+                        .context(InlineJsonEncodingSnafu)
+                        .to_protobuf()?,
+                )
+            }
+            InlineData::ArrowIpc(b64) => Some(b64.clone()),
+            InlineData::None => None,
+        };
+
+        if let Some(base64_data) = inline_base64 {
+            let remote_rows: i32 = chunk_data.remote_chunks.iter().map(|c| c.row_count).sum();
+            let inline_row_count = descriptor
+                .rows_affected
+                .map(|total| (total as i32).saturating_sub(remote_rows))
+                .unwrap_or(0);
+
+            chunks.push(ResultChunk {
+                format: ChunkFormat::ArrowIpc as i32,
+                data: Some(result_chunk::Data::Inline(base64_data)),
+                row_count: inline_row_count,
+            });
+        }
+
+        for c in &chunk_data.remote_chunks {
+            chunks.push(ResultChunk {
+                format: ChunkFormat::from(chunk_data.format) as i32,
+                data: Some(result_chunk::Data::Remote(RemoteChunk {
+                    url: c.url.clone(),
+                    headers: c.headers.clone(),
+                    compressed_size: c.compressed_size,
+                    uncompressed_size: c.uncompressed_size,
+                })),
+                row_count: c.row_count,
+            });
+        }
+
+        Ok(ResultSetGetChunksResponse { chunks, columns })
     }
 }
 

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -3,16 +3,14 @@ mod converter;
 use crate::apis::database_driver_v1::BindingType;
 use crate::apis::database_driver_v1::DatabaseDriverV1;
 use crate::apis::database_driver_v1::FetchChunkInput;
-use crate::apis::database_driver_v1::InlineData;
-use crate::apis::database_driver_v1::error::{ConfigurationSnafu, InlineJsonEncodingSnafu};
+use crate::apis::database_driver_v1::error::ConfigurationSnafu;
 use crate::config::config_manager;
 use crate::config::path_resolver;
 use crate::handle_manager::Handle;
 use crate::protobuf::generated::database_driver_v1::*;
 use converter::{
     ToProtobuf, column_metadata_to_row_type, core_validation_issue_to_proto,
-    flat_sections_to_nested_json, json_rowset_to_arrow_ipc_base64, proto_chunk_format_to_kind,
-    proto_options_to_hashmap,
+    flat_sections_to_nested_json, proto_chunk_format_to_kind, proto_options_to_hashmap,
 };
 use error_trace::ErrorTrace;
 use snafu::ResultExt;
@@ -35,70 +33,6 @@ fn not_implemented(message: &str) -> DriverException {
         status_code: StatusCode::NotImplemented as i32,
         ..Default::default()
     }
-}
-
-#[allow(clippy::result_large_err)]
-fn chunk_info_to_result_chunks_result(
-    chunk_info: crate::apis::database_driver_v1::StoredChunkInfo,
-) -> Result<ResultChunksResult, DriverException> {
-    let columns: Vec<ColumnMetadata> = chunk_info
-        .descriptor
-        .columns
-        .iter()
-        .cloned()
-        .map(|c| c.into())
-        .collect();
-
-    let mut chunks = Vec::new();
-
-    let inline_base64 = match &chunk_info.inline {
-        InlineData::Json(rowset) => {
-            let row_types: Vec<crate::query_types::RowType> = chunk_info
-                .descriptor
-                .columns
-                .iter()
-                .map(column_metadata_to_row_type)
-                .collect::<Result<Vec<_>, _>>()
-                .to_protobuf()?;
-            Some(
-                json_rowset_to_arrow_ipc_base64(rowset, &row_types)
-                    .context(InlineJsonEncodingSnafu)
-                    .to_protobuf()?,
-            )
-        }
-        InlineData::ArrowIpc(b64) => Some(b64.clone()),
-        InlineData::None => None,
-    };
-
-    if let Some(base64_data) = inline_base64 {
-        let remote_rows: i32 = chunk_info.chunks.iter().map(|c| c.row_count).sum();
-        let inline_row_count = chunk_info
-            .descriptor
-            .rows_affected
-            .map(|total| (total as i32).saturating_sub(remote_rows))
-            .unwrap_or(0);
-
-        chunks.push(ResultChunk {
-            format: ChunkFormat::ArrowIpc as i32,
-            data: Some(result_chunk::Data::Inline(base64_data)),
-            row_count: inline_row_count,
-        });
-    }
-
-    for c in &chunk_info.chunks {
-        chunks.push(ResultChunk {
-            format: ChunkFormat::from(chunk_info.format) as i32,
-            data: Some(result_chunk::Data::Remote(RemoteChunk {
-                url: c.url.clone(),
-                headers: c.headers.clone(),
-                compressed_size: c.compressed_size,
-                uncompressed_size: c.uncompressed_size,
-            })),
-            row_count: c.row_count,
-        });
-    }
-
-    Ok(ResultChunksResult { chunks, columns })
 }
 
 pub struct DatabaseDriverImpl {
@@ -556,7 +490,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
         let result = self
             .driver
-            .connection_get_result_set(conn_handle.into(), input.query_id)
+            .create_result_set_from_sfqid(conn_handle.into(), input.query_id)
             .await
             .to_protobuf()?;
 
@@ -817,22 +751,6 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(result.into())
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_get_result_set", skip(self, input))]
-    async fn statement_get_result_set(
-        &self,
-        input: StatementGetResultSetRequest,
-    ) -> Result<ResultSetResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
-
-        let result = self
-            .driver
-            .statement_get_result_set(stmt_handle.into(), input.query_id)
-            .await
-            .to_protobuf()?;
-
-        Ok(result.into())
-    }
-
     #[instrument(name = "DatabaseDriverV1::statement_execute_async", skip(self, input))]
     async fn statement_execute_async(
         &self,
@@ -888,42 +806,48 @@ impl DatabaseDriver for DatabaseDriverImpl {
         ))
     }
 
-    #[instrument(name = "DatabaseDriverV1::statement_result_chunks", skip(self, input))]
-    async fn statement_result_chunks(
+    #[instrument(name = "DatabaseDriverV1::result_set_get_stream", skip(self, input))]
+    async fn result_set_get_stream(
         &self,
-        input: StatementResultChunksRequest,
-    ) -> Result<StatementResultChunksResponse, DriverException> {
-        let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
+        input: ResultSetGetStreamRequest,
+    ) -> Result<ResultSetGetStreamResponse, DriverException> {
+        let handle = required(input.result_set_handle, "ResultSet handle is required")?;
 
-        let chunk_info = self
+        let result = self
             .driver
-            .statement_result_chunks(stmt_handle.into(), &input.query_id)
+            .result_set_get_stream(handle.into())
             .await
             .to_protobuf()?;
 
-        let result = chunk_info_to_result_chunks_result(chunk_info)?;
-        Ok(StatementResultChunksResponse {
-            result: Some(result),
-        })
+        Ok(result.into())
     }
 
-    #[instrument(name = "DatabaseDriverV1::connection_result_chunks", skip(self, input))]
-    async fn connection_result_chunks(
+    #[instrument(name = "DatabaseDriverV1::result_set_get_chunks", skip(self, input))]
+    async fn result_set_get_chunks(
         &self,
-        input: ConnectionResultChunksRequest,
-    ) -> Result<ConnectionResultChunksResponse, DriverException> {
-        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+        input: ResultSetGetChunksRequest,
+    ) -> Result<ResultSetGetChunksResponse, DriverException> {
+        let result_set_handle = required(input.result_set_handle, "ResultSet handle is required")?;
 
-        let chunk_info = self
-            .driver
-            .connection_result_chunks(conn_handle.into(), input.query_id)
+        self.driver
+            .result_set_get_chunks(result_set_handle.into())
             .await
+            .to_protobuf()?
+            .try_into()
+    }
+
+    #[instrument(name = "DatabaseDriverV1::result_set_release", skip(self, input))]
+    async fn result_set_release(
+        &self,
+        input: ResultSetReleaseRequest,
+    ) -> Result<ResultSetReleaseResponse, DriverException> {
+        let handle = required(input.result_set_handle, "ResultSet handle is required")?;
+
+        self.driver
+            .result_set_release(handle.into())
             .to_protobuf()?;
 
-        let result = chunk_info_to_result_chunks_result(chunk_info)?;
-        Ok(ConnectionResultChunksResponse {
-            result: Some(result),
-        })
+        Ok(ResultSetReleaseResponse {})
     }
 
     #[instrument(name = "DatabaseDriverV1::config_load_all_sections", skip(self, input))]
@@ -1114,14 +1038,6 @@ pub trait DatabaseDriverClientBlockingExt {
         &self,
         input: StatementReleaseRequest,
     ) -> BlockingProtoResult<StatementReleaseResponse>;
-    fn statement_result_chunks_blocking(
-        &self,
-        input: StatementResultChunksRequest,
-    ) -> BlockingProtoResult<StatementResultChunksResponse>;
-    fn connection_result_chunks_blocking(
-        &self,
-        input: ConnectionResultChunksRequest,
-    ) -> BlockingProtoResult<ConnectionResultChunksResponse>;
     fn database_fetch_chunk_blocking(
         &self,
         input: DatabaseFetchChunkRequest,
@@ -1146,14 +1062,22 @@ pub trait DatabaseDriverClientBlockingExt {
         &self,
         input: ConnectionGetInfoRequest,
     ) -> BlockingProtoResult<ConnectionGetInfoResponse>;
-    fn statement_get_result_set_blocking(
-        &self,
-        input: StatementGetResultSetRequest,
-    ) -> Result<ResultSetResponse, proto_utils::ProtoError<DriverException>>;
     fn connection_get_result_set_blocking(
         &self,
         input: ConnectionGetResultSetRequest,
     ) -> Result<ResultSetResponse, proto_utils::ProtoError<DriverException>>;
+    fn result_set_get_stream_blocking(
+        &self,
+        input: ResultSetGetStreamRequest,
+    ) -> BlockingProtoResult<ResultSetGetStreamResponse>;
+    fn result_set_get_chunks_blocking(
+        &self,
+        input: ResultSetGetChunksRequest,
+    ) -> BlockingProtoResult<ResultSetGetChunksResponse>;
+    fn result_set_release_blocking(
+        &self,
+        input: ResultSetReleaseRequest,
+    ) -> BlockingProtoResult<ResultSetReleaseResponse>;
 }
 
 #[allow(clippy::result_large_err)]
@@ -1228,20 +1152,6 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
         block_on_client_call(self.statement_release(input))
     }
 
-    fn statement_result_chunks_blocking(
-        &self,
-        input: StatementResultChunksRequest,
-    ) -> BlockingProtoResult<StatementResultChunksResponse> {
-        block_on_client_call(self.statement_result_chunks(input))
-    }
-
-    fn connection_result_chunks_blocking(
-        &self,
-        input: ConnectionResultChunksRequest,
-    ) -> BlockingProtoResult<ConnectionResultChunksResponse> {
-        block_on_client_call(self.connection_result_chunks(input))
-    }
-
     fn database_fetch_chunk_blocking(
         &self,
         input: DatabaseFetchChunkRequest,
@@ -1284,17 +1194,31 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
         block_on_client_call(self.connection_get_info(input))
     }
 
-    fn statement_get_result_set_blocking(
-        &self,
-        input: StatementGetResultSetRequest,
-    ) -> Result<ResultSetResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.statement_get_result_set(input))
-    }
-
     fn connection_get_result_set_blocking(
         &self,
         input: ConnectionGetResultSetRequest,
     ) -> Result<ResultSetResponse, proto_utils::ProtoError<DriverException>> {
         BLOCKING_CLIENT_RUNTIME.block_on(self.connection_get_result_set(input))
+    }
+
+    fn result_set_get_stream_blocking(
+        &self,
+        input: ResultSetGetStreamRequest,
+    ) -> BlockingProtoResult<ResultSetGetStreamResponse> {
+        block_on_client_call(self.result_set_get_stream(input))
+    }
+
+    fn result_set_get_chunks_blocking(
+        &self,
+        input: ResultSetGetChunksRequest,
+    ) -> BlockingProtoResult<ResultSetGetChunksResponse> {
+        block_on_client_call(self.result_set_get_chunks(input))
+    }
+
+    fn result_set_release_blocking(
+        &self,
+        input: ResultSetReleaseRequest,
+    ) -> BlockingProtoResult<ResultSetReleaseResponse> {
+        block_on_client_call(self.result_set_release(input))
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -184,7 +184,7 @@ pub struct NameValueParameter {
     pub value: serde_json::Value,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RowType {
     #[serde(rename = "name")]
     pub name: String,
@@ -209,7 +209,7 @@ pub struct RowType {
     pub _fields: Option<Vec<FieldMetadata>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct FieldMetadata {
     //unused fields
     #[serde(rename = "name")]
@@ -440,45 +440,40 @@ impl Data {
         })
     }
 
-    pub fn to_rowset_data<'a>(&'a self) -> RowsetData<'a> {
+    /// Converts to `RowsetData` by moving fields out of `Data`.
+    pub fn into_rowset_data(self) -> RowsetData {
+        let chunk_download_data = self.to_chunk_download_data();
+        let initial_base64_opt = self.rowset_base64.filter(|v| !v.is_empty());
+
         match self.query_result_format.as_deref() {
-            Some("arrow") => {
-                match (
-                    self.to_initial_base64_opt(),
-                    self.to_chunk_download_data(),
-                    self.row_type.as_ref(),
-                ) {
-                    (initial_base64_opt, Some(chunk_download_data), _) => {
-                        RowsetData::ArrowMultiChunk {
-                            initial_base64_opt,
-                            chunk_download_data,
-                        }
-                    }
-                    (Some(chunk_base64), None, _) => RowsetData::ArrowSingleChunk { chunk_base64 },
-                    (None, None, Some(rowtype)) => RowsetData::SchemaOnly { rowtype },
-                    _ => {
-                        tracing::error!(
-                            "Initial base64 and/or chunk download data are missing for Arrow result format"
-                        );
-                        RowsetData::NoData
-                    }
+            Some("arrow") => match (initial_base64_opt, chunk_download_data, self.row_type) {
+                (initial_base64_opt, Some(chunk_download_data), _) => RowsetData::ArrowMultiChunk {
+                    initial_base64_opt,
+                    chunk_download_data,
+                },
+                (Some(chunk_base64), None, _) => RowsetData::ArrowSingleChunk { chunk_base64 },
+                (None, None, Some(rowtype)) => RowsetData::SchemaOnly { rowtype },
+                _ => {
+                    tracing::error!(
+                        "Initial base64 and/or chunk download data are missing for Arrow result format"
+                    );
+                    RowsetData::NoData
                 }
-            }
-            Some("json") => {
-                if let Some((rowset, rowtype)) = self.to_json_rowset() {
-                    match self.to_chunk_download_data() {
-                        Some(chunk_download_data) => RowsetData::JsonMultiChunk {
-                            rowset,
-                            rowtype,
-                            chunk_download_data,
-                        },
-                        None => RowsetData::JsonRowset { rowset, rowtype },
-                    }
-                } else {
+            },
+            Some("json") => match (self.rowset, self.row_type) {
+                (Some(rowset), Some(rowtype)) => match chunk_download_data {
+                    Some(chunk_download_data) => RowsetData::JsonMultiChunk {
+                        rowset,
+                        rowtype,
+                        chunk_download_data,
+                    },
+                    None => RowsetData::JsonRowset { rowset, rowtype },
+                },
+                _ => {
                     tracing::error!("Rowset and/or rowtype are missing for JSON result format");
                     RowsetData::NoData
                 }
-            }
+            },
             Some(other) => {
                 tracing::error!("Unsupported query result format: {other}");
                 RowsetData::NoData
@@ -532,26 +527,30 @@ impl Data {
 }
 
 #[derive(Debug)]
-pub enum RowsetData<'a> {
+pub enum RowsetData {
     SchemaOnly {
-        rowtype: &'a Vec<RowType>,
+        rowtype: Vec<RowType>,
     },
     ArrowMultiChunk {
-        initial_base64_opt: Option<&'a str>,
+        initial_base64_opt: Option<String>,
         chunk_download_data: Vec<ChunkDownloadData>,
     },
     ArrowSingleChunk {
-        chunk_base64: &'a str,
+        chunk_base64: String,
     },
     JsonRowset {
-        rowset: &'a Vec<Vec<Option<String>>>,
-        rowtype: &'a Vec<RowType>,
+        rowset: Vec<Vec<Option<String>>>,
+        rowtype: Vec<RowType>,
     },
     JsonMultiChunk {
-        rowset: &'a Vec<Vec<Option<String>>>,
-        rowtype: &'a Vec<RowType>,
+        rowset: Vec<Vec<Option<String>>>,
+        rowtype: Vec<RowType>,
         chunk_download_data: Vec<ChunkDownloadData>,
     },
+    /// PUT (UPLOAD) result: file transfer already executed, results stored.
+    Upload(Vec<crate::file_manager::UploadResult>),
+    /// GET (DOWNLOAD) result: file transfer already executed, results stored.
+    Download(Vec<crate::file_manager::DownloadResult>),
     NoData,
 }
 
@@ -1034,7 +1033,7 @@ mod tests {
         let response: Response = serde_json::from_str(json).unwrap();
 
         assert!(matches!(
-            response.data.to_rowset_data(),
+            response.data.into_rowset_data(),
             RowsetData::ArrowMultiChunk { .. }
         ));
     }

--- a/sf_core/tests/common/arrow_result_helper.rs
+++ b/sf_core/tests/common/arrow_result_helper.rs
@@ -13,7 +13,7 @@ use arrow::datatypes::{DataType, FieldRef, Schema};
 use arrow::ffi_stream::ArrowArrayStreamReader;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
-use sf_core::protobuf::generated::database_driver_v1::ResultSetResponse;
+use sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::mem::discriminant;
@@ -25,8 +25,8 @@ pub struct ArrowResultHelper {
 }
 
 impl ArrowResultHelper {
-    /// Creates a new Arrow result helper from a ResultSetResponse
-    pub fn from_result(result: ResultSetResponse) -> Self {
+    /// Creates a new Arrow result helper from a ResultSetGetStreamResponse
+    pub fn from_result(result: ResultSetGetStreamResponse) -> Self {
         let stream_ptr: *mut FFI_ArrowArrayStream = result.stream.unwrap().into();
         let stream: FFI_ArrowArrayStream = unsafe { FFI_ArrowArrayStream::from_raw(stream_ptr) };
         let reader = ArrowArrayStreamReader::try_new(stream).unwrap();

--- a/sf_core/tests/common/put_get_common.rs
+++ b/sf_core/tests/common/put_get_common.rs
@@ -1,7 +1,7 @@
 pub use super::arrow_deserialize::ArrowDeserialize;
 use crate::common::file_utils::path_to_sql_uri;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use sf_core::protobuf::generated::database_driver_v1::ResultSetResponse;
+use sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse;
 
 // Structured types for Snowflake command results using our arrow_deserialize macro
 #[derive(ArrowDeserialize, Debug, PartialEq)]
@@ -28,7 +28,7 @@ pub fn upload_to_stage(
     client: &SnowflakeTestClient,
     stage_name: &str,
     file_pattern: &str,
-) -> ResultSetResponse {
+) -> ResultSetGetStreamResponse {
     upload_to_stage_with_options(client, stage_name, file_pattern, "")
 }
 
@@ -37,7 +37,7 @@ pub fn upload_to_stage_with_options(
     stage_name: &str,
     file_pattern: &str,
     options: &str,
-) -> ResultSetResponse {
+) -> ResultSetGetStreamResponse {
     client.create_temporary_stage(stage_name);
     let put_sql = build_put_command(stage_name, file_pattern, options);
     client.execute_query(&put_sql)
@@ -47,7 +47,7 @@ pub fn get_file_from_stage(
     client: &SnowflakeTestClient,
     stage_name: &str,
     filename: &str,
-) -> (ResultSetResponse, tempfile::TempDir) {
+) -> (ResultSetGetStreamResponse, tempfile::TempDir) {
     let download_dir = tempfile::TempDir::new().unwrap();
     let get_sql = format!(
         "GET @{stage_name}/{filename} file://{}/",

--- a/sf_core/tests/common/snowflake_test_client.rs
+++ b/sf_core/tests/common/snowflake_test_client.rs
@@ -243,14 +243,11 @@ impl SnowflakeTestClient {
         serde_json::to_string(&bindings).unwrap()
     }
 
-    pub fn result_chunks(&self, stmt: &StatementHandle, query_id: &str) -> ResultChunksResult {
+    pub fn result_set_get_chunks(&self, rs_handle: &ResultSetHandle) -> ResultSetGetChunksResponse {
         self.client
-            .statement_result_chunks_blocking(StatementResultChunksRequest {
-                stmt_handle: Some(*stmt),
-                query_id: query_id.to_string(),
+            .result_set_get_chunks_blocking(ResultSetGetChunksRequest {
+                result_set_handle: Some(*rs_handle),
             })
-            .unwrap()
-            .result
             .unwrap()
     }
 
@@ -330,28 +327,33 @@ impl SnowflakeTestClient {
         result
     }
 
-    /// Execute a single query and get the result set (Arrow stream) directly.
-    pub fn execute_query(&self, sql: &str) -> ResultSetResponse {
+    /// Execute a single query and get the Arrow stream directly.
+    pub fn execute_query(&self, sql: &str) -> ResultSetGetStreamResponse {
         let stmt_handle = self.new_statement();
         self.set_sql_query(&stmt_handle, sql);
         let result = self.execute_statement_query(&stmt_handle);
-        let query_id = unwrap_single_query_id(&result);
-        let rs = self.get_result_set(&stmt_handle, &query_id);
+        let rs_handle = unwrap_single_rs_handle(&result);
+        let stream = self.result_set_get_stream(&rs_handle);
+        self.result_set_release(&rs_handle);
         self.release_statement(&stmt_handle);
-        rs
+        stream
     }
 
-    /// Get a result set by query_id using the statement handle.
-    pub fn get_result_set(&self, stmt: &StatementHandle, query_id: &str) -> ResultSetResponse {
-        self.client
-            .statement_get_result_set_blocking(StatementGetResultSetRequest {
-                stmt_handle: Some(*stmt),
-                query_id: query_id.to_string(),
-            })
-            .unwrap()
+    /// Get an Arrow stream for a query_id by looking it up via the connection,
+    /// fetching the stream, and releasing the handle.
+    pub fn get_result_set(
+        &self,
+        _stmt: &StatementHandle,
+        query_id: &str,
+    ) -> ResultSetGetStreamResponse {
+        let rs = self.connection_get_result_set(query_id);
+        let rs_handle = rs.result_set_handle.unwrap();
+        let stream = self.result_set_get_stream(&rs_handle);
+        self.result_set_release(&rs_handle);
+        stream
     }
 
-    /// Get a result set by query_id using the connection handle.
+    /// Get a ResultSetResponse (handle + descriptor) by query_id via the connection.
     pub fn connection_get_result_set(&self, query_id: &str) -> ResultSetResponse {
         self.client
             .connection_get_result_set_blocking(ConnectionGetResultSetRequest {
@@ -359,6 +361,22 @@ impl SnowflakeTestClient {
                 query_id: query_id.to_string(),
             })
             .unwrap()
+    }
+
+    pub fn result_set_get_stream(&self, rs_handle: &ResultSetHandle) -> ResultSetGetStreamResponse {
+        self.client
+            .result_set_get_stream_blocking(ResultSetGetStreamRequest {
+                result_set_handle: Some(*rs_handle),
+            })
+            .unwrap()
+    }
+
+    pub fn result_set_release(&self, rs_handle: &ResultSetHandle) {
+        self.client
+            .result_set_release_blocking(ResultSetReleaseRequest {
+                result_set_handle: Some(*rs_handle),
+            })
+            .unwrap();
     }
 
     /// Execute a multistatement query.
@@ -649,7 +667,20 @@ impl Drop for SnowflakeTestClient {
 /// Panics if the result is a multi-statement result.
 pub fn unwrap_single_query_id(result: &execute_query_response::Result) -> String {
     match result {
-        execute_query_response::Result::Single(d) => d.query_id.clone(),
+        execute_query_response::Result::Single(rs) => {
+            rs.result_descriptor.as_ref().unwrap().query_id.clone()
+        }
+        execute_query_response::Result::Multi(_) => {
+            panic!("Expected single-statement result, got multi-statement")
+        }
+    }
+}
+
+/// Extract the ResultSetHandle from a single-statement execute result.
+/// Panics if the result is a multi-statement result.
+pub fn unwrap_single_rs_handle(result: &execute_query_response::Result) -> ResultSetHandle {
+    match result {
+        execute_query_response::Result::Single(rs) => rs.result_set_handle.unwrap(),
         execute_query_response::Result::Multi(_) => {
             panic!("Expected single-statement result, got multi-statement")
         }

--- a/sf_core/tests/e2e/put_get/put_get_overwrite.rs
+++ b/sf_core/tests/e2e/put_get/put_get_overwrite.rs
@@ -107,7 +107,7 @@ fn upload_original_file(client: &SnowflakeTestClient, stage_name: &str) {
 }
 
 fn assert_put_result_status(
-    put_result: sf_core::protobuf::generated::database_driver_v1::ResultSetResponse,
+    put_result: sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse,
     expected_filename: &str,
     expected_status: &str,
 ) {

--- a/sf_core/tests/e2e/put_get/put_get_source_compression.rs
+++ b/sf_core/tests/e2e/put_get/put_get_source_compression.rs
@@ -3,7 +3,7 @@ use crate::common::file_utils::shared_test_data_dir;
 use crate::common::put_get_common::PutResult;
 use crate::common::put_get_common::upload_to_stage_with_options;
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use sf_core::protobuf::generated::database_driver_v1::ResultSetResponse;
+use sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse;
 use std::path::PathBuf;
 use test_case::test_case;
 
@@ -170,7 +170,7 @@ fn should_compress_uncompressed_file_when_source_compression_set_to_none_and_aut
 }
 
 fn assert_put_results(
-    put_data: ResultSetResponse,
+    put_data: ResultSetGetStreamResponse,
     expected_source_filename: &str,
     expected_source_compression: &str,
     expected_target_filename: &str,

--- a/sf_core/tests/e2e/put_get/put_get_wildcards.rs
+++ b/sf_core/tests/e2e/put_get/put_get_wildcards.rs
@@ -2,7 +2,7 @@ use crate::common::arrow_result_helper::ArrowResultHelper;
 use crate::common::file_utils::{create_test_file, path_to_sql_uri};
 use crate::common::put_get_common::{assert_file_exists, upload_to_stage};
 use crate::common::snowflake_test_client::SnowflakeTestClient;
-use sf_core::protobuf::generated::database_driver_v1::ResultSetResponse;
+use sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse;
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -199,7 +199,7 @@ fn get_from_stage_with_pattern(
     stage_name: &str,
     pattern: &str,
     download_dir: &Path,
-) -> ResultSetResponse {
+) -> ResultSetGetStreamResponse {
     let get_sql = format!(
         "GET @{stage_name} file://{}/ PATTERN='{}'",
         path_to_sql_uri(download_dir),

--- a/sf_core/tests/e2e/query/distributed_fetch.rs
+++ b/sf_core/tests/e2e/query/distributed_fetch.rs
@@ -1,4 +1,4 @@
-use crate::common::snowflake_test_client::{SnowflakeTestClient, unwrap_single_query_id};
+use crate::common::snowflake_test_client::{SnowflakeTestClient, unwrap_single_rs_handle};
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use sf_core::protobuf::generated::database_driver_v1::*;
 
@@ -19,11 +19,11 @@ fn distributed_fetch_simple_query() {
     // When Query "SELECT 42 AS answer, 'hello' AS greeting" is executed
     let stmt = client.new_statement();
     client.set_sql_query(&stmt, "SELECT 42 AS answer, 'hello' AS greeting");
-    let _execute_result = client.execute_statement_query(&stmt);
-    let query_id = unwrap_single_query_id(&_execute_result);
+    let execute_result = client.execute_statement_query(&stmt);
+    let rs_handle = unwrap_single_rs_handle(&execute_result);
 
     // Then result chunks should contain at least one inline chunk
-    let chunks_result = client.result_chunks(&stmt, &query_id);
+    let chunks_result = client.result_set_get_chunks(&rs_handle);
     assert!(
         !chunks_result.chunks.is_empty(),
         "Should have at least one chunk"
@@ -43,7 +43,8 @@ fn distributed_fetch_simple_query() {
     assert_eq!(total_rows, 1);
     assert_eq!(batches[0].num_columns(), 2);
 
-    // And Statement should be released
+    // And resources should be released
+    client.result_set_release(&rs_handle);
     client.release_statement(&stmt);
 }
 
@@ -59,11 +60,11 @@ fn distributed_fetch_large_result_produces_multiple_chunks() {
         "SELECT seq8() AS id, RANDSTR(100, RANDOM()) AS payload \
          FROM TABLE(GENERATOR(ROWCOUNT => 500000)) v ORDER BY id",
     );
-    let _execute_result = client.execute_statement_query(&stmt);
-    let query_id = unwrap_single_query_id(&_execute_result);
+    let execute_result = client.execute_statement_query(&stmt);
+    let rs_handle = unwrap_single_rs_handle(&execute_result);
 
     // Then result chunks should contain at least 2 chunks
-    let chunks_result = client.result_chunks(&stmt, &query_id);
+    let chunks_result = client.result_set_get_chunks(&rs_handle);
     assert!(
         chunks_result.chunks.len() >= 2,
         "Large result should produce at least 2 chunks, got {}",
@@ -92,6 +93,7 @@ fn distributed_fetch_large_result_produces_multiple_chunks() {
     }
     assert_eq!(total_rows, 500000);
 
-    // And Statement should be released
+    // And resources should be released
+    client.result_set_release(&rs_handle);
     client.release_statement(&stmt);
 }

--- a/sf_core/tests/e2e/query/multistatement.rs
+++ b/sf_core/tests/e2e/query/multistatement.rs
@@ -20,7 +20,10 @@ fn should_execute_multiple_select_statements() {
     // And each result set contains correct data
     for (i, query_id) in multi.query_ids.iter().enumerate() {
         let rs = client.connection_get_result_set(query_id);
-        let mut helper = ArrowResultHelper::from_result(rs);
+        let rs_handle = rs.result_set_handle.unwrap();
+        let stream = client.result_set_get_stream(&rs_handle);
+        client.result_set_release(&rs_handle);
+        let mut helper = ArrowResultHelper::from_result(stream);
         let rows = helper.transform_into_array::<i64>().unwrap();
         assert_eq!(rows.len(), 1, "Result set {i} should have 1 row");
         assert_eq!(
@@ -75,7 +78,10 @@ fn should_execute_mixed_statement_types() {
 
     // And the SELECT result contains expected data
     let select_rs = client.connection_get_result_set(&multi.query_ids[3]);
-    let mut helper = ArrowResultHelper::from_result(select_rs);
+    let rs_handle = select_rs.result_set_handle.unwrap();
+    let stream = client.result_set_get_stream(&rs_handle);
+    client.result_set_release(&rs_handle);
+    let mut helper = ArrowResultHelper::from_result(stream);
     let rows = helper.transform_into_array::<String>().unwrap();
     assert_eq!(rows.len(), 1, "SELECT should return 1 row");
     assert_eq!(rows[0][0], "hello");

--- a/sf_core/tests/integration/query/json_result_set.rs
+++ b/sf_core/tests/integration/query/json_result_set.rs
@@ -250,7 +250,11 @@ fn should_handle_empty_result_set_for_arrow_and_json() {
         execute_query_response::Result::Single(d) => d,
         _ => panic!("expected single"),
     };
-    assert_eq!(desc.rows_affected, Some(1), "Cannot force JSON result set");
+    assert_eq!(
+        desc.result_descriptor.as_ref().unwrap().rows_affected,
+        Some(1),
+        "Cannot force JSON result set"
+    );
 
     client.set_sql_query(&stmt, select_query);
     let json_result = client.execute_statement_query(&stmt);
@@ -330,7 +334,11 @@ fn run_arrow_and_json_and_match(create_table_query: &str, insert_query: &str, se
         execute_query_response::Result::Single(d) => d,
         _ => panic!("expected single"),
     };
-    assert_eq!(desc.rows_affected, Some(1), "Cannot force JSON result set");
+    assert_eq!(
+        desc.result_descriptor.as_ref().unwrap().rows_affected,
+        Some(1),
+        "Cannot force JSON result set"
+    );
 
     client.set_sql_query(&stmt, &select_query);
     let json_result = client.execute_statement_query(&stmt);

--- a/sf_core/tests/integration/query/json_result_set_large.rs
+++ b/sf_core/tests/integration/query/json_result_set_large.rs
@@ -2,7 +2,7 @@ use crate::common::arrow_deserialize::RecordBatch;
 use crate::common::arrow_result_helper::{
     ArrowResultHelper, assert_record_batches_match, assert_schemas_match,
 };
-use crate::common::snowflake_test_client::{SnowflakeTestClient, unwrap_single_query_id};
+use crate::common::snowflake_test_client::{SnowflakeTestClient, unwrap_single_rs_handle};
 use crate::common::test_utils::{TableCleanupGuard, unique_table_name};
 use arrow::array::Array;
 use arrow::compute::concat_batches;
@@ -91,8 +91,9 @@ fn should_return_arrow_matching_json_for_large_multi_chunk_result() {
 
     client.set_sql_query(&stmt, &select_query);
     let arrow_result = client.execute_statement_query(&stmt);
-    let arrow_query_id = unwrap_single_query_id(&arrow_result);
-    let arrow_rs = client.get_result_set(&stmt, &arrow_query_id);
+    let arrow_rs_handle = unwrap_single_rs_handle(&arrow_result);
+    let arrow_rs = client.result_set_get_stream(&arrow_rs_handle);
+    client.result_set_release(&arrow_rs_handle);
 
     client.set_sql_query(
         &stmt,
@@ -103,12 +104,17 @@ fn should_return_arrow_matching_json_for_large_multi_chunk_result() {
         execute_query_response::Result::Single(d) => d,
         _ => panic!("expected single"),
     };
-    assert_eq!(desc.rows_affected, Some(1), "Cannot force JSON result set");
+    assert_eq!(
+        desc.result_descriptor.as_ref().unwrap().rows_affected,
+        Some(1),
+        "Cannot force JSON result set"
+    );
 
     client.set_sql_query(&stmt, &select_query);
     let json_result = client.execute_statement_query(&stmt);
-    let json_query_id = unwrap_single_query_id(&json_result);
-    let json_rs = client.get_result_set(&stmt, &json_query_id);
+    let json_rs_handle = unwrap_single_rs_handle(&json_result);
+    let json_rs = client.result_set_get_stream(&json_rs_handle);
+    client.result_set_release(&json_rs_handle);
 
     let mut arrow_helper = ArrowResultHelper::from_result(arrow_rs);
     let mut json_helper = ArrowResultHelper::from_result(json_rs);

--- a/sf_core/tests/integration/query/json_result_set_nulls.rs
+++ b/sf_core/tests/integration/query/json_result_set_nulls.rs
@@ -17,7 +17,11 @@ fn execute_json_query(client: &SnowflakeTestClient, query: &str) -> ArrowResultH
         execute_query_response::Result::Single(d) => d,
         _ => panic!("expected single"),
     };
-    assert_eq!(desc.rows_affected, Some(1), "Cannot force JSON result set");
+    assert_eq!(
+        desc.result_descriptor.as_ref().unwrap().rows_affected,
+        Some(1),
+        "Cannot force JSON result set"
+    );
 
     client.set_sql_query(&stmt, query);
     let result = client.execute_statement_query(&stmt);

--- a/tests/performance/drivers/core/app/src/arrow.rs
+++ b/tests/performance/drivers/core/app/src/arrow.rs
@@ -2,10 +2,10 @@
 
 type Result<T> = std::result::Result<T, String>;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
-use sf_core::protobuf::generated::database_driver_v1::ResultSetResponse;
+use sf_core::protobuf::generated::database_driver_v1::ResultSetGetStreamResponse;
 
-/// Creates an Arrow reader from a protobuf ResultSetResponse
-pub fn create_arrow_reader(result: ResultSetResponse) -> Result<ArrowArrayStreamReader> {
+/// Creates an Arrow reader from a ResultSetGetStreamResponse
+pub fn create_arrow_reader(result: ResultSetGetStreamResponse) -> Result<ArrowArrayStreamReader> {
     let stream_ptr: *mut FFI_ArrowArrayStream = result
         .stream
         .ok_or_else(|| "No stream in result".to_string())?
@@ -17,8 +17,8 @@ pub fn create_arrow_reader(result: ResultSetResponse) -> Result<ArrowArrayStream
         .map_err(|e| format!("Failed to create Arrow stream reader: {}", e))
 }
 
-/// Fetches all rows from a ResultSetResponse and returns the count
-pub fn fetch_result_rows(result: ResultSetResponse) -> Result<usize> {
+/// Fetches all rows from a ResultSetGetStreamResponse and returns the count
+pub fn fetch_result_rows(result: ResultSetGetStreamResponse) -> Result<usize> {
     let mut reader = create_arrow_reader(result)?;
     let mut total_rows = 0;
 

--- a/tests/performance/drivers/core/app/src/connection.rs
+++ b/tests/performance/drivers/core/app/src/connection.rs
@@ -168,18 +168,22 @@ pub fn get_server_version(rt: &DriverRuntime, conn_handle: ConnectionHandle) -> 
         })
         .map_err(|e| format!("Query execution failed: {:?}", e))?;
 
-    let query_id = match response.result {
-        Some(execute_query_response::Result::Single(descriptor)) => descriptor.query_id,
+    let rs_handle = match response.result {
+        Some(execute_query_response::Result::Single(rs)) => rs
+            .result_set_handle
+            .ok_or_else(|| "Missing ResultSet handle".to_string())?,
         _ => return Err("Unexpected result type from server version query".to_string()),
     };
-    let result_set = rt
+    let stream_response = rt
         .client
-        .statement_get_result_set_blocking(StatementGetResultSetRequest {
-            stmt_handle: Some(version_stmt),
-            query_id,
+        .result_set_get_stream_blocking(ResultSetGetStreamRequest {
+            result_set_handle: Some(rs_handle.clone()),
         })
-        .map_err(|e| format!("Failed to get result set: {:?}", e))?;
-    let mut reader = create_arrow_reader(result_set)?;
+        .map_err(|e| format!("Failed to get result set stream: {:?}", e))?;
+    let _ = rt.client.result_set_release_blocking(ResultSetReleaseRequest {
+        result_set_handle: Some(rs_handle),
+    });
+    let mut reader = create_arrow_reader(stream_response)?;
 
     if let Some(batch_result) = reader.next() {
         let batch = batch_result.map_err(|e| format!("Failed to read batch: {:?}", e))?;

--- a/tests/performance/drivers/core/app/src/query_execution.rs
+++ b/tests/performance/drivers/core/app/src/query_execution.rs
@@ -174,8 +174,10 @@ fn execute_iteration(rt: &DriverRuntime, stmt_handle: StatementHandle) -> Result
 
     sf_core::perf_timing::reset_perf_counters();
 
-    let query_id = match response.result {
-        Some(execute_query_response::Result::Single(descriptor)) => descriptor.query_id,
+    let rs_handle = match response.result {
+        Some(execute_query_response::Result::Single(rs)) => rs
+            .result_set_handle
+            .ok_or_else(|| "Missing ResultSet handle".to_string())?,
         Some(execute_query_response::Result::Multi(_)) => {
             return Err("Multi-statement results are not supported in performance tests".to_string());
         }
@@ -190,14 +192,16 @@ fn execute_iteration(rt: &DriverRuntime, stmt_handle: StatementHandle) -> Result
 
     let cpu_before = process_cpu_seconds();
     let start_fetch = Instant::now();
-    let result_set = rt
+    let stream_response = rt
         .client()
-        .statement_get_result_set_blocking(StatementGetResultSetRequest {
-            stmt_handle: Some(stmt_handle),
-            query_id,
+        .result_set_get_stream_blocking(ResultSetGetStreamRequest {
+            result_set_handle: Some(rs_handle.clone()),
         })
-        .map_err(|e| format!("Failed to get result set: {e:?}"))?;
-    let row_count = fetch_result_rows(result_set).map_err(|e| format!("Failed to fetch results: {e:?}"))?;
+        .map_err(|e| format!("Failed to get result set stream: {e:?}"))?;
+    let _ = rt.client().result_set_release_blocking(ResultSetReleaseRequest {
+        result_set_handle: Some(rs_handle),
+    });
+    let row_count = fetch_result_rows(stream_response).map_err(|e| format!("Failed to fetch results: {e:?}"))?;
     let fetch_time = start_fetch.elapsed().as_secs_f64();
     let cpu_time_s = process_cpu_seconds() - cpu_before;
     let peak_rss_mb = get_peak_rss_mb();


### PR DESCRIPTION
## Summary

- Promotes result sets from an internal cache on `Statement` into a first-class, handle-managed resource (`HandleManager<Mutex<ResultSet>>`) with dedicated RPCs and independent lifetime.
- Replaces eager stream construction with **lazy, repeatable stream building** from owned `RowsetData` — the Arrow stream is constructed on-demand each time `ResultSetGetStream` is called.
- Unifies PUT/GET file transfer results as `RowsetData::Upload` / `RowsetData::Download` variants, eliminating the separate `ResultSetSource` enum.

## Context

Previously, result set data (Arrow stream, chunk metadata) lived as `StoredChunkInfo` inside `Statement`, coupling consumers to a statement handle for data access. The stream was pre-built during `execute`, consumed once, and discarded. Multi-statement children required duplicated connection-level RPCs.

This PR introduces a clean three-resource model: **Connection → Statement → ResultSet**, each with its own handle manager and lifecycle.

## Architecture

### `ResultSet` resource

```rust
pub(super) struct ResultSet {
    pub descriptor: ResultSetDescriptor,
    pub data: RowsetData,           // owned, no lifetime
    pub reader_ctx: ReaderContext,  // for HTTP client access
}
```

**Stream is lazy and repeatable:** `result_set_get_stream` builds a fresh `RecordBatchReader` from the stored `RowsetData` each time it's called — no pre-materialized `FFI_ArrowArrayStream` sitting in memory.

**Chunks derived on-demand:** `result_set_get_chunks` derives `ChunkData` via `impl From<&RowsetData> for ChunkData` — the `RowsetData` is preserved, so both access patterns work from one source of truth.

### Execution pipeline (linear, top-to-bottom)

```
1. Execute query → Data
2. response_to_descriptor(&data, &wrapper_presets) → ResultSetDescriptor
3. try_into_multi_result() → early return for multi-statement
4. match data.command { PUT/GET → perform_put_get_transfer(), _ → data.into_rowset_data() }
5. build_execute_result(rowset_data, descriptor, conn) → registers ResultSet, returns handle
```

### `RowsetData` as a closed, self-describing enum (owned, no lifetime)

```rust
pub enum RowsetData {
    ArrowSingleChunk { chunk_base64: String },
    ArrowMultiChunk { initial_base64_opt: Option<String>, chunk_download_data: Vec<...> },
    JsonRowset { rowset: Vec<...>, rowtype: Vec<RowType> },
    JsonMultiChunk { rowset: Vec<...>, rowtype: Vec<RowType>, chunk_download_data: Vec<...> },
    SchemaOnly { rowtype: Vec<RowType> },
    NoData,
    Upload(Vec<UploadResult>),
    Download(Vec<DownloadResult>),
}
```

`Data::into_rowset_data(self)` consumes the response in a single move — no cloning, no borrowed lifetimes.

## Protobuf changes

| Added | Removed |
| --- | --- |
| `ResultSetHandle { id, magic }` | `StatementGetResultSetRequest` |
| `ResultSetGetStream` RPC | `StatementResultChunks` RPC |
| `ResultSetGetChunks` RPC | `ConnectionResultChunks` RPC |
| `ResultSetRelease` RPC | Old `ResultSetResponse` (descriptor + stream) |
| New `ResultSetResponse` (handle + descriptor) |  |

`ExecuteQueryResponse.single` now carries `ResultSetResponse { result_set_handle, result_descriptor }` instead of a bare `ResultSetDescriptor`.

## File structure (sf_core)

| File | Responsibility |
| --- | --- |
| `result_set.rs` (new) | `ResultSet` struct, handle lifecycle, `response_to_descriptor`, `calculate_rows_affected`, `ChunkData`, `From<&RowsetData>`, `resolve_prefetch_config`, `fetch_query_response_data`, `create_result_set_from_sfqid` |
| `statement.rs` | Statement lifecycle, query execution, `execute_query_internal`, `connection_get_query_result` (lean — no result storage) |
| `query.rs` | `perform_put_get_transfer`, `build_reader_from_rowset_data`, `read_batches`, PUT/GET Arrow readers, `WrapperPresets`\-aware column metadata |
| `multistatement.rs` | `try_into_multi_result`, `child_query_ids`, `child_statement_type_ids` |
| `query_response.rs` | `Data`, `RowsetData` (owned enum), `into_rowset_data(self)` |

## Wrapper changes

### Python

New `_ResultSetWrapper` guard on the cursor owns a `ResultSetHandle`. Provides `get_arrow_stream_ptr()` (single-use, raises on double-consume) and `get_chunks()` (repeatable). `__del__` safety-net releases the handle.

### ODBC

`fetch_result_set_by_query_id` (connection-level) and `fetch_stream_and_release` (get stream + release in one shot). Multi-statement `more_results` uses the same two-step flow.

### JDBC

`fetchResultSetByQueryId` (connection-level), new `fetchStreamAndRelease` / `releaseResultSet` methods. Both single-result and multi-statement children go through the handle lifecycle.

## Design decisions

1. **No PUT/GET in** **`create_result_set_from_sfqid`** — this path is for multi-statement children and async query retrieval, neither of which involves file transfers (verified against Python/JDBC old drivers).
2. **Stream rebuilding vs single-use** — the core supports repeated `get_stream` calls (data is preserved). Python enforces single-consumption at the wrapper level to catch accidental double-reads.
3. **`ChunkData`** **clone is intentional** — the clone in `From<&RowsetData>` is load-bearing: the caller receives owned data while `ResultSet` keeps its `RowsetData` alive for future `get_stream` calls.

## Test plan

- `cargo clippy -p sf_core -p odbc -- -D warnings` passes clean
- `cargo test -p sf_core --lib` — all unit tests pass
- Python unit tests pass (`test_cursor.py`, `test_api_usage_telemetry.py`)
- ODBC builds and existing E2E tests pass
- JDBC builds successfully
- Integration/E2E tests pass (distributed fetch, multistatement, put_get, json result sets)