### PR TITLE
NO-SNOW: add dummy nodejs/README.md to verify CI gating

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,0 +1,5 @@
+# Snowflake Node.js Driver
+
+This directory will host the upcoming Node.js wrapper for the Snowflake universal driver.
+
+It is currently a placeholder; real source, dependencies, and build/test pipelines will land in follow-up PRs.


### PR DESCRIPTION
## Summary
- Adds a placeholder `nodejs/README.md` to the `nodejs/` skeleton introduced in the parent PR.
- Purpose: verify on CI that a PR touching only `nodejs/**` skips the four wrapper test workflows (Rust Core, JDBC, ODBC, Python). Pre-commit and Validate-generated-data are expected to still run.

## Context
Stacked on top of the `nodejs-foundation` PR that introduces the folder + `detect-changes.yml` `nodejs` filter. This PR exists purely as a smoke test for the path-filter gating. Should be discarded (or kept as docs) once verified.

## Test plan
- After CI runs on this PR:
  - Confirm `Rust Core CI`, `JDBC CI`, `ODBC CI`, `Python CI` all show their per-stack jobs as `skipped`.
  - Confirm `Pre-commit` and `Validate generated data` still run successfully.
  - Confirm the `detect-changes` step summary shows `Node.js: true`, all other component flags `false`, and all `run_*` flags `false` except `run_nodejs` (which has no consumer yet).
