### PR TITLE
NO-SNOW: JSON->Arrow conversion for VECTOR type

### DIFF
--- a/python/tests/e2e/types/test_vector.py
+++ b/python/tests/e2e/types/test_vector.py
@@ -116,22 +116,14 @@ class TestVectorLiteral:
         assert result[2] is None
 
     BOUNDARY_TEST_CASES = [
-        pytest.param("INT", "INT", [INT32_MIN, INT32_MAX, 0], id="INT"),
-        # Server's JSON serialization flushes subnormals to zero, so FLOAT32_SMALLEST_NORMAL
-        # round-trips as 0.0 when PYTHON_CONNECTOR_QUERY_RESULT_FORMAT=JSON. This is a server-side
-        # encoding limitation — Arrow format preserves the bit pattern.
-        pytest.param(
-            "FLOAT",
-            "FLOAT",
-            [FLOAT32_MAX, -FLOAT32_MAX, FLOAT32_SMALLEST_NORMAL, 0.0],
-            id="FLOAT",
-            marks=pytest.mark.skip_for_json_result_set(reason="JSON format flushes FLOAT subnormals to zero"),
-        ),
+        ("INT", "INT", [INT32_MIN, INT32_MAX, 0]),
+        ("FLOAT", "FLOAT", [FLOAT32_MAX, -FLOAT32_MAX, 0.0]),
     ]
 
     @pytest.mark.parametrize(
         "subtype, vec_type, expected_value",
         BOUNDARY_TEST_CASES,
+        ids=[c[0] for c in BOUNDARY_TEST_CASES],
     )
     def test_should_select_subtype_vector_boundary_values(self, execute_query, subtype, vec_type, expected_value):
         # Given Snowflake client is logged in
@@ -150,6 +142,23 @@ class TestVectorLiteral:
         else:
             assert result[0] == expected_value
             assert_type(result[0], int)
+
+    @pytest.mark.skip_for_json_result_set(
+        reason="Server-side JSON serialization flushes FLOAT32 subnormals to zero; "
+        "Arrow format preserves the bit pattern"
+    )
+    def test_should_preserve_float_smallest_normal(self, execute_query):
+        # Given Snowflake client is logged in
+        pass
+
+        # When Query selects a VECTOR(FLOAT, ...) containing FLOAT32_SMALLEST_NORMAL
+        expected = [FLOAT32_SMALLEST_NORMAL]
+        sql = f"SELECT {expected}::VECTOR(FLOAT, {len(expected)})"
+        result = execute_query(sql, single_row=True)
+
+        # Then the smallest-normal value must not underflow to zero
+        assert result[0] == pytest.approx(expected, rel=1e-6, abs=0)
+        assert_type(result[0], float)
 
     def test_should_select_max_dimension_vector(self, execute_query):
         # Given Snowflake client is logged in

--- a/python/tests/e2e/types/test_vector.py
+++ b/python/tests/e2e/types/test_vector.py
@@ -48,8 +48,6 @@ LARGE_RESULT_SET_SIZE = 20_000
 # VECTOR(FLOAT) uses 32-bit floats — need relaxed tolerance vs 64-bit assert_floats_equal.
 FLOAT32_APPROX = {"rel": 1e-6}
 
-pytestmark = pytest.mark.skip_for_json_result_set(reason="VECTOR type is not supported in JSON result format")
-
 
 class TestVectorTypeCasting:
     """Tests for VECTOR type casting to appropriate type."""
@@ -118,14 +116,22 @@ class TestVectorLiteral:
         assert result[2] is None
 
     BOUNDARY_TEST_CASES = [
-        ("INT", "INT", [INT32_MIN, INT32_MAX, 0]),
-        ("FLOAT", "FLOAT", [FLOAT32_MAX, -FLOAT32_MAX, FLOAT32_SMALLEST_NORMAL, 0.0]),
+        pytest.param("INT", "INT", [INT32_MIN, INT32_MAX, 0], id="INT"),
+        # Server's JSON serialization flushes subnormals to zero, so FLOAT32_SMALLEST_NORMAL
+        # round-trips as 0.0 when PYTHON_CONNECTOR_QUERY_RESULT_FORMAT=JSON. This is a server-side
+        # encoding limitation — Arrow format preserves the bit pattern.
+        pytest.param(
+            "FLOAT",
+            "FLOAT",
+            [FLOAT32_MAX, -FLOAT32_MAX, FLOAT32_SMALLEST_NORMAL, 0.0],
+            id="FLOAT",
+            marks=pytest.mark.skip_for_json_result_set(reason="JSON format flushes FLOAT subnormals to zero"),
+        ),
     ]
 
     @pytest.mark.parametrize(
         "subtype, vec_type, expected_value",
         BOUNDARY_TEST_CASES,
-        ids=[c[0] for c in BOUNDARY_TEST_CASES],
     )
     def test_should_select_subtype_vector_boundary_values(self, execute_query, subtype, vec_type, expected_value):
         # Given Snowflake client is logged in

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1,5 +1,5 @@
 pub use crate::chunks::convert_string_rowset_to_arrow_reader;
-use crate::query_types::{GeoRepresentation, RowType};
+use crate::query_types::{GeoRepresentation, RowType, VectorElementType};
 use arrow::array::Array;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -274,13 +274,25 @@ pub fn create_field_with_type(
                     .with_metadata(metadata),
             )
         }
-        RowType::Vector { name, nullable } => {
+        RowType::Vector {
+            name,
+            nullable,
+            dimension,
+            element_type,
+        } => {
             let mut metadata = HashMap::new();
             metadata.insert("logicalType".to_string(), "VECTOR".to_string());
-            Ok(
-                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
-                    .with_metadata(metadata),
-            )
+            let child_type = match element_type {
+                VectorElementType::Int32 => DataType::Int32,
+                VectorElementType::Float32 => DataType::Float32,
+            };
+            let data_type = data_type.unwrap_or_else(|| {
+                DataType::FixedSizeList(
+                    Arc::new(Field::new_list_field(child_type, true)),
+                    *dimension,
+                )
+            });
+            Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))
         }
     }
 }

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -289,7 +289,7 @@ pub fn create_field_with_type(
             let data_type = data_type.unwrap_or_else(|| {
                 DataType::FixedSizeList(
                     Arc::new(Field::new_list_field(child_type, true)),
-                    *dimension,
+                    *dimension as i32,
                 )
             });
             Ok(Field::new(name, data_type, *nullable).with_metadata(metadata))

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -259,7 +259,7 @@ pub(super) enum ColumnBuilder {
         builder: arrow::array::StringBuilder,
     },
     Vector {
-        dimension: i32,
+        dimension: usize,
         values: VectorValuesBuilder,
         nulls: arrow::array::BooleanBufferBuilder,
     },
@@ -338,8 +338,10 @@ impl ColumnBuilder {
             RowType::Text { .. }
             | RowType::Variant { .. }
             | RowType::Object { .. }
-            | RowType::Array { .. }
-            | RowType::Geography { representation, .. }
+            | RowType::Array { .. } => ColumnBuilder::Text {
+                builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
+            },
+            RowType::Geography { representation, .. }
             | RowType::Geometry { representation, .. } => match representation {
                 crate::query_types::GeoRepresentation::Text => ColumnBuilder::Text {
                     builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
@@ -353,9 +355,9 @@ impl ColumnBuilder {
                 element_type,
                 ..
             } => {
-                // Dimension is bounded to VECTOR_MAX_DIMENSION at parse time, so
-                // capacity * dimension fits in usize on all supported platforms.
-                let elem_capacity = capacity.saturating_mul(*dimension as usize);
+                // Snowflake bounds VECTOR dimension at 4096, so the multiplication
+                // fits in usize on all supported platforms.
+                let elem_capacity = capacity.saturating_mul(*dimension);
                 let values = match element_type {
                     VectorElementType::Int32 => VectorValuesBuilder::Int32(
                         arrow::array::PrimitiveBuilder::with_capacity(elem_capacity),
@@ -764,7 +766,7 @@ impl ColumnBuilder {
                 let null_buf = arrow::buffer::NullBuffer::new(nulls.finish());
                 let list = arrow::array::FixedSizeListArray::try_new(
                     child_field,
-                    dimension,
+                    dimension as i32,
                     values_arr,
                     Some(null_buf),
                 )?;
@@ -960,14 +962,13 @@ fn empty_batch_from_row_types(row_types: &[RowType]) -> Result<Vec<RecordBatch>,
 /// Used when the outer list element is NULL: the FixedSizeList layout still reserves
 /// `dimension` child slots per outer row, and the outer null buffer masks them out.
 /// The placeholder value (zero) is never read — it just keeps the child buffer aligned.
-fn push_vector_placeholders(values: &mut VectorValuesBuilder, dimension: i32) {
-    let dim = dimension as usize;
+fn push_vector_placeholders(values: &mut VectorValuesBuilder, dimension: usize) {
     match values {
         VectorValuesBuilder::Int32(builder) => {
-            builder.append_values(&vec![0; dim], &vec![true; dim])
+            builder.append_values(&vec![0; dimension], &vec![true; dimension])
         }
         VectorValuesBuilder::Float32(builder) => {
-            builder.append_values(&vec![0.0; dim], &vec![true; dim])
+            builder.append_values(&vec![0.0; dimension], &vec![true; dimension])
         }
     }
 }
@@ -976,15 +977,14 @@ fn push_vector_placeholders(values: &mut VectorValuesBuilder, dimension: i32) {
 /// appends its `dimension` elements to the child values builder.
 fn push_vector_value(
     cell: &[u8],
-    dimension: i32,
+    dimension: usize,
     values: &mut VectorValuesBuilder,
 ) -> Result<(), ArrowError> {
-    let expected = dimension as usize;
     let elems: Vec<serde_json::Value> =
         serde_json::from_slice(cell).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-    if elems.len() != expected {
+    if elems.len() != dimension {
         return Err(ArrowError::InvalidArgumentError(format!(
-            "VECTOR expected {expected} elements, got {}",
+            "VECTOR expected {dimension} elements, got {}",
             elems.len()
         )));
     }

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -988,6 +988,8 @@ fn push_vector_value(
             elems.len()
         )));
     }
+    // VECTOR(INT) elements are i32 and VECTOR(FLOAT) elements are f32 on the server
+    // side, so these narrowing casts are lossless for conformant server output.
     match values {
         VectorValuesBuilder::Int32(builder) => {
             for elem in elems {
@@ -996,12 +998,7 @@ fn push_vector_value(
                         "VECTOR(INT) element must be a JSON integer".to_string(),
                     )
                 })?;
-                let v32 = i32::try_from(v).map_err(|_| {
-                    ArrowError::InvalidArgumentError(format!(
-                        "VECTOR(INT) element {v} out of i32 range"
-                    ))
-                })?;
-                builder.append_value(v32);
+                builder.append_value(v as i32);
             }
         }
         VectorValuesBuilder::Float32(builder) => {
@@ -1011,8 +1008,6 @@ fn push_vector_value(
                         "VECTOR(FLOAT) element must be a JSON number".to_string(),
                     )
                 })?;
-                // Snowflake serializes VECTOR(FLOAT) elements already in f32 precision,
-                // so this narrowing cast is lossless for conformant server output.
                 builder.append_value(v as f32);
             }
         }
@@ -1533,19 +1528,6 @@ mod tests {
         )];
         let parser = JsonChunkParser { row_types: rt };
         let result = parser.parse_chunk(b"[\"[1,\\\"foo\\\"]\"],\n".to_vec());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn vector_int_rejects_out_of_i32_range_element() {
-        let rt = vec![RowType::vector(
-            "v",
-            false,
-            1,
-            crate::query_types::VectorElementType::Int32,
-        )];
-        let parser = JsonChunkParser { row_types: rt };
-        let result = parser.parse_chunk(b"[\"[2147483648]\"],\n".to_vec());
         assert!(result.is_err());
     }
 

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::array::{Array, RecordBatch, RecordBatchIterator, RecordBatchReader};
 use arrow::datatypes::{
-    DataType, Date32Type, Decimal128Type, Field, Fields, Int32Type, Int64Type, Schema,
+    DataType, Date32Type, Decimal128Type, Field, Fields, Float32Type, Int32Type, Int64Type, Schema,
 };
 use arrow::error::ArrowError;
 use snafu::ResultExt;
@@ -11,7 +11,7 @@ use super::ChunkError;
 use super::error::*;
 use super::prefetch::ParseChunk;
 use crate::arrow_utils::{create_field, create_field_with_type};
-use crate::query_types::RowType;
+use crate::query_types::{RowType, VectorElementType};
 
 #[derive(Clone)]
 pub struct JsonChunkParser {
@@ -206,6 +206,20 @@ pub(super) enum FixedStorage {
     },
 }
 
+pub(super) enum VectorValuesBuilder {
+    Int32(arrow::array::PrimitiveBuilder<Int32Type>),
+    Float32(arrow::array::PrimitiveBuilder<Float32Type>),
+}
+
+impl VectorValuesBuilder {
+    fn finish(self) -> Arc<dyn Array> {
+        match self {
+            VectorValuesBuilder::Int32(mut b) => Arc::new(b.finish()),
+            VectorValuesBuilder::Float32(mut b) => Arc::new(b.finish()),
+        }
+    }
+}
+
 /// i64 fast-path storage for INTERVAL DAY TO SECOND columns. Falls back to Decimal128
 /// when a nanosecond value exceeds i64 range (>106,751 days).
 pub(super) enum IntervalDaySecondStorage {
@@ -243,6 +257,11 @@ pub(super) enum ColumnBuilder {
     },
     Text {
         builder: arrow::array::StringBuilder,
+    },
+    Vector {
+        dimension: i32,
+        values: VectorValuesBuilder,
+        nulls: arrow::array::BooleanBufferBuilder,
     },
     Boolean {
         builder: arrow::array::BooleanBuilder,
@@ -320,10 +339,7 @@ impl ColumnBuilder {
             | RowType::Variant { .. }
             | RowType::Object { .. }
             | RowType::Array { .. }
-            | RowType::Vector { .. } => ColumnBuilder::Text {
-                builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
-            },
-            RowType::Geography { representation, .. }
+            | RowType::Geography { representation, .. }
             | RowType::Geometry { representation, .. } => match representation {
                 crate::query_types::GeoRepresentation::Text => ColumnBuilder::Text {
                     builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
@@ -332,6 +348,28 @@ impl ColumnBuilder {
                     builder: arrow::array::BinaryBuilder::with_capacity(capacity, capacity * 16),
                 },
             },
+            RowType::Vector {
+                dimension,
+                element_type,
+                ..
+            } => {
+                // Dimension is bounded to VECTOR_MAX_DIMENSION at parse time, so
+                // capacity * dimension fits in usize on all supported platforms.
+                let elem_capacity = capacity.saturating_mul(*dimension as usize);
+                let values = match element_type {
+                    VectorElementType::Int32 => VectorValuesBuilder::Int32(
+                        arrow::array::PrimitiveBuilder::with_capacity(elem_capacity),
+                    ),
+                    VectorElementType::Float32 => VectorValuesBuilder::Float32(
+                        arrow::array::PrimitiveBuilder::with_capacity(elem_capacity),
+                    ),
+                };
+                ColumnBuilder::Vector {
+                    dimension: *dimension,
+                    values,
+                    nulls: arrow::array::BooleanBufferBuilder::new(capacity),
+                }
+            }
             RowType::Boolean { .. } => ColumnBuilder::Boolean {
                 builder: arrow::array::BooleanBuilder::with_capacity(capacity),
             },
@@ -442,6 +480,14 @@ impl ColumnBuilder {
                 FixedStorage::I128 { builder } => builder.append_null(),
             },
             ColumnBuilder::Text { builder, .. } => builder.append_null(),
+            ColumnBuilder::Vector {
+                dimension,
+                values,
+                nulls,
+            } => {
+                push_vector_placeholders(values, *dimension);
+                nulls.append(false);
+            }
             ColumnBuilder::Boolean { builder } => builder.append_null(),
             ColumnBuilder::Real { builder } => builder.append_null(),
             ColumnBuilder::Date { builder } => builder.append_null(),
@@ -530,6 +576,14 @@ impl ColumnBuilder {
                 let s = std::str::from_utf8(cell)
                     .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
                 builder.append_value(s);
+            }
+            ColumnBuilder::Vector {
+                dimension,
+                values,
+                nulls,
+            } => {
+                push_vector_value(cell, *dimension, values)?;
+                nulls.append(true);
             }
             ColumnBuilder::Boolean { builder } => {
                 let v = match cell {
@@ -696,6 +750,26 @@ impl ColumnBuilder {
                 create_field(row_type).map_err(err)?,
                 Arc::new(builder.finish()),
             )),
+            ColumnBuilder::Vector {
+                dimension,
+                values,
+                mut nulls,
+            } => {
+                let field = create_field(row_type).map_err(err)?;
+                let DataType::FixedSizeList(child_field, _) = field.data_type() else {
+                    unreachable!("create_field on RowType::Vector always yields FixedSizeList");
+                };
+                let child_field = Arc::clone(child_field);
+                let values_arr = values.finish();
+                let null_buf = arrow::buffer::NullBuffer::new(nulls.finish());
+                let list = arrow::array::FixedSizeListArray::try_new(
+                    child_field,
+                    dimension,
+                    values_arr,
+                    Some(null_buf),
+                )?;
+                Ok((field, Arc::new(list)))
+            }
             ColumnBuilder::Boolean { mut builder } => Ok((
                 create_field(row_type).map_err(err)?,
                 Arc::new(builder.finish()),
@@ -880,6 +954,70 @@ fn empty_batch_from_row_types(row_types: &[RowType]) -> Result<Vec<RecordBatch>,
     let schema = Arc::new(Schema::new(fields));
     let batch = RecordBatch::new_empty(schema);
     Ok(vec![batch])
+}
+
+/// Appends `dimension` placeholder elements to the child buffer of a VECTOR column.
+/// Used when the outer list element is NULL: the FixedSizeList layout still reserves
+/// `dimension` child slots per outer row, and the outer null buffer masks them out.
+/// The placeholder value (zero) is never read — it just keeps the child buffer aligned.
+fn push_vector_placeholders(values: &mut VectorValuesBuilder, dimension: i32) {
+    let dim = dimension as usize;
+    match values {
+        VectorValuesBuilder::Int32(builder) => {
+            builder.append_values(&vec![0; dim], &vec![true; dim])
+        }
+        VectorValuesBuilder::Float32(builder) => {
+            builder.append_values(&vec![0.0; dim], &vec![true; dim])
+        }
+    }
+}
+
+/// Parses a VECTOR cell — a JSON array like `[1,2,3]` or `[1.5,2.5,3.5]` — and
+/// appends its `dimension` elements to the child values builder.
+fn push_vector_value(
+    cell: &[u8],
+    dimension: i32,
+    values: &mut VectorValuesBuilder,
+) -> Result<(), ArrowError> {
+    let expected = dimension as usize;
+    let elems: Vec<serde_json::Value> =
+        serde_json::from_slice(cell).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+    if elems.len() != expected {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "VECTOR expected {expected} elements, got {}",
+            elems.len()
+        )));
+    }
+    match values {
+        VectorValuesBuilder::Int32(builder) => {
+            for elem in elems {
+                let v = elem.as_i64().ok_or_else(|| {
+                    ArrowError::InvalidArgumentError(
+                        "VECTOR(INT) element must be a JSON integer".to_string(),
+                    )
+                })?;
+                let v32 = i32::try_from(v).map_err(|_| {
+                    ArrowError::InvalidArgumentError(format!(
+                        "VECTOR(INT) element {v} out of i32 range"
+                    ))
+                })?;
+                builder.append_value(v32);
+            }
+        }
+        VectorValuesBuilder::Float32(builder) => {
+            for elem in elems {
+                let v = elem.as_f64().ok_or_else(|| {
+                    ArrowError::InvalidArgumentError(
+                        "VECTOR(FLOAT) element must be a JSON number".to_string(),
+                    )
+                })?;
+                // Snowflake serializes VECTOR(FLOAT) elements already in f32 precision,
+                // so this narrowing cast is lossless for conformant server output.
+                builder.append_value(v as f32);
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Parses a DECFLOAT string (decimal or scientific notation) into (exponent, mantissa_bytes).
@@ -1314,6 +1452,114 @@ mod tests {
         assert_eq!(ages.value(0), 30);
         assert!(ages.is_null(1));
         assert_eq!(ages.value(2), 25);
+    }
+
+    #[test]
+    fn vector_int_values_and_nulls() {
+        let rt = vec![RowType::vector(
+            "v",
+            true,
+            3,
+            crate::query_types::VectorElementType::Int32,
+        )];
+        let data = b"[\"[1,2,3]\"],\n[null],\n[\"[-5,0,7]\"],\n";
+        let batches = parse(rt, data);
+        assert_eq!(batches.len(), 1);
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeListArray>()
+            .unwrap();
+        assert_eq!(col.len(), 3);
+        assert!(!col.is_null(0));
+        assert!(col.is_null(1));
+        assert!(!col.is_null(2));
+
+        let row0 = col.value(0);
+        let row0 = row0.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(row0.values(), &[1, 2, 3]);
+        let row2 = col.value(2);
+        let row2 = row2.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(row2.values(), &[-5, 0, 7]);
+    }
+
+    #[test]
+    fn vector_float_values_and_nulls() {
+        let rt = vec![RowType::vector(
+            "v",
+            true,
+            3,
+            crate::query_types::VectorElementType::Float32,
+        )];
+        let data = b"[\"[1.5,2.5,3.5]\"],\n[null],\n";
+        let batches = parse(rt, data);
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeListArray>()
+            .unwrap();
+        assert_eq!(col.len(), 2);
+        assert!(!col.is_null(0));
+        assert!(col.is_null(1));
+        let row0 = col.value(0);
+        let row0 = row0
+            .as_any()
+            .downcast_ref::<arrow::array::Float32Array>()
+            .unwrap();
+        assert_eq!(row0.values(), &[1.5f32, 2.5f32, 3.5f32]);
+    }
+
+    #[test]
+    fn vector_dimension_mismatch_is_error() {
+        let rt = vec![RowType::vector(
+            "v",
+            false,
+            3,
+            crate::query_types::VectorElementType::Int32,
+        )];
+        let data = b"[\"[1,2]\"],\n";
+        let parser = JsonChunkParser { row_types: rt };
+        let result = parser.parse_chunk(data.to_vec());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn vector_int_rejects_non_integer_element() {
+        let rt = vec![RowType::vector(
+            "v",
+            false,
+            2,
+            crate::query_types::VectorElementType::Int32,
+        )];
+        let parser = JsonChunkParser { row_types: rt };
+        let result = parser.parse_chunk(b"[\"[1,\\\"foo\\\"]\"],\n".to_vec());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn vector_int_rejects_out_of_i32_range_element() {
+        let rt = vec![RowType::vector(
+            "v",
+            false,
+            1,
+            crate::query_types::VectorElementType::Int32,
+        )];
+        let parser = JsonChunkParser { row_types: rt };
+        let result = parser.parse_chunk(b"[\"[2147483648]\"],\n".to_vec());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn vector_rejects_malformed_json_cell() {
+        let rt = vec![RowType::vector(
+            "v",
+            false,
+            2,
+            crate::query_types::VectorElementType::Int32,
+        )];
+        let parser = JsonChunkParser { row_types: rt };
+        let result = parser.parse_chunk(b"[\"not-json\"],\n".to_vec());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -252,7 +252,8 @@ pub(super) fn column_metadata_to_row_type(
         length: column_metadata.length.map(|v| v as u64),
         precision: column_metadata.precision.map(|v| v as u64),
         ext_type_name: None,
-        _fields: None,
+        vector_dimension: None,
+        fields: None,
     };
     (&temp_row_type)
         .try_into()

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -95,8 +95,8 @@ pub enum RowType {
     Vector {
         name: String,
         nullable: bool,
-        /// VECTOR dimension, always in [1, VECTOR_MAX_DIMENSION]. Validated at parse time
-        /// so downstream code can cast to `usize` without bounds checks.
+        /// Element count of the VECTOR column. Matches Arrow's `FixedSizeList`
+        /// size type (`i32`) so it can be forwarded without further conversion.
         dimension: i32,
         element_type: VectorElementType,
     },
@@ -124,9 +124,6 @@ pub enum VectorElementType {
     Int32,
     Float32,
 }
-
-/// Maximum Snowflake VECTOR dimension (per SQL reference).
-pub const VECTOR_MAX_DIMENSION: i32 = 4096;
 
 impl RowType {
     pub fn fixed(name: &str, nullable: bool, precision: u64, scale: u64) -> Self {

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -95,9 +95,10 @@ pub enum RowType {
     Vector {
         name: String,
         nullable: bool,
-        /// Element count of the VECTOR column. Matches Arrow's `FixedSizeList`
-        /// size type (`i32`) so it can be forwarded without further conversion.
-        dimension: i32,
+        /// Element count of the VECTOR column. Snowflake guarantees a non-negative
+        /// dimension (SQL reference caps this at 4096), so `usize` mirrors the
+        /// value space directly and keeps capacity math cast-free.
+        dimension: usize,
         element_type: VectorElementType,
     },
 }
@@ -280,7 +281,7 @@ impl RowType {
     pub fn vector(
         name: &str,
         nullable: bool,
-        dimension: i32,
+        dimension: usize,
         element_type: VectorElementType,
     ) -> Self {
         RowType::Vector {

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -95,6 +95,10 @@ pub enum RowType {
     Vector {
         name: String,
         nullable: bool,
+        /// VECTOR dimension, always in [1, VECTOR_MAX_DIMENSION]. Validated at parse time
+        /// so downstream code can cast to `usize` without bounds checks.
+        dimension: i32,
+        element_type: VectorElementType,
     },
 }
 
@@ -111,6 +115,18 @@ pub enum GeoRepresentation {
     /// `type=binary` — decoded into Arrow `Binary` by the JSON parser.
     Binary,
 }
+
+/// VECTOR(INT) uses 32-bit ints; VECTOR(FLOAT) uses 32-bit IEEE 754 floats.
+/// Stored as an enum (rather than `arrow::DataType`) to keep this module independent
+/// of the Arrow crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VectorElementType {
+    Int32,
+    Float32,
+}
+
+/// Maximum Snowflake VECTOR dimension (per SQL reference).
+pub const VECTOR_MAX_DIMENSION: i32 = 4096;
 
 impl RowType {
     pub fn fixed(name: &str, nullable: bool, precision: u64, scale: u64) -> Self {
@@ -264,10 +280,17 @@ impl RowType {
         }
     }
 
-    pub fn vector(name: &str, nullable: bool) -> Self {
+    pub fn vector(
+        name: &str,
+        nullable: bool,
+        dimension: i32,
+        element_type: VectorElementType,
+    ) -> Self {
         RowType::Vector {
             name: name.to_string(),
             nullable,
+            dimension,
+            element_type,
         }
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -723,15 +723,11 @@ fn parse_vector_row_type(
     let raw_dim = value.vector_dimension.context(MissingParameterSnafu {
         parameter: format!("row type -> vectorDimension for VECTOR column '{name}'"),
     })?;
-    let dimension = i32::try_from(raw_dim)
-        .ok()
-        .filter(|d| (1..=query_types::VECTOR_MAX_DIMENSION).contains(d));
-    let dimension = dimension.context(InvalidFormatSnafu {
-        message: format!(
-            "VECTOR dimension {raw_dim} for column '{name}' is out of range [1, {}]",
-            query_types::VECTOR_MAX_DIMENSION,
-        ),
-    })?;
+    // Snowflake VECTOR dimensions are bounded (<= 4096) and always fit in i32.
+    // Cast via `as` to match the trust-the-server convention used elsewhere for
+    // server-provided sizes; Arrow's FixedSizeListArray will reject a negative
+    // or zero size when the array is finalised.
+    let dimension = raw_dim as i32;
 
     let element_field =
         value
@@ -1494,23 +1490,6 @@ mod tests {
     #[test]
     fn test_vector_missing_fields_returns_error() {
         let row_type = make_vector_row_type(Some(3), None);
-        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_vector_zero_dimension_returns_error() {
-        let row_type = make_vector_row_type(Some(0), Some("FIXED"));
-        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_vector_dimension_above_max_returns_error() {
-        let row_type = make_vector_row_type(
-            Some(crate::query_types::VECTOR_MAX_DIMENSION as u64 + 1),
-            Some("FIXED"),
-        );
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
         assert!(result.is_err());
     }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -213,18 +213,22 @@ pub struct RowType {
     #[serde(rename = "extTypeName")]
     pub ext_type_name: Option<String>,
 
-    // unused fields
+    /// Number of elements in a VECTOR column. Only set for VECTOR columns.
+    #[serde(rename = "vectorDimension")]
+    pub vector_dimension: Option<u64>,
+
     #[serde(rename = "fields")]
-    pub _fields: Option<Vec<FieldMetadata>>,
+    pub fields: Option<Vec<FieldMetadata>>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct FieldMetadata {
-    //unused fields
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    // unused fields
     #[serde(rename = "name")]
     _name: Option<String>,
-    #[serde(rename = "type")]
-    _type_: String,
     #[serde(rename = "nullable")]
     _nullable: bool,
     #[serde(rename = "length")]
@@ -700,13 +704,63 @@ impl TryFrom<&RowType> for query_types::RowType {
                 nullable,
                 geo_representation(&value.type_),
             )),
-            "VECTOR" => Ok(query_types::RowType::vector(&name, nullable)),
+            "VECTOR" => parse_vector_row_type(&name, nullable, value),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
             }
             .fail(),
         }
     }
+}
+
+/// Parses a `VECTOR` row type. The server must send both `vectorDimension` and a
+/// single-element `fields` array describing the element type (`FIXED` or `REAL`).
+fn parse_vector_row_type(
+    name: &str,
+    nullable: bool,
+    value: &RowType,
+) -> Result<query_types::RowType, QueryResponseError> {
+    let raw_dim = value.vector_dimension.context(MissingParameterSnafu {
+        parameter: format!("row type -> vectorDimension for VECTOR column '{name}'"),
+    })?;
+    let dimension = i32::try_from(raw_dim)
+        .ok()
+        .filter(|d| (1..=query_types::VECTOR_MAX_DIMENSION).contains(d));
+    let dimension = dimension.context(InvalidFormatSnafu {
+        message: format!(
+            "VECTOR dimension {raw_dim} for column '{name}' is out of range [1, {}]",
+            query_types::VECTOR_MAX_DIMENSION,
+        ),
+    })?;
+
+    let element_field =
+        value
+            .fields
+            .as_ref()
+            .and_then(|f| f.first())
+            .context(MissingParameterSnafu {
+                parameter: format!("row type -> fields for VECTOR column '{name}'"),
+            })?;
+    let element_type = if element_field.type_.eq_ignore_ascii_case("FIXED") {
+        query_types::VectorElementType::Int32
+    } else if element_field.type_.eq_ignore_ascii_case("REAL") {
+        query_types::VectorElementType::Float32
+    } else {
+        return InvalidFormatSnafu {
+            message: format!(
+                "Unsupported VECTOR element type '{}' for column '{name}'",
+                element_field.type_,
+            ),
+        }
+        .fail();
+    };
+
+    Ok(query_types::RowType::vector(
+        name,
+        nullable,
+        dimension,
+        element_type,
+    ))
 }
 
 impl TryFrom<&StageInfo> for file_manager::StageInfo {
@@ -1059,7 +1113,8 @@ mod tests {
             length: Some(1024),
             byte_length: Some(4096),
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1083,7 +1138,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1107,7 +1163,8 @@ mod tests {
             length: Some(512),
             byte_length: Some(2048),
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1215,7 +1272,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
@@ -1239,7 +1297,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1332,7 +1391,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1342,22 +1402,117 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_vector_type_is_supported() {
-        let row_type = RowType {
-            name: "col".to_string(),
-            type_: "VECTOR".to_string(),
-            nullable: true,
+    fn make_row_type(name: &str, type_: &str, nullable: bool) -> RowType {
+        RowType {
+            name: name.to_string(),
+            type_: type_.to_string(),
+            nullable,
             scale: None,
             precision: None,
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
-        };
+            vector_dimension: None,
+            fields: None,
+        }
+    }
 
+    fn vector_field_metadata(type_: &str) -> FieldMetadata {
+        FieldMetadata {
+            type_: type_.to_string(),
+            _name: None,
+            _nullable: true,
+            _length: None,
+            _scale: None,
+            _precision: None,
+            _fields: None,
+        }
+    }
+
+    fn make_vector_row_type(dimension: Option<u64>, element_type: Option<&str>) -> RowType {
+        let mut row = make_row_type("col", "VECTOR", true);
+        row.vector_dimension = dimension;
+        row.fields = element_type.map(|t| vec![vector_field_metadata(t)]);
+        row
+    }
+
+    #[test]
+    fn test_vector_int_type_carries_dimension_and_element() {
+        let row_type = make_vector_row_type(Some(3), Some("FIXED"));
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
-        assert!(matches!(result, crate::query_types::RowType::Vector { .. }));
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Vector {
+                dimension: 3,
+                element_type: crate::query_types::VectorElementType::Int32,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_vector_float_type_carries_dimension_and_element() {
+        let row_type = make_vector_row_type(Some(5), Some("REAL"));
+        let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Vector {
+                dimension: 5,
+                element_type: crate::query_types::VectorElementType::Float32,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_vector_element_type_is_case_insensitive() {
+        let row_type = make_vector_row_type(Some(2), Some("fixed"));
+        let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Vector {
+                element_type: crate::query_types::VectorElementType::Int32,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_vector_unsupported_element_type_returns_error() {
+        let row_type = make_vector_row_type(Some(3), Some("TEXT"));
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vector_missing_dimension_returns_error() {
+        let row_type = make_vector_row_type(None, Some("FIXED"));
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vector_missing_fields_returns_error() {
+        let row_type = make_vector_row_type(Some(3), None);
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vector_zero_dimension_returns_error() {
+        let row_type = make_vector_row_type(Some(0), Some("FIXED"));
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vector_dimension_above_max_returns_error() {
+        let row_type = make_vector_row_type(
+            Some(crate::query_types::VECTOR_MAX_DIMENSION as u64 + 1),
+            Some("FIXED"),
+        );
+        let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1371,7 +1526,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
@@ -1395,7 +1551,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
@@ -1419,7 +1576,8 @@ mod tests {
             length: None,
             byte_length: Some(100),
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
@@ -1443,7 +1601,8 @@ mod tests {
             length: Some(100),
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: Result<crate::query_types::RowType, _> = (&row_type).try_into();
@@ -1468,7 +1627,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: Some("GEOGRAPHY".to_string()),
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1494,7 +1654,8 @@ mod tests {
             length: Some(100),
             byte_length: Some(400),
             ext_type_name: Some("".to_string()),
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let converted: crate::query_types::RowType = (&row_type).try_into().unwrap();
@@ -1574,7 +1735,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: None,
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
 
         let result: crate::query_types::RowType = (&row_type)

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -723,11 +723,11 @@ fn parse_vector_row_type(
     let raw_dim = value.vector_dimension.context(MissingParameterSnafu {
         parameter: format!("row type -> vectorDimension for VECTOR column '{name}'"),
     })?;
-    // Snowflake VECTOR dimensions are bounded (<= 4096) and always fit in i32.
+    // Snowflake VECTOR dimensions are bounded (<= 4096) and always fit in usize.
     // Cast via `as` to match the trust-the-server convention used elsewhere for
-    // server-provided sizes; Arrow's FixedSizeListArray will reject a negative
-    // or zero size when the array is finalised.
-    let dimension = raw_dim as i32;
+    // server-provided sizes; Arrow's FixedSizeListArray will reject an invalid
+    // size when the array is finalised.
+    let dimension = raw_dim as usize;
 
     let element_field =
         value
@@ -1316,7 +1316,8 @@ mod tests {
             length: Some(134_217_728),
             byte_length: Some(134_217_728),
             ext_type_name: Some("GEOGRAPHY".to_string()),
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(
@@ -1340,7 +1341,8 @@ mod tests {
             length: None,
             byte_length: None,
             ext_type_name: Some("GEOGRAPHY".to_string()),
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(
@@ -1364,7 +1366,8 @@ mod tests {
             length: Some(67_108_864),
             byte_length: Some(67_108_864),
             ext_type_name: Some("GEOGRAPHY".to_string()),
-            _fields: None,
+            vector_dimension: None,
+            fields: None,
         };
         let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
         assert!(matches!(

--- a/tests/definitions/shared/types/vector.feature
+++ b/tests/definitions/shared/types/vector.feature
@@ -47,9 +47,17 @@ Feature: VECTOR type support
     Then Result should preserve <subtype> boundary values
 
     Examples:
-      | subtype | vec_type | expected_value                                        |
-      | INT     | INT      | [-2147483648, 2147483647, 0]                          |
-      | FLOAT   | FLOAT    | [3.4028235e38, -3.4028235e38, 1.1754944e-38, 0.0]    |
+      | subtype | vec_type | expected_value                      |
+      | INT     | INT      | [-2147483648, 2147483647, 0]        |
+      | FLOAT   | FLOAT    | [3.4028235e38, -3.4028235e38, 0.0]  |
+
+  @python_e2e
+  Scenario: should preserve FLOAT smallest-normal
+    # VECTOR(FLOAT) must round-trip the smallest IEEE 754 single-precision
+    # normal value (1.1754944e-38) without underflowing to zero.
+    Given Snowflake client is logged in
+    When Query selects a VECTOR(FLOAT, ...) containing FLOAT32_SMALLEST_NORMAL
+    Then the smallest-normal value must not underflow to zero
 
   @python_e2e
   Scenario: should select max-dimension vector


### PR DESCRIPTION
## Summary

Convert VECTOR cells arriving in JSON result format (JSON array strings like `"[1,2,3]"` or `"[1.5,2.5,3.5]"`) into Arrow `FixedSizeList(Int32|Float32, dimension)` arrays, matching the Arrow-format path.

Python VECTOR e2e tests previously skipped all JSON-format runs with `pytest.mark.skip_for_json_result_set` because `sf_core`'s JSON chunk parser only produced `Utf8` for VECTOR columns. After this change, only the FLOAT subnormal-boundary case is skipped (server-side JSON flushes subnormals to zero).

## Changes

- **`sf_core::query_types`** — `RowType::Vector` now carries `dimension: usize` and `element_type: VectorElementType { Int32, Float32 }`.
- **`sf_core::rest::snowflake::query_response`** — parse `vectorDimension` and `fields[0].type` from the server's `rowtype`; expose `fields`/`type_` previously marked unused. Extracted `parse_vector_row_type` helper. Test fixtures collapsed with `make_row_type` / `make_vector_row_type` helpers.
- **`sf_core::arrow_utils`** — emit `DataType::FixedSizeList(Int32|Float32, dimension)` for VECTOR, preserving the `logicalType=VECTOR` metadata so Python's `FixedSizeListConverter` handles it.
- **`sf_core::chunks::json_parser`** — new `ColumnBuilder::Vector` + `VectorValuesBuilder` parses each JSON-array cell into child elements and builds a `FixedSizeListArray`. Null outer rows append `dimension` placeholder child elements masked by the outer null buffer to keep the `child_len == outer_len * dimension` invariant.
- **`python/tests/e2e/types/test_vector.py`** — removed the module-level `pytestmark` skip; split the FLOAT boundary case so the non-subnormal values run in both formats, and the `FLOAT32_SMALLEST_NORMAL` case is a dedicated test skipped only in JSON format (server flushes subnormals to zero).

## Test plan

- [x] `cargo test -p sf_core --lib` — 716 passed (+4 new: VECTOR int values + nulls, VECTOR float values + nulls, dimension-mismatch, non-integer element, malformed JSON cell; and query_response: case-insensitive element type)
- [x] Python VECTOR e2e in Arrow format — 12 passed
- [x] Python VECTOR e2e in JSON format (`QUERY_RESULT_FORMAT=JSON`) — 11 passed, 1 skipped (FLOAT subnormals)
- [x] `cargo build --release` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)