### PR TITLE
SNOW-3098562: Add flag for enabling/disabling traces in error messages

### DIFF
--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -487,12 +487,20 @@ fn is_well_formed_sql_state(state: &str) -> bool {
 impl OdbcError {
     pub fn message_text(&self) -> String {
         let trace = self.error_trace();
-        self.structured_message().unwrap_or_else(|| {
+        let base = self.structured_message().unwrap_or_else(|| {
             trace
                 .last()
                 .map(|entry| entry.message.clone())
                 .unwrap_or_default()
-        })
+        });
+        if crate::api::error_trace_flag::error_trace_enabled() && !trace.is_empty() {
+            format!(
+                "{base}\nerror trace:\n{}",
+                error_trace::format_error_trace(&trace)
+            )
+        } else {
+            base
+        }
     }
 
     /// Extract a user-facing message from structured protobuf error fields

--- a/odbc/src/api/error_trace_flag.rs
+++ b/odbc/src/api/error_trace_flag.rs
@@ -3,8 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// User-facing error-rendering policy toggle, seeded at env allocation time
 /// from `LogManager::error_trace_enabled()`. Defaults to `true` so errors
 /// produced before env init (lock poisoning, invalid handles) still print a
-/// full trace. `Relaxed` is sufficient: the flag is a standalone boolean that
-/// gates a formatting branch and publishes no other memory.
+/// full trace. `Relaxed` is sufficient: the flag is a standalone boolean that is
+/// initialized as a part of env allocation during sqlallochandle init.
+/// Nothing happens before that concludes.
 static ERROR_TRACE_ENABLED: AtomicBool = AtomicBool::new(true);
 
 /// Whether `OdbcError::message_text()` should append the full error trace.
@@ -24,7 +25,7 @@ mod tests {
     use crate::api::OdbcError;
     use std::sync::Mutex;
 
-    /// Serialises any test that reads or writes the process-wide
+    /// Serializes any test that reads or writes the process-wide
     /// `ERROR_TRACE_ENABLED`, so parallel test execution doesn't let two
     /// tests interleave their get/set pairs.
     static FLAG_TEST_LOCK: Mutex<()> = Mutex::new(());

--- a/odbc/src/api/error_trace_flag.rs
+++ b/odbc/src/api/error_trace_flag.rs
@@ -1,0 +1,75 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// User-facing error-rendering policy toggle, seeded at env allocation time
+/// from `LogManager::error_trace_enabled()`. Defaults to `true` so errors
+/// produced before env init (lock poisoning, invalid handles) still print a
+/// full trace. `Relaxed` is sufficient: the flag is a standalone boolean that
+/// gates a formatting branch and publishes no other memory.
+static ERROR_TRACE_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Whether `OdbcError::message_text()` should append the full error trace.
+pub(crate) fn error_trace_enabled() -> bool {
+    ERROR_TRACE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Records the configured error-trace flag. Called once from
+/// `api::runtime::env_allocated` during global init.
+pub(crate) fn set_error_trace_enabled(value: bool) {
+    ERROR_TRACE_ENABLED.store(value, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::OdbcError;
+    use std::sync::Mutex;
+
+    /// Serialises any test that reads or writes the process-wide
+    /// `ERROR_TRACE_ENABLED`, so parallel test execution doesn't let two
+    /// tests interleave their get/set pairs.
+    static FLAG_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn sample_error() -> OdbcError {
+        OdbcError::EnvironmentHasConnections {
+            location: snafu::Location::new("test", 0, 0),
+        }
+    }
+
+    #[test]
+    fn message_text_includes_trace_when_enabled() {
+        let _guard = FLAG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = error_trace_enabled();
+        set_error_trace_enabled(true);
+
+        let rendered = sample_error().message_text();
+        assert!(
+            rendered.contains("error trace:"),
+            "flag=true should include `error trace:` header, got: {rendered:?}",
+        );
+        assert!(
+            rendered.contains("environment has connections"),
+            "flag=true should also contain base message, got: {rendered:?}",
+        );
+
+        set_error_trace_enabled(previous);
+    }
+
+    #[test]
+    fn message_text_omits_trace_when_disabled() {
+        let _guard = FLAG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = error_trace_enabled();
+        set_error_trace_enabled(false);
+
+        let rendered = sample_error().message_text();
+        assert!(
+            !rendered.contains("error trace:"),
+            "flag=false must omit `error trace:` header, got: {rendered:?}",
+        );
+        assert!(
+            rendered.contains("environment has connections"),
+            "flag=false should still contain base message, got: {rendered:?}",
+        );
+
+        set_error_trace_enabled(previous);
+    }
+}

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod diagnostic;
 pub mod encoding;
 pub mod environment;
 pub mod error;
+pub(crate) mod error_trace_flag;
 pub mod handle_allocation;
 pub mod handle_registry;
 pub mod query_type;

--- a/odbc/src/api/runtime.rs
+++ b/odbc/src/api/runtime.rs
@@ -88,8 +88,12 @@ pub fn global() -> Result<GlobalsGuard, OdbcRuntimeError> {
 pub fn env_allocated() -> Result<(), OdbcRuntimeError> {
     let mut guard = STATE.write().map_err(|_| LockPoisonedSnafu.build())?;
     if guard.globals.is_none() {
+        let log_manager = sf_core::logging::LogManager::for_odbc();
+        if let Some(lm) = &log_manager {
+            crate::api::error_trace_flag::set_error_trace_enabled(lm.error_trace_enabled());
+        }
         let providers = DriverProviders {
-            log_manager: sf_core::logging::LogManager::for_odbc(),
+            log_manager,
             wrapper_presets: WrapperPresets::odbc(),
             ..Default::default()
         };

--- a/sf_core/src/logging/ini_config.rs
+++ b/sf_core/src/logging/ini_config.rs
@@ -13,7 +13,7 @@ use crate::config::settings::Setting;
 ///
 /// Supported keys (case-insensitive):
 /// `LogLevel`, `LogPath`, `LogFile`, `LogMaxSize`, `LogMaxCount`,
-/// `LogEnabled`, `LogQueryText`, `LogQueryParameters`.
+/// `LogEnabled`, `LogQueryText`, `LogQueryParameters`, `ErrorTraceEnabled`.
 ///
 /// Checks file permissions before reading (rejects group/world-writable files
 /// on Unix).
@@ -61,6 +61,7 @@ fn apply_ini_section(props: &ini::Properties) -> Result<LoggingConfig, LogError>
             "logenabled" => config.enabled = parse_bool(value)?,
             "logquerytext" => config.log_query_text = Some(parse_bool(value)?),
             "logqueryparameters" => config.log_query_parameters = Some(parse_bool(value)?),
+            "errortraceenabled" => config.error_trace_enabled = parse_bool(value)?,
             other => eprintln!("ignoring unknown INI key: {other}"),
         }
     }
@@ -109,6 +110,9 @@ pub fn load_from_toml_section(section: &HashMap<String, Setting>) -> LoggingConf
     }
     if let Some(Setting::Bool(b)) = section.get("log_query_parameters") {
         config.log_query_parameters = Some(*b);
+    }
+    if let Some(Setting::Bool(error_trace)) = section.get("error_trace_enabled") {
+        config.error_trace_enabled = *error_trace;
     }
 
     config
@@ -282,6 +286,7 @@ LogFile=driver.log
 LogMaxSize=1048576
 LogMaxCount=5
 LogEnabled=true
+ErrorTraceEnabled=false
 ";
         let config = parse_ini_content(ini).unwrap();
         assert_eq!(config.level, LevelFilter::DEBUG);
@@ -294,6 +299,7 @@ LogEnabled=true
         assert_eq!(config.max_file_count.unwrap(), 5);
         assert!(config.enabled);
         assert!(!config.open_telemetry);
+        assert!(!config.error_trace_enabled);
     }
 
     #[test]
@@ -306,6 +312,27 @@ LogEnabled=true
         assert!(config.max_file_count.is_none());
         assert!(config.enabled);
         assert!(!config.open_telemetry);
+        assert!(config.error_trace_enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_error_trace_enabled_true() {
+        let config = parse_ini_content("ErrorTraceEnabled=true").unwrap();
+        assert!(config.error_trace_enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_error_trace_enabled_false() {
+        let config = parse_ini_content("ErrorTraceEnabled=false").unwrap();
+        assert!(!config.error_trace_enabled);
+    }
+
+    #[test]
+    fn parse_ini_content_error_trace_enabled_case_insensitive() {
+        let config = parse_ini_content("errortraceenabled=false").unwrap();
+        assert!(!config.error_trace_enabled);
+        let config = parse_ini_content("ERRORTRACEENABLED=false").unwrap();
+        assert!(!config.error_trace_enabled);
     }
 
     #[test]
@@ -542,6 +569,7 @@ LOGENABLED=false
         section.insert("rotation".into(), Setting::String("DAILY".into()));
         section.insert("enabled".into(), Setting::Bool(false));
         section.insert("opentelemetry".into(), Setting::Bool(true));
+        section.insert("error_trace_enabled".into(), Setting::Bool(false));
 
         let config = load_from_toml_section(&section);
         assert_eq!(config.level, LevelFilter::DEBUG);
@@ -552,6 +580,7 @@ LOGENABLED=false
         assert_eq!(config.rotation, LogRotation::Daily);
         assert!(!config.enabled);
         assert!(config.open_telemetry);
+        assert!(!config.error_trace_enabled);
     }
 
     #[test]
@@ -565,6 +594,18 @@ LOGENABLED=false
         assert!(config.max_file_count.is_none());
         assert!(config.enabled);
         assert!(!config.open_telemetry);
+        assert!(config.error_trace_enabled);
+    }
+
+    #[test]
+    fn load_from_toml_section_error_trace_enabled_wrong_type_ignored() {
+        let mut section = HashMap::new();
+        section.insert(
+            "error_trace_enabled".into(),
+            Setting::String("false".into()),
+        );
+        let config = load_from_toml_section(&section);
+        assert!(config.error_trace_enabled);
     }
 
     #[test]

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -36,6 +36,7 @@ pub struct LogManager {
     /// Process-wide default for `log_query_parameters`. See
     /// [`Self::log_query_text`].
     log_query_parameters: Option<bool>,
+    error_trace_enabled: bool,
 }
 
 impl LogManager {
@@ -64,6 +65,13 @@ impl LogManager {
         self.log_query_parameters
     }
 
+    /// Whether user-facing error messages should include the full error trace,
+    /// as parsed from the INI/TOML logging config. Consumer crates read this
+    /// during init to seed their own rendering-policy state.
+    pub fn error_trace_enabled(&self) -> bool {
+        self.error_trace_enabled
+    }
+
     /// Create a `LogManager` without installing a global tracing subscriber.
     ///
     /// The returned instance still provides a `SessionRegistry` and
@@ -79,6 +87,7 @@ impl LogManager {
             fs,
             log_query_text: None,
             log_query_parameters: None,
+            error_trace_enabled: LoggingConfig::default().error_trace_enabled,
         }
     }
 
@@ -104,6 +113,7 @@ impl LogManager {
         let sessions = SessionRegistry::default();
         let log_query_text = config.log_query_text;
         let log_query_parameters = config.log_query_parameters;
+        let error_trace_enabled = config.error_trace_enabled;
         let provider = Self::try_init(config, None::<EmptyLayer>, Some(sessions.clone()))?
             .ok_or_else(|| {
                 InitSnafu {
@@ -118,6 +128,7 @@ impl LogManager {
             fs: Arc::new(RealFs),
             log_query_text,
             log_query_parameters,
+            error_trace_enabled,
         })
     }
 
@@ -134,6 +145,7 @@ impl LogManager {
     {
         let log_query_text = config.log_query_text;
         let log_query_parameters = config.log_query_parameters;
+        let error_trace_enabled = config.error_trace_enabled;
         let provider =
             Self::try_init(config, Some(app_sink), Some(registry.clone()))?.ok_or_else(|| {
                 InitSnafu {
@@ -148,6 +160,7 @@ impl LogManager {
             fs: Arc::new(RealFs),
             log_query_text,
             log_query_parameters,
+            error_trace_enabled,
         })
     }
 

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -66,6 +66,9 @@ pub struct LoggingConfig {
     /// Process-wide default for `log_query_parameters`. See
     /// [`Self::log_query_text`] for precedence semantics.
     pub log_query_parameters: Option<bool>,
+    /// When `true`, `OdbcError::message_text()` appends the full error trace
+    /// to user-facing diagnostic messages. Default `true`.
+    pub error_trace_enabled: bool,
 }
 
 impl Default for LoggingConfig {
@@ -82,6 +85,7 @@ impl Default for LoggingConfig {
             stderr: false,
             log_query_text: None,
             log_query_parameters: None,
+            error_trace_enabled: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds an `ErrorTraceEnabled` INI / `error_trace_enabled` TOML config key that controls whether `OdbcError::message_text()` appends the full error trace to user-facing diagnostics.    Defaults to `true`, preserving existing behavior; set to `false` to get a terse base message.
- `sf_core::logging::LoggingConfig` parses the value from INI/TOML and exposes it via `LogManager::error_trace_enabled()`.
- The odbc crate owns the runtime toggle (`odbc::api::error_trace_flag`), seeded at `SQLAllocHandle(ENV)` time from the `LogManager`. Other consumer crates (`jdbc_bridge`, Python    `sf_core_init`) are untouched — no cross-crate coupling through a sf_core-level static.
- Previously-unconditional `"\nTrace:\n<...>"` suffix is now conditional on the flag; label also updated to `"\nerror trace:\n<...>"`. 