### PR TITLE
Fixup Python packaging tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -83,10 +83,14 @@ jobs:
       - name: Install Hatch
         run: uv tool install hatch --with "virtualenv<21.0.0"
 
+      - name: Mock parameters.json
+        run: echo '{"testconnection":{}}' > parameters.json
+
       - name: Run packaging tests
         working-directory: ./python
         run: hatch run packaging.py3.13:test -v --timeout=900
         env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           CORE_CARGO_TARGET_DIR: ${{ github.workspace }}/core-target
           PROTO_CARGO_TARGET_DIR: ${{ github.workspace }}/proto-target
 


### PR DESCRIPTION

Fix `packaging_tests` CI job failing with exit code 3 by adding a mock `parameters.json` stub and setting `PARAMETER_PATH`. The shared `conftest.py` bootstrap tries to open `parameters.json` even for packaging tests that don't need credentials; the stub satisfies it with an early no-op return

Testing in #1079 (rebased atop): https://github.com/snowflakedb/universal-driver/actions/runs/25548805232/job/74991460521?pr=1079
