### PR TITLE
Add WrapperPresets mechanism for per-wrapper behavioral configuration

### DIFF
--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -23,7 +23,7 @@ impl JdbcBridge {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .take(),
-            wrapper_presets: WrapperPresets::for_wrapper("jdbc"),
+            wrapper_presets: WrapperPresets::jdbc(),
             ..Default::default()
         };
         Self {

--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -6,7 +6,7 @@ use jni::sys::{jint, jobject};
 use proto_utils::{ProtoError, Transport};
 use sf_core::logging::LogManager;
 use sf_core::protobuf::apis::RustTransport;
-use sf_core::protobuf::apis::database_driver_v1::DriverProviders;
+use sf_core::protobuf::apis::database_driver_v1::{DriverProviders, WrapperPresets};
 use sf_core::telemetry::snowflake_exporter::SessionRegistry;
 
 static JDBC_LOG_MANAGER: Mutex<Option<LogManager>> = Mutex::new(None);
@@ -23,6 +23,7 @@ impl JdbcBridge {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .take(),
+            wrapper_presets: WrapperPresets::for_wrapper("jdbc"),
             ..Default::default()
         };
         Self {

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::sync::RwLock;
 
 use sf_core::protobuf::apis::database_driver_v1::{
-    DatabaseDriverClient, DriverProviders, database_driver_client_with,
+    DatabaseDriverClient, DriverProviders, WrapperPresets, database_driver_client_with,
 };
 use snafu::{Location, ResultExt, Snafu};
 
@@ -90,6 +90,7 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
     if guard.globals.is_none() {
         let providers = DriverProviders {
             log_manager: sf_core::logging::LogManager::for_odbc(),
+            wrapper_presets: WrapperPresets::for_wrapper("odbc"),
             ..Default::default()
         };
 

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -90,7 +90,7 @@ pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
     if guard.globals.is_none() {
         let providers = DriverProviders {
             log_manager: sf_core::logging::LogManager::for_odbc(),
-            wrapper_presets: WrapperPresets::for_wrapper("odbc"),
+            wrapper_presets: WrapperPresets::odbc(),
             ..Default::default()
         };
 

--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -60,7 +60,7 @@ except OSError as err:
 LOGGER_CALLBACK = ctypes.CFUNCTYPE(
     ctypes.c_uint32, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p
 )
-core.sf_core_init.argtypes = [LOGGER_CALLBACK]
+core.sf_core_init.argtypes = [LOGGER_CALLBACK, ctypes.c_char_p]
 core.sf_core_init.restype = ctypes.c_uint32
 
 core.sf_core_api_call_proto.restype = ctypes.c_uint32
@@ -121,7 +121,7 @@ def sf_core_free_buffer(buffer: Any, length: int) -> None:
 
 
 def sf_core_init(callback: Any) -> None:
-    core.sf_core_init(callback)
+    core.sf_core_init(callback, b"python")
 
 
 level_map = {

--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -60,7 +60,7 @@ except OSError as err:
 LOGGER_CALLBACK = ctypes.CFUNCTYPE(
     ctypes.c_uint32, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p
 )
-core.sf_core_init.argtypes = [LOGGER_CALLBACK, ctypes.c_char_p]
+core.sf_core_init.argtypes = [LOGGER_CALLBACK]
 core.sf_core_init.restype = ctypes.c_uint32
 
 core.sf_core_api_call_proto.restype = ctypes.c_uint32
@@ -121,7 +121,7 @@ def sf_core_free_buffer(buffer: Any, length: int) -> None:
 
 
 def sf_core_init(callback: Any) -> None:
-    core.sf_core_init(callback, b"python")
+    core.sf_core_init(callback)
 
 
 level_map = {

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -13,6 +13,44 @@ use crate::telemetry::platform_detection::{DetectionConfig, detect_platforms};
 use crate::telemetry::snowflake_exporter::SessionRegistry;
 use crate::token_cache::{KeyringTokenCache, TokenCacheError};
 
+/// Which shape the PUT/GET result set should take.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PutGetResultsetFlavor {
+    #[default]
+    Python,
+    Odbc,
+}
+
+/// Immutable behavioural presets declared by each wrapper (Python, ODBC, JDBC)
+/// at startup. These are **not** exposed to end users — they capture
+/// compile-time / init-time differences between wrappers so that shared Rust
+/// code can branch on them without hard-coding wrapper knowledge everywhere.
+#[derive(Debug, Clone, Default)]
+pub struct WrapperPresets {
+    pub put_get_resultset_flavor: PutGetResultsetFlavor,
+}
+
+impl WrapperPresets {
+    /// Build a preset bundle for the named wrapper.
+    ///
+    /// Starts from `Self::default()` and overrides only the fields that
+    /// differ for the given wrapper. To add a new preset, add a field
+    /// with a `Default` value to the struct, then add a line in the
+    /// match arm of every wrapper that needs a non-default value.
+    pub fn for_wrapper(name: &str) -> Self {
+        let mut presets = Self::default();
+        match name.to_ascii_lowercase().as_str() {
+            "python" => {}
+            "odbc" => {
+                presets.put_get_resultset_flavor = PutGetResultsetFlavor::Odbc;
+            }
+            "jdbc" => {}
+            _ => {}
+        }
+        presets
+    }
+}
+
 /// Injection points for `DatabaseDriverV1`.
 ///
 /// Each field is optional; `None` means "use the production default".
@@ -25,6 +63,7 @@ pub struct DriverProviders {
     /// `LogManager` instance created during logging initialization.
     /// Owns the `SdkTracerProvider`, `SessionRegistry`, and OS details.
     pub log_manager: Option<LogManager>,
+    pub wrapper_presets: WrapperPresets,
 }
 
 pub struct DatabaseDriverV1 {
@@ -35,6 +74,7 @@ pub struct DatabaseDriverV1 {
     fs: Arc<dyn FsAdapter>,
     platforms: tokio::sync::OnceCell<Vec<String>>,
     log_manager: Option<LogManager>,
+    pub(super) wrapper_presets: WrapperPresets,
 }
 
 impl Default for DatabaseDriverV1 {
@@ -57,6 +97,7 @@ impl DatabaseDriverV1 {
             fs: providers.fs.unwrap_or_else(|| Arc::new(RealFs)),
             platforms: tokio::sync::OnceCell::const_new(),
             log_manager: providers.log_manager,
+            wrapper_presets: providers.wrapper_presets,
         }
     }
 

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -31,23 +31,26 @@ pub struct WrapperPresets {
 }
 
 impl WrapperPresets {
-    /// Build a preset bundle for the named wrapper.
+    /// Presets for the Python connector.
     ///
-    /// Starts from `Self::default()` and overrides only the fields that
-    /// differ for the given wrapper. To add a new preset, add a field
-    /// with a `Default` value to the struct, then add a line in the
-    /// match arm of every wrapper that needs a non-default value.
-    pub fn for_wrapper(name: &str) -> Self {
-        let mut presets = Self::default();
-        match name.to_ascii_lowercase().as_str() {
-            "python" => {}
-            "odbc" => {
-                presets.put_get_resultset_flavor = PutGetResultsetFlavor::Odbc;
-            }
-            "jdbc" => {}
-            _ => {}
+    /// Currently identical to `Default` — listed explicitly so that
+    /// future Python-specific overrides have a clear home.
+    pub fn python() -> Self {
+        Self::default()
+    }
+
+    /// Presets for the ODBC driver.
+    #[allow(clippy::needless_update)]
+    pub fn odbc() -> Self {
+        Self {
+            put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
+            ..Self::default()
         }
-        presets
+    }
+
+    /// Presets for the JDBC bridge.
+    pub fn jdbc() -> Self {
+        Self::default()
     }
 }
 

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -19,7 +19,7 @@ pub use async_query_registry::AsyncQueryRegistry;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use database::FetchChunkInput;
 pub use error::ApiError;
-pub use global_state::{DatabaseDriverV1, DriverProviders};
+pub use global_state::{DatabaseDriverV1, DriverProviders, WrapperPresets};
 pub use statement::{
     BindingType, ColumnMetadata, DataPtr, ExecuteQueryResult, InlineData, ResolvedResultSet,
     ResultSetDescriptor, StoredChunkInfo,

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -1,4 +1,5 @@
 use super::ColumnMetadata;
+use super::global_state::WrapperPresets;
 use crate::arrow_utils::ArrowUtilsError;
 use crate::arrow_utils::{boxed_arrow_reader, create_schema};
 use crate::chunks::{
@@ -29,9 +30,10 @@ pub async fn process_query_response(
     data: &query_response::Data,
     http_client: &Client,
     prefetch_config: &PrefetchConfig,
+    wrapper_presets: &WrapperPresets,
 ) -> Result<QueryResult, QueryResponseProcessingError> {
     match data.command {
-        Some(ref command) => perform_put_get(command.clone(), data).await,
+        Some(ref command) => perform_put_get(command.clone(), data, wrapper_presets).await,
         None => {
             let reader = read_batches(data.to_rowset_data(), http_client.clone(), prefetch_config)
                 .await
@@ -44,6 +46,7 @@ pub async fn process_query_response(
 async fn perform_put_get(
     command: String,
     data: &query_response::Data,
+    wrapper_presets: &WrapperPresets,
 ) -> Result<QueryResult, QueryResponseProcessingError> {
     match command.as_str() {
         "UPLOAD" => {
@@ -53,8 +56,8 @@ async fn perform_put_get(
             let upload_results = upload_files(&file_upload_data)
                 .await
                 .context(FileUploadSnafu)?;
-            let reader =
-                upload_results_reader(upload_results).context(UploadResultsConversionSnafu)?;
+            let reader = upload_results_reader(upload_results, wrapper_presets)
+                .context(UploadResultsConversionSnafu)?;
             Ok(QueryResult { reader })
         }
         "DOWNLOAD" => {
@@ -68,7 +71,7 @@ async fn perform_put_get(
             let download_results = download_files(file_download_data)
                 .await
                 .context(FileDownloadSnafu)?;
-            let reader = download_results_reader(download_results)
+            let reader = download_results_reader(download_results, wrapper_presets)
                 .context(DownloadResultsConversionSnafu)?;
             Ok(QueryResult { reader })
         }
@@ -183,7 +186,7 @@ macro_rules! int64_array {
     };
 }
 
-fn upload_row_types() -> Vec<(RowType, DataType)> {
+fn upload_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
     vec![
         build_generic_text_rowtype("source"),
         build_generic_text_rowtype("target"),
@@ -196,7 +199,7 @@ fn upload_row_types() -> Vec<(RowType, DataType)> {
     ]
 }
 
-fn download_row_types() -> Vec<(RowType, DataType)> {
+fn download_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
     vec![
         build_generic_text_rowtype("file"),
         build_generic_fixed_rowtype("size"),
@@ -208,8 +211,10 @@ fn download_row_types() -> Vec<(RowType, DataType)> {
 /// Converts upload results to Arrow format
 pub fn upload_results_reader(
     upload_results: Vec<UploadResult>,
+    wrapper_presets: &WrapperPresets,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ArrowError> {
-    let schema = create_schema(&upload_row_types()).expect("Failed to create schema from RowTypes");
+    let schema = create_schema(&upload_row_types(wrapper_presets))
+        .expect("Failed to create schema from RowTypes");
 
     let columns: Vec<Arc<dyn Array>> = vec![
         string_array!(upload_results, source),
@@ -228,9 +233,10 @@ pub fn upload_results_reader(
 /// Converts download results to Arrow format
 pub fn download_results_reader(
     download_results: Vec<DownloadResult>,
+    wrapper_presets: &WrapperPresets,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ArrowError> {
-    let schema =
-        create_schema(&download_row_types()).expect("Failed to create schema from RowTypes");
+    let schema = create_schema(&download_row_types(wrapper_presets))
+        .expect("Failed to create schema from RowTypes");
 
     let columns: Vec<Arc<dyn Array>> = vec![
         string_array!(download_results, file),
@@ -297,16 +303,16 @@ fn rowtype_to_column_metadata(rt: &RowType) -> ColumnMetadata {
 }
 
 /// Build column metadata for PUT (UPLOAD) results.
-pub fn upload_column_metadata() -> Vec<ColumnMetadata> {
-    upload_row_types()
+pub fn upload_column_metadata(wrapper_presets: &WrapperPresets) -> Vec<ColumnMetadata> {
+    upload_row_types(wrapper_presets)
         .iter()
         .map(|(r, _)| rowtype_to_column_metadata(r))
         .collect()
 }
 
 /// Build column metadata for GET (DOWNLOAD) results.
-pub fn download_column_metadata() -> Vec<ColumnMetadata> {
-    download_row_types()
+pub fn download_column_metadata(wrapper_presets: &WrapperPresets) -> Vec<ColumnMetadata> {
+    download_row_types(wrapper_presets)
         .iter()
         .map(|(r, _)| rowtype_to_column_metadata(r))
         .collect()
@@ -411,7 +417,7 @@ mod tests {
 
     #[test]
     fn upload_column_metadata_has_correct_structure() {
-        let columns = upload_column_metadata();
+        let columns = upload_column_metadata(&WrapperPresets::default());
 
         assert_eq!(columns.len(), 8, "PUT should have 8 columns");
 
@@ -448,7 +454,7 @@ mod tests {
 
     #[test]
     fn download_column_metadata_has_correct_structure() {
-        let columns = download_column_metadata();
+        let columns = download_column_metadata(&WrapperPresets::default());
 
         assert_eq!(columns.len(), 4, "GET should have 4 columns");
 

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -460,10 +460,14 @@ impl DatabaseDriverV1 {
         let prebuilt_stream = if super::multistatement::is_multistatement(&response.data) {
             None
         } else {
-            let query_result =
-                process_query_response(&response.data, &http_client, &prefetch_config, &self.wrapper_presets)
-                    .await
-                    .context(QueryResponseProcessingSnafu)?;
+            let query_result = process_query_response(
+                &response.data,
+                &http_client,
+                &prefetch_config,
+                &self.wrapper_presets,
+            )
+            .await
+            .context(QueryResponseProcessingSnafu)?;
             Some(Box::new(FFI_ArrowArrayStream::new(query_result.reader)))
         };
 
@@ -895,9 +899,10 @@ async fn fetch_and_resolve_result_set(
     let prefetch_config = resolve_prefetch_config(conn_ptr).await;
 
     let descriptor = response_to_descriptor(&data, wrapper_presets);
-    let query_result = process_query_response(&data, &http_client, &prefetch_config, wrapper_presets)
-        .await
-        .context(QueryResponseProcessingSnafu)?;
+    let query_result =
+        process_query_response(&data, &http_client, &prefetch_config, wrapper_presets)
+            .await
+            .context(QueryResponseProcessingSnafu)?;
     let stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));
 
     Ok(ResolvedResultSet { descriptor, stream })

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -450,7 +450,7 @@ impl DatabaseDriverV1 {
             .await;
         }
 
-        let descriptor = response_to_descriptor(&response.data);
+        let descriptor = response_to_descriptor(&response.data, &self.wrapper_presets);
 
         let prefetch_config = resolve_prefetch_config(&conn_arc).await;
 
@@ -461,7 +461,7 @@ impl DatabaseDriverV1 {
             None
         } else {
             let query_result =
-                process_query_response(&response.data, &http_client, &prefetch_config)
+                process_query_response(&response.data, &http_client, &prefetch_config, &self.wrapper_presets)
                     .await
                     .context(QueryResponseProcessingSnafu)?;
             Some(Box::new(FFI_ArrowArrayStream::new(query_result.reader)))
@@ -650,7 +650,7 @@ impl DatabaseDriverV1 {
             .await;
         }
 
-        let descriptor = response_to_descriptor(&response.data);
+        let descriptor = response_to_descriptor(&response.data, &self.wrapper_presets);
         if super::multistatement::is_multistatement(&response.data) {
             let query_ids = super::multistatement::child_query_ids(&response.data);
             let statement_type_ids =
@@ -750,7 +750,10 @@ fn response_inline_data(data: &Data, format: ChunkFormatKind) -> InlineData {
 }
 
 /// Extract metadata from a Snowflake query response into a `ResultSetDescriptor`.
-fn response_to_descriptor(data: &Data) -> ResultSetDescriptor {
+fn response_to_descriptor(
+    data: &Data,
+    wrapper_presets: &super::global_state::WrapperPresets,
+) -> ResultSetDescriptor {
     let query_id = data.query_id.clone().unwrap_or_default();
     let rows_affected = calculate_rows_affected(data);
     let columns = data
@@ -775,7 +778,7 @@ fn response_to_descriptor(data: &Data) -> ResultSetDescriptor {
                 })
                 .collect()
         })
-        .unwrap_or_else(|| put_get_columns(data.command.as_deref()));
+        .unwrap_or_else(|| put_get_columns(data.command.as_deref(), wrapper_presets));
 
     // Snowflake's REST response for PUT / GET does not always carry a `statementTypeId`,
     // wrapper classifiers need a client-side fallback to recognise the synthesized PUT / GET cursor.
@@ -799,11 +802,14 @@ fn response_to_descriptor(data: &Data) -> ResultSetDescriptor {
 
 /// Return client-synthesized column metadata for PUT/GET commands,
 /// which don't include `rowType` in the Snowflake response.
-fn put_get_columns(command: Option<&str>) -> Vec<ColumnMetadata> {
+fn put_get_columns(
+    command: Option<&str>,
+    wrapper_presets: &super::global_state::WrapperPresets,
+) -> Vec<ColumnMetadata> {
     use super::query::{download_column_metadata, upload_column_metadata};
     match command {
-        Some("UPLOAD") => upload_column_metadata(),
-        Some("DOWNLOAD") => download_column_metadata(),
+        Some("UPLOAD") => upload_column_metadata(wrapper_presets),
+        Some("DOWNLOAD") => download_column_metadata(wrapper_presets),
         _ => Vec::new(),
     }
 }
@@ -883,12 +889,13 @@ async fn fetch_query_response_data(
 async fn fetch_and_resolve_result_set(
     conn_ptr: &Arc<Mutex<Connection>>,
     query_id: &str,
+    wrapper_presets: &super::global_state::WrapperPresets,
 ) -> Result<ResolvedResultSet, ApiError> {
     let (data, http_client) = fetch_query_response_data(conn_ptr, query_id).await?;
     let prefetch_config = resolve_prefetch_config(conn_ptr).await;
 
-    let descriptor = response_to_descriptor(&data);
-    let query_result = process_query_response(&data, &http_client, &prefetch_config)
+    let descriptor = response_to_descriptor(&data, wrapper_presets);
+    let query_result = process_query_response(&data, &http_client, &prefetch_config, wrapper_presets)
         .await
         .context(QueryResponseProcessingSnafu)?;
     let stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));
@@ -900,10 +907,11 @@ async fn fetch_and_resolve_result_set(
 async fn fetch_chunk_info_by_query_id(
     conn_ptr: &Arc<Mutex<Connection>>,
     query_id: &str,
+    wrapper_presets: &super::global_state::WrapperPresets,
 ) -> Result<StoredChunkInfo, ApiError> {
     let (data, _http_client) = fetch_query_response_data(conn_ptr, query_id).await?;
 
-    let descriptor = response_to_descriptor(&data);
+    let descriptor = response_to_descriptor(&data, wrapper_presets);
     let format = response_chunk_format(&data)?;
 
     Ok(StoredChunkInfo {
@@ -950,7 +958,7 @@ impl DatabaseDriverV1 {
         // Slow path: fetch from Snowflake by query_id (multi-statement children)
         let conn = stmt.conn.clone();
         drop(stmt);
-        fetch_and_resolve_result_set(&conn, &query_id).await
+        fetch_and_resolve_result_set(&conn, &query_id, &self.wrapper_presets).await
     }
 
     /// Fetch a result set by query_id using the connection (stateless, always fetches from Snowflake).
@@ -966,7 +974,7 @@ impl DatabaseDriverV1 {
             .build()
         })?;
 
-        fetch_and_resolve_result_set(&conn_ptr, &query_id).await
+        fetch_and_resolve_result_set(&conn_ptr, &query_id, &self.wrapper_presets).await
     }
 
     /// Fetch chunk metadata by query_id using the connection (no statement handle required).
@@ -982,7 +990,7 @@ impl DatabaseDriverV1 {
             .build()
         })?;
 
-        fetch_chunk_info_by_query_id(&conn_ptr, &query_id).await
+        fetch_chunk_info_by_query_id(&conn_ptr, &query_id, &self.wrapper_presets).await
     }
 }
 

--- a/sf_core/src/logging/c_api.rs
+++ b/sf_core/src/logging/c_api.rs
@@ -1,5 +1,3 @@
-use std::ffi::CStr;
-
 use crate::apis::database_driver_v1::WrapperPresets;
 use crate::logging;
 use crate::logging::{LogManager, LoggingConfig};
@@ -7,29 +5,11 @@ use crate::telemetry::snowflake_exporter::SessionRegistry;
 
 /// Initialise the core state: logging, tokio runtime, and transport.
 ///
-/// Wrapper calls this at import time, before any API call.
-/// `wrapper_name` is a null-terminated C string identifying the calling
-/// wrapper (e.g. `"python"`, `"odbc"`). It selects behavioural presets
-/// baked into the driver for that wrapper.
-///
+/// Called by the Python connector at import time, before any API call.
 /// Returns 0 on success, 1 on failure.
-///
-/// # Safety
-/// `wrapper_name` must be either null or point to a valid null-terminated
-/// C string that remains alive for the duration of this call.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sf_core_init(
-    callback: logging::CLogCallback,
-    wrapper_name: *const std::ffi::c_char,
-) -> u32 {
-    let name = if wrapper_name.is_null() {
-        ""
-    } else {
-        unsafe { CStr::from_ptr(wrapper_name) }
-            .to_str()
-            .unwrap_or("")
-    };
-    let wrapper_presets = WrapperPresets::for_wrapper(name);
+pub extern "C" fn sf_core_init(callback: logging::CLogCallback) -> u32 {
+    let wrapper_presets = WrapperPresets::python();
 
     let layer = logging::CallbackLayer::new(callback);
     let sessions = SessionRegistry::default();

--- a/sf_core/src/logging/c_api.rs
+++ b/sf_core/src/logging/c_api.rs
@@ -1,3 +1,6 @@
+use std::ffi::CStr;
+
+use crate::apis::database_driver_v1::WrapperPresets;
 use crate::logging;
 use crate::logging::{LogManager, LoggingConfig};
 use crate::telemetry::snowflake_exporter::SessionRegistry;
@@ -5,18 +8,38 @@ use crate::telemetry::snowflake_exporter::SessionRegistry;
 /// Initialise the core state: logging, tokio runtime, and transport.
 ///
 /// Wrapper calls this at import time, before any API call.
+/// `wrapper_name` is a null-terminated C string identifying the calling
+/// wrapper (e.g. `"python"`, `"odbc"`). It selects behavioural presets
+/// baked into the driver for that wrapper.
+///
 /// Returns 0 on success, 1 on failure.
+///
+/// # Safety
+/// `wrapper_name` must be either null or point to a valid null-terminated
+/// C string that remains alive for the duration of this call.
 #[unsafe(no_mangle)]
-pub extern "C" fn sf_core_init(callback: logging::CLogCallback) -> u32 {
+pub unsafe extern "C" fn sf_core_init(
+    callback: logging::CLogCallback,
+    wrapper_name: *const std::ffi::c_char,
+) -> u32 {
+    let name = if wrapper_name.is_null() {
+        ""
+    } else {
+        unsafe { CStr::from_ptr(wrapper_name) }
+            .to_str()
+            .unwrap_or("")
+    };
+    let wrapper_presets = WrapperPresets::for_wrapper(name);
+
     let layer = logging::CallbackLayer::new(callback);
     let sessions = SessionRegistry::default();
 
     match LogManager::with_app_sink(LoggingConfig::default(), layer, sessions) {
         Ok(lm) => {
             #[cfg(feature = "protobuf")]
-            crate::protobuf::c_api::init_core_state(lm);
+            crate::protobuf::c_api::init_core_state(lm, wrapper_presets);
             #[cfg(not(feature = "protobuf"))]
-            drop(lm);
+            drop((lm, wrapper_presets));
             0
         }
         Err(e) => {

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -1035,7 +1035,7 @@ pub type DatabaseDriverClient =
         crate::protobuf::apis::RustTransport,
     >;
 
-pub use crate::apis::database_driver_v1::DriverProviders;
+pub use crate::apis::database_driver_v1::{DriverProviders, WrapperPresets};
 use crate::chunks::ChunkFormatKind;
 use crate::query_types::RowType;
 

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -1,7 +1,7 @@
 use std::ffi::c_char;
 use std::sync::OnceLock;
 
-use crate::apis::database_driver_v1::DriverProviders;
+use crate::apis::database_driver_v1::{DriverProviders, WrapperPresets};
 use crate::logging::LogManager;
 use crate::protobuf::apis::RustTransport;
 use proto_utils::{ProtoError, Transport};
@@ -15,10 +15,11 @@ static STATE: OnceLock<CApiState> = OnceLock::new();
 
 /// Eagerly build the entire core state (tokio runtime + transport) using the
 /// given `LogManager`.  Called once from `sf_core_init`.
-pub(crate) fn init_core_state(lm: LogManager) {
+pub(crate) fn init_core_state(lm: LogManager, wrapper_presets: WrapperPresets) {
     STATE.get_or_init(|| {
         let providers = DriverProviders {
             log_manager: Some(lm),
+            wrapper_presets,
             ..Default::default()
         };
 

--- a/sf_core/tests/integration/authentication/os_details.rs
+++ b/sf_core/tests/integration/authentication/os_details.rs
@@ -33,6 +33,7 @@ fn should_include_os_details_on_linux() {
         DriverProviders {
             fs: Some(fs),
             log_manager: Some(log_manager),
+            ..Default::default()
         },
     );
     client.set_connection_option("password", "test_password"); // pragma: allowlist secret


### PR DESCRIPTION
Each wrapper calls dedicated constructor creating immutable WrapperPresets struct from defaults, overriding only what differs for that wrapper. First preset: put_get_resultset_flavor (Python vs Odbc column layouts).

Decision grounds:
* all presets live in one place - for_wrapper constructor. Easy to find, develop and maintain

This PR does not implement PUT/GET result logic, just passed WrapperPresets object reference as dummy.