### PR TITLE
ci(perf): collapse Windows x86 + ARM64 build+test into one compile pass

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -322,43 +322,54 @@ jobs:
         with:
           arch: arm64
 
-      - name: Build and test
+      # Single compile pass in the test profile; the `Run tests` step below
+      # reuses these artifacts. Splitting build and test across cargo profiles
+      # would recompile the whole dependency tree twice.
+      - name: Compile (test profile, no run)
+        shell: cmd
+        run: cargo test --no-run --package sf_core --target aarch64-pc-windows-msvc
+
+      # sf_core's cdylib isn't built by `cargo test`, so check a test binary
+      # instead — same target triple, so same arch proof.
+      - name: Verify test binaries are ARM64
+        shell: cmd
+        run: |
+          set "TEST_EXE="
+          for %%f in (target\aarch64-pc-windows-msvc\debug\deps\integration_tests-*.exe) do (
+            if not defined TEST_EXE set "TEST_EXE=%%f"
+          )
+          if not defined TEST_EXE (
+            echo ERROR: integration_tests binary not found under target\aarch64-pc-windows-msvc\debug\deps\
+            dir target\aarch64-pc-windows-msvc\debug\deps\
+            exit /b 1
+          )
+          echo Checking machine type of %TEST_EXE%
+          dumpbin /headers "%TEST_EXE%" | findstr "AA64" >nul
+          if %ERRORLEVEL% neq 0 (
+            echo ERROR: %TEST_EXE% is not ARM64
+            dumpbin /headers "%TEST_EXE%" | findstr "machine"
+            exit /b 1
+          )
+
+      - name: Stage ARM64 OpenSSL DLLs next to test binaries
+        shell: cmd
+        run: |
+          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
+          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
+
+      - name: Run tests
         id: run_rust_tests_windows_arm64
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          cargo build --package sf_core --target aarch64-pc-windows-msvc
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          :: Guard: verify sf_core.dll is ARM64
-          dumpbin /headers target\aarch64-pc-windows-msvc\debug\sf_core.dll | findstr "AA64" >nul
-          if %ERRORLEVEL% neq 0 (
-            echo ERROR: sf_core.dll is not ARM64
-            dumpbin /headers target\aarch64-pc-windows-msvc\debug\sf_core.dll | findstr "machine"
-            exit /b 1
-          )
-
-          :: Copy ARM64 OpenSSL DLLs next to test binaries so Windows finds them
-          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
           cargo test --package sf_core --target aarch64-pc-windows-msvc -- --nocapture
 
       - name: Rerun tests (Windows ARM64)
         if: steps.run_rust_tests_windows_arm64.outcome == 'failure' && github.event_name == 'merge_group'
         shell: cmd
         run: |
-          :: Full re-setup (not just cargo test) so reruns work even if the first run failed
-          :: before reaching cargo test (e.g., build failure, DLL copy missed). Matches the
-          :: first-run steps above. The MSVC env from setup-msvc above persists across steps.
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          cargo build --package sf_core --target aarch64-pc-windows-msvc
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          copy "C:\vcpkg\installed\arm64-windows\bin\libcrypto-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
-          copy "C:\vcpkg\installed\arm64-windows\bin\libssl-3-arm64.dll" target\aarch64-pc-windows-msvc\debug\deps\ 2>nul
           cargo test --package sf_core --target aarch64-pc-windows-msvc -- --nocapture
 
       # Post-mortem diagnostics for Windows ARM64 failures: ARM64-specific build issues
@@ -376,8 +387,9 @@ jobs:
           dir /s target\aarch64-pc-windows-msvc\debug > windows-arm64-diagnostics\target-listing.txt 2>&1
           :: OpenSSL DLLs present next to deps?
           dir target\aarch64-pc-windows-msvc\debug\deps\*.dll > windows-arm64-diagnostics\deps-dlls.txt 2>&1
-          :: sf_core.dll architecture header
-          where dumpbin >nul 2>&1 && dumpbin /headers target\aarch64-pc-windows-msvc\debug\sf_core.dll > windows-arm64-diagnostics\sf_core-headers.txt 2>&1
+          :: integration_tests binary architecture header (sf_core's cdylib
+          :: isn't built by `cargo test`; the test binary proves toolchain arch)
+          where dumpbin >nul 2>&1 && for %%f in (target\aarch64-pc-windows-msvc\debug\deps\integration_tests-*.exe) do dumpbin /headers "%%f" >> windows-arm64-diagnostics\test-binary-headers.txt 2>&1
 
       - name: Upload Windows ARM64 diagnostics
         if: failure()

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -486,24 +486,47 @@ jobs:
         with:
           arch: x86
 
-      - name: Build and test
+      # Build everything once in the test profile (a separate `cargo build` in the
+      # dev profile would force a full ~600-crate recompile because dev and test
+      # profiles have distinct cargo fingerprints — that's where the previous
+      # ~14 minutes went). The subsequent `cargo test` in the next step reuses
+      # all of these artifacts and only does test execution.
+      - name: Compile (test profile, no run)
+        shell: cmd
+        run: cargo test --no-run --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
+
+      # Verify the toolchain actually emitted x86 binaries. Since `sf_core` is
+      # `crate-type = ["cdylib", "rlib"]` and `cargo test` only needs the rlib,
+      # `sf_core.dll` isn't produced here — but every test binary is, and they
+      # come from the same `--target i686-pc-windows-msvc`, so checking one of
+      # them proves the toolchain is x86. Build scripts live under `build\`,
+      # not `deps\`, so anything in `deps\` is target-arch.
+      - name: Verify test binaries are x86
+        shell: cmd
+        run: |
+          set "TEST_EXE="
+          for %%f in (target\i686-pc-windows-msvc\debug\deps\integration_tests-*.exe) do (
+            if not defined TEST_EXE set "TEST_EXE=%%f"
+          )
+          if not defined TEST_EXE (
+            echo ERROR: integration_tests binary not found under target\i686-pc-windows-msvc\debug\deps\
+            dir target\i686-pc-windows-msvc\debug\deps\
+            exit /b 1
+          )
+          echo Checking machine type of %TEST_EXE%
+          dumpbin /headers "%TEST_EXE%" | findstr "14C" >nul
+          if %ERRORLEVEL% neq 0 (
+            echo ERROR: %TEST_EXE% is not x86
+            dumpbin /headers "%TEST_EXE%" | findstr "machine"
+            exit /b 1
+          )
+
+      - name: Run tests
         id: run_rust_tests_x86
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         shell: cmd
         run: |
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
-
-          cargo build --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          :: Verify the DLL is 32-bit (machine type 14C = x86)
-          dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "14C" >nul
-          if %ERRORLEVEL% neq 0 (
-            echo ERROR: sf_core.dll is not x86
-            dumpbin /headers target\i686-pc-windows-msvc\debug\sf_core.dll | findstr "machine"
-            exit /b 1
-          )
-
           cargo test --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc -- --nocapture
 
       - name: Rerun tests (Windows x86)

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -486,21 +486,15 @@ jobs:
         with:
           arch: x86
 
-      # Build everything once in the test profile (a separate `cargo build` in the
-      # dev profile would force a full ~600-crate recompile because dev and test
-      # profiles have distinct cargo fingerprints — that's where the previous
-      # ~14 minutes went). The subsequent `cargo test` in the next step reuses
-      # all of these artifacts and only does test execution.
+      # Single compile pass in the test profile; the `Run tests` step below
+      # reuses these artifacts. Splitting build and test across cargo profiles
+      # would recompile the whole dependency tree twice.
       - name: Compile (test profile, no run)
         shell: cmd
         run: cargo test --no-run --package sf_core --no-default-features --features protobuf,vendored-openssl --target i686-pc-windows-msvc
 
-      # Verify the toolchain actually emitted x86 binaries. Since `sf_core` is
-      # `crate-type = ["cdylib", "rlib"]` and `cargo test` only needs the rlib,
-      # `sf_core.dll` isn't produced here — but every test binary is, and they
-      # come from the same `--target i686-pc-windows-msvc`, so checking one of
-      # them proves the toolchain is x86. Build scripts live under `build\`,
-      # not `deps\`, so anything in `deps\` is target-arch.
+      # sf_core's cdylib isn't built by `cargo test`, so check a test binary
+      # instead — same target triple, so same arch proof.
       - name: Verify test binaries are x86
         shell: cmd
         run: |


### PR DESCRIPTION
## Why

Today's Windows Rust-core test jobs each run \`cargo build\` followed by \`cargo test\`. These use the \`dev\` and \`test\` cargo profiles respectively, which have distinct cargo fingerprints (the \`test\` profile enables \`cfg(test)\`, changing codegen for *every* dependency, not just first-party crates). So the entire ~600-crate dep tree is compiled twice.

Measured baseline on \`test (Windows x86)\` (PR #1062 final run on \`windows-2025-vs2026\`):

| Step | Duration |
|---|---|
| \`cargo build --package sf_core ...\` | ~12 min (\`dev\` profile) |
| \`cargo test ...\` rebuild of test binaries | ~20 min (\`test\` profile) |
| Test execution (~933 tests) | ~3.5 min |
| **Total** | **~36 min** |

ARM64 follows the same pattern on the \`windows-11-arm\` runner (no measured baseline yet; the runner is generally slower than \`windows-latest\`).

## What this PR does

For both \`test_windows_x86\` and \`test_windows_arm64_nonfips\`: collapse the two compile passes into one and split the step into clearly-named pieces.

**Before (both jobs):**

\`\`\`yaml
- name: Build and test
  run: |
    cargo build --package sf_core ...                        # ~12 min (dev profile)
    dumpbin /headers ...\sf_core.dll | findstr <arch>        # arch guard on cdylib
    cargo test  --package sf_core ... -- --nocapture         # ~20 min compile + ~3.5 min run
\`\`\`

**After:**

\`\`\`yaml
- name: Compile (test profile, no run)
  run: cargo test --no-run --package sf_core ...             # ~20 min, single pass

- name: Verify test binaries are <arch>
  run: dumpbin /headers <integration_tests-*.exe> | findstr <arch>

# (ARM64 only) stage OpenSSL DLLs next to the freshly-built test binaries
- name: Stage ARM64 OpenSSL DLLs next to test binaries
  run: copy ...\libcrypto-3-arm64.dll target\...\deps\

- name: Run tests
  run: cargo test --package sf_core ... -- --nocapture       # ~3.5 min, all artifacts cached
\`\`\`

The two \`cargo test\` invocations share identical feature flags and target triple, so the second one is cache-warm and only does test execution.

### Why the dumpbin target changed

\`sf_core\` is declared as \`crate-type = [\"cdylib\", \"rlib\"]\`. Without an explicit \`cargo build --lib\` in the dev profile, \`sf_core.dll\` isn't produced — \`cargo test\` only needs the rlib. Building the cdylib separately would re-introduce the dev-profile recompile and erase the savings.

The arch guard now checks an \`integration_tests-*.exe\` test binary instead. Same proof: cargo applies \`--target\` uniformly across all artifacts in a single invocation, so an x86/ARM64 test binary implies an x86/ARM64 toolchain. Build scripts (which run on the host) live under \`target\\<triple>\\debug\\build\\\`, *not* under \`deps\\\`, so they can't accidentally be picked up. The cdylib build path is still exercised in CI by other lanes (\`test-odbc.yml\`'s \`build_odbc_driver (Windows x86)\` and \`_build-python-wheels.yml\`'s \`build_wheel\` for ARM64).

The Windows ARM64 failure-diagnostics bundle now captures \`dumpbin /headers\` for the test binary instead of \`sf_core.dll\`.

## Measured impact (x86 only — ARM64 baseline TBD)

Comparison from CI runs on \`windows-2025-vs2026\` today:

| Lane | Before (job total) | After (job total) | Delta |
|---|---|---|---|
| \`test (Windows x86)\` | 36 min 42 s | 24 min 55 s | **−11 min 47 s (−32%)** |
| \`test (Windows ARM64, non-FIPS)\` | TBD | TBD | similar % expected |

The savings come purely from skipping the \`dev\`-profile compile pass — the compile-once+run-warm shape doesn't change the test execution time at all (3 min 35 s vs ~3.5 min historical, ±5 s).

## Splitting steps

Three named steps make failure attribution clear in the GitHub Actions UI: a compile failure, an arch-mismatch failure, an OpenSSL-stage failure (ARM64 only), and a test failure are now visually distinct. \`continue-on-error: \${{ github.event_name == 'merge_group' }}\` and the \`run_rust_tests_*\` step IDs stay on the actual test-running step so the existing rerun-on-merge-queue logic keeps working unchanged.

A consequence worth knowing: a transient compile failure in the merge queue (e.g., crates.io hiccup) no longer triggers the merge-queue rerun (the previous \`Build and test\` combined step did). Arguably an improvement — rerunning a compile failure is wasteful since it's deterministic — but it is a behavior change.

## Out of scope

- Same optimization isn't applied to \`build-without-protobuf\`: those two passes have intentionally different scope (cdylib build coverage + lib unit-test compile), collapsing would lose the cdylib check that's literally the point of that lane.
- Linux + macOS \`test\` job already uses \`cargo llvm-cov\` (single build+run invocation) — no change needed.
- Replacing \`vendored-openssl\` with vcpkg-installed OpenSSL on x86 (a few more minutes of savings, but adds vcpkg setup; left as a follow-up).
- \`cargo nextest\` for test execution speedup (~1-2 min more savings, low priority since execution is only ~12-15% of the job today).

## Test plan

- [x] \`test (Windows x86)\` is green on this PR's prior run (run \`25482310771\` at 24 min 55 s vs the parent's 36 min 42 s).
- [ ] \`test (Windows x86)\` stays green after the ARM64 changes (no functional overlap, but workflow YAML changed).
- [ ] \`test (Windows ARM64, non-FIPS)\` is green and shows a similar % saving.
- [ ] On a deliberately-broken ARM64 build (locally), the \`Verify test binaries are ARM64\` step finds an \`integration_tests-*.exe\` and validates its machine type.