### PR TITLE
NO-SNOW: fix _TRACKING ContextVar leak from unconsumed generators

### DIFF
--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -81,24 +81,11 @@ _TRACKING: ContextVar[bool] = ContextVar("_api_tracking", default=True)
 
 
 def api_telemetry(func: F) -> F:
-    """Send api_usage telemetry on the first public-method entry.
+    """Record ``{ClassName}.{method_name}`` telemetry for the outermost call.
 
-    When the decorated method is called and tracking is enabled (the default),
-    record the call via :pymeth:`TelemetryClient.send_api_usage` and then
-    *disable* tracking for the duration of the method body.  Any nested
-    decorated calls (e.g. ``commit`` -> ``cursor`` -> ``execute``) are
-    therefore suppressed automatically, ensuring only the outermost
-    user-initiated call is recorded.
-
-    For generator functions (including generators wrapped by other decorators),
-    tracking stays suppressed for the entire lifetime of the generator
-    (including iteration), so that nested decorated calls during ``yield``
-    are also suppressed.  Detection is done at runtime via ``isinstance``
-    on the return value rather than ``inspect.isgeneratorfunction``, which
-    would fail when intermediate decorators hide the generator nature.
-
-    The ``api_method`` string is derived at runtime as
-    ``"{ClassName}.{method_name}"``.
+    Suppresses ``_TRACKING`` for the method body so nested decorated calls
+    are not recorded.  Generator results are wrapped to suppress only during
+    each iteration step (see :func:`_suppress_tracking_generator`).
     """
 
     @functools.wraps(func)
@@ -113,18 +100,15 @@ def api_telemetry(func: F) -> F:
             elif isinstance(self, SnowflakeCursorBase):
                 self._connection._telemetry_client.send_api_usage(api_name)
 
-            token = _TRACKING.set(False)
+            _TRACKING.set(False)
             try:
                 result = func(self, *args, **kwargs)
-            except BaseException:
-                _TRACKING.reset(token)
-                raise
+            finally:
+                _TRACKING.set(True)
 
             if isinstance(result, types.GeneratorType):
-                # Keep tracking suppressed for the generator's entire lifetime.
-                return _suppress_tracking_generator(result, token)
+                return _suppress_tracking_generator(result)
 
-            _TRACKING.reset(token)
             return result
         return func(self, *args, **kwargs)
 
@@ -133,10 +117,21 @@ def api_telemetry(func: F) -> F:
 
 def _suppress_tracking_generator(
     gen: Generator[Any, Any, Any],
-    token: Any,
 ) -> Generator[Any, Any, Any]:
-    """Wrap a generator so ``_TRACKING`` stays ``False`` for its entire lifetime."""
+    """Suppress ``_TRACKING`` during each iteration step, restore between yields.
+
+    Safe against never-started generators: the wrapper body only runs when
+    iterated, and ``api_telemetry`` resets ``_TRACKING`` before creating it.
+    """
+    _TRACKING.set(False)
     try:
-        yield from gen
+        for value in gen:
+            _TRACKING.set(True)
+            try:
+                yield value
+            except GeneratorExit:
+                gen.close()
+                return
+            _TRACKING.set(False)
     finally:
-        _TRACKING.reset(token)
+        _TRACKING.set(True)

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -1,5 +1,6 @@
 """Unit tests for api_telemetry decorator and api_usage tracking."""
 
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -243,6 +244,49 @@ class TestApiTelemetryResetBehavior:
 
         methods = _get_api_methods(mock_db_api)
         assert "SnowflakeCursor.execute" in methods
+
+    def test_unconsumed_generator_does_not_leak_tracking(self, connection, mock_db_api):
+        """A never-iterated generator must not suppress subsequent telemetry."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+
+        gen = connection.execute_stream(StringIO("SELECT 1"))
+        del gen
+
+        connection.cursor()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.execute_stream" in methods
+        assert "Connection.cursor" in methods
+
+    def test_tracking_true_between_generator_yields(self, connection, mock_db_api):
+        """Between yields, _TRACKING is True so independent calls are tracked."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+
+        gen = connection.execute_stream(StringIO("SELECT 1; SELECT 2"))
+        next(gen)
+
+        connection.get_query_status("")
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.execute_stream" in methods
+        assert "Connection.get_query_status" in methods
+
+    def test_telemetry_works_after_abandoned_generator(self, connection, mock_db_api):
+        """cursor() + close() send telemetry even after an abandoned generator."""
+        mock_db_api.telemetry_send_api_usage.reset_mock()
+
+        gen = connection.execute_stream(StringIO("SELECT 1"))
+        del gen
+
+        cur = connection.cursor()
+        cur.close()
+        connection.close()
+
+        methods = _get_api_methods(mock_db_api)
+        assert "Connection.execute_stream" in methods
+        assert "Connection.cursor" in methods
+        assert "SnowflakeCursor.close" in methods
+        assert "Connection.close" in methods
 
 
 class TestApiTelemetryFailureIsolation:


### PR DESCRIPTION
## Summary

- Fix permanent `_TRACKING` ContextVar leak caused by unconsumed generators from `@api_telemetry`\-decorated methods (`execute_stream`, `fetch_arrow_batches`, `fetch_pandas_batches`)
- The old wrapper held `_TRACKING=False` for the generator's entire lifetime via a `finally` clause — but Python never executes `finally` when `close()` is called on a never-started generator, so `_TRACKING` stayed `False` permanently
- Now `api_telemetry` resets `_TRACKING` immediately, and the wrapper toggles it around each iteration step only

## Context

Flaky CI failure in `test_api_usage_telemetry_sent_on_cursor_creation`: a preceding test that created an `execute_stream` generator without iterating it would poison `_TRACKING` for the rest of the process, silently suppressing all subsequent telemetry.

## Test plan

- Added 3 regression tests to `TestApiTelemetryResetBehavior`: unconsumed generator not leaking, tracking restored between yields, telemetry working after abandoned generators