### PR TITLE
SNOW-2314157: wire OAuth flows into auth_request_data and login retry

### DIFF
--- a/sf_core/src/auth.rs
+++ b/sf_core/src/auth.rs
@@ -42,9 +42,7 @@ pub enum Credentials {
     },
     /// Pre-acquired OAuth access token forwarded to Snowflake unchanged
     /// (analysis §6 — legacy `AUTHENTICATOR=OAUTH` with raw `token=`).
-    /// Fields are populated by `create_credentials` in step 2.1 but are
-    /// only read once `auth_request_data` is wired in step 2.3.
-    #[allow(dead_code)]
+    /// Consumed by `auth_request_data` to populate the legacy login body.
     OAuth {
         username: String,
         access_token: SensitiveString,
@@ -201,13 +199,6 @@ pub enum AuthError {
     ))]
     UnsupportedLoginMethod {
         method: &'static str,
-        #[snafu(implicit)]
-        location: Location,
-    },
-    #[snafu(display("OAuth flow '{flow}' is not yet wired into the login pipeline"))]
-    #[snafu(visibility(pub(crate)))]
-    OAuthFlowNotWired {
-        flow: &'static str,
         #[snafu(implicit)]
         location: Location,
     },

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -86,6 +86,18 @@ pub mod param_names {
     pub const DISABLE_SAML_URL_CHECK: ParamKey = ParamKey("disable_saml_url_check");
     pub const LOG_MAX_QUERY_LENGTH: ParamKey = ParamKey("log_max_query_length");
     pub const CLIENT_TELEMETRY_ENABLED: ParamKey = ParamKey("CLIENT_TELEMETRY_ENABLED");
+    // ── OAuth (analysis_feature_oauth.md §9) ───────────────────────────────
+    pub const OAUTH_CLIENT_ID: ParamKey = ParamKey("oauth_client_id");
+    pub const OAUTH_CLIENT_SECRET: ParamKey = ParamKey("oauth_client_secret");
+    pub const OAUTH_AUTHORIZATION_URL: ParamKey = ParamKey("oauth_authorization_url");
+    pub const OAUTH_TOKEN_REQUEST_URL: ParamKey = ParamKey("oauth_token_request_url");
+    pub const OAUTH_REDIRECT_URI: ParamKey = ParamKey("oauth_redirect_uri");
+    pub const OAUTH_SCOPE: ParamKey = ParamKey("oauth_scope");
+    pub const OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS: ParamKey =
+        ParamKey("oauth_enable_single_use_refresh_tokens");
+    pub const OAUTH_DISABLE_PKCE: ParamKey = ParamKey("oauth_disable_pkce");
+    pub const OAUTH_ENABLE_DPOP: ParamKey = ParamKey("oauth_enable_dpop");
+    pub const OAUTH_DISABLE_CONSOLE_LOGIN: ParamKey = ParamKey("oauth_disable_console_login");
     // Logout configuration
     pub const SERVER_SESSION_KEEP_ALIVE: ParamKey = ParamKey("server_session_keep_alive");
     pub const ENABLE_SERVER_SESSION_KEEP_ALIVE_AUTO_DETECTION: ParamKey =
@@ -296,7 +308,7 @@ static PARAM_DEFS: &[ParamDef] = &[
         required: Required::Never,
         default: None,
         sensitive: false,
-        description: "Authentication method (SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA)",
+        description: "Authentication method (SNOWFLAKE_PASSWORD, SNOWFLAKE_JWT, PROGRAMMATIC_ACCESS_TOKEN, USERNAME_PASSWORD_MFA, OAUTH, OAUTH_AUTHORIZATION_CODE, OAUTH_CLIENT_CREDENTIALS)",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,
@@ -352,7 +364,7 @@ static PARAM_DEFS: &[ParamDef] = &[
         required: Required::WhenAuthMethod("PROGRAMMATIC_ACCESS_TOKEN"),
         default: None,
         sensitive: true,
-        description: "Programmatic access token",
+        description: "Pre-acquired bearer token (PROGRAMMATIC_ACCESS_TOKEN or legacy AUTHENTICATOR=OAUTH)",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,
@@ -437,6 +449,150 @@ static PARAM_DEFS: &[ParamDef] = &[
         default: Some(|| Setting::Bool(false)),
         sensitive: false,
         description: "Skip the Okta SAML URL host-match safety check",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    // ── OAuth ───────────────────────────────────────────────────────────
+    // Cross-driver canonical naming follows JDBC `SFSessionProperty.OAUTH_*`
+    // (analysis_feature_oauth.md §9). All OAuth params are connect-time
+    // and immutable for the life of the connection.
+    ParamDef {
+        canonical_name: param_names::OAUTH_CLIENT_ID.as_str(),
+        aliases: &["OAUTH_CLIENT_ID"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "OAuth client identifier (LOCAL_APPLICATION when Snowflake is the IdP)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_CLIENT_SECRET.as_str(),
+        aliases: &["OAUTH_CLIENT_SECRET"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: true,
+        description: "OAuth client secret (redacted from logs)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_AUTHORIZATION_URL.as_str(),
+        aliases: &["OAUTH_AUTHORIZATION_URL"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "IdP authorization endpoint (defaults to https://{host}/oauth/authorize)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_TOKEN_REQUEST_URL.as_str(),
+        aliases: &["OAUTH_TOKEN_REQUEST_URL"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::WhenAuthMethod("OAUTH_CLIENT_CREDENTIALS"),
+        default: None,
+        sensitive: false,
+        description: "IdP token endpoint (required for OAUTH_CLIENT_CREDENTIALS; defaults to https://{host}/oauth/token-request for AC)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_REDIRECT_URI.as_str(),
+        aliases: &["OAUTH_REDIRECT_URI"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Loopback redirect URI advertised to the IdP (defaults to http://127.0.0.1:<random>)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_SCOPE.as_str(),
+        aliases: &["OAUTH_SCOPE"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "OAuth scope (space-separated; defaults to session:role:<role>)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS.as_str(),
+        aliases: &["OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Request single-use refresh-token rotation (Snowflake-IdP only)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_DISABLE_PKCE.as_str(),
+        aliases: &["OAUTH_DISABLE_PKCE"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Disable PKCE S256 challenge for OAUTH_AUTHORIZATION_CODE (Python-compatible escape hatch)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_ENABLE_DPOP.as_str(),
+        aliases: &["OAUTH_ENABLE_DPOP"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Enable RFC 9449 DPoP proof-of-possession (JDBC-compatible)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::OAUTH_DISABLE_CONSOLE_LOGIN.as_str(),
+        aliases: &["OAUTH_DISABLE_CONSOLE_LOGIN"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Disable EXTERNALBROWSER console-login fallback (registered for JDBC parity; does not gate OAuth)",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,
@@ -931,6 +1087,19 @@ mod tests {
             ("CRL_MODE", "crl_check_mode"),
             ("CRL_ENABLED", "crl_check_mode"),
             ("ALLOWUNDERSCORESINHOST", "preserve_underscores_in_hostname"),
+            ("OAUTH_CLIENT_ID", "oauth_client_id"),
+            ("OAUTH_CLIENT_SECRET", "oauth_client_secret"),
+            ("OAUTH_AUTHORIZATION_URL", "oauth_authorization_url"),
+            ("OAUTH_TOKEN_REQUEST_URL", "oauth_token_request_url"),
+            ("OAUTH_REDIRECT_URI", "oauth_redirect_uri"),
+            ("OAUTH_SCOPE", "oauth_scope"),
+            (
+                "OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS",
+                "oauth_enable_single_use_refresh_tokens",
+            ),
+            ("OAUTH_DISABLE_PKCE", "oauth_disable_pkce"),
+            ("OAUTH_ENABLE_DPOP", "oauth_enable_dpop"),
+            ("OAUTH_DISABLE_CONSOLE_LOGIN", "oauth_disable_console_login"),
         ];
         for (alias, expected_canonical) in cases {
             let def = r
@@ -1046,6 +1215,39 @@ mod tests {
                 );
                 assert!(!p.effective_used_at_connect());
             }
+        }
+    }
+
+    #[test]
+    fn oauth_params_are_registered_with_correct_sensitive_flags() {
+        let r = registry();
+        let cases: &[(&str, bool)] = &[
+            ("oauth_client_id", false),
+            ("oauth_client_secret", true),
+            ("oauth_authorization_url", false),
+            ("oauth_token_request_url", false),
+            ("oauth_redirect_uri", false),
+            ("oauth_scope", false),
+            ("oauth_enable_single_use_refresh_tokens", false),
+            ("oauth_disable_pkce", false),
+            ("oauth_enable_dpop", false),
+            ("oauth_disable_console_login", false),
+        ];
+        for (name, expected_sensitive) in cases {
+            let def = r
+                .resolve(*name)
+                .unwrap_or_else(|| panic!("OAuth param {name} should be registered"));
+            assert_eq!(
+                def.sensitive, *expected_sensitive,
+                "{name}: expected sensitive={expected_sensitive}, got {}",
+                def.sensitive
+            );
+            assert_eq!(def.scope, ParamScope::Connection, "{name}: scope");
+            assert!(def.used_at_connect, "{name}: used_at_connect");
+            assert!(
+                !def.mutable_after_connect,
+                "{name}: mutable_after_connect must be false"
+            );
         }
     }
 

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -429,6 +429,58 @@ impl LoginMethod {
         settings.get_string(key).filter(|s| !s.is_empty())
     }
 
+    /// Read a boolean parameter that wrappers may submit as a typed bool,
+    /// a string (`"true"`, `"1"`), or an int (`0`/`1`). Defaults to `false`
+    /// when absent or unparseable so OAuth knobs like `enable_dpop` behave
+    /// the same regardless of the wrapper's setting representation.
+    fn get_flexible_bool(settings: &dyn Settings, key: &str) -> bool {
+        settings
+            .get_bool(key)
+            .or_else(|| {
+                settings
+                    .get_string(key)
+                    .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            })
+            .or_else(|| settings.get_int(key).map(|v| v != 0))
+            .unwrap_or(false)
+    }
+
+    /// Parse an optional URL parameter, returning [`InvalidParameterValue`]
+    /// when the user supplied a value that cannot be parsed by the `url`
+    /// crate. Empty/missing values resolve to `None` so callers can fall
+    /// back to flow-time defaults (e.g. `https://{host}/oauth/authorize`).
+    fn parse_optional_url(
+        settings: &dyn Settings,
+        key: &'static str,
+    ) -> Result<Option<Url>, ConfigError> {
+        let Some(raw) = Self::non_empty_string(settings, key) else {
+            return Ok(None);
+        };
+        let url = Url::parse(&raw).map_err(|e| {
+            InvalidParameterValueSnafu {
+                parameter: key,
+                value: raw,
+                explanation: format!("Could not parse URL: {e}"),
+            }
+            .build()
+        })?;
+        Ok(Some(url))
+    }
+
+    /// Parse a required URL parameter (e.g. CC `oauth_token_request_url`).
+    fn parse_required_url(settings: &dyn Settings, key: &'static str) -> Result<Url, ConfigError> {
+        let raw = Self::non_empty_string(settings, key)
+            .context(MissingParameterSnafu { parameter: key })?;
+        Url::parse(&raw).map_err(|e| {
+            InvalidParameterValueSnafu {
+                parameter: key,
+                value: raw,
+                explanation: format!("Could not parse URL: {e}"),
+            }
+            .build()
+        })
+    }
+
     pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         let authenticator = settings.get_string("authenticator").unwrap_or_default();
         let auth_upper = authenticator.to_ascii_uppercase();
@@ -505,6 +557,86 @@ impl LoginMethod {
                     authentication_timeout_secs,
                 }))
             }
+            "OAUTH" => Ok(Self::OAuthAccessToken {
+                username: Self::non_empty_string(settings, "user")
+                    .context(MissingParameterSnafu { parameter: "user" })?,
+                token: Self::non_empty_string(settings, "token")
+                    .context(MissingParameterSnafu { parameter: "token" })?
+                    .into(),
+            }),
+            "OAUTH_AUTHORIZATION_CODE" => {
+                let username = Self::non_empty_string(settings, "user")
+                    .context(MissingParameterSnafu { parameter: "user" })?;
+                // Snowflake-as-IdP substitutes `LOCAL_APPLICATION` for
+                // missing client_id/client_secret at flow time
+                // (analysis_feature_oauth.md §1, §9). Keep them empty here
+                // and let the AC/CC providers apply that default.
+                let client_id =
+                    Self::non_empty_string(settings, "oauth_client_id").unwrap_or_default();
+                let client_secret =
+                    Self::non_empty_string(settings, "oauth_client_secret").unwrap_or_default();
+                let authorization_url =
+                    Self::parse_optional_url(settings, "oauth_authorization_url")?;
+                let token_url = Self::parse_optional_url(settings, "oauth_token_request_url")?;
+                let redirect_uri = Self::parse_optional_url(settings, "oauth_redirect_uri")?;
+                let scope = Self::non_empty_string(settings, "oauth_scope");
+                let enable_single_use_refresh_tokens =
+                    Self::get_flexible_bool(settings, "oauth_enable_single_use_refresh_tokens");
+                let disable_pkce = Self::get_flexible_bool(settings, "oauth_disable_pkce");
+                let enable_dpop = Self::get_flexible_bool(settings, "oauth_enable_dpop");
+                let client_store_temporary_credential =
+                    Self::get_flexible_bool(settings, "client_store_temporary_credential");
+                let authentication_timeout_secs = settings
+                    .get_u64("authentication_timeout")
+                    .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+
+                Ok(Self::OAuthAuthorizationCode(OAuthAuthorizationCodeConfig {
+                    username,
+                    client_id,
+                    client_secret: client_secret.into(),
+                    authorization_url,
+                    token_url,
+                    redirect_uri,
+                    scope,
+                    enable_single_use_refresh_tokens,
+                    disable_pkce,
+                    enable_dpop,
+                    client_store_temporary_credential,
+                    authentication_timeout_secs,
+                }))
+            }
+            "OAUTH_CLIENT_CREDENTIALS" => {
+                // CC is external-IdP only: Snowflake's GS does not issue
+                // tokens for `grant_type=client_credentials` (analysis §4),
+                // so client_id, client_secret and token_url are mandatory.
+                let username = Self::non_empty_string(settings, "user")
+                    .context(MissingParameterSnafu { parameter: "user" })?;
+                let client_id = Self::non_empty_string(settings, "oauth_client_id").context(
+                    MissingParameterSnafu {
+                        parameter: "oauth_client_id",
+                    },
+                )?;
+                let client_secret = Self::non_empty_string(settings, "oauth_client_secret")
+                    .context(MissingParameterSnafu {
+                        parameter: "oauth_client_secret",
+                    })?;
+                let token_url = Self::parse_required_url(settings, "oauth_token_request_url")?;
+                let scope = Self::non_empty_string(settings, "oauth_scope");
+                let enable_dpop = Self::get_flexible_bool(settings, "oauth_enable_dpop");
+                let authentication_timeout_secs = settings
+                    .get_u64("authentication_timeout")
+                    .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+
+                Ok(Self::OAuthClientCredentials(OAuthClientCredentialsConfig {
+                    username,
+                    client_id,
+                    client_secret: client_secret.into(),
+                    token_url,
+                    scope,
+                    enable_dpop,
+                    authentication_timeout_secs,
+                }))
+            }
             "USERNAME_PASSWORD_MFA" => Ok(Self::UserPasswordMfa {
                 username: Self::non_empty_string(settings, "user")
                     .context(MissingParameterSnafu { parameter: "user" })?,
@@ -538,7 +670,7 @@ impl LoginMethod {
             _ => InvalidParameterValueSnafu {
                 parameter: "authenticator",
                 value: authenticator,
-                explanation: "Allowed values are snowflake, snowflake_jwt, snowflake_password, programmatic_access_token, username_password_mfa, or an https:// URL for native Okta SSO (case-insensitive)",
+                explanation: "Allowed values are snowflake, snowflake_jwt, snowflake_password, programmatic_access_token, username_password_mfa, oauth, oauth_authorization_code, oauth_client_credentials, or an https:// URL for native Okta SSO (case-insensitive)",
             }
             .fail()?,
         }
@@ -919,6 +1051,217 @@ mod tests {
             "whitespace-only should become None"
         );
         assert!(info.compiler.is_none(), "whitespace+tab should become None");
+    }
+
+    #[test]
+    fn test_oauth_legacy_authenticator_resolves_to_oauth_access_token() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            ("token", Setting::String("legacy-bearer".to_string())),
+            ("authenticator", Setting::String("OAUTH".to_string())),
+        ]);
+        match LoginMethod::from_settings(&settings).unwrap() {
+            LoginMethod::OAuthAccessToken { username, token } => {
+                assert_eq!(username, "alice");
+                assert_eq!(token.reveal(), "legacy-bearer");
+            }
+            other => panic!("Expected OAuthAccessToken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_oauth_legacy_requires_token() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            ("authenticator", Setting::String("oauth".to_string())),
+        ]);
+        let err = LoginMethod::from_settings(&settings).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Missing required parameter") && msg.contains("token"),
+            "Expected missing-token error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_oauth_authorization_code_authenticator_parses_config() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            (
+                "authenticator",
+                Setting::String("OAUTH_AUTHORIZATION_CODE".to_string()),
+            ),
+            ("oauth_client_id", Setting::String("client-x".to_string())),
+            (
+                "oauth_client_secret",
+                Setting::String("super-secret".to_string()),
+            ),
+            (
+                "oauth_authorization_url",
+                Setting::String("https://idp.example.com/oauth/authorize".to_string()),
+            ),
+            (
+                "oauth_token_request_url",
+                Setting::String("https://idp.example.com/oauth/token".to_string()),
+            ),
+            (
+                "oauth_redirect_uri",
+                Setting::String("http://127.0.0.1:9090/".to_string()),
+            ),
+            (
+                "oauth_scope",
+                Setting::String("session:role:DEV".to_string()),
+            ),
+            (
+                "oauth_enable_single_use_refresh_tokens",
+                Setting::Bool(true),
+            ),
+            ("oauth_disable_pkce", Setting::Bool(false)),
+            ("oauth_enable_dpop", Setting::Bool(true)),
+            ("client_store_temporary_credential", Setting::Bool(true)),
+            ("authentication_timeout", Setting::Int(45)),
+        ]);
+        match LoginMethod::from_settings(&settings).unwrap() {
+            LoginMethod::OAuthAuthorizationCode(cfg) => {
+                assert_eq!(cfg.username, "alice");
+                assert_eq!(cfg.client_id, "client-x");
+                assert_eq!(cfg.client_secret.reveal(), "super-secret");
+                assert_eq!(
+                    cfg.authorization_url.as_ref().map(Url::as_str),
+                    Some("https://idp.example.com/oauth/authorize")
+                );
+                assert_eq!(
+                    cfg.token_url.as_ref().map(Url::as_str),
+                    Some("https://idp.example.com/oauth/token")
+                );
+                assert_eq!(
+                    cfg.redirect_uri.as_ref().map(Url::as_str),
+                    Some("http://127.0.0.1:9090/")
+                );
+                assert_eq!(cfg.scope.as_deref(), Some("session:role:DEV"));
+                assert!(cfg.enable_single_use_refresh_tokens);
+                assert!(!cfg.disable_pkce);
+                assert!(cfg.enable_dpop);
+                assert!(cfg.client_store_temporary_credential);
+                assert_eq!(cfg.authentication_timeout_secs, 45);
+            }
+            other => panic!("Expected OAuthAuthorizationCode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_oauth_authorization_code_minimal_uses_defaults() {
+        // Bare authenticator + user; ensures the Snowflake-as-IdP wiring
+        // path can still construct the config with default URLs / empty
+        // client credentials (LOCAL_APPLICATION substitution happens at
+        // flow time, analysis §1 / §9).
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            (
+                "authenticator",
+                Setting::String("oauth_authorization_code".to_string()),
+            ),
+        ]);
+        match LoginMethod::from_settings(&settings).unwrap() {
+            LoginMethod::OAuthAuthorizationCode(cfg) => {
+                assert!(cfg.client_id.is_empty(), "client_id default is empty");
+                assert!(cfg.client_secret.reveal().is_empty());
+                assert!(cfg.authorization_url.is_none());
+                assert!(cfg.token_url.is_none());
+                assert!(cfg.redirect_uri.is_none());
+                assert!(cfg.scope.is_none());
+                assert!(!cfg.enable_single_use_refresh_tokens);
+                assert!(!cfg.disable_pkce);
+                assert!(!cfg.enable_dpop);
+                assert!(!cfg.client_store_temporary_credential);
+                assert_eq!(
+                    cfg.authentication_timeout_secs,
+                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS
+                );
+            }
+            other => panic!("Expected OAuthAuthorizationCode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_oauth_client_credentials_requires_token_url() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            (
+                "authenticator",
+                Setting::String("OAUTH_CLIENT_CREDENTIALS".to_string()),
+            ),
+            ("oauth_client_id", Setting::String("cid".to_string())),
+            ("oauth_client_secret", Setting::String("sss".to_string())),
+            // oauth_token_request_url intentionally omitted
+        ]);
+        let err = LoginMethod::from_settings(&settings).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Missing required parameter") && msg.contains("oauth_token_request_url"),
+            "Expected missing token URL error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_oauth_client_credentials_authenticator_parses_config() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("svc-account".to_string())),
+            (
+                "authenticator",
+                Setting::String("oauth_client_credentials".to_string()),
+            ),
+            ("oauth_client_id", Setting::String("cid".to_string())),
+            ("oauth_client_secret", Setting::String("sss".to_string())),
+            (
+                "oauth_token_request_url",
+                Setting::String("https://idp.example.com/oauth/token".to_string()),
+            ),
+            (
+                "oauth_scope",
+                Setting::String("session:role:READER".to_string()),
+            ),
+            ("oauth_enable_dpop", Setting::String("true".to_string())),
+        ]);
+        match LoginMethod::from_settings(&settings).unwrap() {
+            LoginMethod::OAuthClientCredentials(cfg) => {
+                assert_eq!(cfg.username, "svc-account");
+                assert_eq!(cfg.client_id, "cid");
+                assert_eq!(cfg.client_secret.reveal(), "sss");
+                assert_eq!(
+                    cfg.token_url.as_str(),
+                    "https://idp.example.com/oauth/token"
+                );
+                assert_eq!(cfg.scope.as_deref(), Some("session:role:READER"));
+                assert!(cfg.enable_dpop, "string \"true\" should resolve to true");
+                assert_eq!(
+                    cfg.authentication_timeout_secs,
+                    DEFAULT_AUTHENTICATION_TIMEOUT_SECS
+                );
+            }
+            other => panic!("Expected OAuthClientCredentials, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_oauth_authenticator_with_invalid_url_fails_fast() {
+        let settings = create_test_settings(vec![
+            ("user", Setting::String("alice".to_string())),
+            (
+                "authenticator",
+                Setting::String("OAUTH_AUTHORIZATION_CODE".to_string()),
+            ),
+            (
+                "oauth_authorization_url",
+                Setting::String("not a url".to_string()),
+            ),
+        ]);
+        let err = LoginMethod::from_settings(&settings).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("oauth_authorization_url") && msg.contains("Could not parse URL"),
+            "Expected URL parse error, got: {msg}"
+        );
     }
 
     #[test]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -46,6 +46,19 @@ pub const SESSION_GONE: i32 = 390111;
 /// GS error code returned when the session token has expired.
 /// The caller must use the master token to obtain a fresh session token and retry.
 pub const SESSION_TOKEN_EXPIRED: i32 = 390112;
+/// GS error code returned when the OAuth access token presented at login is
+/// invalid (analysis_feature_oauth.md §8). Treated cross-driver as a signal
+/// to evict the cached access token and replay the OAuth flow.
+pub const OAUTH_ACCESS_TOKEN_INVALID: i32 = 390303;
+/// GS error code returned when the OAuth access token presented at login has
+/// expired (analysis_feature_oauth.md §8). Same eviction-and-retry behavior
+/// as [`OAUTH_ACCESS_TOKEN_INVALID`].
+pub const OAUTH_ACCESS_TOKEN_EXPIRED: i32 = 390318;
+/// GS error codes that indicate the cached OAuth access token (and any
+/// DPoP-bundled cache entry) must be evicted, after which the login is
+/// retried once. Mirrors JDBC/Go's `refreshOAuthTokenErrorCodes` set.
+const OAUTH_REFRESH_ERROR_CODES: [i32; 2] =
+    [OAUTH_ACCESS_TOKEN_INVALID, OAUTH_ACCESS_TOKEN_EXPIRED];
 
 /// Session tokens returned from login, used for authentication and refresh
 #[derive(Debug, Clone)]
@@ -322,6 +335,40 @@ fn remove_mfa_token_from_cache(
     }
 }
 
+/// Evict the cached OAuth access token (and DPoP-bundled entry, when
+/// present) for an Authorization Code login. Used by the
+/// `390303 / 390318` retry block in [`snowflake_login_with_client`]:
+/// after eviction the next call to `auth_request_data` will run the
+/// refresh-token leg or, if that also fails, the full interactive flow
+/// (analysis_feature_oauth.md §8 + §3.2 state machine).
+///
+/// The cache key host follows the cross-driver convention from analysis
+/// §7.3: prefer the IdP token URL host, otherwise fall back to the
+/// Snowflake server host. The synthetic `https://{host}` URL string
+/// passed to the eviction helpers parses cleanly into the same host the
+/// AC flow used when storing the token.
+fn evict_oauth_access_token_for_authorization_code(
+    cfg: &crate::config::rest_parameters::OAuthAuthorizationCodeConfig,
+    server_url: &str,
+    token_cache: Option<&dyn TokenCache>,
+) {
+    let token_url_str = cfg
+        .token_url
+        .as_ref()
+        .map(|u| u.as_str().to_string())
+        .unwrap_or_default();
+    let Some(host) = oauth::host_from_token_url(&token_url_str, server_url) else {
+        tracing::warn!(
+            "Cannot evict cached OAuth access token: unable to derive IdP host from token_url or server_url"
+        );
+        return;
+    };
+    let synthetic_host_url = format!("https://{host}");
+    tracing::debug!(host = %host, "Evicting cached OAuth access token for IdP host");
+    oauth::remove_oauth_access_token(&synthetic_host_url, &cfg.username, token_cache);
+    oauth::remove_oauth_dpop_bundled(&synthetic_host_url, &cfg.username, token_cache);
+}
+
 pub async fn auth_request_data(
     client: &reqwest::Client,
     login_parameters: &LoginParameters,
@@ -351,6 +398,41 @@ pub async fn auth_request_data(
             data.authenticator = Some(okta_config.okta_url.to_string());
             data.raw_saml_response = Some(saml_html.into());
         }
+        // Authorization Code orchestration runs the PKCE/state/loopback flow
+        // (and any cache hits / refresh-token exchange) before forwarding the
+        // resulting access token to Snowflake under AUTHENTICATOR=OAUTH.
+        // Per analysis §10.1 / §14 #5, the body always uses uppercase
+        // "OAUTH" — never the user-supplied authenticator string verbatim —
+        // and tags the request with OAUTH_TYPE=OAUTH_AUTHORIZATION_CODE so
+        // GS knows which flow produced the token. LOGIN_NAME is always set
+        // (§14 #10).
+        LoginMethod::OAuthAuthorizationCode(cfg) => {
+            let acquired = oauth::acquire_authorization_code(
+                client,
+                &login_parameters.server_url,
+                cfg,
+                token_cache,
+            )
+            .await
+            .context(OAuthFlowSnafu)?;
+            data.login_name = Some(cfg.username.clone());
+            data.token = Some(acquired.access_token);
+            data.authenticator = Some("OAUTH".to_string());
+            data.oauth_type = Some("OAUTH_AUTHORIZATION_CODE".to_string());
+        }
+        // Client Credentials is external-IdP only (analysis §4) and tokens
+        // are intentionally not cached (§14 #12). On Snowflake error codes
+        // 390303/390318 we have no cache to evict, so the retry block in
+        // `snowflake_login_with_client` simply bubbles the error.
+        LoginMethod::OAuthClientCredentials(cfg) => {
+            let acquired = oauth::acquire_client_credentials(client, cfg)
+                .await
+                .context(OAuthFlowSnafu)?;
+            data.login_name = Some(cfg.username.clone());
+            data.token = Some(acquired.access_token);
+            data.authenticator = Some("OAUTH".to_string());
+            data.oauth_type = Some("OAUTH_CLIENT_CREDENTIALS".to_string());
+        }
         _ => match create_credentials(login_parameters).context(AuthenticationSnafu)? {
             Credentials::Password { username, password } => {
                 data.login_name = Some(username);
@@ -366,16 +448,17 @@ pub async fn auth_request_data(
                 data.token = Some(token);
                 data.authenticator = Some("PROGRAMMATIC_ACCESS_TOKEN".to_string());
             }
-            Credentials::OAuth { .. } => {
-                // Legacy AUTHENTICATOR=OAUTH body wiring lands in step 2.3
-                // (analysis_feature_oauth.md §6 / §10.1). This skeleton
-                // surfaces a typed error so the variant remains constructible
-                // without smuggling in flow logic.
-                return crate::auth::OAuthFlowNotWiredSnafu {
-                    flow: "OAuthAccessToken",
-                }
-                .fail()
-                .context(AuthenticationSnafu);
+            // Legacy pre-acquired access token: forward unchanged (analysis
+            // §6 / §10.1). LOGIN_NAME is always set (§14 #10) — never the
+            // .NET-only `loginName=""` quirk — and OAUTH_TYPE is omitted to
+            // distinguish the legacy flow from AC/CC.
+            Credentials::OAuth {
+                username,
+                access_token,
+            } => {
+                data.login_name = Some(username);
+                data.token = Some(access_token);
+                data.authenticator = Some("OAUTH".to_string());
             }
             Credentials::UserPasswordMfa {
                 username,
@@ -551,6 +634,41 @@ pub async fn snowflake_login_with_client(
             );
             remove_mfa_token_from_cache(&login_parameters.server_url, username, token_cache);
             tracing::info!("Retrying login without cached MFA token");
+            let retry_data =
+                auth_request_data(client, login_parameters, session_parameters, token_cache)
+                    .await?;
+            let retry_request = AuthRequest { data: retry_data };
+            auth_response = send_login_request(client, login_parameters, &retry_request).await?;
+        }
+    }
+
+    // OAuth refresh-on-failure (analysis_feature_oauth.md §8 / §14 #9):
+    // when GS rejects the OAuth access token with 390303 / 390318, evict
+    // the cached access token (and any DPoP-bundled entry) for the IdP
+    // host and replay the login once. The eviction is a no-op for
+    // OAuthClientCredentials (CC tokens are never cached, §14 #12) and
+    // for the legacy OAuthAccessToken flow (caller-supplied token), so
+    // those paths effectively bubble the error.
+    if !auth_response.success
+        && let LoginMethod::OAuthAuthorizationCode(cfg) = &login_parameters.login_method
+    {
+        let code = auth_response
+            ._code
+            .as_deref()
+            .and_then(|c| c.parse::<i32>().ok())
+            .unwrap_or(-1);
+        if OAUTH_REFRESH_ERROR_CODES.contains(&code) {
+            tracing::info!(
+                code = code,
+                oauth_type = "OAUTH_AUTHORIZATION_CODE",
+                "OAuth access token cached eviction triggered by Snowflake error code {code}"
+            );
+            evict_oauth_access_token_for_authorization_code(
+                cfg,
+                &login_parameters.server_url,
+                token_cache,
+            );
+            tracing::info!("Retrying login after OAuth refresh");
             let retry_data =
                 auth_request_data(client, login_parameters, session_parameters, token_cache)
                     .await?;
@@ -1525,6 +1643,12 @@ pub enum RestError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("OAuth flow failed"))]
+    OAuthFlow {
+        source: oauth::OAuthError,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Invalid Snowflake response"))]
     InvalidSnowflakeResponse {
         source: SnowflakeResponseError,
@@ -1874,6 +1998,106 @@ mod tests {
         }
     }
 
+    mod evict_oauth_access_token_for_authorization_code_tests {
+        use super::*;
+        use crate::config::rest_parameters::OAuthAuthorizationCodeConfig;
+        use crate::token_cache::TokenType;
+
+        fn ac_config(token_url: Option<&str>) -> OAuthAuthorizationCodeConfig {
+            OAuthAuthorizationCodeConfig {
+                username: "alice".to_string(),
+                client_id: String::new(),
+                client_secret: String::new().into(),
+                authorization_url: None,
+                token_url: token_url.map(|u| Url::parse(u).expect("test url parses")),
+                redirect_uri: None,
+                scope: None,
+                enable_single_use_refresh_tokens: false,
+                disable_pkce: false,
+                enable_dpop: false,
+                client_store_temporary_credential: false,
+                authentication_timeout_secs: 30,
+            }
+        }
+
+        /// When `token_url` is set, eviction targets the IdP host (analysis §7.3
+        /// cache key derivation), not the Snowflake server host.
+        #[test]
+        fn evicts_under_idp_host_when_token_url_present() {
+            let cache = StubTokenCache::with_token(
+                "idp.example.com",
+                "alice",
+                TokenType::OAuthAccessToken,
+                "stale-access",
+            );
+            let cfg = ac_config(Some("https://idp.example.com/oauth/token"));
+
+            evict_oauth_access_token_for_authorization_code(
+                &cfg,
+                "https://snowflake.example.com",
+                Some(&cache),
+            );
+
+            let after = cache
+                .get_token("idp.example.com", "alice", TokenType::OAuthAccessToken)
+                .unwrap();
+            assert!(after.is_none(), "AC retry must evict the IdP-host entry");
+        }
+
+        /// When `token_url` is absent, eviction falls back to the Snowflake
+        /// server host (Snowflake-as-IdP path; analysis §7.3).
+        #[test]
+        fn evicts_under_server_host_when_token_url_absent() {
+            let cache = StubTokenCache::with_token(
+                "snowflake.example.com",
+                "alice",
+                TokenType::OAuthAccessToken,
+                "stale-access",
+            );
+            let cfg = ac_config(None);
+
+            evict_oauth_access_token_for_authorization_code(
+                &cfg,
+                "https://snowflake.example.com",
+                Some(&cache),
+            );
+
+            let after = cache
+                .get_token(
+                    "snowflake.example.com",
+                    "alice",
+                    TokenType::OAuthAccessToken,
+                )
+                .unwrap();
+            assert!(
+                after.is_none(),
+                "AC retry must fall back to the Snowflake host when no token_url"
+            );
+        }
+
+        /// No cache, no panic — production wiring may pass `None` when token
+        /// caching is disabled.
+        #[test]
+        fn no_cache_is_a_noop() {
+            let cfg = ac_config(Some("https://idp.example.com/oauth/token"));
+            evict_oauth_access_token_for_authorization_code(
+                &cfg,
+                "https://snowflake.example.com",
+                None,
+            );
+        }
+
+        /// Refresh-on-failure error code constants must match the cross-driver
+        /// values (analysis §8). Locking this in catches accidental edits.
+        #[test]
+        fn refresh_error_codes_are_390303_and_390318() {
+            assert_eq!(OAUTH_ACCESS_TOKEN_INVALID, 390303);
+            assert_eq!(OAUTH_ACCESS_TOKEN_EXPIRED, 390318);
+            assert!(OAUTH_REFRESH_ERROR_CODES.contains(&OAUTH_ACCESS_TOKEN_INVALID));
+            assert!(OAUTH_REFRESH_ERROR_CODES.contains(&OAUTH_ACCESS_TOKEN_EXPIRED));
+        }
+    }
+
     mod into_query_result_tests {
         use super::*;
         use serde_json::json;
@@ -2106,6 +2330,39 @@ mod tests {
         assert!(
             data.authenticator.is_none(),
             "Password auth should NOT include AUTHENTICATOR field (matching old driver behavior)"
+        );
+    }
+
+    #[test]
+    fn oauth_legacy_auth_payload_includes_authenticator_and_token_no_oauth_type() {
+        // Pre-acquired AUTHENTICATOR=OAUTH legacy flow per
+        // analysis_feature_oauth.md §6 / §10.1: TOKEN is forwarded
+        // unchanged, LOGIN_NAME is always set (gotcha §14 #10), and
+        // OAUTH_TYPE is intentionally absent — only AC/CC tag the body
+        // with that discriminator.
+        let login_params = LoginParameters {
+            login_method: LoginMethod::OAuthAccessToken {
+                username: "alice".to_string(),
+                token: "legacy-bearer".into(),
+            },
+            ..test_login_params()
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = reqwest::Client::new();
+        let data = rt
+            .block_on(auth_request_data(&client, &login_params, None, None))
+            .expect("legacy OAuth login body builds");
+
+        assert_eq!(data.login_name.as_deref(), Some("alice"));
+        assert_eq!(data.token.as_ref().unwrap().reveal(), "legacy-bearer");
+        assert_eq!(data.authenticator.as_deref(), Some("OAUTH"));
+        assert!(
+            data.oauth_type.is_none(),
+            "Legacy OAUTH must not set OAUTH_TYPE; only AC/CC do"
+        );
+        assert!(
+            data.password.is_none(),
+            "Legacy OAUTH must not include a password field"
         );
     }
 

--- a/sf_core/src/rest/snowflake/oauth/authorization_code.rs
+++ b/sf_core/src/rest/snowflake/oauth/authorization_code.rs
@@ -48,11 +48,18 @@ use crate::token_cache::TokenCache;
 #[derive(Debug)]
 pub(crate) struct AcquiredOAuthToken {
     pub(crate) access_token: SensitiveString,
+    /// Refresh token returned by the IdP, when issued. Persisted by the
+    /// flow itself; the wiring layer does not consume it directly.
+    #[allow(dead_code)]
     pub(crate) refresh_token: Option<SensitiveString>,
-    /// Present iff DPoP was negotiated. Carries the JWK JSON so step 2.3
-    /// can reuse the same key when signing the Snowflake login-request
-    /// (analysis §5.1).
+    /// Present iff DPoP was negotiated. Carries the JWK JSON so the
+    /// Snowflake login-request can reuse the same key (analysis §5.1).
+    /// The wiring layer reads this only when DPoP login support lands.
+    #[allow(dead_code)]
     pub(crate) dpop_jwk_json: Option<String>,
+    /// IdP-reported lifetime of the access token, when present. Snowflake
+    /// drives session validity itself, so this is informational only.
+    #[allow(dead_code)]
     pub(crate) expires_in: Option<Duration>,
 }
 

--- a/sf_core/src/rest/snowflake/oauth/dpop.rs
+++ b/sf_core/src/rest/snowflake/oauth/dpop.rs
@@ -54,6 +54,9 @@ impl DPoPKey {
     }
 
     /// Recover a key previously serialized by [`DPoPKey::to_jwk_json`].
+    /// Reserved for the DPoP-bundled cache rehydration path that step 2.4
+    /// will wire into the login retry loop.
+    #[allow(dead_code)]
     pub(crate) fn from_jwk_json(json: &str) -> Result<Self, OAuthError> {
         let jwk: serde_json::Value =
             serde_json::from_str(json).context(TokenResponseDecodeSnafu)?;
@@ -131,6 +134,7 @@ fn bn_to_b64url(bn: &openssl::bn::BigNumRef) -> Result<String, OAuthError> {
     Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 
+#[allow(dead_code)]
 fn decode_b64url_bn(s: &str) -> Result<BigNum, OAuthError> {
     let bytes = URL_SAFE_NO_PAD
         .decode(s.as_bytes())

--- a/sf_core/src/rest/snowflake/oauth/error.rs
+++ b/sf_core/src/rest/snowflake/oauth/error.rs
@@ -19,7 +19,7 @@ use snafu::{Location, Snafu};
 
 #[derive(Debug, Snafu, error_trace::ErrorTrace)]
 #[snafu(visibility(pub(crate)))]
-pub(crate) enum OAuthError {
+pub enum OAuthError {
     /// `state` mismatch on the loopback redirect — analysis §14 #7. The
     /// display string is the verbatim ODBC/JDBC message; SREs grep for it.
     #[snafu(display(

--- a/sf_core/src/rest/snowflake/oauth/mod.rs
+++ b/sf_core/src/rest/snowflake/oauth/mod.rs
@@ -7,47 +7,22 @@
 //! names, redaction expectations, and gotchas are catalogued in
 //! `analysis_feature_oauth.md` (especially §2–§9 and §14).
 //!
-//! Re-exports below pin the surface that step 2.3 (`auth_request_data`
-//! wiring) will consume; everything else stays private to this module.
-//!
-//! `#![allow(dead_code)]` is intentional: until step 2.3 wires
-//! `LoginMethod::OAuth*` into `auth_request_data`, no production caller
-//! references these helpers — exclusively the unit tests below do. The
-//! allow is removed by the wiring step.
-#![allow(dead_code)]
+//! The re-exports below pin the surface that `auth_request_data`
+//! consumes when wiring `LoginMethod::OAuth*` (analysis §6 / §10.1)
+//! and that `snowflake_login_with_client` uses for the
+//! refresh-on-failure retry path (analysis §8 / §14 #9).
 
-// The submodules below are not yet wired into `auth_request_data` (that is
-// step 2.3). Suppress dead-code warnings on the new surface until then so
-// that `cargo clippy -D warnings` stays green for downstream consumers.
-#[allow(dead_code)]
 mod authorization_code;
-#[allow(dead_code)]
 mod browser;
-#[allow(dead_code)]
 mod client_credentials;
-#[allow(dead_code)]
 mod dpop;
-#[allow(dead_code)]
 mod error;
-#[allow(dead_code)]
 mod loopback_server;
-#[allow(dead_code)]
 mod pkce;
-#[allow(dead_code)]
 mod state;
-#[allow(dead_code)]
 mod token;
 
-#[allow(unused_imports)]
-pub(crate) use authorization_code::{AcquiredOAuthToken, acquire_authorization_code};
-#[allow(unused_imports)]
+pub(crate) use authorization_code::acquire_authorization_code;
 pub(crate) use client_credentials::acquire_client_credentials;
-#[allow(unused_imports)]
-pub(crate) use error::OAuthError;
-#[allow(unused_imports)]
-pub(crate) use token::{
-    host_from_token_url, remove_oauth_access_token, remove_oauth_dpop_bundled,
-    remove_oauth_refresh_token, store_oauth_access_token, store_oauth_dpop_bundled,
-    store_oauth_refresh_token, try_get_cached_oauth_access_token,
-    try_get_cached_oauth_dpop_bundled, try_get_cached_oauth_refresh_token,
-};
+pub use error::OAuthError;
+pub(crate) use token::{host_from_token_url, remove_oauth_access_token, remove_oauth_dpop_bundled};

--- a/sf_core/src/rest/snowflake/oauth/token.rs
+++ b/sf_core/src/rest/snowflake/oauth/token.rs
@@ -180,6 +180,7 @@ pub(crate) fn pack_dpop_bundle(access_token: &str, jwk_json: &str) -> String {
 /// recognized so callers can evict the corrupt entry and start over
 /// (mirrors JDBC's "legacy non-base64 encoded cache values" branch —
 /// analysis §14 #9).
+#[allow(dead_code)]
 pub(crate) fn unpack_dpop_bundle(packed: &str) -> Option<(String, String)> {
     let (at_b64, jwk_b64) = packed.split_once('.')?;
     let at = BASE64_STD.decode(at_b64.as_bytes()).ok()?;
@@ -187,6 +188,7 @@ pub(crate) fn unpack_dpop_bundle(packed: &str) -> Option<(String, String)> {
     Some((String::from_utf8(at).ok()?, String::from_utf8(jwk).ok()?))
 }
 
+#[allow(dead_code)]
 pub(crate) fn try_get_cached_oauth_dpop_bundled(
     token_url_or_server_url: &str,
     username: &str,


### PR DESCRIPTION
Wires the OAuth Authorization Code, Client Credentials, and pre-acquired
access-token (legacy) flows into `auth_request_data`, adds the
390303/390318 refresh-on-failure retry path inside
`snowflake_login_with_client`, registers the OAuth connection parameters
in `param_registry`, and teaches `LoginMethod::from_settings` to parse
the new `authenticator` values per analysis_feature_oauth.md §6 / §8 /
§9 / §10.1 / §14.

- sf_core/src/rest/snowflake/mod.rs:
  * Replaces the placeholder `Credentials::OAuth` arm with the legacy
    OAUTH body (LOGIN_NAME + TOKEN + AUTHENTICATOR=OAUTH, no OAUTH_TYPE).
  * Adds explicit `LoginMethod::OAuthAuthorizationCode` and
    `LoginMethod::OAuthClientCredentials` arms before the catch-all,
    invoking the AC/CC providers and setting OAUTH_TYPE accordingly.
  * Adds module-level `OAUTH_ACCESS_TOKEN_INVALID` (390303),
    `OAUTH_ACCESS_TOKEN_EXPIRED` (390318), and
    `OAUTH_REFRESH_ERROR_CODES` constants.
  * Adds an OAuth refresh-on-failure block in
    `snowflake_login_with_client` that evicts the cached access token
    (and DPoP-bundled entry) for AC and replays the login once.
  * Adds `RestError::OAuthFlow { source: oauth::OAuthError }` for
    propagation of provider failures.

- sf_core/src/auth.rs:
  * Removes `#[allow(dead_code)]` from `Credentials::OAuth` (now
    consumed by `auth_request_data`).
  * Removes the transitional `AuthError::OAuthFlowNotWired` variant.

- sf_core/src/config/rest_parameters.rs:
  * Extends `LoginMethod::from_settings` with `OAUTH`,
    `OAUTH_AUTHORIZATION_CODE`, and `OAUTH_CLIENT_CREDENTIALS` arms.
  * Adds private helpers `get_flexible_bool`, `parse_optional_url`,
    `parse_required_url` to keep parsing consistent.
  * Updates the catch-all error message to enumerate the new
    authenticator values.

- sf_core/src/config/param_registry.rs:
  * Registers `oauth_client_id`, `oauth_client_secret` (sensitive),
    `oauth_authorization_url`, `oauth_token_request_url`,
    `oauth_redirect_uri`, `oauth_scope`,
    `oauth_enable_single_use_refresh_tokens`, `oauth_disable_pkce`,
    `oauth_enable_dpop`, `oauth_disable_console_login`, all
    Connection-scope, used_at_connect, immutable.
  * Updates AUTHENTICATOR and TOKEN ParamDef descriptions for OAuth.

- sf_core/src/rest/snowflake/oauth/mod.rs:
  * Removes the transitional `#![allow(dead_code)]` and the per-`mod`
    allows; tightens re-exports to the surface consumed by the wiring
    layer.

- sf_core/src/rest/snowflake/oauth/error.rs: makes `OAuthError` `pub`
  so it can appear inside the public `RestError::OAuthFlow` source.

- sf_core/src/rest/snowflake/oauth/{authorization_code,dpop,token}.rs:
  scoped `#[allow(dead_code)]` annotations on the small set of helpers
  that remain unused until step 2.4 lands the DPoP-login path.

- Tests:
  * rest_parameters.rs: legacy-resolves, AC parses-config,
    AC minimal-defaults, CC requires-token-url, CC parses-config,
    invalid-URL fails-fast, legacy-requires-token.
  * param_registry.rs: oauth_params_are_registered_with_correct_sensitive_flags
    and OAuth aliases added to `resolve_aliases_to_canonical`.
  * rest/snowflake/mod.rs:
    `oauth_legacy_auth_payload_includes_authenticator_and_token_no_oauth_type`.

Co-authored-by: Cursor <cursoragent@cursor.com>