### PR TITLE
ci(perf): fix vcpkg binary-cache key on Windows ODBC jobs (~7-8 min/job)

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -130,6 +130,25 @@ jobs:
           path: .cache/reference-odbc
           key: ${{ runner.os }}-ref-odbc-${{ hashFiles('ci/reference-odbc-version') }}
 
+      # See odbc_tests below for rationale: VCPKG_VER must be in the cache key
+      # because vcpkg's package ABI hashes change with the runner's vcpkg version.
+      - name: Capture vcpkg version (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/vcpkg-version
+
+      - name: Restore vcpkg binary cache (Windows)
+        if: matrix.os == 'windows-latest'
+        id: vcpkg-cache-ref
+        # Cache restore failures never fail the job — fall back to clean build.
+        continue-on-error: true
+        uses: actions/cache/restore@v5
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-vcpkg-x64-windows-${{ env.VCPKG_VER }}-v3
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-x64-windows-${{ env.VCPKG_VER }}-
+            ${{ runner.os }}-vcpkg-x64-windows-
+
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -145,6 +164,9 @@ jobs:
 
           Invoke-Checked "choco install ccache" { choco install ccache -y --no-progress }
           New-Item -ItemType Directory -Force -Path $env:CCACHE_DIR | Out-Null
+          # VCPKG_BINARY_SOURCES (workflow-level env) points at this directory;
+          # vcpkg refuses to use a missing path silently — create it before install.
+          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
 
           Invoke-Checked "vcpkg install zlib:x64-windows" { vcpkg install zlib:x64-windows }
 
@@ -288,6 +310,19 @@ jobs:
         with:
           path: .ccache
           key: ${{ runner.os }}-ccache-odbc-${{ hashFiles('odbc_tests/CMakeLists.txt') }}
+
+      - name: Save vcpkg binary cache (Windows)
+        if: always() && matrix.os == 'windows-latest' && steps.vcpkg-cache-ref.outputs.cache-hit != 'true'
+        # Cache save is best-effort — see cargo-cache action for rationale.
+        # timeout-minutes + ZSTD_NBTHREADS guard against tar+zstdmt hangs.
+        continue-on-error: true
+        timeout-minutes: 10
+        env:
+          ZSTD_NBTHREADS: '2'
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-vcpkg-x64-windows-${{ env.VCPKG_VER }}-v3
 
   # Build ODBC driver once per platform and share via artifact.
   # Avoids rebuilding in each of the 9 test matrix cells (3 OSes × 3 cloud providers).
@@ -513,6 +548,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.msvc_arch || 'default' }}-ccache-odbc-
 
+      # vcpkg's binary cache stores prebuilt packages keyed by an ABI hash that
+      # depends on the vcpkg version. When the runner image bumps vcpkg the
+      # ABI hashes change, the cached binaries become unusable, and vcpkg
+      # rebuilds zlib/openssl from source (~7-8 min). Including VCPKG_VER in
+      # the key invalidates stale entries on vcpkg version changes so we
+      # always either get a usable cache or build fresh, never both.
+      - name: Capture vcpkg version (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/vcpkg-version
+
       - name: Restore vcpkg binary cache (Windows)
         if: runner.os == 'Windows'
         id: vcpkg-cache
@@ -521,8 +566,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v2
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-v3
           restore-keys: |
+            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-
             ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-
 
       # Cache Homebrew bottle downloads to avoid re-fetching unixodbc/ccache on every run
@@ -770,7 +816,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-v2
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-v3
 
       - name: Save Homebrew cache (macOS)
         if: always() && runner.os == 'macOS' && steps.brew-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What's broken

Recent run on `main` ([25484184341](https://github.com/snowflakedb/universal-driver/actions/runs/25484184341)) shows the slowest Windows ODBC test cell at **26 minutes**, of which 10 min 25 sec is spent in `Install dependencies (Windows)`. The vcpkg portion of that step reports:

```
Restored 0 package(s) from D:\a\universal-driver\universal-driver/.vcpkg-binary-cache in 107 us
...
Building vcpkg-cmake:x64-windows@2024-04-23
Building vcpkg-cmake-config:x64-windows@2024-05-23
...
Total install time: 7.8 min
```

…even though the cache step right above it logs:

```
Cache hit for: Windows-vcpkg-x86-windows-v2
Cache restored from key: Windows-vcpkg-x86-windows-v2
```

So the cache is being restored to disk, but vcpkg can't use any of it.

## Root cause

vcpkg's binary cache stores prebuilt packages keyed by an ABI hash that includes the vcpkg version. When GitHub bumps vcpkg in the runner image (which happens regularly), the new vcpkg computes different ABI hashes for the same packages — the binaries in the restored directory are still there, but vcpkg considers them unusable and rebuilds from source.

`actions/cache` reports a hit because the *directory* is populated. vcpkg silently restores 0 packages and proceeds to a 7-8 min source build. Worst of both worlds.

## Why the repo already has a fix lying around

The repo has a composite action whose entire purpose is exactly this:

```1:6:.github/actions/vcpkg-version/action.yml
name: Capture vcpkg version
description: >
  Captures the installed vcpkg version and exports it as the VCPKG_VER env var so it can be
  embedded in cache keys. When GitHub updates the runner's vcpkg, the key
  changes automatically and stale caches are not reused. Windows-only.
```

It's correctly used by `./.github/actions/setup-windows-openssl` (whose cache hits work fine). `test-odbc.yml` just forgot to wire it up.

## Changes

### 1. `odbc_tests` matrix — fix the cache key

- Add `Capture vcpkg version (Windows)` step before the cache restore.
- Add `${{ env.VCPKG_VER }}` to both the restore key and the matching save key.
- Bump suffix `v2` → `v3` so existing v2 entries (unusable post-vcpkg-bump anyway) get cleared on first save.
- Add a `restore-keys` fallback for partial-prefix matches across vcpkg versions (cheap, lets us at least get `vcpkg-cmake`/`vcpkg-cmake-config` from a slightly-different vcpkg release).

### 2. `odbc_tests_reference` Windows — add the cache (was missing entirely)

The Windows reference test job currently runs `vcpkg install zlib:x64-windows` cold every time — no binary cache at all. Same ~7-8 min hit. Added:

- `Capture vcpkg version (Windows)` step.
- `Restore vcpkg binary cache (Windows)` step (same key shape as `odbc_tests` so the two jobs share the cache for `x64-windows`).
- `Save vcpkg binary cache (Windows)` step at the end.
- An explicit `New-Item -ItemType Directory -Force -Path .vcpkg-binary-cache` in `Install dependencies`. The workflow-level `VCPKG_BINARY_SOURCES` env points at this path; vcpkg silently disables the cache if the directory doesn't exist.

## Measured impact

Compared cold-cache (run 1, this PR's first attempt) vs warm-cache (run 2, the same workflow re-run after run 1 populated the new key):

| Cell | Cold | Warm | Saving | % |
|---|---|---|---|---|
| `odbc_tests (Windows x64, aws)`   | 24:19 | 15:06 | **−9:13** | −38% |
| `odbc_tests (Windows x64, azure)` | 24:19 | 14:43 | **−9:36** | −39% |
| `odbc_tests (Windows x64, gcp)`   | 22:58 | 14:44 | **−8:14** | −36% |
| `odbc_tests (Windows x86, aws)`   | 23:24 | 16:42 | **−6:42** | −29% |
| `odbc_tests (Windows x86, azure)` | 24:21 | 16:00 | **−8:21** | −34% |
| `odbc_tests (Windows x86, gcp)`   | 20:42 | 16:05 | **−4:37** | −22% |
| **Total CPU per run**             | **140 min** | **93 min** | **−47 min** | **−33%** |
| **Critical-path wall-clock**      | **24:21** | **16:42** | **−7:39** | **−31%** |

Verified via the expected log signal too — warm-cache run shows e.g. `Cache hit for: Windows-vcpkg-x86-windows-2026-04-08-e0612b42...-v3` with `Restored N packages` (N > 0) and no `Building openssl/zlib from source` messages.

`odbc_tests_reference` Windows wasn't exercised on this run (it's gated behind reference-test changes), but it shares the same cache key shape so it'll benefit on the first run that triggers it.

## Risk

Very low. Worst case is a one-off cold cache miss on the first run (the same situation we have *every* run today), and the next run is faster. The `continue-on-error: true` on every cache step is unchanged, so a cache failure can never fail the build.

## Out of scope (intentional, called out for the next pass)

- Sharing C++ test binaries across the 3 cloud-provider matrix cells per Windows arch (currently each cell rebuilds them via ccache, which mitigates but doesn't eliminate the duplication). That's a more invasive refactor — separate `build_odbc_tests` job + artifact, mirroring the existing `build_odbc_driver` pattern. Worth doing as a follow-up if Windows test cells are still on the critical path after this lands.