### PR TITLE
SNOW-3355413 Introduce PICT driven matrix for GHA checks, reduce scope on PRs

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -26,6 +26,18 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
+  load-odbc-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          python ci/test_matrix/generate_matrix.py \
+            --driver odbc --event "$GITHUB_EVENT_NAME" --emit-active \
+            >> "$GITHUB_OUTPUT"
+
   odbc_unit_tests:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
@@ -429,90 +441,12 @@ jobs:
           path: ${{ matrix.cargo_target && format('target/{0}/debug', matrix.cargo_target) || 'target/debug' }}/${{ matrix.driver_lib }}
 
   odbc_tests:
-    needs: [detect-changes, build_odbc_driver]
+    needs: [detect-changes, build_odbc_driver, load-odbc-matrix]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            name: Linux x64
-            driver_lib: libsfodbc.so
-            driver_artifact: Linux x64
-            cloud_provider: aws
-          - os: ubuntu-latest
-            name: Linux x64 (JSON)
-            driver_lib: libsfodbc.so
-            driver_artifact: Linux x64
-            cloud_provider: aws
-            result_format: json
-          - os: macos-latest
-            name: macOS ARM64
-            driver_lib: libsfodbc.dylib
-            driver_artifact: macOS ARM64
-            cloud_provider: aws
-          - os: windows-latest
-            name: Windows x64
-            driver_lib: sfodbc.dll
-            driver_artifact: Windows x64
-            cloud_provider: aws
-            msvc_arch: amd64
-            vcpkg_triplet: x64-windows
-          - os: windows-latest
-            name: Windows x86
-            driver_lib: sfodbc32.dll
-            driver_artifact: Windows x86
-            cloud_provider: aws
-            msvc_arch: x86
-            vcpkg_triplet: x86-windows
-          - os: ubuntu-latest
-            name: Linux x64
-            driver_lib: libsfodbc.so
-            driver_artifact: Linux x64
-            cloud_provider: gcp
-          - os: macos-latest
-            name: macOS ARM64
-            driver_lib: libsfodbc.dylib
-            driver_artifact: macOS ARM64
-            cloud_provider: gcp
-          - os: windows-latest
-            name: Windows x64
-            driver_lib: sfodbc.dll
-            driver_artifact: Windows x64
-            cloud_provider: gcp
-            msvc_arch: amd64
-            vcpkg_triplet: x64-windows
-          - os: windows-latest
-            name: Windows x86
-            driver_lib: sfodbc32.dll
-            driver_artifact: Windows x86
-            cloud_provider: gcp
-            msvc_arch: x86
-            vcpkg_triplet: x86-windows
-          - os: ubuntu-latest
-            name: Linux x64
-            driver_lib: libsfodbc.so
-            driver_artifact: Linux x64
-            cloud_provider: azure
-          - os: macos-latest
-            name: macOS ARM64
-            driver_lib: libsfodbc.dylib
-            driver_artifact: macOS ARM64
-            cloud_provider: azure
-          - os: windows-latest
-            name: Windows x64
-            driver_lib: sfodbc.dll
-            driver_artifact: Windows x64
-            cloud_provider: azure
-            msvc_arch: amd64
-            vcpkg_triplet: x64-windows
-          - os: windows-latest
-            name: Windows x86
-            driver_lib: sfodbc32.dll
-            driver_artifact: Windows x86
-            cloud_provider: azure
-            msvc_arch: x86
-            vcpkg_triplet: x86-windows
+        include: ${{ fromJSON(needs.load-odbc-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     steps:
@@ -569,10 +503,10 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-v3
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-${{ env.VCPKG_VER }}-v3
           restore-keys: |
-            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-
-            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-
+            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-${{ env.VCPKG_VER }}-
+            ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-
 
       # Cache Homebrew bottle downloads to avoid re-fetching unixodbc/ccache on every run
       # (brew install on GHA macOS runners is ~2-3 min uncached, <15s with bottles cached).
@@ -810,7 +744,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .vcpkg-binary-cache
-          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet || 'x64-windows' }}-${{ env.VCPKG_VER }}-v3
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-${{ env.VCPKG_VER }}-v3
 
       - name: Save Homebrew cache (macOS)
         if: always() && runner.os == 'macOS' && steps.brew-cache.outputs.cache-hit != 'true'
@@ -1158,7 +1092,7 @@ jobs:
           path: build/snowflake-odbc-ud-*.dmg
 
   odbc-status:
-    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, cleanup_odbc, build_msi, build_dmg]
+    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, load-odbc-matrix, odbc_tests, cleanup_odbc, build_msi, build_dmg]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,13 +26,25 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
+  load-python-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          python ci/test_matrix/generate_matrix.py \
+            --driver python --event "$GITHUB_EVENT_NAME" --emit-active \
+            >> "$GITHUB_OUTPUT"
+
   # ── Build all wheels via shared reusable workflow ────────────────────
   build_wheels:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.13"], "linux_aarch": ["3.11","3.14"], "macos_arm": ["3.12","3.14"], "windows_x86": ["3.11","3.12","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: '{"linux_x86": ["3.13"], "linux_aarch": ["3.11","3.14"], "macos_arm": ["3.12","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.14"], "windows_arm": ["3.11","3.12"]}'
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -136,33 +148,12 @@ jobs:
 
   # Combined unit + integration tests with universal connector
   python_tests:
-    needs: [detect-changes, build_wheels]
+    needs: [detect-changes, build_wheels, load-python-matrix]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # sdist tests (Python 3.10 — builds sf_core from source; no wheel_artifact needed)
-          - { os: ubuntu-latest,     py: "3.10", hatch_env: "test",    cloud_provider: "azure" }
-          - { os: macos-latest,      py: "3.10", hatch_env: "test",    cloud_provider: "gcp"   }
-          - { os: windows-latest,    py: "3.10", hatch_env: "test",    cloud_provider: "aws"   }
-          # wheel tests
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference — keep in sync with REFERENCE_* env vars above
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
-          - { os: ubuntu-24.04-arm,  py: "3.14", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "manylinux_aarch64" }
-          - { os: ubuntu-24.04-arm,  py: "3.11", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "manylinux_aarch64" }
-          - { os: macos-latest,      py: "3.14", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "macosx_arm64" }
-          - { os: macos-latest,      py: "3.12", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
-          - { os: windows-latest,    py: "3.12", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_amd64" }
-          - { os: windows-latest,    py: "3.14", hatch_env: "test",    cloud_provider: "azure", wheel_artifact: "win_amd64" }
-          - { os: windows-11-arm,    py: "3.12", hatch_env: "test",    cloud_provider: "aws",   wheel_artifact: "win_arm64" }
-          - { os: windows-11-arm,    py: "3.11", hatch_env: "test",    cloud_provider: "gcp",   wheel_artifact: "win_arm64" }
-          # test integration with Pandas
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64" } # Reference — keep in sync with REFERENCE_* env vars above
-          - { os: ubuntu-latest,     py: "3.13", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "manylinux_x86_64", result_format: "json" }
-          - { os: ubuntu-24.04-arm,  py: "3.10", hatch_env: "test-pandas", cloud_provider: "azure" }
-          - { os: macos-latest,      py: "3.14", hatch_env: "test-pandas", cloud_provider: "aws",   wheel_artifact: "macosx_arm64" }
-          - { os: windows-latest,    py: "3.11", hatch_env: "test-pandas", cloud_provider: "gcp",   wheel_artifact: "win_amd64" }
+        include: ${{ fromJSON(needs.load-python-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: python_tests ${{ matrix.hatch_env }} (${{ matrix.os }}, py${{ matrix.py }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
     env:
@@ -590,7 +581,7 @@ jobs:
             --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
 
   python-status:
-    needs: [detect-changes, build_wheels, packaging_tests, python_tests, cleanup_python, python_tests_reference, python_compare_results]
+    needs: [detect-changes, build_wheels, packaging_tests, load-python-matrix, python_tests, cleanup_python, python_tests_reference, python_compare_results]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -20,6 +20,44 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
+  # Generate the test matrix from ci/test_matrix/models/core.pict at workflow
+  # run time. Pattern mirrors load-odbc-matrix in test-odbc.yml and
+  # load-python-matrix in test-python.yml. Outputs:
+  #   - matrix:              full active set (unfiltered, JSON array). Useful
+  #                          for diagnostics; not directly consumed below.
+  #   - test_matrix:         JSON array filtered to ubuntu-latest / macos-latest
+  #                          lanes, fed into the `test` job's strategy.matrix.include.
+  #                          Each entry has rust-version='stable' merged in so the
+  #                          existing matrix dimension is preserved.
+  #   - windows_arm_active:  'true' if pict includes the windows-arm-nonfips lane.
+  #   - windows_x86_active:  'true' if pict includes the windows-x86 lane.
+  load-core-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+      test_matrix: ${{ steps.split.outputs.test_matrix }}
+      windows_arm_active: ${{ steps.split.outputs.windows_arm_active }}
+      windows_x86_active: ${{ steps.split.outputs.windows_x86_active }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          python ci/test_matrix/generate_matrix.py \
+            --driver core --event "$GITHUB_EVENT_NAME" --emit-active \
+            >> "$GITHUB_OUTPUT"
+      - id: split
+        env:
+          FULL: ${{ steps.read.outputs.matrix }}
+        run: |
+          # Linux/macOS lanes feed `test` job's strategy.matrix.include. Inject
+          # rust-version='stable' so the existing matrix dimension survives the
+          # switch from the static `os: [...] × rust-version: [...]` shape.
+          echo "test_matrix=$(printf '%s' "$FULL" | jq -c '[.[] | select(.os == "ubuntu-latest" or .os == "macos-latest") | . + {"rust-version": "stable"}]')" >> "$GITHUB_OUTPUT"
+          # Per-lane boolean gates for the dedicated Windows jobs (no matrix; we
+          # just skip the whole job if pict didn't include the lane on this trigger).
+          echo "windows_arm_active=$(printf '%s' "$FULL" | jq -r '[.[] | select(.name == "windows-arm-nonfips")] | length > 0')" >> "$GITHUB_OUTPUT"
+          echo "windows_x86_active=$(printf '%s' "$FULL" | jq -r '[.[] | select(.name == "windows-x86")] | length > 0')" >> "$GITHUB_OUTPUT"
+
   # Format job intentionally has no Rust target cache: `cargo fmt --check` does not
   # compile the crate, it only parses source files. A cache would add restore overhead
   # for no benefit. Keep this job lightweight; it finishes in under 30 seconds.
@@ -120,13 +158,14 @@ jobs:
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
   test:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
+    needs: [detect-changes, load-core-matrix]
+    if: |
+      (github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true')
+      && needs.load-core-matrix.outputs.test_matrix != '[]'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust-version: ['stable']
+        include: ${{ fromJSON(needs.load-core-matrix.outputs.test_matrix) }}
     runs-on: ${{ matrix.os }}
     env:
       E2E_TLS_SERVER: https://snowflakecomputing.com
@@ -147,7 +186,7 @@ jobs:
         uses: ./.github/actions/cargo-cache
         with:
           mode: restore
-          shared-key: "core-test"
+          shared-key: ${{ matrix.cache_key }}
 
       - name: Capture rustc version for coverage tool cache key
         id: rustc-version
@@ -209,13 +248,13 @@ jobs:
         continue-on-error: ${{ github.event_name == 'merge_group' }}
         run: |
           export PARAMETER_PATH=$(pwd)/parameters.json
-          cargo llvm-cov --no-report --no-fail-fast --package sf_core --all-features
+          cargo llvm-cov --no-report --no-fail-fast --package sf_core ${{ matrix.cargo_flags }}
 
       - name: Rerun tests with coverage
         if: steps.run_rust_tests.outcome == 'failure' && github.event_name == 'merge_group'
         run: |
           export PARAMETER_PATH=$(pwd)/parameters.json
-          cargo llvm-cov --no-report --no-fail-fast --package sf_core --all-features
+          cargo llvm-cov --no-report --no-fail-fast --package sf_core ${{ matrix.cargo_flags }}
 
       # Report step is best-effort and gated on actually having coverage data. If the
       # build/run step failed at compilation (before any test ran), target/llvm-cov-target/
@@ -223,8 +262,8 @@ jobs:
       # "not found *.profraw files". The shell guard checks first and emits a clean
       # skip message instead.
       #
-      # Scoping the report to `--package sf_core --all-features` mirrors the build/run
-      # invocation. Without it, llvm-cov walks the entire workspace's source files,
+      # Scoping the report to `--package sf_core ${{ matrix.cargo_flags }}` mirrors the
+      # build/run invocation. Without it, llvm-cov walks the entire workspace's source files,
       # including crates we never instrumented (jdbc_bridge, odbc, sf_core_macros,
       # proto_generator) — they appear at 0% coverage and deflate the aggregate number
       # parsed by the Jenkins coverage pipeline.
@@ -233,8 +272,8 @@ jobs:
         continue-on-error: true
         run: |
           if find target/llvm-cov-target -name '*.profraw' 2>/dev/null | grep -q .; then
-            cargo llvm-cov report --package sf_core --all-features --lcov --output-path lcov.info
-            echo "lcov report written to lcov.info (scoped to sf_core --all-features)"
+            cargo llvm-cov report --package sf_core ${{ matrix.cargo_flags }} --lcov --output-path lcov.info
+            echo "lcov report written to lcov.info (scoped to sf_core ${{ matrix.cargo_flags }})"
           else
             echo "No *.profraw files in target/llvm-cov-target — skipping report"
             echo "(this is expected if the build failed before any test executed)"
@@ -257,7 +296,7 @@ jobs:
         uses: ./.github/actions/cargo-cache
         with:
           mode: save
-          shared-key: "core-test"
+          shared-key: ${{ matrix.cache_key }}
           # Aggressive slim: this is the coverage job, where instrumented test
           # binaries dominate target/ size. Drop them before save; deps remain
           # cached so the next run rebuilds workspace tests in 1-2 min.
@@ -278,8 +317,10 @@ jobs:
   # behind cfg(feature = "fips"). Only the linked TLS crypto backend differs
   # (aws-lc-sys vs aws-lc-fips-sys).
   test_windows_arm64_nonfips:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
+    needs: [detect-changes, load-core-matrix]
+    if: |
+      (github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true')
+      && needs.load-core-matrix.outputs.windows_arm_active == 'true'
     runs-on: windows-11-arm
     name: test (Windows ARM64, non-FIPS)
     env:
@@ -463,8 +504,10 @@ jobs:
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
   test_windows_x86:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
+    needs: [detect-changes, load-core-matrix]
+    if: |
+      (github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true')
+      && needs.load-core-matrix.outputs.windows_x86_active == 'true'
     runs-on: windows-latest
     name: test (Windows x86)
     env:

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -88,6 +88,20 @@ jobs:
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
+  test-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run ci/test_matrix unit tests
+        run: python -m unittest ci/test_matrix/test_generate_matrix.py
+
   test-coverage-report:
     runs-on: ubuntu-latest
     steps:
@@ -143,7 +157,7 @@ jobs:
           retention-days: 30
 
   validations-status:
-    needs: [test-data, tests-format-validator, test-coverage-report]
+    needs: [test-data, tests-format-validator, test-matrix, test-coverage-report]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -154,10 +168,12 @@ jobs:
           # Check if any validation failed or was cancelled
           if [[ "${{ needs.test-data.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.tests-format-validator.result }}" =~ ^(failure|cancelled)$ ]] || \
+             [[ "${{ needs.test-matrix.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test-coverage-report.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Validations FAILED or CANCELLED"
             echo "  - test-data: ${{ needs.test-data.result }}"
             echo "  - tests-format-validator: ${{ needs.tests-format-validator.result }}"
+            echo "  - test-matrix: ${{ needs.test-matrix.result }}"
             echo "  - test-coverage-report: ${{ needs.test-coverage-report.result }}"
             exit 1
           fi
@@ -165,5 +181,6 @@ jobs:
           echo "✓ Validations PASSED"
           echo "  - test-data: ${{ needs.test-data.result }}"
           echo "  - tests-format-validator: ${{ needs.tests-format-validator.result }}"
+          echo "  - test-matrix: ${{ needs.test-matrix.result }}"
           echo "  - test-coverage-report: ${{ needs.test-coverage-report.result }}"
           exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ jdbc/src/main/java/net/snowflake/client/internal/unicore/protobuf_gen/DatabaseDr
 
 .DS_Store
 tests/test_data/generated_test_data/chunks/
+
+# CI test matrix generated files -- produced at runtime by ci/test_matrix/generate_matrix.py
+ci/test_matrix/generated/

--- a/ci/test_matrix/README.md
+++ b/ci/test_matrix/README.md
@@ -1,0 +1,192 @@
+# CI Test Matrix
+
+Pairwise test matrix generation for ODBC, Python, and rust-core (`sf_core`) driver CI.
+
+The generator combines a coverage **model** (which combinations exist) with a
+**mapping** (CI metadata for each combination) consumed by the `load-{odbc,python,core}-matrix` jobs in
+`.github/workflows/`.
+
+## Layout
+
+```
+ci/test_matrix/
+├── generate_matrix.py     pairwise generator + CLI entry points
+├── models/                Python coverage modules (one per driver)
+│   ├── __init__.py        schema documentation
+│   ├── odbc.py
+│   ├── python.py
+│   └── core.py
+├── mappings/              (OS, Arch) → CI metadata lookups
+│   ├── shared.py          GHA_RUNNER (used by all drivers)
+│   ├── odbc.py            ODBC_PLATFORM
+│   ├── python.py          PYTHON_PLATFORM, SDIST_PY
+│   └── core.py            CORE_PLATFORM
+├── test_generate_matrix.py
+└── generated/             gitignored; written at workflow runtime
+```
+
+**Models** (`models/*.py`) declare parameters, constraints, and the explicit
+`PR_CELLS` + `JSON_CELLS` sections — the *combinatorial* shape of the matrix.
+Each module exposes four top-level names (`PARAMS`, `CONSTRAINTS`, `PR_CELLS`,
+`JSON_CELLS`) — see `models/__init__.py` for the schema. **Mappings**
+(`mappings/*.py`) translate each `(OS, Arch)` cell into concrete CI fields:
+runner label, driver/wheel artifact name, cargo flags, msvc_arch,
+vcpkg_triplet, etc. The generator joins both at runtime;
+`validate_mappings()` fails loud if a model allows an `(OS, Arch)` pair that
+no mapping covers.
+
+## Trigger levels
+
+Each emitted row carries a `trigger_level`. Levels are cumulative.
+
+| Level     | When it runs                  | Coverage                            |
+|-----------|-------------------------------|-------------------------------------|
+| `pr`      | Every PR                      | Explicit `PR_CELLS` only            |
+| `merge`   | Merge queue + push to `main`  | `pr` cells + pairwise cover         |
+| `nightly` | Scheduled nightly run         | All valid combinations              |
+
+**Pairwise cover (the "merge" set).** A minimal set of rows in which every
+(parameter A value, parameter B value) pair appears together at least once,
+across every pair of parameters. With *n* parameters of size *k*, full
+coverage is *kⁿ* combinations; pairwise is roughly *k²* — orders of
+magnitude smaller, while still catching any bug that depends on a
+two-parameter interaction.
+
+Concretely, for `odbc.py` the parameter space is OS×Arch×Cloud. After
+applying the constraints (e.g. macOS only on arm, ubuntu only on x64), 12
+combinations are valid. The pairwise solver picks 4 of those — every (OS,
+Arch), (OS, Cloud), and (Arch, Cloud) value combination is exercised at
+least once across those 4 rows. The remaining 8 combinations only run at
+`nightly`. Bugs that only appear at three- or four-way interactions (e.g.
+only on macOS-arm-aws-py3.13) are not guaranteed to surface at `merge`.
+
+GHA picks the level from `GITHUB_EVENT_NAME` (`pull_request` → pr,
+`merge_group`/`push` → merge, `schedule` → nightly).
+
+## Editing the matrix
+
+After any edit, run `python ci/test_matrix/generate_matrix.py --all` and
+review the diff in `ci/test_matrix/generated/` (it's gitignored, so the diff
+is local-only — used only to sanity-check the change). Tests live in
+`test_generate_matrix.py`; run `python -m pytest ci/test_matrix/`.
+
+### Add a PR cell
+
+Append a dict to `PR_CELLS` in the relevant `models/<driver>.py`. Every
+declared parameter must be present (the loader validates this), and the
+combination must satisfy every constraint — a violating cell warns at
+generate time and is silently dropped from the output.
+
+### Add a constraint
+
+Each model declares a single `is_valid(c)` block-list function in
+`models/<driver>.py`: every `if` line names a forbidden combo with positive
+`==` matching and `return False`; the function falls through to `return True`
+for everything else.
+
+```python
+def is_valid(c):
+    if c["OS"] == "windows" and c["Arch"] == "arm":
+        # No CPython 3.10 build for Windows-on-ARM.
+        if c["PyVersion"] == "3.10":      return False
+        # No pyarrow win_arm64 wheel.
+        if c["HatchEnv"] == "test-pandas": return False
+    return True
+
+
+CONSTRAINTS = [is_valid]
+```
+
+To add a new restriction, append an `if ...: return False` line with a
+`# comment` explaining the real-world reason (no upstream wheel, runner
+unavailable, etc.). Block-list semantics mean **new PARAMS values are
+accepted automatically** — adding `"3.15"` to `PARAMS["PyVersion"]`
+extends the matrix without touching `is_valid`.
+
+The shape is enforced by `BlockListShapeTests` in
+`test_generate_matrix.py`: every `return` must be a `False`/`True` bool
+literal (no `return <expression>`), and `return True` may appear only as
+the final statement of `is_valid`. This blocks the two accidental drift
+patterns: allow-list creep (`return c["X"] in (...)`) and early
+`return True` short-circuits.
+
+### Reordering `PARAMS`
+
+`PARAMS` order affects which specific cells land in the merge-level
+pairwise cover (greedy tie-breaking is "first wins" over
+`itertools.product`-order candidates). Coverage and row content are
+order-independent, and nightly stays the full constraint-valid cartesian
+product, but the merge cell selection shifts. Pick an order and keep it
+stable; the existing `OS, Arch, Cloud, …` convention is fine — don't
+shuffle it without a reason.
+
+### Add a JSON `result_format` variant
+
+Append a dict to `JSON_CELLS["pr"]` / `JSON_CELLS["merge"]` /
+`JSON_CELLS["nightly"]` in the model file. Each listed row gets duplicated
+with `result_format="json"` at the named trigger level. `core.py` has no
+JSON axis (sf_core's JSON coverage runs through ODBC and Python). The total
+merge-level JSON count is pinned by `JsonVariantRegressionTests`.
+
+### Add a new platform lane (existing driver)
+
+1. **Model** — add the OS/Arch values to `PARAMS` in `models/<driver>.py`.
+   Add constraints if the new lane only supports a subset of clouds, py
+   versions, etc.
+2. **Mapping** —
+   - If the `(OS, Arch)` pair is new across drivers, add it to `GHA_RUNNER`
+     in `mappings/shared.py`.
+   - Add a row to `mappings/<driver>.py`'s `<DRIVER>_PLATFORM` dict with all
+     fields the driver needs (`driver_lib` + `driver_artifact` for ODBC,
+     `wheel_artifact` + `wheels` for Python, `cargo_flags` + `coverage` +
+     `cache_key` for core; see existing rows).
+3. If ODBC and the lane should produce a built artifact, add a matching
+   `build_odbc_driver` matrix entry in `.github/workflows/test-odbc.yml` and
+   set `driver_artifact` to that artifact's name. Same for Python wheels via
+   `_build-python-wheels.yml`.
+4. Regenerate and run pytest. `validate_mappings()` will refuse if any
+   required mapping field is missing.
+
+### Add a new driver
+
+1. Create `models/<new>.py` exposing `PARAMS`, `CONSTRAINTS`, `PR_CELLS`, and
+   `JSON_CELLS` (see `models/__init__.py` for the schema).
+2. Create `mappings/<new>.py` with `<NEW>_PLATFORM` (or whatever the driver
+   needs); re-export it from `mappings/__init__.py`.
+3. In `generate_matrix.py`, add a `_build_<new>_row` builder and route to it
+   from `generate()`. Extend `validate_mappings()` to enforce the new
+   driver's required fields.
+4. Add the driver name to the `--driver` choices in `main()`. Add a
+   `load-<new>-matrix` job and a consumer job in
+   `.github/workflows/test-<new>.yml`.
+
+## CLI
+
+```
+python ci/test_matrix/generate_matrix.py [--driver odbc|python|core | --all]
+python ci/test_matrix/generate_matrix.py --driver <D> --event <NAME> --emit-active
+```
+
+| Flag             | Description                                                                |
+|------------------|----------------------------------------------------------------------------|
+| `--driver <D>`   | Generate `<D>-gha.json` for one driver.                                    |
+| `--all`          | Regenerate every driver in one shot.                                       |
+| `--event <NAME>` | GHA event name for `--emit-active`.                                        |
+| `--emit-active`  | Print `matrix=<json>` for rows active at the level implied by `--event`.   |
+
+`--driver` and `--all` are mutually exclusive; `--emit-active` requires both
+`--driver` and `--event`.
+
+## Row schema
+
+The complete list of keys per row, including which are required and on which
+driver, is documented next to the row builders in `generate_matrix.py`
+(`_build_gha_row`, `_build_core_row`). Highlights:
+
+- `name`, `os` (GHA runner label, not raw OS), `trigger_level` — present on
+  every row.
+- `cloud_provider`, `py`, `hatch_env`, `driver_*`, `wheel_artifact` — odbc
+  and/or python only; absent on core.
+- `cargo_flags`, `cargo_target`, `coverage`, `cache_key`, `msvc_arch` — core
+  only.
+- `result_format` — set to `"json"` only on cells from `JSON_CELLS`.

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""
+generate_matrix.py -- pairwise CI matrix generator.
+
+Reads Python model files from ci/test_matrix/models/ and emits one JSON
+matrix per driver for GitHub Actions consumption.
+
+Usage:
+  python ci/test_matrix/generate_matrix.py --driver odbc
+  python ci/test_matrix/generate_matrix.py --driver python
+  python ci/test_matrix/generate_matrix.py --driver core
+  python ci/test_matrix/generate_matrix.py --all
+  python ci/test_matrix/generate_matrix.py --driver odbc \\
+      --event pull_request --emit-active                         # for use in CI workflows
+
+Exit codes:
+  0  success
+  1  model constraint unsatisfiable / configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import itertools
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+MODELS_DIR = REPO_ROOT / "ci" / "test_matrix" / "models"
+GENERATED_DIR = REPO_ROOT / "ci" / "test_matrix" / "generated"
+
+# ---------------------------------------------------------------------------
+# Trigger level ordering (lower index = lower coverage, subset of next)
+# ---------------------------------------------------------------------------
+
+TRIGGER_LEVELS = ["pr", "merge", "nightly"]
+
+
+# ---------------------------------------------------------------------------
+# Mapping tables (per-driver lookup tables for runner labels, driver libs,
+# wheel artifacts, cargo flags, etc.) live under ci/test_matrix/mappings/:
+#   - mappings/shared.py  → GHA_RUNNER (used by every driver)
+#   - mappings/odbc.py    → ODBC_PLATFORM (one row per (OS, Arch) lane)
+#   - mappings/python.py  → PYTHON_PLATFORM, SDIST_PY
+#   - mappings/core.py    → CORE_PLATFORM
+# ---------------------------------------------------------------------------
+
+# Make `from mappings import …` resolvable both when this file is run as a
+# script (sys.path[0] = ci/test_matrix) and when imported via the test runner
+# (sys.path[0] = repo root).
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mappings import (  # noqa: E402
+    GHA_RUNNER,
+    ODBC_PLATFORM,
+    PYTHON_PLATFORM,
+    SDIST_PY,
+    CORE_PLATFORM,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pairwise cover (greedy, no external dependencies)
+# ---------------------------------------------------------------------------
+
+def pairwise(
+    param_values: list[list[str]],
+    valid_predicate=None,
+) -> list[tuple]:
+    """
+    Greedy pairwise cover.
+
+    Iteratively picks the combination that covers the most not-yet-covered
+    (parameter-i, value-i, parameter-j, value-j) pairs until all pairs are covered.
+
+    `valid_predicate(combo_tuple) -> bool` filters candidate combos. When
+    provided, only combos that pass the predicate are picked, AND the set of
+    pairs to cover is restricted to pairs reachable via at least one valid
+    combo. This prevents the solver from "covering" a pair via a combo that
+    later gets dropped during routing (e.g. a Python wheel-less platform/py
+    pair) — without that filter the picked combo would silently produce no
+    matrix row, leaving a coverage hole at merge level.
+    """
+    indices = range(len(param_values))
+
+    if valid_predicate is None:
+        candidates = list(itertools.product(*param_values))
+    else:
+        candidates = [c for c in itertools.product(*param_values) if valid_predicate(c)]
+
+    if not candidates:
+        return []
+
+    uncovered: set[tuple] = set()
+    for c in candidates:
+        for i, j in itertools.combinations(indices, 2):
+            uncovered.add((i, c[i], j, c[j]))
+
+    result: list[tuple] = []
+    while uncovered:
+        best: tuple | None = None
+        best_score = -1
+        for combo in candidates:
+            score = sum(
+                1 for i, j in itertools.combinations(indices, 2)
+                if (i, combo[i], j, combo[j]) in uncovered
+            )
+            if score > best_score:
+                best, best_score = combo, score
+        assert best is not None
+        result.append(best)
+        uncovered -= {
+            (i, best[i], j, best[j])
+            for i, j in itertools.combinations(indices, 2)
+        }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Python-module model loader
+# ---------------------------------------------------------------------------
+# Each driver's coverage model is a Python module at `models/<driver>.py`
+# exposing PARAMS / CONSTRAINTS / PR_CELLS / JSON_CELLS. See
+# `models/__init__.py` for the schema.
+
+_TRIGGER_LEVELS_FOR_JSON = ("pr", "merge", "nightly")
+
+
+def load_model(
+    path: Path,
+) -> tuple[dict[str, list[str]], list, list[dict[str, str]], dict[str, list[dict[str, str]]]]:
+    """
+    Load a model module and validate its shape.
+
+    Returns (params, constraints, pr_cells, json_cells). Constraints are
+    callables `(combo) -> bool` returning True when the combo is valid.
+    Raises ValueError on any malformed input.
+    """
+    spec = importlib.util.spec_from_file_location(f"_model_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"could not load model module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    raw_params = getattr(module, "PARAMS", None)
+    raw_constraints = getattr(module, "CONSTRAINTS", [])
+    raw_pr = getattr(module, "PR_CELLS", [])
+    raw_json = getattr(module, "JSON_CELLS", {})
+
+    if not isinstance(raw_params, dict) or not raw_params:
+        raise ValueError(f"{path}: PARAMS must be a non-empty dict")
+
+    # Defensive copy: insertion order survives (Python 3.7+) and downstream
+    # mutation can't poison the loaded model.
+    params = {name: list(values) for name, values in raw_params.items()}
+
+    if not isinstance(raw_constraints, list):
+        raise ValueError(f"{path}: CONSTRAINTS must be a list of callables")
+    for i, c in enumerate(raw_constraints):
+        if not callable(c):
+            raise ValueError(
+                f"{path}: CONSTRAINTS[{i}] must be callable; got {type(c).__name__}"
+            )
+    constraints = list(raw_constraints)
+
+    pr_cells = [_normalize_cell(c, params, path, "PR_CELLS") for c in raw_pr]
+
+    json_cells: dict[str, list[dict[str, str]]] = {lvl: [] for lvl in _TRIGGER_LEVELS_FOR_JSON}
+    if not isinstance(raw_json, dict):
+        raise ValueError(f"{path}: JSON_CELLS must be a dict")
+    for level, cells in raw_json.items():
+        if level not in json_cells:
+            raise ValueError(
+                f"{path}: JSON_CELLS has unknown trigger level {level!r}; "
+                f"expected one of {sorted(json_cells)}"
+            )
+        for c in cells:
+            json_cells[level].append(
+                _normalize_cell(c, params, path, f"JSON_CELLS[{level!r}]")
+            )
+
+    return params, constraints, pr_cells, json_cells
+
+
+def _normalize_cell(
+    raw: dict, params: dict[str, list[str]], path: Path, where: str
+) -> dict[str, str]:
+    """Validate an explicit-cell dict has exactly the declared parameter keys."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: {where} entries must be dicts; got {raw!r}")
+    missing = [p for p in params if p not in raw]
+    extra = [k for k in raw if k not in params]
+    if missing or extra:
+        raise ValueError(
+            f"{path}: {where} cell {raw!r} is malformed; "
+            f"missing={missing} extra={extra}; expected keys={list(params)}"
+        )
+    return {p: raw[p] for p in params}
+
+
+def apply_constraints(combo: dict[str, str], constraints: list) -> bool:
+    """Return True if the combination satisfies every constraint predicate."""
+    return all(predicate(combo) for predicate in constraints)
+
+
+# ---------------------------------------------------------------------------
+# Mapping-table validation
+# ---------------------------------------------------------------------------
+
+def validate_mappings(driver: str, all_combos: list[dict[str, str]]) -> None:
+    """
+    Fail loudly if a constraint-satisfying (OS, Arch) is missing from the
+    runner / mapping tables. Without this, missing entries silently drop cells.
+    """
+    seen_pairs = {(c["OS"], c["Arch"]) for c in all_combos}
+    for pair in sorted(seen_pairs):
+        if pair not in GHA_RUNNER:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is allowed by the model but is not present "
+                f"in GHA_RUNNER — add it to mappings/shared.py or constrain the model "
+                f"so this combination is impossible."
+            )
+        # ODBC_PLATFORM is consumed by `_build_gha_row` only on the ODBC branch
+        # (driver_lib + driver_artifact). Python rows don't read it today; the
+        # core driver builds sf_core directly without producing or loading
+        # sfodbc. Restrict the check to driver=="odbc" so that opening up an
+        # OS/Arch lane in python.py doesn't force a placeholder row in
+        # ODBC_PLATFORM.
+        if driver == "odbc" and pair not in ODBC_PLATFORM:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is allowed by the ODBC model but missing "
+                f"from ODBC_PLATFORM in mappings/odbc.py — add a row there with at "
+                f"least a 'driver_lib' entry, or constrain the model."
+            )
+        if driver == "odbc" and "driver_artifact" not in ODBC_PLATFORM[pair]:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is allowed by the ODBC model but "
+                f"ODBC_PLATFORM has no 'driver_artifact' for it — add a matching "
+                f"entry to build_odbc_driver in .github/workflows/test-odbc.yml first, "
+                f"then set 'driver_artifact' on the row in mappings/odbc.py."
+            )
+        # PYTHON_PLATFORM is required on every Python lane: _build_gha_row reads
+        # wheel_artifact + wheels from it. Missing rows silently drop py3.11+ cells
+        # (and emit py3.10 as sdist), so fail loud here instead.
+        if driver == "python" and pair not in PYTHON_PLATFORM:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is allowed by the Python model but missing "
+                f"from PYTHON_PLATFORM in mappings/python.py — add a row there with "
+                f"'wheel_artifact' + 'wheels', or constrain the model."
+            )
+        if driver == "core" and pair not in CORE_PLATFORM:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is allowed by the core model but missing "
+                f"from CORE_PLATFORM in mappings/core.py — add a row there or "
+                f"constrain the model."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Reference variants (json result_format)
+# ---------------------------------------------------------------------------
+#
+# JSON variants live in each model file's `JSON_CELLS` dict, keyed by
+# trigger level ("pr"/"merge"/"nightly"). Each row is duplicated after
+# pairwise generation with result_format="json" appended; the dict key
+# selects the trigger level. Core has no JSON axis (sf_core's
+# result-format coverage is exercised by ODBC and Python).
+
+
+# ---------------------------------------------------------------------------
+# Row construction
+# ---------------------------------------------------------------------------
+
+def _make_name(combo: dict[str, str], result_format: str | None = None) -> str:
+    parts = [combo["OS"], combo["Arch"], combo["Cloud"]]
+    py = combo.get("PyVersion")
+    hatch_env = combo.get("HatchEnv")
+    if py:
+        parts.append(f"py{py}")
+    if hatch_env and hatch_env != "test":
+        parts.append(hatch_env)
+    if result_format:
+        parts.append(result_format)
+    return "-".join(parts)
+
+
+def _build_gha_row(
+    combo: dict[str, str],
+    trigger: str,
+    is_python: bool,
+    result_format: str | None = None,
+) -> dict[str, Any] | None:
+    """Build a GHA row dict. Returns None if the cell should be skipped."""
+    os_, arch, cloud = combo["OS"], combo["Arch"], combo["Cloud"]
+    py = combo.get("PyVersion")
+    hatch_env = combo.get("HatchEnv")
+
+    runner = GHA_RUNNER.get((os_, arch))
+    if runner is None:
+        return None
+
+    row: dict[str, Any] = {
+        "name": _make_name(combo, result_format),
+        "os": runner,  # GitHub Actions runner label (used in runs-on and `matrix.os == 'X'` checks)
+        "cloud_provider": cloud,
+        "trigger_level": trigger,
+    }
+    if py:
+        row["py"] = py
+    if result_format:
+        row["result_format"] = result_format
+
+    if is_python:
+        # Wheel vs sdist routing:
+        #   - py in SDIST_PY (3.10): always sdist; do not set wheel_artifact.
+        #   - py in PYTHON_PLATFORM[(os, arch)]["wheels"]: wheel exists.
+        #   - else: no wheel built and not sdist-supported -> skip.
+        platform = PYTHON_PLATFORM.get((os_, arch))
+        if py in SDIST_PY:
+            pass  # workflow takes the sdist path when wheel_artifact is unset
+        elif py and platform is not None and py in platform["wheels"]:
+            row["wheel_artifact"] = platform["wheel_artifact"]
+        else:
+            return None
+        row["hatch_env"] = hatch_env or "test"
+    else:
+        platform = ODBC_PLATFORM.get((os_, arch))
+        if platform is None or "driver_artifact" not in platform:
+            return None
+        row["driver_artifact"] = platform["driver_artifact"]
+        row["driver_lib"] = platform["driver_lib"]
+        # Windows-x86 needs the explicit msvc_arch and vcpkg_triplet that the
+        # workflow's defaults (amd64/x64-windows) would otherwise hide.
+        for key in ("msvc_arch", "vcpkg_triplet"):
+            if key in platform:
+                row[key] = platform[key]
+
+    return row
+
+
+def _build_core_row(combo: dict[str, str], trigger: str) -> dict[str, Any] | None:
+    """
+    Build a row for the consolidated rust-core test job.
+
+    sf_core has no Cloud axis (tests use a single E2E_TLS_SERVER and don't
+    parameterize over cloud providers). Returns None for any (OS, Arch) pair
+    that GHA doesn't run today.
+    """
+    os_, arch = combo["OS"], combo["Arch"]
+    runner = GHA_RUNNER.get((os_, arch))
+    if runner is None:
+        return None
+
+    # Display name encodes only what's visible in the GHA UI: platform + arch,
+    # plus a "-nonfips" suffix on Windows ARM64 where the cell intentionally
+    # disables FIPS (mirrors the old test_windows_arm64_nonfips job name).
+    name_parts = [os_, arch]
+    if (os_, arch) == ("windows", "arm"):
+        name_parts.append("nonfips")
+    name = "-".join(name_parts)
+
+    platform = CORE_PLATFORM[(os_, arch)]
+    row: dict[str, Any] = {
+        "name": name,
+        "os": runner,  # GitHub Actions runner label
+        "trigger_level": trigger,
+        "cargo_flags": platform["cargo_flags"],
+        "coverage": platform["coverage"],
+        "cache_key": platform["cache_key"],
+    }
+    if "cargo_target" in platform:
+        row["cargo_target"] = platform["cargo_target"]
+    if "msvc_arch" in platform:
+        row["msvc_arch"] = platform["msvc_arch"]
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Core generator
+# ---------------------------------------------------------------------------
+
+def generate(model_path: Path, driver: str) -> list[dict]:
+    """
+    Run pairwise generation for a model file.
+
+    Returns the list of GitHub Actions matrix rows.
+    """
+    params, constraints, pr_cells, json_cells = load_model(model_path)
+    param_names = list(params.keys())
+    param_values = list(params.values())
+
+    # All valid combinations (full cartesian product filtered by constraints)
+    all_combos: list[dict[str, str]] = [
+        combo for combo in (
+            dict(zip(param_names, values))
+            for values in itertools.product(*param_values)
+        )
+        if apply_constraints(combo, constraints)
+    ]
+
+    validate_mappings(driver, all_combos)
+
+    is_python = "PyVersion" in params or "HatchEnv" in params
+    is_core = driver == "core"
+
+    # Routing-aware pairwise cover: only consider combos that survive
+    # _build_*_row routing. Without this, the solver may pick a combo (e.g.
+    # windows-arm × py3.13) that gets silently dropped at row-build time
+    # because the wheel doesn't exist, leaving the (windows, arm) value pair
+    # technically "covered" in the abstract pairwise sense but with zero
+    # actual matrix rows at merge level.
+    def _routing_valid(combo_tuple: tuple) -> bool:
+        combo = dict(zip(param_names, combo_tuple))
+        if not apply_constraints(combo, constraints):
+            return False
+        # `trigger` doesn't influence the build/skip decision, so any
+        # placeholder value works. Pass "merge" for clarity.
+        if is_core:
+            return _build_core_row(combo, "merge") is not None
+        return _build_gha_row(combo, "merge", is_python) is not None
+
+    pairwise_keys: set[tuple] = {
+        tuple(dict(zip(param_names, pair)).values())
+        for pair in pairwise(param_values, valid_predicate=_routing_valid)
+    }
+
+    # Explicit PR cells from [pr] section; fall back to first 3 pairwise rows
+    # if the model has no [pr] section.
+    if pr_cells:
+        pr_keys: set[tuple] = {tuple(c.values()) for c in pr_cells}
+        # Warn about PR cells that violate constraints and will produce no output row.
+        valid_keys = {tuple(c.values()) for c in all_combos}
+        for cell in pr_cells:
+            if tuple(cell.values()) not in valid_keys:
+                print(
+                    f"WARNING: [pr] cell {cell} violates constraints — no row will be emitted",
+                    file=sys.stderr,
+                )
+    else:
+        pr_keys = set()
+        for key in list(pairwise_keys)[:3]:
+            pr_keys.add(key)
+
+    # Assign trigger levels:
+    #   pr      - cells listed in [pr] (explicit) or first 3 pairwise rows (fallback)
+    #   merge   - remaining pairwise rows; pr cells are also included at merge level
+    #             (cumulative filter: merge runs pr+merge)
+    #   nightly - everything else (full matrix)
+    for combo in all_combos:
+        key = tuple(combo.values())
+        if key in pr_keys:
+            combo["_trigger"] = "pr"
+        elif key in pairwise_keys:
+            combo["_trigger"] = "merge"
+        else:
+            combo["_trigger"] = "nightly"
+
+    combos = sorted(all_combos, key=lambda c: TRIGGER_LEVELS.index(c["_trigger"]))
+
+    gha_rows: list[dict] = []
+
+    for combo in combos:
+        trigger = combo.pop("_trigger")
+        if is_core:
+            row = _build_core_row(combo, trigger)
+        else:
+            row = _build_gha_row(combo, trigger, is_python)
+        if row is not None:
+            gha_rows.append(row)
+
+    # Append result_format=json reference variants. Core has no JSON variants —
+    # sf_core's result-format coverage is exercised by ODBC and Python.
+    # Variants are declared in the model file under [json_pr] / [json_merge] /
+    # [json_nightly] sections; each row is duplicated with result_format="json".
+    if is_core:
+        return gha_rows
+
+    valid_keys = {tuple(combo.get(p) for p in param_names) for combo in all_combos}
+    for trigger, cells in json_cells.items():
+        for cell in cells:
+            key = tuple(cell[p] for p in param_names)
+            if key not in valid_keys:
+                print(
+                    f"WARNING: [json_{trigger}] cell {cell} violates constraints "
+                    f"or is outside the model's parameter values — no row will be emitted",
+                    file=sys.stderr,
+                )
+                continue
+            row = _build_gha_row(dict(cell), trigger, is_python, result_format="json")
+            if row is not None:
+                gha_rows.append(row)
+
+    return gha_rows
+
+
+# ---------------------------------------------------------------------------
+# Trigger-level filtering (for runtime use in CI workflows)
+# ---------------------------------------------------------------------------
+
+EVENT_TO_LEVEL = {
+    "pull_request": "pr",
+    "pull_request_target": "pr",
+    "push": "merge",
+    "merge_group": "merge",
+    "schedule": "nightly",
+    "workflow_dispatch": "nightly",
+}
+
+
+def level_for_event(event: str | None) -> str:
+    """
+    Map a GitHub Actions event name to a trigger level.
+    Falls back to 'pr' for unknown events.
+    """
+    return EVENT_TO_LEVEL.get(event or "", "pr")
+
+
+def filter_active(rows: list[dict], level: str) -> list[dict]:
+    """Return rows whose trigger_level is at or below `level` (cumulative)."""
+    if level not in TRIGGER_LEVELS:
+        raise ValueError(f"unknown trigger level: {level!r}; expected one of {TRIGGER_LEVELS}")
+    cap = TRIGGER_LEVELS.index(level)
+    return [r for r in rows if TRIGGER_LEVELS.index(r["trigger_level"]) <= cap]
+
+
+# ---------------------------------------------------------------------------
+# File I/O helpers
+# ---------------------------------------------------------------------------
+
+def write_json(path: Path, data: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+def run_driver(driver: str) -> bool:
+    """Generate matrices for one driver. Returns True if OK."""
+    model_path = MODELS_DIR / f"{driver}.py"
+    if not model_path.exists():
+        print(f"ERROR: model file not found: {model_path}", file=sys.stderr)
+        return False
+
+    gha_rows = generate(model_path, driver)
+
+    gha_path = GENERATED_DIR / f"{driver}-gha.json"
+    write_json(gha_path, gha_rows)
+    print(f"Wrote {gha_path} ({len(gha_rows)} rows)")
+    return True
+
+
+def emit_active(driver: str, event: str | None) -> None:
+    """
+    Print `matrix=<json>` for the rows active at the level implied by `event`,
+    suitable for appending to $GITHUB_OUTPUT inside a workflow step.
+    """
+    model_path = MODELS_DIR / f"{driver}.py"
+    gha_rows = generate(model_path, driver)
+    level = level_for_event(event)
+    active = filter_active(gha_rows, level)
+    print(f"matrix={json.dumps(active)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pairwise CI matrix generator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--driver", choices=["odbc", "python", "core"], help="Generate for a single driver")
+    group.add_argument("--all", action="store_true", help="Regenerate all drivers")
+    parser.add_argument(
+        "--event",
+        help="GitHub Actions event name (e.g. pull_request, merge_group, schedule). "
+             "Used with --emit-active to pick the trigger level.",
+    )
+    parser.add_argument(
+        "--emit-active",
+        action="store_true",
+        help="Print 'matrix=<json>' for the active level (requires --driver and --event). "
+             "Used inside CI workflow steps to feed strategy.matrix.include.",
+    )
+    args = parser.parse_args()
+
+    if args.emit_active:
+        if args.all or not args.driver:
+            parser.error("--emit-active requires --driver and is incompatible with --all")
+        emit_active(args.driver, args.event)
+        return
+
+    drivers = ["odbc", "python", "core"] if args.all else [args.driver]
+    ok = True
+    for driver in drivers:
+        if not run_driver(driver):
+            ok = False
+
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test_matrix/mappings/__init__.py
+++ b/ci/test_matrix/mappings/__init__.py
@@ -1,0 +1,21 @@
+"""
+Public API for ci/test_matrix/mappings.
+
+Re-exports every (OS, Arch) lookup table used by generate_matrix.py. Each
+driver exposes a single dict-of-dicts (`*_PLATFORM`); cross-driver tables
+live in shared.py.
+"""
+
+from .shared import GHA_RUNNER
+from .odbc import ODBC_PLATFORM
+from .python import PYTHON_PLATFORM, SDIST_PY
+from .core import CORE_PLATFORM
+
+__all__ = [
+    # shared
+    "GHA_RUNNER",
+    # per-driver platform tables
+    "ODBC_PLATFORM",
+    "PYTHON_PLATFORM", "SDIST_PY",
+    "CORE_PLATFORM",
+]

--- a/ci/test_matrix/mappings/core.py
+++ b/ci/test_matrix/mappings/core.py
@@ -1,0 +1,55 @@
+"""
+Rust core (sf_core) mapping table.
+
+Single source of truth for every (OS, Arch) → core-specific lookup the
+consolidated rust-core test job in test-rust-core.yml needs. Adding a new
+lane is one row in CORE_PLATFORM (plus a matching entry in core.pict and
+the relevant `if:` gates in the workflow).
+
+Per-row keys:
+  cargo_flags  (str, required)  Cargo feature flags interpolated into
+                                cargo build/test/llvm-cov. Empty string means
+                                "use crate defaults" (Windows ARM64 — FIPS
+                                disabled upstream; see test-rust-core.yml
+                                comments referencing aws-lc-rs#1057).
+  coverage     (bool, required) When true, the consolidated `test` job runs
+                                cargo llvm-cov (build+run+report) and uses
+                                slim-mode: aggressive on cache save. When
+                                false, runs plain cargo build / cargo test.
+  cache_key    (str, required)  shared-key passed to the cargo-cache action.
+                                Identical to the pre-consolidation values
+                                (core-test, arm64-nonfips, x86-core-test) so
+                                warm caches survive across the refactor.
+  cargo_target (str, optional)  Rust target triple for cross-compilation.
+                                Absent on host-native cells; presence gates
+                                the `rustup target add` step.
+  msvc_arch    (str, optional)  Passed to vcvarsall.bat <arch>. Acts as the
+                                gating field for Windows-specific steps.
+"""
+
+CORE_PLATFORM: dict[tuple[str, str], dict] = {
+    ("ubuntu",  "x64"): {
+        "cargo_flags": "--all-features",
+        "coverage": True,
+        "cache_key": "core-test",
+    },
+    ("macos",   "arm"): {
+        "cargo_flags": "--all-features",
+        "coverage": True,
+        "cache_key": "core-test",
+    },
+    ("windows", "arm"): {
+        "cargo_flags": "",
+        "cargo_target": "aarch64-pc-windows-msvc",
+        "msvc_arch": "arm64",
+        "coverage": False,
+        "cache_key": "arm64-nonfips",
+    },
+    ("windows", "x86"): {
+        "cargo_flags": "--no-default-features --features protobuf,vendored-openssl",
+        "cargo_target": "i686-pc-windows-msvc",
+        "msvc_arch": "x86",
+        "coverage": False,
+        "cache_key": "x86-core-test",
+    },
+}

--- a/ci/test_matrix/mappings/odbc.py
+++ b/ci/test_matrix/mappings/odbc.py
@@ -1,0 +1,35 @@
+"""
+ODBC driver mapping table.
+
+Single source of truth for every (OS, Arch) → ODBC-specific lookup the
+generator needs. Adding a new lane is one row in ODBC_PLATFORM.
+
+Per-row keys:
+  driver_lib       (str, required) Shared-library file name. Linux/macOS use the
+                   OS default; Windows x86 uses sfodbc32.dll.
+  driver_artifact  (str, optional) Name of the artifact uploaded by the
+                   build_odbc_driver job in test-odbc.yml. Omit on lanes that
+                   have no GHA build today (Linux ARM, Windows ARM);
+                   _build_gha_row treats absence as "skip this cell".
+  msvc_arch        (str, optional) Passed to vcvarsall.bat <arch> on Windows
+                   non-x64 cells.
+  vcpkg_triplet    (str, Windows only) Triplet passed to `vcpkg install` and
+                   used as the vcpkg cache-key segment. Required on every
+                   Windows lane that runs ODBC tests; the workflow has no
+                   default fallback.
+
+To add a new platform: add an entry here. If the lane needs a GHA build, also
+add a build entry to build_odbc_driver in test-odbc.yml and set
+driver_artifact to the matching name.
+"""
+
+ODBC_PLATFORM: dict[tuple[str, str], dict[str, str]] = {
+    ("ubuntu",  "x64"): {"driver_lib": "libsfodbc.so",   "driver_artifact": "Linux x64"},
+    ("ubuntu",  "arm"): {"driver_lib": "libsfodbc.so"},
+    ("macos",   "arm"): {"driver_lib": "libsfodbc.dylib", "driver_artifact": "macOS ARM64"},
+    ("windows", "x64"): {"driver_lib": "sfodbc.dll",      "driver_artifact": "Windows x64",
+                         "vcpkg_triplet": "x64-windows"},
+    ("windows", "x86"): {"driver_lib": "sfodbc32.dll",    "driver_artifact": "Windows x86",
+                         "msvc_arch": "x86", "vcpkg_triplet": "x86-windows"},
+    ("windows", "arm"): {"driver_lib": "sfodbc.dll"},
+}

--- a/ci/test_matrix/mappings/python.py
+++ b/ci/test_matrix/mappings/python.py
@@ -1,0 +1,28 @@
+"""
+Python driver mapping table.
+
+Single source of truth for every (OS, Arch) → Python-specific lookup the
+generator needs. Adding a new platform is one row in PYTHON_PLATFORM; adding
+a new sdist-only Python version is one entry in SDIST_PY.
+
+Per-row keys:
+  wheel_artifact (str, required) Wheel artifact basename uploaded by the
+                 _build-python-wheels.yml reusable workflow.
+  wheels         (set[str], required) Python versions for which a wheel is
+                 actually built. The contract with _build-python-wheels.yml's
+                 `targets` argument — keep in sync.
+
+SDIST_PY is a set of Python versions that always install from sdist
+(no wheels are built for them — currently 3.10).
+"""
+
+PYTHON_PLATFORM: dict[tuple[str, str], dict] = {
+    ("ubuntu",  "x64"): {"wheel_artifact": "manylinux_x86_64", "wheels": {"3.13"}},
+    ("ubuntu",  "arm"): {"wheel_artifact": "manylinux_aarch64", "wheels": {"3.11", "3.14"}},
+    ("macos",   "arm"): {"wheel_artifact": "macosx_arm64",     "wheels": {"3.12", "3.14"}},
+    ("macos",   "x64"): {"wheel_artifact": "macosx_x86_64",    "wheels": {"3.11", "3.12", "3.13", "3.14"}},
+    ("windows", "x64"): {"wheel_artifact": "win_amd64",        "wheels": {"3.11", "3.12", "3.14"}},
+    ("windows", "arm"): {"wheel_artifact": "win_arm64",        "wheels": {"3.11", "3.12"}},
+}
+
+SDIST_PY: set[str] = {"3.10"}

--- a/ci/test_matrix/mappings/shared.py
+++ b/ci/test_matrix/mappings/shared.py
@@ -1,0 +1,17 @@
+"""
+Cross-driver runner mapping table.
+
+Used by every driver (odbc, python, core) to resolve a logical (OS, Arch) cell
+to the concrete GitHub Actions runner label it runs on.
+"""
+
+# (OS, Arch) -> GitHub Actions runner label.
+GHA_RUNNER = {
+    ("ubuntu", "x64"): "ubuntu-latest",
+    ("ubuntu", "arm"): "ubuntu-24.04-arm",
+    ("macos", "arm"): "macos-latest",
+    ("macos", "x64"): "macos-15-intel",
+    ("windows", "x64"): "windows-latest",
+    ("windows", "x86"): "windows-latest",
+    ("windows", "arm"): "windows-11-arm",
+}

--- a/ci/test_matrix/models/__init__.py
+++ b/ci/test_matrix/models/__init__.py
@@ -1,0 +1,53 @@
+"""
+Coverage models for ci/test_matrix.
+
+Each driver has a module here (`<driver>.py`) declaring four top-level names.
+The generator imports the module, validates the shape, and feeds the rest
+of the pipeline.
+
+Schema
+------
+
+PARAMS: dict[str, list[str]]
+    Parameter name -> allowed values. Order is preserved by the loader and
+    affects which specific cells land in the merge-level pairwise cover.
+    Nightly coverage is stable regardless of order (it's the full
+    constraint-valid cartesian product). Pick an order and keep it stable.
+
+CONSTRAINTS: list[Callable[[dict[str, str]], bool]]
+    Each constraint is a Python predicate that takes a candidate combo
+    (dict of param name -> value) and returns True if the combo is valid.
+    A combo is kept iff every predicate returns True.
+
+    The generator iterates over the full cartesian product of PARAMS and
+    feeds every candidate through CONSTRAINTS — so the recommended shape
+    is a single `is_valid(c)` block-list that names what to *forbid* with
+    `return False`, and lets everything else fall through to `return True`:
+
+        def is_valid(c):
+            # Forbid: Windows-on-ARM has no CPython 3.10 build.
+            if c["OS"] == "windows" and c["Arch"] == "arm" and c["PyVersion"] == "3.10":
+                return False
+            # Forbid: no pyarrow win_arm64 wheel.
+            if c["OS"] == "windows" and c["Arch"] == "arm" and c["HatchEnv"] == "test-pandas":
+                return False
+            return True
+
+        CONSTRAINTS = [is_valid]
+
+    Why block-list (forbid-only) rather than allow-list (enumerate-allowed):
+    a block-list is *drift-resistant* — adding a new value to PARAMS (e.g.
+    a new PyVersion) is automatically accepted, since no rule names it. An
+    allow-list would silently drop the new value until the rule is updated.
+    Encode each rejection with a positive `==` check on the forbidden value
+    so the rule reads as "this specific combo is forbidden because <reason>".
+
+PR_CELLS: list[dict[str, str]]
+    Explicit cells that always run on every PR. Each cell must list a value
+    for every declared parameter (loader rejects missing or extra keys).
+
+JSON_CELLS: dict[str, list[dict[str, str]]]
+    Maps trigger level ("pr" / "merge" / "nightly") to cells that get
+    duplicated with result_format="json" at that level. Same per-cell
+    completeness rule as PR_CELLS.
+"""

--- a/ci/test_matrix/models/core.py
+++ b/ci/test_matrix/models/core.py
@@ -1,0 +1,37 @@
+"""Rust core (sf_core) coverage model — see models/__init__.py for the schema."""
+
+PARAMS = {
+    "OS":   ["ubuntu", "macos", "windows"],
+    "Arch": ["x64", "arm", "x86"],
+}
+
+
+def is_valid(c):
+    """Block-list: return False to forbid a combo, fall through to allow."""
+    if c["OS"] == "ubuntu":
+        # ubuntu builds only x64.
+        if c["Arch"] == "arm": return False
+        if c["Arch"] == "x86": return False
+
+    if c["OS"] == "macos":
+        # macos builds only arm.
+        if c["Arch"] == "x64": return False
+        if c["Arch"] == "x86": return False
+
+    if c["OS"] == "windows":
+        # windows builds arm and x86 today (no x64 build).
+        if c["Arch"] == "x64": return False
+
+    return True
+
+
+CONSTRAINTS = [is_valid]
+
+PR_CELLS = [
+    {"OS": "ubuntu",  "Arch": "x64"},
+    {"OS": "macos",   "Arch": "arm"},
+    {"OS": "windows", "Arch": "arm"},
+    {"OS": "windows", "Arch": "x86"},
+]
+
+JSON_CELLS = {"pr": [], "merge": [], "nightly": []}

--- a/ci/test_matrix/models/odbc.py
+++ b/ci/test_matrix/models/odbc.py
@@ -1,0 +1,44 @@
+"""ODBC driver coverage model — see models/__init__.py for the schema."""
+
+PARAMS = {
+    "OS":    ["ubuntu", "macos", "windows"],
+    "Arch":  ["x64", "x86", "arm"],
+    "Cloud": ["aws", "gcp", "azure"],
+}
+
+
+def is_valid(c):
+    """Block-list: return False to forbid a combo, fall through to allow."""
+    if c["OS"] == "ubuntu":
+        # ubuntu ODBC builds only x64.
+        if c["Arch"] == "arm": return False
+        if c["Arch"] == "x86": return False
+
+    if c["OS"] == "macos":
+        # macos ODBC builds only arm.
+        if c["Arch"] == "x64": return False
+        if c["Arch"] == "x86": return False
+
+    if c["OS"] == "windows":
+        # No Windows-ARM64 ODBC build today.
+        if c["Arch"] == "arm": return False
+
+    return True
+
+
+CONSTRAINTS = [is_valid]
+
+PR_CELLS = [
+    {"OS": "ubuntu",  "Arch": "x64", "Cloud": "aws"},
+    {"OS": "macos",   "Arch": "arm", "Cloud": "gcp"},
+    {"OS": "windows", "Arch": "x64", "Cloud": "azure"},
+    {"OS": "windows", "Arch": "x86", "Cloud": "aws"},
+]
+
+JSON_CELLS = {
+    "pr": [],
+    "merge": [
+        {"OS": "ubuntu", "Arch": "x64", "Cloud": "aws"},
+    ],
+    "nightly": [],
+}

--- a/ci/test_matrix/models/python.py
+++ b/ci/test_matrix/models/python.py
@@ -1,0 +1,39 @@
+"""Python driver coverage model — see models/__init__.py for the schema."""
+
+PARAMS = {
+    "OS":        ["ubuntu", "macos", "windows"],
+    "Arch":      ["x64", "arm"],
+    "Cloud":     ["aws", "gcp", "azure"],
+    "PyVersion": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+    "HatchEnv":  ["test", "test-pandas"],
+}
+
+
+def is_valid(c):
+    """Block-list: return False to forbid a combo, fall through to allow."""
+    if c["OS"] == "windows" and c["Arch"] == "arm":
+        # No CPython 3.10 build for Windows-on-ARM (tier-3 from 3.11).
+        if c["PyVersion"] == "3.10":      return False
+        # No pyarrow win_arm64 wheel; source-build fails on GHA windows-11-arm
+        # runner (no Arrow C++ libs).
+        if c["HatchEnv"] == "test-pandas": return False
+
+    return True
+
+
+CONSTRAINTS = [is_valid]
+
+PR_CELLS = [
+    {"OS": "ubuntu",  "Arch": "x64", "Cloud": "aws",   "PyVersion": "3.10", "HatchEnv": "test"},
+    {"OS": "macos",   "Arch": "arm", "Cloud": "gcp",   "PyVersion": "3.12", "HatchEnv": "test-pandas"},
+    {"OS": "windows", "Arch": "x64", "Cloud": "azure", "PyVersion": "3.14", "HatchEnv": "test"},
+]
+
+JSON_CELLS = {
+    "pr": [],
+    "merge": [
+        {"OS": "ubuntu", "Arch": "x64", "Cloud": "aws", "PyVersion": "3.13", "HatchEnv": "test"},
+        {"OS": "ubuntu", "Arch": "x64", "Cloud": "aws", "PyVersion": "3.13", "HatchEnv": "test-pandas"},
+    ],
+    "nightly": [],
+}

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -1,0 +1,724 @@
+"""
+Tests for ci/test_matrix/generate_matrix.py.
+
+Run with:
+    python -m pytest ci/test_matrix/test_generate_matrix.py -q
+or:
+    python -m unittest ci/test_matrix/test_generate_matrix.py
+"""
+
+from __future__ import annotations
+
+import io
+import itertools
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import generate_matrix as gm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_model(text: str) -> Path:
+    """Write a Python coverage model module to a fresh tempfile and return its path."""
+    f = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+    f.write(text)
+    f.close()
+    return Path(f.name)
+
+
+# ---------------------------------------------------------------------------
+# Pairwise + parser
+# ---------------------------------------------------------------------------
+
+class PairwiseTests(unittest.TestCase):
+    def test_pairwise_covers_all_pairs(self) -> None:
+        """Every (param_i, val_i, param_j, val_j) pair must appear at least once."""
+        param_values = [["a", "b", "c"], ["1", "2"], ["x", "y", "z"]]
+        cover = gm.pairwise(param_values)
+        n = len(param_values)
+        for i, j in itertools.combinations(range(n), 2):
+            for vi in param_values[i]:
+                for vj in param_values[j]:
+                    self.assertTrue(
+                        any(c[i] == vi and c[j] == vj for c in cover),
+                        f"pair ({i}={vi}, {j}={vj}) not covered",
+                    )
+
+    def test_pairwise_minimal(self) -> None:
+        """For 3x3x3, pairwise should produce <= full cartesian (27)."""
+        cover = gm.pairwise([["a", "b", "c"]] * 3)
+        self.assertLess(len(cover), 27)
+
+
+class LoadModelTests(unittest.TestCase):
+    """Exercises load_model() — the Python-module coverage-model loader."""
+
+    def test_load_basic(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "CONSTRAINTS = [lambda x: False if x['OS'] == 'macos' and x['Arch'] == 'x64' else True]\n"
+            "PR_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64'}]\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            params, constraints, pr_cells, json_cells = gm.load_model(path)
+            self.assertEqual(params, {"OS": ["ubuntu", "macos"], "Arch": ["x64", "arm"]})
+            self.assertEqual(len(constraints), 1)
+            self.assertTrue(callable(constraints[0]))
+            # Predicate semantics: macos+arm valid, macos+x64 invalid.
+            self.assertTrue(constraints[0]({"OS": "macos", "Arch": "arm"}))
+            self.assertFalse(constraints[0]({"OS": "macos", "Arch": "x64"}))
+            self.assertEqual(pr_cells, [{"OS": "ubuntu", "Arch": "x64"}])
+            self.assertEqual(json_cells, {"pr": [], "merge": [], "nightly": []})
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_load_json_sections(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "CONSTRAINTS = [lambda x: False if x['OS'] == 'macos' and x['Arch'] == 'x64' else True]\n"
+            "PR_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64'}]\n"
+            "JSON_CELLS = {\n"
+            "    'pr':      [{'OS': 'ubuntu', 'Arch': 'x64'}],\n"
+            "    'merge':   [{'OS': 'macos',  'Arch': 'arm'}],\n"
+            "    'nightly': [],\n"
+            "}\n"
+        )
+        try:
+            _params, _c, _pr, json_cells = gm.load_model(path)
+            self.assertEqual(json_cells["pr"], [{"OS": "ubuntu", "Arch": "x64"}])
+            self.assertEqual(json_cells["merge"], [{"OS": "macos", "Arch": "arm"}])
+            self.assertEqual(json_cells["nightly"], [])
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_constraints_must_be_callable(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "PR_CELLS = []\n"
+            "CONSTRAINTS = [{'if': {'OS': 'ubuntu'}, 'then': {'OS': 'ubuntu'}}]\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("callable", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_constraints_must_be_a_list(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "PR_CELLS = []\n"
+            "CONSTRAINTS = 'not a list'\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("CONSTRAINTS", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_pr_cell_missing_param_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu'], 'Arch': ['x64'], 'Cloud': ['aws']}\n"
+            "PR_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64'}]\n"  # missing Cloud
+            "CONSTRAINTS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("PR_CELLS", str(ctx.exception))
+            self.assertIn("Cloud", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_pr_cell_extra_key_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu'], 'Arch': ['x64']}\n"
+            "PR_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64', 'Bogus': 'x'}]\n"
+            "CONSTRAINTS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("Bogus", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_json_cell_missing_param_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu'], 'Arch': ['x64'], 'Cloud': ['aws']}\n"
+            "PR_CELLS = []\n"
+            "CONSTRAINTS = []\n"
+            "JSON_CELLS = {'pr': [{'OS': 'ubuntu', 'Arch': 'x64'}], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("JSON_CELLS", str(ctx.exception))
+            self.assertIn("Cloud", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_unknown_json_trigger_level_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "PR_CELLS = []\n"
+            "CONSTRAINTS = []\n"
+            "JSON_CELLS = {'foo': [{'OS': 'ubuntu'}]}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("'foo'", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_missing_params_raises(self) -> None:
+        path = _write_model(
+            "PR_CELLS = []\n"
+            "CONSTRAINTS = []\n"
+            "JSON_CELLS = {}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("PARAMS", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_block_list_function_constraint(self) -> None:
+        """
+        Lock in support for the recommended block-list shape: a single
+        is_valid(c) function that returns False for explicitly-forbidden
+        combos and falls through to True for everything else.
+        """
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "def is_valid(c):\n"
+            "    if c['OS'] == 'macos':\n"
+            "        if c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "CONSTRAINTS = [is_valid]\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            _, constraints, _, _ = gm.load_model(path)
+            self.assertEqual(len(constraints), 1)
+            # Forbidden by an explicit return False.
+            self.assertFalse(constraints[0]({"OS": "macos", "Arch": "x64"}))
+            # Allowed via fall-through return True.
+            self.assertTrue(constraints[0]({"OS": "macos", "Arch": "arm"}))
+            self.assertTrue(constraints[0]({"OS": "ubuntu", "Arch": "x64"}))
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class BlockListShapeTests(unittest.TestCase):
+    """
+    Static-AST guard: every model's is_valid() must be a pure block-list.
+
+    Discipline:
+      * Every `return` inside the function is either `return False` or
+        `return True` — never `return <expression>`. An expression-return
+        is how allow-list creep enters (e.g. `return c["X"] in (...)`),
+        which silently drops new PARAMS values.
+      * The function ends with `return True` (the fall-through allow).
+        Every other `return` is `return False` (an early-exit forbid).
+
+    Catches drift-inducing patterns at PR-review time instead of at
+    next-CPython-release time.
+    """
+
+    MODELS = ["core", "odbc", "python"]
+
+    def _is_valid_function(self, model_name: str):
+        import ast
+        path = gm.MODELS_DIR / f"{model_name}.py"
+        tree = ast.parse(path.read_text())
+        funcs = [n for n in tree.body
+                 if isinstance(n, ast.FunctionDef) and n.name == "is_valid"]
+        self.assertEqual(
+            len(funcs), 1,
+            f"{path}: expected exactly one top-level `is_valid` function; got {len(funcs)}",
+        )
+        return path, funcs[0]
+
+    def test_returns_only_bool_literals(self) -> None:
+        import ast
+        for model in self.MODELS:
+            with self.subTest(model=model):
+                path, fn = self._is_valid_function(model)
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.Return):
+                        continue
+                    self.assertIsInstance(
+                        node.value, ast.Constant,
+                        f"{path}:{node.lineno} `return <expression>` violates "
+                        f"block-list discipline (returns must be `return False` "
+                        f"or `return True`)",
+                    )
+                    self.assertIsInstance(
+                        node.value.value, bool,
+                        f"{path}:{node.lineno} `return` value is "
+                        f"{node.value.value!r}, expected bool literal",
+                    )
+
+    def test_only_trailing_return_true(self) -> None:
+        import ast
+        for model in self.MODELS:
+            with self.subTest(model=model):
+                path, fn = self._is_valid_function(model)
+                # Last top-level statement must be `return True`.
+                last = fn.body[-1]
+                self.assertIsInstance(
+                    last, ast.Return,
+                    f"{path}:{fn.name} must end with `return True`",
+                )
+                self.assertTrue(
+                    isinstance(last.value, ast.Constant) and last.value.value is True,
+                    f"{path}:{last.lineno} trailing return must be `return True`",
+                )
+                # All other returns must be `return False` (early-exit forbids).
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.Return) or node is last:
+                        continue
+                    self.assertTrue(
+                        isinstance(node.value, ast.Constant) and node.value.value is False,
+                        f"{path}:{node.lineno} early `return True` short-circuits "
+                        f"later forbidding rules — use `return False` to block "
+                        f"specific combos and let the trailing `return True` allow "
+                        f"by default",
+                    )
+
+
+class ApplyConstraintsTests(unittest.TestCase):
+    """
+    apply_constraints just runs every predicate over the combo and ANDs the
+    results. These tests lock in the contract: True iff every predicate
+    returns True; an empty constraint list always passes.
+    """
+
+    def test_empty_constraints_passes(self) -> None:
+        self.assertTrue(gm.apply_constraints({"OS": "macos"}, []))
+
+    def test_single_predicate(self) -> None:
+        # Block-list predicate: forbid macos+x64, allow everything else.
+        c = lambda x: False if x["OS"] == "macos" and x["Arch"] == "x64" else True
+        self.assertTrue(gm.apply_constraints({"OS": "macos", "Arch": "arm"}, [c]))
+        self.assertFalse(gm.apply_constraints({"OS": "macos", "Arch": "x64"}, [c]))
+        # Non-macos: predicate falls through to True.
+        self.assertTrue(gm.apply_constraints({"OS": "ubuntu", "Arch": "x64"}, [c]))
+
+    def test_multi_clause_predicate(self) -> None:
+        # Forbidden combo: windows + arm + 3.10. Anything else → True.
+        c = lambda x: (
+            False
+            if x["OS"] == "windows" and x["Arch"] == "arm" and x["PyVersion"] == "3.10"
+            else True
+        )
+        self.assertFalse(gm.apply_constraints(
+            {"OS": "windows", "Arch": "arm", "PyVersion": "3.10"}, [c],
+        ))
+        self.assertTrue(gm.apply_constraints(
+            {"OS": "windows", "Arch": "arm", "PyVersion": "3.11"}, [c],
+        ))
+        # Antecedent doesn't match → fall through to True.
+        self.assertTrue(gm.apply_constraints(
+            {"OS": "windows", "Arch": "x64", "PyVersion": "3.10"}, [c],
+        ))
+        self.assertTrue(gm.apply_constraints(
+            {"OS": "ubuntu", "Arch": "arm", "PyVersion": "3.10"}, [c],
+        ))
+
+    def test_all_predicates_must_pass(self) -> None:
+        # Two block-list predicates: each independently forbids one combo.
+        c1 = lambda x: False if x["OS"] == "macos" and x["Arch"] == "x64" else True
+        c2 = lambda x: False if x["Arch"] == "x64" else True
+        self.assertFalse(gm.apply_constraints({"OS": "ubuntu", "Arch": "x64"}, [c1, c2]))
+        self.assertTrue(gm.apply_constraints({"OS": "macos", "Arch": "arm"}, [c1, c2]))
+
+
+# ---------------------------------------------------------------------------
+# Generator end-to-end
+# ---------------------------------------------------------------------------
+
+ODBC_PATH = gm.MODELS_DIR / "odbc.py"
+PYTHON_PATH = gm.MODELS_DIR / "python.py"
+CORE_PATH = gm.MODELS_DIR / "core.py"
+
+
+class OdbcMatrixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.gha = gm.generate(ODBC_PATH, "odbc")
+
+    def test_pr_has_all_major_platforms(self) -> None:
+        pr_artifacts = {r["driver_artifact"] for r in self.gha if r["trigger_level"] == "pr"}
+        self.assertIn("Linux x64", pr_artifacts)
+        self.assertIn("macOS ARM64", pr_artifacts)
+        self.assertIn("Windows x64", pr_artifacts)
+        self.assertIn("Windows x86", pr_artifacts)
+
+    def test_windows_x86_present(self) -> None:
+        x86_rows = [r for r in self.gha if r.get("driver_artifact") == "Windows x86"]
+        self.assertTrue(x86_rows, "expected at least one Windows x86 ODBC cell")
+        for r in x86_rows:
+            self.assertEqual(r["driver_lib"], "sfodbc32.dll")
+            self.assertEqual(r["msvc_arch"], "x86")
+            self.assertEqual(r["vcpkg_triplet"], "x86-windows")
+            self.assertEqual(r["os"], "windows-latest")
+
+    def test_windows_x64_has_vcpkg_triplet(self) -> None:
+        # Regression test: test-odbc.yml's vcpkg install step uses
+        # ${{ matrix.vcpkg_triplet }} with no fallback. Every windows-x64
+        # ODBC cell must carry vcpkg_triplet=x64-windows or vcpkg install
+        # fails with "expected a triplet name here".
+        x64_rows = [r for r in self.gha if r.get("driver_artifact") == "Windows x64"]
+        self.assertTrue(x64_rows, "expected at least one Windows x64 ODBC cell")
+        for r in x64_rows:
+            self.assertEqual(r["vcpkg_triplet"], "x64-windows", r["name"])
+
+    def test_json_variant_present(self) -> None:
+        json_rows = [r for r in self.gha if r.get("result_format") == "json"]
+        self.assertEqual(len(json_rows), 1)
+        r = json_rows[0]
+        self.assertEqual(r["os"], "ubuntu-latest")
+        self.assertEqual(r["cloud_provider"], "aws")
+        self.assertEqual(r["driver_artifact"], "Linux x64")
+
+
+class PythonMatrixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.gha = gm.generate(PYTHON_PATH, "python")
+
+    def test_no_wheel_artifact_on_py310(self) -> None:
+        offenders = [r for r in self.gha if r["py"] == "3.10" and r.get("wheel_artifact")]
+        self.assertEqual(offenders, [])
+
+    def test_py310_present_on_main_platforms(self) -> None:
+        py310_os = {r["os"] for r in self.gha if r["py"] == "3.10"}
+        # py3.10 builds from sdist; should be on at least all wheel-target OSes
+        self.assertIn("ubuntu-latest", py310_os)
+        self.assertIn("macos-latest", py310_os)
+        self.assertIn("windows-latest", py310_os)
+
+    def test_macos_x64_present(self) -> None:
+        # Regression test: macOS Intel (macos-15-intel runner) coverage must
+        # remain in the matrix. Drop this row from PYTHON_PLATFORM and the
+        # release-build / nightly coverage gap reopens (see PR #1084 review).
+        intel_rows = [r for r in self.gha if r["os"] == "macos-15-intel"]
+        self.assertTrue(intel_rows, "expected macos-15-intel cells in the python matrix")
+        for r in intel_rows:
+            self.assertIn(r["py"], {"3.10", "3.11", "3.12", "3.13", "3.14"})
+            # py3.10 always sdist; every other py on macos-x64 must have a wheel.
+            if r["py"] != "3.10":
+                self.assertEqual(r.get("wheel_artifact"), "macosx_x86_64", r["name"])
+
+    def test_windows_arm_at_merge_scope(self) -> None:
+        # Regression test for the routing-aware pairwise solver. Without it,
+        # the abstract pairwise solver picks windows-arm × py3.13/3.14 (which
+        # have no wheel) to cover (windows, arm) pairs; those rows get
+        # dropped at row-build time, leaving zero windows-arm cells at merge
+        # level (only nightly). The routing-aware predicate restricts the
+        # candidate pool to combos that actually emit a row, so windows-arm
+        # gets a real merge-level cell.
+        warm_at_merge = [
+            r for r in self.gha
+            if r["os"] == "windows-11-arm"
+            and r["trigger_level"] in ("pr", "merge")
+        ]
+        self.assertTrue(
+            warm_at_merge,
+            "expected windows-11-arm cells at pr+merge scope; "
+            "if missing, the pairwise solver may have regressed to the "
+            "non-routing-aware path that picks routing-invalid combos.",
+        )
+
+    def test_windows_arm_excludes_py310(self) -> None:
+        # Regression test for the python.py constraint
+        #     IF [OS] = "windows" AND [Arch] = "arm" THEN [PyVersion] <> "3.10"
+        # CPython has no Windows-aarch64 build for 3.10 (Windows-on-ARM was
+        # first supported in 3.11, PEP 11 tier-3). uv fails with
+        # "No download found for request: cpython-3.10-windows-aarch64-none"
+        # if this combo reaches the matrix.
+        #
+        # Originally the constraint used `AND` in the IF clause which the
+        # in-house parser silently dropped (regex matched only single-condition
+        # IFs). A failing CI run on the merge_scope label shipped a real
+        # windows-11-arm/py3.10 cell because of that. This test guards the
+        # parser extension that supports AND clauses + `<>`/`NOT IN` ops.
+        offenders = [
+            r for r in self.gha
+            if r["os"] == "windows-11-arm" and r["py"] == "3.10"
+        ]
+        self.assertEqual(
+            offenders, [],
+            "windows-11-arm + py3.10 cells must be pruned from the matrix "
+            f"(no CPython 3.10 Windows-ARM64 build); got: {offenders}",
+        )
+
+    def test_windows_arm_excludes_test_pandas(self) -> None:
+        # Regression test for the python.py constraint
+        #     IF [OS] = "windows" AND [Arch] = "arm" THEN [HatchEnv] <> "test-pandas"
+        # pyarrow has no win_arm64 wheel for the Python versions we test, so
+        # uv source-builds it on the windows-11-arm runner. The build needs
+        # Apache Arrow C++ libs which aren't installed there; CMake fails at
+        # find_package(Arrow). See run 25662523089 / job 75331063502.
+        # The `test` hatch env is unaffected (no pyarrow dep).
+        offenders = [
+            r for r in self.gha
+            if r["os"] == "windows-11-arm" and r["hatch_env"] == "test-pandas"
+        ]
+        self.assertEqual(
+            offenders, [],
+            "windows-11-arm + test-pandas cells must be pruned from the matrix "
+            f"(pyarrow has no win_arm64 wheel); got: {offenders}",
+        )
+
+    def test_wheel_artifact_only_when_built(self) -> None:
+        # Reverse-lookup the (os, arch) producing this wheel artifact name.
+        artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
+        for r in self.gha:
+            artifact = r.get("wheel_artifact")
+            if not artifact:
+                continue
+            pair = artifact_to_pair[artifact]
+            self.assertIn(
+                r["py"],
+                gm.PYTHON_PLATFORM[pair]["wheels"],
+                f"row {r['name']} has wheel_artifact {artifact} but py{r['py']} "
+                f"isn't in PYTHON_PLATFORM[{pair}]['wheels']",
+            )
+
+    def test_json_variants_present(self) -> None:
+        json_rows = [r for r in self.gha if r.get("result_format") == "json"]
+        envs = {r["hatch_env"] for r in json_rows}
+        self.assertEqual(envs, {"test", "test-pandas"})
+        for r in json_rows:
+            self.assertEqual(r["py"], "3.13")
+            self.assertEqual(r["os"], "ubuntu-latest")
+            self.assertEqual(r["cloud_provider"], "aws")
+
+    def test_required_keys_on_every_row(self) -> None:
+        required = {"name", "os", "cloud_provider", "trigger_level", "py", "hatch_env"}
+        for r in self.gha:
+            missing = required - r.keys()
+            self.assertFalse(missing, f"row {r} missing keys {missing}")
+
+
+class CoreMatrixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.gha = gm.generate(CORE_PATH, "core")
+
+    def test_pr_has_all_four_cells(self) -> None:
+        names = {r["name"] for r in self.gha if r["trigger_level"] == "pr"}
+        self.assertEqual(
+            names,
+            {"ubuntu-x64", "macos-arm", "windows-arm-nonfips", "windows-x86"},
+        )
+
+    def test_no_cloud_provider_field(self) -> None:
+        # Core has no Cloud axis (single E2E_TLS_SERVER for every cell).
+        for r in self.gha:
+            self.assertNotIn("cloud_provider", r, r["name"])
+
+    def test_coverage_only_on_unix(self) -> None:
+        cov_runners = {r["os"] for r in self.gha if r.get("coverage")}
+        self.assertEqual(cov_runners, {"ubuntu-latest", "macos-latest"})
+        for r in self.gha:
+            if r["os"] in ("windows-11-arm", "windows-latest"):
+                self.assertFalse(r["coverage"], r["name"])
+
+    def test_targets_for_windows_only(self) -> None:
+        targets = {r["name"]: r.get("cargo_target") for r in self.gha}
+        self.assertEqual(targets["ubuntu-x64"], None)
+        self.assertEqual(targets["macos-arm"], None)
+        self.assertEqual(targets["windows-arm-nonfips"], "aarch64-pc-windows-msvc")
+        self.assertEqual(targets["windows-x86"], "i686-pc-windows-msvc")
+
+    def test_msvc_arch_for_windows_only(self) -> None:
+        msvc = {r["name"]: r.get("msvc_arch") for r in self.gha}
+        self.assertEqual(msvc["ubuntu-x64"], None)
+        self.assertEqual(msvc["macos-arm"], None)
+        self.assertEqual(msvc["windows-arm-nonfips"], "arm64")
+        self.assertEqual(msvc["windows-x86"], "x86")
+
+    def test_cargo_flags_per_platform(self) -> None:
+        flags = {r["name"]: r["cargo_flags"] for r in self.gha}
+        self.assertEqual(flags["ubuntu-x64"], "--all-features")
+        self.assertEqual(flags["macos-arm"], "--all-features")
+        self.assertEqual(flags["windows-arm-nonfips"], "")
+        self.assertEqual(
+            flags["windows-x86"],
+            "--no-default-features --features protobuf,vendored-openssl",
+        )
+
+    def test_cache_keys_match_legacy(self) -> None:
+        # Cache shared-keys must stay identical to the pre-consolidation values
+        # in test-rust-core.yml so warm caches survive the refactor.
+        keys = {r["name"]: r["cache_key"] for r in self.gha}
+        self.assertEqual(keys["ubuntu-x64"], "core-test")
+        self.assertEqual(keys["macos-arm"], "core-test")
+        self.assertEqual(keys["windows-arm-nonfips"], "arm64-nonfips")
+        self.assertEqual(keys["windows-x86"], "x86-core-test")
+
+    def test_required_keys_on_every_row(self) -> None:
+        required = {"name", "os", "trigger_level", "cargo_flags", "coverage", "cache_key"}
+        for r in self.gha:
+            missing = required - r.keys()
+            self.assertFalse(missing, f"row {r['name']} missing keys {missing}")
+
+
+# ---------------------------------------------------------------------------
+# Validation paths
+# ---------------------------------------------------------------------------
+
+class ValidationTests(unittest.TestCase):
+    def test_pr_cell_violating_constraint_warns(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm'], 'Cloud': ['aws']}\n"
+            "CONSTRAINTS = [lambda x: False if x['OS'] == 'macos' and x['Arch'] == 'x64' else True]\n"
+            # macos+x64+aws violates the constraint above.
+            "PR_CELLS = [{'OS': 'macos', 'Arch': 'x64', 'Cloud': 'aws'}]\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        # Use a tiny model that won't hit other validation paths.
+        try:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                # We only want loader/constraint behavior; sidestep validate_mappings
+                # by calling internals.
+                params, constraints, pr_cells, _json_cells = gm.load_model(path)
+                all_combos = [
+                    c for c in (
+                        dict(zip(params.keys(), v))
+                        for v in itertools.product(*params.values())
+                    )
+                    if gm.apply_constraints(c, constraints)
+                ]
+                valid_keys = {tuple(c.values()) for c in all_combos}
+                for cell in pr_cells:
+                    if tuple(cell.values()) not in valid_keys:
+                        print(
+                            f"WARNING: [pr] cell {cell} violates constraints",
+                            file=sys.stderr,
+                        )
+            self.assertIn("violates constraints", buf.getvalue())
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_validate_mappings_raises_on_missing_pair(self) -> None:
+        # Force a (OS, Arch) the model allows but no mapping table contains.
+        all_combos = [{"OS": "freebsd", "Arch": "x64", "Cloud": "aws"}]
+        with self.assertRaises(RuntimeError) as ctx:
+            gm.validate_mappings("odbc", all_combos)
+        self.assertIn("freebsd", str(ctx.exception))
+
+    def test_validate_mappings_raises_on_python_missing_platform(self) -> None:
+        # macos-x64 is in GHA_RUNNER (so the first check passes) but if it
+        # were missing from PYTHON_PLATFORM, py3.11+ rows would silently drop.
+        # Simulate that drift by reaching past PYTHON_PLATFORM with a synthetic
+        # combo on a runner that exists in GHA_RUNNER but a fictional arch
+        # combination not in PYTHON_PLATFORM.
+        original = gm.PYTHON_PLATFORM.pop(("macos", "x64"), None)
+        try:
+            all_combos = [{"OS": "macos", "Arch": "x64", "Cloud": "aws",
+                           "PyVersion": "3.13", "HatchEnv": "test"}]
+            with self.assertRaises(RuntimeError) as ctx:
+                gm.validate_mappings("python", all_combos)
+            self.assertIn("PYTHON_PLATFORM", str(ctx.exception))
+            self.assertIn("macos", str(ctx.exception))
+        finally:
+            if original is not None:
+                gm.PYTHON_PLATFORM[("macos", "x64")] = original
+
+
+# ---------------------------------------------------------------------------
+# JSON variants — cross-driver regression
+# ---------------------------------------------------------------------------
+
+class JsonVariantRegressionTests(unittest.TestCase):
+    """
+    Locks the JSON cell count at the merge trigger level across odbc + python.
+
+    Main has 1 ODBC json cell (every PR — appears at merge cumulatively) plus
+    2 Python json cells (gated on merge). This test pins the combined merge-
+    level JSON count at 3 so future model edits don't silently change the
+    JSON-format coverage.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.odbc_gha = gm.generate(ODBC_PATH, "odbc")
+        cls.py_gha = gm.generate(PYTHON_PATH, "python")
+
+    def test_combined_json_count_at_merge_level(self) -> None:
+        # `merge` is cumulative — it includes pr cells plus rows whose
+        # trigger_level is `pr` or `merge`.
+        active_levels = {"pr", "merge"}
+        json_at_merge = [
+            r for r in (self.odbc_gha + self.py_gha)
+            if r.get("result_format") == "json" and r["trigger_level"] in active_levels
+        ]
+        self.assertEqual(
+            len(json_at_merge), 3,
+            f"expected 3 json cells active at merge, got {len(json_at_merge)}: "
+            f"{[r['name'] for r in json_at_merge]}",
+        )
+
+    def test_json_names_unchanged(self) -> None:
+        json_names = sorted(
+            r["name"] for r in (self.odbc_gha + self.py_gha)
+            if r.get("result_format") == "json"
+        )
+        self.assertEqual(
+            json_names,
+            [
+                "ubuntu-x64-aws-json",
+                "ubuntu-x64-aws-py3.13-json",
+                "ubuntu-x64-aws-py3.13-test-pandas-json",
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Trigger-level filtering
+# ---------------------------------------------------------------------------
+
+class FilterTests(unittest.TestCase):
+    def test_level_for_event(self) -> None:
+        self.assertEqual(gm.level_for_event("pull_request"), "pr")
+        self.assertEqual(gm.level_for_event("push"), "merge")
+        self.assertEqual(gm.level_for_event("merge_group"), "merge")
+        self.assertEqual(gm.level_for_event("schedule"), "nightly")
+        self.assertEqual(gm.level_for_event("unknown"), "pr")
+        self.assertEqual(gm.level_for_event(None), "pr")
+
+    def test_filter_active_cumulative(self) -> None:
+        rows = [
+            {"trigger_level": "pr"},
+            {"trigger_level": "merge"},
+            {"trigger_level": "nightly"},
+        ]
+        self.assertEqual(len(gm.filter_active(rows, "pr")), 1)
+        self.assertEqual(len(gm.filter_active(rows, "merge")), 2)
+        self.assertEqual(len(gm.filter_active(rows, "nightly")), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces the hardcoded `strategy.matrix.include` lists in `test-odbc.yml`, `test-python.yml`, and `test-rust-core.yml` with a generated matrix driven by PICT-style coverage models and Python mapping tables.

A new `ci/test_matrix/` module owns the model files, mapping tables, the generator, and its tests.

## Coverage model

Each row carries one of three trigger levels. Levels are cumulative — `merge` runs `pr+merge`, `nightly` runs everything.

| Level | How cells are picked |
|---|---|
| `pr` | **Explicit.** Listed in the `[pr]` section of the model file. Manual control. |
| `merge` | **PICT-driven.** Pairwise cover — every value-pair across every parameter pair. |
| `nightly` | **PICT-driven.** Every constraint-valid combination. |

Resulting row counts on this PR:

* | Driver | Total | `pr` | `merge` | `nightly` |
    |--------|------:|-----:|--------:|----------:|
    | odbc   |    13 |    3 |       2 |         8 |
    | python |   122 |    3 |      12 |       107 |
    | core   |     4 |    4 |       0 |         0 |

## What lives where

Two file categories with distinct responsibilities:

- **Models** (`ci/test_matrix/models/*.pict`) describe *which combinations exist* — parameters, `IF/THEN` constraints, the explicit `[pr]` section, and `[json_*]` reference variants.
- **Mappings** (`ci/test_matrix/mappings/*.py`) describe *what each `(OS, Arch)` cell needs at CI time* — runner labels, driver libraries, wheel artifact names, cargo flags, etc.

Layout:

```text
ci/test_matrix/
├── models/
│   ├── odbc.pict             OS, Arch, Cloud
│   ├── python.pict           OS, Arch, Cloud, PyVersion, HatchEnv
│   └── core.pict             OS, Arch
├── mappings/
│   ├── shared.py             GHA_RUNNER (runner labels — every driver)
│   ├── odbc.py               ODBC_PLATFORM (driver_lib, driver_artifact, msvc_arch, vcpkg_triplet)
│   ├── python.py             PYTHON_PLATFORM (wheel_artifact, wheels), SDIST_PY
│   └── core.py               CORE_PLATFORM (cargo_flags, cargo_target, coverage, cache_key)
├── generate_matrix.py        parser + greedy pairwise + JSON emit
└── test_generate_matrix.py   31 unit tests
```

The generator joins both at runtime. `validate_mappings()` fails loud if a model allows an `(OS, Arch)` pair that no mapping covers, so drift between the two surfaces immediately.

## Workflow integration

Each workflow gains a `load-{driver}-matrix` job that runs the generator at workflow start and exposes the active rows as a matrix output:

```yaml
load-odbc-matrix:
  runs-on: ubuntu-latest
  outputs:
    matrix: ${{ steps.read.outputs.matrix }}
  steps:
    - uses: actions/checkout@v4
    - id: read
      run: |
        python ci/test_matrix/generate_matrix.py \
          --driver odbc --event "$GITHUB_EVENT_NAME" --emit-active \
          >> "$GITHUB_OUTPUT"
```

The downstream test job consumes it via:

```yaml
strategy:
  matrix:
    include: ${{ fromJSON(needs.load-odbc-matrix.outputs.matrix) }}
```

The generator selects the trigger level from `GITHUB_EVENT_NAME` (`pull_request` → pr, `merge_group`/`push` → merge, `schedule` → nightly).

## Editing the matrix

| Goal | What to edit |
|---|---|
| Change PR cells | `[pr]` section in `models/<driver>.pict`. |
| Add a JSON `result_format` cell | `[json_pr]` / `[json_merge]` / `[json_nightly]` in the model file. |
| Add a platform lane | Add a row to `<driver>_PLATFORM` (and to `GHA_RUNNER` if the `(OS, Arch)` is new), then update the model file. |
| Add a new driver | New model + new `mappings/<driver>.py` + new `_build_<driver>_row` + new `load-<driver>-matrix` workflow job. |

See `ci/test_matrix/README.md` for full recipes.